### PR TITLE
Failed now delays for a second and then retries

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.uuid.Uuid
 
@@ -41,8 +42,14 @@ class DriveSyncManager(
                     is BackendEvent.DriveEvent.Completed     -> updateState(event.driveId) {
                         it.copy(state = DriveState.Completed(totalCount = event.totalCount))
                     }
-                    is BackendEvent.DriveEvent.Failed        -> updateState(event.driveId) {
-                        it.copy(state = DriveState.Failed(event.errorMessage))
+                    is BackendEvent.DriveEvent.Failed        -> {
+                        updateState(event.driveId) {
+                            it.copy(state = DriveState.Failed(event.errorMessage))
+                        }
+                        scope.launch {
+                            delay(1000L)
+                            driveSyncs[event.driveId]?.sync()
+                        }
                     }
                     else -> Unit
                 }
@@ -98,6 +105,15 @@ class DriveSyncManager(
         jobs.joinAll()
 
         eventBus.emit(BackendEvent.DriveEvent.SyncAllCompleted)
+    }
+
+    suspend fun syncAllFailed() {
+        val failedIds = _driveStatuses.value
+            .filter { (_, status) -> status.state is DriveState.Failed }
+            .keys
+
+        val jobs = failedIds.mapNotNull { driveSyncs[it]?.sync() }
+        jobs.joinAll()
     }
 
     fun syncDrive(driveId: Uuid) {

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncManagerTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncManagerTest.kt
@@ -12,10 +12,15 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpStatusCode
+import id.homebase.api.client.eventbus.BackendEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.uuid.Uuid
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -51,6 +56,57 @@ class DriveSyncManagerTest {
             manager.start(mapOf(driveId to "Test Drive"))
 
             assertEquals(DriveState.Initialized, manager.driveStatuses.value[driveId]?.state)
+        }
+
+        db.close()
+    }
+
+    @Test
+    fun failedDriveAutoRetriesSyncAfterOneSecond() {
+        val db = DatabaseManager { createInMemoryDatabase() }
+
+        runTest {
+            val credentialsManager = CredentialsManager()
+            credentialsManager.setActiveCredentials(
+                ApiCredentials.create(
+                    domain = OdinId("test.homebase.id"),
+                    clientAccessToken = "fake-token",
+                    sharedSecret = SecureByteArray(ByteArray(16))
+                )
+            )
+
+            // Mock that never responds — keeps sync in Synchronizing state so we can assert cleanly
+            val mockEngine = MockEngine { awaitCancellation() }
+            val httpClient = HttpClient(mockEngine)
+            val driveQueryProvider = DriveQueryProvider(httpClient, credentialsManager)
+            val eventBus = EventBus()
+
+            val manager = DriveSyncManager(
+                driveQueryProvider = driveQueryProvider,
+                credentialsManager = credentialsManager,
+                eventBus = eventBus,
+                scope = this,
+                databaseManager = db
+            )
+
+            val driveId = Uuid.random()
+            manager.start(mapOf(driveId to "Test Drive"))
+
+            // Emit a Failed event directly (simulating what DriveSync emits after a real failure)
+            eventBus.emit(BackendEvent.DriveEvent.Failed(driveId, "simulated network error"))
+            advanceTimeBy(1)
+
+            assertEquals(
+                DriveState.Failed("simulated network error"),
+                manager.driveStatuses.value[driveId]?.state
+            )
+
+            // Advance past the 1-second retry delay and drain pending coroutines
+            advanceTimeBy(1000)
+            runCurrent()
+
+            // sync() was called — performSync() emits DriveEvent.Started, transitioning to Synchronizing
+            assertIs<DriveState.Synchronizing>(manager.driveStatuses.value[driveId]?.state)
         }
 
         db.close()


### PR DESCRIPTION
 Auto-retry failed drive sync after 1-second delay

  - DriveSyncManager: on DriveEvent.Failed, launch a non-blocking coroutine that waits 1 s then calls driveSyncs[driveId]?.sync().
  Null-safe, so a stop() mid-delay is a no-op. If the retry also fails, another Failed event fires → another retry (infinite recovery
   loop by design).
  - DriveSyncManagerTest: added failedDriveAutoRetriesSyncAfterOneSecond — emits a Failed event, advances virtual time 1001 ms,
  confirms state transitions to Synchronizing (proving sync() was called).