### PR TITLE
fix: guard against null WebSocket notification payload

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/CryptoHelper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/CryptoHelper.kt
@@ -31,8 +31,10 @@ object CryptoHelper {
      * Deserializes JSON string to type T
      */
     inline fun <reified T> deserialize(json: String): T {
-        return OdinSystemSerializer.deserialize<T>(json)
-            ?: throw Exception("Error deserializing $json")
+        val result: Any? = OdinSystemSerializer.deserialize<T>(json)
+        if (result == null) throw Exception("Deserialization returned null for: ${json.take(200)}")
+        @Suppress("UNCHECKED_CAST")
+        return result as T
     }
 
     /**

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/query/DriveQueryProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/query/DriveQueryProvider.kt
@@ -77,7 +77,11 @@ class DriveQueryProvider(
 
     private suspend fun createServerFileWithSafeMetadata(serverFileJson: JsonObject, secret: SecureByteArray): HomebaseFile {
         // First deserialize ServerFile with FileMetadata as JsonObject
-        val serverFileWithRawMetadata = OdinSystemSerializer.json.decodeFromString<ServerFileWithRawMetadata>(serverFileJson.toString())
+        val serverFileWithRawMetadata = try {
+            OdinSystemSerializer.json.decodeFromString<ServerFileWithRawMetadata>(serverFileJson.toString())
+        } catch (e: Throwable) {
+            throw IllegalStateException("Failed to deserialize ServerFileWithRawMetadata: ${serverFileJson.toString().take(200)}", e)
+        }
         
         // Try to deserialize FileMetadata separately, fallback to bad metadata if it fails
         val fileMetadata = try {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/query/QueryBatchCursor.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/query/QueryBatchCursor.kt
@@ -20,7 +20,11 @@ data class TimeRowCursor(
 
     companion object {
         fun fromJson(jsonString: String): TimeRowCursor {
-            return Json.decodeFromString(jsonString)
+            try {
+                return Json.decodeFromString(jsonString)
+            } catch (e: Exception) {
+                throw IllegalArgumentException("Invalid TimeRowCursor JSON: ${jsonString.take(100)}", e)
+            }
         }
     }
 }
@@ -36,12 +40,6 @@ data class QueryBatchCursor(
     val stop: TimeRowCursor? = null,
     val next: TimeRowCursor? = null
 ) {
-    constructor(jsonString: String) : this() {
-        val decoded = Json.decodeFromString<QueryBatchCursor>(jsonString)
-        // Note: In Kotlin, we can't reassign val properties after construction
-        // The decoded object would need to be used directly or this pattern refactored
-    }
-
     fun clone(): QueryBatchCursor {
         return QueryBatchCursor(
             paging = paging?.copy(),
@@ -65,7 +63,11 @@ data class QueryBatchCursor(
         }
 
         fun fromJson(jsonString: String): QueryBatchCursor {
-            return Json.decodeFromString(jsonString)
+            try {
+                return Json.decodeFromString(jsonString)
+            } catch (e: Exception) {
+                throw IllegalArgumentException("Invalid QueryBatchCursor JSON: ${jsonString.take(100)}", e)
+            }
         }
     }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
@@ -243,7 +243,11 @@ class OdinWebSocketClient(
             notificationBuffer.clear()
 
             for (n in batch) {
-                dispatchNotification(n)
+                try {
+                    dispatchNotification(n)
+                } catch (e: Exception) {
+                    Logger.e(e) { "Failed to dispatch notification type=${n.notificationType}, data=${n.data.take(200)}" }
+                }
             }
         }
     }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
@@ -215,8 +215,13 @@ class OdinWebSocketClient(
             val text = frame.readText()
 
             val decryptedJson = decryptData(text)
-            val notification = OdinSystemSerializer
+            val notification: ClientNotificationPayload? = OdinSystemSerializer
                 .deserialize<ClientNotificationPayload>(decryptedJson)
+
+            if (notification == null) {
+                Logger.e { "Received null WebSocket notification payload, ignoring" }
+                return
+            }
 
             handleNotification(notification)
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/crypto/EccKeyFunctions.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/crypto/EccKeyFunctions.kt
@@ -134,7 +134,11 @@ suspend fun publicKeyToJwkBase64Url(publicKey: EccPublicKey): String {
  * @return Public key
  */
 suspend fun publicKeyFromJwk(jwk: String, expirationHours: Int = 1): EccPublicKey {
-    val jwkMap = Json.decodeFromString<Map<String, String>>(jwk)
+    val jwkMap = try {
+        Json.decodeFromString<Map<String, String>>(jwk)
+    } catch (e: Exception) {
+        throw IllegalArgumentException("Invalid JWK JSON: ${jwk.take(200)}", e)
+    }
 
     require(jwkMap["kty"] == "EC") { "Invalid key type, kty must be EC" }
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/ChatReadCountWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/ChatReadCountWrapper.kt
@@ -41,7 +41,14 @@ class ChatReadCountWrapper(
      */
     fun selectAllConversations(): List<HomebaseFile> {
         val list = delegate.selectAllCoversations().executeAsList()
-        return list.map { OdinSystemSerializer.deserialize<HomebaseFile>(it) }
+        return list.mapNotNull {
+            try {
+                OdinSystemSerializer.deserialize<HomebaseFile>(it)
+            } catch (e: Exception) {
+                logger.e(e) { "Skipping corrupt conversation row: ${it.take(200)}" }
+                null
+            }
+        }
     }
 
     private val logger = Logger.withTag("ConversationQueries")

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/MainIndexMeta.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/MainIndexMeta.kt
@@ -133,7 +133,11 @@ object MainIndexMetaHelpers {
         fun convertDriveMainIndexRecordToFileHeader(
             driveMainIndex: DriveMainIndex
         ): HomebaseFile {
-            return OdinSystemSerializer.deserialize<HomebaseFile>(driveMainIndex.jsonHeader)
+            try {
+                return OdinSystemSerializer.deserialize<HomebaseFile>(driveMainIndex.jsonHeader)
+            } catch (e: Exception) {
+                throw IllegalStateException("Corrupt DB row: fileId=${driveMainIndex.fileId}, json=${driveMainIndex.jsonHeader.take(200)}", e)
+            }
         }
 
         /**

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoContentResolver.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoContentResolver.kt
@@ -27,7 +27,11 @@ suspend fun resolveVideoContent(
                 key = stubMetadata.key,
                 keyHeader = data.keyHeader,
             )?.bytes?.decodeToString() ?: error("Failed to fetch video metadata")
-            OdinSystemSerializer.deserialize<VideoMetadata>(json)
+            try {
+                OdinSystemSerializer.deserialize<VideoMetadata>(json)
+            } catch (e: Exception) {
+                error("Failed to deserialize video metadata for ${data.fileId}/${data.payloadKey}: ${json.take(200)}, cause=${e.message}")
+            }
         } else {
             stubMetadata
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
@@ -385,7 +385,11 @@ class ChatMessageSenderService(
         val content = sourceFile.fileMetadata.appData.content
             ?: throw IllegalArgumentException("source message has no content")
 
-        val messageAppData = OdinSystemSerializer.deserialize<MessageAppData>(content)
+        val messageAppData = try {
+            OdinSystemSerializer.deserialize<MessageAppData>(content)
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Failed to deserialize source message content for $sourceMessageUniqueId: ${content.take(200)}", e)
+        }
 
         val fullText = chatMessageStream.loadFullMessage(
             conversationId = sourceFile.fileMetadata.appData.groupId!!,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -863,9 +863,13 @@ class ConversationService(
         if (adminFile != null) {
             val content = adminFile.fileMetadata.appData.content
             if (!content.isNullOrEmpty()) {
-                val adminInfo = OdinSystemSerializer.deserialize<ConversationAdminInfo>(content)
-                if (!adminInfo.admins.isNullOrEmpty()) {
-                    return adminInfo.admins.toSet()
+                try {
+                    val adminInfo = OdinSystemSerializer.deserialize<ConversationAdminInfo>(content)
+                    if (!adminInfo.admins.isNullOrEmpty()) {
+                        return adminInfo.admins.toSet()
+                    }
+                } catch (e: Exception) {
+                    Logger.e(e) { "Failed to deserialize admin info for conversation=$conversationId: ${content.take(200)}" }
                 }
             }
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/DriveContactService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/DriveContactService.kt
@@ -111,7 +111,12 @@ class DriveContactService(
         }
 
         val content = appData.content ?: ""
-        val parsedContact = OdinSystemSerializer.deserialize<ContactServerFile>(content)
+        val parsedContact = try {
+            OdinSystemSerializer.deserialize<ContactServerFile>(content)
+        } catch (e: Exception) {
+            Logger.e(e) { "Failed to deserialize contact content for uid=$uid: ${content.take(200)}" }
+            return null
+        }
 
         return ContactUiModel(
             id = uid,


### PR DESCRIPTION
OdinSystemSerializer.deserialize<T>() can return a JVM-level null that bypasses Kotlin's compile-time null safety. When the server sends a malformed or empty notification during heavy sync activity, the null propagates through the notification buffer and causes a NullPointerException in dispatchNotification() when accessing notificationType.

Add an explicit null check after deserialization in handleTextFrame() so null payloads are logged and discarded instead of crashing the WebSocket connection.