### PR TITLE
fix: scroll to bottom when opening conversation from notification

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -280,14 +280,14 @@ class ConversationListViewModel(
         }
     }
 
-    fun selectConversation(conversationId: Uuid, messageId: Uuid? = null) {
+    fun selectConversation(conversationId: Uuid, messageId: Uuid? = null, scrollToBottom: Boolean = false) {
         // Check for pending shared content (from iOS share extension or other handoff)
         viewModelScope.launch {
             processPendingSharedContent(conversationId)
         }
 
         ActiveConversation.selectConversation(conversationId)
-        loadMessagesForConversation(conversationId, messageId)
+        loadMessagesForConversation(conversationId, messageId, scrollToBottom)
     }
 
     fun eventConsumed() {
@@ -1589,7 +1589,7 @@ class ConversationListViewModel(
         }
     }
 
-    private fun loadMessagesForConversation(conversationId: Uuid, messageIdForScroll: Uuid?) {
+    private fun loadMessagesForConversation(conversationId: Uuid, messageIdForScroll: Uuid?, scrollToBottom: Boolean = false) {
         _messagesUiState.update { it.copy(scrollPosition = null, isLoadingMessages = true) }
 
 
@@ -1658,7 +1658,7 @@ class ConversationListViewModel(
                                     isLoadingMessages = false,
                                     messages = messagesModels.toPersistentList(),
                                     scrollPosition = if (indexOfMessageForScroll == null) {
-                                        if (setInitialScroll) getScrollPosition(conversationId) else null
+                                        if (setInitialScroll && !scrollToBottom) getScrollPosition(conversationId) else null
                                     } else {
                                         ScrollPosition(
                                             indexOfMessageForScroll,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonPrimitive
 import kotlin.io.encoding.Base64
+import kotlin.time.Duration.Companion.seconds
 import kotlin.uuid.Uuid
 
 class ChatMessageStream(
@@ -60,6 +61,7 @@ class ChatMessageStream(
     private val conversationState = ActiveConversationState()
     private val chatDrive = chatTargetDrive.alias
     private val loadedConversations = mutableSetOf<Uuid>()
+    private val conversationLoadTimestamps = mutableMapOf<Uuid, kotlin.time.TimeMark>()
 
     // Messages for open conversations are loaded on demand via loadConversation().
     // All subsequent updates arrive incrementally through BatchReceived events —
@@ -103,6 +105,7 @@ class ChatMessageStream(
     suspend fun loadConversation(conversationId: Uuid) {
         Logger.d("ChatMessageStream: loadConversation($conversationId)")
         loadedConversations += conversationId
+        conversationLoadTimestamps[conversationId] = kotlin.time.TimeSource.Monotonic.markNow()
         val result = fetchMessages(conversationId)
         Logger.d("ChatMessageStream: loadConversation($conversationId) → ${result.records.size} messages")
         conversationState.set(conversationId, result.records)
@@ -120,6 +123,21 @@ class ChatMessageStream(
         Logger.d("ChatMessageStream: processIncrementalBatch ${messages.size} messages across ${grouped.size} conversation(s)")
         grouped.forEach { (conversationId, msgs) ->
             conversationState.upsert(conversationId, msgs)
+        }
+    }
+
+    private suspend fun refreshLoadedConversations() {
+        val snapshot = loadedConversations.toSet()
+        Logger.d("ChatMessageStream: refreshLoadedConversations called, ${snapshot.size} active conversations")
+        snapshot.forEach { conversationId ->
+            val loadedAt = conversationLoadTimestamps[conversationId]
+            if (loadedAt != null && loadedAt.elapsedNow() < REFRESH_COOLDOWN) {
+                Logger.d("ChatMessageStream: skipping refresh for $conversationId (loaded ${loadedAt.elapsedNow()} ago)")
+                return@forEach
+            }
+            val result = fetchMessages(conversationId)
+            Logger.d("ChatMessageStream: fetchMessages($conversationId) → ${result.records.size} messages")
+            conversationState.set(conversationId, result.records)
         }
     }
 
@@ -330,6 +348,7 @@ class ChatMessageStream(
     }
 
     companion object {
+        private val REFRESH_COOLDOWN = 5.seconds
 
         private fun getDeliveryStatus(header: HomebaseFile): ChatDeliveryStatus {
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -158,7 +158,7 @@ fun AppNavHost(
             when (event) {
                 is NotificationNavigationEvent.OpenConversation -> {
                     Uuid.parseOrNull(event.conversationId)?.let {
-                        navController.selectConversationOnChatList(it)
+                        navController.selectConversationOnChatList(it, scrollToBottom = true)
                     }
                     navController.popBackStack(Route.ChatList, inclusive = false)
                 }
@@ -307,11 +307,13 @@ fun AppNavHost(
                         if (isAuthenticated) {
                             val conversationListViewModel: ConversationListViewModel = koinViewModel()
                             val pendingConversationId by backStackEntry.savedStateHandle.getStateFlow<String?>("pendingConversationId", null).collectAsState()
+                            val pendingScrollToBottom by backStackEntry.savedStateHandle.getStateFlow("pendingScrollToBottom", false).collectAsState()
                             LaunchedEffect(pendingConversationId) {
                                 pendingConversationId?.let { idStr ->
                                     Uuid.parseOrNull(idStr)?.let {
-                                        conversationListViewModel.selectConversation(it)
+                                        conversationListViewModel.selectConversation(it, scrollToBottom = pendingScrollToBottom)
                                         backStackEntry.savedStateHandle["pendingConversationId"] = null
+                                        backStackEntry.savedStateHandle["pendingScrollToBottom"] = false
                                     }
                                 }
                             }
@@ -545,8 +547,9 @@ fun AppNavHost(
     }
 }
 
-private fun NavHostController.selectConversationOnChatList(conversationId: Uuid) {
+private fun NavHostController.selectConversationOnChatList(conversationId: Uuid, scrollToBottom: Boolean = false) {
     getBackStackEntry<Route.ChatList>().savedStateHandle["pendingConversationId"] = conversationId.toString()
+    getBackStackEntry<Route.ChatList>().savedStateHandle["pendingScrollToBottom"] = scrollToBottom
 }
 
 sealed class TopLevelRoute(


### PR DESCRIPTION
DONT MERGE NEEDS TESTING

When tapping a notification, the app was restoring the old saved scroll position instead of scrolling to the bottom where the new message is. Additionally, background sync events (refreshLoadedConversations) could clobber the scroll position during the initial load window.

- Pass scrollToBottom flag from notification intent through to ViewModel
- Skip saved scroll position restoration when scrollToBottom is true
- Add 5-second cooldown per conversation in refreshLoadedConversations to prevent sync events from resetting scroll during initial load