### PR TITLE
Add confirmation dialog before deleting a conversation

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -51,6 +51,8 @@ import id.homebase.core.widget.DialogTitle
 import id.homebase.resources.MR
 import id.homebase.resources.action_cannot_be_undone
 import id.homebase.resources.cancel
+import id.homebase.resources.chat_delete
+import id.homebase.resources.chat_delete_conversation_title
 import id.homebase.resources.chat_message_delete_dialog_title
 import id.homebase.resources.chat_message_delete_for_everyone
 import id.homebase.resources.chat_message_delete_for_me
@@ -216,6 +218,34 @@ fun ConversationListScreen(
                     }) {
                     DialogTitle(
                         text = stringResource(MR.string.chat_message_delete_dialog_title),
+                    )
+                }
+            }
+        }
+
+        is ConversationListUiDialog.DeleteConversation -> {
+            Dialog(onDismissRequest = { viewModel.dialogClosed() }) {
+                DialogCard(
+                    buttons = {
+                        DialogButtons(
+                            primaryText = stringResource(MR.string.chat_delete),
+                            onPrimaryClick = {
+                                viewModel.onAction(
+                                    ConversationListUiAction.ConfirmDeleteConversation(
+                                        dialog.conversationId
+                                    )
+                                )
+                                viewModel.dialogClosed()
+                            },
+                            secondaryText = stringResource(MR.string.cancel),
+                            onSecondaryClick = { viewModel.dialogClosed() },
+                        )
+                    }) {
+                    DialogTitle(
+                        text = stringResource(MR.string.chat_delete_conversation_title),
+                    )
+                    DialogText(
+                        text = stringResource(MR.string.action_cannot_be_undone),
                     )
                 }
             }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
@@ -85,6 +85,7 @@ sealed interface ConversationListUiAction {
         ConversationListUiAction
 
     data class DeleteConversation(val conversationId: Uuid) : ConversationListUiAction
+    data class ConfirmDeleteConversation(val conversationId: Uuid) : ConversationListUiAction
     data class ArchiveConversation(val conversationId: Uuid) : ConversationListUiAction
 
     data class UnarchiveConversation(val conversationId: Uuid) : ConversationListUiAction

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiDialog.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiDialog.kt
@@ -7,4 +7,6 @@ sealed interface ConversationListUiDialog {
         ConversationListUiDialog
 
     data class DiscardDraft(val messageId: Uuid, val versionTag: Uuid) : ConversationListUiDialog
+
+    data class DeleteConversation(val conversationId: Uuid) : ConversationListUiDialog
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -1457,6 +1457,12 @@ class ConversationListViewModel(
             }
 
             is ConversationListUiAction.DeleteConversation -> {
+                _uiState.update {
+                    it.copy(uiDialog = ConversationListUiDialog.DeleteConversation(action.conversationId))
+                }
+            }
+
+            is ConversationListUiAction.ConfirmDeleteConversation -> {
                 viewModelScope.launch {
                     try {
                         conversationService.deleteConversation(action.conversationId)

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -185,6 +185,7 @@
     <string name="chat_settings">Samtale indstillinger</string>
     <string name="chat_group_settings">Gruppe indstillinger</string>
     <string name="chat_delete">Slet</string>
+    <string name="chat_delete_conversation_title">Slet samtale?</string>
     <string name="chat_archive">Arkivér</string>
     <string name="chat_archived">Arkiveret</string>
     <string name="chat_unarchive">Gendan</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -213,6 +213,7 @@
     <string name="chat_settings">Conversation settings</string>
     <string name="chat_group_settings">Group settings</string>
     <string name="chat_delete">Delete</string>
+    <string name="chat_delete_conversation_title">Delete conversation?</string>
     <string name="chat_archive">Archive</string>
     <string name="chat_archived">Archived</string>
     <string name="chat_unarchive">Restore</string>


### PR DESCRIPTION
Prevent accidental conversation deletion by showing a confirmation dialog with Delete/Cancel buttons and a warning that the action can't be undone. Follows the existing DeleteMessage/DiscardDraft dialog pattern.