### PR TITLE
fix: clear input text after editing a message

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -1963,6 +1963,7 @@ class ConversationListViewModel(
                         isEditingVersionTag = null
                     )
                 }
+                messageInputTextState.clear()
             } catch (e: Exception) {
                 sendEvent(ShowErrorMessage("Failed to edit message: ${e.message}"))
             } finally {


### PR DESCRIPTION
The editMessage() function was missing a messageInputTextState.clear() call after a successful edit, causing the edited text to remain in the input box and the send button to be immediately re-enabled.