### PR TITLE
fix: restore feed drive to sync list and ignore JVM crash logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ xcuserdata/
 /desktopApp/output/
 /desktopApp/proguard-jars/
 /desktopApp/mapping.txt
+hs_err_pid*.log
+replay_pid*.log

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/config/AppConfig.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/config/AppConfig.kt
@@ -97,7 +97,7 @@ val targetDriveAccessRequest: List<TargetDriveAccessRequest> =
     )
 
 // Drives we listen to for sockets and synchronization
-val syncLabeledDrives: List<LabeledDrive> = listOf(chatLabeledDrive, contactLabeledDrive)
+val syncLabeledDrives: List<LabeledDrive> = listOf(chatLabeledDrive, contactLabeledDrive, feedLabeledDrive)
 
 // Circle drive requests
 val circleDriveTargetRequest: List<TargetDriveAccessRequest> =


### PR DESCRIPTION
Feed drive was accidentally removed from syncLabeledDrives during the leave-group WIP commit. Also added hs_err_pid*.log and replay_pid*.log to .gitignore to prevent JVM crash dumps from being committed.