### PR TITLE
fix: coerce unknown WebSocket notification types to prevent NPE crash

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/ClientNotificationPayload.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/ClientNotificationPayload.kt
@@ -4,6 +4,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class ClientNotificationPayload(
-    val notificationType: ClientNotificationType,
+    val notificationType: ClientNotificationType = ClientNotificationType.unused,
     val data: String = ""
 )

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/serialization/OdinSystemSerializer.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/serialization/OdinSystemSerializer.kt
@@ -34,7 +34,7 @@ object OdinSystemSerializer {
      * - allowStructuredMapKeys = true → allows complex types as map keys
      * - prettyPrint = false → compact JSON output (minified)
      * - explicitNulls = false → exclude null values from output for compactness
-     * - coerceInputValues = false → don't coerce invalid values to defaults (default)
+     * - coerceInputValues = true → coerce unknown enum values and nulls to defaults
      */
     val json = Json {
         ignoreUnknownKeys = true
@@ -44,7 +44,7 @@ object OdinSystemSerializer {
         allowStructuredMapKeys = true
         prettyPrint = false
         explicitNulls = false
-        coerceInputValues = false
+        coerceInputValues = true
 
         serializersModule = SerializersModule {
             contextual(Uuid::class, UuidSerializer)


### PR DESCRIPTION
When the server sends a notification type the client doesn't recognize, deserialization could produce a null notificationType on Android (R8), crashing the app. Enable coerceInputValues and default notificationType to `unused` so unknown types are handled gracefully.