### PR TITLE
fix: warm notification tap stuck on previous conversation

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -405,9 +405,16 @@ fun ConversationListUi(
     var lastNavigatedConversationId by remember { mutableStateOf<Uuid?>(null) }
     LaunchedEffect(uiState.selectedConversationId) {
         val selectedId = uiState.selectedConversationId
-        if (selectedId != null && selectedId != lastNavigatedConversationId && scaffoldDirective.maxHorizontalPartitions == 1) {
+        if (selectedId != null && selectedId != lastNavigatedConversationId) {
             Logger.i(tag = "ConversationListUi") { "Restore detail pane for $selectedId" }
             lastNavigatedConversationId = selectedId
+            val cur = scaffoldNavigator.currentDestination
+            // If we're already on Detail with a stale contentKey (e.g. warm notification
+            // tap while viewing a different conversation), pop first so navigateTo
+            // actually updates the content key rather than being treated as a no-op.
+            if (cur?.pane == ListDetailPaneScaffoldRole.Detail && cur.contentKey != selectedId) {
+                scaffoldNavigator.navigateBack()
+            }
             scaffoldNavigator.navigateTo(ListDetailPaneScaffoldRole.Detail, selectedId)
         } else if (selectedId == null) {
             lastNavigatedConversationId = null


### PR DESCRIPTION
Follow-up to PR #314 (fix-notification-tap-navigation-drop). That PR fixed the cold-start case where a notification tap was dropped because MutableSharedFlow(replay=0) discarded the emission before any subscriber attached. It did not fix the warm case, where the app is already running on another conversation.

Symptom: open Todd's conversation, receive and tap a push from Shelly — the app stays on Todd's conversation instead of switching to Shelly's. Reproduced on Android phone.

Root cause: on a notification tap the chain runs
  NotificationService → AppViewModel → AppNavHost
                   → savedStateHandle["pendingConversationId"]
                   → ConversationListViewModel.selectConversation
                   → uiState.selectedConversationId = shelly
                   → LaunchedEffect(uiState.selectedConversationId)
                   → scaffoldNavigator.navigateTo(Detail, shelly)
The last step is a no-op when the ListDetailPaneScaffoldNavigator is already sitting at Detail with contentKey = todd — the scaffold keeps the stale content key, so the detailPane continues to resolve Todd's conversation from activeConversations.

Fix: in ConversationListUi's LaunchedEffect(selectedConversationId), detect the stale-contentKey case and call navigateBack() before navigateTo() so the destination is actually replaced. Also drop the maxHorizontalPartitions == 1 gate so the correction also runs in desktop two-pane layouts (where the detailPane likewise renders from scaffoldNavigator.currentDestination.contentKey). The existing lastNavigatedConversationId guard still prevents list refreshes from pushing the user back into the detail pane.

PR #314's Channel(BUFFERED).receiveAsFlow() change remains correct for the cold-start path and is not touched here.