### PR TITLE
fix: use userDate instead of created for unread count and conversation ordering

### DIFF
--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ChatReadCount.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ChatReadCount.sq
@@ -6,16 +6,16 @@ CREATE TABLE IF NOT EXISTS ChatReadCount(
 );
 
 -- This table and these queries will benefit from this index on DriveMainIndex
-CREATE INDEX IF NOT EXISTS idx_messages_groupId_filetype_created
-  ON DriveMainIndex(groupId, fileType, created);
+CREATE INDEX IF NOT EXISTS idx_messages_groupId_filetype_userDate
+  ON DriveMainIndex(groupId, fileType, userDate);
 
 -- To make the conversation + last-message performant
-CREATE INDEX IF NOT EXISTS idx_chatmessage_convid_created ON DriveMainIndex(groupId,fileType,created DESC);
+CREATE INDEX IF NOT EXISTS idx_chatmessage_convid_userDate ON DriveMainIndex(groupId,fileType,userDate DESC);
 
 -- Speeds up message scans in selectAllConversationPlusLastMessage and selectAllUnreadCount
 -- (fileType first lets SQLite seek directly to message rows without a full table scan)
-CREATE INDEX IF NOT EXISTS idx_messages_filetype_datatype_groupid_created
-  ON DriveMainIndex(fileType, dataType, groupId, created DESC);
+CREATE INDEX IF NOT EXISTS idx_messages_filetype_datatype_groupid_userDate
+  ON DriveMainIndex(fileType, dataType, groupId, userDate DESC);
 
 -- Get full list of conversations (8888) from the DriveMainIndex table
 -- here to not contaminate it. Can also be easily fetched with QB()
@@ -32,7 +32,7 @@ selectAllConversationPlusLastMessage:
 SELECT
   d.jsonHeader AS convJsonHeader,
   m.jsonHeader AS msgJsonHeader,
-  m.created    AS msgCreated
+  m.userDate   AS msgUserDate
 FROM DriveMainIndex AS d
 LEFT JOIN DriveMainIndex AS m
   ON m.rowId = (
@@ -41,11 +41,11 @@ LEFT JOIN DriveMainIndex AS m
     WHERE m2.groupId = d.uniqueId
       AND m2.fileType = 7878
       AND m2.dataType = 0
-    ORDER BY m2.created DESC
+    ORDER BY m2.userDate DESC
     LIMIT 1
   )
 WHERE d.fileType = 8888 -- Conversation
-ORDER BY msgCreated DESC;
+ORDER BY msgUserDate DESC;
 
 -- Return unread message count for a specific groupId
 -- probably shouldn't be needed - with good design we should only need to call selectAllReadCount
@@ -55,7 +55,7 @@ FROM DriveMainIndex d
 LEFT JOIN ChatReadCount c ON d.groupId = c.groupId
 WHERE d.groupId = ?
   AND d.fileType = 7878 AND d.dataType = 0
-  AND (c.lastReadTime IS NULL OR d.created > c.lastReadTime);
+  AND (c.lastReadTime IS NULL OR d.userDate > c.lastReadTime);
 
 -- Return list of {groupId, unreadCount} for all chat conversations (8888)
 -- Will return (groupId, unread-count) for all Chat conversations with 1 or more unread messages.
@@ -65,7 +65,7 @@ WHERE d.groupId = ?
 -- FROM DriveMainIndex AS d
 -- LEFT JOIN ChatReadCount ON d.groupId = ChatReadCount.groupId
 -- WHERE d.fileType = 7878 AND d.dataType = 0 -- Message
---   AND (ChatReadCount.lastReadTime IS NULL OR d.created > ChatReadCount.lastReadTime)
+--   AND (ChatReadCount.lastReadTime IS NULL OR d.userDate > ChatReadCount.lastReadTime)
 --   AND d.groupId IS NOT NULL
 -- GROUP BY d.groupId;
 
@@ -75,7 +75,7 @@ FROM DriveMainIndex AS d
 LEFT JOIN ChatReadCount c ON d.groupId = c.groupId
 WHERE d.fileType = 7878  -- Message
   AND d.dataType = 0 -- Standard message
-  AND (c.lastReadTime IS NULL OR d.created > c.lastReadTime)
+  AND (c.lastReadTime IS NULL OR d.userDate > c.lastReadTime)
   AND d.groupId IS NOT NULL
   AND (d.originalAuthor IS NULL OR d.originalAuthor != ?)
 GROUP BY d.groupId;

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/DriveMainIndex.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/DriveMainIndex.sq
@@ -1,6 +1,6 @@
 import kotlin.uuid.Uuid;
 
-CREATE TABLE IF NOT EXISTS DriveMainIndex( -- Version: 2
+CREATE TABLE IF NOT EXISTS DriveMainIndex( -- Version: 4
    rowId INTEGER PRIMARY KEY AUTOINCREMENT,
    identityId BLOB AS Uuid NOT NULL,
    driveId BLOB AS Uuid NOT NULL,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
@@ -58,6 +58,8 @@ class ChatMessageActionService(
                         (isSelfConversation || !it.isAuthoredBy(domain))
             }
 
+        Logger.d { "markAsRead: convo=$conversationId unread=${unreadRecords.size}/${batch.records.size} newReadTime=${newReadTime.milliseconds}" }
+
         if (unreadRecords.isEmpty()) {
             dbm.chatReadCount.upsertLastReadTime(conversationId, newReadTime)
             conversationStream.updateUnreadCounts()
@@ -67,6 +69,7 @@ class ChatMessageActionService(
         // Use server-side 'created' timestamp for the read receipt endTime.
         // The server matches against 'created', not the client-side 'userDate'.
         val endTime = unreadRecords.maxOf { it.created }
+        Logger.d { "markAsRead: convo=$conversationId endTime=${endTime.toEpochMilliseconds()}" }
 
         dbm.chatReadCount.upsertLastReadTime(conversationId, newReadTime)
         conversationStream.updateUnreadCounts()

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -183,9 +183,13 @@ class ConversationStream(
         if (m.userDate >= c.latestMessageTimestamp) {
             val domain = credentialsManager.getActiveDomain()
 
-            // new message that was not sent by the current user
+            val increment = if (!m.isEdited && !m.isAuthoredBy(domain) && !m.isStatusMessage) 1 else 0
+            if (increment > 0) {
+                Logger.d("ConversationStream: unread++ convo=${c.id} count=${c.unreadCount + increment}")
+            }
+
             val updatedConversation = c.copy(
-                unreadCount = c.unreadCount + if (!m.isEdited && !m.isAuthoredBy(domain) && !m.isStatusMessage) 1 else 0,
+                unreadCount = c.unreadCount + increment,
                 latestMessageTimestamp = m.userDate,
                 lastMessage = m.content.truncateToCodePoints(40), // TODO: Global constant
                 lastMessageDeliveryStatus = m.messageAppData.deliveryStatus,
@@ -196,10 +200,6 @@ class ConversationStream(
             )
             updateConversation(c, updatedConversation)
         }
-
-
-        // Logger.i("Unread count now ${c.unreadCount} edited ${m.isEdited} on conversation id
-        // ${c.id}")
     }
 
     private suspend fun processConversationBatchIncrementally(
@@ -317,6 +317,7 @@ class ConversationStream(
             val newCount = unreadMap[convo.id] ?: 0
             if (newCount != convo.unreadCount) {
                 changed = true
+                Logger.d("ConversationStream: unreadSync convo=${convo.id} ${convo.unreadCount}->${newCount}")
                 convo.copy(unreadCount = newCount)
             } else {
                 convo


### PR DESCRIPTION
SQL queries for unread counts and last-message selection were using DriveMainIndex.created while the incremental (WebSocket) path and conversation list sorting used userDate. This mismatch caused the two code paths to diverge on which messages are considered unread.

Switches all chat-specific SQL queries and indexes to userDate for consistency with the rest of the stack. userDate is the right choice because that's also how messages are ordered in the chat list.