### PR TITLE
fix: cache 404s in DriveFileProviderCached and stop retrying on NotFo…

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/DriveSyncWorker.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/DriveSyncWorker.kt
@@ -7,6 +7,7 @@ import androidx.core.app.NotificationCompat
 import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
+import co.touchlab.kermit.Logger
 import id.homebase.core.sync.BackgroundSyncOrchestrator
 import id.homebase.core.sync.SyncOutcome
 import org.koin.core.component.KoinComponent
@@ -16,11 +17,21 @@ class DriveSyncWorker(appContext: Context, params: WorkerParameters) :
     CoroutineWorker(appContext, params), KoinComponent {
 
     override suspend fun doWork(): Result {
+        Logger.i(tag = "DriveSyncWorker") { "doWork: starting (attempt=$runAttemptCount)" }
         val orchestrator: BackgroundSyncOrchestrator = get()
-        return when (orchestrator.syncIfAuthenticated()) {
-            is SyncOutcome.Success -> Result.success()
-            is SyncOutcome.NoCredentials -> Result.success()
-            is SyncOutcome.Failed -> Result.failure()
+        return when (val outcome = orchestrator.syncIfAuthenticated()) {
+            is SyncOutcome.Success -> {
+                Logger.i(tag = "DriveSyncWorker") { "doWork: success" }
+                Result.success()
+            }
+            is SyncOutcome.NoCredentials -> {
+                Logger.i(tag = "DriveSyncWorker") { "doWork: no credentials" }
+                Result.success()
+            }
+            is SyncOutcome.Failed -> {
+                Logger.e(tag = "DriveSyncWorker") { "doWork: failed — ${outcome.cause.message}" }
+                Result.failure()
+            }
         }
     }
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
@@ -5,6 +5,7 @@ import com.mayakapps.kache.FileKache
 import kotlin.time.measureTimedValue
 import id.homebase.api.client.ByteApiResponse
 import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.NotFoundException
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.drives.files.BytesResponse
 import id.homebase.api.client.drives.files.DriveFileHelpers
@@ -135,6 +136,10 @@ class DriveFileProviderCached(
                         Logger.d(tag = "VideoIO") { "payload cache-write: ${result.bytes.size} bytes in $cacheWriteElapsed" }
                         result
                     }
+                } catch (e: NotFoundException) {
+                    // 404 thrown by network layer — cache it so future calls skip the network
+                    notFoundCacheMutex.withLock { notFoundCache = notFoundCache + cacheKey }
+                    throw e
                 } catch (e: Exception) {
                     // For other errors (500, network issues, etc.), don't cache and rethrow
                     throw e
@@ -165,7 +170,7 @@ class DriveFileProviderCached(
                         onDownloadProgress = onDownloadProgress,
                 )
 
-        if (raw.status == 404) return null
+        if (raw.status == 404) throw NotFoundException()
 
         val rangeResult = DriveFileHelpers.getRangeHeader(chunkStart, chunkLength)
 
@@ -298,6 +303,10 @@ class DriveFileProviderCached(
                         }
                         result
                     }
+                } catch (e: NotFoundException) {
+                    // 404 thrown by network layer — cache it so future calls skip the network
+                    notFoundCacheMutex.withLock { notFoundCache = notFoundCache + cacheKey }
+                    throw e
                 } catch (e: Exception) {
                     // For other errors (500, network issues, etc.), don't cache and rethrow
                     throw e
@@ -325,7 +334,7 @@ class DriveFileProviderCached(
                         lastModified = lastModified
                 )
 
-        if (raw.status == 404) return null
+        if (raw.status == 404) throw NotFoundException()
 
         val decryptedBytes = delegate.decryptBytes(keyHeader, raw.headers, raw.bytes)
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
@@ -1,6 +1,7 @@
 package id.homebase.core.image
 
 import co.touchlab.kermit.Logger
+import id.homebase.api.client.NotFoundException
 import id.homebase.api.client.RetryConfig
 import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.client.withRetry
@@ -44,7 +45,11 @@ class HomebaseImageLoader(
 
         // Default retry configuration for image loading
         val DEFAULT_RETRY_CONFIG = RetryConfig(
-            maxRetries = 3, initialDelayMs = 500L, maxDelayMs = 5000L, backoffMultiplier = 2.0
+            maxRetries = 3,
+            initialDelayMs = 500L,
+            maxDelayMs = 5000L,
+            backoffMultiplier = 2.0,
+            retryOn = { e -> e !is NotFoundException }
         )
     }
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/BackgroundSyncOrchestrator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/BackgroundSyncOrchestrator.kt
@@ -1,5 +1,6 @@
 package id.homebase.core.sync
 
+import co.touchlab.kermit.Logger
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.sync.DriveSyncManager
 import id.homebase.core.auth.AuthConnectionCoordinator
@@ -15,16 +16,30 @@ class BackgroundSyncOrchestrator(
     private val authConnectionCoordinator: AuthConnectionCoordinator,
 ) {
     suspend fun syncIfAuthenticated(): SyncOutcome {
-        if (!credentialsManager.hasActiveCredentials()) return SyncOutcome.NoCredentials
+        Logger.d(tag = "BackgroundSync") { "syncIfAuthenticated: checking..." }
+        if (!credentialsManager.hasActiveCredentials()) {
+            Logger.i(tag = "BackgroundSync") { "syncIfAuthenticated: no credentials, skipping" }
+            return SyncOutcome.NoCredentials
+        }
         // If the WebSocket is live, the connection loop is already handling sync — no duplicate work needed.
         // Background sync is only meaningful when WS is offline (e.g. iOS background fetch).
-        if (authConnectionCoordinator.isOnline.value) return SyncOutcome.Success
+        if (authConnectionCoordinator.isOnline.value) {
+            Logger.d(tag = "BackgroundSync") { "syncIfAuthenticated: WS online — skipping (WS handles sync)" }
+            return SyncOutcome.Success
+        }
+        Logger.i(tag = "BackgroundSync") { "syncIfAuthenticated: WS offline — running background sync" }
         return runCatching {
             driveSyncManager.start()
             driveSyncManager.syncAll()
         }.fold(
-            onSuccess = { SyncOutcome.Success },
-            onFailure = { SyncOutcome.Failed(it) },
+            onSuccess = {
+                Logger.i(tag = "BackgroundSync") { "syncIfAuthenticated: completed" }
+                SyncOutcome.Success
+            },
+            onFailure = {
+                Logger.e(tag = "BackgroundSync") { "syncIfAuthenticated: failed — ${it.message}" }
+                SyncOutcome.Failed(it)
+            },
         )
     }
 


### PR DESCRIPTION
…undException

The notFoundCache for thumbnails and payloads was dead code: the HTTP layer calls throwForFailure() on non-200 responses, which throws NotFoundException before the status-check branch could run. As a result, every missing image triggered 4 real HTTP requests (1 + 3 retries) with 500ms/1000ms/2000ms delays between them, generating hundreds of error log entries per session.

Fix:
- DriveFileProviderCached: catch NotFoundException specifically before the generic catch in both getThumbBytesRaw() and getPayloadBytesRaw(), populate notFoundCache, then rethrow. Also change the EMPTY_404 null-return in getThumbBytesDecrypted/getPayloadBytesDecrypted to throw NotFoundException() so the in-memory cache fast-path also terminates retries immediately (no null-based retry delays).
- HomebaseImageLoader: add retryOn = { e -> e !is NotFoundException } to DEFAULT_RETRY_CONFIG so 404s fail on the first attempt with no delays.

After this change: 1 network call per missing image (down from 4), and 0 calls for the same image within the same session.

Also add structured logging to BackgroundSyncOrchestrator and DriveSyncWorker so FCM-triggered background sync is observable in logs (previously completely silent — impossible to tell if the worker ran, was skipped because WS was online, or failed).