### PR TITLE
Fixing bug where emits entered empty caches => no load from DB

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ActiveConversationState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ActiveConversationState.kt
@@ -15,6 +15,9 @@ class ActiveConversationState {
     val messages: StateFlow<Map<Uuid, List<MessageUiModel>>> =
         _messages.asStateFlow()
 
+    fun hasCachedMessages(conversationId: Uuid): Boolean =
+        _messages.value.containsKey(conversationId)
+
     fun set(conversationId: Uuid, messages: List<MessageUiModel>) {
         _messages.update { current ->
             current.toMutableMap().apply {
@@ -33,10 +36,11 @@ class ActiveConversationState {
 
     fun upsert(conversationId: Uuid, incoming: List<MessageUiModel>) {
         if (incoming.isEmpty()) return
+        if (!hasCachedMessages(conversationId)) return
 
         _messages.update { current ->
+            val existing = current[conversationId] ?: return@update current
             current.toMutableMap().apply {
-                val existing = this[conversationId].orEmpty()
                 this[conversationId] = upsertMessages(existing, incoming)
             }
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -115,7 +115,7 @@ class ChatMessageStream(
             .stateIn(scope, SharingStarted.WhileSubscribed(5_000), ChatMessagesData.Initializing)
 
     fun hasCachedMessages(conversationId: Uuid): Boolean =
-        conversationState.messages.value.containsKey(conversationId)
+        conversationState.hasCachedMessages(conversationId)
 
     // Full message load from local DB for a single conversation.
     // Called when the user opens a conversation (ConversationListViewModel.selectConversation).

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/services/ActiveConversationStateTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/services/ActiveConversationStateTest.kt
@@ -79,4 +79,30 @@ class ActiveConversationStateTest {
         assertNull(state.messages.value[convo1]!!.firstOrNull { it.id == target.id })
         assertEquals(1, state.messages.value[convo2]!!.size)
     }
+
+    @Test
+    fun upsert_skipsConversationsNotYetLoaded() {
+        val state = ActiveConversationState()
+        val convoId = Uuid.random()
+        val msg = message(conversationId = convoId)
+
+        // Upsert into a conversation that was never set() — should be a no-op
+        state.upsert(convoId, listOf(msg))
+
+        assertEquals(null, state.messages.value[convoId])
+    }
+
+    @Test
+    fun upsert_updatesConversationThatWasLoaded() {
+        val state = ActiveConversationState()
+        val convoId = Uuid.random()
+        val existing = message(conversationId = convoId)
+        state.set(convoId, listOf(existing))
+
+        val incoming = message(conversationId = convoId)
+        state.upsert(convoId, listOf(incoming))
+
+        val messages = state.messages.value[convoId]!!
+        assertEquals(2, messages.size)
+    }
 }


### PR DESCRIPTION
Context

     When messages arrive via WebSocket/DriveSync for conversations that are not currently open, processIncrementalBatch calls conversationState.upsert()
     which creates a cache entry with only 1-2 messages. Later, when the user opens that conversation, hasCachedMessages() returns true (because
     containsKey() finds the partial entry), so the full DB load via loadConversation() is skipped. The user sees only the 2-3 messages that trickled in via
      WebSocket, not the full history of 300+ messages.

     After app restart, the in-memory cache is cleared, so hasCachedMessages() returns false, triggering a full DB load — which is why the messages
     "reappear" after restart.

     Root Cause

     ActiveConversationState.upsert() creates new map entries for conversations not yet in the cache. Only the active/open conversation should have a cache
     entry. The containsKey() check in hasCachedMessages() then wrongly treats these partial entries as fully loaded.