### PR TITLE
Fix thumbnail loading failure after logout/re-login

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
@@ -53,21 +53,27 @@ class DriveFileProviderCached(
     @Volatile private var notFoundCache: Set<String> = emptySet()
     private val notFoundCacheMutex = Mutex()
 
-    private val payloadDiskKache by lazy {
-        kotlinx.coroutines.runBlocking {
-            FileKache(
+    private var _payloadDiskKache: FileKache? = null
+    private var _thumbDiskKache: FileKache? = null
+    private val kacheMutex = Mutex()
+
+    private suspend fun payloadDiskKache(): FileKache {
+        _payloadDiskKache?.let { return it }
+        return kacheMutex.withLock {
+            _payloadDiskKache ?: FileKache(
                     directory = "$directory/homebase-payloads",
                     maxSize = 200L * 1024L * 1024L // 200MB
-            )
+            ).also { _payloadDiskKache = it }
         }
     }
 
-    private val thumbDiskKache by lazy {
-        kotlinx.coroutines.runBlocking {
-            FileKache(
+    private suspend fun thumbDiskKache(): FileKache {
+        _thumbDiskKache?.let { return it }
+        return kacheMutex.withLock {
+            _thumbDiskKache ?: FileKache(
                     directory = "$directory/homebase-thumbs",
                     maxSize = 300L * 1024L * 1024L // 300MB
-            )
+            ).also { _thumbDiskKache = it }
         }
     }
 
@@ -91,7 +97,7 @@ class DriveFileProviderCached(
         }
 
         // 2️⃣ Peek in disk cache and return result if it's there
-        payloadDiskKache.get(cacheKey)?.let { filePath ->
+        payloadDiskKache().get(cacheKey)?.let { filePath ->
             val (result, elapsed) = measureTimedValue { readBytesResponse(filePath) }
             Logger.d(tag = "VideoIO") { "payload cache-hit: read ${result.bytes.size} bytes in $elapsed" }
             return result
@@ -107,7 +113,7 @@ class DriveFileProviderCached(
             if (cacheKey in notFoundCache) {
                 return@withLock ByteApiResponse.EMPTY_404
             }
-            payloadDiskKache.get(cacheKey)?.let { filePath ->
+            payloadDiskKache().get(cacheKey)?.let { filePath ->
                 val (result, elapsed) = measureTimedValue { readBytesResponse(filePath) }
                 Logger.d(tag = "VideoIO") { "payload cache-hit (post-lock): read ${result.bytes.size} bytes in $elapsed" }
                 return@withLock result
@@ -129,7 +135,7 @@ class DriveFileProviderCached(
                     } else {
                         // 3️⃣ Store to disk
                         val (_, cacheWriteElapsed) = measureTimedValue {
-                            payloadDiskKache.put(cacheKey) { filePath ->
+                            payloadDiskKache().put(cacheKey) { filePath ->
                                 writeBytesResponse(filePath, result)
                             }
                         }
@@ -212,7 +218,7 @@ class DriveFileProviderCached(
             fileOps: FileOperationsProvider
     ): Boolean {
         val cacheKey = buildPayloadCacheKey(driveId, fileId, key, null, null)
-        val cachedFilePath = payloadDiskKache.get(cacheKey)
+        val cachedFilePath = payloadDiskKache().get(cacheKey)
                 ?: return delegate.streamPayloadDecryptedToPath(driveId, fileId, key, keyHeader, outputPath, fileOps)
 
         val encryptedFlow = channelFlow<ByteArray> {
@@ -258,7 +264,7 @@ class DriveFileProviderCached(
         }
 
         // 2️⃣ Peek in disk cache and return result if it's there
-        thumbDiskKache.get(cacheKey)?.let { filePath ->
+        thumbDiskKache().get(cacheKey)?.let { filePath ->
             return readBytesResponse(filePath)
         }
 
@@ -272,7 +278,7 @@ class DriveFileProviderCached(
             if (cacheKey in notFoundCache) {
                 return@withLock ByteApiResponse.EMPTY_404
             }
-            thumbDiskKache.get(cacheKey)?.let { filePath ->
+            thumbDiskKache().get(cacheKey)?.let { filePath ->
                 return@withLock readBytesResponse(filePath)
             }
 
@@ -297,7 +303,7 @@ class DriveFileProviderCached(
                         // 3️⃣ Store to disk; only allow one writer per GPT indicating
                         // many writers can corrupt the journal file
                         thumbnailKacheWriteMutex.withLock {
-                            thumbDiskKache.put(cacheKey) { filePath ->
+                            thumbDiskKache().put(cacheKey) { filePath ->
                                 writeBytesResponse(filePath, result)
                             }
                         }
@@ -417,14 +423,20 @@ class DriveFileProviderCached(
         val preloadDir = "$directory/hbvid_preload".toPath()
 
         try {
-            payloadDiskKache.clear()
-            thumbDiskKache.clear()
+            _payloadDiskKache?.clear()
+            _thumbDiskKache?.clear()
         } catch (e: Exception) {
             Logger.w("Kache.clear() failed, falling back to manual delete", e)
-
-            fileSystem.delete(payloadDir, mustExist = false)
-            fileSystem.delete(thumbDir, mustExist = false)
+            try {
+                fileSystem.delete(payloadDir, mustExist = false)
+                fileSystem.delete(thumbDir, mustExist = false)
+            } catch (deleteEx: Exception) {
+                Logger.w("Manual cache delete also failed", deleteEx)
+            }
         }
+
+        _payloadDiskKache = null
+        _thumbDiskKache = null
 
         try {
             fileSystem.deleteRecursively(preloadDir)


### PR DESCRIPTION
Exception #1: NPE during Kache.clear() at logout (line 6-37)

 When: 14:10:51.282 — during logout
 Where: DriveFileProviderCached.clearCaches() → thumbDiskKache lazy init
 What: NullPointerException: Attempt to invoke virtual method 'java.lang.Class java.lang.Object.getClass()' on a null object reference

 The lazy thumbDiskKache property (line 65-72 of DriveFileProviderCached.kt) uses runBlocking { FileKache(...) }. When clearCaches() accesses it during logout, the FileKache constructor fails with an NPE inside obfuscated Kache library code. This is caught and logged as a warning.

Exception #2: Uncaught IOException during fallback delete (line 39-63)

When: 14:10:51.282 — immediately after exception #1
Where: clearCaches() catch block → fileSystem.delete(payloadDir)
What: IOException: failed to delete /data/user/0/id.homebase.feed/cache/homebase-payloads

The fallback manual delete in the catch block (line 425-426 of DriveFileProviderCached.kt) is not wrapped in its own try-catch, so this IOExceptionpropagates as an UNCAUGHT EXCEPTION on the main thread. The CrashLogger captures it.

Exception #3 (x113): All thumbnail loads fail permanently (lines 64 → 22,435)

When: 14:10:52 through 14:12:51 (entire 2-minute session after re-login)
Where: HomebaseImageLoader.loadThumbnail() → DriveFileProviderCached.getThumbBytesDecrypted()
What: Same NPE, 113 "All 4 attempts failed" errors

This is the bug you're seeing — every thumbnail shows a warning triangle because every load fails.

Root cause chain:
1. DriveFileProviderCached is registered as a Koin singleton (singleOf(::DriveFileProviderCached) in ApiModule.kt:50)
2. The thumbDiskKache is a by lazy property — once its initializer throws, Kotlin's lazy delegate is left in a permanently broken state
3. After logout + re-login, the same singleton instance is reused
4. Every access to thumbDiskKache re-throws the cached NPE
5. The withRetry logic retries 4 times per thumbnail, but the error is deterministic — it will never succeed


The disk cache (FileKache) for thumbnails and payloads used Kotlin's `by lazy` with `runBlocking`, which has two problems:

1. Once the lazy initializer throws (e.g. during logout when the cache directory is being deleted), the delegate is permanently broken and every subsequent access re-throws the cached exception. Since DriveFileProviderCached is a Koin singleton, this means all thumbnail loads fail until the app is force-restarted.

2. The fallback manual delete in clearCaches() was not wrapped in its own try-catch, so an IOException during directory deletion propagated as an uncaught exception on the main thread.

Fix:
- Replace `by lazy { runBlocking { ... } }` with nullable backing fields and suspend getter functions that use double-checked locking via a Mutex. This also eliminates runBlocking entirely.
- clearCaches() now uses safe-calls on the backing fields (skips if never initialized), nulls both references after clearing so the next access creates fresh instances, and wraps the fallback delete in its own try-catch.