### PR TITLE
fix: restore tap-to-open on sent media and 4th gallery cell

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaGallery.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaGallery.kt
@@ -3,7 +3,6 @@ package id.homebase.chat.widget
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -323,12 +322,7 @@ private fun FourPlusImageLayout(
             )
 
             // Fourth image with optional overlay
-            Box(
-                modifier =
-                    Modifier.weight(1f).fillMaxSize().clickable {
-                        onMediaClick?.invoke(payloads[3])
-                    },
-            ) {
+            Box(modifier = Modifier.weight(1f).fillMaxSize()) {
                 MediaItem(
                     payload = payloads[3],
                     fileId = fileId,
@@ -338,7 +332,7 @@ private fun FourPlusImageLayout(
                     modifier = Modifier.fillMaxSize(),
                     imageSize = ImageSize.THUMB_SMALL,
                     shape = RectangleShape,
-                    onClick = null, // Handled by parent Box
+                    onClick = { onMediaClick?.invoke(payloads[3]) },
                     onLongPress = { offset -> onMediaLongPress?.invoke(payloads[3], offset) },
                     sharedTransitionScope = sharedTransitionScope,
                     animatedVisibilityScope = animatedVisibilityScope,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -29,6 +30,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -185,10 +187,20 @@ fun MediaItem(
         contentType.startsWith("image/") -> {
             val imageLocalContext = localContext as? LocalAttachmentContext.Image
             if (imageLocalContext != null) {
+                val gestureModifier = if (onClick != null || onLongPress != null) {
+                    finalModifier.pointerInput(onClick, onLongPress) {
+                        detectTapGestures(
+                            onTap = { onClick?.invoke() },
+                            onLongPress = { offset -> onLongPress?.invoke(offset) },
+                        )
+                    }
+                } else {
+                    finalModifier
+                }
                 AsyncImage(
                     model = imageLocalContext.localFilePath,
                     contentDescription = stringResource(MR.string.chat_message_image_attachment),
-                    modifier = finalModifier,
+                    modifier = gestureModifier,
                     contentScale = imageContentScale,
                 )
             } else {
@@ -286,10 +298,21 @@ fun MediaItem(
                             videoLocalContext.thumbnailBytes.toImageBitmap()
                         }
                         if (uploadBitmap != null) {
+                            val thumbBaseModifier = Modifier.fillMaxSize()
+                            val thumbModifier = if (onClick != null || onLongPress != null) {
+                                thumbBaseModifier.pointerInput(onClick, onLongPress) {
+                                    detectTapGestures(
+                                        onTap = { onClick?.invoke() },
+                                        onLongPress = { offset -> onLongPress?.invoke(offset) },
+                                    )
+                                }
+                            } else {
+                                thumbBaseModifier
+                            }
                             Image(
                                 bitmap = uploadBitmap,
                                 contentDescription = stringResource(MR.string.chat_message_video_thumbnail),
-                                modifier = Modifier.fillMaxSize(),
+                                modifier = thumbModifier,
                                 contentScale = ContentScale.Crop,
                             )
                         }


### PR DESCRIPTION
Two regressions from the multi-item send refactor (79405dc9) left media untappable in the chat bubble:

1) LocalAttachmentContext fast-path had no gesture wiring.
   LocalAttachmentContextStore keeps the local preview for the whole app
   session after upload, so every message sent in a session renders
   through that branch. The image branch (AsyncImage) and the video
   branch (Image(bitmap=...)) never installed onClick/onLongPress, so
   tapping a just-sent image or video did nothing. Added
   pointerInput + detectTapGestures to both, matching HomebaseImage.

2) 4th cell in FourPlusImageLayout swallowed taps.
   The cell wrapped MediaItem in a Box.clickable and passed onClick=null
   but a non-null onLongPress. HomebaseImage installs detectTapGestures
   whenever either callback is non-null, so the child consumed the tap
   (invoking a null onClick) and the outer Box.clickable never fired.
   Dropped the outer clickable and wired onClick on the MediaItem itself
   like cells 1-3. Removed the now-unused clickable import.

Cells 1-3 were fine because they already pass onClick through to MediaItem's gesture path.