### PR TITLE
perf: reduce log noise in conversation list load path

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/ChatReadCountWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/ChatReadCountWrapper.kt
@@ -70,10 +70,10 @@ class ChatReadCountWrapper(
         val result = list.mapIndexed { index, it ->
 
             try {
-                logger.d {
-                    "Mapping row[$index] | convSize=${it.convJsonHeader.length} " +
-                            "hasMsg=${it.msgJsonHeader != null}"
-                }
+//                logger.d {
+//                    "Mapping row[$index] | convSize=${it.convJsonHeader.length} " +
+//                            "hasMsg=${it.msgJsonHeader != null}"
+//                }
 
                 val conversation =
                     OdinSystemSerializer.deserialize<HomebaseFile>(it.convJsonHeader)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -479,8 +479,10 @@ class ChatMessageStream(
                             authorSpecificDate
                         } else {
                             if (appData.userDate == null) {
-                                Logger.w { "Message (uid: ${appData.uniqueId}) with no version and not edited has null userDate. using authorSpecificDate" }
-                                Logger.w { "See File here: https://${domain}/owner/drives/9ff813aff2d61e2f9b9db189e72d1a11_66ea8355ae4155c39b5a719166b510e3/${appData.uniqueId}" }
+                                Logger.w {
+                                    "Message (uid: ${appData.uniqueId}) with no version and not edited has null userDate. " +
+                                        "using authorSpecificDate. See file: https://${domain}/owner/drives/9ff813aff2d61e2f9b9db189e72d1a11_66ea8355ae4155c39b5a719166b510e3/${appData.uniqueId}"
+                                }
                                 authorSpecificDate
                             } else
                                 UnixTimeUtc(appData.userDate!!)


### PR DESCRIPTION
The conversation list query emitted a per-row Debug log inside selectAllConversationPlusLastMessage(...). Kermit's file sink is configured at Severity.Verbose and writes synchronously, so ~180 rows produced ~180 formatted strings + 180 file writes on the query dispatcher before the list could render, contributing to visible UI jitter when opening the chat list. The surrounding "Fetched rows=N in Nms" summary already provides the same diagnostic signal, so the per-row log is commented out.

Also collapses the paired "null userDate" + "See File here" Warn lines in ChatMessageStream into a single Warn so anomalous messages produce one log entry instead of two.