### PR TITLE
Restore pipelined DB writes in DriveSync with correct event ordering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,9 +86,12 @@ Use `expect`/`actual` declarations for platform-specific code. The flag `-Xexpec
 
 homebase-core exports as `ComposeApp` framework, transitively exporting homebase-api and homebase-common. Other modules export individual frameworks (`homebase-commonKit`, `homebase-authKit`, `homebase-chatKit`).
 
-## Android Emulator Logs (adb)
+## Android Emulator/Device Logs (adb)
 
-The Android app (`id.homebase.feed.dev`) logs via Kermit to **both** logcat and an on-device log file.
+`adb` must be in PATH (ships with the Android SDK under `platform-tools/`).
+
+**Package names:** debug = `id.homebase.feed.dev`, release = `id.homebase.feed`.
+The examples below use the debug package; substitute for release as needed.
 
 ### On-device log file (preferred — contains all app-level Kermit logs)
 
@@ -103,8 +106,8 @@ adb shell run-as id.homebase.feed.dev cat files/logs/homebase.log > homebase.log
 adb shell run-as id.homebase.feed.dev cat files/logs/homebase.log | grep -v "^\tat " | tail -50
 ```
 
-The file is at `/data/user/0/id.homebase.feed.dev/files/logs/homebase.log` on the device.
 The `run-as` prefix is required because the app's data directory is not world-readable.
+Note: `run-as` only works on debug builds (or devices with root).
 
 ### Logcat (system-level, includes non-Kermit logs)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,36 @@ Use `expect`/`actual` declarations for platform-specific code. The flag `-Xexpec
 
 homebase-core exports as `ComposeApp` framework, transitively exporting homebase-api and homebase-common. Other modules export individual frameworks (`homebase-commonKit`, `homebase-authKit`, `homebase-chatKit`).
 
+## Android Emulator Logs (adb)
+
+The Android app (`id.homebase.feed.dev`) logs via Kermit to **both** logcat and an on-device log file.
+
+### On-device log file (preferred — contains all app-level Kermit logs)
+
+```bash
+# Read the log file directly
+adb shell run-as id.homebase.feed.dev cat files/logs/homebase.log
+
+# Copy to local machine
+adb shell run-as id.homebase.feed.dev cat files/logs/homebase.log > homebase.log
+
+# Tail recent entries (filter out stack trace lines)
+adb shell run-as id.homebase.feed.dev cat files/logs/homebase.log | grep -v "^\tat " | tail -50
+```
+
+The file is at `/data/user/0/id.homebase.feed.dev/files/logs/homebase.log` on the device.
+The `run-as` prefix is required because the app's data directory is not world-readable.
+
+### Logcat (system-level, includes non-Kermit logs)
+
+```bash
+# Dump recent logs for the app
+adb logcat -d --pid=$(adb shell pidof id.homebase.feed.dev)
+
+# Clear buffer before a fresh capture
+adb logcat -c
+```
+
 ## CI/CD
 
 GitHub Actions workflows in `.github/workflows/`:

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
@@ -16,9 +16,11 @@ import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.MainIndexMetaHelpers
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -98,6 +100,7 @@ class DriveSync(
     private suspend fun performSync() {
         var totalCount = 0
         var queryBatchResponse: QueryBatchResponse? = null
+        var pendingDbJob: Deferred<Unit>? = null
 
         eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
 
@@ -105,6 +108,10 @@ class DriveSync(
         val maxRetries = 3
 
         while (true) {
+            // Wait for previous batch's DB write to complete before starting next network call
+            pendingDbJob?.await()
+            pendingDbJob = null
+
             Logger.i("Synchronizing drive $driveId")
             val request = QueryBatchRequest(
                 queryParams = FileQueryParams(
@@ -142,27 +149,30 @@ class DriveSync(
                         recordsRead = searchResults.size
                         totalCount += recordsRead
                         val batchCursorToSave = cursor
-
-                        // Write to DB before emitting event to ensure DB is consistent
-                        // when any event handler (e.g. loadConversation) reads from it.
-                        fileHeaderProcessor.baseUpsertEntryZapZap(
-                            identityId = identityId,
-                            driveId = driveId,
-                            fileHeaders = searchResults,
-                            cursor = batchCursorToSave
-                        )
-
+                        val batchTotalCount = totalCount
+                        val batchRecordsRead = recordsRead
                         val latestModified = searchResults.last().fileMetadata.updated
 
-                        eventBus.emit(
-                            BackendEvent.DriveEvent.BatchReceived(
+                        // Launch DB write + event emission in background;
+                        // next loop iteration awaits this before starting a new DB write
+                        pendingDbJob = scope.async {
+                            fileHeaderProcessor.baseUpsertEntryZapZap(
+                                identityId = identityId,
                                 driveId = driveId,
-                                totalCount = totalCount,
-                                batchCount = recordsRead,
-                                latestModified = latestModified,
-                                batchData = searchResults
+                                fileHeaders = searchResults,
+                                cursor = batchCursorToSave
                             )
-                        )
+
+                            eventBus.emit(
+                                BackendEvent.DriveEvent.BatchReceived(
+                                    driveId = driveId,
+                                    totalCount = batchTotalCount,
+                                    batchCount = batchRecordsRead,
+                                    latestModified = latestModified,
+                                    batchData = searchResults
+                                )
+                            )
+                        }
                     }
 
                     if (!queryBatchResponse.hasMoreRows)
@@ -207,7 +217,14 @@ class DriveSync(
             }
         }
 
-        eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, totalCount, BackendEvent.DriveResult.Success))
-        Logger.d("Drive $driveId synchronized with $totalCount records read.")
+        try {
+            pendingDbJob?.await()
+            Logger.d("DriveSync: all DB writes complete for drive $driveId ($totalCount total records)")
+            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, totalCount, BackendEvent.DriveResult.Success))
+            Logger.d("Drive $driveId synchronized with $totalCount records read.")
+        } catch (e: Exception) {
+            Logger.e("Sync failed due to DB error: ${e.message}")
+            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, totalCount, BackendEvent.DriveResult.Failure(e.message ?: "DB upsert failed")))
+        }
     }
 }

--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginScreen.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -75,6 +76,7 @@ import id.homebase.resources.login_successful
 import id.homebase.resources.login_title
 import id.homebase.resources.login_try_again_button
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.coroutines.delay
 import kotlinx.collections.immutable.persistentListOf
 import org.jetbrains.compose.resources.stringResource
 
@@ -163,7 +165,8 @@ fun LoginUi(
 
             when {
                 uiState.isLoading -> LoginLoading(
-                    driveProgresses = uiState.driveProgresses
+                    driveProgresses = uiState.driveProgresses,
+                    isPinging = uiState.isPinging
                 )
                 uiState.isAuthenticated -> LoginSuccess()
                 uiState.errorMessage != null ->
@@ -196,7 +199,7 @@ fun LoginUi(
 /* ---------- STATES ---------- */
 
 @Composable
-private fun LoginLoading(driveProgresses: ImmutableList<DriveProgress>) {
+private fun LoginLoading(driveProgresses: ImmutableList<DriveProgress>, isPinging: Boolean = false) {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         Text(
             text = stringResource(MR.string.loading),
@@ -212,6 +215,21 @@ private fun LoginLoading(driveProgresses: ImmutableList<DriveProgress>) {
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+            if (isPinging) {
+                var secondsLeft by remember { mutableIntStateOf(15) }
+                LaunchedEffect(Unit) {
+                    while (secondsLeft > 0) {
+                        delay(1000)
+                        secondsLeft--
+                    }
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "Timeout in ${secondsLeft}s",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
         } else {
             driveProgresses.forEach { drive ->
                 DriveProgressRow(

--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginScreen.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginScreen.kt
@@ -42,6 +42,8 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
@@ -329,7 +331,9 @@ private fun LoginForm(
     onCreateAccountClick: () -> Unit,
 ) {
     val focusRequester = remember { FocusRequester() }
-    var homebaseId by remember { mutableStateOf(homebaseId) }
+    var homebaseIdField by remember {
+        mutableStateOf(TextFieldValue(homebaseId, selection = TextRange(homebaseId.length)))
+    }
 
     LaunchedEffect(Unit) { focusRequester.requestFocus() }
 
@@ -357,15 +361,15 @@ private fun LoginForm(
             Spacer(modifier = Modifier.height(16.dp))
         }
         HomebaseIdField(
-            value = homebaseId,
-            onValueChange = { homebaseId = it.cleanDomain().replace(".", " ") },
+            value = homebaseIdField,
+            onValueChange = { homebaseIdField = it.copy(text = it.text.cleanDomain().replace(".", " ")) },
             focusRequester = focusRequester,
-            onDone = { onLoginClick(homebaseId.cleanDomain(preserveTrailingDot = false)) }
+            onDone = { onLoginClick(homebaseIdField.text.cleanDomain(preserveTrailingDot = false)) }
         )
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        Button(onClick = { onLoginClick(homebaseId.cleanDomain(preserveTrailingDot = false)) }, modifier = Modifier.fillMaxWidth()) {
+        Button(onClick = { onLoginClick(homebaseIdField.text.cleanDomain(preserveTrailingDot = false)) }, modifier = Modifier.fillMaxWidth()) {
             if (errorMessage != null) Text(stringResource(MR.string.login_try_again_button)) else Text(stringResource(MR.string.login_sign_in_button))
         }
         Spacer(modifier = Modifier.height(16.dp))
@@ -381,14 +385,14 @@ private fun LoginForm(
 
 @Composable
 private fun HomebaseIdField(
-    value: String,
-    onValueChange: (String) -> Unit,
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
     focusRequester: FocusRequester,
     onDone: () -> Unit,
 ) {
     OutlinedTextField(
         value = value,
-        onValueChange = { onValueChange(it) },
+        onValueChange = onValueChange,
         modifier = Modifier.fillMaxWidth().focusRequester(focusRequester),
         placeholder = { Text(stringResource(MR.string.login_id_placeholder)) },
         label = { Text(stringResource(MR.string.login_id_label)) },

--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginUiState.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginUiState.kt
@@ -8,6 +8,7 @@ import kotlinx.collections.immutable.persistentListOf
 data class LoginUiState(
     val homebaseId: String = "",
     val isLoading: Boolean = false,
+    val isPinging: Boolean = false,
     val isAuthenticated: Boolean = false,
     val errorMessage: String? = null,
     val driveProgresses: ImmutableList<DriveProgress> = persistentListOf(),

--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt
@@ -127,6 +127,7 @@ class LoginViewModel(
                 it.copy(
                     homebaseId = homebaseId.domainName,
                     isLoading = true,
+                    isPinging = true,
                     errorMessage = null
                 )
             }
@@ -136,12 +137,15 @@ class LoginViewModel(
                 _uiState.update {
                     it.copy(
                         isLoading = false,
+                        isPinging = false,
                         errorMessage = "Unable to ping $homebaseId - are you sure it's a Homebase ID?"
                     )
                 }
 
                 return@launch
             }
+
+            _uiState.update { it.copy(isPinging = false) }
 
             try {
                 Logger.i(tag = "LoginViewModel", messageString = "Ping OK, calling youAuthFlowManager.authorize()...")

--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt
@@ -21,6 +21,7 @@ import id.homebase.core.notifications.NotificationService
 import id.homebase.core.util.StartupState
 import id.homebase.core.util.mapToStartupState
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.timeout
 import io.ktor.client.request.get
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -90,22 +91,31 @@ class LoginViewModel(
 
     suspend fun isValidHomebaseId(identity: OdinId): Boolean {
         try {
-            val response = httpClient.get("https://$identity/api/v2/health/ping")
+            Logger.i(tag = "LoginViewModel", messageString = "Pinging https://$identity/api/v2/health/ping ...")
+            val response = httpClient.get("https://$identity/api/v2/health/ping") {
+                timeout {
+                    requestTimeoutMillis = 15_000
+                    connectTimeoutMillis = 10_000
+                }
+            }
+            Logger.i(tag = "LoginViewModel", messageString = "Ping response: ${response.status.value}")
             return when (response.status.value) {
                 200 -> true
                 else -> false
             }
-        } catch (_: Throwable) {
-//            Logger.e("LoginViewModel", t, "failed while trying to ping $identity")
+        } catch (t: Throwable) {
+            Logger.e(tag = "LoginViewModel", messageString = "Ping failed for $identity: ${t::class.simpleName}: ${t.message}")
             return false
         }
     }
 
     private fun startLogin(homebaseIdValue: String) {
+        Logger.i(tag = "LoginViewModel", messageString = "startLogin($homebaseIdValue)")
 
         val homebaseId = try {
             OdinId(homebaseIdValue)
         } catch (_: Exception) {
+            Logger.w(tag = "LoginViewModel", messageString = "Invalid Homebase ID: $homebaseIdValue")
             _uiState.update {
                 it.copy(errorMessage = "Valid Homebase ID is required")
             }
@@ -122,6 +132,7 @@ class LoginViewModel(
             }
 
             if (!isValidHomebaseId(homebaseId)) {
+                Logger.w(tag = "LoginViewModel", messageString = "Identity $homebaseId failed ping check, aborting login")
                 _uiState.update {
                     it.copy(
                         isLoading = false,
@@ -133,6 +144,7 @@ class LoginViewModel(
             }
 
             try {
+                Logger.i(tag = "LoginViewModel", messageString = "Ping OK, calling youAuthFlowManager.authorize()...")
                 val authUrl = youAuthFlowManager.authorize(
                     identity = homebaseId,
                     appId = AppConfig.APP_ID,
@@ -143,10 +155,12 @@ class LoginViewModel(
                     circles =
                         listOf(CONFIRMED_CONNECTIONS_CIRCLE_ID, AUTO_CONNECTIONS_CIRCLE_ID)
                 )
+                Logger.i(tag = "LoginViewModel", messageString = "Auth URL ready, launching browser")
                 _uiState.update { it.copy(uiEvent = LoginUiEvent.OpenAuthUrl(authUrl)) }
             } catch (_: AuthInProgressException) {
-                // ignore
+                Logger.w(tag = "LoginViewModel", messageString = "Auth already in progress, ignoring")
             } catch (e: Exception) {
+                Logger.e(tag = "LoginViewModel", messageString = "authorize() failed: ${e::class.simpleName}: ${e.message}")
                 _uiState.update {
                     it.copy(isLoading = false, errorMessage = e.message ?: "Login failed")
                 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -130,7 +130,7 @@ class ConversationStream(
             }
 
         if (messageFiles.size != incomingMessages.size)
-            throw IllegalArgumentException("Size mismatch - conversion problem")
+            Logger.w("ConversationStream: ${messageFiles.size - incomingMessages.size} of ${messageFiles.size} messages failed to convert")
 
         for (m in incomingMessages) {
             val matchingConversation = _conversations.value.items.find { it.id == m.conversationId }


### PR DESCRIPTION
Re-introduces background DB writes that were disabled in 7a8d0ee3 while hunting a sync bug, but with two key fixes over the original approach:

1. BatchReceived is now emitted AFTER the DB write completes (inside the async block), so event handlers always see consistent DB state.
2. Only one background DB write is in flight at a time — the next loop iteration awaits the previous job before issuing a new network call.

This gives us a pipeline where network call N+1 overlaps with DB write N, without the race condition that caused the original sync bug.

Mutable loop variables (totalCount, recordsRead) are snapshotted into local vals before the async launch to prevent capture-by-reference bugs.