### PR TITLE
Fix edited messages changing position in chat list

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -102,7 +102,7 @@ sealed interface ConversationListContentModel {
 sealed class MessageListContentModel(val id: String) {
     data object Header : MessageListContentModel("header")
     data class Section(val date: LocalDate) : MessageListContentModel(date.toString())
-    data class System(val text: String, val created: Instant) : MessageListContentModel(created.toString())
+    data class System(val text: String, val userDate: Instant) : MessageListContentModel(userDate.toString())
     data class Message(val message: MessageUiModel) :
         MessageListContentModel(message.id.toString() + message.versionTag.toString() + message.hasMore)
 }
@@ -132,7 +132,7 @@ sealed interface FullScreenOverlay {
     data class ViewMessageData(
         val messageId: Uuid,
         val title: String,
-        val created: Instant,
+        val userDate: Instant,
         val content: String,
         val fileId: Uuid,
         val driveId: Uuid,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -1010,7 +1010,7 @@ class ConversationListViewModel(
                                             messageId = action.message.id,
                                             title = action.message.originalAuthor?.domainName
                                                 ?: "null",
-                                            created = action.message.created,
+                                            userDate = action.message.userDate,
                                             content = action.message.content,
                                             fileId = action.message.fileId,
                                             driveId = chatTargetDrive.alias,
@@ -1613,8 +1613,8 @@ class ConversationListViewModel(
                             // Group messages within day sections
                             val timezone = TimeZone.currentSystemDefault()
                             val groupedMessages =
-                                messages.sortedBy { it.created }.groupBy { message ->
-                                    val date = message.created.toLocalDateTime(timezone).date
+                                messages.sortedBy { it.userDate }.groupBy { message ->
+                                    val date = message.userDate.toLocalDateTime(timezone).date
                                     date
                                 }
                             val messagesModels: MutableList<MessageListContentModel> =
@@ -1623,7 +1623,7 @@ class ConversationListViewModel(
                             messagesModels.addAll(groupedMessages.flatMap { (date, messages) ->
                                 listOf(MessageListContentModel.Section(date)) + messages.map {
                                     if (it.isStatusMessage)
-                                        MessageListContentModel.System(it.content, it.created)
+                                        MessageListContentModel.System(it.content, it.userDate)
                                     else
                                         MessageListContentModel.Message(it)
                                 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/ConversationUiModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/ConversationUiModel.kt
@@ -58,10 +58,10 @@ data class ConversationUiModel(
             activeUserDomain: OdinId?
         ): ConversationUiModel {
             // TODO: Should we also increase unread count here if it's a new message?
-            if (msg.created >= timestamp) {
+            if (msg.userDate >= timestamp) {
                 return this.copy(
                     lastMessage = msg.content.truncateToCodePoints(40),
-                    timestamp = msg.created,
+                    timestamp = msg.userDate,
                     lastMessageDeliveryStatus = msg.messageAppData.deliveryStatus,
                     lastMessageIsDeleted = msg.isDeleted,
                     lastMessageFirstPayload = msg.payloads?.firstOrNull(),

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/MessageUiModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/MessageUiModel.kt
@@ -22,7 +22,7 @@ data class MessageUiModel(
     val fileId: Uuid, // fileId
     val conversationId: Uuid, // groupId
     val content: String, // the message
-    val created: Instant, // When the message was created by the author
+    val userDate: Instant, // User-specified message timestamp (from appData.userDate)
     val modified: Instant?, // When the message was last modified
     val originalAuthor: OdinId?,
     val displayName: String,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoScreen.kt
@@ -137,7 +137,7 @@ fun MessageInfoUi(
                 Text(
                     text = stringResource(
                         MR.string.label_sent,
-                        uiState.message?.created?.let { formateDateTime(it) } ?: "",
+                        uiState.message?.userDate?.let { formateDateTime(it) } ?: "",
                     ),
                     style = MaterialTheme.typography.bodyMedium,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
@@ -146,7 +146,7 @@ fun MessageInfoUi(
                     text = stringResource(
                         MR.string.label_updated,
                         uiState.message?.modified?.let { formateDateTime(it) }
-                            ?: uiState.message?.created?.let { formateDateTime(it) } ?: "",
+                            ?: uiState.message?.userDate?.let { formateDateTime(it) } ?: "",
                     ),
                     style = MaterialTheme.typography.bodyMedium,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ActiveConversationState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ActiveConversationState.kt
@@ -50,6 +50,6 @@ class ActiveConversationState {
         for (msg in incoming) {
             byId[msg.id] = msg
         }
-        return byId.values.sortedByDescending { it.created }
+        return byId.values.sortedByDescending { it.userDate }
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
@@ -72,7 +72,7 @@ class ChatMessageActionService(
 
         Logger.d { "Calling mark-as-read for unread-records count: ${unreadRecords.size}" }
 
-        val endTime = unreadRecords.maxOf { it.created }
+        val endTime = unreadRecords.maxOf { it.userDate }
 
         Logger.d { "Upserting chatReadCount->lastReadTime=${newReadTime.milliseconds} for $conversationId" }
         dbm.chatReadCount.upsertLastReadTime(conversationId, newReadTime)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
@@ -340,7 +340,7 @@ class ChatMessageSenderService(
                 groupId = msg.conversationId,
                 fileType = ChatProtocol.MessageFileType,
                 dataType = 0,
-                userDate = UnixTimeUtc.now().milliseconds,
+                userDate = msg.userDate.toEpochMilliseconds(),
                 content = built.headerContent,
                 previewThumbnail = msg.previewThumbnail
             )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -376,14 +376,17 @@ class ChatMessageStream(
                         header.fileMetadata.appData.archivalStatus == ArchivalStatus.Removed
 
                 if (isDeleted) {
+                    val deletedUserDate = if (appData.userDate == null)
+                        metadata.created
+                    else
+                        minOf(UnixTimeUtc(appData.userDate!!), metadata.created)
+
                     return MessageUiModel(
                         id = appData.uniqueId ?: header.fileId,
                         globalTransitId = metadata.globalTransitId,
                         fileId = header.fileId,
                         conversationId = appData.groupId!!,
-                        created = if (appData.userDate == null)
-                            metadata.created.toInstant() else
-                            UnixTimeUtc(appData.userDate!!).toInstant(),
+                        userDate = deletedUserDate.toInstant(),
                         modified = metadata.updated.toInstant(),
                         originalAuthor = metadata.originalAuthor,
                         displayName = metadata.originalAuthor?.domainName ?: "",
@@ -437,7 +440,7 @@ class ChatMessageStream(
                 else
                     metadata.transitCreated
 
-                val created =
+                val rawUserDate =
                     if (messageAppData.version == null) {
                         // older edited messages; use older logic that seems to drop the
                         // appData.userDate when a message is edited
@@ -461,13 +464,16 @@ class ChatMessageStream(
                             UnixTimeUtc(appData.userDate!!)
                     }
 
+                // Clamp: userDate should never exceed the server-side timestamp
+                val userDate = minOf(rawUserDate, authorSpecificDate)
+
                 return MessageUiModel(
                     id = appData.uniqueId!!,
                     globalTransitId = metadata.globalTransitId,
                     fileId = header.fileId,
                     conversationId = appData.groupId!!,
                     content = messageAppData.getMessage(),
-                    created = created.toInstant(),
+                    userDate = userDate.toInstant(),
                     modified = metadata.updated.toInstant(),
                     originalAuthor = metadata.originalAuthor,
                     displayName = displayName,
@@ -497,7 +503,7 @@ class ChatMessageStream(
                         fileId = header.fileId,
                         conversationId = appData.groupId!!,
                         content = "Failed to parse message from server",
-                        created = metadata.created.toInstant(),
+                        userDate = metadata.created.toInstant(),
                         modified = metadata.updated.toInstant(),
                         originalAuthor = metadata.originalAuthor,
                         displayName = metadata.originalAuthor?.domainName ?: "",

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -140,7 +140,7 @@ class ConversationStream(
                         id = m.conversationId,
                         name = "Pending...",
                         lastMessage = m.content,
-                        timestamp = m.created,
+                        timestamp = m.userDate,
                         admins = (if (m.originalAuthor == null) emptySet() else setOf(m.originalAuthor)),
                         unreadCount = 0,
                         avatarTiny = null,
@@ -180,13 +180,13 @@ class ConversationStream(
         c: ConversationUiModel,
         m: MessageUiModel
     ) {
-        if (m.created > c.timestamp) {
+        if (m.userDate > c.timestamp) {
             val domain = credentialsManager.getActiveDomain()
 
             // new message that was not sent by the current user
             val updatedConversation = c.copy(
                 unreadCount = c.unreadCount + if (!m.isEdited && !m.isAuthoredBy(domain) && !m.isStatusMessage) 1 else 0,
-                timestamp = m.created,
+                timestamp = m.userDate,
                 lastMessage = m.content.truncateToCodePoints(40), // TODO: Global constant
                 lastMessageDeliveryStatus = m.messageAppData.deliveryStatus,
                 lastMessageIsDeleted = m.isDeleted,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
@@ -493,7 +493,7 @@ fun ConversationLisContentItem(
                 memberName = listItem.message.displayName,
                 message = listItem.message.content,
                 contactOdinId = listItem.message.originalAuthor,
-                timestamp = listItem.message.created,
+                timestamp = listItem.message.userDate,
                 onClick = {
                     onUiAction(
                         ConversationListUiAction.ConversationClicked(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenMediaViewer.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenMediaViewer.kt
@@ -213,7 +213,7 @@ fun FullScreenMediaViewer(
                             fontWeight = FontWeight.SemiBold
                         )
                         Text(
-                            text = formatTimestamp(data.created),
+                            text = formatTimestamp(data.userDate),
                             style = MaterialTheme.typography.labelMedium,
                         )
                     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -794,7 +794,7 @@ private fun testMessageUiModel(message: String): MessageUiModel {
         fileId = Uuid.generateV4(),
         conversationId = Uuid.generateV4(),
         content = message,
-        created = Clock.System.now(),
+        userDate = Clock.System.now(),
         modified = null,
         originalAuthor = null,
         displayName = "John Doe",

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -159,7 +159,7 @@ fun MessageBubbleRaw(
         }
     }
 
-    val timestamp = formatMessageTimestamp(message.created)
+    val timestamp = formatMessageTimestamp(message.userDate)
     val messageInfoText =
         if (message.isEdited) "${stringResource(MR.string.chat_message_edited)} $timestamp" else timestamp
     val mediaOnly = remember { !message.content.hasContent() && hasMedia }

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/services/ActiveConversationStateTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/services/ActiveConversationStateTest.kt
@@ -19,7 +19,7 @@ class ActiveConversationStateTest {
             fileId = Uuid.random(),
             conversationId = conversationId,
             content = "test",
-            created = Instant.fromEpochMilliseconds(0),
+            userDate = Instant.fromEpochMilliseconds(0),
             modified = null,
             originalAuthor = null,
             displayName = "Tester",


### PR DESCRIPTION
Editing a message was updating userDate to the current time, causing the message to jump to a new position since messages are sorted by this field.

Three changes:
- Preserve original userDate when editing a message instead of overwriting it with UnixTimeUtc.now()
- Rename MessageUiModel.created → userDate to match the authoritative FileMetadata.appData.userDate field and eliminate confusing naming where the server-side 'created' timestamp was being shadowed
- Clamp userDate to min(userDate, server created) so a rogue client setting a far-future date cannot permanently pin a message to the top