### PR TITLE
Trying to fix the 'sync' issue on receiving messages

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
@@ -16,12 +16,9 @@ import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.MainIndexMetaHelpers
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -101,7 +98,6 @@ class DriveSync(
     private suspend fun performSync() {
         var totalCount = 0
         var queryBatchResponse: QueryBatchResponse? = null
-        val dbDeferreds = mutableListOf<Deferred<Unit>>()
 
         eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
 
@@ -132,8 +128,6 @@ class DriveSync(
 
                     if (queryBatchResponse.cursorState != null)
                         cursor = QueryBatchCursor.fromJson(queryBatchResponse.cursorState)
-                    // Snapshot cursor into a local val so the fire-and-forget DB coroutine below
-                    // always uses this batch's cursor, not whatever `cursor` is when it eventually runs.
                     Logger.i("Received ${queryBatchResponse.searchResults.size} records from QueryBatch() on Drive $driveId")
 
                     val searchResults = queryBatchResponse.searchResults
@@ -149,19 +143,14 @@ class DriveSync(
                         totalCount += recordsRead
                         val batchCursorToSave = cursor
 
-                        // Run DB operation in background without waiting - fire and forget
-                        val job = scope.async {
-                            val dbMs = measureTimedValue {
-                                fileHeaderProcessor.baseUpsertEntryZapZap(
-                                    identityId = identityId,
-                                    driveId = driveId,
-                                    fileHeaders = searchResults,
-                                    cursor = batchCursorToSave
-                                )
-                            }
-                            // Logger.i("DB insert time $dbMs for ${searchResults.size} rows")
-                        }
-                        dbDeferreds.add(job)
+                        // Write to DB before emitting event to ensure DB is consistent
+                        // when any event handler (e.g. loadConversation) reads from it.
+                        fileHeaderProcessor.baseUpsertEntryZapZap(
+                            identityId = identityId,
+                            driveId = driveId,
+                            fileHeaders = searchResults,
+                            cursor = batchCursorToSave
+                        )
 
                         val latestModified = searchResults.last().fileMetadata.updated
 
@@ -218,14 +207,7 @@ class DriveSync(
             }
         }
 
-        try {
-            dbDeferreds.awaitAll()  // Suspends until all complete; rethrows the first exception if any
-            Logger.d("DriveSync: all DB writes complete for drive $driveId ($totalCount total records)")
-            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, totalCount, BackendEvent.DriveResult.Success))
-            Logger.d("Drive $driveId synchronized with $totalCount records read.")
-        } catch (e: Exception) {
-            Logger.e("Sync failed due to DB error: ${e.message}")
-            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, totalCount, BackendEvent.DriveResult.Failure(e.message ?: "DB upsert failed")))
-        }
+        eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, totalCount, BackendEvent.DriveResult.Success))
+        Logger.d("Drive $driveId synchronized with $totalCount records read.")
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ActiveConversationState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ActiveConversationState.kt
@@ -4,6 +4,7 @@ import id.homebase.chat.data.MessageUiModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlin.uuid.Uuid
 
 class ActiveConversationState {
@@ -15,28 +16,30 @@ class ActiveConversationState {
         _messages.asStateFlow()
 
     fun set(conversationId: Uuid, messages: List<MessageUiModel>) {
-        _messages.value =
-            _messages.value.toMutableMap().apply {
+        _messages.update { current ->
+            current.toMutableMap().apply {
                 this[conversationId] = messages
             }
+        }
     }
 
     fun removeMessage(messageId: Uuid) {
-        _messages.value = _messages.value.mapValues { (_, messages) ->
-            messages.filter { it.id != messageId }
+        _messages.update { current ->
+            current.mapValues { (_, messages) ->
+                messages.filter { it.id != messageId }
+            }
         }
     }
 
     fun upsert(conversationId: Uuid, incoming: List<MessageUiModel>) {
         if (incoming.isEmpty()) return
 
-        val updated =
-            _messages.value.toMutableMap().apply {
-                val current = this[conversationId].orEmpty()
-                this[conversationId] = upsertMessages(current, incoming)
+        _messages.update { current ->
+            current.toMutableMap().apply {
+                val existing = this[conversationId].orEmpty()
+                this[conversationId] = upsertMessages(existing, incoming)
             }
-
-        _messages.value = updated
+        }
     }
 
     private fun upsertMessages(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -46,7 +46,6 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonPrimitive
 import kotlin.io.encoding.Base64
-import kotlin.time.Duration.Companion.seconds
 import kotlin.uuid.Uuid
 
 class ChatMessageStream(
@@ -60,8 +59,6 @@ class ChatMessageStream(
 
     private val conversationState = ActiveConversationState()
     private val chatDrive = chatTargetDrive.alias
-    private val loadedConversations = mutableSetOf<Uuid>()
-    private val conversationLoadTimestamps = mutableMapOf<Uuid, kotlin.time.TimeMark>()
 
     // Messages for open conversations are loaded on demand via loadConversation().
     // All subsequent updates arrive incrementally through BatchReceived events —
@@ -104,8 +101,6 @@ class ChatMessageStream(
     // Do NOT call from DriveEvent.Stopped or other sync events — see init block above.
     suspend fun loadConversation(conversationId: Uuid) {
         Logger.d("ChatMessageStream: loadConversation($conversationId)")
-        loadedConversations += conversationId
-        conversationLoadTimestamps[conversationId] = kotlin.time.TimeSource.Monotonic.markNow()
         val result = fetchMessages(conversationId)
         Logger.d("ChatMessageStream: loadConversation($conversationId) → ${result.records.size} messages")
         conversationState.set(conversationId, result.records)
@@ -123,21 +118,6 @@ class ChatMessageStream(
         Logger.d("ChatMessageStream: processIncrementalBatch ${messages.size} messages across ${grouped.size} conversation(s)")
         grouped.forEach { (conversationId, msgs) ->
             conversationState.upsert(conversationId, msgs)
-        }
-    }
-
-    private suspend fun refreshLoadedConversations() {
-        val snapshot = loadedConversations.toSet()
-        Logger.d("ChatMessageStream: refreshLoadedConversations called, ${snapshot.size} active conversations")
-        snapshot.forEach { conversationId ->
-            val loadedAt = conversationLoadTimestamps[conversationId]
-            if (loadedAt != null && loadedAt.elapsedNow() < REFRESH_COOLDOWN) {
-                Logger.d("ChatMessageStream: skipping refresh for $conversationId (loaded ${loadedAt.elapsedNow()} ago)")
-                return@forEach
-            }
-            val result = fetchMessages(conversationId)
-            Logger.d("ChatMessageStream: fetchMessages($conversationId) → ${result.records.size} messages")
-            conversationState.set(conversationId, result.records)
         }
     }
 
@@ -348,8 +328,6 @@ class ChatMessageStream(
     }
 
     companion object {
-        private val REFRESH_COOLDOWN = 5.seconds
-
         private fun getDeliveryStatus(header: HomebaseFile): ChatDeliveryStatus {
 
             val count = header.serverMetadata.originalRecipientCount


### PR DESCRIPTION

  Change 1 — DriveSync.kt: Removed the fire-and-forget scope.async wrapper around baseUpsertEntryZapZap(). The DB write now completes before BatchReceived is emitted, eliminating the race where loadConversation() could read stale DB data and wipe in-memory messages. Removed dbDeferreds list and awaitAll().  Removed unused imports (Deferred, async, awaitAll).

  Change 2 — ActiveConversationState.kt: Replaced non-atomic _messages.value = _messages.value.toMutableMap()... with _messages.update { } in set(), removeMessage(), and upsert(). This uses CAS internally to prevent lost updates from concurrent coroutines.

  Change 3 — ChatMessageStream.kt: Removed dead code: refreshLoadedConversations(), loadedConversations, conversationLoadTimestamps, REFRESH_COOLDOWN, and unused seconds import. All were orphaned after commit 0b14bf29.

Tests pass (homebase-api:jvmTest and homebase-chat:jvmTest).
