### PR TITLE
perf: preload conversations and contacts at auth time, not after navi…

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ConnectionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ConnectionService.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import co.touchlab.kermit.Logger
 import org.koin.core.component.getScopeId
@@ -29,8 +30,11 @@ class ConnectionService(
     val connections: StateFlow<ConnectionState> =
         _connections.asStateFlow()
 
+    private var startJob: Job? = null
+
     fun start() {
-        scope.launch {
+        if (startJob?.isActive == true) return
+        startJob = scope.launch {
             refresh()
         }
     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ContactService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ContactService.kt
@@ -22,7 +22,12 @@ class ContactService(
     private val contactByOdinId =
         MutableStateFlow<Map<OdinId, ContactUiModel>>(emptyMap())
 
+    private var started = false
+
     fun start() {
+        if (started) return
+        started = true
+
         driveContacts.start()
         connections.start()
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/DriveContactService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/DriveContactService.kt
@@ -17,6 +17,7 @@ import id.homebase.chat.data.ContactUiModel
 import id.homebase.chat.services.ChatProtocol
 import id.homebase.core.config.contactTargetDrive
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -51,8 +52,11 @@ class DriveContactService(
         }
     }
 
+    private var startJob: Job? = null
+
     fun start() {
-        scope.launch {
+        if (startJob?.isActive == true) return
+        startJob = scope.launch {
             refresh()
         }
     }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -33,7 +33,8 @@ class AuthConnectionCoordinator(
     private val driveSyncManager: DriveSyncManager,
     private val outboxSync: OutboxSync,
     private val eventBus: EventBus,
-    private val databaseManager: DatabaseManager
+    private val databaseManager: DatabaseManager,
+    private val onPostAuthenticated: () -> Unit = {},
 ) {
     private val scope = CoroutineScope(Dispatchers.Default)
     private var wsClient: OdinWebSocketClient? = null
@@ -81,6 +82,7 @@ class AuthConnectionCoordinator(
     suspend fun onAuthStateChanged(state: YouAuthState) {
         when (state) {
             is YouAuthState.Authenticated -> {
+                onPostAuthenticated()
                 connect()
                 loadProfile()
             }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -56,7 +56,23 @@ val appModule = module {
             syncLabeledDrives.associate { it.drive.alias to it.label })
     }
 
-    singleOf(::AuthConnectionCoordinator)
+    single {
+        AuthConnectionCoordinator(
+            credentialsManager = get(),
+            ownerSessionRepository = get(),
+            youAuthFlowManager = get(),
+            driveSyncManager = get(),
+            outboxSync = get(),
+            eventBus = get(),
+            databaseManager = get(),
+            onPostAuthenticated = {
+                // Preload conversations and contacts from local DB while navigation
+                // and Compose composition are still in progress, saving ~800ms.
+                get<ConversationStream>().start()
+                get<ContactService>().start()
+            }
+        )
+    }
     singleOf(::BackgroundSyncOrchestrator)
 
     factoryOf(::PayloadBundleEncryptionService)


### PR DESCRIPTION
…gation

On cold start (already logged in), conversations took ~1.86s from session restore to data ready. The main bottleneck was that ConversationStream.start() only ran after: auth → Compose navigation to ChatList → ViewModel creation (~800ms of idle time). Since conversation data lives in the local SQLite DB, it needs no network and can load as soon as auth completes.

This change adds an `onPostAuthenticated` callback to AuthConnectionCoordinator, wired in AppModule.kt to eagerly call ConversationStream.start() and ContactService.start(). The local DB query and WebSocket connection now run concurrently instead of sequentially — the conversation fetch starts ~800ms earlier while navigation and Compose composition proceed in parallel.

Also adds idempotency guards to ContactService, ConnectionService, and DriveContactService.start() so the duplicate call from ConversationListViewModel is a harmless no-op (same pattern already used in ConversationStream).

Measured impact (cold start, session restored):
  Before: auth → 1098ms → conversation fetch start
  After:  auth →  786ms → conversation fetch start (overlaps with WebSocket)