### PR TITLE
Skip warm start message reload

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -1669,8 +1669,13 @@ class ConversationListViewModel(
         messageIdForScroll: Uuid?,
         scrollToBottom: Boolean = false
     ) {
-        _messagesUiState.update { it.copy(scrollPosition = null, isLoadingMessages = true) }
+        val hasCachedMessages =
+            conversationId == _uiState.value.selectedConversationId &&
+                    chatMessageStream.hasCachedMessages(conversationId)
 
+        _messagesUiState.update {
+            it.copy(scrollPosition = null, isLoadingMessages = !hasCachedMessages)
+        }
 
         // When loading message for newly selected conversation, cancel any previous job to
         // avoid observing multiple messageStreams
@@ -1680,7 +1685,9 @@ class ConversationListViewModel(
                 var messageIdForScrollNullable = messageIdForScroll
                 var setInitialScroll = true
 
-                chatMessageStream.loadConversation(conversationId)
+                if (!hasCachedMessages) {
+                    chatMessageStream.loadConversation(conversationId)
+                }
                 chatMessageStream.observeMessages(conversationId).collect { messageState ->
                     when (messageState) {
                         is ChatMessagesData.Initializing -> {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -112,6 +112,9 @@ class ChatMessageStream(
             .map { ChatMessagesData.Messages(it[conversationId].orEmpty()) }
             .stateIn(scope, SharingStarted.WhileSubscribed(5_000), ChatMessagesData.Initializing)
 
+    fun hasCachedMessages(conversationId: Uuid): Boolean =
+        conversationState.messages.value.containsKey(conversationId)
+
     // Full message load from local DB for a single conversation.
     // Called when the user opens a conversation (ConversationListViewModel.selectConversation).
     // Do NOT call from DriveEvent.Stopped or other sync events — see init block above.


### PR DESCRIPTION
Problem

When the app warm-starts (e.g. brought from background) with a conversation already open, the user sees a loading spinner while 1000 messages are re-queried from the local SQLite database — even though those exact messages are already cached in memory inside the singleton ChatMessageStream.

This causes a noticeable delay and UI flash every time the user returns to the app.

Root Cause

  ConversationListViewModel.loadMessagesForConversation() unconditionally:
  1. Sets isLoadingMessages = true (shows a full-screen spinner, hiding all messages)
  2. Calls ChatMessageStream.loadConversation() which queries SQLite for 1000 messages
  3. Only then re-establishes the observeMessages flow and hides the spinner

It never checks whether the messages are already available in the in-memory ActiveConversationState cache — which they are on warm start, because ChatMessageStream is a Koin singleton that survives ViewModel recreation.

Fix

ChatMessageStream.kt — Added hasCachedMessages(conversationId) method that checks whether ActiveConversationState already holds messages for a given conversation.

ConversationListViewModel.kt — Before showing the spinner or querying the DB, loadMessagesForConversation now checks two conditions:
  - The conversation being loaded is the same one already selected (conversationId == selectedConversationId)
  - The singleton cache has messages for it (chatMessageStream.hasCachedMessages(conversationId))

If both are true (the warm-start case), the spinner and DB query are skipped entirely. The observeMessages flow is still set up so incremental updates continue to arrive via EventBus.

If either condition is false (cold start, or switching to a different conversation), the full spinner + DB load runs exactly as before.

Files Changed
  - homebase-chat/.../services/ChatMessageStream.kt — Added hasCachedMessages()
  - homebase-chat/.../conversationlist/ConversationListViewModel.kt — Conditional skip in loadMessagesForConversation()