### PR TITLE
Keep sync progress count monotonic

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
@@ -73,8 +73,12 @@ class DriveSyncManager(
                         // Only update progress count during an active sync (Started already fired).
                         // Don't let stray BatchReceived from OptimisticWriter transition
                         // a Completed/Failed drive back to Synchronizing.
+                        // Ignore events whose totalCount is below the count we've already
+                        // shown — real-time WebSocket pushes and optimistic writes emit
+                        // totalCount=1 and would otherwise snap the progress bar backwards
+                        // mid-backfill.
                         val current = _driveStatuses.value[event.driveId]?.state
-                        if (current is DriveState.Synchronizing) {
+                        if (current is DriveState.Synchronizing && event.totalCount >= current.count) {
                             updateState(event.driveId) {
                                 it.copy(state = DriveState.Synchronizing(count = event.totalCount))
                             }


### PR DESCRIPTION
Real-time WebSocket pushes (OdinWebSocketClient.handleFileEvent_manual) and optimistic local writes (OptimisticWriter) emit DriveEvent.BatchReceived with totalCount=1. While a drive is backfilling, DriveSyncManager was assigning that 1 to the progress count, snapping the loading-screen counter backwards (e.g. ...18500, 1, 19500, 20000, 1, 21000...).

Ignore BatchReceived events whose totalCount is below the count already displayed for that drive in the current sync session.