### PR TITLE
Log outgoing message delivery status per recipient

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveOutboxUploader.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveOutboxUploader.kt
@@ -57,13 +57,19 @@ class DriveOutboxUploader(
 
                     else -> {
                         Logger.e(
-                            "Non-recoverable 400 for outbox item ${outboxRecord.uniqueId} " +
-                                    "uploadType=${outboxRecord.uploadType} errorCode=${e.errorCode} — " +
-                                    "rethrowing for retry: ${e.message}"
+                            "$TAG upload: 400 for outbox item ${outboxRecord.uniqueId} " +
+                                    "uploadType=${outboxRecord.uploadType} errorCode=${e.errorCode} " +
+                                    "— will retry (server message: ${e.message})"
                         )
+                        throw e
                     }
                 }
             }
+            Logger.e(
+                "$TAG upload: failing outbox item ${outboxRecord.uniqueId} " +
+                        "uploadType=${outboxRecord.uploadType} status=${e.status} " +
+                        "errorCode=${e.errorCode} message=${e.message}"
+            )
             throw e
         }
     }
@@ -72,11 +78,23 @@ class DriveOutboxUploader(
         val request = OdinSystemSerializer.deserialize<UploadFileRequest>(outboxRecord.json.decodeToString())
         Logger.d("$TAG uploadNewFile: uniqueId=${request.metadata.appData.uniqueId} fileType=${request.metadata.appData.fileType} driveId=${request.driveId}")
         try {
-            driveUploadProvider.uploadFile(request, onProgress = { sent, total ->
+            val result = driveUploadProvider.uploadFile(request, onProgress = { sent, total ->
                 val percent = percentOf(sent, total)
                 eventBus.emit(BackendEvent.OutboxEvent.ItemProgress(outboxRecord.driveId, outboxRecord.uniqueId, percent, sent))
             })
-            Logger.d("$TAG uploadNewFile: success uniqueId=${request.metadata.appData.uniqueId}")
+            val rStatus = result?.recipientStatus
+            if (rStatus.isNullOrEmpty()) {
+                Logger.d(
+                    "$TAG uploadNewFile: success uniqueId=${request.metadata.appData.uniqueId} " +
+                            "fileId=${result?.fileId} (no recipients)"
+                )
+            } else {
+                Logger.i(
+                    "$TAG uploadNewFile: success uniqueId=${request.metadata.appData.uniqueId} " +
+                            "fileId=${result.fileId} " +
+                            "recipientStatus=${rStatus.entries.joinToString { "${it.key}=${it.value}" }}"
+                )
+            }
         // region Recovery: missing conversation file
         // If the server already has a file with this uniqueId (e.g. stale/archived
         // from a previous install), convert the failed UploadNewFile into an
@@ -157,21 +175,45 @@ class DriveOutboxUploader(
         )
 
         Logger.d("$TAG retryAsUpdate: sending update for uniqueId=$uniqueId versionTag=$versionTag")
-        driveUploadProvider.updateFileByUniqueId(updateRequest, onProgress = { sent, total ->
+        val updateResult = driveUploadProvider.updateFileByUniqueId(updateRequest, onProgress = { sent, total ->
             val percent = percentOf(sent, total)
             eventBus.emit(BackendEvent.OutboxEvent.ItemProgress(outboxRecord.driveId, outboxRecord.uniqueId, percent, sent))
         })
-        Logger.i("$TAG retryAsUpdate: SUCCESS — uniqueId=$uniqueId updated on server (was ExistingFileWithUniqueId)")
+        val rStatus = updateResult?.recipientStatus
+        if (rStatus.isNullOrEmpty()) {
+            Logger.i(
+                "$TAG retryAsUpdate: SUCCESS — uniqueId=$uniqueId updated on server " +
+                        "(was ExistingFileWithUniqueId) fileId=${updateResult?.fileId} (no recipients)"
+            )
+        } else {
+            Logger.i(
+                "$TAG retryAsUpdate: SUCCESS — uniqueId=$uniqueId updated on server " +
+                        "(was ExistingFileWithUniqueId) fileId=${updateResult.fileId} " +
+                        "recipientStatus=${rStatus.entries.joinToString { "${it.key}=${it.value}" }}"
+            )
+        }
     }
     // endregion
 
     private suspend fun updateFile(outboxRecord: Outbox, eventBus: EventBus) {
         val request = OdinSystemSerializer.deserialize<UpdateFileByUniqueIdRequest>(outboxRecord.json.decodeToString())
-        driveUploadProvider.updateFileByUniqueId(request, onProgress = { sent, total ->
+        val result = driveUploadProvider.updateFileByUniqueId(request, onProgress = { sent, total ->
             val percent = percentOf(sent, total)
             eventBus.emit(BackendEvent.OutboxEvent.ItemProgress(outboxRecord.driveId, outboxRecord.uniqueId, percent, sent))
-//            println("Upload: $percent%")
         })
+        val rStatus = result?.recipientStatus
+        if (rStatus.isNullOrEmpty()) {
+            Logger.d(
+                "$TAG updateFile: success uniqueId=${request.uniqueId} " +
+                        "fileId=${result?.fileId} (no recipients)"
+            )
+        } else {
+            Logger.i(
+                "$TAG updateFile: success uniqueId=${request.uniqueId} " +
+                        "fileId=${result.fileId} " +
+                        "recipientStatus=${rStatus.entries.joinToString { "${it.key}=${it.value}" }}"
+            )
+        }
     }
 
     private suspend fun deleteFile(outboxRecord: Outbox) {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
@@ -29,6 +29,20 @@ interface OutboxUploader {
     suspend fun upload(outboxRecord: Outbox, eventBus: EventBus): Unit
 }
 
+private fun uploadTypeName(t: Long): String = when (t) {
+    DriveOutboxUploader.UploadNewFile -> "UploadNewFile"
+    DriveOutboxUploader.UpdateFile -> "UpdateFile"
+    DriveOutboxUploader.DeleteFile -> "DeleteFile"
+    DriveOutboxUploader.UpdateLocalMetadataTags -> "UpdateLocalMetadataTags"
+    DriveOutboxUploader.UpdateLocalMetadataContent -> "UpdateLocalMetadataContent"
+    DriveOutboxUploader.SendReadReceiptByTime -> "SendReadReceiptByTime"
+    DriveOutboxUploader.ToggleReaction -> "ToggleReaction"
+    DriveOutboxUploader.DeleteFilesByGroupId -> "DeleteFilesByGroupId"
+    else -> "Unknown"
+}
+
+private fun Outbox.uploadTypeLabel(): String = "${uploadTypeName(uploadType)}($uploadType)"
+
 class OutboxSync(
     private val databaseManager: DatabaseManager,
     private val uploader: OutboxUploader,
@@ -127,13 +141,13 @@ class OutboxSync(
                         outboxRecord.uniqueId
                     )
                 )
-                Logger.i("OutboxSync: sending uniqueId=${outboxRecord.uniqueId} uploadType=${outboxRecord.uploadType} driveId=${outboxRecord.driveId} attempt=${outboxRecord.checkOutCount + 1}")
+                Logger.i("OutboxSync: sending uniqueId=${outboxRecord.uniqueId} uploadType=${outboxRecord.uploadTypeLabel()} driveId=${outboxRecord.driveId} attempt=${outboxRecord.checkOutCount + 1}")
 
                 uploader.upload(outboxRecord, eventBus)
 
                 // if successful we remove it from the database
                 databaseManager.outbox.deleteByRowId(outboxRecord.rowId)
-                Logger.i("OutboxSync: completed uniqueId=${outboxRecord.uniqueId} uploadType=${outboxRecord.uploadType}")
+                Logger.i("OutboxSync: completed uniqueId=${outboxRecord.uniqueId} uploadType=${outboxRecord.uploadTypeLabel()}")
 
                 // We sent the item, send an event
                 eventBus.emit(
@@ -149,7 +163,7 @@ class OutboxSync(
                 if (attempts >= MAX_RETRIES) {
                     Logger.e(
                         "OutboxSync: DROPPING uniqueId=${outboxRecord.uniqueId} " +
-                                "uploadType=${outboxRecord.uploadType} after $attempts failed attempts. " +
+                                "uploadType=${outboxRecord.uploadTypeLabel()} after $attempts failed attempts. " +
                                 "Last error: ${e.message}",
                         e
                     )
@@ -167,7 +181,7 @@ class OutboxSync(
                 // Exponential backoff: 30s, 60s, 2m, 4m, 8m, 16m, 32m, 64m, 2h, 4h, 4h, ...
                 val n = minOf(BASE_DELAY_SECONDS * (1L shl minOf(outboxRecord.checkOutCount.toInt(), 30)), MAX_DELAY_SECONDS)
                 Logger.w(
-                    "Failed upload for ${outboxRecord.uniqueId}, retry in $n seconds (attempt $attempts/$MAX_RETRIES)",
+                    "Failed upload for ${outboxRecord.uniqueId} uploadType=${outboxRecord.uploadTypeLabel()}, retry in $n seconds (attempt $attempts/$MAX_RETRIES)",
                     e
                 )
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
@@ -160,7 +160,14 @@ class ChatMessageSenderService(
         val recipients = conversationStream.getRecipients(conversationId, additionalRecipients)
         val isLocalOnly = recipients.isEmpty() // self-conversation: no distribution
 
-        Logger.d(tag = TAG) { "sendMessageInternal: encrypting message=$messageUniqueId recipients=${recipients.size}" }
+        Logger.d(tag = TAG) {
+            "sendMessageInternal: encrypting message=$messageUniqueId " +
+                "conversation=$conversationId " +
+                "recipients=${recipients.size} " +
+                "recipientIds=${recipients.map { it.domainName }} " +
+                "isLocalOnly=$isLocalOnly " +
+                "payloads=${payloadBundle?.payloads?.size ?: 0}"
+        }
         val encryptedBundle = payloadBundleEncryptionService.encryptBundle(
             messageUniqueId, payloadBundle, keyHeader.aesKey, scope = scope
         )


### PR DESCRIPTION
So we can actually tell from homebase.log whether a sent message reached its recipient(s), not just whether it uploaded to our own drive.

- ChatMessageSenderService: include recipient odin-ids, isLocalOnly and payload count in the "encrypting" log line (was count-only).
- DriveOutboxUploader: capture the CreateFileResult / UpdateFileResult returned by uploadFile / updateFileByUniqueId and log the server's per-recipient transit status (Delivered / Pending / Failed) for uploadNewFile, retryAsUpdate and updateFile. Replace the misleading "Non-recoverable 400 ... rethrowing for retry" message with a truthful "will retry" line, and add a non-400 failure log line that captures status + errorCode + message before rethrowing.
- OutboxSync: annotate the existing "sending", "completed", "Failed upload" and "DROPPING" log lines with the human-readable uploadType name alongside the numeric code.

No behavior changes; log-only. jvmTest green for homebase-api and homebase-chat.