### PR TITLE
Fixing DriveSyncManager to properly handle events for multiple drives

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/eventbus/BackendEvent.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/eventbus/BackendEvent.kt
@@ -43,6 +43,8 @@ sealed interface BackendEvent {
 
         data object SyncAllCompleted: BackendEvent
 
+        data object SyncAllFailed: BackendEvent
+
         data class Started(
             override val driveId: Uuid,
         ) : DriveEvent // Only raised by Drive.sync()

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveStatus.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveStatus.kt
@@ -14,3 +14,18 @@ sealed interface DriveState {
     data class  Completed(val totalCount: Int = 0)  : DriveState
     data class  Failed(val message: String)          : DriveState
 }
+
+sealed interface SyncState {
+    data object Idle      : SyncState  // No drives registered
+    data object Syncing   : SyncState  // One or more drives are Synchronizing
+    data object Completed : SyncState  // All drives Completed, none Failed/Syncing
+    data object Failed    : SyncState  // One or more Failed; rest Completed/Initialized
+}
+
+fun computeSyncState(statuses: Map<Uuid, DriveStatus>): SyncState = when {
+    statuses.isEmpty()                                                -> SyncState.Idle
+    statuses.values.any { it.state is DriveState.Synchronizing }     -> SyncState.Syncing
+    statuses.values.any { it.state is DriveState.Failed }            -> SyncState.Failed
+    statuses.values.all { it.state is DriveState.Completed }         -> SyncState.Completed
+    else                                                              -> SyncState.Idle
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
@@ -9,8 +9,11 @@ import id.homebase.api.sync.database.DatabaseManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.delay
@@ -29,7 +32,29 @@ class DriveSyncManager(
     private val _driveStatuses = MutableStateFlow<Map<Uuid, DriveStatus>>(emptyMap())
     val driveStatuses: StateFlow<Map<Uuid, DriveStatus>> = _driveStatuses.asStateFlow()
 
+    val syncState: StateFlow<SyncState> = _driveStatuses
+        .map { computeSyncState(it) }
+        .stateIn(scope, SharingStarted.Eagerly, SyncState.Idle)
+
+    fun numberOfDrivesSyncing(): Int =
+        _driveStatuses.value.values.count { it.state is DriveState.Synchronizing }
+
     init {
+        scope.launch {
+            var previous: SyncState = SyncState.Idle
+            syncState.collect { current ->
+                when {
+                    previous !is SyncState.Syncing && current is SyncState.Syncing ->
+                        eventBus.emit(BackendEvent.DriveEvent.SyncAllStarted)
+                    previous is SyncState.Syncing && current is SyncState.Completed ->
+                        eventBus.emit(BackendEvent.DriveEvent.SyncAllCompleted)
+                    previous is SyncState.Syncing && current is SyncState.Failed ->
+                        eventBus.emit(BackendEvent.DriveEvent.SyncAllFailed)
+                }
+                previous = current
+            }
+        }
+
         scope.launch {
             eventBus.events.collect { event ->
                 when (event) {
@@ -98,13 +123,9 @@ class DriveSyncManager(
     }
 
     suspend fun syncAll() {
-        eventBus.emit(BackendEvent.DriveEvent.SyncAllStarted)
-
         val snapshot = driveSyncs.values.toList()
         val jobs = snapshot.mapNotNull { it.sync() }
         jobs.joinAll()
-
-        eventBus.emit(BackendEvent.DriveEvent.SyncAllCompleted)
     }
 
     suspend fun syncAllFailed() {

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncManagerTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncManagerTest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 import kotlin.uuid.Uuid
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -109,6 +110,204 @@ class DriveSyncManagerTest {
             assertIs<DriveState.Synchronizing>(manager.driveStatuses.value[driveId]?.state)
         }
 
+        db.close()
+    }
+
+    private fun buildManager(
+        db: DatabaseManager,
+        credentialsManager: CredentialsManager,
+        eventBus: EventBus,
+        scope: kotlinx.coroutines.CoroutineScope
+    ): DriveSyncManager {
+        val mockEngine = MockEngine { awaitCancellation() }
+        val httpClient = HttpClient(mockEngine)
+        val driveQueryProvider = DriveQueryProvider(httpClient, credentialsManager)
+        return DriveSyncManager(
+            driveQueryProvider = driveQueryProvider,
+            credentialsManager = credentialsManager,
+            eventBus = eventBus,
+            scope = scope,
+            databaseManager = db
+        )
+    }
+
+    private fun buildCredentials(): CredentialsManager {
+        val credentialsManager = CredentialsManager()
+        credentialsManager.setActiveCredentials(
+            ApiCredentials.create(
+                domain = OdinId("test.homebase.id"),
+                clientAccessToken = "fake-token",
+                sharedSecret = SecureByteArray(ByteArray(16))
+            )
+        )
+        return credentialsManager
+    }
+
+    @Test
+    fun syncStateIsIdleBeforeStart() {
+        val db = DatabaseManager { createInMemoryDatabase() }
+        runTest {
+            val manager = buildManager(db, buildCredentials(), EventBus(), this)
+            assertEquals(SyncState.Idle, manager.syncState.value)
+        }
+        db.close()
+    }
+
+    @Test
+    fun syncStateTransitionsToSyncingOnStartedEvent() {
+        val db = DatabaseManager { createInMemoryDatabase() }
+        runTest {
+            val eventBus = EventBus()
+            val manager = buildManager(db, buildCredentials(), eventBus, this)
+            val driveId = Uuid.random()
+            manager.start(mapOf(driveId to "Drive"))
+            runCurrent()
+
+            eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
+            runCurrent()
+
+            assertIs<SyncState.Syncing>(manager.syncState.value)
+        }
+        db.close()
+    }
+
+    @Test
+    fun syncStateTransitionsToCompletedWhenAllDrivesComplete() {
+        val db = DatabaseManager { createInMemoryDatabase() }
+        runTest {
+            val eventBus = EventBus()
+            val manager = buildManager(db, buildCredentials(), eventBus, this)
+            val driveId = Uuid.random()
+            manager.start(mapOf(driveId to "Drive"))
+            runCurrent()
+
+            eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
+            runCurrent()
+            eventBus.emit(BackendEvent.DriveEvent.Completed(driveId, totalCount = 5))
+            runCurrent()
+
+            assertIs<SyncState.Completed>(manager.syncState.value)
+        }
+        db.close()
+    }
+
+    @Test
+    fun syncStateTransitionsToFailedOnFailedEvent() {
+        val db = DatabaseManager { createInMemoryDatabase() }
+        runTest {
+            val eventBus = EventBus()
+            val manager = buildManager(db, buildCredentials(), eventBus, this)
+            val driveId = Uuid.random()
+            manager.start(mapOf(driveId to "Drive"))
+            runCurrent()
+
+            eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
+            runCurrent()
+            eventBus.emit(BackendEvent.DriveEvent.Failed(driveId, "error"))
+            advanceTimeBy(1)
+
+            assertIs<SyncState.Failed>(manager.syncState.value)
+        }
+        db.close()
+    }
+
+    @Test
+    fun syncAllStartedEventFiredOnTransitionToSyncing() {
+        val db = DatabaseManager { createInMemoryDatabase() }
+        runTest {
+            val eventBus = EventBus()
+            val manager = buildManager(db, buildCredentials(), eventBus, this)
+            val driveId = Uuid.random()
+            manager.start(mapOf(driveId to "Drive"))
+            runCurrent()
+
+            val emittedEvents = mutableListOf<BackendEvent>()
+            val job = launch { eventBus.events.collect { emittedEvents.add(it) } }
+
+            eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
+            runCurrent()
+
+            assertTrue(emittedEvents.any { it is BackendEvent.DriveEvent.SyncAllStarted })
+            job.cancel()
+        }
+        db.close()
+    }
+
+    @Test
+    fun syncAllCompletedEventFiredOnTransitionToCompleted() {
+        val db = DatabaseManager { createInMemoryDatabase() }
+        runTest {
+            val eventBus = EventBus()
+            val manager = buildManager(db, buildCredentials(), eventBus, this)
+            val driveId = Uuid.random()
+            manager.start(mapOf(driveId to "Drive"))
+            runCurrent()
+
+            eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
+            runCurrent()
+
+            val emittedEvents = mutableListOf<BackendEvent>()
+            val job = launch { eventBus.events.collect { emittedEvents.add(it) } }
+
+            eventBus.emit(BackendEvent.DriveEvent.Completed(driveId, totalCount = 3))
+            runCurrent()
+
+            assertTrue(emittedEvents.any { it is BackendEvent.DriveEvent.SyncAllCompleted })
+            job.cancel()
+        }
+        db.close()
+    }
+
+    @Test
+    fun syncAllFailedEventFiredOnTransitionToFailed() {
+        val db = DatabaseManager { createInMemoryDatabase() }
+        runTest {
+            val eventBus = EventBus()
+            val manager = buildManager(db, buildCredentials(), eventBus, this)
+            val driveId = Uuid.random()
+            manager.start(mapOf(driveId to "Drive"))
+            runCurrent()
+
+            eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
+            runCurrent()
+
+            val emittedEvents = mutableListOf<BackendEvent>()
+            val job = launch { eventBus.events.collect { emittedEvents.add(it) } }
+
+            eventBus.emit(BackendEvent.DriveEvent.Failed(driveId, "network error"))
+            advanceTimeBy(1)
+
+            assertTrue(emittedEvents.any { it is BackendEvent.DriveEvent.SyncAllFailed })
+            job.cancel()
+        }
+        db.close()
+    }
+
+    @Test
+    fun numberOfDrivesSyncingReturnsCorrectCount() {
+        val db = DatabaseManager { createInMemoryDatabase() }
+        runTest {
+            val eventBus = EventBus()
+            val manager = buildManager(db, buildCredentials(), eventBus, this)
+            val driveId1 = Uuid.random()
+            val driveId2 = Uuid.random()
+            manager.start(mapOf(driveId1 to "Drive 1", driveId2 to "Drive 2"))
+            runCurrent()
+
+            assertEquals(0, manager.numberOfDrivesSyncing())
+
+            eventBus.emit(BackendEvent.DriveEvent.Started(driveId1))
+            runCurrent()
+            assertEquals(1, manager.numberOfDrivesSyncing())
+
+            eventBus.emit(BackendEvent.DriveEvent.Started(driveId2))
+            runCurrent()
+            assertEquals(2, manager.numberOfDrivesSyncing())
+
+            eventBus.emit(BackendEvent.DriveEvent.Completed(driveId1, totalCount = 0))
+            runCurrent()
+            assertEquals(1, manager.numberOfDrivesSyncing())
+        }
         db.close()
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -252,11 +252,12 @@ class ConversationListViewModel(
 
         // Set isConnecting state
         viewModelScope.launch {
-            eventBus.events.filter { it is BackendEvent.DriveEvent }.collectLatest { state ->
-                if (state is BackendEvent.DriveEvent.SyncAllCompleted || state is BackendEvent.DriveEvent.Completed) {
-                    _uiState.update { it.copy(driveIsSyncing = false) }
-                } else if (state is BackendEvent.DriveEvent.Started || state is BackendEvent.DriveEvent.SyncAllStarted) {
-                    _uiState.update { it.copy(driveIsSyncing = true) }
+            eventBus.events.filter { it is BackendEvent.DriveEvent }.collectLatest { event ->
+                when (event) {
+                    is BackendEvent.DriveEvent.SyncAllStarted                    -> _uiState.update { it.copy(driveIsSyncing = true) }
+                    is BackendEvent.DriveEvent.SyncAllCompleted,
+                    is BackendEvent.DriveEvent.SyncAllFailed                     -> _uiState.update { it.copy(driveIsSyncing = false) }
+                    else -> Unit
                 }
             }
         }


### PR DESCRIPTION
 Fix DriveSyncManager aggregate state tracking and SyncAll events

  Problem

  The SyncAllStarted and SyncAllCompleted events emitted by syncAll() were unreliable:

  - SyncAllStarted fired unconditionally at the top of syncAll(), even if no drives actually began syncing.
  - SyncAllCompleted fired after jobs.joinAll() for only the jobs launched in that call — drives already syncing from WebSocket-triggered syncDrive() calls were ignored,
  so SyncAllCompleted could fire while drives were still active.

  Solution

  Removed manual event emission from syncAll() and instead derive aggregate state from the per-drive DriveState map, emitting SyncAll* events only on real state
  transitions.

  Changes

  DriveStatus.kt — Added SyncState sealed interface and computeSyncState() helper:
  - Idle — no drives registered
  - Syncing — one or more drives are Synchronizing
  - Completed — all drives completed, none failed or syncing
  - Failed — one or more drives failed, rest completed/initialized

  BackendEvent.kt — Added SyncAllFailed event (aggregate counterpart to the existing SyncAllStarted/SyncAllCompleted).

  DriveSyncManager.kt:
  - Added syncState: StateFlow<SyncState> — derived from driveStatuses via map + stateIn
  - Added numberOfDrivesSyncing(): Int helper
  - Added a state-transition watcher in init that emits SyncAllStarted, SyncAllCompleted, or SyncAllFailed based on actual syncState transitions
  - Removed the two manual eventBus.emit(SyncAllStarted/Completed) calls from syncAll()

  ConversationListViewModel.kt — Simplified the sync event handler to use only the aggregate SyncAll* events (removed noisy per-drive Started/Completed handling), and
  added handling for the new SyncAllFailed.

  DriveSyncManagerTest.kt — Added 8 new tests covering: syncState initial value, transitions to Syncing/Completed/Failed, SyncAllStarted/SyncAllCompleted/SyncAllFailed
  event emission, and numberOfDrivesSyncing() count accuracy.