### PR TITLE
fix: compact warm notification tap lands on empty detail pane

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -390,36 +390,14 @@ fun ConversationListUi(
     // Notify parent about detail pane visibility in compact view
     LaunchedEffect(showingOnlyDetail) { onDetailPaneVisibilityChanged(showingOnlyDetail) }
 
-    // Clear selectedConversationId when user navigates back to list in compact mode
-    // This ensures that when returning to the screen, it shows the list instead of detail
-    LaunchedEffect(isListPaneHidden, isDetailPaneVisible) {
-        if (scaffoldDirective.maxHorizontalPartitions == 1 && !isListPaneHidden && !isDetailPaneVisible && uiState.selectedConversationId != null) {
-            // User is back on list in compact mode, clear the selection
-            onUiAction(ConversationListUiAction.ClearSelection)
-        }
-    }
-
-    // Navigate to detail pane only when selectedConversationId changes to a NEW value.
-    // Without tracking, list refreshes can re-emit the same ID and push the user
-    // back into the detail pane after they navigated away.
-    var lastNavigatedConversationId by remember { mutableStateOf<Uuid?>(null) }
-    LaunchedEffect(uiState.selectedConversationId) {
-        val selectedId = uiState.selectedConversationId
-        if (selectedId != null && selectedId != lastNavigatedConversationId) {
-            Logger.i(tag = "ConversationListUi") { "Restore detail pane for $selectedId" }
-            lastNavigatedConversationId = selectedId
-            val cur = scaffoldNavigator.currentDestination
-            // If we're already on Detail with a stale contentKey (e.g. warm notification
-            // tap while viewing a different conversation), pop first so navigateTo
-            // actually updates the content key rather than being treated as a no-op.
-            if (cur?.pane == ListDetailPaneScaffoldRole.Detail && cur.contentKey != selectedId) {
-                scaffoldNavigator.navigateBack()
-            }
-            scaffoldNavigator.navigateTo(ListDetailPaneScaffoldRole.Detail, selectedId)
-        } else if (selectedId == null) {
-            lastNavigatedConversationId = null
-        }
-    }
+    // Installs the coupled cleanup + swap effects that drive notification-tap navigation.
+    // See NotificationNavigationEffects.kt for why the two effects must be coordinated.
+    NotificationNavigationEffects(
+        scaffoldNavigator = scaffoldNavigator,
+        selectedConversationId = uiState.selectedConversationId,
+        scaffoldDirective = scaffoldDirective,
+        onClearSelection = { onUiAction(ConversationListUiAction.ClearSelection) },
+    )
 
     @Suppress("DEPRECATION") BackHandler(scaffoldNavigator.canNavigateBack(BackNavigationBehavior.PopUntilContentChange)) {
         scope.launch {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/NotificationNavigationEffects.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/NotificationNavigationEffects.kt
@@ -1,0 +1,78 @@
+package id.homebase.chat.conversationlist
+
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
+import androidx.compose.material3.adaptive.layout.PaneAdaptedValue
+import androidx.compose.material3.adaptive.layout.PaneScaffoldDirective
+import androidx.compose.material3.adaptive.navigation.ThreePaneScaffoldNavigator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import co.touchlab.kermit.Logger
+import kotlin.uuid.Uuid
+
+/**
+ * Installs the two coupled `LaunchedEffect`s that drive notification-tap navigation
+ * between the list and detail panes.
+ *
+ * Effect 1 (cleanup): in compact single-pane layouts, when the scaffold transitions to
+ * list-only while a conversation is still selected, dispatch `ClearSelection`. This is
+ * the user-back-to-list path.
+ *
+ * Effect 2 (swap): when `selectedConversationId` changes to a new value, navigate the
+ * scaffold to `Detail(selectedId)`. If the scaffold is already at `Detail` with a stale
+ * `contentKey`, pop first so `navigateTo` is not treated as a no-op.
+ *
+ * The two effects race during a programmatic swap: `navigateBack()` transits the
+ * scaffold through the "list-only" state that effect 1 watches for. `isSwappingDetailPane`
+ * gates effect 1 during that window so it doesn't null out `selectedConversationId`
+ * mid-swap.
+ */
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+@Composable
+internal fun NotificationNavigationEffects(
+    scaffoldNavigator: ThreePaneScaffoldNavigator<Uuid>,
+    selectedConversationId: Uuid?,
+    scaffoldDirective: PaneScaffoldDirective,
+    onClearSelection: () -> Unit,
+) {
+    val isListPaneHidden =
+        scaffoldNavigator.scaffoldValue[ListDetailPaneScaffoldRole.List] == PaneAdaptedValue.Hidden
+    val isDetailPaneVisible =
+        scaffoldNavigator.scaffoldValue[ListDetailPaneScaffoldRole.Detail] != PaneAdaptedValue.Hidden
+
+    var isSwappingDetailPane by remember { mutableStateOf(false) }
+    LaunchedEffect(isListPaneHidden, isDetailPaneVisible) {
+        if (!isSwappingDetailPane && scaffoldDirective.maxHorizontalPartitions == 1 && !isListPaneHidden && !isDetailPaneVisible && selectedConversationId != null) {
+            Logger.i(tag = "ConversationListUi") { "ClearSelection fired (compact back-to-list) selectedId=$selectedConversationId" }
+            onClearSelection()
+        }
+    }
+
+    var lastNavigatedConversationId by remember { mutableStateOf<Uuid?>(null) }
+    LaunchedEffect(selectedConversationId) {
+        val selectedId = selectedConversationId
+        if (selectedId != null && selectedId != lastNavigatedConversationId) {
+            Logger.i(tag = "ConversationListUi") { "Restore detail pane for $selectedId" }
+            lastNavigatedConversationId = selectedId
+            val cur = scaffoldNavigator.currentDestination
+            if (cur?.pane == ListDetailPaneScaffoldRole.Detail && cur.contentKey != selectedId) {
+                Logger.i(tag = "ConversationListUi") { "Swapping detail pane ${cur.contentKey}->$selectedId" }
+                isSwappingDetailPane = true
+                try {
+                    scaffoldNavigator.navigateBack()
+                    scaffoldNavigator.navigateTo(ListDetailPaneScaffoldRole.Detail, selectedId)
+                } finally {
+                    isSwappingDetailPane = false
+                }
+            } else {
+                scaffoldNavigator.navigateTo(ListDetailPaneScaffoldRole.Detail, selectedId)
+            }
+        } else if (selectedId == null) {
+            lastNavigatedConversationId = null
+        }
+    }
+}

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/conversationlist/NotificationNavigationEffectsTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/conversationlist/NotificationNavigationEffectsTest.kt
@@ -1,0 +1,228 @@
+package id.homebase.chat.conversationlist
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.layout.AnimatedPane
+import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffold
+import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
+import androidx.compose.material3.adaptive.layout.PaneScaffoldDirective
+import androidx.compose.material3.adaptive.layout.ThreePaneScaffoldDestinationItem
+import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaffoldNavigator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+
+/**
+ * Regression tests for the notification-tap navigation race described in
+ * NotificationNavigationEffects.kt. These tests do not render the full
+ * ConversationListUi — they exercise the helper directly with trivial pane
+ * content so the scaffold's pane-adaptation logic is real (the bug lives in
+ * how the helper's two LaunchedEffects interact with `scaffoldValue`
+ * transitions) but without the weight of ConversationMessagesPane / file
+ * pickers that don't initialise cleanly under `runComposeUiTest` on JVM.
+ */
+@OptIn(ExperimentalTestApi::class, ExperimentalMaterial3AdaptiveApi::class)
+class NotificationNavigationEffectsTest {
+
+    private fun compactDirective() = PaneScaffoldDirective(
+        maxHorizontalPartitions = 1,
+        horizontalPartitionSpacerSize = 0.dp,
+        maxVerticalPartitions = 1,
+        verticalPartitionSpacerSize = 0.dp,
+        defaultPanePreferredWidth = 360.dp,
+        excludedBounds = emptyList(),
+    )
+
+    private fun expandedDirective() = PaneScaffoldDirective(
+        maxHorizontalPartitions = 2,
+        horizontalPartitionSpacerSize = 0.dp,
+        maxVerticalPartitions = 1,
+        verticalPartitionSpacerSize = 0.dp,
+        defaultPanePreferredWidth = 360.dp,
+        excludedBounds = emptyList(),
+    )
+
+    @Composable
+    private fun TestHost(
+        selectedId: MutableState<Uuid?>,
+        directive: PaneScaffoldDirective,
+        onClearSelection: () -> Unit,
+    ) {
+        val scaffoldNavigator = rememberListDetailPaneScaffoldNavigator<Uuid>(
+            scaffoldDirective = directive,
+            initialDestinationHistory = if (directive.maxHorizontalPartitions > 1) {
+                listOf(
+                    ThreePaneScaffoldDestinationItem(ListDetailPaneScaffoldRole.List),
+                    ThreePaneScaffoldDestinationItem(ListDetailPaneScaffoldRole.Detail),
+                )
+            } else {
+                listOf(ThreePaneScaffoldDestinationItem(ListDetailPaneScaffoldRole.List))
+            },
+        )
+
+        NotificationNavigationEffects(
+            scaffoldNavigator = scaffoldNavigator,
+            selectedConversationId = selectedId.value,
+            scaffoldDirective = directive,
+            onClearSelection = onClearSelection,
+        )
+
+        ListDetailPaneScaffold(
+            directive = directive,
+            scaffoldState = scaffoldNavigator.scaffoldState,
+            listPane = { AnimatedPane { Text("list") } },
+            detailPane = {
+                AnimatedPane {
+                    val key = scaffoldNavigator.currentDestination?.contentKey
+                    Text("detail=${key?.toString() ?: "null"}")
+                }
+            },
+        )
+    }
+
+    @Test
+    fun compact_warm_swap_does_not_fire_clear_selection() = runComposeUiTest {
+        val idA = Uuid.parse("cc0577d2-2c92-4843-b08d-166e05ad4c19")
+        val idB = Uuid.parse("37c7d258-e56c-4446-bf6c-0fcc12862577")
+        // Start with no selection — mirrors the production startup path where selection
+        // arrives as a state transition (user tap or notification) rather than on mount.
+        // Starting non-null would race the cleanup effect on initial composition because
+        // the scaffold's default history is list-only in compact mode.
+        val selected = mutableStateOf<Uuid?>(null)
+        var clearCount = 0
+
+        setContent {
+            MaterialTheme {
+                TestHost(
+                    selectedId = selected,
+                    directive = compactDirective(),
+                    onClearSelection = { clearCount++ },
+                )
+            }
+        }
+        waitForIdle()
+
+        // User taps conversation A from the list → selectedId = A → swap effect navigates
+        // scaffold to Detail(A).
+        selected.value = idA
+        waitForIdle()
+        onNodeWithText("detail=$idA").assertExists()
+        assertEquals(0, clearCount, "baseline: no clear-selection expected before any swap")
+
+        // Warm notification tap for B while user is on A — the regression under test.
+        // Scenario-3 bug (pre-fix): navigateBack() transits scaffold through
+        // {List=Expanded, Detail=Hidden}, firing the cleanup effect and dispatching
+        // ClearSelection mid-swap. With the `isSwappingDetailPane` guard in place the
+        // cleanup effect must NOT fire.
+        selected.value = idB
+        waitForIdle()
+
+        onNodeWithText("detail=$idB").assertExists()
+        assertEquals(
+            0,
+            clearCount,
+            "swap must not dispatch ClearSelection — the isSwappingDetailPane guard should gate the cleanup effect"
+        )
+    }
+
+    @Test
+    fun expanded_warm_swap_updates_detail_content_key() = runComposeUiTest {
+        val idA = Uuid.parse("cc0577d2-2c92-4843-b08d-166e05ad4c19")
+        val idB = Uuid.parse("37c7d258-e56c-4446-bf6c-0fcc12862577")
+        val selected = mutableStateOf<Uuid?>(idA)
+        var clearCount = 0
+
+        setContent {
+            MaterialTheme {
+                TestHost(
+                    selectedId = selected,
+                    directive = expandedDirective(),
+                    onClearSelection = { clearCount++ },
+                )
+            }
+        }
+
+        waitForIdle()
+        onNodeWithText("detail=$idA").assertExists()
+
+        // Warm tap while both panes are already expanded. Pre-#318, navigateTo was a
+        // no-op so the detail pane stayed on A.
+        selected.value = idB
+        waitForIdle()
+
+        onNodeWithText("detail=$idB").assertExists()
+        assertEquals(0, clearCount, "expanded layout never dispatches ClearSelection from this effect")
+    }
+
+    @Test
+    fun no_selection_does_not_fire_clear_selection() = runComposeUiTest {
+        // Baseline/sanity: starting with no selection should leave clearCount at 0.
+        // In compact mode the list pane is the only visible pane; the detail pane is
+        // elided so we don't assert on its content here.
+        val selected = mutableStateOf<Uuid?>(null)
+        var clearCount = 0
+
+        setContent {
+            MaterialTheme {
+                TestHost(
+                    selectedId = selected,
+                    directive = compactDirective(),
+                    onClearSelection = { clearCount++ },
+                )
+            }
+        }
+
+        waitForIdle()
+        onNodeWithText("list").assertExists()
+        assertEquals(0, clearCount)
+    }
+
+    @Test
+    fun compact_user_back_to_list_fires_clear_selection() = runComposeUiTest {
+        // Scenario 4: once the scaffold is at Detail(A) in compact mode, the user's
+        // system-back transitions it back to list-only. The cleanup effect MUST fire
+        // then — that's its legitimate purpose. This test guards against an overeager
+        // guard that would suppress the real user-back path.
+        val idA = Uuid.parse("cc0577d2-2c92-4843-b08d-166e05ad4c19")
+        val selected = mutableStateOf<Uuid?>(null)
+        var clearCount = 0
+
+        setContent {
+            MaterialTheme {
+                TestHost(
+                    selectedId = selected,
+                    directive = compactDirective(),
+                    onClearSelection = { clearCount++ },
+                )
+            }
+        }
+        waitForIdle()
+
+        selected.value = idA
+        waitForIdle()
+        onNodeWithText("detail=$idA").assertExists()
+        assertEquals(0, clearCount, "no clear expected after selecting A")
+
+        // Simulate user-back: the production path calls scaffoldNavigator.navigateBack()
+        // from a BackHandler. We don't have access to the navigator from outside the
+        // test host, so we synthesize the same end-state by clearing selection and also
+        // expecting the cleanup effect to NOT run an extra time (clear must come from
+        // the user-back path, not from `selected.value = null`). To keep the test faithful
+        // to production, drive only the scaffold back via the host's BackHandler once we
+        // have one exposed. For now, verify the inverse invariant: setting selected=null
+        // does NOT add a ClearSelection dispatch (the cleanup effect's condition requires
+        // selectedId != null). This narrowly guards the guard from over-firing; the full
+        // back-to-list round-trip is covered by manual QA until we add a back-gesture hook.
+        selected.value = null
+        waitForIdle()
+        assertEquals(0, clearCount, "clearing selection externally must not re-dispatch ClearSelection")
+    }
+}


### PR DESCRIPTION
Continuing work from PR #318 (commit a1c249eb, "fix: warm notification tap stuck on previous conversation"). #318 unblocked the tablet/expanded case where `ListDetailPaneScaffoldNavigator.navigateTo(Detail, B)` was a no-op when the scaffold already sat at `Detail(A)` with a stale contentKey. The fix there was to `navigateBack()` first so `navigateTo` actually replaced the destination.

That fix introduced a new failure mode on compact/phone layouts (`maxHorizontalPartitions == 1`):

Repro:
  1. User is on conversation A in compact mode. Scaffold state is {List=Hidden, Detail=Expanded}.
  2. Push for conversation B arrives and the user taps the notification.
  3. App lands on an empty "Select a conversation" placeholder with no list visible — just the empty-detail pane and the bottom bar.

Root cause:
  `LaunchedEffect(selectedConversationId)` calls
  `scaffoldNavigator.navigateBack()` (suspend, animates) before
  `navigateTo(Detail, B)`. During the back-transition the scaffold
  reports `{List=Expanded, Detail=Hidden}`. A sibling
  `LaunchedEffect(isListPaneHidden, isDetailPaneVisible)` watches for
  exactly that state to detect user-back-to-list in compact mode, and
  dispatches `ConversationListUiAction.ClearSelection`. ClearSelection
  nulls `selectedConversationId` and drops B from
  `uiState.activeConversations` via `ActiveConversation.selectConversation(null)`
  and a message-load job cancel. By the time the outer effect's
  `navigateTo(Detail, B)` completes, scaffold.contentKey == B but no
  matching `EnrichedConversationUiModel` exists in activeConversations,
  so the `detailPane` lookup falls through to `EmptyDetailPane`. Log
  signature from the repro: "Restore detail pane for B" fires without
  a following "Pre-initializing scroll position ... id=B" — i.e.
  `ConversationMessagesPane` never composes.

Fix:
  Add an `isSwappingDetailPane` flag that the outer effect raises for
  the duration of the `navigateBack() → navigateTo()` pair. The cleanup
  effect skips its dispatch while the flag is set, so the transient
  `{List=Expanded, Detail=Hidden}` state mid-swap no longer nulls out
  the selection. Legitimate user-initiated back-to-list paths leave the
  flag at false and continue to dispatch ClearSelection as before.

Refactor:
  The two coupled LaunchedEffects are moved out of the 500-line
  ConversationListUi body into a new helper composable
  `NotificationNavigationEffects` in the same package. No behavioural
  change — this makes the interaction testable in isolation without
  needing to render the heavy ConversationMessagesPane / file-picker
  machinery that doesn't initialise cleanly under `runComposeUiTest`
  on JVM.

Tests (new file `NotificationNavigationEffectsTest`):
  * `compact_warm_swap_does_not_fire_clear_selection` — scenario regression guard for this PR. Drives selectedId through null → A → B under a compact directive, asserts the detail pane updates to B and `onClearSelection` is never called. Verified that removing the `!isSwappingDetailPane` guard causes this test to fail (log shows `ClearSelection fired (compact back-to-list)` mid-swap).
  * `expanded_warm_swap_updates_detail_content_key` — regression guard for PR #318's fix; asserts `navigateTo` reaches Detail(B) under an expanded directive.
  * `compact_user_back_to_list_fires_clear_selection` — narrow invariant that externally clearing selection doesn't double-fire the cleanup effect (full back-gesture coverage deferred).
  * `no_selection_does_not_fire_clear_selection` — baseline/sanity.

Observability:
  Also adds two `Logger.i` lines for future diagnosis — one logs
  `Swapping detail pane <old>-><new>` when the swap path is entered,
  the other logs `ClearSelection fired (compact back-to-list)` when the
  legitimate user-back cleanup fires. The original repro log lacked
  both, which is what made this take a second pass to diagnose.

Related prior work:
  * PR #314 — fix-notification-tap-navigation-drop (cold-start SharedFlow replay=0 → Channel(BUFFERED).receiveAsFlow()).
  * PR #318 — fix: warm notification tap stuck on previous conversation (commit a1c249eb). This PR builds on that fix.