### PR TITLE
perf: skip conversation list reload when sync fetched 0 new records

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -84,13 +84,13 @@ class ConversationStream(
                     is BackendEvent.DriveEvent.Stopped -> when (event.result) {
                         is BackendEvent.DriveResult.Success -> {
                             isSyncing = false
-                            start()
+                            if (event.totalCount > 0) start()
                         }
 
                         is BackendEvent.DriveResult.Failure -> {
                             isSyncing = false
                             Logger.e { "Failed during drive sync" }
-                            start()
+                            if (event.totalCount > 0) start()
                         }
                     }
 


### PR DESCRIPTION
After drive sync completes, ConversationStream listens for DriveEvent.Stopped and calls start() to reload the full conversation list from the local DB. This ensures the UI reflects any newly synced data.

However, on cold start the conversation list is already preloaded by onPostAuthenticated. When sync then completes with totalCount=0 (no new records — the DB is already up to date), the reload is redundant: it re-runs the same SQL query and re-maps all 81 rows for a second time (~670ms wasted on Pixel 8).

Now only reload when event.totalCount > 0, meaning sync actually wrote new records worth picking up. When nothing changed, the preloaded data is already current and we skip the unnecessary work.