### PR TITLE
fix: reorder message info status labels to match enum and rename "Sen…

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoScreen.kt
@@ -52,7 +52,7 @@ import id.homebase.resources.menu_back
 import id.homebase.resources.reactions
 import id.homebase.resources.read_by
 import id.homebase.resources.sending_to
-import id.homebase.resources.sent_to
+import id.homebase.resources.uploaded
 import id.homebase.resources.unknown_status
 import org.jetbrains.compose.resources.stringResource
 
@@ -178,10 +178,10 @@ fun MessageInfoUi(
                     }
 
                     val statusOrder = listOf(
-                        ChatDeliveryStatus.Read,
-                        ChatDeliveryStatus.Delivered,
-                        ChatDeliveryStatus.Sent,
                         ChatDeliveryStatus.Sending,
+                        ChatDeliveryStatus.Sent,
+                        ChatDeliveryStatus.Delivered,
+                        ChatDeliveryStatus.Read,
                         ChatDeliveryStatus.Failed,
                     )
 
@@ -193,7 +193,7 @@ fun MessageInfoUi(
                         val label = when (status) {
                             ChatDeliveryStatus.Read -> stringResource(MR.string.read_by)
                             ChatDeliveryStatus.Delivered -> stringResource(MR.string.delivered_to)
-                            ChatDeliveryStatus.Sent -> stringResource(MR.string.sent_to)
+                            ChatDeliveryStatus.Sent -> stringResource(MR.string.uploaded)
                             ChatDeliveryStatus.Sending -> stringResource(MR.string.sending_to)
                             ChatDeliveryStatus.Failed -> stringResource(MR.string.failed)
                             else -> stringResource(MR.string.unknown_status)

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -36,7 +36,7 @@
     <string name="read_by">Read by</string>
     <string name="delivered_to">Delivered to</string>
     <string name="sending_to">Sending to</string>
-    <string name="sent_to">Sent to</string>
+    <string name="uploaded">Uploaded</string>
     <string name="failed">Failed</string>
     <string name="unknown_status">Other</string>
     <string name="updated">Updated</string>


### PR DESCRIPTION
…t to" to "Uploaded"

- Reorder statusOrder list in MessageInfoScreen to follow the ChatDeliveryStatus enum declaration order: Sending → Sent → Delivered → Read → Failed
- Rename the "Sent to" label to "Uploaded" to better reflect the actual status meaning (message uploaded to server)