### PR TITLE
Speed-up ConversationList initial render

### DIFF
--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ChatReadCount.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ChatReadCount.sq
@@ -12,6 +12,11 @@ CREATE INDEX IF NOT EXISTS idx_messages_groupId_filetype_created
 -- To make the conversation + last-message performant
 CREATE INDEX IF NOT EXISTS idx_chatmessage_convid_created ON DriveMainIndex(groupId,fileType,created DESC);
 
+-- Speeds up message scans in selectAllConversationPlusLastMessage and selectAllUnreadCount
+-- (fileType first lets SQLite seek directly to message rows without a full table scan)
+CREATE INDEX IF NOT EXISTS idx_messages_filetype_datatype_groupid_created
+  ON DriveMainIndex(fileType, dataType, groupId, created DESC);
+
 -- Get full list of conversations (8888) from the DriveMainIndex table
 -- here to not contaminate it. Can also be easily fetched with QB()
 selectAllCoversations:

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/DriveMainIndex.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/DriveMainIndex.sq
@@ -1,6 +1,6 @@
 import kotlin.uuid.Uuid;
 
-CREATE TABLE IF NOT EXISTS DriveMainIndex( -- Version: 1
+CREATE TABLE IF NOT EXISTS DriveMainIndex( -- Version: 2
    rowId INTEGER PRIMARY KEY AUTOINCREMENT,
    identityId BLOB AS Uuid NOT NULL,
    driveId BLOB AS Uuid NOT NULL,
@@ -29,6 +29,7 @@ CREATE TABLE IF NOT EXISTS DriveMainIndex( -- Version: 1
 CREATE INDEX IF NOT EXISTS Idx0DriveMainIndex ON DriveMainIndex(identityId,driveId,fileSystemType,created,rowId);
 CREATE INDEX IF NOT EXISTS Idx1DriveMainIndex ON DriveMainIndex(identityId,driveId,fileSystemType,modified,rowId);
 CREATE INDEX IF NOT EXISTS Idx2DriveMainIndex ON DriveMainIndex(identityId,driveId,fileSystemType,userDate,rowId);
+-- Other DriveMainIndex INDEX is created in ChatReadCount.sq
 
 -- Upsert a record
 upsertDriveMainIndex:

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlin.uuid.Uuid
 
@@ -272,6 +273,9 @@ class ConversationStream(
     fun start() {
         scope.launch {
             loadConversations()
+        }
+        scope.launch {
+            _conversations.first { it.dataReady }
             updateUnreadCounts()
         }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ConnectionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ConnectionService.kt
@@ -4,6 +4,8 @@ import id.homebase.api.client.connections.ConnectionNetworkProvider
 import id.homebase.api.client.connections.RedactedIdentityConnectionRegistration
 import id.homebase.api.common.OdinId
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -35,23 +37,18 @@ class ConnectionService(
 
     suspend fun refresh() {
         try {
-            Logger.d { "Fetching connected connections..." }
-            val connected = provider.getConnected(1000, null)
-
-            Logger.d { "Loaded connections ${connected.results.size}..." }
-
-            Logger.d { "Fetching blocked connections..." }
-            val blocked = provider.getBlocked(1000, null)
-
-            val merged =
-                (connected.results + blocked.results)
-                    .associateBy { it.odinId }
-
-            _connections.value = ConnectionState(
-                isLoaded = true,
-                map = merged
-            )
-
+            coroutineScope {
+                Logger.d { "Fetching connected and blocked connections in parallel..." }
+                val connectedDeferred = async { provider.getConnected(1000, null) }
+                val blockedDeferred = async { provider.getBlocked(1000, null) }
+                val connected = connectedDeferred.await()
+                val blocked = blockedDeferred.await()
+                Logger.d { "Loaded connections ${connected.results.size} connected, ${blocked.results.size} blocked" }
+                _connections.value = ConnectionState(
+                    isLoaded = true,
+                    map = (connected.results + blocked.results).associateBy { it.odinId }
+                )
+            }
         } catch (e: Exception) {
             Logger.e(e) {
                 "ConnectionService.refresh failed: ${e.message}"


### PR DESCRIPTION
Three changes to reduce time from app open to conversation list visible:

1. Add DB index (fileType, dataType, groupId, created DESC) on DriveMainIndex. The selectAllConversationPlusLastMessage CTE scans all message rows filtered by fileType/dataType, but existing indexes start with groupId — unhelpful for this filter, causing a full table scan. The new index lets SQLite seek directly to message rows. selectAllUnreadCount has the same filter and benefits too.

2. Decouple updateUnreadCounts() from the initial load coroutine in ConversationStream.start(). It now runs in its own coroutine, gated on _conversations.first { it.dataReady }, so the DB dispatcher is free between the two queries and unread counts load independently after the list is visible.

3. Parallelize ConnectionService.refresh() — getConnected and getBlocked are independent HTTP calls that were running sequentially. Wrapping them in coroutineScope { async } halves the time until connection-state badges resolve. Note: this does not affect initial list render (contacts emit emptyList() immediately); it only affects how quickly the Connected/Pending badges appear.