### PR TITLE
fix: prevent ghost WebSocket loop, duplicate queries, and notificatio…

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
@@ -49,6 +49,7 @@ class OdinWebSocketClient(
 
     private var reconnectDelayMs = 1_000L
     private val MAX_RECONNECT_DELAY_MS = 5_000L
+    private var closed = false
 
     private val client = HttpClient {
         // TODO: enable per-message deflate compression via WebSocketDeflateExtension once
@@ -87,6 +88,8 @@ class OdinWebSocketClient(
     )
 
     private suspend fun handleDisconnected() {
+        if (closed) return
+
         eventBus.emit(BackendEvent.ConnectionOffline)
         onDisconnected()
 
@@ -106,11 +109,13 @@ class OdinWebSocketClient(
                 eventBus.emit(BackendEvent.Connecting)
 
                 try {
-                    connectOnce()
+                    val connected = connectOnce()
 
-                    // If connectOnce returns normally, we consider that a success
-                    // Reset backoff so next failure retries fast again
-                    reconnectDelayMs = 1_000L
+                    // Only reset backoff if we actually established a connection.
+                    // Early returns (e.g. no credentials) should not reset backoff.
+                    if (connected) {
+                        reconnectDelayMs = 1_000L
+                    }
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
@@ -136,11 +141,11 @@ class OdinWebSocketClient(
         return delayMs + (-jitter..jitter).random()
     }
 
-    private suspend fun connectOnce() {
+    private suspend fun connectOnce(): Boolean {
         val creds = credentialsManager.getActiveCredentials()
             ?: run {
                 Logger.w { "No active credentials, cannot connect WebSocket" }
-                return
+                return false
             }
 
         val identity = creds.domain
@@ -199,6 +204,7 @@ class OdinWebSocketClient(
                 Logger.i { "WebSocket connection ended" }
             }
         }
+        return true
     }
 
     private suspend fun handleTextFrame(frame: Frame.Text) {
@@ -486,6 +492,7 @@ class OdinWebSocketClient(
      * Disconnect from the WebSocket
      */
     fun disconnect() {
+        closed = true
         pingSupervisor.stop()
         session = null
         connectionJob?.cancel()

--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt
@@ -265,7 +265,7 @@ class LoginViewModel(
     private fun handleAuthenticatedUser() {
         if (didHandleAuthenticated) return
         didHandleAuthenticated = true
-        viewModelScope.launch { notificationService.reRegister() }
+        notificationService.reRegisterAsync()
         usernameStorage.saveUsername(_uiState.value.homebaseId)
         _uiState.update {
             it.copy(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -26,6 +26,7 @@ import id.homebase.core.share.ShareCacheStorage
 import id.homebase.core.share.ShareConversationCacheWriter
 import id.homebase.core.share.ShareableConversation
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -50,6 +51,8 @@ class ConversationStream(
     private val _conversations = MutableStateFlow(ConversationsData(dataReady = false))
     private val _shareableConversations = MutableStateFlow<List<ShareableConversation>>(emptyList())
     private var isSyncing = false // Track if chat drive sync is in progress
+    private var loadJob: Job? = null
+    private var shareCacheJob: Job? = null
 
     private val mapper: ConversationMapper = ConversationMapper(
         credentialsManager = credentialsManager
@@ -271,7 +274,8 @@ class ConversationStream(
     }
 
     fun start() {
-        scope.launch {
+        if (loadJob?.isActive == true) return
+        loadJob = scope.launch {
             loadConversations()
         }
         scope.launch {
@@ -281,18 +285,21 @@ class ConversationStream(
 
         // Reactively update share cache when conversations or contacts change,
         // so the iOS share extension always has resolved display names.
-        scope.launch {
-            @OptIn(kotlinx.coroutines.FlowPreview::class)
-            combine(
-                _conversations,
-                contactService.contacts,
-            ) { convos, contacts -> Pair(convos, contacts) }
-                .debounce(500) // Avoid rapid writes during initial load
-                .collect { (convos, contacts) ->
-                    if (convos.dataReady) {
-                        updateShareCache(convos.items, contacts)
+        // Only launch once — subsequent start() calls reuse the existing collector.
+        if (shareCacheJob == null) {
+            shareCacheJob = scope.launch {
+                @OptIn(kotlinx.coroutines.FlowPreview::class)
+                combine(
+                    _conversations,
+                    contactService.contacts,
+                ) { convos, contacts -> Pair(convos, contacts) }
+                    .debounce(500) // Avoid rapid writes during initial load
+                    .collect { (convos, contacts) ->
+                        if (convos.dataReady) {
+                            updateShareCache(convos.items, contacts)
+                        }
                     }
-                }
+            }
         }
     }
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -112,6 +112,7 @@ class AuthConnectionCoordinator(
     private suspend fun connect() {
         if (wsClient != null) return
 
+        _connectionState.update { it.copy(isConnecting = true) }
         wsClient =
             OdinWebSocketClient(
                 credentialsManager = credentialsManager,
@@ -165,7 +166,10 @@ class AuthConnectionCoordinator(
 
     private suspend fun disconnect() {
         outboxSync.setOnline(false)
-        _connectionState.update { it.copy(isConnected = false, isConnecting = false) }
+        // Keep isConnecting = true so the next login cycle correctly starts in
+        // StartupState.Loading.  While logged out the auth state is Unauthenticated,
+        // so isConnecting has no visible effect on the UI.
+        _connectionState.update { it.copy(isConnected = false, isConnecting = true) }
         wsClient?.close()
         wsClient = null
         driveSyncManager.stop()

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
@@ -454,4 +454,10 @@ class NotificationService(
             Result.failure(e)
         }
     }
+
+    /** Fire-and-forget re-registration that runs in the service's own long-lived scope,
+     *  surviving ViewModel destruction (e.g. navigation away from login screen). */
+    fun reRegisterAsync() {
+        scope.launch { reRegister() }
+    }
 }


### PR DESCRIPTION
…n cancellation on login

After logout, the WebSocket retry loop continued indefinitely because the connectOnce() finally block called handleDisconnected() → start(), creating a ghost loop that outlived the client. This caused: 1) ~30 reconnect attempts with no backoff (delay reset treated no-credentials
   as success), 2) a duplicate WebSocket connection on next login when both
   the new client and the ghost loop connected simultaneously.

Additionally, ConversationStream.start() had no idempotency guard, so the DriveEvent.Stopped listener and ConversationListViewModel.init both triggered the same 64-row conversation fetch back-to-back. And reRegister() ran in viewModelScope which was cancelled on navigation to Home.

Changes:
- OdinWebSocketClient: add `closed` flag set by disconnect(); handleDisconnected() returns early when closed. connectOnce() returns Boolean so backoff only resets after a real connection, not on missing-credentials early return.
- ConversationStream: guard start() with loadJob?.isActive check; launch share cache collector only once.
- NotificationService: add reRegisterAsync() that runs in the service's own long-lived scope instead of the caller's viewModelScope.
- LoginViewModel: call reRegisterAsync() instead of viewModelScope.launch.
- AuthConnectionCoordinator: keep isConnecting=true on disconnect so the next login correctly shows the Loading screen (Authenticated+isConnecting=true → StartupState.Loading). Also set isConnecting=true in connect() as defense.