### PR TITLE
perf: skip message refresh on empty syncs + add sync diagnostic logging

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -60,6 +60,7 @@ class ChatMessageStream(
     private val conversationState = ActiveConversationState()
     private val chatDrive = chatTargetDrive.alias
     private var isSyncing = false
+    private var syncedMessageCount = 0
     private val loadedConversations = mutableSetOf<Uuid>()
 
     init {
@@ -75,18 +76,36 @@ class ChatMessageStream(
                 when (event) {
                     is BackendEvent.DriveEvent.Started -> {
                         isSyncing = true
+                        syncedMessageCount = 0
                     }
 
                     is BackendEvent.DriveEvent.Stopped -> {
                         isSyncing = false
-                        refreshLoadedConversations()
+                        if (event.totalCount > 0) {
+                            Logger.d("ChatMessageStream: Stopped with totalCount=${event.totalCount}, syncedMessageCount=$syncedMessageCount")
+                            refreshLoadedConversations()
+                        } else {
+                            Logger.d("ChatMessageStream: Stopped with totalCount=0, skipping refresh")
+                        }
                     }
 
                     is BackendEvent.DriveEvent.BatchReceived -> {
                         if (!isSyncing) {
                             processIncrementalBatch(event.batchData)
                         } else {
-                            Logger.d("ChatMessageStream: BatchReceived suppressed (isSyncing=true), ${event.batchData.size} files buffered by sync")
+                            val messageFiles = event.batchData.count {
+                                it.fileMetadata.appData.fileType == ChatProtocol.MessageFileType
+                            }
+                            val conversationFiles = event.batchData.count {
+                                it.fileMetadata.appData.fileType == ChatProtocol.ConversationFileType
+                            }
+                            val otherFiles = event.batchData.size - messageFiles - conversationFiles
+                            syncedMessageCount += messageFiles
+                            Logger.d(
+                                "ChatMessageStream: BatchReceived suppressed (isSyncing=true), " +
+                                "${event.batchData.size} files (messages=$messageFiles, " +
+                                "conversations=$conversationFiles, other=$otherFiles)"
+                            )
                         }
                     }
                 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -84,12 +84,14 @@ class ConversationStream(
                     is BackendEvent.DriveEvent.Stopped -> when (event.result) {
                         is BackendEvent.DriveResult.Success -> {
                             isSyncing = false
+                            Logger.d("ConversationStream: Stopped(totalCount=${event.totalCount})")
                             if (event.totalCount > 0) start()
                         }
 
                         is BackendEvent.DriveResult.Failure -> {
                             isSyncing = false
                             Logger.e { "Failed during drive sync" }
+                            Logger.d("ConversationStream: Stopped(FAILED, totalCount=${event.totalCount})")
                             if (event.totalCount > 0) start()
                         }
                     }


### PR DESCRIPTION
ChatMessageStream was calling refreshLoadedConversations() on every DriveEvent.Stopped regardless of whether any records were synced. This caused 47 full message reloads in a 13-minute session, with SQL query times spiking to 22.6s under write-lock contention.

- Skip refreshLoadedConversations() when totalCount == 0 (matches the guard ConversationStream already has)
- Track file type breakdown (messages vs conversations vs other) in suppressed BatchReceived events to diagnose whether refreshes are triggered by actual new messages or just reactions/metadata
- Add diagnostic logging to ConversationStream Stopped handler