### PR TITLE
feat: auto-unarchive, camera video recording, share media preview

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -145,6 +145,8 @@ dependencies {
     implementation(libs.smart.exception.java)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.filekit.dialogs.compose)
+    implementation(libs.richeditor.compose)
+    implementation(libs.jetbrains.compose.resources)
     implementation(libs.kermit)
     implementation(libs.androidx.work.runtime)
     implementation(libs.androidx.sharetarget)

--- a/androidApp/src/main/kotlin/id/homebase/feed/share/SharePickerScreen.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/SharePickerScreen.kt
@@ -47,6 +47,10 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.api.client.auth.OwnerSessionRepository
+import id.homebase.resources.MR
+import id.homebase.resources.share_picker_next
+import id.homebase.resources.share_picker_send
+import org.jetbrains.compose.resources.stringResource
 import id.homebase.chat.services.convo.ConversationEnricher
 import id.homebase.chat.services.convo.ConversationStream
 import id.homebase.chat.services.convo.EnrichedConversationUiModel
@@ -66,6 +70,7 @@ fun SharePickerScreen(
     contactService: ContactService,
     ownerSessionRepository: OwnerSessionRepository,
     sharedContent: SharedContent,
+    hasFiles: Boolean,
     isSending: Boolean,
     onSendToConversations: (Set<Uuid>) -> Unit,
     onCancel: () -> Unit,
@@ -150,6 +155,7 @@ fun SharePickerScreen(
             if (selectedIds.isNotEmpty() && !isSending) {
                 ShareSendBar(
                     count = selectedIds.size,
+                    buttonText = if (hasFiles) stringResource(MR.string.share_picker_next) else stringResource(MR.string.share_picker_send),
                     onSend = { onSendToConversations(selectedIds) },
                 )
             }
@@ -290,6 +296,7 @@ fun SharePickerScreen(
 @Composable
 private fun ShareSendBar(
     count: Int,
+    buttonText: String,
     onSend: () -> Unit,
 ) {
     Column {
@@ -308,7 +315,7 @@ private fun ShareSendBar(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             FilledTonalButton(onClick = onSend) {
-                Text("Send")
+                Text(buttonText)
             }
         }
     }

--- a/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
@@ -6,29 +6,55 @@ import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import co.touchlab.kermit.Logger
+import com.mohamedrejeb.richeditor.model.RichTextState
 import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.video.FFmpegUtils
 import id.homebase.api.youauth.YouAuthFlowManager
 import id.homebase.api.youauth.YouAuthState
+import id.homebase.chat.conversationlist.AttachmentPendingFile
+import id.homebase.chat.conversationlist.FullScreenOverlay
 import id.homebase.chat.services.ChatMessageSenderService
 import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.builder.AttachmentInput
 import id.homebase.chat.services.builder.MessageAttachmentBuilder
 import id.homebase.chat.services.convo.ConversationStream
 import id.homebase.chat.services.convo.contact.ContactService
+import id.homebase.chat.widget.FullScreenAttachmentEditor
 import id.homebase.core.settings.ThemeState
 import id.homebase.core.settings.UserPreferences
 import id.homebase.core.ui.theme.HomebaseTheme
 import id.homebase.feed.MainActivity
+import id.homebase.feed.R
+import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitType
+import io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher
+import io.github.vinceglb.filekit.mimeType
+import io.github.vinceglb.filekit.name
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.dropWhile
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.core.component.KoinComponent
@@ -54,25 +80,37 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
     private val userPreferences: UserPreferences by inject()
 
     private var isSending by mutableStateOf(false)
+    private var isProcessing by mutableStateOf(false)
+    private var screenState by mutableStateOf<ShareScreenState>(ShareScreenState.Picking)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
-        // Check authentication
-        val authState = youAuthFlowManager.authState.value
-        if (authState !is YouAuthState.Authenticated) {
-            Toast.makeText(this, "Please open Homebase Chat and sign in first", Toast.LENGTH_LONG)
-                .show()
-            finish()
-            return
+        // Wait for auth state to finish initializing (handles process-kill restart race)
+        lifecycleScope.launch {
+            val authState = youAuthFlowManager.authState
+                .dropWhile { it is YouAuthState.Initializing }
+                .first()
+            if (authState !is YouAuthState.Authenticated) {
+                Toast.makeText(
+                    this@ShareReceiverActivity,
+                    getString(R.string.share_auth_required),
+                    Toast.LENGTH_LONG
+                ).show()
+                finish()
+                return@launch
+            }
+            initShareFlow()
         }
+    }
 
+    private fun initShareFlow() {
         // Extract shared content
         val tempDir = File(cacheDir, "share_temp")
         val sharedContent = SharedContentExtractor.extract(intent, contentResolver, tempDir)
         if (sharedContent == null || sharedContent.isEmpty) {
-            Toast.makeText(this, "Nothing to share", Toast.LENGTH_SHORT).show()
+            Toast.makeText(this, getString(R.string.share_nothing_to_share), Toast.LENGTH_SHORT).show()
             finish()
             return
         }
@@ -82,8 +120,26 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
         if (shortcutId != null) {
             try {
                 val conversationId = Uuid.parse(shortcutId.removePrefix("share_"))
-                sendSharedContent(conversationId, sharedContent)
-                return
+                if (sharedContent.hasFiles) {
+                    // Show overlay while converting files, then transition to editor
+                    isProcessing = true
+                    lifecycleScope.launch {
+                        val attachments = withContext(Dispatchers.IO) {
+                            convertToAttachmentFiles(sharedContent.files)
+                        }
+                        val title = resolveConversationTitle(setOf(conversationId))
+                        isProcessing = false
+                        screenState = ShareScreenState.Previewing(
+                            selectedConversationIds = setOf(conversationId),
+                            attachments = attachments,
+                            conversationTitle = title,
+                        )
+                    }
+                } else {
+                    // Text-only: send directly
+                    sendSharedContent(conversationId, sharedContent)
+                    return
+                }
             } catch (_: Exception) {
                 // Invalid UUID — fall through to picker
             }
@@ -94,18 +150,133 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
             val isDarkTheme = if (prefState.theme == ThemeState.System) isSystemInDarkTheme()
             else prefState.theme == ThemeState.Dark
 
+            // Hoisted unconditionally to satisfy Compose composition rules for ActivityResult launchers
+            var editorAttachments by remember { mutableStateOf<List<AttachmentPendingFile>>(emptyList()) }
+            val fileLauncher = rememberFilePickerLauncher { file ->
+                file?.let {
+                    editorAttachments = editorAttachments + AttachmentPendingFile.File(
+                        Uuid.random(), it
+                    )
+                }
+            }
+            val galleryLauncher = rememberFilePickerLauncher(
+                type = FileKitType.ImageAndVideo
+            ) { file ->
+                file?.let {
+                    val mimeType = it.mimeType()?.toString() ?: ""
+                    val pending = if (mimeType.startsWith("video/")) {
+                        AttachmentPendingFile.FileVideo(Uuid.random(), it)
+                    } else {
+                        AttachmentPendingFile.FileImage(Uuid.random(), it)
+                    }
+                    editorAttachments = editorAttachments + pending
+                }
+            }
+
             HomebaseTheme(darkTheme = isDarkTheme) {
-                SharePickerScreen(
-                    conversationStream = conversationStream,
-                    contactService = contactService,
-                    ownerSessionRepository = ownerSessionRepository,
-                    sharedContent = sharedContent,
-                    isSending = isSending,
-                    onSendToConversations = { conversationIds ->
-                        sendToMultipleConversations(conversationIds, sharedContent)
-                    },
-                    onCancel = { finish() },
-                )
+                Box(modifier = Modifier.fillMaxSize()) {
+                when (val state = screenState) {
+                    is ShareScreenState.Picking -> {
+                        SharePickerScreen(
+                            conversationStream = conversationStream,
+                            contactService = contactService,
+                            ownerSessionRepository = ownerSessionRepository,
+                            sharedContent = sharedContent,
+                            hasFiles = sharedContent.hasFiles,
+                            isSending = isSending,
+                            onSendToConversations = { conversationIds ->
+                                if (sharedContent.hasFiles) {
+                                    // Show overlay while converting files
+                                    isProcessing = true
+                                    lifecycleScope.launch {
+                                        val attachments = withContext(Dispatchers.IO) {
+                                            convertToAttachmentFiles(sharedContent.files)
+                                        }
+                                        val title = resolveConversationTitle(conversationIds)
+                                        editorAttachments = attachments
+                                        isProcessing = false
+                                        screenState = ShareScreenState.Previewing(
+                                            selectedConversationIds = conversationIds,
+                                            attachments = attachments,
+                                            conversationTitle = title,
+                                        )
+                                    }
+                                } else {
+                                    // Text-only: send directly as before
+                                    sendToMultipleConversations(conversationIds, sharedContent)
+                                }
+                            },
+                            onCancel = { finish() },
+                        )
+                    }
+
+                    is ShareScreenState.Previewing -> {
+                        val textFieldState = remember { RichTextState() }
+                        var currentPage by remember { mutableStateOf(0) }
+
+                        // Sync hoisted attachments from state on first entry
+                        LaunchedEffect(state) {
+                            if (editorAttachments.isEmpty()) {
+                                editorAttachments = state.attachments
+                            }
+                        }
+
+                        if (editorAttachments.isEmpty()) {
+                            // User removed all files — go back to picker
+                            screenState = ShareScreenState.Picking
+                        } else {
+                            FullScreenAttachmentEditor(
+                                data = FullScreenOverlay.AttachmentData(
+                                    selected = editorAttachments[currentPage.coerceIn(0, editorAttachments.lastIndex)].attachmentId,
+                                    conversationTitle = state.conversationTitle,
+                                    conversationId = state.selectedConversationIds.first(),
+                                    attachments = editorAttachments,
+                                ),
+                                textFieldState = textFieldState,
+                                currentPage = currentPage,
+                                onPageChanged = { currentPage = it },
+                                onSaveFile = { /* Not needed in share flow */ },
+                                onAddFile = { fileLauncher.launch() },
+                                onAddImage = { galleryLauncher.launch() },
+                                onRemoveFile = { _, attachmentId ->
+                                    val updated = editorAttachments.filter { it.attachmentId != attachmentId }
+                                    editorAttachments = updated
+                                    if (currentPage >= updated.size) {
+                                        currentPage = maxOf(0, updated.lastIndex)
+                                    }
+                                },
+                                onSendMessage = { _, message, files ->
+                                    sendEditedFiles(
+                                        conversationIds = state.selectedConversationIds,
+                                        caption = message,
+                                        files = files,
+                                    )
+                                },
+                                onDismiss = {
+                                    editorAttachments = emptyList()
+                                    screenState = ShareScreenState.Picking
+                                },
+                            )
+                        }
+                    }
+
+                }
+
+                // Semi-transparent overlay while processing (file conversion or sending)
+                if (isProcessing) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.5f))
+                            .clickable(onClick = {}),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CircularProgressIndicator(
+                            color = MaterialTheme.colorScheme.inversePrimary,
+                        )
+                    }
+                }
+                } // Box
             }
         }
     }
@@ -132,8 +303,11 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
                     }
                 }
 
-                val countLabel =
-                    if (conversationIds.size > 1) "Sent to ${conversationIds.size} conversations" else "Sent"
+                val countLabel = if (conversationIds.size > 1) {
+                    getString(R.string.share_sent_multiple, conversationIds.size)
+                } else {
+                    getString(R.string.share_sent)
+                }
                 Toast.makeText(this@ShareReceiverActivity, countLabel, Toast.LENGTH_SHORT).show()
 
                 // Open the first conversation in the main app
@@ -181,7 +355,7 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
                     }
                 }
 
-                Toast.makeText(this@ShareReceiverActivity, "Sent", Toast.LENGTH_SHORT).show()
+                Toast.makeText(this@ShareReceiverActivity, getString(R.string.share_sent), Toast.LENGTH_SHORT).show()
 
                 // Open conversation in main app
                 val mainIntent =
@@ -237,5 +411,143 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
         } catch (_: Exception) {
             // Ignore cleanup errors
         }
+    }
+
+    private suspend fun convertToAttachmentFiles(files: List<SharedFile>): List<AttachmentPendingFile> {
+        return files.map { sharedFile ->
+            val platformFile = PlatformFile(java.io.File(sharedFile.path))
+            when {
+                sharedFile.mimeType.startsWith("image/") ->
+                    AttachmentPendingFile.FileImage(Uuid.random(), platformFile)
+                sharedFile.mimeType.startsWith("video/") -> {
+                    val thumbnailPath = FFmpegUtils.grabThumbnail(sharedFile.path)
+                    val thumbnailBytes = thumbnailPath?.let {
+                        java.io.File(it).readBytes()
+                    }
+                    AttachmentPendingFile.FileVideo(Uuid.random(), platformFile, thumbnailBytes)
+                }
+                else ->
+                    AttachmentPendingFile.File(Uuid.random(), platformFile)
+            }
+        }
+    }
+
+    private fun resolveConversationTitle(conversationIds: Set<Uuid>): String {
+        val conversations = conversationStream.conversations.value.items
+        val names = conversationIds.take(2).mapNotNull { id ->
+            conversations.find { it.id == id }?.name
+        }
+        val remaining = conversationIds.size - names.size.coerceAtMost(2)
+
+        return when {
+            names.isEmpty() -> getString(R.string.share_preview_title_single)
+            names.size == 1 && remaining == 0 -> names.first()
+            names.size == 1 && remaining > 0 -> getString(R.string.share_preview_title_others, names.first(), remaining)
+            remaining > 0 -> getString(R.string.share_preview_title_others, names.joinToString(", "), remaining)
+            else -> names.joinToString(", ")
+        }
+    }
+
+    private fun sendEditedFiles(
+        conversationIds: Set<Uuid>,
+        caption: String,
+        files: List<AttachmentPendingFile>,
+    ) {
+        isProcessing = true
+
+        lifecycleScope.launch {
+            try {
+                // Build payload on IO (thumbnail generation is the slow part)
+                val attachments = withContext(Dispatchers.IO) {
+                    files.map { attachment ->
+                        when (attachment) {
+                            is AttachmentPendingFile.FileImage -> AttachmentInput(
+                                filePath = attachment.file.toString(),
+                                contentType = attachment.file.mimeType()?.toString() ?: "image/jpeg",
+                                displayName = attachment.file.name,
+                            )
+                            is AttachmentPendingFile.FileVideo -> AttachmentInput(
+                                filePath = attachment.file.toString(),
+                                contentType = attachment.file.mimeType()?.toString() ?: "video/mp4",
+                                displayName = attachment.file.name,
+                            )
+                            is AttachmentPendingFile.File -> AttachmentInput(
+                                filePath = attachment.file.toString(),
+                                contentType = attachment.file.mimeType()?.toString() ?: "application/octet-stream",
+                                displayName = attachment.file.name,
+                            )
+                            is AttachmentPendingFile.Gallery -> AttachmentInput(
+                                filePath = attachment.image.file.toString(),
+                                contentType = "image/jpeg",
+                                displayName = attachment.image.fileName,
+                            )
+                            is AttachmentPendingFile.Audio -> AttachmentInput(
+                                filePath = attachment.audioFile.toString(),
+                                contentType = "audio/m4a",
+                                displayName = attachment.audioFile.name,
+                                waveformFile = attachment.waveformFile?.toString(),
+                                audioLengthSeconds = attachment.lengthSeconds,
+                            )
+                        }
+                    }
+                }
+
+                val payloadBundle = withContext(Dispatchers.IO) {
+                    MessageAttachmentBuilder.build(
+                        attachments = attachments,
+                        fileOperationsProvider = fileOperationsProvider,
+                    ) { index, _ -> "${ChatProtocol.PAYLOAD_KEY_MESSAGE_WEB}$index" }
+                }
+
+                // Navigate immediately — don't wait for sends to complete
+                val firstId = conversationIds.first()
+                val mainIntent = Intent(this@ShareReceiverActivity, MainActivity::class.java).apply {
+                    data = "homebase-fchat://conversation/${firstId}".toUri()
+                    flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+                }
+                startActivity(mainIntent)
+
+                // Fire sends in background scope that survives the activity finish.
+                // Safe because MainActivity starts before finish(), keeping the process alive.
+                // For large uploads, consider migrating to WorkManager.
+                val sendScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+                sendScope.launch {
+                    try {
+                        for (conversationId in conversationIds) {
+                            chatMessageSenderService.sendNewMessage(
+                                messageUniqueId = Uuid.random(),
+                                conversationId = conversationId,
+                                messageText = caption,
+                                previousMessageUniqueId = null,
+                                payloadBundle = payloadBundle,
+                            )
+                        }
+                    } catch (e: Exception) {
+                        Logger.e(tag = "ShareReceiver") { "Background send failed: ${e.message}" }
+                    } finally {
+                        cleanupTempFiles()
+                    }
+                }
+
+                finish()
+            } catch (e: Exception) {
+                Logger.e(tag = "ShareReceiver") { "Failed to prepare send: ${e.message}" }
+                isProcessing = false
+                Toast.makeText(
+                    this@ShareReceiverActivity,
+                    "Failed to send: ${e.message}",
+                    Toast.LENGTH_LONG
+                ).show()
+            }
+        }
+    }
+
+    private sealed class ShareScreenState {
+        data object Picking : ShareScreenState()
+        data class Previewing(
+            val selectedConversationIds: Set<Uuid>,
+            val attachments: List<AttachmentPendingFile>,
+            val conversationTitle: String,
+        ) : ShareScreenState()
     }
 }

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -1,3 +1,9 @@
 <resources>
     <string name="app_name">Homebase</string>
+    <string name="share_auth_required">Please open Homebase Chat and sign in first</string>
+    <string name="share_nothing_to_share">Nothing to share</string>
+    <string name="share_sent">Sent</string>
+    <string name="share_sent_multiple">Sent to %1$d conversations</string>
+    <string name="share_preview_title_single">Conversation</string>
+    <string name="share_preview_title_others">%1$s +%2$d others</string>
 </resources>

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -70,6 +70,12 @@ class ConversationStream(
     var onRecoverConversation: (suspend (conversationId: Uuid, originalAuthor: OdinId) -> Unit)? = null
     // endregion
 
+    // region Auto-unarchive: incoming message for archived conversation
+    /** Called when a message arrives for an archived conversation.
+     *  Wired in AppModule to ConversationService.unarchiveConversation(). */
+    var onUnarchiveConversation: (suspend (conversationId: Uuid) -> Unit)? = null
+    // endregion
+
 
     // The full conversation list is loaded once from the local DB on authentication
     // (via start(), called from onPostAuthenticated in AppModule).
@@ -159,6 +165,27 @@ class ConversationStream(
             if (matchingConversation?.conversationState == ConversationState.Left
                 || matchingConversation?.conversationState == ConversationState.Removed
             ) continue
+
+            // region Auto-unarchive: Signal-style unarchive on incoming message
+            if (matchingConversation?.conversationState == ConversationState.Archived) {
+                // Only unarchive for messages from others, not our own synced messages
+                if (!m.isAuthoredBy(credentialsManager.getActiveDomain())) {
+                    Logger.i("ConversationStream: unarchiving conversation ${m.conversationId} due to incoming message from ${m.originalAuthor}")
+                    val unarchived = matchingConversation.copy(conversationState = ConversationState.Active)
+                    _conversations.value = ConversationsData(
+                        items = _conversations.value.items.map { if (it.id == unarchived.id) unarchived else it }
+                    )
+                    scope.launch {
+                        try {
+                            onUnarchiveConversation?.invoke(m.conversationId)
+                        } catch (e: Exception) {
+                            Logger.e(e) { "ConversationStream: failed to unarchive conversation ${m.conversationId}: ${e.message}" }
+                        }
+                    }
+                }
+                // Fall through to updateConversationFromNewMessage below (don't continue)
+            }
+            // endregion
 
             // region Recovery: revive deleted conversation on new incoming message
             // Compare server-stamped *created* timestamp against the conversation's

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -111,6 +111,7 @@ import id.homebase.core.util.isWeb
 import id.homebase.core.util.keyboardAsState
 import id.homebase.core.util.programmaticBackspace
 import id.homebase.core.util.rememberCameraManager
+import id.homebase.core.util.rememberVideoRecorderManager
 import id.homebase.core.widget.EmojiSelectorSheet
 import id.homebase.core.widget.EmojiSummary
 import id.homebase.core.widget.HomebaseVerticalScrollbar
@@ -299,6 +300,17 @@ fun ConversationContent(
                     conversationId = conversation.conversation.id,
                     files = listOf(file),
                     isImage = true,
+                )
+            )
+        }
+    }
+    val videoRecorderLauncher = rememberVideoRecorderManager { file ->
+        file?.let {
+            onUiAction(
+                ConversationListUiAction.AttachPlatformFile(
+                    conversationId = conversation.conversation.id,
+                    files = listOf(file),
+                    isImage = false,
                 )
             )
         }
@@ -952,6 +964,7 @@ fun ConversationContent(
                                 }
                             },
                             onCameraClick = { cameraLauncher.launch() },
+                            onVideoRecordClick = { videoRecorderLauncher.launch() },
                             onRecordingStarted = {
                                 onUiAction(
                                     ConversationListUiAction.StartRecording(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenAttachmentEditor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenAttachmentEditor.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -102,6 +103,7 @@ fun FullScreenAttachmentEditor(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.surface)
+            .statusBarsPadding()
     ) {
         Box(
             modifier = Modifier.weight(1f)
@@ -215,6 +217,7 @@ fun FullScreenAttachmentEditor(
                 modifier = Modifier
                     .align(Alignment.TopEnd)
                     .padding(16.dp)
+                    .fillMaxWidth(0.6f)
                     .clip(RoundedCornerShape(16.dp))
                     .background(MaterialTheme.colorScheme.surfaceContainerHighest)
                     .padding(horizontal = 16.dp, vertical = 8.dp),
@@ -222,7 +225,12 @@ fun FullScreenAttachmentEditor(
             ) {
                 Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = null)
                 Spacer(modifier = Modifier.width(8.dp))
-                Text(data.conversationTitle, style = MaterialTheme.typography.labelSmall)
+                Text(
+                    text = data.conversationTitle,
+                    style = MaterialTheme.typography.labelSmall,
+                    maxLines = 1,
+                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                )
             }
 
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
@@ -43,6 +43,9 @@ import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.PhotoCamera
+import androidx.compose.material.icons.filled.Videocam
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material.icons.outlined.FormatBold
 import androidx.compose.material.icons.outlined.FormatItalic
 import androidx.compose.material.icons.outlined.FormatListNumbered
@@ -109,6 +112,9 @@ import id.homebase.core.util.keyboardAsState
 import id.homebase.resources.MR
 import id.homebase.resources.cancel
 import id.homebase.resources.chat_message_attachment_options
+import id.homebase.resources.chat_message_camera
+import id.homebase.resources.chat_message_record_video
+import id.homebase.resources.chat_message_take_photo
 import id.homebase.resources.chat_message_edit_message
 import id.homebase.resources.chat_message_emoji_options
 import id.homebase.resources.chat_message_hide_keyboard
@@ -141,6 +147,7 @@ fun MessageInputBar(
     onFocused: () -> Unit,
     onAddAttachmentClick: () -> Unit,
     onCameraClick: () -> Unit,
+    onVideoRecordClick: () -> Unit,
     onRecordingStarted: () -> Unit,
     onRecordingStopped: () -> Unit,
     onRecordingCancelled: () -> Unit,
@@ -269,6 +276,7 @@ fun MessageInputBar(
                 onKeyboardClick = onKeyboardClick,
                 onAddAttachmentClick = onAddAttachmentClick,
                 onCameraClick = onCameraClick,
+                onVideoRecordClick = onVideoRecordClick,
                 onRecordingStarted = onRecordingStarted,
                 onRecordingStopped = onRecordingStopped,
                 onRecordingCancelled = onRecordingCancelled,
@@ -439,6 +447,7 @@ fun MessageTextFieldCompact(
     onKeyboardClick: () -> Unit,
     onAddAttachmentClick: () -> Unit,
     onCameraClick: () -> Unit,
+    onVideoRecordClick: () -> Unit,
     onRecordingStarted: () -> Unit,
     onRecordingStopped: () -> Unit,
     onRecordingCancelled: () -> Unit,
@@ -630,12 +639,39 @@ fun MessageTextFieldCompact(
                                             )
                                         }
                                     } else if (isMobile()) {
-                                        // Camera only; mic has moved to the right-side button below.
-                                        IconButton(onClick = onCameraClick) {
-                                            Icon(
-                                                imageVector = Icons.Default.PhotoCamera,
-                                                contentDescription = "Camera"
-                                            )
+                                        var showCameraMenu by remember { mutableStateOf(false) }
+                                        Box {
+                                            IconButton(onClick = { showCameraMenu = true }) {
+                                                Icon(
+                                                    imageVector = Icons.Default.PhotoCamera,
+                                                    contentDescription = stringResource(MR.string.chat_message_camera)
+                                                )
+                                            }
+                                            DropdownMenu(
+                                                expanded = showCameraMenu,
+                                                onDismissRequest = { showCameraMenu = false }
+                                            ) {
+                                                DropdownMenuItem(
+                                                    text = { Text(stringResource(MR.string.chat_message_take_photo)) },
+                                                    onClick = {
+                                                        showCameraMenu = false
+                                                        onCameraClick()
+                                                    },
+                                                    leadingIcon = {
+                                                        Icon(Icons.Default.PhotoCamera, contentDescription = null)
+                                                    }
+                                                )
+                                                DropdownMenuItem(
+                                                    text = { Text(stringResource(MR.string.chat_message_record_video)) },
+                                                    onClick = {
+                                                        showCameraMenu = false
+                                                        onVideoRecordClick()
+                                                    },
+                                                    leadingIcon = {
+                                                        Icon(Icons.Default.Videocam, contentDescription = null)
+                                                    }
+                                                )
+                                            }
                                         }
                                     }
                                 }

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/util/CameraUtil.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/util/CameraUtil.android.kt
@@ -1,10 +1,17 @@
 package id.homebase.core.util
 
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.FileProvider
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.FileKitCameraFacing
 import io.github.vinceglb.filekit.dialogs.compose.rememberCameraPickerLauncher
+import java.io.File
 
 @Composable
 actual fun rememberCameraManager(onResult: (PlatformFile?) -> Unit): PlatformCameraManager {
@@ -15,6 +22,42 @@ actual fun rememberCameraManager(onResult: (PlatformFile?) -> Unit): PlatformCam
         object : PlatformCameraManager {
             override fun launch() {
                 launcher.launch(cameraFacing = FileKitCameraFacing.Back)
+            }
+        }
+    }
+}
+
+@Composable
+actual fun rememberVideoRecorderManager(onResult: (PlatformFile?) -> Unit): PlatformVideoRecorderManager {
+    val context = LocalContext.current
+    val videoUri = remember { mutableStateOf<Uri?>(null) }
+
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CaptureVideo()
+    ) { success ->
+        if (success) {
+            videoUri.value?.let { uri ->
+                onResult(PlatformFile(uri))
+            }
+        } else {
+            onResult(null)
+        }
+    }
+
+    return remember {
+        object : PlatformVideoRecorderManager {
+            override fun launch() {
+                val file = File(
+                    context.cacheDir,
+                    "video_${System.currentTimeMillis()}.mp4"
+                )
+                val uri = FileProvider.getUriForFile(
+                    context,
+                    "${context.packageName}.fileprovider",
+                    file
+                )
+                videoUri.value = uri
+                launcher.launch(uri)
             }
         }
     }

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -280,6 +280,11 @@
     <string name="chat_message_delete_for_me">Delete for me</string>
     <string name="chat_message_options">Message options</string>
     <string name="chat_message_attachment_options">Attachment options</string>
+    <string name="chat_message_camera">Camera</string>
+    <string name="chat_message_take_photo">Take photo</string>
+    <string name="chat_message_record_video">Record video</string>
+    <string name="share_picker_next">Next</string>
+    <string name="share_picker_send">Send</string>
     <string name="chat_message_emoji_options">Emoji options</string>
     <string name="chat_message_edited">Edited</string>
     <string name="chat_message_deleted">🚫 This message was deleted</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/util/CameraUtil.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/util/CameraUtil.kt
@@ -9,3 +9,10 @@ expect fun rememberCameraManager(onResult: (PlatformFile?) -> Unit): PlatformCam
 interface PlatformCameraManager {
     fun launch()
 }
+
+@Composable
+expect fun rememberVideoRecorderManager(onResult: (PlatformFile?) -> Unit): PlatformVideoRecorderManager
+
+interface PlatformVideoRecorderManager {
+    fun launch()
+}

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/util/CameraUtil.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/util/CameraUtil.jvm.kt
@@ -7,7 +7,16 @@ import io.github.vinceglb.filekit.PlatformFile
 actual fun rememberCameraManager(onResult: (PlatformFile?) -> Unit): PlatformCameraManager {
     return object : PlatformCameraManager {
         override fun launch() {
-            // No-op on web
+            // No-op on desktop
+        }
+    }
+}
+
+@Composable
+actual fun rememberVideoRecorderManager(onResult: (PlatformFile?) -> Unit): PlatformVideoRecorderManager {
+    return object : PlatformVideoRecorderManager {
+        override fun launch() {
+            // No-op on desktop
         }
     }
 }

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/CameraUtil.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/CameraUtil.native.kt
@@ -2,8 +2,17 @@ package id.homebase.core.util
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.compose.rememberCameraPickerLauncher
+import platform.Foundation.NSURL
+import platform.UIKit.UIApplication
+import platform.UIKit.UIImagePickerController
+import platform.UIKit.UIImagePickerControllerDelegateProtocol
+import platform.UIKit.UIImagePickerControllerMediaURL
+import platform.UIKit.UIImagePickerControllerSourceType
+import platform.UIKit.UINavigationControllerDelegateProtocol
+import platform.darwin.NSObject
 
 @Composable
 actual fun rememberCameraManager(onResult: (PlatformFile?) -> Unit): PlatformCameraManager {
@@ -15,6 +24,60 @@ actual fun rememberCameraManager(onResult: (PlatformFile?) -> Unit): PlatformCam
             override fun launch() {
                 launcher.launch()
             }
+        }
+    }
+}
+
+@Composable
+actual fun rememberVideoRecorderManager(onResult: (PlatformFile?) -> Unit): PlatformVideoRecorderManager {
+    val currentOnResult = rememberUpdatedState(onResult)
+    return remember {
+        object : PlatformVideoRecorderManager {
+            // Retained to prevent garbage collection while picker is presented
+            private var delegate: VideoPickerDelegate? = null
+
+            override fun launch() {
+                val rootVC = UIApplication.sharedApplication.keyWindow?.rootViewController ?: return
+
+                val picker = UIImagePickerController()
+                picker.sourceType = UIImagePickerControllerSourceType.UIImagePickerControllerSourceTypeCamera
+                picker.mediaTypes = listOf("public.movie")
+                picker.videoQuality = 0L // UIImagePickerControllerQualityTypeHigh
+
+                val d = VideoPickerDelegate { url ->
+                    if (url != null) {
+                        currentOnResult.value(PlatformFile(url))
+                    } else {
+                        currentOnResult.value(null)
+                    }
+                    delegate = null
+                }
+                delegate = d
+                picker.delegate = d
+
+                rootVC.presentViewController(picker, animated = true, completion = null)
+            }
+        }
+    }
+}
+
+private class VideoPickerDelegate(
+    private val onResult: (NSURL?) -> Unit
+) : NSObject(), UIImagePickerControllerDelegateProtocol, UINavigationControllerDelegateProtocol {
+
+    override fun imagePickerController(
+        picker: UIImagePickerController,
+        didFinishPickingMediaWithInfo: Map<Any?, *>
+    ) {
+        val mediaURL = didFinishPickingMediaWithInfo[UIImagePickerControllerMediaURL] as? NSURL
+        picker.dismissViewControllerAnimated(true) {
+            onResult(mediaURL)
+        }
+    }
+
+    override fun imagePickerControllerDidCancel(picker: UIImagePickerController) {
+        picker.dismissViewControllerAnimated(true) {
+            onResult(null)
         }
     }
 }

--- a/homebase-common/src/webMain/kotlin/id/homebase/core/util/CameraUtil.web.kt
+++ b/homebase-common/src/webMain/kotlin/id/homebase/core/util/CameraUtil.web.kt
@@ -11,3 +11,12 @@ actual fun rememberCameraManager(onResult: (PlatformFile?) -> Unit): PlatformCam
         }
     }
 }
+
+@Composable
+actual fun rememberVideoRecorderManager(onResult: (PlatformFile?) -> Unit): PlatformVideoRecorderManager {
+    return object : PlatformVideoRecorderManager {
+        override fun launch() {
+            // No-op on web
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -93,6 +93,12 @@ val appModule = module {
                     conversationService.recoverConversation(conversationId, originalAuthor)
                 }
                 // endregion
+
+                // region Auto-unarchive: incoming message for archived conversation
+                conversationStream.onUnarchiveConversation = { conversationId ->
+                    conversationService.unarchiveConversation(conversationId)
+                }
+                // endregion
             }
         )
     }


### PR DESCRIPTION
- Auto-unarchive conversations on incoming message (Signal behavior) Archived conversations are automatically unarchived when a new message arrives from another user. State flips optimistically in memory, then persists via ConversationService.

- Camera video recording with native camera (Phase 1) Camera button shows dropdown: Take Photo / Record Video. Android uses ActivityResultContracts.CaptureVideo, iOS uses UIImagePickerController with video media type and high quality. JVM/Web are no-op.

- Share-to-app media preview/editor When files are shared into the app, FullScreenAttachmentEditor is shown for preview, caption editing, and file management before sending. Text-only shares still send directly. State machine in ShareReceiverActivity (Picking → Previewing). Sends fire in background after immediate navigation to conversation.

- Fix auth race condition in ShareReceiverActivity Wait for YouAuthFlowManager.authState to leave Initializing before checking auth, fixing false "Please sign in" toast on process-kill restart.

- Fix FullScreenAttachmentEditor status bar overlap Added statusBarsPadding() to root Column.