### PR TITLE
Handle note-to-self in recoverConversation

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -854,6 +854,14 @@ class ConversationService(
      */
     suspend fun recoverConversation(conversationId: Uuid, originalAuthor: OdinId) {
         val domain = credentialsManager.requireActiveDomain()
+        val isNoteToSelf = conversationId == ChatProtocol.ConversationWithYourselfId
+
+        if (isNoteToSelf) {
+            Logger.i("ConversationService: recoverConversation($conversationId) — note-to-self, delegating to ensureNoteToSelfExists()")
+            ensureNoteToSelfExists()
+            return
+        }
+
         val isOneToOne = conversationId == XorIdUtil.getNewXorId(
             domain.domainName, originalAuthor.domainName
         )


### PR DESCRIPTION
recoverConversation uses an XOR-based check to distinguish 1:1 from group conversations, but note-to-self uses a hardcoded UUID that never matches that check. Without explicit handling, a deleted or missing note-to-self conversation would be incorrectly recovered as a group and would not get pinned.

Add an early isNoteToSelf check that delegates to the existing ensureNoteToSelfExists(), which already handles revival, creation, and pinning correctly.