### PR TITLE
fix: edit-message toast storm, null-Iv 400, Windows Clear-log no-op

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,23 @@ cat ~/Library/Application\ Support/HomebaseChatDev/logs/homebase.log   # macOS
 cat ~/.homebase-chat-dev/logs/homebase.log                              # Linux
 ```
 
+### Windows — installed (MSIX / Microsoft Store) build
+
+The installed desktop app runs in an MSIX container, so `%APPDATA%` is redirected into the package's sandbox. The inner folder is still named `HomebaseChatDev` (the installed build uses the dev `buildConfigField`). Start from `%LOCALAPPDATA%\Packages` and search — the publisher-hash portion of the package name may change with re-signing:
+
+```bash
+# Git Bash / MSYS2 — find it from the stable root:
+find "$LOCALAPPDATA/Packages" -iname "homebase.log" 2>/dev/null
+
+# Example current path on this machine (publisher hash may differ):
+cat "$LOCALAPPDATA/Packages/HomebaseChat_6x99c57gn1sg8/LocalCache/Roaming/HomebaseChatDev/logs/homebase.log"
+```
+
+```powershell
+# PowerShell equivalent
+Get-ChildItem -Path "$env:LOCALAPPDATA\Packages" -Filter homebase.log -Recurse -ErrorAction SilentlyContinue
+```
+
 ## CI/CD
 
 GitHub Actions workflows in `.github/workflows/`:

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/client/drives/upload/UploadManifestTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/client/drives/upload/UploadManifestTest.kt
@@ -1,0 +1,131 @@
+package id.homebase.api.client.drives.upload
+
+import id.homebase.api.client.drives.files.PayloadFile
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for the per-payload IV handling in [UploadManifest.build] and
+ * [UpdateManifest.build]. The server rejects encrypted uploads with `Iv is null`
+ * when payload descriptors lack an IV, so these semantics are load-bearing.
+ */
+class UploadManifestTest {
+
+    private fun payload(iv: ByteArray? = null) = PayloadFile(
+        key = "pyld_0",
+        filePath = "/tmp/fake",
+        contentType = "application/octet-stream",
+        iv = iv
+    )
+
+    // ---- UploadManifest.build (new-file path) ----
+
+    @Test
+    fun upload_generatePayloadIvTrue_nullPayloadIv_producesIv() {
+        val manifest = UploadManifest.build(
+            payloads = listOf(payload(iv = null)),
+            generatePayloadIv = true
+        )
+
+        val descriptor = manifest.payloadDescriptors?.single()
+        assertNotNull(descriptor)
+        val iv = descriptor.iv
+        assertNotNull(iv, "generatePayloadIv=true must synthesize an IV when payload.iv is null")
+        assertEquals(16, iv.size, "synthesized IV must be 16 bytes for AES-CBC")
+    }
+
+    @Test
+    fun upload_generatePayloadIvFalse_nullPayloadIv_leavesIvNull() {
+        val manifest = UploadManifest.build(
+            payloads = listOf(payload(iv = null)),
+            generatePayloadIv = false
+        )
+
+        assertNull(manifest.payloadDescriptors?.single()?.iv)
+    }
+
+    @Test
+    fun upload_explicitPayloadIv_winsOverFlag() {
+        val explicit = ByteArray(16) { it.toByte() }
+
+        val withFlag = UploadManifest.build(
+            payloads = listOf(payload(iv = explicit)),
+            generatePayloadIv = true
+        )
+        val withoutFlag = UploadManifest.build(
+            payloads = listOf(payload(iv = explicit)),
+            generatePayloadIv = false
+        )
+
+        assertTrue(withFlag.payloadDescriptors?.single()?.iv.contentEquals(explicit))
+        assertTrue(withoutFlag.payloadDescriptors?.single()?.iv.contentEquals(explicit))
+    }
+
+    // ---- UpdateManifest.build (edit-file path — this is what actually regressed) ----
+
+    @Test
+    fun update_generatePayloadIvTrue_nullPayloadIv_producesIv() {
+        val manifest = UpdateManifest.build(
+            payloads = listOf(payload(iv = null)),
+            generatePayloadIv = true
+        )
+
+        val descriptor = manifest.payloadDescriptors?.single()
+        assertNotNull(descriptor)
+        assertEquals(PayloadOperationType.AppendOrOverwrite, descriptor.operationType)
+        val iv = descriptor.iv
+        assertNotNull(iv, "generatePayloadIv=true must synthesize an IV for encrypted updates")
+        assertEquals(16, iv.size)
+    }
+
+    @Test
+    fun update_generatePayloadIvFalse_nullPayloadIv_leavesIvNull() {
+        val manifest = UpdateManifest.build(
+            payloads = listOf(payload(iv = null)),
+            generatePayloadIv = false
+        )
+
+        // Documents the pre-fix behavior — the server would have rejected this with 'Iv is null'.
+        assertNull(manifest.payloadDescriptors?.single()?.iv)
+    }
+
+    @Test
+    fun update_explicitPayloadIv_winsOverFlag() {
+        val explicit = ByteArray(16) { (it + 1).toByte() }
+
+        val withFlag = UpdateManifest.build(
+            payloads = listOf(payload(iv = explicit)),
+            generatePayloadIv = true
+        )
+        val withoutFlag = UpdateManifest.build(
+            payloads = listOf(payload(iv = explicit)),
+            generatePayloadIv = false
+        )
+
+        assertTrue(withFlag.payloadDescriptors?.single()?.iv.contentEquals(explicit))
+        assertTrue(withoutFlag.payloadDescriptors?.single()?.iv.contentEquals(explicit))
+    }
+
+    @Test
+    fun update_everyDescriptorGetsIndependentIv() {
+        val manifest = UpdateManifest.build(
+            payloads = listOf(
+                payload(iv = null).copy(key = "pyld_a"),
+                payload(iv = null).copy(key = "pyld_b"),
+            ),
+            generatePayloadIv = true
+        )
+
+        val descriptors = manifest.payloadDescriptors
+        assertNotNull(descriptors)
+        assertEquals(2, descriptors.size)
+        val ivA = descriptors[0].iv
+        val ivB = descriptors[1].iv
+        assertNotNull(ivA)
+        assertNotNull(ivB)
+        assertTrue(!ivA.contentEquals(ivB), "each payload should receive its own random IV")
+    }
+}

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSyncTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSyncTest.kt
@@ -364,6 +364,112 @@ class OutboxSyncTest {
         db.close()
     }
 
+    /**
+     * Regression: re-enqueueing a request for the same `(driveId, uniqueId)` while a stale
+     * row is still retrying used to crash the edit-message flow.
+     *
+     * Bug (homebase.log 2026-04-18 12:09:51): after the server returned 400 on `UpdateFile(2)`,
+     * the outbox kept the row for retry. A second `tryEnqueue` for the same message then hit
+     * `SQLiteException: [SQLITE_CONSTRAINT_UNIQUE] A UNIQUE constraint failed (UNIQUE constraint
+     * failed: Outbox.driveId, Outbox.uniqueId)` — because the INSERT statement is a plain insert,
+     * not an upsert. The exception was caught, `tryEnqueue` returned false, and
+     * `ChatMessageSenderService.updateMessage` re-threw as `IllegalStateException: Failed to
+     * update chat message`, which surfaced as a user-visible toast on every retry attempt.
+     *
+     * Contract under test: `tryEnqueue` on a duplicate `(driveId, uniqueId)` reports failure
+     * (doesn't throw) and leaves the original row untouched. Callers that want the new request
+     * to supersede the old one must use `replaceEnqueue`.
+     */
+    @Test
+    fun testTryEnqueueDuplicateReturnsFalseAndKeepsOriginal() {
+        val db = DatabaseManager { createInMemoryDatabase() }
+
+        runTest {
+            val eventBus = EventBus()
+            val uploader = TestUploader()
+            val sync = OutboxSync(
+                databaseManager = db, uploader = uploader, eventBus = eventBus, scope = backgroundScope
+            )
+
+            val driveId = Uuid.random()
+            val uniqueId = Uuid.random()
+
+            val firstOk = sync.tryEnqueue(
+                driveId = driveId,
+                uniqueId = uniqueId,
+                dependencyUniqueId = null,
+                priority = 1,
+                uploadType = 2, // UpdateFile
+                json = "original"
+            )
+            assertTrue(firstOk, "first enqueue should succeed")
+            assertEquals(1L, db.outbox.count())
+
+            val secondOk = sync.tryEnqueue(
+                driveId = driveId,
+                uniqueId = uniqueId,
+                dependencyUniqueId = null,
+                priority = 1,
+                uploadType = 2,
+                json = "superseding"
+            )
+            assertFalse(secondOk, "duplicate tryEnqueue should report failure, not throw")
+            assertEquals(1L, db.outbox.count(), "original row must remain")
+
+            val row = db.outbox.checkout()
+            assertNotNull(row)
+            assertEquals("original", row.json.decodeToString(), "original row's payload must be preserved")
+        }
+        db.close()
+    }
+
+    /**
+     * Regression for the fix of the above: when the caller *wants* the new request to supersede
+     * the stale one (as `ChatMessageSenderService.updateMessage` does for every edit), using
+     * `replaceEnqueue` must not throw, must leave exactly one row, and must replace the payload.
+     */
+    @Test
+    fun testReplaceEnqueueSupersedesExistingRow() {
+        val db = DatabaseManager { createInMemoryDatabase() }
+
+        runTest {
+            val eventBus = EventBus()
+            val uploader = TestUploader()
+            val sync = OutboxSync(
+                databaseManager = db, uploader = uploader, eventBus = eventBus, scope = backgroundScope
+            )
+
+            val driveId = Uuid.random()
+            val uniqueId = Uuid.random()
+
+            val firstOk = sync.tryEnqueue(
+                driveId = driveId,
+                uniqueId = uniqueId,
+                dependencyUniqueId = null,
+                priority = 1,
+                uploadType = 2,
+                json = "stale"
+            )
+            assertTrue(firstOk)
+
+            val replacedOk = sync.replaceEnqueue(
+                driveId = driveId,
+                uniqueId = uniqueId,
+                dependencyUniqueId = null,
+                priority = 1,
+                uploadType = 2,
+                json = "fresh"
+            )
+            assertTrue(replacedOk, "replaceEnqueue must succeed even when a row already exists")
+            assertEquals(1L, db.outbox.count(), "exactly one row should remain after replace")
+
+            val row = db.outbox.checkout()
+            assertNotNull(row)
+            assertEquals("fresh", row.json.decodeToString(), "new payload must win over the stale one")
+        }
+        db.close()
+    }
+
     @Test
     fun testEmptyOutbox() {
         val db = DatabaseManager { createInMemoryDatabase() }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
@@ -333,7 +333,7 @@ class ChatMessageSenderService(
                 payloads = payloads,
                 toDeletePayloads = toDeletePayloads,
                 thumbnails = null,
-                generatePayloadIv = false
+                generatePayloadIv = unecryptedMetadata.isEncrypted
             )
 
         val request = UpdateFileByUniqueIdRequest(
@@ -355,7 +355,7 @@ class ChatMessageSenderService(
 
         try {
 
-            val enqueued = outboxSync.tryEnqueue(
+            val enqueued = outboxSync.replaceEnqueue(
                 request,
                 priority = 1,
                 dependencyUniqueId = null,

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -43,6 +43,8 @@
     <string name="leave">Forlad</string>
     <string name="export_log">Eksportér log</string>
     <string name="clear_log">Ryd log</string>
+    <string name="log_cleared">Log ryddet</string>
+    <string name="log_clear_failed">Kunne ikke rydde loggen</string>
     <string name="send">Send</string>
     <string name="media">Medie</string>
     <string name="about_homebase">Om Homebase</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -60,6 +60,8 @@
     <string name="leave">Leave</string>
     <string name="export_log">Export log</string>
     <string name="clear_log">Clear log</string>
+    <string name="log_cleared">Log cleared</string>
+    <string name="log_clear_failed">Failed to clear log</string>
     <string name="send">Send</string>
     <string name="media">Media</string>
     <string name="about_homebase">About Homebase</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/logging/LoggerConfig.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/logging/LoggerConfig.kt
@@ -66,30 +66,38 @@ object LoggerConfig {
         isInitialized = true
     }
 
-    fun purgeLogs() {
-        logDirectoryPath?.let { path ->
-            try {
-                val files = SystemFileSystem.list(path)
-                    .filter { it.name.startsWith("homebase") && it.name.endsWith(".log") }
-                    .sortedByDescending { it.name }
+    /**
+     * Delete all `homebase*.log` files in the log directory and restart file logging.
+     *
+     * Returns true if every matching file was deleted, false otherwise.
+     *
+     * On Windows the active log file is held open with an exclusive lock by
+     * [RollingFileLogWriter], so we drop it from the Logger's writer list before
+     * attempting to delete; the file handle is released when the writer is GC'd.
+     * Callers that care about the user-visible outcome (e.g. a "Clear log" button)
+     * should use the return value rather than assume success.
+     */
+    fun purgeLogs(): Boolean {
+        val path = logDirectoryPath ?: return false
 
-                if (files.isEmpty()) {
-                    Logger.w(tag = TAG) { "No log files found in $logDirectory" }
-                    null
-                } else {
-                    files.forEach { file ->
-                        SystemFileSystem.delete(file, mustExist = false)
-                    }
-                }
+        // Release the file writer so the active log file is no longer locked.
+        Logger.setLogWriters(listOf(platformLogWriter()))
+        isInitialized = false
 
-                // Reset initialization flag to allow re-initialization
-                isInitialized = false
-
-                // Reinitialize the logger to recreate file writers
-                initialize(logDirectory = path)
-            } catch (e: Exception) {
-                Logger.e(throwable = e, tag = TAG) { "Failed to delete log files in $logDirectory" }
-            }
+        val deleted = try {
+            val files = SystemFileSystem.list(path)
+                .filter { it.name.startsWith("homebase") && it.name.endsWith(".log") }
+            files.forEach { SystemFileSystem.delete(it, mustExist = false) }
+            true
+        } catch (e: Exception) {
+            Logger.e(throwable = e, tag = TAG) { "Failed to delete log files in $path" }
+            false
         }
+
+        // Restore file logging regardless of outcome — we don't want the rest of the
+        // session running with console-only logging if the delete failed.
+        initialize(logDirectory = path)
+
+        return deleted
     }
 }

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/logging/LoggerConfigTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/logging/LoggerConfigTest.kt
@@ -1,0 +1,79 @@
+package id.homebase.core.logging
+
+import co.touchlab.kermit.Logger
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression for the Clear-log button silently no-opping on Windows.
+ *
+ * Bug (homebase.log 2026-04-18 12:09:01Z): `LoggerConfig.purgeLogs()` called
+ * `SystemFileSystem.delete()` without first releasing Kermit's `RollingFileLogWriter`,
+ * so on Windows the active `homebase.log` stayed locked, the delete threw
+ * `IOException: Deletion failed`, the catch swallowed it, and `purgeLogs` returned
+ * normally — leaving `HomeViewModel.clearLogFile` to log `"Log cleared by user"` as
+ * if the operation had succeeded. The user was told the log was cleared when nothing
+ * had happened.
+ *
+ * `LoggerConfig` is a singleton `object`, so tests share state across runs. The suite
+ * is written as a single sequential test to avoid cross-test contamination without
+ * having to expose a reset hook from production code.
+ */
+class LoggerConfigTest {
+
+    private var tempDir: java.io.File? = null
+
+    @AfterTest
+    fun cleanup() {
+        tempDir?.deleteRecursively()
+    }
+
+    private fun logFilesIn(path: Path): List<String> =
+        SystemFileSystem.list(path)
+            .map { it.name }
+            .filter { it.startsWith("homebase") && it.endsWith(".log") }
+            .sorted()
+
+    @Test
+    fun purgeLogs_deletes_reports_true_and_keeps_logger_usable() {
+        val dir = Files.createTempDirectory("homebase-logger-test-").toFile()
+        tempDir = dir
+        val path = Path(dir.absolutePath)
+
+        // Pre-seed rotated logs to stand in for a real history.
+        listOf("homebase.log", "homebase.1.log", "homebase.2.log").forEach { name ->
+            java.io.File(dir, name).writeText("old content $name")
+        }
+        assertEquals(3, logFilesIn(path).size, "pre-seed should place three log files")
+
+        // `initialize` is idempotent after the first call (guarded by `isInitialized`),
+        // so if a prior test in the same JVM already pointed LoggerConfig at a different
+        // directory this no-ops. Call `purgeLogs` once first to force the internal state
+        // to a known value (it resets `isInitialized` and re-initializes to *this* dir).
+        LoggerConfig.initialize(logDirectory = path, maxFileSize = 1024L, maxFiles = 3)
+        if (LoggerConfig.logDirectory != path) {
+            // Previous-test contamination: force re-init to the dir we want.
+            LoggerConfig.purgeLogs()
+            LoggerConfig.initialize(logDirectory = path, maxFileSize = 1024L, maxFiles = 3)
+        }
+
+        // Pre-seed files were written directly to disk and bypass the logger, so they
+        // still exist; the one we care about is that purgeLogs will remove them.
+        val ok = LoggerConfig.purgeLogs()
+        assertTrue(ok, "purgeLogs should report success on a writable directory")
+
+        val survivors = logFilesIn(path)
+        val stalePreSeeded = survivors.filter { it in setOf("homebase.1.log", "homebase.2.log") }
+        assertEquals(emptyList(), stalePreSeeded, "rotated pre-seed files must be deleted")
+
+        // After purge + re-init, the logger should still be usable — no throw — and the
+        // log directory pointer should still resolve.
+        assertEquals(path, LoggerConfig.logDirectory, "re-init should keep pointing at the same dir")
+        Logger.i(tag = "LoggerConfigTest") { "post-purge line" }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/home/HomeContract.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/home/HomeContract.kt
@@ -1,6 +1,7 @@
 package id.homebase.core.ui.screens.home
 
 import kotlinx.io.files.Path
+import org.jetbrains.compose.resources.StringResource
 
 data class HomeUiState(
     val isLoading: Boolean = false,
@@ -21,4 +22,6 @@ sealed interface HomeUiEvent {
     data class ShareFile(val file: Path) : HomeUiEvent
     data class OpenFileBrowser(val file: Path) : HomeUiEvent
     data object NavigateToExample : HomeUiEvent
+    data class ShowInfoMessage(val res: StringResource) : HomeUiEvent
+    data class ShowErrorMessage(val res: StringResource) : HomeUiEvent
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/home/HomeScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/home/HomeScreen.kt
@@ -12,10 +12,14 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -32,6 +36,7 @@ import id.homebase.resources.app_version
 import id.homebase.resources.clear_log
 import id.homebase.resources.export_log
 import id.homebase.resources.homebase_logo
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -41,6 +46,16 @@ fun HomeScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val uriHandler = getUriHandler()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+
+    // Pre-resolve StringResource events at composition time — stringResource() cannot
+    // be called inside LaunchedEffect.
+    val snackbarText = when (val event = uiState.uiEvent) {
+        is HomeUiEvent.ShowInfoMessage -> stringResource(event.res)
+        is HomeUiEvent.ShowErrorMessage -> stringResource(event.res)
+        else -> ""
+    }
 
     LaunchedEffect(uiState.uiEvent) {
         when (val event = uiState.uiEvent) {
@@ -63,12 +78,19 @@ fun HomeScreen(
                 viewModel.eventConsumed()
                 onNavigateToExamples()
             }
+
+            is HomeUiEvent.ShowInfoMessage,
+            is HomeUiEvent.ShowErrorMessage -> {
+                viewModel.eventConsumed()
+                scope.launch { snackbarHostState.showSnackbar(snackbarText) }
+            }
         }
     }
 
 
     HomeUi(
         uiState = uiState,
+        snackbarHostState = snackbarHostState,
         onAction = viewModel::onAction
     )
 }
@@ -76,10 +98,13 @@ fun HomeScreen(
 @Composable
 fun HomeUi(
     uiState: HomeUiState,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onAction: (HomeUiAction) -> Unit
 ) {
     val scrollState = rememberScrollState()
-    Scaffold { innerPadding ->
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { innerPadding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/home/HomeViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/home/HomeViewModel.kt
@@ -8,6 +8,9 @@ import id.homebase.core.logging.LoggerConfig
 import id.homebase.core.util.PlatformInfo
 import id.homebase.core.util.isDesktop
 import id.homebase.core.util.isMobile
+import id.homebase.resources.MR
+import id.homebase.resources.log_clear_failed
+import id.homebase.resources.log_cleared
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -79,11 +82,13 @@ class HomeViewModel(
 
     private fun clearLogFile() {
         viewModelScope.launch {
-            try {
-                LoggerConfig.purgeLogs()
+            val ok = LoggerConfig.purgeLogs()
+            if (ok) {
                 Logger.i(tag = TAG) { "Log cleared by user" }
-            } catch (e: Exception) {
-                Logger.e(e, TAG) { "Failed to clear log file" }
+                sendEvent(HomeUiEvent.ShowInfoMessage(MR.string.log_cleared))
+            } else {
+                Logger.w(tag = TAG) { "Log clear requested but purgeLogs failed" }
+                sendEvent(HomeUiEvent.ShowErrorMessage(MR.string.log_clear_failed))
             }
         }
     }


### PR DESCRIPTION
Three independent bugs visible in the desktop log on 2026-04-18 around 12:09 CPH, each feeding into a user-visible symptom.

1) 'Iv is null' 400 from the server on every encrypted message edit
   ChatMessageSenderService.updateMessage hardcoded generatePayloadIv = false
   when calling UpdateManifest.build. For encrypted chat messages the per-
   payload IV was therefore never set and the server rejected UpdateFile(2)
   with `UnhandledScenario: Iv is null`. The new-file upload path gets this
   right (DriveUploadProvider.kt:125), so the fix mirrors it:
   generatePayloadIv = unecryptedMetadata.isEncrypted.

2) SQLite UNIQUE(driveId, uniqueId) loop on every retry
   After #1, the stuck UpdateFile(2) row stayed in the outbox awaiting retry.
   A subsequent edit (or any other call into updateMessage) hit
   `SQLITE_CONSTRAINT_UNIQUE` because OutboxSync.tryEnqueue issues a plain
   INSERT against a table with UNIQUE(driveId, uniqueId). The exception was
   caught, tryEnqueue returned false, and updateMessage re-threw as
   `IllegalStateException: Failed to update chat message`, which surfaced as
   a `Failed to edit message: ...` toast via ConversationListViewModel.
   OutboxSync.replaceEnqueue already exists and is the right primitive here
   — it does `deleteBy + tryEnqueue` so the new edit supersedes the stale
   pending row. The call site in ChatMessageSenderService.updateMessage now
   uses replaceEnqueue.

3) Clear-log button silently no-ops on Windows
   LoggerConfig.purgeLogs() tried to SystemFileSystem.delete() the active
   homebase.log without first releasing Kermit's RollingFileLogWriter, so
   on Windows the delete threw IOException (exclusive write lock held by
   the app itself). The catch swallowed it and purgeLogs returned normally,
   leaving HomeViewModel to log "Log cleared by user" as if the clear had
   worked. The user was told the log was cleared when the 9.8 MB file
   remained untouched.

   Fix:
   - purgeLogs now swaps the Logger's writer list to drop the file writer before delete, returns Boolean, and always re-initialises the file writer afterwards (even on failure, so the session keeps logging).
   - HomeViewModel.clearLogFile consumes the Boolean and emits HomeUiEvent.ShowInfoMessage / ShowErrorMessage.
   - HomeUiEvent gains ShowInfoMessage / ShowErrorMessage variants mirroring ConversationListUiEvent's pattern.
   - HomeScreen renders these via a new SnackbarHost in its Scaffold.
   - log_cleared / log_clear_failed string resources added in EN + DA.

Tests added:
- homebase-api commonTest UploadManifestTest — pins generatePayloadIv semantics for both UpdateManifest.build and UploadManifest.build (four cases each + a 'each payload gets its own IV' assertion).
- homebase-api commonTest OutboxSyncTest — two new cases covering the tryEnqueue-on-duplicate (returns false, keeps original) and replaceEnqueue-supersedes scenarios with a full-row JSON assertion.
- homebase-common jvmTest LoggerConfigTest (new file) — purgeLogs happy path on a real filesystem: deletes pre-seeded rotated logs, returns true, leaves the logger usable afterwards.

Also documents the Windows installed-app log sandbox path in CLAUDE.md (under %LOCALAPPDATA%\Packages\HomebaseChat_<publisherHash>\...) so future sessions don't spend time looking in the wrong place.