### PR TITLE
fix: deliver notification-tap navigation events on cold start

### DIFF
--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
@@ -18,10 +18,13 @@ import id.homebase.core.navigation.ActiveConversation
 import id.homebase.core.settings.UserPreferences
 import id.homebase.core.util.Platform
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import kotlin.random.Random
@@ -61,8 +64,11 @@ class NotificationService(
     private val ALERT_COOLDOWN = 15.minutes
     private var lastAlertMark = TimeSource.Monotonic.markNow() - ALERT_COOLDOWN
 
-    private val _navigationEvents = MutableSharedFlow<NotificationNavigationEvent>(extraBufferCapacity = 5)
-    val navigationEvents: SharedFlow<NotificationNavigationEvent> = _navigationEvents.asSharedFlow()
+    // Channel (not SharedFlow) so a notification tap on cold start is queued until the
+    // UI collector attaches, rather than dropped (MutableSharedFlow with replay=0 discards
+    // emissions that happen before the first subscriber subscribes).
+    private val _navigationEvents = Channel<NotificationNavigationEvent>(Channel.BUFFERED)
+    val navigationEvents: Flow<NotificationNavigationEvent> = _navigationEvents.receiveAsFlow()
 
     private val _inAppNotificationEvents =
         MutableSharedFlow<RichNotificationData>(extraBufferCapacity = 1)
@@ -431,7 +437,7 @@ class NotificationService(
             }
 
             if (event != null) {
-                _navigationEvents.tryEmit(event)
+                _navigationEvents.trySend(event)
             }
         } catch (e: Exception) {
             Logger.e(tag = "NotificationService") {
@@ -442,7 +448,7 @@ class NotificationService(
 
     /** Navigate to a specific conversation (used for deep links and share shortcuts). */
     fun navigateToConversation(conversationId: String) {
-        _navigationEvents.tryEmit(NotificationNavigationEvent.OpenConversation(conversationId))
+        _navigationEvents.trySend(NotificationNavigationEvent.OpenConversation(conversationId))
     }
 
     /** Displays a rich notification using platform-specific APIs. */

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppViewModel.kt
@@ -17,12 +17,12 @@ import id.homebase.core.share.ShareContentProcessor
 import id.homebase.core.share.registerShareHandler
 import id.homebase.core.share.unregisterShareHandler
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.coroutines.cancellation.CancellationException
@@ -37,9 +37,11 @@ class AppViewModel(
     private val _uiState = MutableStateFlow(AppUiState())
     val uiState: StateFlow<AppUiState> = _uiState.asStateFlow()
 
-    private val _navigationEvents =
-        MutableSharedFlow<NotificationNavigationEvent>(extraBufferCapacity = 5)
-    val navigationEvents: SharedFlow<NotificationNavigationEvent> = _navigationEvents.asSharedFlow()
+    // Channel (not SharedFlow) so events forwarded from NotificationService are queued until
+    // AppNavHost's collector attaches. A SharedFlow with replay=0 would drop events emitted
+    // before the first subscriber — e.g. a notification tap processed during cold start.
+    private val _navigationEvents = Channel<NotificationNavigationEvent>(Channel.BUFFERED)
+    val navigationEvents: Flow<NotificationNavigationEvent> = _navigationEvents.receiveAsFlow()
 
     private var credentialsJob: Job? = null
     private var listenForConnectionRequestsJob: Job? = null
@@ -86,7 +88,7 @@ class AppViewModel(
     private fun collectNotificationEvents() {
         viewModelScope.launch {
             notificationService.navigationEvents.collect { event ->
-                _navigationEvents.tryEmit(event)
+                _navigationEvents.trySend(event)
             }
         }
         viewModelScope.launch {
@@ -115,7 +117,7 @@ class AppViewModel(
         Logger.i(tag = "AppViewModel") { "Handling share intent for conversation: $conversationId" }
         val pending = shareContentProcessor.readPendingContent()
         if (pending != null) {
-            _navigationEvents.tryEmit(NotificationNavigationEvent.OpenConversation(conversationId))
+            _navigationEvents.trySend(NotificationNavigationEvent.OpenConversation(conversationId))
         } else {
             Logger.w(tag = "AppViewModel") { "No pending shared content found for conversation: $conversationId" }
         }


### PR DESCRIPTION
Tapping an Android push notification while the app was cold-starting landed on the conversation overview instead of the target conversation. The log showed the intent arriving (`MainActivity: Notification intent detected`) but no subsequent `Navigating to detail for <id>` entry.

Root cause: both `NotificationService._navigationEvents` and `AppViewModel._navigationEvents` were `MutableSharedFlow(replay = 0)`. `MainActivity.handleNotificationIntent` runs synchronously in onCreate and emits the event before `AppViewModel.init` subscribes to the service flow, and before `AppNavHost`'s `LaunchedEffect(Unit)` subscribes to the ViewModel flow. With replay=0, emissions that predate the first subscriber are silently dropped — so the event was lost at one of the two layers every cold start.

Replace both flows with `Channel<NotificationNavigationEvent>(BUFFERED) .receiveAsFlow()`. A Channel queues emissions until a collector attaches and delivers each event exactly once, which is the right semantic for a fire-once navigation intent. `receiveAsFlow` is single-consumer, matching the one-collector-per-flow topology we already have. Switches `tryEmit` → `trySend` at the three call sites.