### PR TITLE
fix: prevent triple reRegister() at login and syncAll skipped on WS r…

### DIFF
--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.Job
 
 class LoginViewModel(
     private val youAuthFlowManager: YouAuthFlowManager,
@@ -43,6 +44,11 @@ class LoginViewModel(
 
     private val _uiState = MutableStateFlow(LoginUiState())
     val uiState: StateFlow<LoginUiState> = _uiState
+
+    // Tracks the active auth-state observer so AppResumed doesn't stack multiple collectors.
+    private var authStateJob: Job? = null
+    // One-shot guard — prevents handleAuthenticatedUser() firing more than once per login.
+    private var didHandleAuthenticated = false
 
     init {
         loadUsernameFromStorage()
@@ -200,8 +206,10 @@ class LoginViewModel(
     }
 
     private fun observeAuthState() {
-
-        viewModelScope.launch {
+        // Cancel any in-flight observer (e.g. from a previous AppResumed) before starting a new one.
+        authStateJob?.cancel()
+        didHandleAuthenticated = false
+        authStateJob = viewModelScope.launch {
             combine(
                 authConnectionCoordinator.connectionState,
                 youAuthFlowManager.authState
@@ -255,6 +263,8 @@ class LoginViewModel(
     }
 
     private fun handleAuthenticatedUser() {
+        if (didHandleAuthenticated) return
+        didHandleAuthenticated = true
         viewModelScope.launch { notificationService.reRegister() }
         usernameStorage.saveUsername(_uiState.value.homebaseId)
         _uiState.update {

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -103,8 +103,6 @@ class AuthConnectionCoordinator(
     private suspend fun connect() {
         if (wsClient != null) return
 
-        driveSyncManager.start()
-
         wsClient =
             OdinWebSocketClient(
                 credentialsManager = credentialsManager,
@@ -118,6 +116,10 @@ class AuthConnectionCoordinator(
                     outboxSync.setOnline(true)
                     scope.launch {
                         try {
+                            // start() must be called on every (re)connect — not just the first —
+                            // because pause() sets isRunning=false on disconnect, and syncAll()
+                            // would silently skip if isRunning is still false.
+                            driveSyncManager.start()
                             driveSyncManager.syncAll()
                         } catch (e: Exception) {
                             Logger.e(e) { "syncAll() failed on connect" }


### PR DESCRIPTION
…econnect

Bug A (LoginViewModel): observeAuthState() was launching a new coroutine on every AppResumed without cancelling the previous one, causing multiple concurrent collectors. Combined with the Authenticated→Loading→Authenticated state sequence on fresh login, handleAuthenticatedUser() fired 3 times, triggering 3 concurrent reRegister() calls that raced and failed each other.
- Track the active observer in authStateJob and cancel it before re-subscribing.
- Guard handleAuthenticatedUser() with a didHandleAuthenticated flag (reset on each new observeAuthState() call) so only the first Authenticated emission acts.

Bug B (AuthConnectionCoordinator): driveSyncManager.start() was only called in connect() when wsClient was null (i.e. the very first connect). On WS internal reconnects, onDisconnected fired pause() setting isRunning=false, but start() was never called again, so the subsequent syncAll() in onConnected silently skipped.
- Moved driveSyncManager.start() from connect() into the onConnected lambda (inside the existing scope.launch), so it runs on every reconnect.