### PR TITLE
Redundant call cleanup

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ConnectionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ConnectionService.kt
@@ -27,12 +27,6 @@ class ConnectionService(
     val connections: StateFlow<ConnectionState> =
         _connections.asStateFlow()
 
-    init {
-        scope.launch {
-            refresh()
-        }
-    }
-
     fun start() {
         scope.launch {
             refresh()

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/DriveContactService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/DriveContactService.kt
@@ -40,8 +40,6 @@ class DriveContactService(
 
     init {
         scope.launch {
-            refresh() // call once for good measure
-
             eventBus.events.collect { event ->
                 if (event is BackendEvent.DriveEvent.Completed &&
                     event.driveId == contactDrive
@@ -50,7 +48,6 @@ class DriveContactService(
                 }
             }
         }
-        start()
     }
 
     fun start() {


### PR DESCRIPTION
Fix: Remove eager network/DB calls on cold app startup

  Problem

  On cold start, ConnectionService and DriveContactService were both firing data fetches from their init blocks. Because ContactService.start()
  (called by the ViewModel) also calls start() on both services, this resulted in duplicate work at startup:

  - 4 network calls to /connections/connected and /connections/blocked (2 from init, 2 from start())
  - 3 DB queries for contacts (2 from init, 1 from start())

  All of this ran eagerly the moment Koin created the singletons, before the UI was even ready to render.

  Fix

  - ConnectionService — removed the init block. start() is now the sole trigger.
  - DriveContactService — removed the eager refresh() call and the start() call from init. The event bus listener (which re-fetches contacts
  when a drive sync completes) is retained.

  The initial loads now only happen when ConversationListViewModel is created and calls contactService.start() in a background coroutine. Both
  services already emit safe initial StateFlow values (isLoaded = false, empty lists), which the rest of the codebase handles gracefully by
  showing Unknown connection states until the real data arrives.

  Result

  The conversation list renders immediately on startup. Contact connection statuses populate in the background once the network calls complete.
