### PR TITLE
Dont loose message

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -58,6 +58,7 @@ data class MessageListUiState(
     val downloadingFiles: Set<String> = emptySet(),
     val recordingData: RecordingData? = null,
     val uiSheet: MessageListUiSheet? = null,
+    val isSendingMessage: Boolean = false,
 )
 
 sealed interface MessageListUiSheet {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -126,6 +126,10 @@ class ConversationListViewModel(
     private val localVideoContextStore: LocalVideoContextStore,
 ) : ViewModel() {
 
+    companion object {
+        private const val TAG = "ConversationListViewModel"
+    }
+
     private val enricher = ConversationEnricher()
     val ownerSession = ownerSessionRepository.user
 
@@ -1839,6 +1843,7 @@ class ConversationListViewModel(
 
                 val newMessageId = Uuid.random()
                 pendingMessageId = newMessageId
+                Logger.d(tag = TAG) { "addMessage: message=$newMessageId conversation=$conversationId" }
 
                 // Write placeholder first — message appears instantly before encryption/network
                 chatMessageSenderService.writePlaceholderMessage(
@@ -1855,7 +1860,9 @@ class ConversationListViewModel(
                     previousMessageUniqueId = null,
                     payloadBundle = payloadBundle,
                 )
+                Logger.d(tag = TAG) { "addMessage: complete message=$newMessageId" }
             } catch (e: Exception) {
+                Logger.e(throwable = e, tag = TAG) { "addMessage failed for conversation=$conversationId" }
                 sendEvent(ShowErrorMessage("Failed to send message: ${e.message}"))
             }
         }
@@ -1881,6 +1888,7 @@ class ConversationListViewModel(
                 )
                 val newMessageId = Uuid.random()
                 pendingMessageId = newMessageId
+                Logger.d(tag = TAG) { "replyToMessage: message=$newMessageId conversation=$conversationId replyTo=${replyTo.id}" }
 
                 // Write placeholder first — reply appears instantly with quote context
                 chatMessageSenderService.writePlaceholderMessage(
@@ -1899,7 +1907,9 @@ class ConversationListViewModel(
                     previousMessageUniqueId = null,
                     payloadBundle = payloadBundle
                 )
+                Logger.d(tag = TAG) { "replyToMessage: complete message=$newMessageId" }
             } catch (e: Exception) {
+                Logger.e(throwable = e, tag = TAG) { "replyToMessage failed for conversation=$conversationId" }
                 sendEvent(ShowErrorMessage("Failed to send reply: ${e.message}"))
             }
         }
@@ -2001,6 +2011,7 @@ class ConversationListViewModel(
             }
 
             val newMessageId = Uuid.random()
+            Logger.d(tag = TAG) { "addMessageWithFiles: message=$newMessageId conversation=$conversationId files=${files.size}" }
 
             // Write a placeholder entry to the DB immediately so the message appears in the
             // list during the build+encrypt phase, before the real optimistic write fires.
@@ -2075,7 +2086,7 @@ class ConversationListViewModel(
                     payloadBundle = bundle,
                 )
             } catch (e: Exception) {
-                Logger.e("Failed to send file(s)", e)
+                Logger.e(throwable = e, tag = TAG) { "addMessageWithFiles failed for message=$newMessageId conversation=$conversationId" }
                 _messagesUiState.update { state ->
                     state.copy(uploadProgress = (state.uploadProgress - newMessageId).toPersistentMap())
                 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -376,6 +376,7 @@ class ConversationListViewModel(
             is ConversationListUiAction.SendMessage -> {
                 val hasMessage = !messageInputTextState.annotatedString.isBlank()
                 if (hasMessage) {
+                    _messagesUiState.update { it.copy(isSendingMessage = true) }
                     val content = messageInputTextState.toMarkdown()
                     val replyTo = _messagesUiState.value.replyToMessage
                     if (replyTo != null) {
@@ -385,7 +386,6 @@ class ConversationListViewModel(
                             content = content,
                             linkPreview = action.linkPreview
                         )
-                        _messagesUiState.update { it.copy(replyToMessage = null) }
                     } else {
                         addMessage(
                             conversationId = action.conversationId,
@@ -393,7 +393,8 @@ class ConversationListViewModel(
                             linkPreview = action.linkPreview
                         )
                     }
-                    messageInputTextState.clear()
+                    // Input is cleared inside addMessage/replyToMessage after
+                    // the send is successfully queued.
                 }
             }
 
@@ -860,14 +861,15 @@ class ConversationListViewModel(
             }
 
             is ConversationListUiAction.SendFile -> {
-                _messagesUiState.update { it.copy(scrollPosition = null, fullScreenOverlay = null) }
+                _messagesUiState.update { it.copy(scrollPosition = null, isSendingMessage = true) }
 
                 addMessageWithFiles(
                     conversationId = action.conversationId,
                     content = action.message,
                     files = action.attachments,
                 )
-                messageInputTextState.clear()
+                // Input is cleared inside addMessageWithFiles after
+                // the send is successfully queued.
             }
 
             is ConversationListUiAction.AttachPlatformFile -> {
@@ -1845,14 +1847,6 @@ class ConversationListViewModel(
                 pendingMessageId = newMessageId
                 Logger.d(tag = TAG) { "addMessage: message=$newMessageId conversation=$conversationId" }
 
-                // Write placeholder first — message appears instantly before encryption/network
-                chatMessageSenderService.writePlaceholderMessage(
-                    messageUniqueId = newMessageId,
-                    conversationId = conversationId,
-                    messageText = content,
-                    payloadDescriptors = null,
-                )
-
                 chatMessageSenderService.sendNewMessage(
                     messageUniqueId = newMessageId,
                     conversationId = conversationId,
@@ -1860,10 +1854,13 @@ class ConversationListViewModel(
                     previousMessageUniqueId = null,
                     payloadBundle = payloadBundle,
                 )
+                messageInputTextState.clear()
                 Logger.d(tag = TAG) { "addMessage: complete message=$newMessageId" }
             } catch (e: Exception) {
                 Logger.e(throwable = e, tag = TAG) { "addMessage failed for conversation=$conversationId" }
                 sendEvent(ShowErrorMessage("Failed to send message: ${e.message}"))
+            } finally {
+                _messagesUiState.update { it.copy(isSendingMessage = false) }
             }
         }
     }
@@ -1890,15 +1887,6 @@ class ConversationListViewModel(
                 pendingMessageId = newMessageId
                 Logger.d(tag = TAG) { "replyToMessage: message=$newMessageId conversation=$conversationId replyTo=${replyTo.id}" }
 
-                // Write placeholder first — reply appears instantly with quote context
-                chatMessageSenderService.writePlaceholderMessage(
-                    messageUniqueId = newMessageId,
-                    conversationId = conversationId,
-                    messageText = content,
-                    payloadDescriptors = null,
-                    replyPreview = replyPreview,
-                )
-
                 chatMessageSenderService.replyToMessage(
                     messageUniqueId = newMessageId,
                     conversationId = conversationId,
@@ -1907,10 +1895,14 @@ class ConversationListViewModel(
                     previousMessageUniqueId = null,
                     payloadBundle = payloadBundle
                 )
+                messageInputTextState.clear()
+                _messagesUiState.update { it.copy(replyToMessage = null) }
                 Logger.d(tag = TAG) { "replyToMessage: complete message=$newMessageId" }
             } catch (e: Exception) {
                 Logger.e(throwable = e, tag = TAG) { "replyToMessage failed for conversation=$conversationId" }
                 sendEvent(ShowErrorMessage("Failed to send reply: ${e.message}"))
+            } finally {
+                _messagesUiState.update { it.copy(isSendingMessage = false) }
             }
         }
     }
@@ -1921,156 +1913,123 @@ class ConversationListViewModel(
         files: List<AttachmentPendingFile>
     ) {
         viewModelScope.launch {
-            val attachments = mutableListOf<AttachmentInput>()
-            files.forEach { attachment ->
-                when (attachment) {
-                    is AttachmentPendingFile.File -> {
-                        attachments.add(
-                            AttachmentInput(
-                                filePath = attachment.file.toString(),
-                                contentType = attachment.file.mimeType()?.toString()
-                                    ?: detectContentTypeFromExtensionOrHint(attachment.file.name),
-                                displayName = attachment.file.name,
-                            )
-                        )
-                    }
-
-                    is AttachmentPendingFile.FileImage -> {
-                        var filePath = attachment.file.toString()
-                        var contentType = detectContentTypeFromExtensionOrHint(attachment.file.name)
-                        if (contentType == "image/heic" || contentType == "image/heif") {
-                            val heicBytes = fileOperationsProvider.readFileBytes(filePath)
-                            val jpegBytes = convertHeicToJpeg(heicBytes)
-                            if (jpegBytes != null) {
-                                filePath = fileOperationsProvider.writeBytesToTempFile(
-                                    jpegBytes,
-                                    "heic_converted_",
-                                    ".jpg"
-                                )
-                                contentType = "image/jpeg"
-                            }
-                        }
-                        attachments.add(
-                            AttachmentInput(
-                                filePath = filePath,
-                                contentType = contentType,
-                                displayName = attachment.file.name,
-                            )
-                        )
-                    }
-
-                    is AttachmentPendingFile.FileVideo -> {
-                        attachments.add(
-                            AttachmentInput(
-                                filePath = attachment.file.toString(),
-                                contentType = attachment.file.mimeType()?.toString()
-                                    ?: detectContentTypeFromExtensionOrHint(attachment.file.name),
-                                displayName = attachment.file.name,
-                            )
-                        )
-                    }
-
-                    is AttachmentPendingFile.Gallery -> {
-                        var filePath = attachment.image.file.toString()
-                        var contentType =
-                            detectContentTypeFromExtensionOrHint(attachment.image.fileName)
-                        if (contentType == "image/heic" || contentType == "image/heif") {
-                            val heicBytes = fileOperationsProvider.readFileBytes(filePath)
-                            val jpegBytes = convertHeicToJpeg(heicBytes)
-                            if (jpegBytes != null) {
-                                filePath = fileOperationsProvider.writeBytesToTempFile(
-                                    jpegBytes,
-                                    "heic_converted_",
-                                    ".jpg"
-                                )
-                                contentType = "image/jpeg"
-                            }
-                        }
-                        attachments.add(
-                            AttachmentInput(
-                                filePath = filePath,
-                                contentType = contentType,
-                                displayName = attachment.image.fileName,
-                            )
-                        )
-                    }
-
-                    is AttachmentPendingFile.Audio -> {
-                        attachments.add(
-                            AttachmentInput(
-                                filePath = attachment.audioFile.toString(),
-                                contentType = attachment.audioFile.mimeType()?.toString()
-                                    ?: detectContentTypeFromExtensionOrHint(attachment.audioFile.name),
-                                displayName = attachment.audioFile.name,
-                                waveformFile = attachment.waveformFile?.toString(),
-                                audioLengthSeconds = attachment.lengthSeconds,
-                            )
-                        )
-                    }
-                }
-            }
-
-            val newMessageId = Uuid.random()
-            Logger.d(tag = TAG) { "addMessageWithFiles: message=$newMessageId conversation=$conversationId files=${files.size}" }
-
-            // Write a placeholder entry to the DB immediately so the message appears in the
-            // list during the build+encrypt phase, before the real optimistic write fires.
-            // For images, read pixel dimensions now so the aspect ratio — and therefore the
-            // bubble size — is stable from the very first frame.
-            val placeholderPayloads = attachments.mapIndexed { index, attachment ->
-                val previewThumbnail = if (attachment.contentType.startsWith("image/")) {
-                    try {
-                        val bytes = fileOperationsProvider.readFileBytes(attachment.filePath)
-                        val naturalSize = ImageUtils.getNaturalSize(bytes)
-                        ThumbnailDescriptor(
-                            pixelWidth = naturalSize.pixelWidth,
-                            pixelHeight = naturalSize.pixelHeight,
-                            contentType = attachment.contentType,
-                        )
-                    } catch (_: Exception) {
-                        null
-                    }
-                } else null
-                PayloadDescriptor(
-                    key = "${ChatProtocol.PAYLOAD_KEY_MESSAGE_WEB}$index",
-                    contentType = attachment.contentType,
-                    iv = null,
-                    descriptorContent = null,
-                    previewThumbnail = previewThumbnail,
-                )
-            }.ifEmpty { null }
-
-            chatMessageSenderService.writePlaceholderMessage(
-                messageUniqueId = newMessageId,
-                conversationId = conversationId,
-                messageText = content,
-                payloadDescriptors = placeholderPayloads,
-            )
-
-            _messagesUiState.update { state ->
-                state.copy(
-                    uploadProgress = (state.uploadProgress + (newMessageId to UploadStatus.Preparing)).toPersistentMap()
-                )
-            }
-
-            // Store local video context for thumbnail preview during upload
-            files.filterIsInstance<AttachmentPendingFile.FileVideo>()
-                .firstOrNull()?.let { videoFile ->
-                    val thumbBytes = videoFile.thumbnailBytes
-                    if (thumbBytes != null) {
-                        localVideoContextStore.put(
-                            newMessageId,
-                            LocalVideoContext(
-                                thumbnailBytes = thumbBytes,
-                                localFilePath = videoFile.file.toString(),
-                            )
-                        )
-                    }
-                }
-
-            pendingMessageId = newMessageId
-
+            var newMessageId: Uuid? = null
             try {
+                val attachments = mutableListOf<AttachmentInput>()
+                for (attachment in files) {
+                    when (attachment) {
+                        is AttachmentPendingFile.File -> {
+                            attachments.add(
+                                AttachmentInput(
+                                    filePath = attachment.file.toString(),
+                                    contentType = attachment.file.mimeType()?.toString()
+                                        ?: detectContentTypeFromExtensionOrHint(attachment.file.name),
+                                    displayName = attachment.file.name,
+                                )
+                            )
+                        }
+
+                        is AttachmentPendingFile.FileImage -> {
+                            var filePath = attachment.file.toString()
+                            var contentType = detectContentTypeFromExtensionOrHint(attachment.file.name)
+                            if (contentType == "image/heic" || contentType == "image/heif") {
+                                val heicBytes = fileOperationsProvider.readFileBytes(filePath)
+                                val jpegBytes = convertHeicToJpeg(heicBytes)
+                                if (jpegBytes != null) {
+                                    filePath = fileOperationsProvider.writeBytesToTempFile(
+                                        jpegBytes,
+                                        "heic_converted_",
+                                        ".jpg"
+                                    )
+                                    contentType = "image/jpeg"
+                                }
+                            }
+                            attachments.add(
+                                AttachmentInput(
+                                    filePath = filePath,
+                                    contentType = contentType,
+                                    displayName = attachment.file.name,
+                                )
+                            )
+                        }
+
+                        is AttachmentPendingFile.FileVideo -> {
+                            attachments.add(
+                                AttachmentInput(
+                                    filePath = attachment.file.toString(),
+                                    contentType = attachment.file.mimeType()?.toString()
+                                        ?: detectContentTypeFromExtensionOrHint(attachment.file.name),
+                                    displayName = attachment.file.name,
+                                )
+                            )
+                        }
+
+                        is AttachmentPendingFile.Gallery -> {
+                            var filePath = attachment.image.file.toString()
+                            var contentType =
+                                detectContentTypeFromExtensionOrHint(attachment.image.fileName)
+                            if (contentType == "image/heic" || contentType == "image/heif") {
+                                val heicBytes = fileOperationsProvider.readFileBytes(filePath)
+                                val jpegBytes = convertHeicToJpeg(heicBytes)
+                                if (jpegBytes != null) {
+                                    filePath = fileOperationsProvider.writeBytesToTempFile(
+                                        jpegBytes,
+                                        "heic_converted_",
+                                        ".jpg"
+                                    )
+                                    contentType = "image/jpeg"
+                                }
+                            }
+                            attachments.add(
+                                AttachmentInput(
+                                    filePath = filePath,
+                                    contentType = contentType,
+                                    displayName = attachment.image.fileName,
+                                )
+                            )
+                        }
+
+                        is AttachmentPendingFile.Audio -> {
+                            attachments.add(
+                                AttachmentInput(
+                                    filePath = attachment.audioFile.toString(),
+                                    contentType = attachment.audioFile.mimeType()?.toString()
+                                        ?: detectContentTypeFromExtensionOrHint(attachment.audioFile.name),
+                                    displayName = attachment.audioFile.name,
+                                    waveformFile = attachment.waveformFile?.toString(),
+                                    audioLengthSeconds = attachment.lengthSeconds,
+                                )
+                            )
+                        }
+                    }
+                }
+
+                newMessageId = Uuid.random()
+                Logger.d(tag = TAG) { "addMessageWithFiles: message=$newMessageId conversation=$conversationId files=${files.size}" }
+
+                _messagesUiState.update { state ->
+                    state.copy(
+                        uploadProgress = (state.uploadProgress + (newMessageId to UploadStatus.Preparing)).toPersistentMap()
+                    )
+                }
+
+                // Store local video context for thumbnail preview during upload
+                files.filterIsInstance<AttachmentPendingFile.FileVideo>()
+                    .firstOrNull()?.let { videoFile ->
+                        val thumbBytes = videoFile.thumbnailBytes
+                        if (thumbBytes != null) {
+                            localVideoContextStore.put(
+                                newMessageId,
+                                LocalVideoContext(
+                                    thumbnailBytes = thumbBytes,
+                                    localFilePath = videoFile.file.toString(),
+                                )
+                            )
+                        }
+                    }
+
+                pendingMessageId = newMessageId
+
                 val bundle = MessageAttachmentBuilder.build(
                     attachments = attachments,
                     fileOperationsProvider = fileOperationsProvider,
@@ -2085,16 +2044,24 @@ class ConversationListViewModel(
                     previousMessageUniqueId = null,
                     payloadBundle = bundle,
                 )
+                messageInputTextState.clear()
+                _messagesUiState.update { it.copy(fullScreenOverlay = null) }
             } catch (e: Exception) {
                 Logger.e(throwable = e, tag = TAG) { "addMessageWithFiles failed for message=$newMessageId conversation=$conversationId" }
                 _messagesUiState.update { state ->
-                    state.copy(uploadProgress = (state.uploadProgress - newMessageId).toPersistentMap())
+                    val progress = if (newMessageId != null)
+                        (state.uploadProgress - newMessageId).toPersistentMap()
+                    else
+                        state.uploadProgress
+                    state.copy(uploadProgress = progress)
                 }
                 sendEvent(
                     ShowErrorMessage(
                         "Failed to send file(s): ${e.message}"
                     )
                 )
+            } finally {
+                _messagesUiState.update { it.copy(isSendingMessage = false) }
             }
         }
     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
@@ -54,54 +54,6 @@ class ChatMessageSenderService(
 
     private val chatDrive = chatTargetDrive.alias
 
-    suspend fun writePlaceholderMessage(
-        messageUniqueId: Uuid,
-        conversationId: Uuid,
-        messageText: String,
-        payloadDescriptors: List<PayloadDescriptor>?,
-        replyPreview: ReplyPreview? = null,
-    ) {
-        Logger.d(tag = TAG) { "writePlaceholderMessage: starting message=$messageUniqueId conversation=$conversationId" }
-
-        val keyHeader = KeyHeader.newRandom16()
-        val recipients = conversationStream.getRecipients(conversationId)
-        val isLocalOnly = recipients.isEmpty()
-
-        val messageData = MessageAppData(
-            replyId = null,
-            replyPreview = replyPreview,
-            message = JsonPrimitive(messageText),
-            deliveryStatus = ChatDeliveryStatus.Sent.value,
-        ).copy(version = ChatProtocol.MessageVersionNumberOne)
-
-        val content = OdinSystemSerializer.serialize(messageData)
-
-        val unencryptedMetadata = UploadFileMetadata(
-            allowDistribution = !isLocalOnly,
-            isEncrypted = true,
-            appData = UploadAppFileMetaData(
-                uniqueId = messageUniqueId,
-                groupId = conversationId,
-                fileType = ChatProtocol.MessageFileType,
-                dataType = 0,
-                userDate = UnixTimeUtc.now().milliseconds,
-                content = content,
-                previewThumbnail = null,
-            )
-        )
-
-        optimisticWriter.writeNewFile(
-            driveId = chatDrive,
-            keyHeader = keyHeader,
-            unecryptedMetadata = unencryptedMetadata,
-            originalRecipientCount = recipients.size,
-            fileSystemType = FileSystemType.Standard,
-            payloadDescriptors = payloadDescriptors,
-        )
-
-        Logger.d(tag = TAG) { "writePlaceholderMessage: optimistic write complete message=$messageUniqueId" }
-    }
-
     suspend fun sendNewMessage(
         messageUniqueId: Uuid,
         conversationId: Uuid,
@@ -247,26 +199,40 @@ class ChatMessageSenderService(
             payloads = encryptedBundle.payloads,
             thumbnails = encryptedBundle.thumbnails
         )
-        try {
+        // Outbox enqueue is the success gate — once accepted, the message
+        // will be delivered regardless of what happens after.
+        val enqueued = outboxSync.tryEnqueue(
+            request,
+            priority = 1,
+            dependencyUniqueId = previousMessageUniqueId,
+        )
 
-            // optimistic write first — message appears in UI before any network work
-            @OptIn(ExperimentalEncodingApi::class)
-            val payloadDescriptors = encryptedBundle.payloads.map { payload ->
-                PayloadDescriptor(
-                    key = payload.key,
-                    contentType = payload.contentType.ifEmpty { null },
-                    iv = payload.iv?.let { Base64.encode(it) },
-                    descriptorContent = payload.descriptorContent,
-                    previewThumbnail = payload.previewThumbnail?.let {
-                        ThumbnailDescriptor(
-                            pixelWidth = it.pixelWidth,
-                            pixelHeight = it.pixelHeight,
-                            contentType = it.contentType,
-                            content = it.content,
-                        )
-                    },
-                )
-            }.ifEmpty { null }
+        if (!enqueued) {
+            error("Failed to send chat message")
+        }
+        Logger.d(tag = TAG) { "sendMessageInternal: outbox enqueued message=$messageUniqueId" }
+
+        // Best-effort optimistic write — makes the message appear in the chat
+        // stream immediately. If it fails, the outbox delivery + sync will
+        // bring the message back.
+        @OptIn(ExperimentalEncodingApi::class)
+        val payloadDescriptors = encryptedBundle.payloads.map { payload ->
+            PayloadDescriptor(
+                key = payload.key,
+                contentType = payload.contentType.ifEmpty { null },
+                iv = payload.iv?.let { Base64.encode(it) },
+                descriptorContent = payload.descriptorContent,
+                previewThumbnail = payload.previewThumbnail?.let {
+                    ThumbnailDescriptor(
+                        pixelWidth = it.pixelWidth,
+                        pixelHeight = it.pixelHeight,
+                        contentType = it.contentType,
+                        content = it.content,
+                    )
+                },
+            )
+        }.ifEmpty { null }
+        try {
             optimisticWriter.writeNewFile(
                 driveId = chatDrive,
                 keyHeader = keyHeader,
@@ -276,45 +242,26 @@ class ChatMessageSenderService(
                 payloadDescriptors = payloadDescriptors,
             )
             Logger.d(tag = TAG) { "sendMessageInternal: optimistic write complete message=$messageUniqueId" }
-
-            val enqueued = outboxSync.tryEnqueue(
-                request,
-                priority = 1,
-                dependencyUniqueId = previousMessageUniqueId,
-            )
-
-            if (!enqueued) {
-                error("Failed to send chat message")
-            }
-            Logger.d(tag = TAG) { "sendMessageInternal: outbox enqueued message=$messageUniqueId" }
-
-            // Donate share suggestion so this conversation appears in OS share sheet
-            try {
-                val conversation = conversationStream.getConversationById(conversationId)
-                if (conversation != null) {
-                    shareSuggestionDonor.donateAfterSend(
-                        conversationId = conversationId,
-                        conversationName = conversation.getDisplayName(),
-                        isGroup = conversation.isGroupConversation,
-                        participantNames = recipients.map { it.domainName },
-                    )
-                }
-            } catch (_: Exception) {
-                // Non-critical — don't fail the send
-            }
-
-            return SendMessageResult(uniqueId = messageUniqueId)
-        } catch (t: Throwable) {
-            Logger.e(throwable = t, tag = TAG) { "sendMessageInternal failed for message=$messageUniqueId conversation=$conversationId" }
-            try {
-                Logger.w(tag = TAG) { "Rolling back optimistic file for message=$messageUniqueId" }
-                optimisticWriter.removeOptimisticFile(chatDrive, messageUniqueId)
-            } catch (re: Exception) {
-                Logger.e(throwable = re, tag = TAG) { "Rollback failed for message=$messageUniqueId" }
-            }
+        } catch (e: Exception) {
+            Logger.e(throwable = e, tag = TAG) { "sendMessageInternal: optimistic write failed (non-fatal) message=$messageUniqueId" }
         }
 
-        error("Failed to send chat message")
+        // Best-effort share suggestion
+        try {
+            val conversation = conversationStream.getConversationById(conversationId)
+            if (conversation != null) {
+                shareSuggestionDonor.donateAfterSend(
+                    conversationId = conversationId,
+                    conversationName = conversation.getDisplayName(),
+                    isGroup = conversation.isGroupConversation,
+                    participantNames = recipients.map { it.domainName },
+                )
+            }
+        } catch (_: Exception) {
+            // Non-critical
+        }
+
+        return SendMessageResult(uniqueId = messageUniqueId)
     }
 
     suspend fun updateMessage(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
@@ -48,6 +48,10 @@ class ChatMessageSenderService(
     private val driveFileProvider: DriveFileProvider,
     private val shareSuggestionDonor: ShareSuggestionDonor = ShareSuggestionDonor(),
 ) {
+    companion object {
+        private const val TAG = "ChatMessageSenderService"
+    }
+
     private val chatDrive = chatTargetDrive.alias
 
     suspend fun writePlaceholderMessage(
@@ -57,6 +61,8 @@ class ChatMessageSenderService(
         payloadDescriptors: List<PayloadDescriptor>?,
         replyPreview: ReplyPreview? = null,
     ) {
+        Logger.d(tag = TAG) { "writePlaceholderMessage: starting message=$messageUniqueId conversation=$conversationId" }
+
         val keyHeader = KeyHeader.newRandom16()
         val recipients = conversationStream.getRecipients(conversationId)
         val isLocalOnly = recipients.isEmpty()
@@ -92,6 +98,8 @@ class ChatMessageSenderService(
             fileSystemType = FileSystemType.Standard,
             payloadDescriptors = payloadDescriptors,
         )
+
+        Logger.d(tag = TAG) { "writePlaceholderMessage: optimistic write complete message=$messageUniqueId" }
     }
 
     suspend fun sendNewMessage(
@@ -184,6 +192,7 @@ class ChatMessageSenderService(
         isStatusMessage: Boolean = false,
         additionalRecipients: List<OdinId> = emptyList()
     ): SendMessageResult {
+        Logger.d(tag = TAG) { "sendMessageInternal: starting message=$messageUniqueId conversation=$conversationId" }
 
         val conversation =
             conversationStream.getConversationById(conversationId) ?: error("no conversation found")
@@ -199,6 +208,7 @@ class ChatMessageSenderService(
         val recipients = conversationStream.getRecipients(conversationId, additionalRecipients)
         val isLocalOnly = recipients.isEmpty() // self-conversation: no distribution
 
+        Logger.d(tag = TAG) { "sendMessageInternal: encrypting message=$messageUniqueId recipients=${recipients.size}" }
         val encryptedBundle = payloadBundleEncryptionService.encryptBundle(
             messageUniqueId, payloadBundle, keyHeader.aesKey, scope = scope
         )
@@ -265,6 +275,7 @@ class ChatMessageSenderService(
                 fileSystemType = FileSystemType.Standard,
                 payloadDescriptors = payloadDescriptors,
             )
+            Logger.d(tag = TAG) { "sendMessageInternal: optimistic write complete message=$messageUniqueId" }
 
             val enqueued = outboxSync.tryEnqueue(
                 request,
@@ -275,6 +286,7 @@ class ChatMessageSenderService(
             if (!enqueued) {
                 error("Failed to send chat message")
             }
+            Logger.d(tag = TAG) { "sendMessageInternal: outbox enqueued message=$messageUniqueId" }
 
             // Donate share suggestion so this conversation appears in OS share sheet
             try {
@@ -293,11 +305,12 @@ class ChatMessageSenderService(
 
             return SendMessageResult(uniqueId = messageUniqueId)
         } catch (t: Throwable) {
-            Logger.e("ChatMessageSenderService", t)
+            Logger.e(throwable = t, tag = TAG) { "sendMessageInternal failed for message=$messageUniqueId conversation=$conversationId" }
             try {
+                Logger.w(tag = TAG) { "Rolling back optimistic file for message=$messageUniqueId" }
                 optimisticWriter.removeOptimisticFile(chatDrive, messageUniqueId)
-            } catch (_: Exception) {
-                // best-effort rollback
+            } catch (re: Exception) {
+                Logger.e(throwable = re, tag = TAG) { "Rollback failed for message=$messageUniqueId" }
             }
         }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
@@ -40,6 +40,10 @@ class OptimisticWriter(
     private val dbm: DatabaseManager,
     private val eventBus: EventBus,
 ) {
+    companion object {
+        private const val TAG = "OptimisticWriter"
+    }
+
     private val fileProcessor: MainIndexMetaHelpers.HomebaseFileProcessor =
         MainIndexMetaHelpers.HomebaseFileProcessor(dbm)
 
@@ -121,7 +125,8 @@ class OptimisticWriter(
             )
 
         } catch (e: Exception) {
-            Logger.e("Optimistic insert failed: ${e.message}")
+            Logger.e(throwable = e, tag = TAG) { "Optimistic insert failed for uniqueId=${unecryptedMetadata.appData.uniqueId} groupId=${unecryptedMetadata.appData.groupId}" }
+            throw e
         }
     }
 
@@ -210,7 +215,8 @@ class OptimisticWriter(
             )
 
         } catch (e: Exception) {
-            Logger.e("Optimistic update failed: ${e.message}")
+            Logger.e(throwable = e, tag = TAG) { "Optimistic update failed for uniqueId=${unecryptedMetadata.appData.uniqueId}" }
+            throw e
         }
     }
 
@@ -252,7 +258,7 @@ class OptimisticWriter(
                 )
             )
         } catch (e: Exception) {
-            Logger.e("Optimistic remove failed: ${e.message}")
+            Logger.e(throwable = e, tag = TAG) { "Optimistic remove failed for uniqueId=$uniqueId" }
         }
     }
 
@@ -310,7 +316,7 @@ class OptimisticWriter(
                 )
             )
         } catch (e: Exception) {
-            Logger.e("Optimistic delete failed: ${e.message}")
+            Logger.e(throwable = e, tag = TAG) { "Optimistic delete failed for uniqueId=$uniqueId" }
             return null
         }
 
@@ -340,7 +346,7 @@ class OptimisticWriter(
                 )
             )
         } catch (e: Exception) {
-            Logger.e("Optimistic delete rollback failed: ${e.message}")
+            Logger.e(throwable = e, tag = TAG) { "Optimistic delete rollback failed for fileId=${original.fileId}" }
         }
     }
 
@@ -423,7 +429,7 @@ class OptimisticWriter(
                 )
             )
         } catch (e: Exception) {
-            Logger.e("Optimistic reaction toggle failed: ${e.message}")
+            Logger.e(throwable = e, tag = TAG) { "Optimistic reaction toggle failed for uniqueId=$uniqueId" }
             return Pair(ToggleReactionResultType.None, null)
         }
 
@@ -512,7 +518,7 @@ class OptimisticWriter(
                 iv = ivBase64
             )
         } catch (e: Exception) {
-            Logger.e("stampConversationExitedAt failed: ${e.message}")
+            Logger.e(throwable = e, tag = TAG) { "stampConversationExitedAt failed for conversationId=$conversationId" }
             null
         }
     }
@@ -573,7 +579,7 @@ class OptimisticWriter(
                 )
             )
         } catch (e: Exception) {
-            Logger.e("Optimistic tag update failed: ${e.message}")
+            Logger.e(throwable = e, tag = TAG) { "Optimistic tag update failed for uniqueId=$uniqueId" }
         }
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -648,6 +648,7 @@ fun ConversationContent(
                         focusRequester = focusRequester,
                         editExistingMode = uiState.isEditingMessageId != null,
                         showingEmojiSheet = showEmojiSheet,
+                        isSendingMessage = uiState.isSendingMessage,
                         onSendMessage = { text, linkPreview ->
                             if (text.isNotBlank()) {
                                 if (uiState.isEditingMessageId != null) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
@@ -138,6 +138,7 @@ fun MessageInputBar(
     focusRequester: FocusRequester,
     editExistingMode: Boolean,
     showingEmojiSheet: Boolean,
+    isSendingMessage: Boolean = false,
     onEmojiClick: () -> Unit,
     onKeyboardClick: () -> Unit,
     onFocused: () -> Unit,
@@ -197,10 +198,10 @@ fun MessageInputBar(
     }
 
     fun sendMessage() {
-        if (textFieldState.annotatedString.isNotBlank()) {
+        if (!isSendingMessage && textFieldState.annotatedString.isNotBlank()) {
             onSendMessage(textFieldState.toMarkdown(), linkPreviewData)
-            linkPreviewData = null
-            textFieldState.clear()
+            // Don't clear here — the ViewModel clears after the send is queued,
+            // so the text stays in the edit box if the send fails.
         }
     }
 
@@ -276,6 +277,7 @@ fun MessageInputBar(
                 onRecordingCancelled = onRecordingCancelled,
                 onRecordingHelp = onRecordingHelp,
                 onPasteImage = onPasteImage,
+                isSendingMessage = isSendingMessage,
                 onSendMessage = { sendMessage() },
                 onCancelEdit = onCancelEdit
             )
@@ -410,7 +412,8 @@ fun MessageTextFieldExpanded(
                 }
             }
             IconButton(
-                onClick = { sendMessage() }, colors = IconButtonDefaults.iconButtonColors(
+                onClick = { sendMessage() },
+                colors = IconButtonDefaults.iconButtonColors(
                     containerColor = HomebaseTheme.extendedColors.bubbleSentSurface,
                     contentColor = HomebaseTheme.extendedColors.bubbleSentOnSurface,
                 )
@@ -444,6 +447,7 @@ fun MessageTextFieldCompact(
     onRecordingHelp: () -> Unit,
     onPasteImage: ((ByteArray) -> Unit)? = null,
     onFocused: () -> Unit = {},
+    isSendingMessage: Boolean = false,
     onSendMessage: () -> Unit,
     onCancelEdit: () -> Unit,
 ) {
@@ -771,6 +775,7 @@ fun MessageTextFieldCompact(
                     }
                     BlueBackgroundIconButton(
                         onClick = onSendMessage,
+                        enabled = !isSendingMessage,
                         imageVector = if (editExistingMode) Icons.Filled.Check else Icons.AutoMirrored.Filled.Send,
                         contentDescription = stringResource(MR.string.chat_send_message_button),
                     )
@@ -855,9 +860,11 @@ fun BlueBackgroundIconButton(
     onClick: () -> Unit,
     imageVector: ImageVector,
     contentDescription: String?,
+    enabled: Boolean = true,
 ) {
     IconButton(
         onClick = onClick,
+        enabled = enabled,
         colors = IconButtonDefaults.iconButtonColors(
             containerColor = HomebaseTheme.extendedColors.bubbleSentSurface,
             contentColor = HomebaseTheme.extendedColors.bubbleSentOnSurface,


### PR DESCRIPTION
# Message Send Pipeline — Change Summary

## Problem

Users reported messages to Todd (and potentially others) disappearing — the message was never visible in the chat stream after tapping send. Investigation of `homebase.log` revealed no errors from the send pipeline, meaning failures were being silently swallowed.

## Root Causes Found

1. **`OptimisticWriter.writeNewFile()` swallowed exceptions** — caught exceptions, logged only `e.message` (no tag, no stack trace), and never re-threw. The caller had no idea the DB insert failed.

2. **Wrong operation ordering** — the optimistic DB insert ran *before* the outbox enqueue. If the insert failed, the outbox enqueue never ran, so the message was silently lost. The outbox is the source of truth; the optimistic insert is just a UI convenience.

3. **Input cleared before send completed** — the message text was cleared synchronously in the action handler, before the async send coroutine even started. If the send failed, the user's text was gone with no way to recover it.

4. **No double-send protection** — with deferred clearing, the user could tap send twice before the first send completed, producing duplicate messages.

## Changes (6 files, net -77 lines)

### 1. `OptimisticWriter.kt` — proper error logging + re-throw

**Before:** All catch blocks used `Logger.e("message string")` — no tag, no throwable, exception swallowed.

**After:** All catch blocks use `Logger.e(throwable = e, tag = TAG) { "context" }` — full stack trace in logs. `writeNewFile()` and `writeUpdate()` now re-throw so callers can handle failures. Cleanup methods (`removeOptimisticFile`, `rollbackWrite`, etc.) still swallow since they're best-effort.

### 2. `ChatMessageSenderService.kt` — outbox-first ordering, drop placeholder

**Before:**
```
writePlaceholderMessage()  →  encrypt  →  optimisticWriter.writeNewFile()  →  outbox enqueue
```
If optimistic write failed, outbox never ran. Message lost.

**After:**
```
encrypt  →  outbox enqueue (success gate)  →  optimisticWriter.writeNewFile() (best-effort)
```
Once the outbox accepts the message, the operation is a success. The optimistic write makes the message appear in the chat stream immediately, but if it fails, the outbox delivery + sync will bring the message back.

`writePlaceholderMessage()` deleted entirely — it did the same thing as the optimistic write (DB insert + `BatchReceived` event emission → message appears in UI), but ran before encryption to shave off a few milliseconds of display latency. Since encryption is near-instant for text, the timing difference is imperceptible, and the optimistic write after outbox enqueue now serves the same purpose with the real encrypted data.

Trace logging added at each step: `sendMessageInternal: starting`, `encrypting`, `outbox enqueued`, `optimistic write complete/failed`.

### 3. `ConversationListViewModel.kt` — deferred input clearing + send button guard

**Input clearing deferred to success path:**
- `messageInputTextState.clear()` moved from the synchronous `SendMessage`/`SendFile` action handlers into `addMessage()`, `replyToMessage()`, and `addMessageWithFiles()` — only after `sendNewMessage()` returns successfully.
- Reply-to preview (`replyToMessage = null`) also deferred.
- Attachment overlay (`fullScreenOverlay = null`) also deferred.
- On failure: text, reply preview, and attachment overlay remain intact so the user can retry.

**Send button disabled during send:**
- `isSendingMessage` flag set `true` synchronously in the action handler (same composition frame — no race window).
- Set `false` in a `finally` block — guaranteed to run on success, failure, cancellation, or even `Error`.
- `addMessageWithFiles()` try/catch widened to cover the entire body (attachment processing, HEIC conversion, etc.) so an early failure can't leave the flag stuck.

**Trace logging added** to `addMessage()`, `replyToMessage()`, `addMessageWithFiles()` — entry, completion, and full throwable in catch blocks.

### 4. `MessageInputBar.kt` — send guard + deferred clearing

- `sendMessage()` checks `!isSendingMessage` before dispatching — blocks both button taps and keyboard Enter during send.
- Removed `textFieldState.clear()` and `linkPreviewData = null` — the ViewModel now owns clearing. `linkPreviewData` auto-clears via existing `LaunchedEffect` when the text is emptied.
- `isSendingMessage` parameter threaded to `MessageTextFieldCompact` and `BlueBackgroundIconButton` for visual disabled state on the compact layout's send button.

### 5. `ConversationContent.kt` — pass `isSendingMessage` to `MessageInputBar`

One line: `isSendingMessage = uiState.isSendingMessage`.

### 6. `ConversationListUiState.kt` — new field

`val isSendingMessage: Boolean = false` added to `MessageListUiState`.

## Architecture: Send Pipeline

```
User taps Send
       |
       v
  ViewModel action handler (synchronous)
    - set isSendingMessage = true
    - read text from messageInputTextState
    - launch coroutine
       |
       v
  sendNewMessage() / replyToMessage()
    - encrypt payload
    - build upload request
       |
       v
  outbox.tryEnqueue()  ← SUCCESS/FAIL DECISION POINT
    |            |
    | fail       | success
    v            v
  throw     optimisticWriter.writeNewFile() (best-effort)
    |            |  → DB insert + BatchReceived event
    |            |  → message appears in chat stream (no network needed)
    v            v
  catch:     messageInputTextState.clear()
  show toast  dismiss overlays
  text stays
       |
       v
  finally: isSendingMessage = false (always runs)
```

## Testing

- Send a text message — should clear input after send, message appears in stream
- Send a reply — input and reply preview clear after send
- Send with attachments — input clears, attachment overlay dismisses after send
- Force a failure (leave a group, then send) — text stays in edit box, error toast, button re-enables
- Rapid double-tap send — only one message sent (button disabled during send)
- Kill network, send message — outbox queues it, optimistic write makes message appear immediately in chat stream (no network needed); delivery to recipient happens when connectivity returns
