### PR TITLE
Add notification message count summary and 15-minute chime throttle

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/receivers/NotificationMarkReadReceiver.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/receivers/NotificationMarkReadReceiver.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import co.touchlab.kermit.Logger
 import id.homebase.chat.services.ChatMessageActionService
+import id.homebase.core.notifications.NotificationService
 import id.homebase.core.notifications.RichNotificationDisplayer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -22,6 +23,7 @@ import kotlin.uuid.Uuid
 class NotificationMarkReadReceiver : BroadcastReceiver(), KoinComponent {
 
     private val chatMessageActionService: ChatMessageActionService by inject()
+    private val notificationService: NotificationService by inject()
 
     @OptIn(ExperimentalUuidApi::class)
     override fun onReceive(context: Context, intent: Intent) {
@@ -33,9 +35,10 @@ class NotificationMarkReadReceiver : BroadcastReceiver(), KoinComponent {
             "Marking conversation as read: $conversationId"
         }
 
-        // Dismiss notification immediately
+        // Dismiss notification and clear accumulated message count
         val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         nm.cancel(notificationId)
+        notificationService.clearNotificationCount(conversationId)
 
         val pendingResult = goAsync()
         CoroutineScope(Dispatchers.IO).launch {

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/notifications/RichNotificationDisplayer.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/notifications/RichNotificationDisplayer.android.kt
@@ -85,6 +85,11 @@ actual class RichNotificationDisplayer actual constructor() {
             .setAutoCancel(true)
         builder.setPublicVersion(publicBuilder.build())
 
+        // Suppress sound when chime cooldown is active
+        if (data.silent) {
+            builder.setSilent(true)
+        }
+
         val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         nm.notify(data.notificationId, builder.build())
 
@@ -141,13 +146,16 @@ actual class RichNotificationDisplayer actual constructor() {
         data: RichNotificationData,
     ) {
         val icon = if (smallIconResId != 0) smallIconResId else context.applicationInfo.icon
-        val summary = NotificationCompat.Builder(context, data.channelId)
+        val summaryBuilder = NotificationCompat.Builder(context, data.channelId)
             .setSmallIcon(icon)
             .setStyle(NotificationCompat.InboxStyle().setSummaryText("Homebase"))
             .setGroup(data.conversationId)
             .setGroupSummary(true)
             .setAutoCancel(true)
-            .build()
+        if (data.silent) {
+            summaryBuilder.setSilent(true)
+        }
+        val summary = summaryBuilder.build()
 
         val summaryId = SUMMARY_ID_OFFSET + (data.conversationId?.hashCode()?.and(0x7FFFFFFF) ?: 0)
         nm.notify(summaryId, summary)

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
@@ -24,6 +24,8 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import kotlin.random.Random
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.TimeSource
 import kotlin.uuid.Uuid
 
 /**
@@ -41,6 +43,13 @@ class NotificationService(
     private var isListening = false
     private val richDisplayer = RichNotificationDisplayer()
 
+    /** Per-conversation message count for notification summary display. */
+    private val conversationMessageCounts = mutableMapOf<String, Int>()
+
+    /** Chime cooldown: suppress alert sounds within this window. */
+    private val ALERT_COOLDOWN = 15.minutes
+    private var lastAlertMark = TimeSource.Monotonic.markNow() - ALERT_COOLDOWN
+
     private val _navigationEvents = MutableSharedFlow<NotificationNavigationEvent>(extraBufferCapacity = 5)
     val navigationEvents: SharedFlow<NotificationNavigationEvent> = _navigationEvents.asSharedFlow()
 
@@ -54,6 +63,17 @@ class NotificationService(
 
     init {
         startListening()
+        // Clear message counts when user opens a conversation
+        scope.launch {
+            ActiveConversation.conversation.collect { id ->
+                if (id != null) conversationMessageCounts.remove(id.toString())
+            }
+        }
+    }
+
+    /** Clears the accumulated message count for a conversation (e.g. on mark-as-read). */
+    fun clearNotificationCount(conversationId: String) {
+        conversationMessageCounts.remove(conversationId)
     }
 
     /**
@@ -191,6 +211,7 @@ class NotificationService(
                     Logger.d(tag = "NotificationService") {
                         "Suppressing notification — user is on chat screen"
                     }
+                    conversationMessageCounts.remove(conversationId)
                     return@launch
                 }
 
@@ -229,6 +250,23 @@ class NotificationService(
                     else -> Pair(appName, bodyText)
                 }
 
+                // Track per-conversation message count for summary display
+                val messageCount = if (conversationId != null) {
+                    val count = (conversationMessageCounts[conversationId] ?: 0) + 1
+                    conversationMessageCounts[conversationId] = count
+                    count
+                } else 1
+
+                // Override body with count summary when multiple messages accumulated
+                val finalBody = if (messageCount > 1) {
+                    "$messageCount new messages"
+                } else {
+                    displayBody
+                }
+
+                // Chime cooldown: suppress alert sound if one played recently
+                val shouldAlert = lastAlertMark.elapsedNow() >= ALERT_COOLDOWN
+
                 // Determine notification channel based on app type
                 val channelId = resolveChannelId(notification.options.appId)
 
@@ -240,18 +278,20 @@ class NotificationService(
                     channelId = channelId,
                     conversationId = resolveConversationId(notification),
                     title = displayTitle,
-                    body = displayBody,
+                    body = finalBody,
                     senderName = displayName,
                     senderId = notification.senderId,
                     senderImageBytes = senderImageBytes,
                     timestamp = notification.created,
                     payloadData = payloadMap,
+                    silent = !shouldAlert,
                 )
 
                 if (isAppInForeground) {
                     // Show in-app banner instead of system notification
                     _inAppNotificationEvents.tryEmit(richData)
                 } else {
+                    if (shouldAlert) lastAlertMark = TimeSource.Monotonic.markNow()
                     showRichNotification(richData)
                     BadgeManager.increment()
                 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/RichNotificationData.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/RichNotificationData.kt
@@ -22,6 +22,8 @@ data class RichNotificationData(
     val payloadData: Map<String, String>,
     val isGroupConversation: Boolean = false,
     val groupTitle: String? = null,
+    /** When true, the notification should not play a sound (chime cooldown active). */
+    val silent: Boolean = false,
 )
 
 /** Extension to generate a stable notification ID from the conversation ID or a random one. */

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/notifications/RichNotificationDisplayer.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/notifications/RichNotificationDisplayer.native.kt
@@ -36,7 +36,9 @@ actual class RichNotificationDisplayer actual constructor() {
         val content = UNMutableNotificationContent().apply {
             setTitle(data.title)
             setBody(data.body)
-            setSound(UNNotificationSound.defaultSound)
+            if (!data.silent) {
+                setSound(UNNotificationSound.defaultSound)
+            }
 
             // Group by conversation
             if (data.conversationId != null) {


### PR DESCRIPTION
When multiple push notifications arrive for the same conversation, the notification body now shows "N new messages" instead of repeating "sender sent a message" each time. The per-conversation count resets when the user opens the conversation or marks it as read.

A 15-minute chime cooldown suppresses repeated alert sounds — the first notification in a window plays a sound, subsequent ones within 15 minutes arrive silently. Applies to both Android (setSilent) and iOS (conditional UNNotificationSound).