### PR TITLE
refactor: move DriveSyncManager drives to constructor, fix stop() mutex gap

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
@@ -46,7 +46,6 @@ val apiModule = module {
     singleOf(::VideoPreloader)
     singleOf(::CredentialsManager)
     singleOf(::OwnerSessionRepository)
-    singleOf(::DriveSyncManager)
     singleOf(::DriveFileHttpProvider)
     singleOf(::DriveFileProviderCached)
     single<OutboxUploader> { DriveOutboxUploader(get(), get(), get(), get()) }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
@@ -28,10 +28,12 @@ class DriveSyncManager(
     private val eventBus: EventBus,
     private val scope: CoroutineScope,
     private val databaseManager: DatabaseManager,
+    private val drives: Map<Uuid, String>,
 ) {
     // Immutable map reference — always replaced, never mutated in-place, preventing CME.
-    // Writes are serialized via driveSyncsMutex (suspend callers) or atomic reference swap (non-suspend callers).
-    private var driveSyncs: Map<Uuid, DriveSync> = emptyMap()
+    // All writes are serialized via driveSyncsMutex. @Volatile ensures readers outside the
+    // mutex always see the latest reference (important on Kotlin/Native).
+    @Volatile private var driveSyncs: Map<Uuid, DriveSync> = emptyMap()
     private val driveSyncsMutex = Mutex()
 
     private val _driveStatuses = MutableStateFlow<Map<Uuid, DriveStatus>>(emptyMap())
@@ -96,7 +98,7 @@ class DriveSyncManager(
         }
     }
 
-    suspend fun start(drives: Map<Uuid, String>) {
+    suspend fun start() {
         val credentials = credentialsManager.requireActiveCredentials()
         val identityId = credentials.getIdentityId()
 
@@ -155,9 +157,12 @@ class DriveSyncManager(
         driveSyncs.values.forEach { it.cancel() }
     }
 
-    fun stop() {
-        val old = driveSyncs
-        driveSyncs = emptyMap()
+    suspend fun stop() {
+        val old = driveSyncsMutex.withLock {
+            val snapshot = driveSyncs
+            driveSyncs = emptyMap()
+            snapshot
+        }
         old.values.forEach { it.cancel() }
         _driveStatuses.update { emptyMap() }
     }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
@@ -31,9 +31,9 @@ class DriveSyncManager(
     private val drives: Map<Uuid, String>,
 ) {
     // Immutable map reference — always replaced, never mutated in-place, preventing CME.
-    // All writes are serialized via driveSyncsMutex. @Volatile ensures readers outside the
-    // mutex always see the latest reference (important on Kotlin/Native).
-    @Volatile private var driveSyncs: Map<Uuid, DriveSync> = emptyMap()
+    // All writes are serialized via driveSyncsMutex, which provides the happens-before
+    // guarantee needed for non-mutex readers (syncDrive, pause, clearStorage).
+    private var driveSyncs: Map<Uuid, DriveSync> = emptyMap()
     private val driveSyncsMutex = Mutex()
 
     private val _driveStatuses = MutableStateFlow<Map<Uuid, DriveStatus>>(emptyMap())

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncManagerTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncManagerTest.kt
@@ -45,16 +45,17 @@ class DriveSyncManagerTest {
             val httpClient = HttpClient(mockEngine)
             val driveQueryProvider = DriveQueryProvider(httpClient, credentialsManager)
 
+            val driveId = Uuid.random()
             val manager = DriveSyncManager(
                 driveQueryProvider = driveQueryProvider,
                 credentialsManager = credentialsManager,
                 eventBus = EventBus(),
                 scope = this,
-                databaseManager = db
+                databaseManager = db,
+                drives = mapOf(driveId to "Test Drive"),
             )
 
-            val driveId = Uuid.random()
-            manager.start(mapOf(driveId to "Test Drive"))
+            manager.start()
 
             assertEquals(DriveState.Initialized, manager.driveStatuses.value[driveId]?.state)
         }
@@ -82,16 +83,17 @@ class DriveSyncManagerTest {
             val driveQueryProvider = DriveQueryProvider(httpClient, credentialsManager)
             val eventBus = EventBus()
 
+            val driveId = Uuid.random()
             val manager = DriveSyncManager(
                 driveQueryProvider = driveQueryProvider,
                 credentialsManager = credentialsManager,
                 eventBus = eventBus,
                 scope = this,
-                databaseManager = db
+                databaseManager = db,
+                drives = mapOf(driveId to "Test Drive"),
             )
 
-            val driveId = Uuid.random()
-            manager.start(mapOf(driveId to "Test Drive"))
+            manager.start()
 
             // Emit a Failed event directly (simulating what DriveSync emits after a real failure)
             eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, 0, BackendEvent.DriveResult.Failure("simulated network error")))
@@ -117,7 +119,8 @@ class DriveSyncManagerTest {
         db: DatabaseManager,
         credentialsManager: CredentialsManager,
         eventBus: EventBus,
-        scope: kotlinx.coroutines.CoroutineScope
+        scope: kotlinx.coroutines.CoroutineScope,
+        drives: Map<Uuid, String> = emptyMap(),
     ): DriveSyncManager {
         val mockEngine = MockEngine { awaitCancellation() }
         val httpClient = HttpClient(mockEngine)
@@ -127,7 +130,8 @@ class DriveSyncManagerTest {
             credentialsManager = credentialsManager,
             eventBus = eventBus,
             scope = scope,
-            databaseManager = db
+            databaseManager = db,
+            drives = drives,
         )
     }
 
@@ -158,9 +162,9 @@ class DriveSyncManagerTest {
         val db = DatabaseManager { createInMemoryDatabase() }
         runTest {
             val eventBus = EventBus()
-            val manager = buildManager(db, buildCredentials(), eventBus, this)
             val driveId = Uuid.random()
-            manager.start(mapOf(driveId to "Drive"))
+            val manager = buildManager(db, buildCredentials(), eventBus, this, mapOf(driveId to "Drive"))
+            manager.start()
             runCurrent()
 
             eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
@@ -176,9 +180,9 @@ class DriveSyncManagerTest {
         val db = DatabaseManager { createInMemoryDatabase() }
         runTest {
             val eventBus = EventBus()
-            val manager = buildManager(db, buildCredentials(), eventBus, this)
             val driveId = Uuid.random()
-            manager.start(mapOf(driveId to "Drive"))
+            val manager = buildManager(db, buildCredentials(), eventBus, this, mapOf(driveId to "Drive"))
+            manager.start()
             runCurrent()
 
             eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
@@ -196,9 +200,9 @@ class DriveSyncManagerTest {
         val db = DatabaseManager { createInMemoryDatabase() }
         runTest {
             val eventBus = EventBus()
-            val manager = buildManager(db, buildCredentials(), eventBus, this)
             val driveId = Uuid.random()
-            manager.start(mapOf(driveId to "Drive"))
+            val manager = buildManager(db, buildCredentials(), eventBus, this, mapOf(driveId to "Drive"))
+            manager.start()
             runCurrent()
 
             eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
@@ -216,9 +220,9 @@ class DriveSyncManagerTest {
         val db = DatabaseManager { createInMemoryDatabase() }
         runTest {
             val eventBus = EventBus()
-            val manager = buildManager(db, buildCredentials(), eventBus, this)
             val driveId = Uuid.random()
-            manager.start(mapOf(driveId to "Drive"))
+            val manager = buildManager(db, buildCredentials(), eventBus, this, mapOf(driveId to "Drive"))
+            manager.start()
             runCurrent()
 
             val emittedEvents = mutableListOf<BackendEvent>()
@@ -238,9 +242,9 @@ class DriveSyncManagerTest {
         val db = DatabaseManager { createInMemoryDatabase() }
         runTest {
             val eventBus = EventBus()
-            val manager = buildManager(db, buildCredentials(), eventBus, this)
             val driveId = Uuid.random()
-            manager.start(mapOf(driveId to "Drive"))
+            val manager = buildManager(db, buildCredentials(), eventBus, this, mapOf(driveId to "Drive"))
+            manager.start()
             runCurrent()
 
             eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
@@ -263,9 +267,9 @@ class DriveSyncManagerTest {
         val db = DatabaseManager { createInMemoryDatabase() }
         runTest {
             val eventBus = EventBus()
-            val manager = buildManager(db, buildCredentials(), eventBus, this)
             val driveId = Uuid.random()
-            manager.start(mapOf(driveId to "Drive"))
+            val manager = buildManager(db, buildCredentials(), eventBus, this, mapOf(driveId to "Drive"))
+            manager.start()
             runCurrent()
 
             eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
@@ -288,10 +292,10 @@ class DriveSyncManagerTest {
         val db = DatabaseManager { createInMemoryDatabase() }
         runTest {
             val eventBus = EventBus()
-            val manager = buildManager(db, buildCredentials(), eventBus, this)
             val driveId1 = Uuid.random()
             val driveId2 = Uuid.random()
-            manager.start(mapOf(driveId1 to "Drive 1", driveId2 to "Drive 2"))
+            val manager = buildManager(db, buildCredentials(), eventBus, this, mapOf(driveId1 to "Drive 1", driveId2 to "Drive 2"))
+            manager.start()
             runCurrent()
 
             assertEquals(0, manager.numberOfDrivesSyncing())

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -87,7 +87,7 @@ class AuthConnectionCoordinator(
     private suspend fun connect() {
         if (wsClient != null) return
 
-        driveSyncManager.start(drives = syncLabeledDrives.associate { it.drive.alias to it.label })
+        driveSyncManager.start()
 
         wsClient =
             OdinWebSocketClient(
@@ -123,7 +123,7 @@ class AuthConnectionCoordinator(
             ).also { it.start() }
     }
 
-    private fun disconnect() {
+    private suspend fun disconnect() {
         _connectionState.update { it.copy(isConnected = false, isConnecting = false) }
         wsClient?.close()
         wsClient = null

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/BackgroundSyncOrchestrator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/BackgroundSyncOrchestrator.kt
@@ -2,7 +2,6 @@ package id.homebase.core.sync
 
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.sync.DriveSyncManager
-import id.homebase.core.config.syncLabeledDrives
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -15,7 +14,7 @@ class BackgroundSyncOrchestrator(
     suspend fun syncIfAuthenticated(): SyncOutcome {
         if (!credentialsManager.hasActiveCredentials()) return SyncOutcome.NoCredentials
         return runCatching {
-            driveSyncManager.start(syncLabeledDrives.associate { it.drive.alias to it.label })
+            driveSyncManager.start()
             driveSyncManager.syncAll()
         }.fold(
             onSuccess = { SyncOutcome.Success },

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -1,6 +1,7 @@
 package id.homebase.core.di
 
 import id.homebase.api.di.apiModule
+import id.homebase.api.sync.DriveSyncManager
 import id.homebase.auth.login.LoginViewModel
 import id.homebase.chat.addgroupmembers.AddGroupMembersViewModel
 import id.homebase.chat.archivedconversations.ArchivedConversationsViewModel
@@ -27,6 +28,7 @@ import id.homebase.chat.services.convo.contact.DriveContactService
 import id.homebase.chat.services.outbox.OptimisticWriter
 import id.homebase.chat.services.requests.ConnectionRequestService
 import id.homebase.core.auth.AuthConnectionCoordinator
+import id.homebase.core.config.syncLabeledDrives
 import id.homebase.core.sync.BackgroundSyncOrchestrator
 import id.homebase.core.image.HomebaseImageLoader
 import id.homebase.core.notifications.NotificationService
@@ -48,6 +50,11 @@ import org.koin.dsl.module
 
 val appModule = module {
     single { UserPreferences(get()) }
+
+    single {
+        DriveSyncManager(get(), get(), get(), get(), get(),
+            syncLabeledDrives.associate { it.drive.alias to it.label })
+    }
 
     singleOf(::AuthConnectionCoordinator)
     singleOf(::BackgroundSyncOrchestrator)


### PR DESCRIPTION
DriveSyncManager is a Koin singleton whose drives (chat, contacts, feed) are a compile-time constant. Previously, both AuthConnectionCoordinator and BackgroundSyncOrchestrator passed the same drives map as an argument to start() on every call — duplicating config at call sites and creating a concurrent start() race that necessitated a Mutex.

Changes:
- Add `drives: Map<Uuid, String>` constructor param; start() uses it directly, removing the parameter from its signature
- Register DriveSyncManager in AppModule (homebase-core) instead of ApiModule, wiring syncLabeledDrives at construction — single source of truth
- Add @Volatile to driveSyncs so readers outside the mutex always see the latest reference (important on Kotlin/Native)
- Make stop() suspend and mutex-protected, closing the race window between a concurrent start() and stop()
- Make AuthConnectionCoordinator.disconnect() suspend to await stop()
- Update tests: drives passed at construction, start() takes no args