### PR TITLE
fix sync engine CPU issues and conversation list jank

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
@@ -70,9 +70,8 @@ class DriveSync(
     }
 
     fun cancel() {
-        // If we really want to cancel in the future... Something like:
-        // job?.cancel()?
-        // we probably want child jobs to be allowed to complete (write to DB)
+        killroy.value = false
+        job?.cancel()
     }
 
     // sync() spawn a thread unless it's already working. Returns a pointer to the
@@ -90,8 +89,10 @@ class DriveSync(
                 job = null
                 mutex.unlock()
             }
-            if (killroy.value)
-                sync() // If killroy was here, do it one extra time
+            if (killroy.value) {
+                Logger.i("DriveSync: killroy triggered recursive sync for drive $driveId")
+                sync()
+            }
         }
 
         return job

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
@@ -69,8 +69,16 @@ class DriveSyncManager(
                     is BackendEvent.DriveEvent.Started       -> updateState(event.driveId) {
                         it.copy(state = DriveState.Synchronizing())
                     }
-                    is BackendEvent.DriveEvent.BatchReceived -> updateState(event.driveId) {
-                        it.copy(state = DriveState.Synchronizing(count = event.totalCount))
+                    is BackendEvent.DriveEvent.BatchReceived -> {
+                        // Only update progress count during an active sync (Started already fired).
+                        // Don't let stray BatchReceived from OptimisticWriter transition
+                        // a Completed/Failed drive back to Synchronizing.
+                        val current = _driveStatuses.value[event.driveId]?.state
+                        if (current is DriveState.Synchronizing) {
+                            updateState(event.driveId) {
+                                it.copy(state = DriveState.Synchronizing(count = event.totalCount))
+                            }
+                        }
                     }
                     is BackendEvent.DriveEvent.Stopped -> when (val r = event.result) {
                         is BackendEvent.DriveResult.Success -> updateState(event.driveId) {
@@ -80,8 +88,10 @@ class DriveSyncManager(
                             updateState(event.driveId) {
                                 it.copy(state = DriveState.Failed(r.errorMessage))
                             }
+                            Logger.w { "DriveSyncManager: drive ${event.driveId} failed: ${r.errorMessage}, scheduling retry in 1s" }
                             scope.launch {
                                 delay(1000L)
+                                Logger.i { "DriveSyncManager: retrying drive ${event.driveId}" }
                                 driveSyncsMutex.withLock { driveSyncs[event.driveId] }?.sync()
                             }
                         }
@@ -160,6 +170,13 @@ class DriveSyncManager(
     fun pause() {
         isRunning = false
         driveSyncs.values.forEach { it.cancel() }
+        _driveStatuses.update { statuses ->
+            statuses.mapValues { (_, status) ->
+                if (status.state is DriveState.Synchronizing)
+                    status.copy(state = DriveState.Completed())
+                else status
+            }
+        }
     }
 
     suspend fun stop() {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
@@ -368,7 +368,19 @@ fun ConversationListPane(
                         }
 
                         is ConversationListContentState.Items -> {
-                            items(uiState.conversationsContent.list) { listItem ->
+                            items(
+                                uiState.conversationsContent.list,
+                                key = { listItem ->
+                                    when (listItem) {
+                                        is ConversationListContentModel.Conversation ->
+                                            listItem.conversation.conversation.id
+                                        is ConversationListContentModel.Message ->
+                                            listItem.message.id
+                                        is ConversationListContentModel.Header ->
+                                            listItem.resource.key
+                                    }
+                                }
+                            ) { listItem ->
                                 ConversationLisContentItem(
                                     listItem = listItem,
                                     selectedConversationId = selectedConversationId,


### PR DESCRIPTION
Sync engine fixes:
- Guard BatchReceived in DriveSyncManager: OptimisticWriter emits BatchReceived after a sync completes, which corrupted drive state to phantom Synchronizing with no matching Stopped event. Now only updates progress if the drive is already Synchronizing (real sync Started).
- Implement DriveSync.cancel(): was a no-op. Now clears killroy flag and cancels the running job so pause()/stop() actually stop syncs. The finally block still runs (mutex unlock, job clear) and pending DB writes complete independently via scope.async.
- Reset drive state on pause(): drives stuck in Synchronizing are transitioned to Completed after cancellation.
- Add diagnostic logging for killroy recursive sync calls and DriveSyncManager retry-on-failure so infinite loops are visible in the log file.

UI fix:
- Add stable keys to conversation list LazyColumn items. Without keys, every list reorder (new message moves conversation to top) caused Compose to destroy and recreate all visible items. Now keyed by conversation/message/resource ID enabling moves instead of recreations.