### PR TITLE
Fix incomplete DB cleanup on logout and add identityId filtering to queries

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
@@ -53,13 +53,13 @@ class DriveSync(
     }
 
 
-    // Call this to clear everything if you want to run a test and re-sync
+    // Wipe all synced data on logout — nothing should survive for security
     suspend fun clearStorage() {
-        // Temp hack, remove soon.
-        databaseManager.driveMainIndex.deleteAll() // TODO: <-- don't delete all! :-)
-        databaseManager.driveTagIndex.deleteAll() // TODO: <-- don't delete all! :-)
-        databaseManager.driveLocalTagIndex.deleteAll() // TODO: <-- don't delete all! :-)
-        databaseManager.keyValue.deleteByKey(driveId) // TODO: <-- don't delete the cursor
+        databaseManager.driveMainIndex.deleteAll()
+        databaseManager.driveTagIndex.deleteAll()
+        databaseManager.driveLocalTagIndex.deleteAll()
+        databaseManager.chatReadCount.deleteAll()
+        databaseManager.keyValue.deleteByKey(driveId)
         val cursorStorage = CursorStorage(databaseManager, driveId)
         cursorStorage.deleteCursor()
         cursor = null

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/ChatReadCountWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/ChatReadCountWrapper.kt
@@ -39,8 +39,8 @@ class ChatReadCountWrapper(
      * Select all conversations (fileType 8888) from DriveMainIndex
      * Note: This implementation is simplified and would need the generated SQLDelight queries
      */
-    fun selectAllConversations(): List<HomebaseFile> {
-        val list = delegate.selectAllCoversations().executeAsList()
+    fun selectAllConversations(identityId: Uuid): List<HomebaseFile> {
+        val list = delegate.selectAllCoversations(identityId).executeAsList()
         return list.mapNotNull {
             try {
                 OdinSystemSerializer.deserialize<HomebaseFile>(it)
@@ -59,11 +59,11 @@ class ChatReadCountWrapper(
      * Note: This implementation is simplified and would need the generated SQLDelight queries
      */
 
-    fun selectAllConversationPlusLastMessage(): List<ConversationWithLastMessage> {
+    fun selectAllConversationPlusLastMessage(identityId: Uuid): List<ConversationWithLastMessage> {
 
         val start = Clock.System.now().toEpochMilliseconds()
 
-        val list = delegate.selectAllConversationPlusLastMessage().executeAsList()
+        val list = delegate.selectAllConversationPlusLastMessage(identityId).executeAsList()
 
         logger.d { "Fetched rows=${list.size} in ${Clock.System.now().toEpochMilliseconds() - start}ms" }
 
@@ -112,8 +112,8 @@ class ChatReadCountWrapper(
      * Get unread message count for a specific conversation
      * Note: This implementation is simplified and would need the generated SQLDelight queries
      */
-    fun selectUnreadCountForConversation(groupId: Uuid): Long {
-        val result = delegate.selectUnreadCountForConversation(groupId).executeAsOneOrNull()
+    fun selectUnreadCountForConversation(identityId: Uuid, groupId: Uuid): Long {
+        val result = delegate.selectUnreadCountForConversation(identityId, groupId).executeAsOneOrNull()
 
         if (result == null)
             return 0
@@ -125,8 +125,8 @@ class ChatReadCountWrapper(
      * Get all conversation read counts
      * Note: This implementation is simplified and would need the generated SQLDelight queries
      */
-    suspend fun selectAllUnreadCount(originalAuthor: OdinId): List<ConversationUnreadCount> {
-        val list = delegate.selectAllUnreadCount(originalAuthor.domainName).executeAsList()
+    suspend fun selectAllUnreadCount(identityId: Uuid, originalAuthor: OdinId): List<ConversationUnreadCount> {
+        val list = delegate.selectAllUnreadCount(identityId, originalAuthor.domainName).executeAsList()
         return list.map {
             ConversationUnreadCount(
                 conversationId = it.groupId,
@@ -150,6 +150,15 @@ class ChatReadCountWrapper(
     suspend fun deleteByGroupId(groupId: Uuid): Boolean {
         return databaseManager.withWriteValue { db ->
             db.chatReadCountQueries.deleteByGroupId(groupId).value > 0
+        }
+    }
+
+    /**
+     * Delete all read count entries (used during logout to ensure no data survives)
+     */
+    suspend fun deleteAll(): Boolean {
+        return databaseManager.withWriteValue { db ->
+            db.chatReadCountQueries.deleteAll().value > 0
         }
     }
 }

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ChatReadCount.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ChatReadCount.sq
@@ -18,7 +18,7 @@ CREATE INDEX IF NOT EXISTS idx_messages_filetype_datatype_groupid_userDate
 selectAllCoversations:
 SELECT jsonHeader
 FROM DriveMainIndex
-WHERE fileType = 8888;
+WHERE identityId = ? AND fileType = 8888;
 
 -- Like above, but add last message from each conversation
 -- This is needed at boot-time to efficiently load the full list of conversations
@@ -34,13 +34,15 @@ LEFT JOIN DriveMainIndex AS m
   ON m.rowId = (
     SELECT m2.rowId
     FROM DriveMainIndex AS m2
-    WHERE m2.groupId = d.uniqueId
+    WHERE m2.identityId = d.identityId
+      AND m2.groupId = d.uniqueId
       AND m2.fileType = 7878
       AND m2.dataType = 0
     ORDER BY m2.userDate DESC
     LIMIT 1
   )
-WHERE d.fileType = 8888 -- Conversation
+WHERE d.identityId = ?
+  AND d.fileType = 8888
 ORDER BY msgUserDate DESC;
 
 -- Return unread message count for a specific groupId
@@ -49,7 +51,8 @@ selectUnreadCountForConversation:
 SELECT COUNT(*) AS unreadCount
 FROM DriveMainIndex d
 LEFT JOIN ChatReadCount c ON d.groupId = c.groupId
-WHERE d.groupId = ?
+WHERE d.identityId = ?
+  AND d.groupId = ?
   AND d.fileType = 7878 AND d.dataType = 0
   AND (c.lastReadTime IS NULL OR d.userDate > c.lastReadTime);
 
@@ -69,8 +72,9 @@ selectAllUnreadCount:
 SELECT d.groupId, COUNT(*) AS unreadCount
 FROM DriveMainIndex AS d
 LEFT JOIN ChatReadCount c ON d.groupId = c.groupId
-WHERE d.fileType = 7878  -- Message
-  AND d.dataType = 0 -- Standard message
+WHERE d.identityId = ?
+  AND d.fileType = 7878
+  AND d.dataType = 0
   AND (c.lastReadTime IS NULL OR d.userDate > c.lastReadTime)
   AND d.groupId IS NOT NULL
   AND (d.originalAuthor IS NULL OR d.originalAuthor != ?)
@@ -88,3 +92,7 @@ SET lastReadTime = MAX(excluded.lastReadTime, lastReadTime);
 deleteByGroupId:
 DELETE FROM ChatReadCount
 WHERE groupId = ?;
+
+-- Delete all records
+deleteAll:
+DELETE FROM ChatReadCount;

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/ChatReadCountWrapperTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/ChatReadCountWrapperTest.kt
@@ -163,7 +163,7 @@ class ChatReadCountWrapperTest {
             val testData = populateMockData(dbm)
             val wrapper = dbm.chatReadCount
 
-            val conversations = wrapper.selectAllConversations()
+            val conversations = wrapper.selectAllConversations(testData.identityId)
 
             // Should return all 3 conversations (fileType 8888)
             assertEquals(3, conversations.size, "Should return all conversations")
@@ -187,7 +187,7 @@ class ChatReadCountWrapperTest {
         DatabaseManager { createInMemoryDatabase() }.use { dbm ->
             val wrapper = dbm.chatReadCount
 
-            val conversations = wrapper.selectAllConversations()
+            val conversations = wrapper.selectAllConversations(Uuid.random())
 
             assertTrue(
                 conversations.isEmpty(), "Should return empty list when no conversations exist"
@@ -201,7 +201,7 @@ class ChatReadCountWrapperTest {
             val testData = populateMockData(dbm)
             val wrapper = dbm.chatReadCount
 
-            val conversationsWithMessages = wrapper.selectAllConversationPlusLastMessage()
+            val conversationsWithMessages = wrapper.selectAllConversationPlusLastMessage(testData.identityId)
 
             // Should return all 3 conversations
             assertEquals(
@@ -261,7 +261,7 @@ class ChatReadCountWrapperTest {
         DatabaseManager { createInMemoryDatabase() }.use { dbm ->
             val wrapper = dbm.chatReadCount
 
-            val conversationsWithMessages = wrapper.selectAllConversationPlusLastMessage()
+            val conversationsWithMessages = wrapper.selectAllConversationPlusLastMessage(Uuid.random())
 
             assertTrue(
                 conversationsWithMessages.isEmpty(),
@@ -279,12 +279,15 @@ class ChatReadCountWrapperTest {
             // No read time set, so all messages should be unread
             // FAILS HERE :
             val conv1Unread = wrapper.selectUnreadCountForConversation(
+                testData.identityId,
                 testData.convWithNoMessages.fileMetadata.appData.uniqueId!!
             )
             val conv2Unread = wrapper.selectUnreadCountForConversation(
+                testData.identityId,
                 testData.convWithOneMessage.first.fileMetadata.appData.uniqueId!!
             )
             val conv3Unread = wrapper.selectUnreadCountForConversation(
+                testData.identityId,
                 testData.convWithThreeMessages.first.fileMetadata.appData.uniqueId!!
             )
 
@@ -313,6 +316,7 @@ class ChatReadCountWrapperTest {
             )
 
             val conv3Unread = wrapper.selectUnreadCountForConversation(
+                testData.identityId,
                 testData.convWithThreeMessages.first.fileMetadata.appData.uniqueId!!
             )
 
@@ -327,7 +331,7 @@ class ChatReadCountWrapperTest {
             val wrapper = dbm.chatReadCount
             val nonExistentGroupId = Uuid.random()
 
-            val unreadCount = wrapper.selectUnreadCountForConversation(nonExistentGroupId)
+            val unreadCount = wrapper.selectUnreadCountForConversation(Uuid.random(), nonExistentGroupId)
 
             assertEquals(
                 0L, unreadCount, "Non-existent conversation should have 0 unread"
@@ -415,7 +419,7 @@ class ChatReadCountWrapperTest {
             val wrapper = dbm.chatReadCount
 
             val originalAuthor: OdinId = OdinId("somewhere.demo.rocks")
-            val allReadCounts = wrapper.selectAllUnreadCount(originalAuthor)
+            val allReadCounts = wrapper.selectAllUnreadCount(Uuid.random(), originalAuthor)
 
             assertTrue(
                 allReadCounts.isEmpty(), "Should return empty list when no conversations exist"
@@ -438,6 +442,7 @@ class ChatReadCountWrapperTest {
 
             // Verify unread count changed
             val unreadCount = wrapper.selectUnreadCountForConversation(
+                testData.identityId,
                 testData.convWithOneMessage.first.fileMetadata.appData.uniqueId!!
             )
             assertEquals(
@@ -469,6 +474,7 @@ class ChatReadCountWrapperTest {
             // Verify unread count changed (should be 0 now since read time is after all
             // messages)
             val unreadCount = wrapper.selectUnreadCountForConversation(
+                testData.identityId,
                 testData.convWithThreeMessages.first.fileMetadata.appData.uniqueId!!
             )
             assertEquals(
@@ -506,6 +512,7 @@ class ChatReadCountWrapperTest {
 
             // Verify it exists by checking unread count
             var unreadCount = wrapper.selectUnreadCountForConversation(
+                testData.identityId,
                 testData.convWithOneMessage.first.fileMetadata.appData.uniqueId!!
             )
             assertEquals(0L, unreadCount, "Should have 0 unread with read time set")
@@ -516,6 +523,7 @@ class ChatReadCountWrapperTest {
 
             // Verify it's gone - unread count should be back to original
             unreadCount = wrapper.selectUnreadCountForConversation(
+                testData.identityId,
                 testData.convWithOneMessage.first.fileMetadata.appData.uniqueId!!
             )
             assertEquals(
@@ -557,6 +565,7 @@ class ChatReadCountWrapperTest {
 
             // Verify unread count is back to original
             var unreadCount = wrapper.selectUnreadCountForConversation(
+                testData.identityId,
                 testData.convWithThreeMessages.first.fileMetadata.appData.uniqueId!!
             )
             assertEquals(3L, unreadCount, "Should have 3 unread after deletion")
@@ -570,6 +579,7 @@ class ChatReadCountWrapperTest {
 
             // Verify new read time is effective
             unreadCount = wrapper.selectUnreadCountForConversation(
+                testData.identityId,
                 testData.convWithThreeMessages.first.fileMetadata.appData.uniqueId!!
             )
             assertEquals(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -393,8 +393,8 @@ class ConversationStream(
     }
 
     suspend fun updateUnreadCounts() {
-        val domain = credentialsManager.requireActiveDomain()
-        val unread = dbm.chatReadCount.selectAllUnreadCount(domain)
+        val c = credentialsManager.requireActiveCredentials()
+        val unread = dbm.chatReadCount.selectAllUnreadCount(c.getIdentityId(), c.domain)
         val unreadMap = unread.associate { it.conversationId to it.unreadCount.toInt() }
 
         var changed = false
@@ -416,9 +416,9 @@ class ConversationStream(
     }
 
     suspend fun fetchConversations(): List<ConversationUiModel> {
-        val result = dbm.chatReadCount.selectAllConversationPlusLastMessage()
-        val conversations = result.map { mapper.mapToConversationUi(it.conversation, it.message) }
         val c = credentialsManager.requireActiveCredentials()
+        val result = dbm.chatReadCount.selectAllConversationPlusLastMessage(c.getIdentityId())
+        val conversations = result.map { mapper.mapToConversationUi(it.conversation, it.message) }
         val domain = c.domain
         var self = ChatProtocol.buildSelfConversation(domain)
 


### PR DESCRIPTION

ChatReadCount was never cleaned on logout, leaving stale read-count data
for the next user. Additionally, all ChatReadCount.sq SELECT queries
against DriveMainIndex lacked identityId filtering, causing cross-user
data leakage.

- Add chatReadCount.deleteAll() to DriveSync.clearStorage()
- Add identityId parameter to all 4 ChatReadCount SELECT queries
- Update ChatReadCountWrapper, ConversationStream, and tests

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>