### PR TITLE
Ignore duplicate auth callback deliveries

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
@@ -126,6 +126,8 @@ class MainActivity : AppCompatActivity() {
             // Auth callback
             val callbackURL = data.toString()
             lifecycleScope.launch { youAuthFlowManager.handleCallback(callbackURL) }
+            // Clear the deep link so it's not re-processed on config changes / onNewIntent
+            intent.data = null
         }
     }
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthFlowManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthFlowManager.kt
@@ -255,8 +255,9 @@ class YouAuthFlowManager(
     private suspend fun completeAuth(url: String, state: String, queryParams: Map<String, String>) {
         val authCodeFlowState = callbackRegistry[state]
         if (authCodeFlowState == null) {
-            Logger.e(tag = TAG) { "No pending auth code flow state" }
-            _authState.value = YouAuthState.Error("No pending auth code flow")
+            // Duplicate or late callback — registry entry was already consumed.
+            // Don't stomp on the current _authState.
+            Logger.d(tag = TAG) { "Ignoring callback for state $state — no pending flow (likely duplicate delivery)" }
             return
         }
 


### PR DESCRIPTION
Android re-delivered the same deep-link Intent on activity resume, causing YouAuthFlowManager to emit AuthState.Error mid-login even though the first callback had succeeded. Clear intent.data after dispatch (matching the conversation branch) and demote a missing registry entry to a debug log so late/duplicate callbacks on any platform cannot stomp the in-flight or completed auth state.