### PR TITLE
adjusted to handle iOS strictness around hls decription -  Decrypt ea…

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveFileProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveFileProvider.kt
@@ -173,6 +173,31 @@ public class DriveFileProvider(
         )
     }
 
+    /**
+     * Fetch the raw (still-encrypted) bytes for a specific byterange of a payload, going through
+     * the disk cache. Used by the iOS HLS resource loader, which decrypts each HLS segment as a
+     * standalone AES-CBC blob (FFmpeg encrypts each segment independently with PKCS7 padding).
+     */
+    suspend fun getPayloadBytesEncryptedChunk(
+        driveId: Uuid,
+        fileId: Uuid,
+        key: String,
+        chunkStart: Long,
+        chunkLength: Long,
+    ): ByteArray? {
+        val response = driveCache.getPayloadBytesRaw(
+            driveId = driveId,
+            fileId = fileId,
+            key = key,
+            options = id.homebase.api.client.drives.files.PayloadOperationOptions(
+                chunkStart = chunkStart,
+                chunkLength = chunkLength,
+            ),
+        )
+        if (response.status == 404) return null
+        return response.bytes
+    }
+
     suspend fun streamPayloadDecryptedToPath(
         driveId: Uuid,
         fileId: Uuid,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -2389,6 +2389,11 @@ class ConversationListViewModel(
             // Store a local preview context per attachment (keyed by the payload key the
             // MessageAttachmentBuilder will emit), so both the placeholder and the eventual
             // real bubble can render the local preview without fetching from the server.
+            // Populate local contexts synchronously with what we have on hand, so the
+            // placeholder shows immediately. For videos the thumbnail bytes give us the
+            // aspect for free; for images we compute aspect asynchronously below and
+            // re-put once we have it — avoids blocking the placeholder on image I/O.
+            val imagePathsToRefine = mutableListOf<Pair<String, String>>()
             files.forEachIndexed { index, file ->
                 val payloadKey = "${ChatProtocol.PAYLOAD_KEY_MESSAGE_WEB}$index"
                 val ctx: LocalAttachmentContext? = when (file) {
@@ -2408,21 +2413,43 @@ class ConversationListViewModel(
                             )
                         } else null
                     }
-                    is AttachmentPendingFile.FileImage ->
-                        LocalAttachmentContext.Image(
-                            localFilePath = file.file.toString(),
-                            aspectRatio = null,
-                        )
-                    is AttachmentPendingFile.Gallery ->
-                        LocalAttachmentContext.Image(
-                            localFilePath = file.image.file.toString(),
-                            aspectRatio = null,
-                        )
+                    is AttachmentPendingFile.FileImage -> {
+                        val path = file.file.toString()
+                        imagePathsToRefine += payloadKey to path
+                        LocalAttachmentContext.Image(localFilePath = path, aspectRatio = null)
+                    }
+                    is AttachmentPendingFile.Gallery -> {
+                        val path = file.image.file.toString()
+                        imagePathsToRefine += payloadKey to path
+                        LocalAttachmentContext.Image(localFilePath = path, aspectRatio = null)
+                    }
                     is AttachmentPendingFile.File -> null
                     is AttachmentPendingFile.Audio -> null
                 }
                 if (ctx != null) {
                     localVideoContextStore.put(newMessageId, payloadKey, ctx)
+                }
+            }
+
+            // Refine image aspect ratios off the main path.
+            if (imagePathsToRefine.isNotEmpty()) {
+                viewModelScope.launch {
+                    imagePathsToRefine.forEach { (payloadKey, path) ->
+                        val aspect = runCatching {
+                            val bytes = fileOperationsProvider.readFileBytes(path)
+                            val size = ImageUtils.getNaturalSize(bytes)
+                            if (size.pixelWidth > 0 && size.pixelHeight > 0)
+                                size.pixelWidth.toFloat() / size.pixelHeight.toFloat()
+                            else null
+                        }.getOrNull()
+                        if (aspect != null) {
+                            localVideoContextStore.put(
+                                newMessageId,
+                                payloadKey,
+                                LocalAttachmentContext.Image(localFilePath = path, aspectRatio = aspect),
+                            )
+                        }
+                    }
                 }
             }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/PendingMessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/PendingMessageBubble.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.drives.files.PayloadDescriptor
+import id.homebase.api.client.drives.files.ThumbnailDescriptor
 import id.homebase.api.common.SecureByteArray
 import id.homebase.chat.conversationlist.PendingOutgoingMessage
 import id.homebase.chat.conversationlist.UploadStatus
@@ -105,10 +106,19 @@ private fun MediaPlaceholderBubble(
                     is LocalAttachmentContext.Video -> "video/mp4"
                     is LocalAttachmentContext.Image -> "image/jpeg"
                 }
+                // Fabricate a previewThumbnail so MediaItem can compute the aspect ratio
+                // (it reads pixelWidth/pixelHeight off the descriptor). Real pixel values
+                // don't matter — only the ratio does.
+                val aspectDescriptor = ctx.aspectRatio?.let { ratio ->
+                    val w = 1000
+                    val h = (w / ratio).toInt().coerceAtLeast(1)
+                    ThumbnailDescriptor(pixelWidth = w, pixelHeight = h)
+                }
                 PayloadDescriptor(
                     key = payloadKey,
                     contentType = contentType,
                     iv = null,
+                    previewThumbnail = aspectDescriptor,
                 )
             }
     }

--- a/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.native.kt
+++ b/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.native.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.viewinterop.UIKitView
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.drives.files.DriveFileProvider
+import id.homebase.api.crypto.AesCbc
 import id.homebase.api.video.VideoContent
 import id.homebase.api.video.VideoPlayerData
 import id.homebase.api.video.VideoPreloader
@@ -203,7 +204,11 @@ private class HomebaseResourceLoaderDelegate(
                     loadingRequest.dataRequest?.respondWithData(bytes.toNSData())
                     withContext(Dispatchers.Main) { loadingRequest.finishLoading() }
                 } else {
-                    // .ts segment — serve content info and/or byte-range data on demand
+                    // .ts segment — iOS asks for the exact byterange of one HLS segment from
+                    // the playlist. FFmpeg encrypted each segment independently (AES-CBC with
+                    // PKCS7 padding, keyHeader.iv as IV), so we decrypt standalone and zero-pad
+                    // the plaintext back up to `length` to honor Range semantics. AVPlayer's TS
+                    // parser resyncs past the trailing zeros on the next 0x47.
                     loadingRequest.contentInformationRequest?.let {
                         it.contentType = "public.mpeg-2-transport-stream"
                         it.contentLength = totalFileSize
@@ -218,16 +223,28 @@ private class HomebaseResourceLoaderDelegate(
                             dataRequest.requestedLength
                         }
                         Logger.d(tag = "VideoHLS") { "Fetching .ts chunk: start=$start, length=$length, totalFileSize=$totalFileSize" }
-                        val bytes = driveFileProvider!!.getPayloadBytesDecrypted(
+                        val encrypted = driveFileProvider!!.getPayloadBytesEncryptedChunk(
                             driveId = driveId!!,
                             fileId = fileId!!,
                             key = payloadKey!!,
-                            keyHeader = keyHeader!!,
                             chunkStart = start,
                             chunkLength = length,
-                        )?.bytes ?: throw Exception("Failed to fetch chunk at $start (length=$length)")
-                        Logger.d(tag = "VideoHLS") { "Got ${bytes.size} bytes for chunk at $start" }
-                        dataRequest.respondWithData(bytes.toNSData())
+                        ) ?: throw Exception("Failed to fetch chunk at $start (length=$length)")
+                        val plaintext = AesCbc.decrypt(
+                            cipherText = encrypted,
+                            key = keyHeader!!.aesKey,
+                            iv = keyHeader.iv,
+                        )
+                        val requested = length.toInt()
+                        val padded = if (plaintext.size >= requested) {
+                            plaintext.copyOfRange(0, requested)
+                        } else {
+                            ByteArray(requested).also { plaintext.copyInto(it, 0) }
+                        }
+                        Logger.d(tag = "VideoHLS") {
+                            "Segment decrypt: ${encrypted.size} cipher → ${plaintext.size} plain → ${padded.size} zero-padded at $start"
+                        }
+                        dataRequest.respondWithData(padded.toNSData())
                     }
                     withContext(Dispatchers.Main) { loadingRequest.finishLoading() }
                 }


### PR DESCRIPTION
…ch HLS segment on iOS as a standalone AES-CBC/PKCS7 blob (matching how FFmpeg

  actually encrypted them) instead of forcing them through the whole-file chunked-CBC path.