### PR TITLE
fix: use incremental BatchReceived updates instead of full re-read on syncStop events

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -59,10 +59,11 @@ class ChatMessageStream(
 
     private val conversationState = ActiveConversationState()
     private val chatDrive = chatTargetDrive.alias
-    private var isSyncing = false
-    private var syncedMessageCount = 0
     private val loadedConversations = mutableSetOf<Uuid>()
 
+    // Messages for open conversations are loaded on demand via loadConversation().
+    // All subsequent updates arrive incrementally through BatchReceived events —
+    // we do not re-read from DB on DriveEvent.Stopped (same rationale as ConversationStream).
     init {
         scope.launch {
             eventBus.events.collect { event ->
@@ -74,39 +75,14 @@ class ChatMessageStream(
                 if (event !is BackendEvent.DriveEvent || event.driveId != chatDrive) return@collect
 
                 when (event) {
-                    is BackendEvent.DriveEvent.Started -> {
-                        isSyncing = true
-                        syncedMessageCount = 0
-                    }
+                    is BackendEvent.DriveEvent.Started -> { }
 
                     is BackendEvent.DriveEvent.Stopped -> {
-                        isSyncing = false
-                        if (event.totalCount > 0) {
-                            Logger.d("ChatMessageStream: Stopped with totalCount=${event.totalCount}, syncedMessageCount=$syncedMessageCount")
-                            refreshLoadedConversations()
-                        } else {
-                            Logger.d("ChatMessageStream: Stopped with totalCount=0, skipping refresh")
-                        }
+                        Logger.d("ChatMessageStream: Stopped(totalCount=${event.totalCount})")
                     }
 
                     is BackendEvent.DriveEvent.BatchReceived -> {
-                        if (!isSyncing) {
-                            processIncrementalBatch(event.batchData)
-                        } else {
-                            val messageFiles = event.batchData.count {
-                                it.fileMetadata.appData.fileType == ChatProtocol.MessageFileType
-                            }
-                            val conversationFiles = event.batchData.count {
-                                it.fileMetadata.appData.fileType == ChatProtocol.ConversationFileType
-                            }
-                            val otherFiles = event.batchData.size - messageFiles - conversationFiles
-                            syncedMessageCount += messageFiles
-                            Logger.d(
-                                "ChatMessageStream: BatchReceived suppressed (isSyncing=true), " +
-                                "${event.batchData.size} files (messages=$messageFiles, " +
-                                "conversations=$conversationFiles, other=$otherFiles)"
-                            )
-                        }
+                        processIncrementalBatch(event.batchData)
                     }
                 }
             }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -116,7 +116,9 @@ class ChatMessageStream(
                 .filter { it.fileMetadata.appData.fileType == ChatProtocol.MessageFileType }
                 .mapNotNull { mapToMessageData(it, credentialsManager, ::resolveDisplayName) }
 
-        messages.groupBy { it.conversationId }.forEach { (conversationId, msgs) ->
+        val grouped = messages.groupBy { it.conversationId }
+        Logger.d("ChatMessageStream: processIncrementalBatch ${messages.size} messages across ${grouped.size} conversation(s)")
+        grouped.forEach { (conversationId, msgs) ->
             conversationState.upsert(conversationId, msgs)
         }
     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -97,6 +97,9 @@ class ChatMessageStream(
             .map { ChatMessagesData.Messages(it[conversationId].orEmpty()) }
             .stateIn(scope, SharingStarted.WhileSubscribed(5_000), ChatMessagesData.Initializing)
 
+    // Full message load from local DB for a single conversation.
+    // Called when the user opens a conversation (ConversationListViewModel.selectConversation).
+    // Do NOT call from DriveEvent.Stopped or other sync events — see init block above.
     suspend fun loadConversation(conversationId: Uuid) {
         Logger.d("ChatMessageStream: loadConversation($conversationId)")
         loadedConversations += conversationId
@@ -115,16 +118,6 @@ class ChatMessageStream(
 
         messages.groupBy { it.conversationId }.forEach { (conversationId, msgs) ->
             conversationState.upsert(conversationId, msgs)
-        }
-    }
-
-    private suspend fun refreshLoadedConversations() {
-        val snapshot = loadedConversations.toSet()
-        Logger.d("ChatMessageStream: refreshLoadedConversations called, ${snapshot.size} active conversations")
-        snapshot.forEach { conversationId ->
-            val result = fetchMessages(conversationId)
-            Logger.d("ChatMessageStream: fetchMessages($conversationId) → ${result.records.size} messages")
-            conversationState.set(conversationId, result.records)
         }
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -99,6 +99,10 @@ class ConversationStream(
                                         ChatProtocol.MessageFileType
                             }
 
+                        Logger.d("ConversationStream: BatchReceived " +
+                                "${event.batchData.size} files " +
+                                "(conversations=${conversationFiles.size}, messages=${messageFiles.size})")
+
                         if (conversationFiles.isNotEmpty())
                             processConversationBatchIncrementally(conversationFiles)
 
@@ -160,6 +164,7 @@ class ConversationStream(
                             m.isAuthoredBy(credentialsManager.getActiveDomain())
                     )
 
+                Logger.w("ConversationStream: message arrived for unknown conversation ${m.conversationId}, creating placeholder")
                 insertNewConversation(emptyConversation)
             } else {
                 updateConversationFromNewMessage(matchingConversation, m)
@@ -272,6 +277,7 @@ class ConversationStream(
     // Do NOT call from DriveEvent.Stopped or other sync events — see init block above.
     fun start() {
         if (loadJob?.isActive == true) return
+        Logger.d("ConversationStream: start() — loading full conversation list from DB")
         loadJob = scope.launch {
             loadConversations()
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -263,6 +263,13 @@ class ConversationStream(
         _conversations.value = ConversationsData(items = result)
     }
 
+    // Full conversation list load from local DB.  Idempotent (skips if already running).
+    // Intended call sites — all user-initiated or startup:
+    //   - AppModule onPostAuthenticated  (auth startup, preloads while UI composes)
+    //   - ConversationListViewModel init (user navigates to list)
+    //   - ArchivedConversationsViewModel init (user opens archived screen)
+    //   - GroupSettingsViewModel init     (user opens group settings)
+    // Do NOT call from DriveEvent.Stopped or other sync events — see init block above.
     fun start() {
         if (loadJob?.isActive == true) return
         loadJob = scope.launch {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -50,7 +50,6 @@ class ConversationStream(
     private val chatDrive = chatTargetDrive.alias
     private val _conversations = MutableStateFlow(ConversationsData(dataReady = false))
     private val _shareableConversations = MutableStateFlow<List<ShareableConversation>>(emptyList())
-    private var isSyncing = false // Track if chat drive sync is in progress
     private var loadJob: Job? = null
     private var shareCacheJob: Job? = null
 
@@ -62,6 +61,14 @@ class ConversationStream(
     val shareableConversations: StateFlow<List<ShareableConversation>> =
         _shareableConversations.asStateFlow()
 
+    // The full conversation list is loaded once from the local DB on authentication
+    // (via start(), called from onPostAuthenticated in AppModule).
+    //
+    // After that, all updates — whether from a reconnect syncAll() or a single WS
+    // file notification — arrive as BatchReceived events and are applied incrementally.
+    // We intentionally do NOT re-read the full list on DriveEvent.Stopped; the
+    // incremental BatchReceived path is sufficient and avoids an expensive full reload
+    // on every incoming message.
     init {
         scope.launch {
             eventBus.events.collect { event ->
@@ -71,51 +78,32 @@ class ConversationStream(
                     return@collect
                 }
 
-
                 if (event !is BackendEvent.DriveEvent || event.driveId != chatDrive) return@collect
 
                 when (event) {
+                    is BackendEvent.DriveEvent.Started -> { }
 
-
-                    is BackendEvent.DriveEvent.Started -> {
-                        isSyncing = true
-                    }
-
-                    is BackendEvent.DriveEvent.Stopped -> when (event.result) {
-                        is BackendEvent.DriveResult.Success -> {
-                            isSyncing = false
-                            Logger.d("ConversationStream: Stopped(totalCount=${event.totalCount})")
-                            if (event.totalCount > 0) start()
-                        }
-
-                        is BackendEvent.DriveResult.Failure -> {
-                            isSyncing = false
-                            Logger.e { "Failed during drive sync" }
-                            Logger.d("ConversationStream: Stopped(FAILED, totalCount=${event.totalCount})")
-                            if (event.totalCount > 0) start()
-                        }
+                    is BackendEvent.DriveEvent.Stopped -> {
+                        Logger.d("ConversationStream: Stopped(totalCount=${event.totalCount})")
                     }
 
                     is BackendEvent.DriveEvent.BatchReceived -> {
-                        if (!isSyncing) {
-                            val conversationFiles =
-                                event.batchData.filter {
-                                    it.fileMetadata.appData.fileType ==
-                                            ChatProtocol.ConversationFileType
-                                }
-                            val messageFiles =
-                                event.batchData.filter {
-                                    it.fileMetadata.appData.fileType ==
-                                            ChatProtocol.MessageFileType
-                                }
+                        val conversationFiles =
+                            event.batchData.filter {
+                                it.fileMetadata.appData.fileType ==
+                                        ChatProtocol.ConversationFileType
+                            }
+                        val messageFiles =
+                            event.batchData.filter {
+                                it.fileMetadata.appData.fileType ==
+                                        ChatProtocol.MessageFileType
+                            }
 
-                            if (!conversationFiles.isEmpty())
-                                processConversationBatchIncrementally(conversationFiles)
+                        if (conversationFiles.isNotEmpty())
+                            processConversationBatchIncrementally(conversationFiles)
 
-                            if (!messageFiles.isEmpty())
-                                processMessageBatchIncrementally(messageFiles)
-                        }
-                        // Ignore during sync; refresh() will cover it post-Completed
+                        if (messageFiles.isNotEmpty())
+                            processMessageBatchIncrementally(messageFiles)
                     }
                 }
             }


### PR DESCRIPTION
ConversationStream and ChatMessageStream previously re-read the entire conversation list / message history from the DB every time a DriveEvent.Stopped fired for the chat drive. Since every WS file notification triggers a syncDrive() → Stopped cycle, this caused a full re-read on every incoming message.

The full list is already loaded from local DB on authentication (onPostAuthenticated). After that, BatchReceived events — emitted by both reconnect syncAll() and individual syncDrive() calls — carry the file data needed for incremental updates. Remove the isSyncing suppression so BatchReceived is always processed, and remove the Stopped-triggered refreshes that are no longer needed.