### PR TITLE
Add Profile Info and Security Setup external links to settings

### DIFF
--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -114,6 +114,8 @@
     <string name="connections_empty_outgoing_subtitle">Tryk på + knappen for at sende en forbindelsesanmodning.</string>
     <string name="connections_send_request">Send anmodning</string>
     <string name="settings_notifications">Notifikationer</string>
+    <string name="settings_profile_info">Profiloplysninger</string>
+    <string name="settings_security_setup">Sikkerhedsopsætning</string>
     <string name="settings_logout">Log ud</string>
     <string name="settings_delete_account">Slet min konto</string>
     <string name="settings_delete_account_dialog_title">Slet din konto?</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -131,6 +131,8 @@
     <string name="connections_empty_outgoing_subtitle">Tap the + button to send a connection request.</string>
     <string name="connections_send_request">Send Request</string>
     <string name="settings_notifications">Notifications</string>
+    <string name="settings_profile_info">Profile Info</string>
+    <string name="settings_security_setup">Security Setup</string>
     <string name="settings_help">Help</string>
     <string name="settings_logout">Log out</string>
     <string name="settings_delete_account">Delete my account</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsScreen.kt
@@ -22,7 +22,10 @@ import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Error
 import androidx.compose.material.icons.outlined.Notifications
+import androidx.compose.material.icons.automirrored.outlined.OpenInNew
 import androidx.compose.material.icons.outlined.People
+import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material.icons.outlined.Security
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -68,6 +71,8 @@ import id.homebase.resources.settings_help
 import id.homebase.resources.settings_logout
 import id.homebase.resources.settings_notifications
 import id.homebase.resources.settings_open_owner_console
+import id.homebase.resources.settings_profile_info
+import id.homebase.resources.settings_security_setup
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -207,6 +212,20 @@ fun SettingsUi(
             )
             Spacer(modifier = Modifier.height(8.dp))
             SettingsItemAction(
+                imageVector = Icons.Outlined.Person,
+                text = stringResource(MR.string.settings_profile_info),
+                onClick = { onAction(SettingsUiAction.ProfileInfoClicked) },
+                trailingContent = {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Outlined.OpenInNew,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            SettingsItemAction(
                 imageVector = Icons.Outlined.Notifications,
                 text = stringResource(MR.string.settings_notifications),
                 onClick = onNavigateToNotifications,
@@ -235,6 +254,20 @@ fun SettingsUi(
                             )
                         }
                     }
+                }
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            SettingsItemAction(
+                imageVector = Icons.Outlined.Security,
+                text = stringResource(MR.string.settings_security_setup),
+                onClick = { onAction(SettingsUiAction.SecuritySetupClicked) },
+                trailingContent = {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Outlined.OpenInNew,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(20.dp)
+                    )
                 }
             )
             Spacer(modifier = Modifier.height(8.dp))

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsUiState.kt
@@ -22,6 +22,8 @@ sealed interface SettingsUiAction {
     data object LogoutClicked : SettingsUiAction
     data object DeleteAccount: SettingsUiAction
     data object OpenOwnerConsoleClicked : SettingsUiAction
+    data object ProfileInfoClicked : SettingsUiAction
+    data object SecuritySetupClicked : SettingsUiAction
 }
 
 /** One-off events for side effects (navigation). */

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsViewModel.kt
@@ -73,6 +73,18 @@ class SettingsViewModel(
                 }
             }
 
+            SettingsUiAction.ProfileInfoClicked -> {
+                uiState.value.ownerSession?.let {
+                    sendEvent(SettingsUiEvent.OpenUrl("https://${it.odinId.domainName}/owner/profile/standard-info"))
+                }
+            }
+
+            SettingsUiAction.SecuritySetupClicked -> {
+                uiState.value.ownerSession?.let {
+                    sendEvent(SettingsUiEvent.OpenUrl("https://${it.odinId.domainName}/owner/security"))
+                }
+            }
+
             SettingsUiAction.DeleteAccount -> {
                 _uiState.update { it.copy(uiDialog = SettingsUiDialog.DeleteAccount) }
             }


### PR DESCRIPTION
Add two new menu items to the settings screen that open the owner console in a browser: "Profile Info" (between Connections and Notifications) and "Security Setup" (between Notifications and Appearance). Both show an OpenInNew trailing icon.