### PR TITLE
Add paginated/windowed chat message loading

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
@@ -74,7 +74,8 @@ sealed interface ConversationListUiAction {
     data class SaveScrollPosition(
         val conversationId: Uuid,
         val firstVisibleItemIndex: Int,
-        val firstVisibleItemScrollOffset: Int
+        val firstVisibleItemScrollOffset: Int,
+        val anchorMessageId: Uuid? = null,
     ) : ConversationListUiAction
 
     data class ShowConversationSettings(val conversation: ConversationUiModel) :
@@ -113,6 +114,9 @@ sealed interface ConversationListUiAction {
     data class ShowReactionDetails(val messageId: Uuid) : ConversationListUiAction
     data class DecryptFile(val messageId: Uuid, val payloadKey: String) : ConversationListUiAction
     data class ScrollToMessageId(val messageId: Uuid) : ConversationListUiAction
+    data class LoadOlderMessages(val conversationId: Uuid) : ConversationListUiAction
+    data class LoadNewerMessages(val conversationId: Uuid) : ConversationListUiAction
+    data class ScrollToLatest(val conversationId: Uuid) : ConversationListUiAction
     data object HideReactionDetails : ConversationListUiAction
     data class StartRecording(val conversationId: Uuid) : ConversationListUiAction
     data object StopRecording : ConversationListUiAction

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -47,6 +47,10 @@ data class MessageListUiState(
     val userDefaultReactions: ImmutableList<String> = persistentListOf(),
     val uploadProgress: ImmutableMap<Uuid, UploadStatus> = persistentMapOf(),
     val isLoadingMessages: Boolean = true,
+    val hasOlderMessages: Boolean = false,
+    val hasNewerMessages: Boolean = false,
+    val isLoadingOlder: Boolean = false,
+    val isLoadingNewer: Boolean = false,
     val scrollPosition: ScrollPosition? = null,
     val fullScreenOverlay: FullScreenOverlay? = null,
     val replyToMessage: MessageUiModel? = null,
@@ -101,6 +105,8 @@ sealed interface ConversationListContentModel {
 @Immutable
 sealed class MessageListContentModel(val id: String) {
     data object Header : MessageListContentModel("header")
+    data object LoadingOlder : MessageListContentModel("loading-older")
+    data object LoadingNewer : MessageListContentModel("loading-newer")
     data class Section(val date: LocalDate) : MessageListContentModel(date.toString())
     data class System(val text: String, val created: Instant) : MessageListContentModel(created.toString())
     data class Message(val message: MessageUiModel) :

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -370,6 +370,7 @@ class ConversationListViewModel(
                         scrollPosition = ScrollPosition(
                             firstVisibleItemIndex = action.firstVisibleItemIndex,
                             firstVisibleItemScrollOffset = action.firstVisibleItemScrollOffset,
+                            anchorMessageId = action.anchorMessageId,
                         )
                     )
                 }
@@ -382,6 +383,11 @@ class ConversationListViewModel(
                     userPreferences.setConversationScrollOffset(
                         action.conversationId.toString(), action.firstVisibleItemScrollOffset
                     )
+                    action.anchorMessageId?.let { messageId ->
+                        userPreferences.setConversationScrollMessageId(
+                            action.conversationId.toString(), messageId.toString()
+                        )
+                    }
                 }
             }
 
@@ -702,6 +708,11 @@ class ConversationListViewModel(
                                         )
                                 )
                             }
+                        } else {
+                            // Message not in current window - reload around it
+                            val conversationId = _uiState.value.selectedConversationId ?: return@launch
+                            _messagesUiState.update { it.copy(isLoadingMessages = true) }
+                            chatMessageStream.loadConversationAroundMessage(conversationId, action.messageId)
                         }
                     } catch (e: Exception) {
                         sendEvent(ShowErrorMessage("Failed to scroll to message: ${e.message}"))
@@ -1478,6 +1489,24 @@ class ConversationListViewModel(
                     _messagesUiState.update { it.copy(recordingData = null) }
                 }
             }
+
+            is ConversationListUiAction.LoadOlderMessages -> {
+                viewModelScope.launch {
+                    chatMessageStream.loadOlderMessages(action.conversationId)
+                }
+            }
+
+            is ConversationListUiAction.LoadNewerMessages -> {
+                viewModelScope.launch {
+                    chatMessageStream.loadNewerMessages(action.conversationId)
+                }
+            }
+
+            is ConversationListUiAction.ScrollToLatest -> {
+                viewModelScope.launch {
+                    chatMessageStream.loadConversation(action.conversationId)
+                }
+            }
         }
     }
 
@@ -1599,7 +1628,17 @@ class ConversationListViewModel(
                 var messageIdForScrollNullable = messageIdForScroll
                 var setInitialScroll = true
 
-                chatMessageStream.loadConversation(conversationId)
+                // Determine how to load: around a specific message, or latest
+                val savedMessageId = getSavedScrollMessageId(conversationId)
+                if (messageIdForScroll != null) {
+                    chatMessageStream.loadConversationAroundMessage(conversationId, messageIdForScroll)
+                } else if (savedMessageId != null) {
+                    chatMessageStream.loadConversationAroundMessage(conversationId, savedMessageId)
+                    messageIdForScrollNullable = savedMessageId
+                } else {
+                    chatMessageStream.loadConversation(conversationId)
+                }
+
                 chatMessageStream.observeMessages(conversationId).collect { messageState ->
                     when (messageState) {
                         is ChatMessagesData.Initializing -> {
@@ -1607,7 +1646,8 @@ class ConversationListViewModel(
                         }
 
                         is ChatMessagesData.Messages -> {
-                            val messages = messageState.messages
+                            val window = messageState.window
+                            val messages = window.messages
                             // Group messages within day sections
                             val timezone = TimeZone.currentSystemDefault()
                             val groupedMessages =
@@ -1616,7 +1656,14 @@ class ConversationListViewModel(
                                     date
                                 }
                             val messagesModels: MutableList<MessageListContentModel> =
-                                mutableListOf(MessageListContentModel.Header)
+                                mutableListOf()
+
+                            // Add loading indicator at the top if there are older messages
+                            if (window.hasOlderMessages) {
+                                messagesModels.add(MessageListContentModel.LoadingOlder)
+                            }
+
+                            messagesModels.add(MessageListContentModel.Header)
 
                             messagesModels.addAll(groupedMessages.flatMap { (date, messages) ->
                                 listOf(MessageListContentModel.Section(date)) + messages.map {
@@ -1626,6 +1673,11 @@ class ConversationListViewModel(
                                         MessageListContentModel.Message(it)
                                 }
                             })
+
+                            // Add loading indicator at the bottom if there are newer messages
+                            if (window.hasNewerMessages) {
+                                messagesModels.add(MessageListContentModel.LoadingNewer)
+                            }
 
                             // Scroll handling, either use new message id, click message id or null
                             val newMessageId =
@@ -1655,8 +1707,19 @@ class ConversationListViewModel(
                                 it.copy(
                                     isLoadingMessages = false,
                                     messages = messagesModels.toPersistentList(),
+                                    hasOlderMessages = window.hasOlderMessages,
+                                    hasNewerMessages = window.hasNewerMessages,
+                                    isLoadingOlder = window.isLoadingOlder,
+                                    isLoadingNewer = window.isLoadingNewer,
                                     scrollPosition = if (indexOfMessageForScroll == null) {
-                                        if (setInitialScroll) getScrollPosition(conversationId) else null
+                                        if (setInitialScroll) {
+                                            if (!window.hasNewerMessages) {
+                                                // At the bottom - scroll to end
+                                                null
+                                            } else {
+                                                getScrollPosition(conversationId)
+                                            }
+                                        } else null
                                     } else {
                                         ScrollPosition(
                                             indexOfMessageForScroll,
@@ -1675,6 +1738,16 @@ class ConversationListViewModel(
             } catch (e: Exception) {
                 sendEvent(ShowErrorMessage("Failed to load messages: ${e.message}"))
             }
+        }
+    }
+
+    private fun getSavedScrollMessageId(conversationId: Uuid): Uuid? {
+        val messageIdStr = userPreferences.getConversationScrollMessageId(conversationId.toString())
+            ?: return null
+        return try {
+            Uuid.parse(messageIdStr)
+        } catch (_: Exception) {
+            null
         }
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -41,11 +41,14 @@ import id.homebase.resources.system_group_conversation_member_left
 import id.homebase.resources.system_group_conversation_started
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.JsonPrimitive
 import kotlin.io.encoding.Base64
 import kotlin.uuid.Uuid
@@ -61,6 +64,8 @@ class ChatMessageStream(
 
     private val paginatedState = PaginatedConversationState()
     private val chatDrive = chatTargetDrive.alias
+    private val loadOlderMutex = Mutex()
+    private val loadNewerMutex = Mutex()
     private var isSyncing = false
     private var syncedMessageCount = 0
     private val loadedConversations = mutableSetOf<Uuid>()
@@ -130,16 +135,18 @@ class ChatMessageStream(
     suspend fun loadConversation(conversationId: Uuid) {
         Logger.d("ChatMessageStream: loadConversation($conversationId)")
         loadedConversations += conversationId
-        val result = fetchMessages(conversationId, limit = PAGE_SIZE)
-        Logger.d("ChatMessageStream: loadConversation($conversationId) → ${result.records.size} messages")
-        paginatedState.setInitialWindow(
-            conversationId = conversationId,
-            messages = result.records,
-            olderCursor = if (result.hasMoreRows) result.cursor else null,
-            hasOlderMessages = result.hasMoreRows,
-            newerCursor = null,
-            hasNewerMessages = false,
-        )
+        withContext(Dispatchers.Default) {
+            val result = fetchMessages(conversationId, limit = PAGE_SIZE)
+            Logger.d("ChatMessageStream: loadConversation($conversationId) → ${result.records.size} messages")
+            paginatedState.setInitialWindow(
+                conversationId = conversationId,
+                messages = result.records,
+                olderCursor = if (result.hasMoreRows) result.cursor else null,
+                hasOlderMessages = result.hasMoreRows,
+                newerCursor = null,
+                hasNewerMessages = false,
+            )
+        }
     }
 
     suspend fun loadConversationAroundMessage(conversationId: Uuid, messageUniqueId: Uuid) {
@@ -153,96 +160,112 @@ class ChatMessageStream(
             return
         }
 
-        val halfPage = PAGE_SIZE / 2
-        val targetTime = UnixTimeUtc(targetMessage.created)
+        withContext(Dispatchers.Default) {
+            val halfPage = PAGE_SIZE / 2
+            val targetTime = UnixTimeUtc(targetMessage.created)
 
-        // Fetch older messages (at and before the target)
-        val olderCursor = QueryBatchCursor(
-            paging = TimeRowCursor(targetTime, Long.MAX_VALUE)
-        )
-        val olderResult = fetchMessages(
-            conversationId, limit = halfPage, cursor = olderCursor,
-            sortOrder = QueryBatchSortOrder.NewestFirst
-        )
+            // Fetch older messages (at and before the target)
+            val olderCursor = QueryBatchCursor(
+                paging = TimeRowCursor(targetTime, Long.MAX_VALUE)
+            )
+            val olderResult = fetchMessages(
+                conversationId, limit = halfPage, cursor = olderCursor,
+                sortOrder = QueryBatchSortOrder.NewestFirst
+            )
 
-        // Fetch newer messages (after the target)
-        val newerCursor = QueryBatchCursor(
-            paging = TimeRowCursor(targetTime, 0L)
-        )
-        val newerResult = fetchMessages(
-            conversationId, limit = halfPage, cursor = newerCursor,
-            sortOrder = QueryBatchSortOrder.OldestFirst
-        )
+            // Fetch newer messages (after the target)
+            val newerCursor = QueryBatchCursor(
+                paging = TimeRowCursor(targetTime, 0L)
+            )
+            val newerResult = fetchMessages(
+                conversationId, limit = halfPage, cursor = newerCursor,
+                sortOrder = QueryBatchSortOrder.OldestFirst
+            )
 
-        // Combine, dedup, sort
-        val combined = (olderResult.records + newerResult.records)
-            .distinctBy { it.id }
-            .sortedBy { it.created }
+            // Combine, dedup, sort
+            val combined = (olderResult.records + newerResult.records)
+                .distinctBy { it.id }
+                .sortedBy { it.created }
 
-        Logger.d("ChatMessageStream: loadConversationAroundMessage → ${combined.size} messages (older=${olderResult.records.size}, newer=${newerResult.records.size})")
+            Logger.d("ChatMessageStream: loadConversationAroundMessage → ${combined.size} messages (older=${olderResult.records.size}, newer=${newerResult.records.size})")
 
-        paginatedState.setInitialWindow(
-            conversationId = conversationId,
-            messages = combined,
-            olderCursor = if (olderResult.hasMoreRows) olderResult.cursor else null,
-            hasOlderMessages = olderResult.hasMoreRows,
-            newerCursor = if (newerResult.hasMoreRows) newerResult.cursor else null,
-            hasNewerMessages = newerResult.hasMoreRows,
-        )
+            paginatedState.setInitialWindow(
+                conversationId = conversationId,
+                messages = combined,
+                olderCursor = if (olderResult.hasMoreRows) olderResult.cursor else null,
+                hasOlderMessages = olderResult.hasMoreRows,
+                newerCursor = if (newerResult.hasMoreRows) newerResult.cursor else null,
+                hasNewerMessages = newerResult.hasMoreRows,
+            )
+        }
     }
 
     suspend fun loadOlderMessages(conversationId: Uuid) {
-        val window = paginatedState.getWindow(conversationId) ?: return
-        if (window.isLoadingOlder || !window.hasOlderMessages) return
-
-        paginatedState.setLoadingOlder(conversationId, true)
+        if (!loadOlderMutex.tryLock()) return
         try {
-            val result = fetchMessages(
-                conversationId, limit = PAGE_SIZE, cursor = window.olderCursor,
-                sortOrder = QueryBatchSortOrder.NewestFirst
-            )
-            Logger.d("ChatMessageStream: loadOlderMessages($conversationId) → ${result.records.size} messages")
-            paginatedState.prependOlderMessages(
-                conversationId = conversationId,
-                olderMessages = result.records,
-                olderCursor = if (result.hasMoreRows) result.cursor else null,
-                hasMore = result.hasMoreRows,
-            )
-        } catch (e: Exception) {
-            Logger.e(e) { "ChatMessageStream: loadOlderMessages failed" }
-            paginatedState.setLoadingOlder(conversationId, false)
+            val window = paginatedState.getWindow(conversationId) ?: return
+            if (window.isLoadingOlder || !window.hasOlderMessages) return
+
+            paginatedState.setLoadingOlder(conversationId, true)
+            try {
+                withContext(Dispatchers.Default) {
+                    val result = fetchMessages(
+                        conversationId, limit = PAGE_SIZE, cursor = window.olderCursor,
+                        sortOrder = QueryBatchSortOrder.NewestFirst
+                    )
+                    Logger.d("ChatMessageStream: loadOlderMessages($conversationId) → ${result.records.size} messages")
+                    paginatedState.prependOlderMessages(
+                        conversationId = conversationId,
+                        olderMessages = result.records,
+                        olderCursor = if (result.hasMoreRows) result.cursor else null,
+                        hasMore = result.hasMoreRows,
+                    )
+                }
+            } catch (e: Exception) {
+                Logger.e(e) { "ChatMessageStream: loadOlderMessages failed" }
+                paginatedState.setLoadingOlder(conversationId, false)
+            }
+        } finally {
+            loadOlderMutex.unlock()
         }
     }
 
     suspend fun loadNewerMessages(conversationId: Uuid) {
-        val window = paginatedState.getWindow(conversationId) ?: return
-        if (window.isLoadingNewer || !window.hasNewerMessages) return
-
-        paginatedState.setLoadingNewer(conversationId, true)
+        if (!loadNewerMutex.tryLock()) return
         try {
-            val newestMessage = window.messages.lastOrNull()
-            val cursor = if (window.newerCursor != null) {
-                window.newerCursor
-            } else if (newestMessage != null) {
-                QueryBatchCursor(paging = TimeRowCursor(UnixTimeUtc(newestMessage.created), 0L))
-            } else {
-                null
-            }
+            val window = paginatedState.getWindow(conversationId) ?: return
+            if (window.isLoadingNewer || !window.hasNewerMessages) return
 
-            val result = fetchMessages(
-                conversationId, limit = PAGE_SIZE, cursor = cursor,
-                sortOrder = QueryBatchSortOrder.OldestFirst
-            )
-            Logger.d("ChatMessageStream: loadNewerMessages($conversationId) → ${result.records.size} messages")
-            paginatedState.appendNewerMessages(
-                conversationId = conversationId,
-                newerMessages = result.records,
-                newerCursor = if (result.hasMoreRows) result.cursor else null,
-                hasMore = result.hasMoreRows,
-            )
-        } catch (e: Exception) {
-            Logger.e(e) { "ChatMessageStream: loadNewerMessages failed" }
-            paginatedState.setLoadingNewer(conversationId, false)
+            paginatedState.setLoadingNewer(conversationId, true)
+            try {
+                withContext(Dispatchers.Default) {
+                    val newestMessage = window.messages.lastOrNull()
+                    val cursor = if (window.newerCursor != null) {
+                        window.newerCursor
+                    } else if (newestMessage != null) {
+                        QueryBatchCursor(paging = TimeRowCursor(UnixTimeUtc(newestMessage.created), 0L))
+                    } else {
+                        null
+                    }
+
+                    val result = fetchMessages(
+                        conversationId, limit = PAGE_SIZE, cursor = cursor,
+                        sortOrder = QueryBatchSortOrder.OldestFirst
+                    )
+                    Logger.d("ChatMessageStream: loadNewerMessages($conversationId) → ${result.records.size} messages")
+                    paginatedState.appendNewerMessages(
+                        conversationId = conversationId,
+                        newerMessages = result.records,
+                        newerCursor = if (result.hasMoreRows) result.cursor else null,
+                        hasMore = result.hasMoreRows,
+                    )
+                }
+            } catch (e: Exception) {
+                Logger.e(e) { "ChatMessageStream: loadNewerMessages failed" }
+                paginatedState.setLoadingNewer(conversationId, false)
+            }
+        } finally {
+            loadNewerMutex.unlock()
         }
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -10,6 +10,7 @@ import id.homebase.api.client.drives.QueryBatchSortOrder
 import id.homebase.api.client.drives.files.ArchivalStatus
 import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.client.drives.query.QueryBatchCursor
+import id.homebase.api.client.drives.query.TimeRowCursor
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.client.withRetry
@@ -20,6 +21,7 @@ import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.QueryBatch
 import id.homebase.chat.data.MessageUiModel
+import id.homebase.chat.services.PaginatedConversationState.Companion.PAGE_SIZE
 import id.homebase.chat.services.convo.contact.ContactService
 import id.homebase.core.config.chatTargetDrive
 import id.homebase.core.localization.TranslationUtil
@@ -57,7 +59,7 @@ class ChatMessageStream(
     private val driveFileProvider: DriveFileProvider
 ) {
 
-    private val conversationState = ActiveConversationState()
+    private val paginatedState = PaginatedConversationState()
     private val chatDrive = chatTargetDrive.alias
     private var isSyncing = false
     private var syncedMessageCount = 0
@@ -67,7 +69,7 @@ class ChatMessageStream(
         scope.launch {
             eventBus.events.collect { event ->
                 if (event is BackendEvent.OutboxEvent.OptimisticRollback && event.driveId == chatDrive) {
-                    conversationState.removeMessage(event.uniqueId)
+                    paginatedState.removeMessage(event.uniqueId)
                     return@collect
                 }
 
@@ -116,17 +118,132 @@ class ChatMessageStream(
     // ---------- PUBLIC API ----------
 
     fun observeMessages(conversationId: Uuid): StateFlow<ChatMessagesData> =
-        conversationState
-            .messages
-            .map { ChatMessagesData.Messages(it[conversationId].orEmpty()) }
+        paginatedState
+            .windows
+            .map { windows ->
+                val window = windows[conversationId]
+                if (window != null) ChatMessagesData.Messages(window)
+                else ChatMessagesData.Initializing
+            }
             .stateIn(scope, SharingStarted.WhileSubscribed(5_000), ChatMessagesData.Initializing)
 
     suspend fun loadConversation(conversationId: Uuid) {
         Logger.d("ChatMessageStream: loadConversation($conversationId)")
         loadedConversations += conversationId
-        val result = fetchMessages(conversationId)
+        val result = fetchMessages(conversationId, limit = PAGE_SIZE)
         Logger.d("ChatMessageStream: loadConversation($conversationId) → ${result.records.size} messages")
-        conversationState.set(conversationId, result.records)
+        paginatedState.setInitialWindow(
+            conversationId = conversationId,
+            messages = result.records,
+            olderCursor = if (result.hasMoreRows) result.cursor else null,
+            hasOlderMessages = result.hasMoreRows,
+            newerCursor = null,
+            hasNewerMessages = false,
+        )
+    }
+
+    suspend fun loadConversationAroundMessage(conversationId: Uuid, messageUniqueId: Uuid) {
+        Logger.d("ChatMessageStream: loadConversationAroundMessage($conversationId, $messageUniqueId)")
+        loadedConversations += conversationId
+
+        val targetMessage = getMessage(messageUniqueId)
+        if (targetMessage == null) {
+            Logger.w("ChatMessageStream: target message $messageUniqueId not found, falling back to loadConversation")
+            loadConversation(conversationId)
+            return
+        }
+
+        val halfPage = PAGE_SIZE / 2
+        val targetTime = UnixTimeUtc(targetMessage.created)
+
+        // Fetch older messages (at and before the target)
+        val olderCursor = QueryBatchCursor(
+            paging = TimeRowCursor(targetTime, Long.MAX_VALUE)
+        )
+        val olderResult = fetchMessages(
+            conversationId, limit = halfPage, cursor = olderCursor,
+            sortOrder = QueryBatchSortOrder.NewestFirst
+        )
+
+        // Fetch newer messages (after the target)
+        val newerCursor = QueryBatchCursor(
+            paging = TimeRowCursor(targetTime, 0L)
+        )
+        val newerResult = fetchMessages(
+            conversationId, limit = halfPage, cursor = newerCursor,
+            sortOrder = QueryBatchSortOrder.OldestFirst
+        )
+
+        // Combine, dedup, sort
+        val combined = (olderResult.records + newerResult.records)
+            .distinctBy { it.id }
+            .sortedBy { it.created }
+
+        Logger.d("ChatMessageStream: loadConversationAroundMessage → ${combined.size} messages (older=${olderResult.records.size}, newer=${newerResult.records.size})")
+
+        paginatedState.setInitialWindow(
+            conversationId = conversationId,
+            messages = combined,
+            olderCursor = if (olderResult.hasMoreRows) olderResult.cursor else null,
+            hasOlderMessages = olderResult.hasMoreRows,
+            newerCursor = if (newerResult.hasMoreRows) newerResult.cursor else null,
+            hasNewerMessages = newerResult.hasMoreRows,
+        )
+    }
+
+    suspend fun loadOlderMessages(conversationId: Uuid) {
+        val window = paginatedState.getWindow(conversationId) ?: return
+        if (window.isLoadingOlder || !window.hasOlderMessages) return
+
+        paginatedState.setLoadingOlder(conversationId, true)
+        try {
+            val result = fetchMessages(
+                conversationId, limit = PAGE_SIZE, cursor = window.olderCursor,
+                sortOrder = QueryBatchSortOrder.NewestFirst
+            )
+            Logger.d("ChatMessageStream: loadOlderMessages($conversationId) → ${result.records.size} messages")
+            paginatedState.prependOlderMessages(
+                conversationId = conversationId,
+                olderMessages = result.records,
+                olderCursor = if (result.hasMoreRows) result.cursor else null,
+                hasMore = result.hasMoreRows,
+            )
+        } catch (e: Exception) {
+            Logger.e(e) { "ChatMessageStream: loadOlderMessages failed" }
+            paginatedState.setLoadingOlder(conversationId, false)
+        }
+    }
+
+    suspend fun loadNewerMessages(conversationId: Uuid) {
+        val window = paginatedState.getWindow(conversationId) ?: return
+        if (window.isLoadingNewer || !window.hasNewerMessages) return
+
+        paginatedState.setLoadingNewer(conversationId, true)
+        try {
+            val newestMessage = window.messages.lastOrNull()
+            val cursor = if (window.newerCursor != null) {
+                window.newerCursor
+            } else if (newestMessage != null) {
+                QueryBatchCursor(paging = TimeRowCursor(UnixTimeUtc(newestMessage.created), 0L))
+            } else {
+                null
+            }
+
+            val result = fetchMessages(
+                conversationId, limit = PAGE_SIZE, cursor = cursor,
+                sortOrder = QueryBatchSortOrder.OldestFirst
+            )
+            Logger.d("ChatMessageStream: loadNewerMessages($conversationId) → ${result.records.size} messages")
+            paginatedState.appendNewerMessages(
+                conversationId = conversationId,
+                newerMessages = result.records,
+                newerCursor = if (result.hasMoreRows) result.cursor else null,
+                hasMore = result.hasMoreRows,
+            )
+        } catch (e: Exception) {
+            Logger.e(e) { "ChatMessageStream: loadNewerMessages failed" }
+            paginatedState.setLoadingNewer(conversationId, false)
+        }
     }
 
 // ---------- EVENT HANDLING ----------
@@ -138,7 +255,13 @@ class ChatMessageStream(
                 .mapNotNull { mapToMessageData(it, credentialsManager, ::resolveDisplayName) }
 
         messages.groupBy { it.conversationId }.forEach { (conversationId, msgs) ->
-            conversationState.upsert(conversationId, msgs)
+            val window = paginatedState.getWindow(conversationId) ?: return@forEach
+            if (!window.hasNewerMessages) {
+                // User is at the bottom - add messages to the window
+                paginatedState.upsertMessage(conversationId, msgs)
+            }
+            // If user has scrolled up (hasNewerMessages=true), new messages are beyond the
+            // current window and will be loaded when they scroll back down
         }
     }
 
@@ -146,9 +269,28 @@ class ChatMessageStream(
         val snapshot = loadedConversations.toSet()
         Logger.d("ChatMessageStream: refreshLoadedConversations called, ${snapshot.size} active conversations")
         snapshot.forEach { conversationId ->
-            val result = fetchMessages(conversationId)
-            Logger.d("ChatMessageStream: fetchMessages($conversationId) → ${result.records.size} messages")
-            conversationState.set(conversationId, result.records)
+            val window = paginatedState.getWindow(conversationId)
+            if (window == null || !window.hasNewerMessages) {
+                // At bottom or no window yet - reload latest page
+                val result = fetchMessages(conversationId, limit = PAGE_SIZE)
+                Logger.d("ChatMessageStream: refreshLoadedConversations($conversationId) → ${result.records.size} messages")
+                paginatedState.setInitialWindow(
+                    conversationId = conversationId,
+                    messages = result.records,
+                    olderCursor = if (result.hasMoreRows) result.cursor else null,
+                    hasOlderMessages = result.hasMoreRows,
+                    newerCursor = null,
+                    hasNewerMessages = false,
+                )
+            } else {
+                // User is mid-history - reload around the anchor (middle of current window)
+                val anchorMessage = window.messages.getOrNull(window.messages.size / 2)
+                if (anchorMessage != null) {
+                    loadConversationAroundMessage(conversationId, anchorMessage.id)
+                } else {
+                    loadConversation(conversationId)
+                }
+            }
         }
     }
 
@@ -189,8 +331,9 @@ class ChatMessageStream(
 
     suspend fun fetchMessages(
         conversationId: Uuid,
-        limit: Int = 1000,
-        cursor: QueryBatchCursor? = null
+        limit: Int = PAGE_SIZE,
+        cursor: QueryBatchCursor? = null,
+        sortOrder: QueryBatchSortOrder = QueryBatchSortOrder.NewestFirst,
     ): BatchResult<MessageUiModel> {
 
         val c = credentialsManager.requireActiveCredentials()
@@ -202,7 +345,7 @@ class ChatMessageStream(
                 driveId = chatDrive,
                 noOfItems = limit,
                 cursor = cursor,
-                sortOrder = QueryBatchSortOrder.NewestFirst,
+                sortOrder = sortOrder,
                 sortField = QueryBatchSortField.CreatedDate,
                 fileSystemType = 0,
                 filetypesAnyOf = listOf(ChatProtocol.MessageFileType),
@@ -630,5 +773,5 @@ class ChatMessageStream(
 
 sealed interface ChatMessagesData {
     data object Initializing : ChatMessagesData
-    data class Messages(val messages: List<MessageUiModel>) : ChatMessagesData
+    data class Messages(val window: MessageWindow) : ChatMessagesData
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/PaginatedConversationState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/PaginatedConversationState.kt
@@ -1,0 +1,189 @@
+package id.homebase.chat.services
+
+import id.homebase.api.client.drives.query.QueryBatchCursor
+import id.homebase.api.client.drives.query.TimeRowCursor
+import id.homebase.api.common.time.UnixTimeUtc
+import id.homebase.chat.data.MessageUiModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlin.uuid.Uuid
+
+data class MessageWindow(
+    val messages: List<MessageUiModel> = emptyList(),
+    val olderCursor: QueryBatchCursor? = null,
+    val newerCursor: QueryBatchCursor? = null,
+    val hasOlderMessages: Boolean = false,
+    val hasNewerMessages: Boolean = false,
+    val isLoadingOlder: Boolean = false,
+    val isLoadingNewer: Boolean = false,
+)
+
+class PaginatedConversationState {
+
+    companion object {
+        const val PAGE_SIZE = 75
+        const val MAX_WINDOW_SIZE = 300
+        const val LOAD_MORE_THRESHOLD = 15
+    }
+
+    private val _windows = MutableStateFlow<Map<Uuid, MessageWindow>>(emptyMap())
+    val windows: StateFlow<Map<Uuid, MessageWindow>> = _windows.asStateFlow()
+
+    fun setInitialWindow(
+        conversationId: Uuid,
+        messages: List<MessageUiModel>,
+        olderCursor: QueryBatchCursor?,
+        hasOlderMessages: Boolean,
+        newerCursor: QueryBatchCursor?,
+        hasNewerMessages: Boolean,
+    ) {
+        _windows.value = _windows.value.toMutableMap().apply {
+            this[conversationId] = MessageWindow(
+                messages = messages.sortedBy { it.created },
+                olderCursor = olderCursor,
+                newerCursor = newerCursor,
+                hasOlderMessages = hasOlderMessages,
+                hasNewerMessages = hasNewerMessages,
+            )
+        }
+    }
+
+    fun prependOlderMessages(
+        conversationId: Uuid,
+        olderMessages: List<MessageUiModel>,
+        olderCursor: QueryBatchCursor?,
+        hasMore: Boolean,
+    ) {
+        _windows.value = _windows.value.toMutableMap().apply {
+            val current = this[conversationId] ?: return
+            val combined = (olderMessages + current.messages)
+                .distinctBy { it.id }
+                .sortedBy { it.created }
+
+            val (trimmed, newerCursor, hasNewer) = trimTail(
+                combined, current.newerCursor, current.hasNewerMessages
+            )
+
+            this[conversationId] = current.copy(
+                messages = trimmed,
+                olderCursor = olderCursor,
+                hasOlderMessages = hasMore,
+                newerCursor = newerCursor,
+                hasNewerMessages = hasNewer,
+                isLoadingOlder = false,
+            )
+        }
+    }
+
+    fun appendNewerMessages(
+        conversationId: Uuid,
+        newerMessages: List<MessageUiModel>,
+        newerCursor: QueryBatchCursor?,
+        hasMore: Boolean,
+    ) {
+        _windows.value = _windows.value.toMutableMap().apply {
+            val current = this[conversationId] ?: return
+            val combined = (current.messages + newerMessages)
+                .distinctBy { it.id }
+                .sortedBy { it.created }
+
+            val (trimmed, olderCursor, hasOlder) = trimHead(
+                combined, current.olderCursor, current.hasOlderMessages
+            )
+
+            this[conversationId] = current.copy(
+                messages = trimmed,
+                olderCursor = olderCursor,
+                hasOlderMessages = hasOlder,
+                newerCursor = newerCursor,
+                hasNewerMessages = hasMore,
+                isLoadingNewer = false,
+            )
+        }
+    }
+
+    fun upsertMessage(conversationId: Uuid, incoming: List<MessageUiModel>) {
+        if (incoming.isEmpty()) return
+        _windows.value = _windows.value.toMutableMap().apply {
+            val current = this[conversationId] ?: return
+            val byId = current.messages.associateBy { it.id }.toMutableMap()
+            for (msg in incoming) {
+                byId[msg.id] = msg
+            }
+            this[conversationId] = current.copy(
+                messages = byId.values.sortedBy { it.created }
+            )
+        }
+    }
+
+    fun removeMessage(messageId: Uuid) {
+        _windows.value = _windows.value.mapValues { (_, window) ->
+            window.copy(messages = window.messages.filter { it.id != messageId })
+        }
+    }
+
+    fun setLoadingOlder(conversationId: Uuid, loading: Boolean) {
+        _windows.value = _windows.value.toMutableMap().apply {
+            val current = this[conversationId] ?: return
+            this[conversationId] = current.copy(isLoadingOlder = loading)
+        }
+    }
+
+    fun setLoadingNewer(conversationId: Uuid, loading: Boolean) {
+        _windows.value = _windows.value.toMutableMap().apply {
+            val current = this[conversationId] ?: return
+            this[conversationId] = current.copy(isLoadingNewer = loading)
+        }
+    }
+
+    fun getWindow(conversationId: Uuid): MessageWindow? {
+        return _windows.value[conversationId]
+    }
+
+    /**
+     * Trim messages from the tail (newest end) when the list exceeds MAX_WINDOW_SIZE.
+     * Returns the trimmed list, updated newerCursor, and updated hasNewerMessages.
+     */
+    private fun trimTail(
+        messages: List<MessageUiModel>,
+        currentNewerCursor: QueryBatchCursor?,
+        currentHasNewer: Boolean,
+    ): Triple<List<MessageUiModel>, QueryBatchCursor?, Boolean> {
+        if (messages.size <= MAX_WINDOW_SIZE) {
+            return Triple(messages, currentNewerCursor, currentHasNewer)
+        }
+        val trimmed = messages.take(MAX_WINDOW_SIZE)
+        val boundaryMessage = trimmed.last()
+        val newerCursor = QueryBatchCursor(
+            paging = TimeRowCursor(
+                UnixTimeUtc(boundaryMessage.created),
+                0L
+            )
+        )
+        return Triple(trimmed, newerCursor, true)
+    }
+
+    /**
+     * Trim messages from the head (oldest end) when the list exceeds MAX_WINDOW_SIZE.
+     * Returns the trimmed list, updated olderCursor, and updated hasOlderMessages.
+     */
+    private fun trimHead(
+        messages: List<MessageUiModel>,
+        currentOlderCursor: QueryBatchCursor?,
+        currentHasOlder: Boolean,
+    ): Triple<List<MessageUiModel>, QueryBatchCursor?, Boolean> {
+        if (messages.size <= MAX_WINDOW_SIZE) {
+            return Triple(messages, currentOlderCursor, currentHasOlder)
+        }
+        val trimmed = messages.takeLast(MAX_WINDOW_SIZE)
+        val boundaryMessage = trimmed.first()
+        val olderCursor = QueryBatchCursor(
+            paging = TimeRowCursor(
+                UnixTimeUtc(boundaryMessage.created),
+                Long.MAX_VALUE
+            )
+        )
+        return Triple(trimmed, olderCursor, true)
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -387,6 +387,18 @@ fun ConversationContent(
                     ) {
                         items(uiState.messages, key = { message -> message.id }) { messageItem ->
                             when (messageItem) {
+                                is MessageListContentModel.LoadingOlder -> {
+                                    Box(
+                                        modifier = Modifier.fillMaxWidth().padding(16.dp),
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        CircularProgressIndicator(
+                                            modifier = Modifier.width(24.dp).height(24.dp),
+                                            strokeWidth = 2.dp,
+                                        )
+                                    }
+                                }
+
                                 is MessageListContentModel.Header -> {
                                     Column {
                                         AvatarNameDisplay(
@@ -439,6 +451,18 @@ fun ConversationContent(
                                         uploadStatus = uiState.uploadProgress[messageItem.message.id],
                                     )
                                 }
+
+                                is MessageListContentModel.LoadingNewer -> {
+                                    Box(
+                                        modifier = Modifier.fillMaxWidth().padding(16.dp),
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        CircularProgressIndicator(
+                                            modifier = Modifier.width(24.dp).height(24.dp),
+                                            strokeWidth = 2.dp,
+                                        )
+                                    }
+                                }
                             }
                         }
                         // If only one message item (the header) show no messages info
@@ -462,8 +486,13 @@ fun ConversationContent(
                         ) {
                             SmallFloatingActionButton(
                                 onClick = {
-                                    coroutineScope.launch {
-                                        listState.animateScrollToItem(listState.layoutInfo.totalItemsCount - 1)
+                                    if (uiState.hasNewerMessages) {
+                                        // User is deep in history - reload latest messages
+                                        onUiAction(ConversationListUiAction.ScrollToLatest(conversation.conversation.id))
+                                    } else {
+                                        coroutineScope.launch {
+                                            listState.animateScrollToItem(listState.layoutInfo.totalItemsCount - 1)
+                                        }
                                     }
                                 },
                                 containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
@@ -20,6 +20,7 @@ import co.touchlab.kermit.Logger
 import com.mohamedrejeb.richeditor.model.RichTextState
 import id.homebase.chat.conversationlist.ConversationListUiAction
 import id.homebase.chat.conversationlist.ConversationListUiAction.CloseFullScreenOverlay
+import id.homebase.chat.services.PaginatedConversationState.Companion.LOAD_MORE_THRESHOLD
 import id.homebase.chat.conversationlist.ConversationListUiAction.DeleteMessage
 import id.homebase.chat.conversationlist.ConversationListUiAction.DownloadMedia
 import id.homebase.chat.conversationlist.ConversationListUiAction.DownloadVideoMedia
@@ -95,6 +96,15 @@ fun ConversationMessagesPane(
         }
     }
 
+    val seen = remember(conversation.conversation.id) { mutableSetOf<Uuid>() }
+    val messageIdByKey = remember(uiState.messages) {
+        uiState.messages.associateNotNull { item ->
+            if (item is MessageListContentModel.Message) {
+                item.id to item.message.id
+            } else null
+        }
+    }
+
     // Save scroll position when it changes
     LaunchedEffect(listState) {
         val conversationId = conversation.conversation.id
@@ -106,13 +116,40 @@ fun ConversationMessagesPane(
                 // and not restoring
                 if (!uiState.isLoadingMessages) {
                     Logger.i("Scroll changed: id=${conversationId} -> $index:$offset")
+
+                    // Resolve the first visible message's uniqueId for anchor-based persistence
+                    val anchorMessageId = listState.layoutInfo.visibleItemsInfo
+                        .firstNotNullOfOrNull { itemInfo ->
+                            val key = itemInfo.key as? String ?: return@firstNotNullOfOrNull null
+                            messageIdByKey[key]
+                        }
+
                     onUiAction(
                         SaveScrollPosition(
                             conversationId = conversationId,
                             firstVisibleItemIndex = index,
-                            firstVisibleItemScrollOffset = offset
+                            firstVisibleItemScrollOffset = offset,
+                            anchorMessageId = anchorMessageId,
                         )
                     )
+                }
+            }
+    }
+
+    // Edge detection: load older/newer messages as user scrolls near boundaries
+    LaunchedEffect(listState, uiState.hasOlderMessages, uiState.hasNewerMessages) {
+        val conversationId = conversation.conversation.id
+        snapshotFlow { listState.firstVisibleItemIndex to listState.layoutInfo.totalItemsCount }
+            .distinctUntilChanged()
+            .collect { (index, totalItems) ->
+                if (totalItems == 0) return@collect
+                // Near the top - load older messages
+                if (index < LOAD_MORE_THRESHOLD && uiState.hasOlderMessages && !uiState.isLoadingOlder) {
+                    onUiAction(ConversationListUiAction.LoadOlderMessages(conversationId))
+                }
+                // Near the bottom - load newer messages
+                if (index > totalItems - LOAD_MORE_THRESHOLD && uiState.hasNewerMessages && !uiState.isLoadingNewer) {
+                    onUiAction(ConversationListUiAction.LoadNewerMessages(conversationId))
                 }
             }
     }
@@ -123,15 +160,6 @@ fun ConversationMessagesPane(
                 uiState.scrollPosition.firstVisibleItemIndex,
                 uiState.scrollPosition.firstVisibleItemScrollOffset
             )
-        }
-    }
-
-    val seen = remember(conversation.conversation.id) { mutableSetOf<Uuid>() }
-    val messageIdByKey = remember(uiState.messages) {
-        uiState.messages.associateNotNull { item ->
-            if (item is MessageListContentModel.Message) {
-                item.id to item.message.id
-            } else null
         }
     }
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/settings/UserPreferences.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/settings/UserPreferences.kt
@@ -59,6 +59,14 @@ class UserPreferences(private val settings: Settings) {
     fun setConversationScrollOffset(conversationId: String, position: Int) {
         settings.putInt("conversationScrollOffset-$conversationId", position)
     }
+
+    fun getConversationScrollMessageId(conversationId: String): String? {
+        return settings.getStringOrNull("conversationScrollMessageId-$conversationId")
+    }
+
+    fun setConversationScrollMessageId(conversationId: String, messageId: String) {
+        settings.putString("conversationScrollMessageId-$conversationId", messageId)
+    }
 }
 
 data class PreferenceState(

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/util/ScrollPosition.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/util/ScrollPosition.kt
@@ -1,10 +1,12 @@
 package id.homebase.core.util
 
 import androidx.compose.runtime.Immutable
+import kotlin.uuid.Uuid
 
 @Immutable
 data class ScrollPosition(
     val firstVisibleItemIndex: Int = 0,
     val firstVisibleItemScrollOffset: Int = 0,
+    val anchorMessageId: Uuid? = null,
     val triggerScroll: Boolean = false,
 )


### PR DESCRIPTION
EXPERIMENTAL DONT MERGE!

Replace the single 1000-message load with a windowed pagination system that loads 75 messages per page and supports bidirectional scrolling.

- Add PaginatedConversationState with MessageWindow model that tracks messages, cursors for both directions, and loading state
- Add sortOrder parameter to fetchMessages for OldestFirst queries
- Add loadConversationAroundMessage for restoring scroll position and jump-to-message by loading pages in both directions around a target
- Add loadOlderMessages/loadNewerMessages triggered by scroll proximity
- Trim far end of message window when exceeding 300 items
- Save/restore scroll position by message uniqueId (anchorMessageId)
- Real-time messages only append when user is at bottom of conversation
- Scroll-to-bottom FAB reloads latest page when deep in history
- Add loading spinner indicators at top/bottom during page fetches