### PR TITLE
Fix slow conversation load: enable message cache, add covering index,…

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DriveMainIndexWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DriveMainIndexWrapper.kt
@@ -6,6 +6,8 @@ import app.cash.sqldelight.db.SqlCursor
 import kotlin.Any
 import kotlin.Long
 import kotlin.compareTo
+import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.serialization.OdinSystemSerializer
 import kotlin.uuid.Uuid
 
 class DriveMainIndexWrapper(
@@ -56,6 +58,14 @@ class DriveMainIndexWrapper(
     ): DriveMainIndex? = delegate.selectByIdentityAndDriveAndUnique(identityId, driveId, uniqueId)
         .executeAsOneOrNull()
 
+    fun selectHomebaseFileByUnique(
+        identityId: Uuid,
+        driveId: Uuid,
+        uniqueId: Uuid,
+    ): HomebaseFile? {
+        val row = selectByIdentityAndDriveAndUnique(identityId, driveId, uniqueId) ?: return null
+        return OdinSystemSerializer.deserialize<HomebaseFile>(row.jsonHeader)
+    }
 
     fun selectByIdentityAndDriveAndGlobal(
         identityId: Uuid,

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ChatReadCount.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ChatReadCount.sq
@@ -5,10 +5,6 @@ CREATE TABLE IF NOT EXISTS ChatReadCount(
    lastReadTime INTEGER NOT NULL
 );
 
--- This table and these queries will benefit from this index on DriveMainIndex
-CREATE INDEX IF NOT EXISTS idx_messages_groupId_filetype_userDate
-  ON DriveMainIndex(groupId, fileType, userDate);
-
 -- To make the conversation + last-message performant
 CREATE INDEX IF NOT EXISTS idx_chatmessage_convid_userDate ON DriveMainIndex(groupId,fileType,userDate DESC);
 

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/DriveMainIndex.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/DriveMainIndex.sq
@@ -29,6 +29,7 @@ CREATE TABLE IF NOT EXISTS DriveMainIndex( -- Version: 4
 CREATE INDEX IF NOT EXISTS Idx0DriveMainIndex ON DriveMainIndex(identityId,driveId,fileSystemType,created,rowId);
 CREATE INDEX IF NOT EXISTS Idx1DriveMainIndex ON DriveMainIndex(identityId,driveId,fileSystemType,modified,rowId);
 CREATE INDEX IF NOT EXISTS Idx2DriveMainIndex ON DriveMainIndex(identityId,driveId,fileSystemType,userDate,rowId);
+CREATE INDEX IF NOT EXISTS Idx3DriveMainIndex ON DriveMainIndex(identityId,driveId,fileSystemType,groupId,fileType,userDate DESC,rowId);
 -- Other DriveMainIndex INDEX is created in ChatReadCount.sq
 
 -- Upsert a record

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -106,7 +106,6 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlinx.serialization.json.JsonPrimitive
 import kotlin.io.encoding.Base64
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeSource
 import kotlin.uuid.Uuid
 
@@ -1789,9 +1788,7 @@ class ConversationListViewModel(
     ) {
         val loadStart = TimeSource.Monotonic.markNow()
 
-        val hasCachedMessages =
-            conversationId == _uiState.value.selectedConversationId &&
-                    chatMessageStream.hasCachedMessages(conversationId)
+        val hasCachedMessages = chatMessageStream.hasCachedMessages(conversationId)
 
         _messagesUiState.update {
             it.copy(scrollPosition = null, isLoadingMessages = !hasCachedMessages)
@@ -1808,7 +1805,6 @@ class ConversationListViewModel(
                 if (!hasCachedMessages) {
                     chatMessageStream.loadConversation(conversationId)
                 }
-                val dbFetchElapsed = loadStart.elapsedNow()
 
                 chatMessageStream.observeMessages(conversationId).collect { messageState ->
                     when (messageState) {
@@ -1907,14 +1903,11 @@ class ConversationListViewModel(
 
                             if (setInitialScroll) {
                                 val totalElapsed = loadStart.elapsedNow()
-                                if (totalElapsed > 200.milliseconds) {
-                                    Logger.w("SlowConversationLoad") {
-                                        "conversationId=$conversationId " +
-                                                "messageCount=${messages.size} " +
-                                                "cached=$hasCachedMessages " +
-                                                "dbFetch=$dbFetchElapsed " +
-                                                "total=$totalElapsed"
-                                    }
+                                Logger.d("ConversationLoad") {
+                                    "conversationId=$conversationId " +
+                                            "messageCount=${messages.size} " +
+                                            "cached=$hasCachedMessages " +
+                                            "total=$totalElapsed"
                                 }
                             }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -154,38 +154,13 @@ class ChatMessageStream(
     }
 
     suspend fun getMessage(messageId: Uuid): MessageUiModel? {
-        val c = credentialsManager.requireActiveCredentials()
-        val queryBatch = QueryBatch(c.getIdentityId())
-
-        val result =
-            queryBatch.queryBatchAsync(
-                dbm = dbm,
-                driveId = chatDrive,
-                noOfItems = 1,
-                filetypesAnyOf = listOf(ChatProtocol.MessageFileType),
-                uniqueIdAnyOf = listOf(messageId),
-                fileSystemType = 0
-            )
-
-        val messageFile = result.records.singleOrNull() ?: return null
+        val messageFile = getMessageFile(messageId) ?: return null
         return mapToMessageData(messageFile, credentialsManager, ::resolveDisplayName)
     }
 
     suspend fun getMessageFile(messageId: Uuid): HomebaseFile? {
         val c = credentialsManager.requireActiveCredentials()
-        val queryBatch = QueryBatch(c.getIdentityId())
-
-        val result =
-            queryBatch.queryBatchAsync(
-                dbm = dbm,
-                driveId = chatDrive,
-                noOfItems = 1,
-                filetypesAnyOf = listOf(ChatProtocol.MessageFileType),
-                uniqueIdAnyOf = listOf(messageId),
-                fileSystemType = 0
-            )
-
-        return result.records.singleOrNull()
+        return dbm.driveMainIndex.selectHomebaseFileByUnique(c.getIdentityId(), chatDrive, messageId)
     }
 
     suspend fun fetchMessages(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMapper.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMapper.kt
@@ -5,11 +5,8 @@ import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.drives.FileState
 import id.homebase.api.client.drives.HomebaseFile
-import id.homebase.api.client.drives.QueryBatchSortField
-import id.homebase.api.client.drives.QueryBatchSortOrder
 import id.homebase.api.client.drives.files.ArchivalStatus
 import id.homebase.api.sync.database.DatabaseManager
-import id.homebase.api.sync.database.QueryBatch
 import id.homebase.api.common.OdinId
 import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.api.serialization.OdinSystemSerializer
@@ -226,21 +223,10 @@ class ConversationMapper(
     private suspend fun queryAdmins(conversationId: Uuid): Set<OdinId>? {
         val c = credentialsManager.requireActiveCredentials()
         val adminUniqueId = ChatProtocol.getAdminFileUniqueId(conversationId)
-        val queryBatch = QueryBatch(c.getIdentityId())
 
-        val result = queryBatch.queryBatchAsync(
-            dbm = dbm,
-            driveId = chatDrive,
-            noOfItems = 1,
-            cursor = null,
-            sortOrder = QueryBatchSortOrder.NewestFirst,
-            sortField = QueryBatchSortField.CreatedDate,
-            fileSystemType = 0,
-            uniqueIdAnyOf = listOf(adminUniqueId),
-            filetypesAnyOf = listOf(ChatProtocol.ConversationAdminFileType),
-        )
-
-        val file = result.records.firstOrNull() ?: return null
+        val file = dbm.driveMainIndex.selectHomebaseFileByUnique(
+            c.getIdentityId(), chatDrive, adminUniqueId
+        ) ?: return null
         val content = file.fileMetadata.appData.content
         if (content.isNullOrEmpty()) return null
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -7,8 +7,6 @@ import id.homebase.api.client.connections.ConnectionIntroductionProvider
 import id.homebase.api.client.connections.IntroductionGroup
 import id.homebase.api.client.drives.FileSystemType
 import id.homebase.api.client.drives.HomebaseFile
-import id.homebase.api.client.drives.QueryBatchSortField
-import id.homebase.api.client.drives.QueryBatchSortOrder
 import id.homebase.api.client.drives.files.ArchivalStatus
 import id.homebase.api.client.drives.files.DeleteFilesByGroupIdOutboxRequest
 import id.homebase.api.client.drives.files.PayloadFile
@@ -29,7 +27,6 @@ import id.homebase.api.crypto.ByteArrayUtil
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.OutboxSync
-import id.homebase.api.sync.database.QueryBatch
 import id.homebase.api.toBase64
 import id.homebase.chat.data.ConversationState
 import id.homebase.chat.data.ConversationUiModel
@@ -816,46 +813,14 @@ class ConversationService(
     }
 
     private suspend fun getConversationHomebaseFile(conversationId: Uuid): HomebaseFile? {
-
         val c = credentialsManager.requireActiveCredentials()
-        val queryBatch = QueryBatch(c.getIdentityId())
-
-        val result =
-            queryBatch.queryBatchAsync(
-                dbm = dbm,
-                driveId = chatDrive,
-                noOfItems = 1,
-                cursor = null,
-                sortOrder = QueryBatchSortOrder.NewestFirst,
-                sortField = QueryBatchSortField.CreatedDate,
-                fileSystemType = 0,
-                uniqueIdAnyOf = listOf(conversationId),
-                filetypesAnyOf = listOf(ChatProtocol.ConversationFileType),
-            )
-
-        val file = result.records.firstOrNull()
-
-        return file
+        return dbm.driveMainIndex.selectHomebaseFileByUnique(c.getIdentityId(), chatDrive, conversationId)
     }
 
     suspend fun getConversationAdminHomebaseFile(conversationId: Uuid): HomebaseFile? {
         val c = credentialsManager.requireActiveCredentials()
-        val queryBatch = QueryBatch(c.getIdentityId())
         val adminUniqueId = ChatProtocol.getAdminFileUniqueId(conversationId)
-
-        val result = queryBatch.queryBatchAsync(
-            dbm = dbm,
-            driveId = chatDrive,
-            noOfItems = 1,
-            cursor = null,
-            sortOrder = QueryBatchSortOrder.NewestFirst,
-            sortField = QueryBatchSortField.CreatedDate,
-            fileSystemType = 0,
-            uniqueIdAnyOf = listOf(adminUniqueId),
-            filetypesAnyOf = listOf(ChatProtocol.ConversationAdminFileType),
-        )
-
-        return result.records.firstOrNull()
+        return dbm.driveMainIndex.selectHomebaseFileByUnique(c.getIdentityId(), chatDrive, adminUniqueId)
     }
 
     /** Reads the admin list from the dedicated admin file, falling back to originalAuthor. */

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -225,19 +225,10 @@ class ConversationStream(
 
     suspend fun loadConversation(conversationId: Uuid) {
         val c = credentialsManager.requireActiveCredentials()
-        val queryBatch = QueryBatch(c.getIdentityId())
 
-        val conversationFile = queryBatch.queryBatchAsync(
-            dbm = dbm,
-            driveId = chatDrive,
-            noOfItems = 1,
-            cursor = null,
-            sortOrder = QueryBatchSortOrder.NewestFirst,
-            sortField = QueryBatchSortField.CreatedDate,
-            fileSystemType = 0,
-            uniqueIdAnyOf = listOf(conversationId),
-            filetypesAnyOf = listOf(ChatProtocol.ConversationFileType)
-        ).records.firstOrNull() ?: return
+        val conversationFile = dbm.driveMainIndex.selectHomebaseFileByUnique(
+            c.getIdentityId(), chatDrive, conversationId
+        ) ?: return
 
         val incoming = mapper.mapToConversationUi(conversationFile, null)
         val existing = _conversations.value.items.find { it.id == conversationId }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
@@ -7,8 +7,6 @@ import id.homebase.api.client.drives.AccessControlList
 import id.homebase.api.client.drives.FileState
 import id.homebase.api.client.drives.FileSystemType
 import id.homebase.api.client.drives.HomebaseFile
-import id.homebase.api.client.drives.QueryBatchSortField
-import id.homebase.api.client.drives.QueryBatchSortOrder
 import id.homebase.api.client.drives.ServerMetadata
 import id.homebase.api.client.drives.files.AppFileMetaData
 import id.homebase.api.client.drives.files.DeleteFilesByGroupIdOutboxRequest
@@ -24,7 +22,6 @@ import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.MainIndexMetaHelpers
-import id.homebase.api.sync.database.QueryBatch
 import id.homebase.api.toBase64
 import id.homebase.api.client.drives.upload.UpdateLocalMetadataContentOutboxRequest
 import id.homebase.api.crypto.ByteArrayUtil
@@ -137,23 +134,12 @@ class OptimisticWriter(
     ) {
 
         val credentials = credentialsManager.requireActiveCredentials()
-        val queryBatch = QueryBatch(credentials.getIdentityId())
         val uid = unecryptedMetadata.appData.uniqueId
             ?: throw IllegalStateException("missing unique id")
 
-        val result = queryBatch.queryBatchAsync(
-            dbm = dbm,
-            driveId = driveId,
-            noOfItems = 1,
-            cursor = null,
-            sortOrder = QueryBatchSortOrder.NewestFirst,
-            sortField = QueryBatchSortField.CreatedDate,
-            fileSystemType = 0,
-            uniqueIdAnyOf = listOf(uid)
-        )
-
-        val existingFile = result.records.singleOrNull()
-            ?: throw IllegalStateException("no file by uid")
+        val existingFile = dbm.driveMainIndex.selectHomebaseFileByUnique(
+            credentials.getIdentityId(), driveId, uid
+        ) ?: throw IllegalStateException("no file by uid")
 
         val lastModified = existingFile.fileMetadata.updated.addMilliseconds(1)
 
@@ -224,20 +210,10 @@ class OptimisticWriter(
      *  pending message is not left stranded in the conversation list. */
     suspend fun removeOptimisticFile(driveId: Uuid, uniqueId: Uuid) {
         val credentials = credentialsManager.requireActiveCredentials()
-        val queryBatch = QueryBatch(credentials.getIdentityId())
 
-        val result = queryBatch.queryBatchAsync(
-            dbm = dbm,
-            driveId = driveId,
-            noOfItems = 1,
-            cursor = null,
-            sortOrder = QueryBatchSortOrder.NewestFirst,
-            sortField = QueryBatchSortField.CreatedDate,
-            fileSystemType = 0,
-            uniqueIdAnyOf = listOf(uniqueId)
-        )
-
-        val file = result.records.singleOrNull() ?: return
+        val file = dbm.driveMainIndex.selectHomebaseFileByUnique(
+            credentials.getIdentityId(), driveId, uniqueId
+        ) ?: return
 
         // Only remove files that are still pending — if the outbox already sent the message
         // the isPendingSendTag will have been removed, and we must not delete it.
@@ -267,20 +243,10 @@ class OptimisticWriter(
      *  Returns the original file so the caller can rollback if the outbox enqueue fails. */
     suspend fun writeDelete(driveId: Uuid, uniqueId: Uuid): HomebaseFile? {
         val credentials = credentialsManager.requireActiveCredentials()
-        val queryBatch = QueryBatch(credentials.getIdentityId())
 
-        val result = queryBatch.queryBatchAsync(
-            dbm = dbm,
-            driveId = driveId,
-            noOfItems = 1,
-            cursor = null,
-            sortOrder = QueryBatchSortOrder.NewestFirst,
-            sortField = QueryBatchSortField.CreatedDate,
-            fileSystemType = 0,
-            uniqueIdAnyOf = listOf(uniqueId)
-        )
-
-        val existingFile = result.records.singleOrNull() ?: return null
+        val existingFile = dbm.driveMainIndex.selectHomebaseFileByUnique(
+            credentials.getIdentityId(), driveId, uniqueId
+        ) ?: return null
 
         val lastModified = existingFile.fileMetadata.updated.addMilliseconds(1)
 
@@ -358,21 +324,10 @@ class OptimisticWriter(
         reactionJson: String,
     ): Pair<ToggleReactionResultType, HomebaseFile?> {
         val credentials = credentialsManager.requireActiveCredentials()
-        val queryBatch = QueryBatch(credentials.getIdentityId())
 
-        val result = queryBatch.queryBatchAsync(
-            dbm = dbm,
-            driveId = driveId,
-            noOfItems = 1,
-            cursor = null,
-            sortOrder = QueryBatchSortOrder.NewestFirst,
-            sortField = QueryBatchSortField.CreatedDate,
-            fileSystemType = 0,
-            uniqueIdAnyOf = listOf(uniqueId)
-        )
-
-        val existingFile = result.records.singleOrNull()
-            ?: return Pair(ToggleReactionResultType.None, null)
+        val existingFile = dbm.driveMainIndex.selectHomebaseFileByUnique(
+            credentials.getIdentityId(), driveId, uniqueId
+        ) ?: return Pair(ToggleReactionResultType.None, null)
 
         val lastModified = existingFile.fileMetadata.updated.addMilliseconds(1)
         val currentReactions =
@@ -443,20 +398,10 @@ class OptimisticWriter(
     @OptIn(ExperimentalEncodingApi::class)
     suspend fun stampConversationExitedAt(driveId: Uuid, conversationId: Uuid): UpdateLocalMetadataContentOutboxRequest? {
         val credentials = credentialsManager.requireActiveCredentials()
-        val queryBatch = QueryBatch(credentials.getIdentityId())
 
-        val result = queryBatch.queryBatchAsync(
-            dbm = dbm,
-            driveId = driveId,
-            noOfItems = 1,
-            cursor = null,
-            sortOrder = QueryBatchSortOrder.NewestFirst,
-            sortField = QueryBatchSortField.CreatedDate,
-            fileSystemType = 0,
-            uniqueIdAnyOf = listOf(conversationId)
-        )
-
-        val existingFile = result.records.singleOrNull() ?: return null
+        val existingFile = dbm.driveMainIndex.selectHomebaseFileByUnique(
+            credentials.getIdentityId(), driveId, conversationId
+        ) ?: return null
 
         val existing = existingFile.fileMetadata.localAppData?.content?.let {
             try { OdinSystemSerializer.deserialize<ConversationLocalAppDataJson>(it) } catch (_: Throwable) { null }
@@ -533,20 +478,10 @@ class OptimisticWriter(
         newTags: List<Uuid>
     ) {
         val credentials = credentialsManager.requireActiveCredentials()
-        val queryBatch = QueryBatch(credentials.getIdentityId())
 
-        val result = queryBatch.queryBatchAsync(
-            dbm = dbm,
-            driveId = driveId,
-            noOfItems = 1,
-            cursor = null,
-            sortOrder = QueryBatchSortOrder.NewestFirst,
-            sortField = QueryBatchSortField.CreatedDate,
-            fileSystemType = 0,
-            uniqueIdAnyOf = listOf(uniqueId)
-        )
-
-        val existingFile = result.records.singleOrNull() ?: return
+        val existingFile = dbm.driveMainIndex.selectHomebaseFileByUnique(
+            credentials.getIdentityId(), driveId, uniqueId
+        ) ?: return
 
         val lastModified = existingFile.fileMetadata.updated.addMilliseconds(1)
 


### PR DESCRIPTION
… consolidate logging

The in-memory message cache was never consulted because the cache check required selectedConversationId to match, but ClearSelection nulls it out before re-entry. Removing that guard lets cached conversations load instantly without a DB hit.

Added a covering index (identityId, driveId, fileSystemType, groupId, fileType, userDate DESC, rowId) so the chat message query can seek directly instead of post-filtering across partial indexes.

Replaced the redundant SlowConversationLoad warn log with a lightweight debug-level ConversationLoad trace — SlowMessageFetch already covers slow DB fetches with more detail.