### PR TITLE
fix: prevent duplicate messages when editing or sending via gallery

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -503,6 +503,7 @@ class ConversationListViewModel(
             }
 
             is ConversationListUiAction.EditMessageSave -> {
+                _messagesUiState.update { it.copy(isSendingMessage = true) }
                 _messagesUiState.value.isEditingMessageId?.let { messageId ->
                     editMessage(
                         messageId = messageId,
@@ -1962,6 +1963,8 @@ class ConversationListViewModel(
                 }
             } catch (e: Exception) {
                 sendEvent(ShowErrorMessage("Failed to edit message: ${e.message}"))
+            } finally {
+                _messagesUiState.update { it.copy(isSendingMessage = false) }
             }
         }
     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
@@ -284,6 +284,7 @@ fun ConversationMessagesPane(
                         FullScreenAttachmentEditor(
                             data = data,
                             textFieldState = textFieldState,
+                            isSendingMessage = uiState.isSendingMessage,
                             currentPage = currentGalleryPage,
                             onPageChanged = { currentGalleryPage = it },
                             onSaveFile = { onUiAction(SaveFile(it)) },

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenAttachmentEditor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenAttachmentEditor.kt
@@ -71,6 +71,7 @@ fun FullScreenAttachmentEditor(
     modifier: Modifier = Modifier,
     data: FullScreenOverlay.AttachmentData,
     textFieldState: RichTextState,
+    isSendingMessage: Boolean = false,
     currentPage: Int,
     onPageChanged: (Int) -> Unit,
     onSaveFile: (file: AttachmentPendingFile) -> Unit,
@@ -356,6 +357,7 @@ fun FullScreenAttachmentEditor(
                 .padding(16.dp)
                 .imePadding(),
             state = textFieldState,
+            isSendingMessage = isSendingMessage,
             onSmileyClick = {},
             onSendMessage = {
                 onSendMessage(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
@@ -930,6 +930,7 @@ private fun MessageEditMessageInfo(
 fun MessageTextFieldForAttachment(
     modifier: Modifier = Modifier,
     state: RichTextState,
+    isSendingMessage: Boolean = false,
     onSmileyClick: () -> Unit,
     onSendMessage: () -> Unit
 ) {
@@ -989,7 +990,9 @@ fun MessageTextFieldForAttachment(
             Spacer(modifier = Modifier.width(8.dp))
             if (!isKeyboardVisible) {
                 IconButton(
-                    onClick = onSendMessage, colors = IconButtonDefaults.iconButtonColors(
+                    onClick = onSendMessage,
+                    enabled = !isSendingMessage,
+                    colors = IconButtonDefaults.iconButtonColors(
                         containerColor = HomebaseTheme.extendedColors.bubbleSentSurface,
                         contentColor = HomebaseTheme.extendedColors.bubbleSentOnSurface,
                     )


### PR DESCRIPTION
The isSendingMessage guard that prevents double-tap on the regular send button was missing from two other send paths:

- Edit message: the EditMessageSave handler never set isSendingMessage, so the check button stayed enabled during the network call.
- Gallery/attachment send: the FullScreenAttachmentEditor send button had no enabled guard at all, and isSendingMessage was never passed down from the ViewModel.

Both paths now set/reset the flag and disable the button while sending, matching the existing pattern used for new message sends.