### PR TITLE
add stable keys to conversation list for smoother transitions

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
@@ -368,7 +368,19 @@ fun ConversationListPane(
                         }
 
                         is ConversationListContentState.Items -> {
-                            items(uiState.conversationsContent.list) { listItem ->
+                            items(
+                                uiState.conversationsContent.list,
+                                key = { listItem ->
+                                    when (listItem) {
+                                        is ConversationListContentModel.Conversation ->
+                                            listItem.conversation.conversation.id
+                                        is ConversationListContentModel.Message ->
+                                            listItem.message.id
+                                        is ConversationListContentModel.Header ->
+                                            listItem.resource.key
+                                    }
+                                }
+                            ) { listItem ->
                                 ConversationLisContentItem(
                                     listItem = listItem,
                                     selectedConversationId = selectedConversationId,


### PR DESCRIPTION
The LazyColumn items() call had no key parameter. When the list reorders (e.g. a new message moves a conversation to the top), Compose destroys and recreates every visible item instead of moving them. This causes visible jank during transitions and message arrival.

Now keyed by conversation ID, message ID, or resource key per item type, enabling Compose to move existing items instead of recreating them.