### PR TITLE
Compose UI tests

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -10,6 +10,9 @@ jobs:
   test:
     name: Run unittests
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
 
     steps:
       - name: Checkout
@@ -41,7 +44,11 @@ jobs:
         if: always()  # Run even if tests fail
         with:
           files: |
-            **/build/test-results/**/*.xml          
+            homebase-api/build/test-results/jvmTest/TEST-*.xml
+            homebase-chat/build/test-results/jvmTest/TEST-*.xml
+            homebase-auth/build/test-results/jvmTest/TEST-*.xml
+            homebase-common/build/test-results/jvmTest/TEST-*.xml
+          check_name: JVM Test Results
 
   build:
     strategy:

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -7,6 +7,42 @@ on:
     branches: [main]
 
 jobs:
+  test:
+    name: Run unittests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "temurin"
+
+      - name: Gradle Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Run JVM unit tests
+        run: ./gradlew homebase-chat:jvmTest homebase-auth:jvmTest homebase-common:jvmTest homebase-api:jvmTest --rerun-tasks
+        env:
+          JDK_21: ${{ env.JAVA_HOME }}
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()  # Run even if tests fail
+        with:
+          files: |
+            **/build/test-results/**/*.xml          
+
   build:
     strategy:
       matrix:

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -25,7 +25,7 @@ jobs:
           distribution: "temurin"
 
       - name: Gradle Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -77,7 +77,7 @@ jobs:
           distribution: "temurin"
 
       - name: Gradle Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "21"
           distribution: "temurin"
@@ -68,10 +68,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "21"
           distribution: "temurin"

--- a/.github/workflows/build-desktop-release-dev.yml
+++ b/.github/workflows/build-desktop-release-dev.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: "21"

--- a/.github/workflows/build-desktop-release-dev.yml
+++ b/.github/workflows/build-desktop-release-dev.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Cache Conveyor installation
         id: cache-conveyor
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .conveyor/install
           key: conveyor-22.0-linux-amd64
@@ -45,7 +45,7 @@ jobs:
           tar xzvf conveyor-22.0-linux-amd64.tar.gz -C .conveyor/install
 
       - name: Cache Conveyor data
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: conveyor-data-${{ github.run_id }}
           path: .conveyor/cache

--- a/.github/workflows/build-mobile-release-dev.yml
+++ b/.github/workflows/build-mobile-release-dev.yml
@@ -86,7 +86,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Cache Gradle (KMP)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -96,7 +96,7 @@ jobs:
             gradle-${{ runner.os }}-
 
       - name: Cache Kotlin/Native
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.konan
           key: konan-${{ runner.os }}-${{ hashFiles('**/gradle.properties') }}
@@ -107,7 +107,7 @@ jobs:
           xcode-version: "26"
 
       - name: Cache CocoaPods
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cocoapods

--- a/.github/workflows/build-mobile-release-dev.yml
+++ b/.github/workflows/build-mobile-release-dev.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: "21"
@@ -74,10 +74,10 @@ jobs:
     runs-on: macos-15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: "17"

--- a/.github/workflows/build-mobile-release-prod.yml
+++ b/.github/workflows/build-mobile-release-prod.yml
@@ -94,7 +94,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Cache Gradle (KMP)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -104,7 +104,7 @@ jobs:
             gradle-${{ runner.os }}-
 
       - name: Cache Kotlin/Native
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.konan
           key: konan-${{ runner.os }}-${{ hashFiles('**/gradle.properties') }}
@@ -115,7 +115,7 @@ jobs:
           xcode-version: "26"
 
       - name: Cache CocoaPods
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cocoapods

--- a/.github/workflows/build-mobile-release-prod.yml
+++ b/.github/workflows/build-mobile-release-prod.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: "21"
@@ -82,10 +82,10 @@ jobs:
     runs-on: macos-15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: "17"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "21"
           distribution: "temurin"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: "temurin"
 
       - name: Gradle Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "21"
           distribution: "temurin"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           distribution: "temurin"
 
       - name: Gradle Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches

--- a/README.md
+++ b/README.md
@@ -49,9 +49,6 @@ Configure signing and user in Xcode.
 **Run all tests (JVM)**
 Currently only tests found in common and api module.
 ```
-./gradlew ./gradlew homebase-common:jvmTest homebase-api:jvmTest --rerun-tasks
+./gradlew homebase-chat:jvmTest homebase-auth:jvmTest homebase-common:jvmTest homebase-api:jvmTest --rerun-tasks
 ```
-To add to IDE as run option in menu, click "Edit configurations" in Run/debug menu, add gradle task, name it "AllTests" and paste below into run field:
-```
-homebase-common:jvmTest homebase-api:jvmTest --rerun-tasks
-```
+To add to IDE as run option in menu, click "Edit configurations" in Run/debug menu, add gradle task, name it "AllTests" and paste above line, minus the .gradlew part.

--- a/homebase-auth/build.gradle.kts
+++ b/homebase-auth/build.gradle.kts
@@ -76,5 +76,12 @@ kotlin {
         jvmMain.dependencies {
             implementation(libs.ktor.client.cio)
         }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+            implementation(libs.jetbrains.compose.ui.test)
+        }
+        jvmTest.dependencies {
+            implementation(compose.desktop.currentOs)
+        }
     }
 }

--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginScreen.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginScreen.kt
@@ -42,13 +42,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
@@ -76,8 +77,8 @@ import id.homebase.resources.login_successful
 import id.homebase.resources.login_title
 import id.homebase.resources.login_try_again_button
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.coroutines.delay
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -204,7 +205,8 @@ private fun LoginLoading(driveProgresses: ImmutableList<DriveProgress>, isPingin
         Text(
             text = stringResource(MR.string.loading),
             style = MaterialTheme.typography.headlineLarge,
-            textAlign = TextAlign.Center
+            textAlign = TextAlign.Center,
+            modifier = Modifier.testTag("loading_text"),
         )
         Spacer(modifier = Modifier.height(16.dp))
         if (driveProgresses.isEmpty()) {
@@ -213,7 +215,8 @@ private fun LoginLoading(driveProgresses: ImmutableList<DriveProgress>, isPingin
             Text(
                 text = stringResource(MR.string.login_authenticating),
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.testTag("authenticating_text"),
             )
             if (isPinging) {
                 var secondsLeft by remember { mutableIntStateOf(15) }
@@ -257,6 +260,7 @@ private fun DriveProgressRow(
                 text = drive.name,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.testTag("drive_name_${drive.driveId}"),
             )
             Spacer(modifier = Modifier.weight(1f))
             if (drive.count > 0 && !drive.completed) {
@@ -335,7 +339,8 @@ private fun LoginSuccess() {
     Text(
         text = stringResource(MR.string.login_successful),
         style = MaterialTheme.typography.bodyLarge,
-        color = MaterialTheme.colorScheme.primary
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.testTag("success_text"),
     )
 }
 
@@ -359,14 +364,16 @@ private fun LoginForm(
         Text(
             text = stringResource(MR.string.login_title),
             style = MaterialTheme.typography.headlineLarge,
-            textAlign = TextAlign.Center
+            textAlign = TextAlign.Center,
+            modifier = Modifier.testTag("title_text"),
         )
         Spacer(modifier = Modifier.height(8.dp))
         Text(
             text = stringResource(MR.string.login_sub_title),
             style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center
+            textAlign = TextAlign.Center,
+            modifier = Modifier.testTag("subtitle_text"),
         )
         Spacer(modifier = Modifier.height(48.dp))
         errorMessage?.let {
@@ -374,7 +381,8 @@ private fun LoginForm(
                 text = it,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.error,
-                textAlign = TextAlign.Center
+                textAlign = TextAlign.Center,
+                modifier = Modifier.testTag("error_message"),
             )
             Spacer(modifier = Modifier.height(16.dp))
         }
@@ -387,12 +395,16 @@ private fun LoginForm(
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        Button(onClick = { onLoginClick(homebaseIdField.text.cleanDomain(preserveTrailingDot = false)) }, modifier = Modifier.fillMaxWidth()) {
+        Button(
+            onClick = { onLoginClick(homebaseIdField.text.cleanDomain(preserveTrailingDot = false)) },
+            modifier = Modifier.fillMaxWidth().testTag(if (errorMessage != null) "try_again_button" else "login_button"),
+        ) {
             if (errorMessage != null) Text(stringResource(MR.string.login_try_again_button)) else Text(stringResource(MR.string.login_sign_in_button))
         }
         Spacer(modifier = Modifier.height(16.dp))
         TextButton(
-            onClick = onCreateAccountClick
+            onClick = onCreateAccountClick,
+            modifier = Modifier.testTag("create_account_button"),
         ) {
             Text(stringResource(MR.string.login_create_account_button))
         }

--- a/homebase-auth/src/commonTest/kotlin/id/homebase/auth/login/LoginUiTest.kt
+++ b/homebase-auth/src/commonTest/kotlin/id/homebase/auth/login/LoginUiTest.kt
@@ -2,6 +2,7 @@ package id.homebase.auth.login
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
@@ -27,10 +28,10 @@ class LoginUiTest {
                 )
             }
         }
-        onNodeWithText("Welcome to Homebase").assertExists()
-        onNodeWithText("Sign in with your Homebase ID").assertExists()
-        onNodeWithText("Sign in").assertExists()
-        onNodeWithText("Create account").assertExists()
+        onNodeWithTag("title_text").assertExists()
+        onNodeWithTag("subtitle_text").assertExists()
+        onNodeWithTag("login_button").assertExists()
+        onNodeWithTag("create_account_button").assertExists()
     }
 
     @Test
@@ -48,10 +49,10 @@ class LoginUiTest {
                 )
             }
         }
-        onNodeWithText("Loading...").assertExists()
-        onNodeWithText("Authenticating\u2026").assertExists()
+        onNodeWithTag("loading_text").assertExists()
+        onNodeWithTag("authenticating_text").assertExists()
         // Form should not be visible
-        onNodeWithText("Sign in").assertDoesNotExist()
+        onNodeWithTag("login_button").assertDoesNotExist()
     }
 
     @Test
@@ -69,8 +70,8 @@ class LoginUiTest {
                 )
             }
         }
-        onNodeWithText("Login successful").assertExists()
-        onNodeWithText("Sign in").assertDoesNotExist()
+        onNodeWithTag("success_text").assertExists()
+        onNodeWithTag("login_button").assertDoesNotExist()
     }
 
     @Test
@@ -88,10 +89,10 @@ class LoginUiTest {
                 )
             }
         }
-        onNodeWithText("Invalid identity").assertExists()
-        onNodeWithText("Try again").assertExists()
+        onNodeWithTag("error_message").assertExists()
+        onNodeWithTag("try_again_button").assertExists()
         // "Sign in" should be replaced by "Try again"
-        onNodeWithText("Sign in").assertDoesNotExist()
+        onNodeWithTag("login_button").assertDoesNotExist()
     }
 
     @Test
@@ -114,7 +115,7 @@ class LoginUiTest {
                 )
             }
         }
-        onNodeWithText("Create account").performClick()
+        onNodeWithTag("create_account_button").performClick()
         assertTrue(actionFired)
     }
 

--- a/homebase-auth/src/commonTest/kotlin/id/homebase/auth/login/LoginUiTest.kt
+++ b/homebase-auth/src/commonTest/kotlin/id/homebase/auth/login/LoginUiTest.kt
@@ -1,0 +1,145 @@
+package id.homebase.auth.login
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlinx.collections.immutable.persistentListOf
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class LoginUiTest {
+
+    @Test
+    fun formState_showsSignInButton() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                LoginUi(
+                    uiState = LoginUiState(
+                        homebaseId = "",
+                        isLoading = false,
+                        isAuthenticated = false,
+                        errorMessage = null,
+                    ),
+                    onAction = {},
+                )
+            }
+        }
+        onNodeWithText("Welcome to Homebase").assertExists()
+        onNodeWithText("Sign in with your Homebase ID").assertExists()
+        onNodeWithText("Sign in").assertExists()
+        onNodeWithText("Create account").assertExists()
+    }
+
+    @Test
+    fun loadingState_showsLoadingText() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                LoginUi(
+                    uiState = LoginUiState(
+                        homebaseId = "",
+                        isLoading = true,
+                        isAuthenticated = false,
+                        errorMessage = null,
+                    ),
+                    onAction = {},
+                )
+            }
+        }
+        onNodeWithText("Loading...").assertExists()
+        onNodeWithText("Authenticating\u2026").assertExists()
+        // Form should not be visible
+        onNodeWithText("Sign in").assertDoesNotExist()
+    }
+
+    @Test
+    fun authenticatedState_showsSuccessMessage() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                LoginUi(
+                    uiState = LoginUiState(
+                        homebaseId = "",
+                        isLoading = false,
+                        isAuthenticated = true,
+                        errorMessage = null,
+                    ),
+                    onAction = {},
+                )
+            }
+        }
+        onNodeWithText("Login successful").assertExists()
+        onNodeWithText("Sign in").assertDoesNotExist()
+    }
+
+    @Test
+    fun errorState_showsErrorAndTryAgainButton() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                LoginUi(
+                    uiState = LoginUiState(
+                        homebaseId = "",
+                        isLoading = false,
+                        isAuthenticated = false,
+                        errorMessage = "Invalid identity",
+                    ),
+                    onAction = {},
+                )
+            }
+        }
+        onNodeWithText("Invalid identity").assertExists()
+        onNodeWithText("Try again").assertExists()
+        // "Sign in" should be replaced by "Try again"
+        onNodeWithText("Sign in").assertDoesNotExist()
+    }
+
+    @Test
+    fun createAccountAction_fires() = runComposeUiTest {
+        var actionFired = false
+        setContent {
+            MaterialTheme {
+                LoginUi(
+                    uiState = LoginUiState(
+                        homebaseId = "",
+                        isLoading = false,
+                        isAuthenticated = false,
+                        errorMessage = null,
+                    ),
+                    onAction = { action ->
+                        if (action is LoginUiAction.CreateAccount) {
+                            actionFired = true
+                        }
+                    },
+                )
+            }
+        }
+        onNodeWithText("Create account").performClick()
+        assertTrue(actionFired)
+    }
+
+    @Test
+    fun loadingWithDriveProgresses_showsDriveNames() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                LoginUi(
+                    uiState = LoginUiState(
+                        homebaseId = "",
+                        isLoading = true,
+                        isAuthenticated = false,
+                        errorMessage = null,
+                        driveProgresses = persistentListOf(
+                            DriveProgress(driveId = "1", name = "Chat", completed = true, total = 42, count = 42, progress = 1f),
+                            DriveProgress(driveId = "2", name = "Feed", count = 17, total = 17),
+                        ),
+                    ),
+                    onAction = {},
+                )
+            }
+        }
+        onNodeWithText("Chat").assertExists()
+        onNodeWithText("Feed").assertExists()
+        // When driveProgresses is non-empty, "Authenticating..." should not appear
+        onNodeWithText("Authenticating\u2026").assertDoesNotExist()
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/AttachmentOptions.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/AttachmentOptions.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import coil3.ImageLoader
@@ -235,6 +236,7 @@ fun AttachmentOptions(
         ) {
             item {
                 AttachmentOption(
+                    modifier = Modifier.testTag("attachment_gallery"),
                     icon = Icons.Default.Image,
                     label = stringResource(MR.string.chat_message_attachment_gallery),
                     onClick = onGalleryClick
@@ -242,6 +244,7 @@ fun AttachmentOptions(
             }
             item {
                 AttachmentOption(
+                    modifier = Modifier.testTag("attachment_file"),
                     icon = Icons.Default.UploadFile,
                     label = stringResource(MR.string.chat_message_attachment_file),
                     onClick = onFileClick
@@ -269,12 +272,13 @@ fun AttachmentOptions(
 
 @Composable
 private fun AttachmentOption(
+    modifier: Modifier = Modifier,
     icon: androidx.compose.ui.graphics.vector.ImageVector,
     label: String,
     onClick: () -> Unit
 ) {
     Column(
-        modifier = Modifier.width(72.dp).noRippleClickable { onClick() },
+        modifier = modifier.width(72.dp).noRippleClickable { onClick() },
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         IconButton(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationItem.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -266,7 +267,8 @@ fun ConversationMessagePreview(
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,
-                overflow = TextOverflow.Ellipsis
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.testTag("no_messages_text"),
             )
         }
     }

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/AttachmentOptionsTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/AttachmentOptionsTest.kt
@@ -1,0 +1,63 @@
+package id.homebase.chat.widget
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class AttachmentOptionsTest {
+
+    @Test
+    fun displaysGalleryAndFileOptions() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                AttachmentOptions(
+                    onGalleryClick = {},
+                    onFileClick = {},
+                    onContactClick = {},
+                    onLocationClick = {},
+                )
+            }
+        }
+        onNodeWithText("Gallery").assertExists()
+        onNodeWithText("File").assertExists()
+    }
+
+    @Test
+    fun galleryClickCallbackFires() = runComposeUiTest {
+        var clicked = false
+        setContent {
+            MaterialTheme {
+                AttachmentOptions(
+                    onGalleryClick = { clicked = true },
+                    onFileClick = {},
+                    onContactClick = {},
+                    onLocationClick = {},
+                )
+            }
+        }
+        onNodeWithText("Gallery").performClick()
+        assertTrue(clicked)
+    }
+
+    @Test
+    fun fileClickCallbackFires() = runComposeUiTest {
+        var clicked = false
+        setContent {
+            MaterialTheme {
+                AttachmentOptions(
+                    onGalleryClick = {},
+                    onFileClick = { clicked = true },
+                    onContactClick = {},
+                    onLocationClick = {},
+                )
+            }
+        }
+        onNodeWithText("File").performClick()
+        assertTrue(clicked)
+    }
+}

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/AttachmentOptionsTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/AttachmentOptionsTest.kt
@@ -2,7 +2,7 @@ package id.homebase.chat.widget
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import kotlin.test.Test
@@ -23,8 +23,8 @@ class AttachmentOptionsTest {
                 )
             }
         }
-        onNodeWithText("Gallery").assertExists()
-        onNodeWithText("File").assertExists()
+        onNodeWithTag("attachment_gallery").assertExists()
+        onNodeWithTag("attachment_file").assertExists()
     }
 
     @Test
@@ -40,7 +40,7 @@ class AttachmentOptionsTest {
                 )
             }
         }
-        onNodeWithText("Gallery").performClick()
+        onNodeWithTag("attachment_gallery").performClick()
         assertTrue(clicked)
     }
 
@@ -57,7 +57,7 @@ class AttachmentOptionsTest {
                 )
             }
         }
-        onNodeWithText("File").performClick()
+        onNodeWithTag("attachment_file").performClick()
         assertTrue(clicked)
     }
 }

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/ConversationMessagePreviewTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/ConversationMessagePreviewTest.kt
@@ -1,0 +1,70 @@
+package id.homebase.chat.widget
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class ConversationMessagePreviewTest {
+
+    @Test
+    fun displaysMessageText() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                ConversationMessagePreview(
+                    text = "Hello there!",
+                    iconRes = null,
+                    isDeleted = false,
+                )
+            }
+        }
+        onNodeWithText("Hello there!").assertExists()
+    }
+
+    @Test
+    fun showsFallbackText_whenEmptyTextAndNoIcon() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                ConversationMessagePreview(
+                    text = "",
+                    iconRes = null,
+                    isDeleted = false,
+                )
+            }
+        }
+        onNodeWithText("No messages yet").assertExists()
+    }
+
+    @Test
+    fun noFallback_whenEmptyTextButHasIcon() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                ConversationMessagePreview(
+                    text = "",
+                    iconRes = Icons.Filled.Image,
+                    isDeleted = false,
+                )
+            }
+        }
+        // Should NOT show fallback when there's an icon
+        onNodeWithText("No messages yet").assertDoesNotExist()
+    }
+
+    @Test
+    fun rendersDeletedMessage() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                ConversationMessagePreview(
+                    text = "Deleted message",
+                    iconRes = null,
+                    isDeleted = true,
+                )
+            }
+        }
+        onNodeWithText("Deleted message").assertExists()
+    }
+}

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/ConversationMessagePreviewTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/ConversationMessagePreviewTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
 import kotlin.test.Test
@@ -36,7 +37,7 @@ class ConversationMessagePreviewTest {
                 )
             }
         }
-        onNodeWithText("No messages yet").assertExists()
+        onNodeWithTag("no_messages_text").assertExists()
     }
 
     @Test
@@ -51,7 +52,7 @@ class ConversationMessagePreviewTest {
             }
         }
         // Should NOT show fallback when there's an icon
-        onNodeWithText("No messages yet").assertDoesNotExist()
+        onNodeWithTag("no_messages_text").assertDoesNotExist()
     }
 
     @Test

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/DeliveryStatusTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/DeliveryStatusTest.kt
@@ -1,0 +1,68 @@
+package id.homebase.chat.widget
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import id.homebase.chat.services.ChatDeliveryStatus
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class DeliveryStatusTest {
+
+    @Test
+    fun rendersForPendingSend() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                DeliveryStatus(
+                    isPendingSend = true,
+                    deliveryStatus = 0,
+                    contentColor = Color.White,
+                )
+            }
+        }
+        waitForIdle()
+    }
+
+    @Test
+    fun rendersForSentStatus() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                DeliveryStatus(
+                    isPendingSend = false,
+                    deliveryStatus = ChatDeliveryStatus.Sent.value,
+                    contentColor = Color.White,
+                )
+            }
+        }
+        waitForIdle()
+    }
+
+    @Test
+    fun rendersForDeliveredStatus() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                DeliveryStatus(
+                    isPendingSend = false,
+                    deliveryStatus = ChatDeliveryStatus.Delivered.value,
+                    contentColor = Color.White,
+                )
+            }
+        }
+        waitForIdle()
+    }
+
+    @Test
+    fun rendersForReadStatus() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                DeliveryStatus(
+                    isPendingSend = false,
+                    deliveryStatus = ChatDeliveryStatus.Read.value,
+                    contentColor = Color.White,
+                )
+            }
+        }
+        waitForIdle()
+    }
+}

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/DocumentMediaItemTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/DocumentMediaItemTest.kt
@@ -1,0 +1,112 @@
+package id.homebase.chat.widget
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import id.homebase.api.client.drives.files.PayloadDescriptor
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class DocumentMediaItemTest {
+
+    @Test
+    fun displaysFileName() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                DocumentMediaItem(
+                    payload = PayloadDescriptor(
+                        key = "payload-key",
+                        contentType = "application/pdf",
+                        descriptorContent = "report.pdf",
+                        bytesWritten = 1024 * 512,
+                    ),
+                    onDownloadClick = {},
+                    onLongPress = {},
+                )
+            }
+        }
+        onNodeWithText("report.pdf").assertExists()
+    }
+
+    @Test
+    fun displaysFileSize() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                DocumentMediaItem(
+                    payload = PayloadDescriptor(
+                        key = "payload-key",
+                        contentType = "application/pdf",
+                        descriptorContent = "report.pdf",
+                        bytesWritten = 1024 * 1024 * 2,
+                    ),
+                    onDownloadClick = {},
+                    onLongPress = {},
+                )
+            }
+        }
+        // 2 MB file — formatFileSize drops trailing .0
+        onNodeWithText("2 MB").assertExists()
+    }
+
+    @Test
+    fun usesKeyAsFallbackName_whenNoDescriptorContent() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                DocumentMediaItem(
+                    payload = PayloadDescriptor(
+                        key = "fallback-key",
+                        contentType = "application/pdf",
+                    ),
+                    onDownloadClick = {},
+                    onLongPress = {},
+                )
+            }
+        }
+        onNodeWithText("fallback-key").assertExists()
+    }
+
+    @Test
+    fun downloadClickFires() = runComposeUiTest {
+        var clicked = false
+        setContent {
+            MaterialTheme {
+                DocumentMediaItem(
+                    payload = PayloadDescriptor(
+                        key = "key",
+                        contentType = "application/pdf",
+                        descriptorContent = "file.pdf",
+                    ),
+                    onDownloadClick = { clicked = true },
+                    onLongPress = {},
+                )
+            }
+        }
+        onNodeWithContentDescription("Download File").performClick()
+        assertTrue(clicked)
+    }
+
+    @Test
+    fun rendersInDownloadingState() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                DocumentMediaItem(
+                    payload = PayloadDescriptor(
+                        key = "key",
+                        contentType = "application/zip",
+                        descriptorContent = "archive.zip",
+                    ),
+                    onDownloadClick = {},
+                    onLongPress = {},
+                    isDownloading = true,
+                )
+            }
+        }
+        onNodeWithText("archive.zip").assertExists()
+        // Download icon should be replaced by progress indicator
+        onNodeWithContentDescription("Download File").assertDoesNotExist()
+    }
+}

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/EmptyListItemTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/EmptyListItemTest.kt
@@ -1,0 +1,21 @@
+package id.homebase.chat.widget
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class EmptyListItemTest {
+
+    @Test
+    fun displaysGivenText() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                EmptyListItem(text = "No conversations yet")
+            }
+        }
+        onNodeWithText("No conversations yet").assertExists()
+    }
+}

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/ErrorInfoItemTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/ErrorInfoItemTest.kt
@@ -1,0 +1,21 @@
+package id.homebase.chat.widget
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class ErrorInfoItemTest {
+
+    @Test
+    fun displaysErrorText() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                ErrorInfoItem(text = "Something went wrong")
+            }
+        }
+        onNodeWithText("Something went wrong").assertExists()
+    }
+}

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/GroupMemberNamesCardTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/GroupMemberNamesCardTest.kt
@@ -1,0 +1,50 @@
+package id.homebase.chat.widget
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import kotlinx.collections.immutable.persistentListOf
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class GroupMemberNamesCardTest {
+
+    @Test
+    fun showsAllNames_whenFourOrFewer() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                GroupMemberNamesCard(
+                    participantNames = persistentListOf("Alice", "Bob"),
+                )
+            }
+        }
+        // String resource: "%1$s and you" → "Alice, Bob and you"
+        onNodeWithText("Alice, Bob and you").assertExists()
+    }
+
+    @Test
+    fun showsTruncatedNames_whenMoreThanFour() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                GroupMemberNamesCard(
+                    participantNames = persistentListOf("Alice", "Bob", "Charlie", "Dave", "Eve"),
+                )
+            }
+        }
+        // String resource: "%1$s, you and %2$s others" → "Alice, Bob, Charlie, you and 2 others"
+        onNodeWithText("Alice, Bob, Charlie, you and 2 others").assertExists()
+    }
+
+    @Test
+    fun showsSingleParticipant() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                GroupMemberNamesCard(
+                    participantNames = persistentListOf("Alice"),
+                )
+            }
+        }
+        onNodeWithText("Alice and you").assertExists()
+    }
+}

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/GroupMemberNamesCardTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/GroupMemberNamesCardTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
+import id.homebase.core.test.setTestLocale
 import kotlinx.collections.immutable.persistentListOf
 import kotlin.test.Test
 
@@ -12,6 +13,7 @@ class GroupMemberNamesCardTest {
 
     @Test
     fun showsAllNames_whenFourOrFewer() = runComposeUiTest {
+        setTestLocale("en-US")
         setContent {
             MaterialTheme {
                 GroupMemberNamesCard(
@@ -25,6 +27,7 @@ class GroupMemberNamesCardTest {
 
     @Test
     fun showsTruncatedNames_whenMoreThanFour() = runComposeUiTest {
+        setTestLocale("en-US")
         setContent {
             MaterialTheme {
                 GroupMemberNamesCard(
@@ -38,6 +41,7 @@ class GroupMemberNamesCardTest {
 
     @Test
     fun showsSingleParticipant() = runComposeUiTest {
+        setTestLocale("en-US")
         setContent {
             MaterialTheme {
                 GroupMemberNamesCard(

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/LoadingListItemTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/LoadingListItemTest.kt
@@ -1,0 +1,25 @@
+package id.homebase.chat.widget
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class LoadingListItemTest {
+
+    @Test
+    fun rendersWithoutCrashing() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                LoadingListItem()
+            }
+        }
+        // LoadingListItem renders a CircularProgressIndicator with no accessible text.
+        // This test verifies the composable renders without error.
+        waitForIdle()
+    }
+}

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/RichTextRenderingTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/RichTextRenderingTest.kt
@@ -1,17 +1,11 @@
 package id.homebase.chat.widget
 
-import androidx.compose.material3.Button
-import androidx.compose.material3.Text
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import com.mohamedrejeb.richeditor.model.RichTextState
 import com.mohamedrejeb.richeditor.ui.material3.RichText
@@ -22,32 +16,7 @@ import kotlin.test.Test
 import kotlin.test.assertFails
 
 @OptIn(ExperimentalTestApi::class)
-class MessageBubbleTest {
-
-    @Test
-    fun testMessageBubble() = runComposeUiTest {
-        // Declares a mock UI to demonstrate API calls
-        //
-        // Replace with your own declarations to test the code of your project
-        setContent {
-            var text by remember { mutableStateOf("Hello") }
-            Text(
-                text = text,
-                modifier = Modifier.testTag("text")
-            )
-            Button(
-                onClick = { text = "Compose" },
-                modifier = Modifier.testTag("button")
-            ) {
-                Text("Click me")
-            }
-        }
-
-        // Tests the declared UI with assertions and actions of the Compose Multiplatform testing API
-        onNodeWithTag("text").assertTextEquals("Hello")
-        onNodeWithTag("button").performClick()
-        onNodeWithTag("text").assertTextEquals("Compose")
-    }
+class RichTextRenderingTest {
 
     @Test
     fun testRichTextSetMarkdown() = runComposeUiTest {

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/RichTextStyleButtonTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/RichTextStyleButtonTest.kt
@@ -1,0 +1,46 @@
+package id.homebase.chat.widget
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FormatBold
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class RichTextStyleButtonTest {
+
+    @Test
+    fun clickCallbackFires() = runComposeUiTest {
+        var clicked = false
+        setContent {
+            MaterialTheme {
+                RichTextStyleButton(
+                    onClick = { clicked = true },
+                    icon = Icons.Filled.FormatBold,
+                )
+            }
+        }
+        onNodeWithContentDescription("Filled.FormatBold").performClick()
+        assertTrue(clicked)
+    }
+
+    @Test
+    fun disabledButtonDoesNotFireCallback() = runComposeUiTest {
+        var clicked = false
+        setContent {
+            MaterialTheme {
+                RichTextStyleButton(
+                    onClick = { clicked = true },
+                    icon = Icons.Filled.FormatBold,
+                    enabled = false,
+                )
+            }
+        }
+        onNodeWithContentDescription("Filled.FormatBold").performClick()
+        assertTrue(!clicked)
+    }
+}

--- a/homebase-common/build.gradle.kts
+++ b/homebase-common/build.gradle.kts
@@ -92,6 +92,10 @@ kotlin {
         commonTest.dependencies {
             implementation(libs.kotlin.test)
             implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.jetbrains.compose.ui.test)
+        }
+        jvmTest.dependencies {
+            implementation(compose.desktop.currentOs)
         }
         androidMain.dependencies {
             implementation(libs.androidx.activity.compose)

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/test/TestHelpers.jvm.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/test/TestHelpers.jvm.kt
@@ -1,0 +1,7 @@
+package id.homebase.core.test
+
+import java.util.Locale
+
+actual fun setTestLocale(languageTag: String) {
+    Locale.setDefault(Locale.forLanguageTag(languageTag))
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/test/TestHelpers.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/test/TestHelpers.kt
@@ -1,0 +1,3 @@
+package id.homebase.core.test
+
+expect fun setTestLocale(languageTag: String)

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/MinimalTextField.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/MinimalTextField.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
@@ -46,7 +47,7 @@ fun MinimalTextField(
         },
         leadingIcon = if (!showBackButton) null else {
             {
-                IconButton(onClick = onBackButtonClick) {
+                IconButton(onClick = onBackButtonClick, modifier = Modifier.testTag("back_button")) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                         contentDescription = stringResource(MR.string.menu_back)
@@ -57,7 +58,7 @@ fun MinimalTextField(
         },
         trailingIcon = {
             if (state.text.isNotEmpty()) {
-                IconButton(onClick = { state.clearText() }) {
+                IconButton(onClick = { state.clearText() }, modifier = Modifier.testTag("clear_input_button")) {
                     Icon(
                         imageVector = Icons.Default.Close,
                         contentDescription = stringResource(MR.string.clear_input)

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionList.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionList.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import id.homebase.api.client.drives.files.ReactionSummary
@@ -119,7 +120,7 @@ fun ReactionMenu(
             }
             IconButton(
                 onClick = onShowAllEmojis,
-                modifier = Modifier.size(40.dp)
+                modifier = Modifier.size(40.dp).testTag("emoji_options_button")
             ) {
                 Icon(
                     Icons.Default.MoreHoriz,

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/StyledSearchTextField.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/StyledSearchTextField.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
@@ -48,7 +49,7 @@ fun StyledSearchTextField(
         leadingIcon = if (!showBackButton && !showSearchIcon) null else {
             {
                 if (showBackButton) {
-                    IconButton(onClick = onBackButtonClick) {
+                    IconButton(onClick = onBackButtonClick, modifier = Modifier.testTag("back_button")) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = stringResource(MR.string.menu_back)
@@ -57,14 +58,15 @@ fun StyledSearchTextField(
                 } else if (showSearchIcon) {
                     Icon(
                         imageVector = Icons.Default.Search,
-                        contentDescription = stringResource(MR.string.search)
+                        contentDescription = stringResource(MR.string.search),
+                        modifier = Modifier.testTag("search_icon")
                     )
                 }
             }
         },
         trailingIcon = {
             if (textFieldState.text.isNotEmpty()) {
-                IconButton(onClick = { textFieldState.clearText() }) {
+                IconButton(onClick = { textFieldState.clearText() }, modifier = Modifier.testTag("clear_input_button")) {
                     Icon(
                         imageVector = Icons.Default.Close,
                         contentDescription = stringResource(MR.string.clear_input)

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/CheckboxRowTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/CheckboxRowTest.kt
@@ -1,0 +1,59 @@
+package id.homebase.core.widget
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class CheckboxRowTest {
+
+    @Test
+    fun displaysLabel() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                CheckboxRow(
+                    label = "Enable notifications",
+                    checked = false,
+                    onCheckedChange = {},
+                )
+            }
+        }
+        onNodeWithText("Enable notifications").assertExists()
+    }
+
+    @Test
+    fun clickingRowTogglesValue() = runComposeUiTest {
+        var lastValue: Boolean? = null
+        setContent {
+            MaterialTheme {
+                CheckboxRow(
+                    label = "Enable notifications",
+                    checked = false,
+                    onCheckedChange = { lastValue = it },
+                )
+            }
+        }
+        onNodeWithText("Enable notifications").performClick()
+        assertEquals(true, lastValue)
+    }
+
+    @Test
+    fun clickingCheckedRowPassesFalse() = runComposeUiTest {
+        var lastValue: Boolean? = null
+        setContent {
+            MaterialTheme {
+                CheckboxRow(
+                    label = "Enable notifications",
+                    checked = true,
+                    onCheckedChange = { lastValue = it },
+                )
+            }
+        }
+        onNodeWithText("Enable notifications").performClick()
+        assertEquals(false, lastValue)
+    }
+}

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/DialogButtonsTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/DialogButtonsTest.kt
@@ -1,0 +1,106 @@
+package id.homebase.core.widget
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class DialogButtonsTest {
+
+    @Test
+    fun showsPrimaryButton_whenTextProvided() = runComposeUiTest {
+        var clicked = false
+        setContent {
+            MaterialTheme {
+                DialogButtons(
+                    primaryText = "OK",
+                    onPrimaryClick = { clicked = true },
+                )
+            }
+        }
+        onNodeWithText("OK").assertExists()
+        onNodeWithText("OK").performClick()
+        assertTrue(clicked)
+    }
+
+    @Test
+    fun hidesPrimaryButton_whenTextNull() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                DialogButtons(
+                    primaryText = null,
+                    onPrimaryClick = null,
+                )
+            }
+        }
+        onNodeWithText("OK").assertDoesNotExist()
+    }
+
+    @Test
+    fun showsAllThreeButtons() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                DialogButtons(
+                    primaryText = "Save",
+                    onPrimaryClick = {},
+                    secondaryText = "Cancel",
+                    onSecondaryClick = {},
+                    tertiaryText = "Delete",
+                    onTertiaryClick = {},
+                )
+            }
+        }
+        onNodeWithText("Save").assertExists()
+        onNodeWithText("Cancel").assertExists()
+        onNodeWithText("Delete").assertExists()
+    }
+
+    @Test
+    fun secondaryClickCallbackFires() = runComposeUiTest {
+        var clicked = false
+        setContent {
+            MaterialTheme {
+                DialogButtons(
+                    secondaryText = "Cancel",
+                    onSecondaryClick = { clicked = true },
+                )
+            }
+        }
+        onNodeWithText("Cancel").performClick()
+        assertTrue(clicked)
+    }
+
+    @Test
+    fun verticalLayout_showsAllButtons() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                DialogButtons(
+                    primaryText = "Save",
+                    onPrimaryClick = {},
+                    secondaryText = "Cancel",
+                    onSecondaryClick = {},
+                    showButtonsVertically = true,
+                )
+            }
+        }
+        onNodeWithText("Save").assertExists()
+        onNodeWithText("Cancel").assertExists()
+    }
+
+    @Test
+    fun hidesButton_whenOnlyTextProvided_butCallbackNull() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                DialogButtons(
+                    primaryText = "OK",
+                    onPrimaryClick = null,
+                )
+            }
+        }
+        onNodeWithText("OK").assertDoesNotExist()
+    }
+}

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/ListItemActionTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/ListItemActionTest.kt
@@ -1,0 +1,76 @@
+package id.homebase.core.widget
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class ListItemActionTest {
+
+    @Test
+    fun displaysText() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                ListItemAction(
+                    imageVector = Icons.Filled.Edit,
+                    text = "Edit message",
+                    onClick = {},
+                )
+            }
+        }
+        onNodeWithText("Edit message").assertExists()
+    }
+
+    @Test
+    fun clickCallbackFires() = runComposeUiTest {
+        var clicked = false
+        setContent {
+            MaterialTheme {
+                ListItemAction(
+                    imageVector = Icons.Filled.Delete,
+                    text = "Delete",
+                    onClick = { clicked = true },
+                )
+            }
+        }
+        onNodeWithText("Delete").performClick()
+        assertTrue(clicked)
+    }
+
+    @Test
+    fun normalIconVariant_displaysText() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                ListItemActionNormalIcon(
+                    imageVector = Icons.Filled.Edit,
+                    text = "Edit",
+                    onClick = {},
+                )
+            }
+        }
+        onNodeWithText("Edit").assertExists()
+    }
+
+    @Test
+    fun normalIconVariant_clickCallbackFires() = runComposeUiTest {
+        var clicked = false
+        setContent {
+            MaterialTheme {
+                ListItemActionNormalIcon(
+                    imageVector = Icons.Filled.Edit,
+                    text = "Edit",
+                    onClick = { clicked = true },
+                )
+            }
+        }
+        onNodeWithText("Edit").performClick()
+        assertTrue(clicked)
+    }
+}

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/MinimalTextFieldTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/MinimalTextFieldTest.kt
@@ -1,0 +1,84 @@
+package id.homebase.core.widget
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class MinimalTextFieldTest {
+
+    @Test
+    fun showsPlaceholder() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                MinimalTextField(
+                    state = TextFieldState(),
+                    placeHolderText = "Enter name...",
+                )
+            }
+        }
+        onNodeWithText("Enter name...").assertExists()
+    }
+
+    @Test
+    fun hidesBackButton_byDefault() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                MinimalTextField(
+                    state = TextFieldState(),
+                    placeHolderText = "Search",
+                )
+            }
+        }
+        onNodeWithContentDescription("Back").assertDoesNotExist()
+    }
+
+    @Test
+    fun showsBackButton_whenEnabled() = runComposeUiTest {
+        var backClicked = false
+        setContent {
+            MaterialTheme {
+                MinimalTextField(
+                    state = TextFieldState(),
+                    showBackButton = true,
+                    placeHolderText = "Search",
+                    onBackButtonClick = { backClicked = true },
+                )
+            }
+        }
+        onNodeWithContentDescription("Back").performClick()
+        assertTrue(backClicked)
+    }
+
+    @Test
+    fun hidesClearButton_whenEmpty() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                MinimalTextField(
+                    state = TextFieldState(),
+                    placeHolderText = "Search",
+                )
+            }
+        }
+        onNodeWithContentDescription("Clear input").assertDoesNotExist()
+    }
+
+    @Test
+    fun showsClearButton_whenTextPresent() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                MinimalTextField(
+                    state = TextFieldState(initialText = "hello"),
+                    placeHolderText = "Search",
+                )
+            }
+        }
+        onNodeWithContentDescription("Clear input").assertExists()
+    }
+}

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/MinimalTextFieldTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/MinimalTextFieldTest.kt
@@ -3,7 +3,7 @@ package id.homebase.core.widget
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
@@ -36,7 +36,7 @@ class MinimalTextFieldTest {
                 )
             }
         }
-        onNodeWithContentDescription("Back").assertDoesNotExist()
+        onNodeWithTag("back_button").assertDoesNotExist()
     }
 
     @Test
@@ -52,7 +52,7 @@ class MinimalTextFieldTest {
                 )
             }
         }
-        onNodeWithContentDescription("Back").performClick()
+        onNodeWithTag("back_button").performClick()
         assertTrue(backClicked)
     }
 
@@ -66,7 +66,7 @@ class MinimalTextFieldTest {
                 )
             }
         }
-        onNodeWithContentDescription("Clear input").assertDoesNotExist()
+        onNodeWithTag("clear_input_button").assertDoesNotExist()
     }
 
     @Test
@@ -79,6 +79,6 @@ class MinimalTextFieldTest {
                 )
             }
         }
-        onNodeWithContentDescription("Clear input").assertExists()
+        onNodeWithTag("clear_input_button").assertExists()
     }
 }

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/ReactionIconTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/ReactionIconTest.kt
@@ -1,0 +1,76 @@
+package id.homebase.core.widget
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class ReactionIconTest {
+
+    @Test
+    fun displaysEmoji() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                ReactionIcon(
+                    emoji = "\uD83D\uDC4D",
+                    count = 1,
+                    onClick = {},
+                    onLongClick = {},
+                )
+            }
+        }
+        onNodeWithText("\uD83D\uDC4D").assertExists()
+    }
+
+    @Test
+    fun hidesCount_whenOne() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                ReactionIcon(
+                    emoji = "\uD83D\uDC4D",
+                    count = 1,
+                    onClick = {},
+                    onLongClick = {},
+                )
+            }
+        }
+        // count "1" should not be displayed when count == 1
+        onNodeWithText("1").assertDoesNotExist()
+    }
+
+    @Test
+    fun showsCount_whenGreaterThanOne() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                ReactionIcon(
+                    emoji = "\uD83D\uDC4D",
+                    count = 5,
+                    onClick = {},
+                    onLongClick = {},
+                )
+            }
+        }
+        onNodeWithText("5").assertExists()
+    }
+
+    @Test
+    fun clickCallbackFires() = runComposeUiTest {
+        var clicked = false
+        setContent {
+            MaterialTheme {
+                ReactionIcon(
+                    emoji = "\uD83D\uDC4D",
+                    count = 1,
+                    onClick = { clicked = true },
+                    onLongClick = {},
+                )
+            }
+        }
+        onNodeWithText("\uD83D\uDC4D").performClick()
+        assertTrue(clicked)
+    }
+}

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/ReactionMenuTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/ReactionMenuTest.kt
@@ -2,7 +2,7 @@ package id.homebase.core.widget
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
@@ -55,7 +55,7 @@ class ReactionMenuTest {
                 )
             }
         }
-        onNodeWithContentDescription("Emoji options").assertExists()
+        onNodeWithTag("emoji_options_button").assertExists()
     }
 
     @Test
@@ -69,7 +69,7 @@ class ReactionMenuTest {
                 )
             }
         }
-        onNodeWithContentDescription("Emoji options").performClick()
+        onNodeWithTag("emoji_options_button").performClick()
         assertTrue(showAll)
     }
 

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/ReactionMenuTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/ReactionMenuTest.kt
@@ -1,0 +1,93 @@
+package id.homebase.core.widget
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlinx.collections.immutable.persistentListOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class ReactionMenuTest {
+
+    @Test
+    fun showsDefaultReactions_whenNoUserReactions() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                ReactionMenu(
+                    onSelect = {},
+                    onShowAllEmojis = {},
+                )
+            }
+        }
+        onNodeWithText("\u2764\uFE0F").assertExists()  // ❤️
+        onNodeWithText("\uD83D\uDC4D").assertExists()  // 👍
+        onNodeWithText("\uD83D\uDC4E").assertExists()  // 👎
+        onNodeWithText("\uD83D\uDE02").assertExists()  // 😂
+    }
+
+    @Test
+    fun selectCallbackFires() = runComposeUiTest {
+        var selected = ""
+        setContent {
+            MaterialTheme {
+                ReactionMenu(
+                    onSelect = { selected = it },
+                    onShowAllEmojis = {},
+                )
+            }
+        }
+        onNodeWithText("\uD83D\uDC4D").performClick()  // 👍
+        assertEquals("\uD83D\uDC4D", selected)
+    }
+
+    @Test
+    fun showsMoreButton() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                ReactionMenu(
+                    onSelect = {},
+                    onShowAllEmojis = {},
+                )
+            }
+        }
+        onNodeWithContentDescription("Emoji options").assertExists()
+    }
+
+    @Test
+    fun moreButtonFiresShowAllEmojis() = runComposeUiTest {
+        var showAll = false
+        setContent {
+            MaterialTheme {
+                ReactionMenu(
+                    onSelect = {},
+                    onShowAllEmojis = { showAll = true },
+                )
+            }
+        }
+        onNodeWithContentDescription("Emoji options").performClick()
+        assertTrue(showAll)
+    }
+
+    @Test
+    fun userReactionsReplaceDefaults() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                ReactionMenu(
+                    userDefaultReactions = persistentListOf("\uD83C\uDF89", "\uD83D\uDD25"),  // 🎉, 🔥
+                    onSelect = {},
+                    onShowAllEmojis = {},
+                )
+            }
+        }
+        onNodeWithText("\uD83C\uDF89").assertExists()  // 🎉
+        onNodeWithText("\uD83D\uDD25").assertExists()  // 🔥
+        // Default reactions should fill remaining slots
+        onNodeWithText("\u2764\uFE0F").assertExists()  // ❤️
+        onNodeWithText("\uD83D\uDC4D").assertExists()  // 👍
+    }
+}

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/SettingsClickableRowTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/SettingsClickableRowTest.kt
@@ -1,0 +1,80 @@
+package id.homebase.core.widget
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlinx.collections.immutable.persistentListOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class SettingsClickableRowTest {
+
+    private val options = persistentListOf(
+        SettingsRowItemData("English", "en"),
+        SettingsRowItemData("Dutch", "nl"),
+        SettingsRowItemData("German", "de"),
+    )
+
+    @Test
+    fun displaysLabelAndSelectedValue() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                SettingsClickableRow(
+                    label = "Language",
+                    selectedValue = options[0],
+                    options = options,
+                    onSelected = {},
+                )
+            }
+        }
+        onNodeWithText("Language").assertExists()
+        onNodeWithText("English").assertExists()
+    }
+
+    @Test
+    fun expandsOptionsOnClick() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                SettingsClickableRow(
+                    label = "Language",
+                    selectedValue = options[0],
+                    options = options,
+                    onSelected = {},
+                )
+            }
+        }
+        // Options should not be visible initially
+        onNodeWithText("Dutch").assertDoesNotExist()
+
+        // Click the row to expand
+        onNodeWithText("Language").performClick()
+
+        // Options should now be visible
+        onNodeWithText("Dutch").assertExists()
+        onNodeWithText("German").assertExists()
+    }
+
+    @Test
+    fun selectingOptionFiresCallback() = runComposeUiTest {
+        var selected = ""
+        setContent {
+            MaterialTheme {
+                SettingsClickableRow(
+                    label = "Language",
+                    selectedValue = options[0],
+                    options = options,
+                    onSelected = { selected = it },
+                )
+            }
+        }
+        // Expand
+        onNodeWithText("Language").performClick()
+        // Select Dutch
+        onNodeWithText("Dutch").performClick()
+        assertEquals("nl", selected)
+    }
+}

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/SettingsItemActionTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/SettingsItemActionTest.kt
@@ -1,0 +1,77 @@
+package id.homebase.core.widget
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class SettingsItemActionTest {
+
+    @Test
+    fun displaysText() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                SettingsItemAction(
+                    imageVector = Icons.Filled.Notifications,
+                    text = "Notifications",
+                    onClick = {},
+                )
+            }
+        }
+        onNodeWithText("Notifications").assertExists()
+    }
+
+    @Test
+    fun clickCallbackFires() = runComposeUiTest {
+        var clicked = false
+        setContent {
+            MaterialTheme {
+                SettingsItemAction(
+                    imageVector = Icons.Filled.Notifications,
+                    text = "Notifications",
+                    onClick = { clicked = true },
+                )
+            }
+        }
+        onNodeWithText("Notifications").performClick()
+        assertTrue(clicked)
+    }
+
+    @Test
+    fun showsTrailingContent_whenProvided() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                SettingsItemAction(
+                    imageVector = Icons.Filled.Notifications,
+                    text = "Notifications",
+                    onClick = {},
+                    trailingContent = { Text("ON") },
+                )
+            }
+        }
+        onNodeWithText("Notifications").assertExists()
+        onNodeWithText("ON").assertExists()
+    }
+
+    @Test
+    fun hidesTrailingContent_whenNull() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                SettingsItemAction(
+                    imageVector = Icons.Filled.Notifications,
+                    text = "Notifications",
+                    onClick = {},
+                    trailingContent = null,
+                )
+            }
+        }
+        onNodeWithText("ON").assertDoesNotExist()
+    }
+}

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/StyledSearchTextFieldTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/StyledSearchTextFieldTest.kt
@@ -3,7 +3,7 @@ package id.homebase.core.widget
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
@@ -36,7 +36,7 @@ class StyledSearchTextFieldTest {
                 )
             }
         }
-        onNodeWithContentDescription("Search").assertExists()
+        onNodeWithTag("search_icon", useUnmergedTree = true).assertExists()
     }
 
     @Test
@@ -52,7 +52,7 @@ class StyledSearchTextFieldTest {
                 )
             }
         }
-        onNodeWithContentDescription("Back").performClick()
+        onNodeWithTag("back_button").performClick()
         assertTrue(backClicked)
     }
 
@@ -66,7 +66,7 @@ class StyledSearchTextFieldTest {
                 )
             }
         }
-        onNodeWithContentDescription("Clear input").assertDoesNotExist()
+        onNodeWithTag("clear_input_button").assertDoesNotExist()
     }
 
     @Test
@@ -79,6 +79,6 @@ class StyledSearchTextFieldTest {
                 )
             }
         }
-        onNodeWithContentDescription("Clear input").assertExists()
+        onNodeWithTag("clear_input_button").assertExists()
     }
 }

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/StyledSearchTextFieldTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/StyledSearchTextFieldTest.kt
@@ -1,0 +1,84 @@
+package id.homebase.core.widget
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class StyledSearchTextFieldTest {
+
+    @Test
+    fun showsPlaceholderText() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                StyledSearchTextField(
+                    textFieldState = TextFieldState(),
+                    placeHolderText = "Search conversations...",
+                )
+            }
+        }
+        onNodeWithText("Search conversations...").assertExists()
+    }
+
+    @Test
+    fun showsSearchIcon_byDefault() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                StyledSearchTextField(
+                    textFieldState = TextFieldState(),
+                    placeHolderText = "Search",
+                )
+            }
+        }
+        onNodeWithContentDescription("Search").assertExists()
+    }
+
+    @Test
+    fun showsBackButton_whenEnabled() = runComposeUiTest {
+        var backClicked = false
+        setContent {
+            MaterialTheme {
+                StyledSearchTextField(
+                    textFieldState = TextFieldState(),
+                    showBackButton = true,
+                    placeHolderText = "Search",
+                    onBackButtonClick = { backClicked = true },
+                )
+            }
+        }
+        onNodeWithContentDescription("Back").performClick()
+        assertTrue(backClicked)
+    }
+
+    @Test
+    fun hidesClearButton_whenEmpty() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                StyledSearchTextField(
+                    textFieldState = TextFieldState(),
+                    placeHolderText = "Search",
+                )
+            }
+        }
+        onNodeWithContentDescription("Clear input").assertDoesNotExist()
+    }
+
+    @Test
+    fun showsClearButton_whenTextPresent() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                StyledSearchTextField(
+                    textFieldState = TextFieldState(initialText = "hello"),
+                    placeHolderText = "Search",
+                )
+            }
+        }
+        onNodeWithContentDescription("Clear input").assertExists()
+    }
+}

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/test/TestHelpers.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/test/TestHelpers.jvm.kt
@@ -1,0 +1,7 @@
+package id.homebase.core.test
+
+import java.util.Locale
+
+actual fun setTestLocale(languageTag: String) {
+    Locale.setDefault(Locale.forLanguageTag(languageTag))
+}

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/test/TestHelpers.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/test/TestHelpers.native.kt
@@ -1,0 +1,9 @@
+package id.homebase.core.test
+
+import platform.Foundation.NSUserDefaults
+
+actual fun setTestLocale(languageTag: String) {
+    val defaults = NSUserDefaults.standardUserDefaults
+    defaults.setObject(listOf(languageTag), forKey = "AppleLanguages")
+    defaults.synchronize()
+}

--- a/homebase-core/build.gradle.kts
+++ b/homebase-core/build.gradle.kts
@@ -103,6 +103,10 @@ kotlin {
             implementation(libs.kotlinx.coroutines.test)
             implementation(libs.kotlinx.datetime)
             implementation(libs.ktor.client.mock)
+            implementation(libs.jetbrains.compose.ui.test)
+        }
+        jvmTest.dependencies {
+            implementation(compose.desktop.currentOs)
         }
         iosTest.dependencies {
             implementation(libs.sqldelight.native.driver)

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/appearance/AppearanceSettingsUiTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/appearance/AppearanceSettingsUiTest.kt
@@ -1,0 +1,118 @@
+package id.homebase.core.ui.screens.appearance
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import id.homebase.core.settings.Language
+import id.homebase.core.settings.ThemeState
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class AppearanceSettingsUiTest {
+
+    @Test
+    fun showsTitle() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                AppearanceSettingsUi(
+                    uiState = AppearanceSettingsUiState(),
+                    onAction = {},
+                    onBackClick = {},
+                )
+            }
+        }
+        onNodeWithText("Appearance").assertExists()
+    }
+
+    @Test
+    fun showsLanguageAndThemeRows() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                AppearanceSettingsUi(
+                    uiState = AppearanceSettingsUiState(),
+                    onAction = {},
+                    onBackClick = {},
+                )
+            }
+        }
+        onNodeWithText("Language").assertExists()
+        onNodeWithText("Theme").assertExists()
+    }
+
+    @Test
+    fun showsSelectedLanguage() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                AppearanceSettingsUi(
+                    uiState = AppearanceSettingsUiState(
+                        selectedLanguage = Language.ENGLISH_US,
+                    ),
+                    onAction = {},
+                    onBackClick = {},
+                )
+            }
+        }
+        onNodeWithText("English (USA)").assertExists()
+    }
+
+    @Test
+    fun showsSelectedTheme() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                AppearanceSettingsUi(
+                    uiState = AppearanceSettingsUiState(
+                        selectedTheme = ThemeState.Dark,
+                    ),
+                    onAction = {},
+                    onBackClick = {},
+                )
+            }
+        }
+        onNodeWithText("Dark").assertExists()
+    }
+
+    @Test
+    fun languageSelectionFiresAction() = runComposeUiTest {
+        var selectedLanguage: Language? = null
+        setContent {
+            MaterialTheme {
+                AppearanceSettingsUi(
+                    uiState = AppearanceSettingsUiState(
+                        selectedLanguage = Language.SYSTEM,
+                    ),
+                    onAction = { action ->
+                        if (action is AppearanceSettingsUiAction.LanguageSelected) {
+                            selectedLanguage = action.language
+                        }
+                    },
+                    onBackClick = {},
+                )
+            }
+        }
+        // Expand language options
+        onNodeWithText("Language").performClick()
+        // Select English (USA)
+        onNodeWithText("English (USA)").performClick()
+        assertTrue(selectedLanguage == Language.ENGLISH_US)
+    }
+
+    @Test
+    fun backClickFires() = runComposeUiTest {
+        var backClicked = false
+        setContent {
+            MaterialTheme {
+                AppearanceSettingsUi(
+                    uiState = AppearanceSettingsUiState(),
+                    onAction = {},
+                    onBackClick = { backClicked = true },
+                )
+            }
+        }
+        onNodeWithContentDescription("Back").performClick()
+        assertTrue(backClicked)
+    }
+}

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/notifications/NotificationSettingsUiTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/notifications/NotificationSettingsUiTest.kt
@@ -1,0 +1,162 @@
+package id.homebase.core.ui.screens.notifications
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class NotificationSettingsUiTest {
+
+    @Test
+    fun showsTitle() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                NotificationSettingsUi(
+                    uiState = NotificationSettingsUiState(),
+                    onAction = {},
+                    onBackClick = {},
+                    onOpenSystemSettings = {},
+                )
+            }
+        }
+        onNodeWithText("Notifications").assertExists()
+    }
+
+    @Test
+    fun showsPermissionCard_whenNotGranted() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                NotificationSettingsUi(
+                    uiState = NotificationSettingsUiState(isPermissionGranted = false),
+                    onAction = {},
+                    onBackClick = {},
+                    onOpenSystemSettings = {},
+                )
+            }
+        }
+        onNodeWithText("Push Notifications are disabled").assertExists()
+        onNodeWithText("Enable Notifications").assertExists()
+    }
+
+    @Test
+    fun hidesPermissionCard_whenGranted() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                NotificationSettingsUi(
+                    uiState = NotificationSettingsUiState(isPermissionGranted = true),
+                    onAction = {},
+                    onBackClick = {},
+                    onOpenSystemSettings = {},
+                )
+            }
+        }
+        onNodeWithText("Push Notifications are disabled").assertDoesNotExist()
+        onNodeWithText("Enable Notifications").assertDoesNotExist()
+    }
+
+    @Test
+    fun showsSoundSettings() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                NotificationSettingsUi(
+                    uiState = NotificationSettingsUiState(),
+                    onAction = {},
+                    onBackClick = {},
+                    onOpenSystemSettings = {},
+                )
+            }
+        }
+        onNodeWithText("Sounds").assertExists()
+        onNodeWithText("Message Sound").assertExists()
+        onNodeWithText("Play While App is Open").assertExists()
+    }
+
+    @Test
+    fun showsNotificationContentSection() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                NotificationSettingsUi(
+                    uiState = NotificationSettingsUiState(
+                        notificationContentLevel = NotificationContentLevel.NAME_ONLY,
+                    ),
+                    onAction = {},
+                    onBackClick = {},
+                    onOpenSystemSettings = {},
+                )
+            }
+        }
+        onNodeWithText("Notification Content").assertExists()
+        onNodeWithText("Name Only").assertExists()
+    }
+
+    @Test
+    fun enableNotificationsFiresAction() = runComposeUiTest {
+        var requestedPermission = false
+        setContent {
+            MaterialTheme {
+                NotificationSettingsUi(
+                    uiState = NotificationSettingsUiState(isPermissionGranted = false),
+                    onAction = { action ->
+                        if (action is NotificationSettingsUiAction.RequestPermission) {
+                            requestedPermission = true
+                        }
+                    },
+                    onBackClick = {},
+                    onOpenSystemSettings = {},
+                )
+            }
+        }
+        onNodeWithText("Enable Notifications").performClick()
+        assertTrue(requestedPermission)
+    }
+
+    @Test
+    fun showsReRegisterButton() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                NotificationSettingsUi(
+                    uiState = NotificationSettingsUiState(),
+                    onAction = {},
+                    onBackClick = {},
+                    onOpenSystemSettings = {},
+                )
+            }
+        }
+        onNodeWithText("Re-register Push Notifications").assertExists()
+    }
+
+    @Test
+    fun showsReRegisteringState() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                NotificationSettingsUi(
+                    uiState = NotificationSettingsUiState(isReRegistering = true),
+                    onAction = {},
+                    onBackClick = {},
+                    onOpenSystemSettings = {},
+                )
+            }
+        }
+        onNodeWithText("Re-registering...").assertExists()
+    }
+
+    @Test
+    fun showsBadgeCountSection() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                NotificationSettingsUi(
+                    uiState = NotificationSettingsUiState(),
+                    onAction = {},
+                    onBackClick = {},
+                    onOpenSystemSettings = {},
+                )
+            }
+        }
+        onNodeWithText("Badge Count").assertExists()
+        onNodeWithText("Include Muted Chats").assertExists()
+    }
+}

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/settings/SettingsUiTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/settings/SettingsUiTest.kt
@@ -1,0 +1,153 @@
+package id.homebase.core.ui.screens.settings
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class SettingsUiTest {
+
+    @Test
+    fun showsTitle() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                SettingsUi(
+                    uiState = SettingsUiState(appVersion = "1.0.0"),
+                    onAction = {},
+                    onBackClick = {},
+                    onNavigateToNotifications = {},
+                    onNavigateToAppearance = {},
+                    onNavigateToHelp = {},
+                )
+            }
+        }
+        onNodeWithText("Settings").assertExists()
+    }
+
+    @Test
+    fun showsAllMenuItems() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                SettingsUi(
+                    uiState = SettingsUiState(appVersion = "1.0.0"),
+                    onAction = {},
+                    onBackClick = {},
+                    onNavigateToNotifications = {},
+                    onNavigateToAppearance = {},
+                    onNavigateToHelp = {},
+                )
+            }
+        }
+        onNodeWithText("Notifications").assertExists()
+        onNodeWithText("Appearance").assertExists()
+        onNodeWithText("Help").assertExists()
+        onNodeWithText("Delete my account").assertExists()
+        onNodeWithText("Log out").assertExists()
+    }
+
+    @Test
+    fun showsAppVersionInfo() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                SettingsUi(
+                    uiState = SettingsUiState(appVersion = "2.5.3"),
+                    onAction = {},
+                    onBackClick = {},
+                    onNavigateToNotifications = {},
+                    onNavigateToAppearance = {},
+                    onNavigateToHelp = {},
+                )
+            }
+        }
+        onNodeWithText("Homebase Chat").assertExists()
+        onNodeWithText("Version 2.5.3").assertExists()
+    }
+
+    @Test
+    fun notificationsClickNavigates() = runComposeUiTest {
+        var navigated = false
+        setContent {
+            MaterialTheme {
+                SettingsUi(
+                    uiState = SettingsUiState(appVersion = "1.0.0"),
+                    onAction = {},
+                    onBackClick = {},
+                    onNavigateToNotifications = { navigated = true },
+                    onNavigateToAppearance = {},
+                    onNavigateToHelp = {},
+                )
+            }
+        }
+        onNodeWithText("Notifications").performClick()
+        assertTrue(navigated)
+    }
+
+    @Test
+    fun appearanceClickNavigates() = runComposeUiTest {
+        var navigated = false
+        setContent {
+            MaterialTheme {
+                SettingsUi(
+                    uiState = SettingsUiState(appVersion = "1.0.0"),
+                    onAction = {},
+                    onBackClick = {},
+                    onNavigateToNotifications = {},
+                    onNavigateToAppearance = { navigated = true },
+                    onNavigateToHelp = {},
+                )
+            }
+        }
+        onNodeWithText("Appearance").performClick()
+        assertTrue(navigated)
+    }
+
+    @Test
+    fun logoutFiresAction() = runComposeUiTest {
+        var loggedOut = false
+        setContent {
+            MaterialTheme {
+                SettingsUi(
+                    uiState = SettingsUiState(appVersion = "1.0.0"),
+                    onAction = { action ->
+                        if (action is SettingsUiAction.LogoutClicked) {
+                            loggedOut = true
+                        }
+                    },
+                    onBackClick = {},
+                    onNavigateToNotifications = {},
+                    onNavigateToAppearance = {},
+                    onNavigateToHelp = {},
+                )
+            }
+        }
+        onNodeWithText("Log out").performClick()
+        assertTrue(loggedOut)
+    }
+
+    @Test
+    fun deleteAccountFiresAction() = runComposeUiTest {
+        var deleteClicked = false
+        setContent {
+            MaterialTheme {
+                SettingsUi(
+                    uiState = SettingsUiState(appVersion = "1.0.0"),
+                    onAction = { action ->
+                        if (action is SettingsUiAction.DeleteAccount) {
+                            deleteClicked = true
+                        }
+                    },
+                    onBackClick = {},
+                    onNavigateToNotifications = {},
+                    onNavigateToAppearance = {},
+                    onNavigateToHelp = {},
+                )
+            }
+        }
+        onNodeWithText("Delete my account").performClick()
+        assertTrue(deleteClicked)
+    }
+}


### PR DESCRIPTION
Add Compose Multiplatform UI tests across all modules

Leverage the Compose Multiplatform testing framework (runComposeUiTest)
to add cross-platform UI tests for composable widgets and screens.
All tests run on JVM and verify rendering, interactions, and conditional logic.

# Gradle changes
- homebase-common: Add compose.uiTest + compose.desktop.currentOs test deps
- homebase-auth: Add compose.uiTest + compose.desktop.currentOs test deps
- homebase-core: Add compose.uiTest + compose.desktop.currentOs test deps
- homebase-chat: Already had deps; cleaned up boilerplate MessageBubbleTest

# homebase-chat (10 test files)
- RichTextRenderingTest: Renamed from MessageBubbleTest, removed boilerplate demo
- EmptyListItemTest: Text rendering
- ErrorInfoItemTest: Error text rendering
- LoadingListItemTest: Composable renders without crash
- RichTextStyleButtonTest: Click callback, disabled state
- GroupMemberNamesCardTest: Name truncation logic (<=4 vs >4 names)
- AttachmentOptionsTest: Gallery/File display and click callbacks
- DeliveryStatusTest: All 4 delivery icon states
- ConversationMessagePreviewTest: Text, fallback, icon-only, deleted state
- DocumentMediaItemTest: File name/size, download click, downloading state

# homebase-common (8 test files)
- DialogButtonsTest: Button visibility, clicks, vertical layout
- SettingsClickableRowTest: Expand/collapse, option selection
- CheckboxRowTest: Toggle interaction
- SettingsItemActionTest: Text, click, trailing content
- ListItemActionTest: Both ListItemAction and NormalIcon variants
- ReactionIconTest: Emoji display, conditional count
- ReactionMenuTest: Default/user reactions, select callback
- StyledSearchTextFieldTest: Placeholder, search/back/clear icons
- MinimalTextFieldTest: Placeholder, back button, clear button

# homebase-auth (1 test file)
- LoginUiTest: All 4 states (form, loading, authenticated, error), actions

# homebase-core (3 test files)
- AppearanceSettingsUiTest: Title, language/theme rows, selection actions
- NotificationSettingsUiTest: Permission card, sounds, content level, re-register
- SettingsUiTest: Menu items, version, navigation, logout/delete actions

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>