### PR TITLE
Fix pipelined await placement in DriveSync to allow network/DB overlap

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
@@ -108,10 +108,6 @@ class DriveSync(
         val maxRetries = 3
 
         while (true) {
-            // Wait for previous batch's DB write to complete before starting next network call
-            pendingDbJob?.await()
-            pendingDbJob = null
-
             Logger.i("Synchronizing drive $driveId")
             val request = QueryBatchRequest(
                 queryParams = FileQueryParams(
@@ -153,8 +149,11 @@ class DriveSync(
                         val batchRecordsRead = recordsRead
                         val latestModified = searchResults.last().fileMetadata.updated
 
-                        // Launch DB write + event emission in background;
-                        // next loop iteration awaits this before starting a new DB write
+                        // Await previous DB write before launching a new one
+                        // (network call above runs concurrently with the previous DB write)
+                        pendingDbJob?.await()
+                        pendingDbJob = null
+
                         pendingDbJob = scope.async {
                             fileHeaderProcessor.baseUpsertEntryZapZap(
                                 identityId = identityId,

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
@@ -141,22 +141,22 @@ class DriveSync(
                             .distinct()
                         Logger.d("DriveSync: batch contains ${chatGroupIds.size} chat conversation(s): $chatGroupIds")
                     }
-                    if (searchResults.isNotEmpty()) {
-                        // Gate: if previous batch's DB write failed, stop sync immediately
-                        try {
-                            pendingDbJob?.await()
-                            pendingDbJob = null
-                        } catch (e: Exception) {
-                            Logger.e("DriveSync: DB write failed for drive $driveId, stopping sync: ${e.message}")
-                            eventBus.emit(
-                                BackendEvent.DriveEvent.Stopped(
-                                    driveId, totalCount,
-                                    BackendEvent.DriveResult.Failure("DB write failed: ${e.message ?: "unknown error"}")
-                                )
+                    // Gate: if previous batch's DB write failed, stop sync immediately
+                    try {
+                        pendingDbJob?.await()
+                        pendingDbJob = null
+                    } catch (e: Exception) {
+                        Logger.e("DriveSync: DB write failed for drive $driveId, stopping sync: ${e.message}")
+                        eventBus.emit(
+                            BackendEvent.DriveEvent.Stopped(
+                                driveId, totalCount,
+                                BackendEvent.DriveResult.Failure("DB write failed: ${e.message ?: "unknown error"}")
                             )
-                            return
-                        }
-                        
+                        )
+                        return
+                    }
+
+                    if (searchResults.isNotEmpty()) {
                         recordsRead = searchResults.size
                         totalCount += recordsRead
                         val batchCursorToSave = cursor

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
@@ -142,17 +142,27 @@ class DriveSync(
                         Logger.d("DriveSync: batch contains ${chatGroupIds.size} chat conversation(s): $chatGroupIds")
                     }
                     if (searchResults.isNotEmpty()) {
+                        // Gate: if previous batch's DB write failed, stop sync immediately
+                        try {
+                            pendingDbJob?.await()
+                            pendingDbJob = null
+                        } catch (e: Exception) {
+                            Logger.e("DriveSync: DB write failed for drive $driveId, stopping sync: ${e.message}")
+                            eventBus.emit(
+                                BackendEvent.DriveEvent.Stopped(
+                                    driveId, totalCount,
+                                    BackendEvent.DriveResult.Failure("DB write failed: ${e.message ?: "unknown error"}")
+                                )
+                            )
+                            return
+                        }
+                        
                         recordsRead = searchResults.size
                         totalCount += recordsRead
                         val batchCursorToSave = cursor
                         val batchTotalCount = totalCount
                         val batchRecordsRead = recordsRead
                         val latestModified = searchResults.last().fileMetadata.updated
-
-                        // Await previous DB write before launching a new one
-                        // (network call above runs concurrently with the previous DB write)
-                        pendingDbJob?.await()
-                        pendingDbJob = null
 
                         pendingDbJob = scope.async {
                             fileHeaderProcessor.baseUpsertEntryZapZap(


### PR DESCRIPTION
Move pendingDbJob?.await() from the top of the while loop to just before launching the next DB write. Previously, placing the await before the network call serialized all operations — each batch's network fetch had to wait for the prior batch's DB write to finish.

Now the network call for batch N+1 runs concurrently with the DB write for batch N, and we only block right before starting a new DB write to ensure sequential database access.