### PR TITLE
feat: add performance timing for slow conversation message loading

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -106,6 +106,8 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlinx.serialization.json.JsonPrimitive
 import kotlin.io.encoding.Base64
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TimeSource
 import kotlin.uuid.Uuid
 
 @OptIn(FlowPreview::class)
@@ -1742,6 +1744,8 @@ class ConversationListViewModel(
         messageIdForScroll: Uuid?,
         scrollToBottom: Boolean = false
     ) {
+        val loadStart = TimeSource.Monotonic.markNow()
+
         val hasCachedMessages =
             conversationId == _uiState.value.selectedConversationId &&
                     chatMessageStream.hasCachedMessages(conversationId)
@@ -1761,6 +1765,8 @@ class ConversationListViewModel(
                 if (!hasCachedMessages) {
                     chatMessageStream.loadConversation(conversationId)
                 }
+                val dbFetchElapsed = loadStart.elapsedNow()
+
                 chatMessageStream.observeMessages(conversationId).collect { messageState ->
                     when (messageState) {
                         is ChatMessagesData.Initializing -> {
@@ -1855,6 +1861,18 @@ class ConversationListViewModel(
                                         ?: it.scrollPosition?.takeIf { pos -> pos.triggerScroll },
                                 )
                             }
+
+                            val totalElapsed = loadStart.elapsedNow()
+                            if (totalElapsed > 200.milliseconds) {
+                                Logger.w("SlowConversationLoad") {
+                                    "conversationId=$conversationId " +
+                                            "messageCount=${messages.size} " +
+                                            "cached=$hasCachedMessages " +
+                                            "dbFetch=$dbFetchElapsed " +
+                                            "total=$totalElapsed"
+                                }
+                            }
+
                             setInitialScroll = false
                         }
                     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -19,6 +19,8 @@ import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.QueryBatch
+import kotlin.time.TimeSource
+import kotlin.time.Duration.Companion.milliseconds
 import id.homebase.chat.data.MessageUiModel
 import id.homebase.chat.services.convo.contact.ContactService
 import id.homebase.core.config.chatTargetDrive
@@ -119,9 +121,11 @@ class ChatMessageStream(
     // Called when the user opens a conversation (ConversationListViewModel.selectConversation).
     // Do NOT call from DriveEvent.Stopped or other sync events — see init block above.
     suspend fun loadConversation(conversationId: Uuid) {
+        val start = TimeSource.Monotonic.markNow()
         Logger.d("ChatMessageStream: loadConversation($conversationId)")
         val result = fetchMessages(conversationId)
-        Logger.d("ChatMessageStream: loadConversation($conversationId) → ${result.records.size} messages")
+        val elapsed = start.elapsedNow()
+        Logger.d("ChatMessageStream: loadConversation($conversationId) → ${result.records.size} messages in $elapsed")
         conversationState.set(conversationId, result.records)
     }
 
@@ -193,6 +197,7 @@ class ChatMessageStream(
         val c = credentialsManager.requireActiveCredentials()
         val queryBatch = QueryBatch(c.getIdentityId())
 
+        val queryStart = TimeSource.Monotonic.markNow()
         val result =
             queryBatch.queryBatchAsync(
                 dbm = dbm,
@@ -205,12 +210,26 @@ class ChatMessageStream(
                 filetypesAnyOf = listOf(ChatProtocol.MessageFileType),
                 groupIdAnyOf = listOf(conversationId)
             )
+        val queryElapsed = queryStart.elapsedNow()
+
+        val mapStart = TimeSource.Monotonic.markNow()
+        val records = result.records.mapNotNull { header ->
+            mapToMessageData(header, credentialsManager, ::resolveDisplayName)
+        }
+        val mapElapsed = mapStart.elapsedNow()
+
+        if (queryElapsed + mapElapsed > 200.milliseconds) {
+            Logger.w("SlowMessageFetch") {
+                "conversationId=$conversationId " +
+                        "rawRecords=${result.records.size} " +
+                        "mappedRecords=${records.size} " +
+                        "dbQuery=$queryElapsed " +
+                        "mapping=$mapElapsed"
+            }
+        }
 
         return BatchResult(
-            records =
-                result.records.mapNotNull { header ->
-                    mapToMessageData(header, credentialsManager, ::resolveDisplayName)
-                },
+            records = records,
             hasMoreRows = result.hasMoreRows,
             cursor = result.cursor
         )


### PR DESCRIPTION
Add instrumentation to diagnose spinner delays when opening conversations. Logs warnings when loading takes >200ms, with breakdown of DB query time, message mapping time, and total end-to-end time.

Timing is measured from loadMessagesForConversation (covers both conversation list taps and push notification opens) through to isLoadingMessages=false.