### PR TITLE
Fix for login navigation weirdness

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthFlowManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthFlowManager.kt
@@ -80,6 +80,10 @@ class YouAuthFlowManager(
     // Registry for callback routing
     private val callbackRegistry = mutableMapOf<String, AuthCodeFlowState>()
 
+    // True once handleCallback() is invoked, preventing onAppResumed from cancelling a
+    // finalization that is still in-flight on a slow network.
+    @Volatile private var callbackReceived = false
+
     companion object {
         private val TAG = "YouAuthFlowManager"
     }
@@ -99,6 +103,7 @@ class YouAuthFlowManager(
 
     /** Handle an authorization callback URL. */
     suspend fun handleCallback(url: String) {
+        callbackReceived = true
         try {
             Logger.d(tag = TAG) { "Received callback: $url" }
 
@@ -309,6 +314,7 @@ class YouAuthFlowManager(
             _authState.value = YouAuthState.Error(e.message ?: "Unknown error")
         } finally {
             callbackRegistry.remove(state)
+            callbackReceived = false
         }
     }
 
@@ -345,6 +351,7 @@ class YouAuthFlowManager(
         if (_authState.value == YouAuthState.Authenticating) {
             Logger.i(tag = TAG) { "Authentication cancelled by user" }
             callbackRegistry.clear()
+            callbackReceived = false
             _authState.value = YouAuthState.Unauthenticated
             credentialsManager.removeActiveCredentials()
         }
@@ -357,12 +364,16 @@ class YouAuthFlowManager(
      * @param delayMs Optional delay to wait for callback before cancelling (default 500ms)
      */
     suspend fun onAppResumed(delayMs: Long = 500) {
+        // If the deep-link callback already arrived, do not interfere — finalizeAuthentication()
+        // may still be running on a slow network and we must not cancel it.
+        if (callbackReceived) return
+
         if (_authState.value == YouAuthState.Authenticating) {
             // Wait a short time for callback to potentially arrive
             delay(delayMs)
 
-            // If still authenticating, assume user cancelled
-            if (_authState.value == YouAuthState.Authenticating) {
+            // If still authenticating and no callback arrived, assume user cancelled
+            if (!callbackReceived && _authState.value == YouAuthState.Authenticating) {
                 Logger.i(tag = TAG) { "App resumed without auth callback, assuming user cancelled" }
                 cancelAuth()
             }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthFlowManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthFlowManager.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlin.concurrent.Volatile
 import kotlinx.coroutines.launch
 import kotlin.io.encoding.Base64
 

--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt
@@ -248,8 +248,8 @@ class LoginViewModel(
         }
     }
 
-    private suspend fun handleAuthenticatedUser() {
-        notificationService.reRegister()
+    private fun handleAuthenticatedUser() {
+        viewModelScope.launch { notificationService.reRegister() }
         usernameStorage.saveUsername(_uiState.value.homebaseId)
         _uiState.update {
             it.copy(


### PR DESCRIPTION
     Plan: Fix Login → Home Navigation Regression

     Context

     After a user completes OAuth authentication in Chrome Custom Tab and returns to the app, they sometimes land back on the login
     screen instead of the home screen — even though auth fully completed (WebSocket connects, processInbox is sent). Clicking login
     again then crashes the app (empty URL passed to the browser launcher — already fixed).

     Root cause: a race condition in onAppResumed() cancels the auth flow while finalizeAuthentication() (a network call) is still
     in-flight. Two secondary issues compound this.

     ---
     Root Cause: onAppResumed Race Condition

     Files:
     - androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt — onResume() triggers the race
     - homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthFlowManager.kt — onAppResumed() + cancelAuth()

     Sequence:
     1. Custom Tab redirects to homebase-fchat://...
     2. onNewIntent fires → launches coroutine for handleCallback(url) (async, not awaited)
     3. onResume fires immediately after → launches coroutine: delay(300ms) → onAppResumed() → delay(500ms) → checks state
     4. handleCallback → completeAuth() → YouAuthProvider.finalizeAuthentication() (network call)
     5. If finalizeAuthentication takes > 800ms: onAppResumed sees state is still Authenticating → cancelAuth() → state =
     Unauthenticated
     6. Global auth guard in AppNavHost (LaunchedEffect(authState, ...)) fires → navigates to Route.Login with popUpTo(0) — user sees
      login screen
     7. finalizeAuthentication eventually completes → _authState = Authenticated → WebSocket connects → processInbox sent (matches
     log at 21:23:53)
     8. User is on login screen; new LoginViewModel instance observes the late-arriving Authenticated state but may not navigate home
      reliably

     ---
     Fix 1 — Guard onAppResumed with a callback-received flag

     File: homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthFlowManager.kt

     Add an @Volatile flag callbackReceived: Boolean:
     - Set to true at the top of handleCallback() (before any async work) — this is the signal that a redirect arrived
     - Set to false in cancelAuth() and restoreSession() (any auth reset)
     - In onAppResumed(), add an early return if callbackReceived == true:

     suspend fun onAppResumed(delayMs: Long = 500) {
         if (callbackReceived) return  // Callback arrived; let handleCallback complete
         if (_authState.value == YouAuthState.Authenticating) {
             delay(delayMs)
             if (!callbackReceived && _authState.value == YouAuthState.Authenticating) {
                 cancelAuth()
             }
         }
     }

     ---
     Fix 2 — Decouple notification re-registration from navigation

     File: homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt

     handleAuthenticatedUser() blocks on notificationService.reRegister() (two network calls) before emitting NavigateToHome. If this
      suspends long or throws, navigation never fires.

     Move reRegister() to a fire-and-forget coroutine so navigation is not gated on it:

     private fun handleAuthenticatedUser() {
         viewModelScope.launch { notificationService.reRegister() }  // fire-and-forget
         usernameStorage.saveUsername(_uiState.value.homebaseId)
         _uiState.update {
             it.copy(
                 isLoading = false,
                 isAuthenticated = true,
                 errorMessage = null,
                 uiEvent = LoginUiEvent.NavigateToHome
             )
         }
     }

     Note: handleAuthenticatedUser can become a regular (non-suspend) function after this change, which also prevents it from being
     cancelled by collectLatest mid-execution.

     ---
     Critical Files

     │ homebase-api/.../YouAuthFlowManager.kt │ Add callbackReceived flag; guard onAppResumed                                  │
     │ homebase-auth/.../LoginViewModel.kt    │ Make reRegister() fire-and-forget; remove suspend from handleAuthenticatedUser │

     ---
     Files to Read Before Implementing

     - homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthFlowManager.kt (full file — lines 1–370)
     - homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt (full file)

     ---
     Verification

     1. Happy path: Log in on a slow network (or add a 2s artificial delay to finalizeAuthentication). Confirm the user navigates
     home without landing on the login screen.
     2. Cancel path: Open the browser and immediately close it without completing auth. Confirm cancelAuth() still fires (state
     returns to Unauthenticated).
     3. Already-fixed crash regression: Start login twice rapidly. Confirm the error message "Authentication already in progress"
     appears and no crash.
     4. Slow notification registration: Simulate a hung api.unsubscribe() call. Confirm NavigateToHome fires immediately rather than
     waiting.