### PR TITLE
Skip http block

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/auth/OwnerSessionRepository.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/auth/OwnerSessionRepository.kt
@@ -23,6 +23,19 @@ class OwnerSessionRepository(
     val user: StateFlow<OwnerSession?> = _user
 
     suspend fun load(odinId: OdinId) {
+        // Emit a minimal fallback immediately so the UI can render without waiting for HTTP.
+        // The same fallback shape is already returned by fetch() on network failure.
+        _user.value = OwnerSession(
+            odinId = odinId,
+            displayName = odinId.toString(),
+            firstName = null,
+            surName = null,
+            profileImageFileId = null,
+            profileImageFileKey = null,
+            profileImagePreviewThumbnail = null,
+            profileImageLastModified = null,
+            status = null
+        )
         val updated = fetch(odinId)
         _user.value = updated
     }


### PR DESCRIPTION
Fix Cold App Startup Blocking on Network

The user experiences a noticeable delay during cold startup before the conversation list renders. In airplane mode it starts faster.
Root-cause analysis reveals the conversation list is gated behind ownerSession != null in ConversationListViewModel, and ownerSession is populated by an HTTP GET to /cdn/sitedata.json that must complete before anything is shown. In airplane mode, the HTTP call fails fast, returning a fallback OwnerSession immediately — which is why it feels faster.

---
Root Cause (Single Blocker)

File: homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt (lines 135–159)

     combine(
         conversationStream.conversations,
         contactService.contacts,
         ownerSessionRepository.user          // <-- starts as null
     ) { conversationState, contacts, ownerSession ->
         if (ownerSession == null) return@combine Pair(false, emptyList())  // <-- GATE
         ...
     }.collect { (dataReady, enriched) ->
         if (dataReady) { _uiState.update { ... } }
     }

     - conversationStream.start() is already called eagerly (line 133) — DB query is fast, dataReady becomes true quickly.
     - contactService.start() also starts fast from local DB.
     - The only real blocker is ownerSession == null, which persists until the HTTP call to /cdn/sitedata.json completes.

OwnerSessionRepository.load() already handles failures by returning a fallback OwnerSession — but only after the HTTP call returns or errors. In airplane mode, it fails fast. On a real network with latency, it can block for seconds.

   ---
   Fix: Emit a Fallback OwnerSession Immediately Before Network Fetch

   File to modify: homebase-api/src/commonMain/kotlin/id/homebase/api/client/auth/OwnerSessionRepository.kt

   Current code (lines 25–28):
   suspend fun load(odinId: OdinId) {
       val updated = fetch(odinId)
       _user.value = updated
   }

   New code:
   suspend fun load(odinId: OdinId) {
       // Emit fallback immediately so UI doesn't wait for HTTP — same shape as the
       // error-path fallback already returned by fetch() on network failure
       _user.value = OwnerSession(
           odinId = odinId,
           displayName = odinId.toString(),
           firstName = null,
           surName = null,
           profileImageFileId = null,
           profileImageFileKey = null,
           profileImagePreviewThumbnail = null,
           profileImageLastModified = null,
           status = null
       )
       // Network fetch runs after fallback is emitted; updates user once data arrives
       val updated = fetch(odinId)
       _user.value = updated
   }

This unblocks the combine in ConversationListViewModel immediately on auth restore. The profile data (display name, avatar) will update once the HTTP call completes — which is fine for a short visual flash.

The fallback shape matches exactly what fetch() already returns on null response / 404 (lines 41–53 of the same file), so no new code path is introduced.

---
Secondary: ConversationsData starts with dataReady = false

File: homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt (line 38)

private val _conversations = MutableStateFlow(ConversationsData(dataReady = false))

conversationStream.start() is called eagerly in the ViewModel and sets dataReady = true once the local DB query completes. This is already fast but the initial false value means the if (dataReady) check on line 149 of the ViewModel could theoretically fire before start() finishes its coroutine. In practice the ownerSession == null gate fires first, so this is moot once Change 1 is applied. No change needed here.

---
Files to Modify   ┌──────────────────────────────────────────────────────────────────────────────────────────┬───────────────────────────────────────────────
     ┐
     │                                           File                                           │                    Change
     │
     ├──────────────────────────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────
     ┤
     │ homebase-api/src/commonMain/kotlin/id/homebase/api/client/auth/OwnerSessionRepository.kt │ Emit fallback OwnerSession before fetch()
     │
     │                                                                                          │ call in load()
     │
     └──────────────────────────────────────────────────────────────────────────────────────────┴───────────────────────────────────────────────
     ┘

No other files need to change.

---
What Does NOT Need Changing

- ConversationListViewModel.kt — the combine logic is correct; just needs ownerSession to be non-null sooner.
- ConversationStream.kt — start() is already called eagerly, DB query is already fast.
- ConnectionService.kt — contacts show as Unknown until HTTP completes, which is acceptable.
- AuthConnectionCoordinator.kt — loadProfile() timing is fine; the fix is in OwnerSessionRepository.