### PR TITLE
fix: allow deleting archived group conversations without crashing

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -1413,13 +1413,27 @@ class ConversationListViewModel(
 
             is ConversationListUiAction.ArchiveConversation -> {
                 viewModelScope.launch {
-                    conversationService.archiveConversation(action.conversationId)
+                    try {
+                        conversationService.archiveConversation(action.conversationId)
+                    } catch (e: Exception) {
+                        Logger.e(throwable = e, tag = "ConversationListViewModel") {
+                            "Failed to archive conversation: ${e.message}"
+                        }
+                        sendEvent(ShowErrorMessage("Failed to archive conversation: ${e.message}"))
+                    }
                 }
             }
 
             is ConversationListUiAction.UnarchiveConversation -> {
                 viewModelScope.launch {
-                    conversationService.unarchiveConversation(action.conversationId)
+                    try {
+                        conversationService.unarchiveConversation(action.conversationId)
+                    } catch (e: Exception) {
+                        Logger.e(throwable = e, tag = "ConversationListViewModel") {
+                            "Failed to unarchive conversation: ${e.message}"
+                        }
+                        sendEvent(ShowErrorMessage("Failed to unarchive conversation: ${e.message}"))
+                    }
                 }
             }
 
@@ -1429,26 +1443,54 @@ class ConversationListViewModel(
 
             is ConversationListUiAction.ClearConversation -> {
                 viewModelScope.launch {
-                    conversationService.clearConversation(action.conversationId)
+                    try {
+                        conversationService.clearConversation(action.conversationId)
+                    } catch (e: Exception) {
+                        Logger.e(throwable = e, tag = "ConversationListViewModel") {
+                            "Failed to clear conversation: ${e.message}"
+                        }
+                        sendEvent(ShowErrorMessage("Failed to clear conversation: ${e.message}"))
+                    }
                 }
             }
 
             is ConversationListUiAction.DeleteConversation -> {
                 viewModelScope.launch {
-                    conversationService.deleteConversation(action.conversationId)
+                    try {
+                        conversationService.deleteConversation(action.conversationId)
+                    } catch (e: Exception) {
+                        Logger.e(throwable = e, tag = "ConversationListViewModel") {
+                            "Failed to delete conversation: ${e.message}"
+                        }
+                        sendEvent(ShowErrorMessage("Failed to delete conversation: ${e.message}"))
+                    }
                 }
             }
 
             is ConversationListUiAction.AcceptRejoin -> {
                 viewModelScope.launch {
-                    conversationService.acceptRejoin(action.conversationId)
+                    try {
+                        conversationService.acceptRejoin(action.conversationId)
+                    } catch (e: Exception) {
+                        Logger.e(throwable = e, tag = "ConversationListViewModel") {
+                            "Failed to accept rejoin: ${e.message}"
+                        }
+                        sendEvent(ShowErrorMessage("Failed to accept rejoin: ${e.message}"))
+                    }
                 }
             }
 
             is ConversationListUiAction.DeclineRejoin -> {
                 viewModelScope.launch {
-                    conversationService.declineRejoin(action.conversationId)
-                    conversationStream.onConversationLeft(action.conversationId)
+                    try {
+                        conversationService.declineRejoin(action.conversationId)
+                        conversationStream.onConversationLeft(action.conversationId)
+                    } catch (e: Exception) {
+                        Logger.e(throwable = e, tag = "ConversationListViewModel") {
+                            "Failed to decline rejoin: ${e.message}"
+                        }
+                        sendEvent(ShowErrorMessage("Failed to decline rejoin: ${e.message}"))
+                    }
                 }
             }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -743,7 +743,8 @@ class ConversationService(
         if (conversation.isGroupConversation && !(
                     conversation.conversationState == ConversationState.Left ||
                             conversation.conversationState == ConversationState.RejoinPending ||
-                            conversation.conversationState == ConversationState.Removed
+                            conversation.conversationState == ConversationState.Removed ||
+                            conversation.conversationState == ConversationState.Archived
                     )
         ) {
             throw IllegalStateException("You must leave the group before deleting it")


### PR DESCRIPTION
fix: allow deleting archived group conversations without crashing

The app crashed with IllegalStateException("You must leave the group
before deleting it") when the user tried to delete an archived group
conversation. The guard in deleteConversation only allowed deletion
when conversationState was Left, RejoinPending, or Removed — but
archived group conversations have conversationState=Archived (set via
tag in ConversationMapper), which was not in the allowed list.

Additionally, the DeleteConversation action handler (and five other
conversation actions) in ConversationListViewModel had no try-catch,
so any service-layer exception crashed the app instead of showing an
error message.

Changes:
- Add ConversationState.Archived to the allowed states in
  ConversationService.deleteConversation
- Wrap Archive, Unarchive, Clear, Delete, AcceptRejoin, and
  DeclineRejoin handlers in try-catch with error logging and
  user-facing error messages

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.co