### PR TITLE
Event Simplification

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/eventbus/BackendEvent.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/eventbus/BackendEvent.kt
@@ -14,10 +14,9 @@ sealed interface BackendEvent {
     }
 
     sealed interface DriveResult {
-        data class Success(val totalCount: Int) : DriveResult
+        data object Success : DriveResult
         data class Failure(
-            val errorMessage: String,
-            val source: SyncSource = SyncSource.DriveSync
+            val errorMessage: String
         ) : DriveResult
     }
 
@@ -58,6 +57,7 @@ sealed interface BackendEvent {
 
         data class Stopped(
             override val driveId: Uuid,
+            val totalCount: Int,  // records fetched so far — always present (0 if failed immediately)
             val result: DriveResult
         ) : DriveEvent  // Only raised by Drive.sync() when a drive finishes (success or failure)
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/eventbus/BackendEvent.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/eventbus/BackendEvent.kt
@@ -13,6 +13,19 @@ sealed interface BackendEvent {
         WebSocket
     }
 
+    sealed interface DriveResult {
+        data class Success(val totalCount: Int) : DriveResult
+        data class Failure(
+            val errorMessage: String,
+            val source: SyncSource = SyncSource.DriveSync
+        ) : DriveResult
+    }
+
+    sealed interface SyncAllResult {
+        data object Success : SyncAllResult
+        data object Failure : SyncAllResult
+    }
+
     sealed interface CircleNetworkEvent : BackendEvent {
 
         data class ConnectionRequestReceived(val sender: OdinId) : CircleNetworkEvent
@@ -43,16 +56,10 @@ sealed interface BackendEvent {
             override val driveId: Uuid,
         ) : DriveEvent // Only raised by Drive.sync()
 
-        data class Completed(
+        data class Stopped(
             override val driveId: Uuid,
-            val totalCount: Int
-        ) : DriveEvent  // Only raised by Drive.sync() when a drive is fully synced
-
-        data class Failed(
-            override val driveId: Uuid,
-            val errorMessage: String,  // Or add throwable: Throwable
-            val source: SyncSource = SyncSource.DriveSync
-        ) : DriveEvent
+            val result: DriveResult
+        ) : DriveEvent  // Only raised by Drive.sync() when a drive finishes (success or failure)
 
         data class BatchReceived(
             override val driveId: Uuid,
@@ -150,8 +157,7 @@ sealed interface BackendEvent {
 
     // Emitted when a full sync-all-drives operation starts/finishes
     data object SyncAllStarted : BackendEvent
-    data object SyncAllCompleted : BackendEvent
-    data object SyncAllFailed : BackendEvent
+    data class SyncAllStopped(val result: SyncAllResult) : BackendEvent
 
     // We go online / offline when the websocket listener is connected / disconnected
     data object Connecting : BackendEvent

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
@@ -188,9 +188,9 @@ class DriveSync(
                     Logger.e("Drive $driveId sync failed ($cursorInfo): $reason")
                     killroy.value = false // don't retry on terminal failure; reconnect will re-sync
                     eventBus.emit(
-                        BackendEvent.DriveEvent.Failed(
+                        BackendEvent.DriveEvent.Stopped(
                             driveId,
-                            "Sync failed: $reason"
+                            BackendEvent.DriveResult.Failure("Sync failed: $reason")
                         )
                     )
                     break
@@ -210,11 +210,11 @@ class DriveSync(
 
         try {
             dbDeferreds.awaitAll()  // Suspends until all complete; rethrows the first exception if any
-            eventBus.emit(BackendEvent.DriveEvent.Completed(driveId, totalCount))
+            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, BackendEvent.DriveResult.Success(totalCount)))
             Logger.d("Drive $driveId synchronized with $totalCount records read.")
         } catch (e: Exception) {
             Logger.e("Sync failed due to DB error: ${e.message}")
-            eventBus.emit(BackendEvent.DriveEvent.Failed(driveId, e.message ?: "DB upsert failed"))
+            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, BackendEvent.DriveResult.Failure(e.message ?: "DB upsert failed")))
         }
     }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
@@ -190,6 +190,7 @@ class DriveSync(
                     eventBus.emit(
                         BackendEvent.DriveEvent.Stopped(
                             driveId,
+                            totalCount,
                             BackendEvent.DriveResult.Failure("Sync failed: $reason")
                         )
                     )
@@ -210,11 +211,11 @@ class DriveSync(
 
         try {
             dbDeferreds.awaitAll()  // Suspends until all complete; rethrows the first exception if any
-            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, BackendEvent.DriveResult.Success(totalCount)))
+            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, totalCount, BackendEvent.DriveResult.Success))
             Logger.d("Drive $driveId synchronized with $totalCount records read.")
         } catch (e: Exception) {
             Logger.e("Sync failed due to DB error: ${e.message}")
-            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, BackendEvent.DriveResult.Failure(e.message ?: "DB upsert failed")))
+            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, totalCount, BackendEvent.DriveResult.Failure(e.message ?: "DB upsert failed")))
         }
     }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
@@ -47,9 +47,9 @@ class DriveSyncManager(
                     previous !is SyncState.Syncing && current is SyncState.Syncing ->
                         eventBus.emit(BackendEvent.SyncAllStarted)
                     previous is SyncState.Syncing && current is SyncState.Completed ->
-                        eventBus.emit(BackendEvent.SyncAllCompleted)
+                        eventBus.emit(BackendEvent.SyncAllStopped(BackendEvent.SyncAllResult.Success))
                     previous is SyncState.Syncing && current is SyncState.Failed ->
-                        eventBus.emit(BackendEvent.SyncAllFailed)
+                        eventBus.emit(BackendEvent.SyncAllStopped(BackendEvent.SyncAllResult.Failure))
                 }
                 previous = current
             }
@@ -64,16 +64,18 @@ class DriveSyncManager(
                     is BackendEvent.DriveEvent.BatchReceived -> updateState(event.driveId) {
                         it.copy(state = DriveState.Synchronizing(count = event.totalCount))
                     }
-                    is BackendEvent.DriveEvent.Completed     -> updateState(event.driveId) {
-                        it.copy(state = DriveState.Completed(totalCount = event.totalCount))
-                    }
-                    is BackendEvent.DriveEvent.Failed        -> {
-                        updateState(event.driveId) {
-                            it.copy(state = DriveState.Failed(event.errorMessage))
+                    is BackendEvent.DriveEvent.Stopped -> when (val r = event.result) {
+                        is BackendEvent.DriveResult.Success -> updateState(event.driveId) {
+                            it.copy(state = DriveState.Completed(totalCount = r.totalCount))
                         }
-                        scope.launch {
-                            delay(1000L)
-                            driveSyncs[event.driveId]?.sync()
+                        is BackendEvent.DriveResult.Failure -> {
+                            updateState(event.driveId) {
+                                it.copy(state = DriveState.Failed(r.errorMessage))
+                            }
+                            scope.launch {
+                                delay(1000L)
+                                driveSyncs[event.driveId]?.sync()
+                            }
                         }
                     }
                     else -> Unit

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
@@ -66,7 +66,7 @@ class DriveSyncManager(
                     }
                     is BackendEvent.DriveEvent.Stopped -> when (val r = event.result) {
                         is BackendEvent.DriveResult.Success -> updateState(event.driveId) {
-                            it.copy(state = DriveState.Completed(totalCount = r.totalCount))
+                            it.copy(state = DriveState.Completed(totalCount = event.totalCount))
                         }
                         is BackendEvent.DriveResult.Failure -> {
                             updateState(event.driveId) {

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncManagerTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncManagerTest.kt
@@ -94,7 +94,7 @@ class DriveSyncManagerTest {
             manager.start(mapOf(driveId to "Test Drive"))
 
             // Emit a Failed event directly (simulating what DriveSync emits after a real failure)
-            eventBus.emit(BackendEvent.DriveEvent.Failed(driveId, "simulated network error"))
+            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, BackendEvent.DriveResult.Failure("simulated network error")))
             advanceTimeBy(1)
 
             assertEquals(
@@ -183,7 +183,7 @@ class DriveSyncManagerTest {
 
             eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
             runCurrent()
-            eventBus.emit(BackendEvent.DriveEvent.Completed(driveId, totalCount = 5))
+            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, BackendEvent.DriveResult.Success(5)))
             runCurrent()
 
             assertIs<SyncState.Completed>(manager.syncState.value)
@@ -203,7 +203,7 @@ class DriveSyncManagerTest {
 
             eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
             runCurrent()
-            eventBus.emit(BackendEvent.DriveEvent.Failed(driveId, "error"))
+            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, BackendEvent.DriveResult.Failure("error")))
             advanceTimeBy(1)
 
             assertIs<SyncState.Failed>(manager.syncState.value)
@@ -227,7 +227,7 @@ class DriveSyncManagerTest {
             eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
             runCurrent()
 
-            assertTrue(emittedEvents.any { it is BackendEvent.DriveEvent.SyncAllStarted })
+            assertTrue(emittedEvents.any { it is BackendEvent.SyncAllStarted })
             job.cancel()
         }
         db.close()
@@ -249,10 +249,10 @@ class DriveSyncManagerTest {
             val emittedEvents = mutableListOf<BackendEvent>()
             val job = launch { eventBus.events.collect { emittedEvents.add(it) } }
 
-            eventBus.emit(BackendEvent.DriveEvent.Completed(driveId, totalCount = 3))
+            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, BackendEvent.DriveResult.Success(3)))
             runCurrent()
 
-            assertTrue(emittedEvents.any { it is BackendEvent.DriveEvent.SyncAllCompleted })
+            assertTrue(emittedEvents.any { it is BackendEvent.SyncAllStopped && it.result is BackendEvent.SyncAllResult.Success })
             job.cancel()
         }
         db.close()
@@ -274,10 +274,10 @@ class DriveSyncManagerTest {
             val emittedEvents = mutableListOf<BackendEvent>()
             val job = launch { eventBus.events.collect { emittedEvents.add(it) } }
 
-            eventBus.emit(BackendEvent.DriveEvent.Failed(driveId, "network error"))
+            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, BackendEvent.DriveResult.Failure("network error")))
             advanceTimeBy(1)
 
-            assertTrue(emittedEvents.any { it is BackendEvent.DriveEvent.SyncAllFailed })
+            assertTrue(emittedEvents.any { it is BackendEvent.SyncAllStopped && it.result is BackendEvent.SyncAllResult.Failure })
             job.cancel()
         }
         db.close()
@@ -304,7 +304,7 @@ class DriveSyncManagerTest {
             runCurrent()
             assertEquals(2, manager.numberOfDrivesSyncing())
 
-            eventBus.emit(BackendEvent.DriveEvent.Completed(driveId1, totalCount = 0))
+            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId1, BackendEvent.DriveResult.Success(0)))
             runCurrent()
             assertEquals(1, manager.numberOfDrivesSyncing())
         }

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncManagerTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncManagerTest.kt
@@ -94,7 +94,7 @@ class DriveSyncManagerTest {
             manager.start(mapOf(driveId to "Test Drive"))
 
             // Emit a Failed event directly (simulating what DriveSync emits after a real failure)
-            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, BackendEvent.DriveResult.Failure("simulated network error")))
+            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, 0, BackendEvent.DriveResult.Failure("simulated network error")))
             advanceTimeBy(1)
 
             assertEquals(
@@ -183,7 +183,7 @@ class DriveSyncManagerTest {
 
             eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
             runCurrent()
-            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, BackendEvent.DriveResult.Success(5)))
+            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, 5, BackendEvent.DriveResult.Success))
             runCurrent()
 
             assertIs<SyncState.Completed>(manager.syncState.value)
@@ -203,7 +203,7 @@ class DriveSyncManagerTest {
 
             eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
             runCurrent()
-            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, BackendEvent.DriveResult.Failure("error")))
+            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, 0, BackendEvent.DriveResult.Failure("error")))
             advanceTimeBy(1)
 
             assertIs<SyncState.Failed>(manager.syncState.value)
@@ -249,7 +249,7 @@ class DriveSyncManagerTest {
             val emittedEvents = mutableListOf<BackendEvent>()
             val job = launch { eventBus.events.collect { emittedEvents.add(it) } }
 
-            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, BackendEvent.DriveResult.Success(3)))
+            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, 3, BackendEvent.DriveResult.Success))
             runCurrent()
 
             assertTrue(emittedEvents.any { it is BackendEvent.SyncAllStopped && it.result is BackendEvent.SyncAllResult.Success })
@@ -274,7 +274,7 @@ class DriveSyncManagerTest {
             val emittedEvents = mutableListOf<BackendEvent>()
             val job = launch { eventBus.events.collect { emittedEvents.add(it) } }
 
-            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, BackendEvent.DriveResult.Failure("network error")))
+            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, 0, BackendEvent.DriveResult.Failure("network error")))
             advanceTimeBy(1)
 
             assertTrue(emittedEvents.any { it is BackendEvent.SyncAllStopped && it.result is BackendEvent.SyncAllResult.Failure })
@@ -304,7 +304,7 @@ class DriveSyncManagerTest {
             runCurrent()
             assertEquals(2, manager.numberOfDrivesSyncing())
 
-            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId1, BackendEvent.DriveResult.Success(0)))
+            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId1, 0, BackendEvent.DriveResult.Success))
             runCurrent()
             assertEquals(1, manager.numberOfDrivesSyncing())
         }

--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt
@@ -206,7 +206,7 @@ class LoginViewModel(
                 authConnectionCoordinator.connectionState,
                 youAuthFlowManager.authState
             ) { connectionState, authState ->
-                authState.mapToStartupState(connectionState.isDoingInitialConnection)
+                authState.mapToStartupState(connectionState.isConnecting)
             }
                 .distinctUntilChanged() // Ensures only unique combined results are emitted
                 .catch { error ->

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -272,23 +272,15 @@ class ConversationListViewModel(
             eventBus.events
                 .filter {
                     it is BackendEvent.SyncAllStarted ||
-                            it is BackendEvent.SyncAllCompleted ||
-                            it is BackendEvent.SyncAllFailed ||
-                            it is BackendEvent.DriveEvent.Failed
+                    it is BackendEvent.SyncAllStopped ||
+                    it is BackendEvent.DriveEvent.Stopped
                 }
                 .collectLatest { event ->
                     when (event) {
-                        is BackendEvent.SyncAllStarted -> _uiState.update {
-                            it.copy(
-                                driveIsSyncing = true,
-                                hasDriveError = false
-                            )
-                        }
-
-                        is BackendEvent.SyncAllCompleted,
-                        is BackendEvent.SyncAllFailed -> _uiState.update { it.copy(driveIsSyncing = false) }
-
-                        is BackendEvent.DriveEvent.Failed -> _uiState.update { it.copy(hasDriveError = true) }
+                        is BackendEvent.SyncAllStarted     -> _uiState.update { it.copy(driveIsSyncing = true, hasDriveError = false) }
+                        is BackendEvent.SyncAllStopped     -> _uiState.update { it.copy(driveIsSyncing = false) }
+                        is BackendEvent.DriveEvent.Stopped -> if (event.result is BackendEvent.DriveResult.Failure)
+                            _uiState.update { it.copy(hasDriveError = true) }
                         else -> Unit
                     }
                 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -272,15 +272,15 @@ class ConversationListViewModel(
             eventBus.events
                 .filter {
                     it is BackendEvent.SyncAllStarted ||
-                    it is BackendEvent.SyncAllStopped ||
-                    it is BackendEvent.DriveEvent.Stopped
+                    it is BackendEvent.SyncAllStopped
                 }
                 .collectLatest { event ->
                     when (event) {
-                        is BackendEvent.SyncAllStarted     -> _uiState.update { it.copy(driveIsSyncing = true, hasDriveError = false) }
-                        is BackendEvent.SyncAllStopped     -> _uiState.update { it.copy(driveIsSyncing = false) }
-                        is BackendEvent.DriveEvent.Stopped -> if (event.result is BackendEvent.DriveResult.Failure)
-                            _uiState.update { it.copy(hasDriveError = true) }
+                        is BackendEvent.SyncAllStarted -> _uiState.update { it.copy(driveIsSyncing = true, hasDriveError = false) }
+                        is BackendEvent.SyncAllStopped -> _uiState.update { it.copy(
+                            driveIsSyncing = false,
+                            hasDriveError = event.result is BackendEvent.SyncAllResult.Failure
+                        )}
                         else -> Unit
                     }
                 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -260,7 +260,7 @@ class ConversationListViewModel(
                 .collectLatest { state ->
                     val status = when {
                         state.isConnected -> ConnectionStatus.Connected
-                        state.isDoingInitialConnection -> ConnectionStatus.Connecting
+                        state.isConnecting -> ConnectionStatus.Connecting
                         else -> ConnectionStatus.Disconnected
                     }
                     _uiState.update { it.copy(connectionStatus = status) }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -72,7 +72,7 @@ class ChatMessageStream(
                         isSyncing = true
                     }
 
-                    is BackendEvent.DriveEvent.Completed, is BackendEvent.DriveEvent.Failed -> {
+                    is BackendEvent.DriveEvent.Stopped -> {
                         isSyncing = false
                         refreshLoadedConversations()
                     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -64,22 +64,17 @@ class ConversationStream(
                         isSyncing = true
                     }
 
-                    is BackendEvent.DriveEvent.Completed -> {
-                        isSyncing = false
-                        // After the drive has been synchronized we fetch all conversations once
-                        // and their unread counts
-                        start()
-                        // From this point on we need to process all incoming messages /
-                        // conversations
-                        // so that everything in the client is up to date.
-                    }
-
-                    is BackendEvent.DriveEvent.Failed -> {
-                        if (event.source == BackendEvent.SyncSource.DriveSync) {
+                    is BackendEvent.DriveEvent.Stopped -> when (val r = event.result) {
+                        is BackendEvent.DriveResult.Success -> {
                             isSyncing = false
-                            Logger.e { "Failed during drive sync" }
                             start()
-                            // Optionally handle failure, e.g., log or partial refresh
+                        }
+                        is BackendEvent.DriveResult.Failure -> {
+                            if (r.source == BackendEvent.SyncSource.DriveSync) {
+                                isSyncing = false
+                                Logger.e { "Failed during drive sync" }
+                                start()
+                            }
                         }
                     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -64,17 +64,15 @@ class ConversationStream(
                         isSyncing = true
                     }
 
-                    is BackendEvent.DriveEvent.Stopped -> when (val r = event.result) {
+                    is BackendEvent.DriveEvent.Stopped -> when (event.result) {
                         is BackendEvent.DriveResult.Success -> {
                             isSyncing = false
                             start()
                         }
                         is BackendEvent.DriveResult.Failure -> {
-                            if (r.source == BackendEvent.SyncSource.DriveSync) {
-                                isSyncing = false
-                                Logger.e { "Failed during drive sync" }
-                                start()
-                            }
+                            isSyncing = false
+                            Logger.e { "Failed during drive sync" }
+                            start()
                         }
                     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/DriveContactService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/DriveContactService.kt
@@ -41,7 +41,8 @@ class DriveContactService(
     init {
         scope.launch {
             eventBus.events.collect { event ->
-                if (event is BackendEvent.DriveEvent.Completed &&
+                if (event is BackendEvent.DriveEvent.Stopped &&
+                    event.result is BackendEvent.DriveResult.Success &&
                     event.driveId == contactDrive
                 ) {
                     refresh()

--- a/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/video/LocalVideoPlayerSurface.native.kt
+++ b/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/video/LocalVideoPlayerSurface.native.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.interop.UIKitView
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.AVFoundation.AVPlayer
 import platform.AVFoundation.AVPlayerItemDidPlayToEndTimeNotification
+import platform.AVFoundation.currentItem
 import platform.AVFoundation.pause
 import platform.AVFoundation.play
 import platform.AVFoundation.seekToTime

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -98,7 +98,9 @@ class AuthConnectionCoordinator(
                         } catch (e: Exception) {
                             Logger.e(e) { "syncAll() failed on connect" }
                         } finally {
-                            _connectionState.update { it.copy(isConnecting = false) }
+                            if (_connectionState.value.isConnected) {
+                                _connectionState.update { it.copy(isConnecting = false) }
+                            }
                             outboxSync.clearCheckout()
                             outboxSync.send()
                         }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -98,24 +98,24 @@ class AuthConnectionCoordinator(
                         } catch (e: Exception) {
                             Logger.e(e) { "syncAll() failed on connect" }
                         } finally {
-                            _connectionState.update { it.copy(isDoingInitialConnection = false) }
+                            _connectionState.update { it.copy(isConnecting = false) }
                             outboxSync.clearCheckout()
                             outboxSync.send()
                         }
                     }
                 },
                 onDisconnected = {
-                    _connectionState.update { it.copy(isConnected = false, isDoingInitialConnection = false) }
+                    _connectionState.update { it.copy(isConnected = false, isConnecting = true) }
                     driveSyncManager.pause()
                 },
                 onConnectError = {
-                    _connectionState.update { it.copy(isConnected = false, isDoingInitialConnection = false) }
+                    _connectionState.update { it.copy(isConnected = false, isConnecting = true) }
                 }
             ).also { it.start() }
     }
 
     private fun disconnect() {
-        _connectionState.update { it.copy(isConnected = false, isDoingInitialConnection = true) }
+        _connectionState.update { it.copy(isConnected = false, isConnecting = true) }
         wsClient?.close()
         wsClient = null
         driveSyncManager.stop()
@@ -124,6 +124,6 @@ class AuthConnectionCoordinator(
 
 @Immutable
 data class AuthConnectionState(
-    val isDoingInitialConnection: Boolean = true,
+    val isConnecting: Boolean = true,
     val isConnected: Boolean = false,
 )

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -53,6 +53,13 @@ class AuthConnectionCoordinator(
                 }
             }
         }
+        scope.launch {
+            eventBus.events.collect { event ->
+                if (event is BackendEvent.Connecting) {
+                    _connectionState.update { it.copy(isConnecting = true) }
+                }
+            }
+        }
     }
 
     suspend fun onAuthStateChanged(state: YouAuthState) {
@@ -107,17 +114,17 @@ class AuthConnectionCoordinator(
                     }
                 },
                 onDisconnected = {
-                    _connectionState.update { it.copy(isConnected = false, isConnecting = true) }
+                    _connectionState.update { it.copy(isConnected = false, isConnecting = false) }
                     driveSyncManager.pause()
                 },
                 onConnectError = {
-                    _connectionState.update { it.copy(isConnected = false, isConnecting = true) }
+                    _connectionState.update { it.copy(isConnected = false, isConnecting = false) }
                 }
             ).also { it.start() }
     }
 
     private fun disconnect() {
-        _connectionState.update { it.copy(isConnected = false, isConnecting = true) }
+        _connectionState.update { it.copy(isConnected = false, isConnecting = false) }
         wsClient?.close()
         wsClient = null
         driveSyncManager.stop()

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/util/AuthUtil.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/util/AuthUtil.kt
@@ -12,9 +12,9 @@ sealed interface StartupState {
     data object Unauthenticated : StartupState
 }
 
-fun YouAuthState.mapToStartupState(isDoingInitialConnection: Boolean): StartupState {
+fun YouAuthState.mapToStartupState(isConnecting: Boolean): StartupState {
     return when (this) {
-        is YouAuthState.Authenticated ->  if (isDoingInitialConnection) StartupState.Loading else StartupState.Authenticated
+        is YouAuthState.Authenticated ->  if (isConnecting) StartupState.Loading else StartupState.Authenticated
         is YouAuthState.Error -> StartupState.Error(this.message)
         YouAuthState.Authenticating -> StartupState.Authenticating
         YouAuthState.Initializing -> StartupState.Loading

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/util/RichTextExtensions.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/util/RichTextExtensions.kt
@@ -48,7 +48,7 @@ fun RichTextState.applyDefaultStyling(
     linkColor: Color = LightColors.Primary,
 ): RichTextState {
     return this.apply {
-        config.listIndent = 0
+        config.listIndent = 20
         config.linkColor = linkColor
         config.linkTextDecoration = TextDecoration.Underline
     }


### PR DESCRIPTION
Simplify drive sync events: Completed/Failed → Stopped(result)

  Replaces the separate Completed and Failed terminal events with a single Stopped event carrying an explicit
  result type, making the Start→Stop lifecycle explicit and reducing branching at every consumer.

  Event changes (BackendEvent.kt)
  - DriveEvent.Completed + DriveEvent.Failed → DriveEvent.Stopped(result: DriveResult)
  - SyncAllCompleted + SyncAllFailed → SyncAllStopped(result: SyncAllResult)
  - New sealed types: DriveResult.Success(totalCount) / DriveResult.Failure(errorMessage, source) and
  SyncAllResult.Success / SyncAllResult.Failure

  Consumer updates
  - DriveSync — 3 emission sites updated
  - DriveSyncManager — SyncAll emission + Completed/Failed branches merged into one Stopped branch
  - ConversationStream — Completed/Failed branches merged
  - ChatMessageStream — Completed/Failed branches merged
  - DriveContactService — checks result is DriveResult.Success instead of matching Completed
  - ConversationListViewModel — spinner now driven entirely by SyncAllStarted/SyncAllStopped(result);
  hasDriveError derived from SyncAllResult.Failure directly, removing the per-drive event listener
  - DriveSyncManagerTest — all assertions updated; fixed pre-existing wrong references to
  BackendEvent.DriveEvent.SyncAll*
  
  Fix missing Orange (Connecting) state on hot app reopen

  On reconnect the connection dot jumped directly Red → Green, skipping the Orange (Connecting) phase entirely.
  Root cause: onDisconnected and onConnectError both set isDoingInitialConnection = false, leaving no state to
  signal a reconnect was in progress.

  Changes:
  - onDisconnected / onConnectError — set isConnecting = true (was false) so Orange shows during every
  reconnection attempt, not just the very first app start
  - Orange persists through the full TCP→handshake window — isConnected is only set to true inside
  onConnected(), which fires after the app-level device handshake (guarded by OdinWebSocketClient's 10-second
  timeout)
  - Rename isDoingInitialConnection → isConnecting — the flag applies to any connection attempt, not only the
  initial one (AuthConnectionCoordinator, AuthUtil, LoginViewModel, ConversationListViewModel)

  Expected dot behavior:
  - First start: Orange → Green
  - Hot reopen / disconnect: Green → Orange → Green
  - Sync failure while connected: Green → Amber dot (unchanged, already wired correctly)
  
  Fix connection dot: use BackendEvent.Connecting for Orange; Red between retries

  The previous approach set isConnecting=true in onDisconnected, making the dot Orange immediately on disconnect
   — incorrect, since no active attempt is running during the backoff delay or while airplane mode is on.

  Correct semantics:
  - Red = disconnected, between retries or no network (airplane mode)
  - Orange = mid-attempt right now (TCP connecting or awaiting WS handshake)
  - Green = handshake complete and connected

  BackendEvent.Connecting is already emitted by OdinWebSocketClient at the top of every connection attempt loop
  — it's the exact right signal for Orange.

  Changes to AuthConnectionCoordinator:
  - New listener for BackendEvent.Connecting → sets isConnecting=true (Orange)
  - onDisconnected / onConnectError / disconnect() → isConnecting=false (Red)
  - syncAll finally guard kept — prevents the finally block clobbering Orange→Red when a disconnect races an
  in-progress sync

  Airplane mode: Green → Red → brief Orange flash per retry → (airplane off) → Orange → Green