### PR TITLE
Auth crash fix

### DIFF
--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt
@@ -136,7 +136,13 @@ class LoginViewModel(
                     circles =
                         listOf(CONFIRMED_CONNECTIONS_CIRCLE_ID, AUTO_CONNECTIONS_CIRCLE_ID)
                 )
-                _uiState.update { it.copy(uiEvent = LoginUiEvent.OpenAuthUrl(authUrl)) }
+                if (authUrl.isNotBlank()) {
+                    _uiState.update { it.copy(uiEvent = LoginUiEvent.OpenAuthUrl(authUrl)) }
+                } else {
+                    _uiState.update {
+                        it.copy(isLoading = false, errorMessage = "Authentication already in progress")
+                    }
+                }
             } catch (e: Exception) {
                 _uiState.update {
                     it.copy(isLoading = false, errorMessage = e.message ?: "Login failed")


### PR DESCRIPTION

● Summary:

  - Crash: authorize() returned "" (already-auth guard) → that empty string was passed directly to launchAuthBrowser() → Android
  Intent with no URL → ActivityNotFoundException
  - Fix: Check authUrl.isNotBlank() before emitting the event; show an error message instead

  Separate issue to investigate: Why the user ended up back on the login screen after the first auth completed (WebSocket was already
   connected). That's likely a navigation bug in how the Authenticated state drives the login→home transition — worth checking
  LoginViewModel's state observer and the navigation logic.