### PR TITLE
Fixing DB crash on reinstall and wrong SQLCipher key

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -38,6 +38,8 @@
     <application
         android:name=".MainApplication"
         android:allowBackup="true"
+        android:fullBackupContent="@xml/full_backup_content"
+        android:dataExtractionRules="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher"

--- a/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
@@ -43,11 +43,26 @@ class MainApplication : Application(), KoinComponent {
 
         runBlocking {
             val dbKey = DatabaseKeyManager.getOrGenerateKey()
-            // DatabaseManager.wipe { DatabaseDriverFactory(applicationContext).createDriver(dbKey)
-            // } //
-            // <-- Uncomment to wipe database
-            DatabaseManager.initialize {
-                DatabaseDriverFactory(applicationContext).createDriver(dbKey)
+            try {
+                DatabaseManager.initialize {
+                    DatabaseDriverFactory(applicationContext).createDriver(dbKey)
+                }
+            } catch (e: Exception) {
+                Logger.e("MainApplication", e, "Database init failed, resetting")
+                // Delete the corrupted/undecryptable database file and its journal files
+                val dbFile = applicationContext.getDatabasePath("odin-2.db")
+                dbFile.delete()
+                java.io.File(dbFile.path + "-journal").delete()
+                java.io.File(dbFile.path + "-wal").delete()
+                java.io.File(dbFile.path + "-shm").delete()
+
+                // Clear the stale encryption key and generate a fresh one
+                DatabaseKeyManager.clearKey()
+                val freshKey = DatabaseKeyManager.getOrGenerateKey()
+
+                DatabaseManager.initialize {
+                    DatabaseDriverFactory(applicationContext).createDriver(freshKey)
+                }
             }
         }
 

--- a/androidApp/src/main/res/xml/backup_rules.xml
+++ b/androidApp/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="database" path="odin-2.db" />
+        <exclude domain="database" path="odin-2.db-journal" />
+        <exclude domain="database" path="odin-2.db-wal" />
+        <exclude domain="database" path="odin-2.db-shm" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="database" path="odin-2.db" />
+        <exclude domain="database" path="odin-2.db-journal" />
+        <exclude domain="database" path="odin-2.db-wal" />
+        <exclude domain="database" path="odin-2.db-shm" />
+    </device-transfer>
+</data-extraction-rules>

--- a/androidApp/src/main/res/xml/full_backup_content.xml
+++ b/androidApp/src/main/res/xml/full_backup_content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <exclude domain="database" path="odin-2.db" />
+    <exclude domain="database" path="odin-2.db-journal" />
+    <exclude domain="database" path="odin-2.db-wal" />
+    <exclude domain="database" path="odin-2.db-shm" />
+</full-backup-content>

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseKeyManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseKeyManager.kt
@@ -8,6 +8,10 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 object DatabaseKeyManager {
     private const val KEY_DB_ENCRYPTION = "odin_db_encryption_key"
 
+    fun clearKey() {
+        SecureStorage.remove(KEY_DB_ENCRYPTION)
+    }
+
     @OptIn(ExperimentalEncodingApi::class)
     fun getOrGenerateKey(): String {
         val existingKey = SecureStorage.get(KEY_DB_ENCRYPTION)

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/MainViewController.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/MainViewController.kt
@@ -16,6 +16,7 @@ import kotlinx.io.files.Path
 import org.koin.core.context.startKoin
 import platform.Foundation.NSDocumentDirectory
 import platform.Foundation.NSFileManager
+import platform.Foundation.NSHomeDirectory
 import platform.Foundation.NSUserDomainMask
 import platform.UIKit.UIViewController
 
@@ -47,8 +48,24 @@ fun MainViewController(): UIViewController {
 
     runBlocking {
         val dbKey = DatabaseKeyManager.getOrGenerateKey()
-        // DatabaseManager.wipe { DatabaseDriverFactory().createDriver(dbKey) }
-        DatabaseManager.initialize { DatabaseDriverFactory().createDriver(dbKey) }
+        try {
+            DatabaseManager.initialize { DatabaseDriverFactory().createDriver(dbKey) }
+        } catch (e: Exception) {
+            Logger.e("MainViewController", e, "Database init failed, resetting")
+            // Delete the corrupted/undecryptable database file
+            val fileManager = NSFileManager.defaultManager
+            val dbDir = "${NSHomeDirectory()}/databases"
+            fileManager.removeItemAtPath("$dbDir/odin-2.db", null)
+            fileManager.removeItemAtPath("$dbDir/odin-2.db-journal", null)
+            fileManager.removeItemAtPath("$dbDir/odin-2.db-wal", null)
+            fileManager.removeItemAtPath("$dbDir/odin-2.db-shm", null)
+
+            // Clear the stale encryption key and generate a fresh one
+            DatabaseKeyManager.clearKey()
+            val freshKey = DatabaseKeyManager.getOrGenerateKey()
+
+            DatabaseManager.initialize { DatabaseDriverFactory().createDriver(freshKey) }
+        }
     }
     val controller = ComposeUIViewController { App() }
     MainViewControllerRef.instance = controller


### PR DESCRIPTION
Problem: App crash-loops on startup after reinstall (SQLCipher key mismatch)

Symptoms

The app crashes immediately after the splash screen with no way to recover. The only fix is manually clearing app data via device Settings. The crash log shows:

FATAL EXCEPTION: main
Process: id.homebase.feed.dev
java.lang.RuntimeException: Unable to create application id.homebase.feed.MainApplication
Caused by: net.zetetic.database.sqlcipher.SQLiteNotADatabaseException:
    file is not a database (code 26): , while compiling: SELECT COUNT(*) FROM sqlite_schema;

Root cause

Our database (odin-2.db) is encrypted with SQLCipher. The encryption key is generated at first launch and stored in platform-secure storage (Android KeyStore / iOS Keychain). When the database is opened on subsequent launches, the stored key is retrieved and used to decrypt it.

The problem occurs when the key is lost but the database file survives. In that scenario, DatabaseKeyManager.getOrGenerateKey() generates a brand new key (because the old one is gone), and SQLCipher fails to decrypt the existing database file with this new key, throwing SQLiteNotADatabaseException.

This was triggered in practice by an uninstall + reinstall on Android. Android's auto-backup (android:allowBackup="true" in our manifest, with no exclusion rules) silently restores the encrypted database file after reinstall. However, the Android KeyStore is wiped on uninstall, so the encryption key  is gone. Fresh key + old database = crash.

The same scenario can occur on iOS via iCloud backup restore to a different device (different Keychain, same database file), or on either platform if the secure storage is invalidated by an OS update, biometric re-enrollment, or other system-level event.

The crash is fatal and unrecoverable because DatabaseManager.initialize() runs inside runBlocking in MainApplication.onCreate() (Android) / MainViewController() (iOS) with no try-catch. The user is stuck in a crash loop until they manually clear app data.

Solution

1. Graceful recovery on initialization failure (Android + iOS)

Wrapped DatabaseManager.initialize() in a try-catch on both platforms. On failure:
- Delete the corrupted/undecryptable database file and its journal/WAL/SHM companions
- Clear the stale encryption key from secure storage via a new DatabaseKeyManager.clearKey() method
- Generate a fresh encryption key
- Retry DatabaseManager.initialize() — succeeds because SQLCipher creates a new empty database

This is safe because the database is a sync cache, not the source of truth. The app will re-sync all data from the server on next login. If the retry also fails (indicating a different, unexpected problem), the exception propagates normally and crashes the app as before.

The retry is safe from a code perspective because the crash occurs inside the DatabaseManager constructor, before the singleton instance field is assigned, so the isInitialized guard in DatabaseManager.initialize() still returns false on the second call.

2. Exclude database from Android auto-backup (prevention)

Added backup_rules.xml (API 31+ data extraction rules) and full_backup_content.xml (API 23-30 full backup content rules) that exclude odin-2.db and its journal files from both cloud backup and device transfer. Wired these into the manifest via android:dataExtractionRules and android:fullBackupContent. We keep android:allowBackup="true" so other app data (preferences, etc.) can still be backed up.

Files changed

- homebase-api/src/commonMain/.../DatabaseKeyManager.kt — added clearKey() method
- androidApp/src/main/.../MainApplication.kt — try-catch recovery around DB init
- androidApp/src/main/AndroidManifest.xml — backup exclusion attributes
- androidApp/src/main/res/xml/backup_rules.xml — new, API 31+ exclusion rules
- androidApp/src/main/res/xml/full_backup_content.xml — new, API 23-30 exclusion rules
- homebase-core/src/nativeMain/.../MainViewController.kt — try-catch recovery around DB init (iOS)

Testing

1. Install the app, open it (creates the database)
2. Go to Settings > Apps > Homebase.id Dev > Storage > Clear Data (simulates key loss while the scenario where the DB file would survive is harder to
reproduce directly)
3. Reopen the app — should recover gracefully and show the login screen instead of crashing
