### PR TITLE
fix: only log SlowConversationLoad on initial load, not incremental u…

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -1905,14 +1905,16 @@ class ConversationListViewModel(
                                 )
                             }
 
-                            val totalElapsed = loadStart.elapsedNow()
-                            if (totalElapsed > 200.milliseconds) {
-                                Logger.w("SlowConversationLoad") {
-                                    "conversationId=$conversationId " +
-                                            "messageCount=${messages.size} " +
-                                            "cached=$hasCachedMessages " +
-                                            "dbFetch=$dbFetchElapsed " +
-                                            "total=$totalElapsed"
+                            if (setInitialScroll) {
+                                val totalElapsed = loadStart.elapsedNow()
+                                if (totalElapsed > 200.milliseconds) {
+                                    Logger.w("SlowConversationLoad") {
+                                        "conversationId=$conversationId " +
+                                                "messageCount=${messages.size} " +
+                                                "cached=$hasCachedMessages " +
+                                                "dbFetch=$dbFetchElapsed " +
+                                                "total=$totalElapsed"
+                                    }
                                 }
                             }
 


### PR DESCRIPTION
…pdates

The warning was firing on every flow emission (sent messages, syncs) using the original load timer, producing misleading multi-second totals. Gate the check behind setInitialScroll so it only measures the actual conversation open.