### PR TITLE
Fix Linux idle CPU usage from repeated ConversationEnricher execution

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -100,6 +100,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
@@ -193,7 +194,7 @@ class ConversationListViewModel(
                     // at least one snapshot (either from the cache or from the network).
                     statusKnown = connections.isLoaded && requestsLoaded,
                 )
-            }
+            }.distinctUntilChanged()
 
             combine(
                 conversationStream.conversations,
@@ -217,7 +218,7 @@ class ConversationListViewModel(
                         connectionStatusKnown = connectionCtx.statusKnown,
                     )
                 })
-            }.collect { (dataReady: Boolean, enriched: List<EnrichedConversationUiModel>) ->
+            }.debounce(50).collect { (dataReady: Boolean, enriched: List<EnrichedConversationUiModel>) ->
                 if (dataReady) {
                     _uiState.update {
                         it.copy(


### PR DESCRIPTION
The ConversationEnricher was running every 1-2 seconds while idle, re-enriching all ~80 conversations even when nothing had changed.

Root cause: ConnectionService.refresh() emits a new ConnectionState on every BackendEvent.ConnectionOnline event. Kotlin's combine() re-emits on every upstream emission regardless of whether the resulting value has changed, so connectionStatusFlow triggered the outer combine on every connection check — even when connections/requests were identical.

Fix 1: Add .distinctUntilChanged() to connectionStatusFlow so the outer combine only re-runs when connection status actually changes (new connections accepted, requests sent/received), not on every poll cycle.

Fix 2: Add .debounce(50ms) before .collect to collapse rapid-fire combine emissions (e.g. multiple StateFlow updates within a single sync batch) into a single enricher run.

Verified: enricher now fires only on genuine data changes (new message received, unread count updated, conversation opened/read). Zero enricher activity during idle between sync cycles.