### PR TITLE
fix: cold-start notification tap crashes NavController

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -80,6 +80,7 @@ import id.homebase.core.widget.ConnectionRequestHeaderBanner
 import id.homebase.core.widget.InAppNotificationBanner
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import org.koin.compose.viewmodel.koinViewModel
 import kotlin.uuid.Uuid
 
@@ -163,9 +164,14 @@ fun AppNavHost(
         viewModel.navigationEvents.collect { event ->
             when (event) {
                 is NotificationNavigationEvent.OpenConversation -> {
-                    Uuid.parseOrNull(event.conversationId)?.let {
-                        navController.selectConversationOnChatList(it, scrollToBottom = true)
-                    }
+                    val id = Uuid.parseOrNull(event.conversationId) ?: return@collect
+                    // Cold-start: NavController may still be on AppLoading while the
+                    // buffered event is drained. Wait for the AppLoading -> ChatList
+                    // transition before touching the ChatList saved state, otherwise
+                    // getBackStackEntry<Route.ChatList>() throws IllegalArgumentException.
+                    navController.currentBackStackEntryFlow
+                        .first { it.destination.hasRoute(Route.ChatList::class) }
+                    navController.selectConversationOnChatList(id, scrollToBottom = true)
                     navController.popBackStack(Route.ChatList, inclusive = false)
                 }
                 is NotificationNavigationEvent.OpenUrl ->
@@ -574,9 +580,11 @@ fun AppNavHost(
     }
 }
 
-private fun NavHostController.selectConversationOnChatList(conversationId: Uuid, scrollToBottom: Boolean = false) {
-    getBackStackEntry<Route.ChatList>().savedStateHandle["pendingConversationId"] = conversationId.toString()
-    getBackStackEntry<Route.ChatList>().savedStateHandle["pendingScrollToBottom"] = scrollToBottom
+private fun NavHostController.selectConversationOnChatList(conversationId: Uuid, scrollToBottom: Boolean = false): Boolean {
+    val entry = runCatching { getBackStackEntry<Route.ChatList>() }.getOrNull() ?: return false
+    entry.savedStateHandle["pendingConversationId"] = conversationId.toString()
+    entry.savedStateHandle["pendingScrollToBottom"] = scrollToBottom
+    return true
 }
 
 // Helper to check if a destination is a top-level route

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/navigation/NotificationTapColdStartTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/navigation/NotificationTapColdStartTest.kt
@@ -1,0 +1,162 @@
+package id.homebase.core.ui.navigation
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import id.homebase.core.notifications.NotificationNavigationEvent
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+import kotlin.uuid.Uuid
+
+/**
+ * Regression test for the cold-start crash captured in homebase.log lines 8856-8887:
+ *
+ *   IllegalArgumentException: No destination with route o16 is on the
+ *   NavController's back stack. The current destination is nv0 route=app-loading
+ *
+ * Sequence from the log:
+ *   1. FCM push delivered into a killed process; NotificationService buffers
+ *      OpenConversation into its Channel(BUFFERED) (PR #314 fix).
+ *   2. App starts; NavController lands on AppLoading.
+ *   3. AuthState transitions to Authenticated.
+ *   4. AppNavHost's navigationEvents collector drains the buffered event and
+ *      calls selectConversationOnChatList -> getBackStackEntry<Route.ChatList>()
+ *      while NavController is still on AppLoading -> IAE -> process crash.
+ *
+ * The collector must wait for Route.ChatList to reach the back stack before
+ * dispatching. This test drives a minimal NavHost(AppLoading, ChatList) and
+ * fires the event during the AppLoading window; with the fix the event is
+ * held until ChatList is pushed, then applied.
+ */
+@Serializable
+internal data object TestAppLoading
+
+@Serializable
+internal data object TestChatList
+
+@OptIn(ExperimentalTestApi::class)
+class NotificationTapColdStartTest {
+
+    @Test
+    fun cold_start_notification_tap_waits_for_chatlist_on_backstack() = runComposeUiTest {
+        val events = Channel<NotificationNavigationEvent>(Channel.BUFFERED)
+        val authReady = mutableStateOf(false)
+
+        setContent {
+            val navController = rememberNavController()
+
+            LaunchedEffect(Unit) {
+                events.consumeAsFlow().collect { event ->
+                    if (event is NotificationNavigationEvent.OpenConversation) {
+                        val id = Uuid.parseOrNull(event.conversationId) ?: return@collect
+                        navController.currentBackStackEntryFlow
+                            .first { it.destination.hasRoute(TestChatList::class) }
+                        navController.getBackStackEntry<TestChatList>()
+                            .savedStateHandle["pendingConversationId"] = id.toString()
+                    }
+                }
+            }
+
+            NavHost(navController, startDestination = TestAppLoading) {
+                composable<TestAppLoading> {
+                    LaunchedEffect(authReady.value) {
+                        if (authReady.value) {
+                            navController.navigate(TestChatList) {
+                                popUpTo(TestAppLoading) { inclusive = true }
+                            }
+                        }
+                    }
+                    Text("loading")
+                }
+                composable<TestChatList> { backStackEntry ->
+                    val pending by backStackEntry.savedStateHandle
+                        .getStateFlow<String?>("pendingConversationId", null)
+                        .collectAsState()
+                    Text("chatlist pending=${pending ?: "null"}")
+                }
+            }
+        }
+
+        waitForIdle()
+        onNodeWithText("loading").assertExists()
+
+        events.trySend(
+            NotificationNavigationEvent.OpenConversation(
+                "cc0577d2-2c92-4843-b08d-166e05ad4c19"
+            )
+        )
+        waitForIdle()
+        onNodeWithText("loading").assertExists()
+
+        authReady.value = true
+        waitForIdle()
+
+        onNodeWithText("chatlist pending=cc0577d2-2c92-4843-b08d-166e05ad4c19")
+            .assertExists()
+    }
+
+    @Test
+    fun unguarded_collector_reproduces_production_crash_on_cold_start() = runComposeUiTest {
+        // Negative control: same scenario, but the collector touches
+        // getBackStackEntry<ChatList>() immediately without awaiting the
+        // AppLoading -> ChatList transition. This mirrors the pre-fix call site
+        // in AppNavHost.kt line 162-175 / selectConversationOnChatList line
+        // 577-580 and must surface an IllegalArgumentException (proving the
+        // positive test above actually exercises the race).
+        val events = Channel<NotificationNavigationEvent>(Channel.BUFFERED)
+        val caught = mutableStateOf<Throwable?>(null)
+
+        setContent {
+            val navController = rememberNavController()
+
+            LaunchedEffect(Unit) {
+                events.consumeAsFlow().collect { event ->
+                    if (event is NotificationNavigationEvent.OpenConversation) {
+                        val id = Uuid.parseOrNull(event.conversationId) ?: return@collect
+                        try {
+                            navController.getBackStackEntry<TestChatList>()
+                                .savedStateHandle["pendingConversationId"] = id.toString()
+                        } catch (t: IllegalArgumentException) {
+                            caught.value = t
+                        }
+                    }
+                }
+            }
+
+            NavHost(navController, startDestination = TestAppLoading) {
+                composable<TestAppLoading> { Text("loading") }
+                composable<TestChatList> { Text("chatlist") }
+            }
+        }
+
+        waitForIdle()
+        events.trySend(
+            NotificationNavigationEvent.OpenConversation(
+                "cc0577d2-2c92-4843-b08d-166e05ad4c19"
+            )
+        )
+        waitForIdle()
+
+        val thrown = caught.value
+        kotlin.test.assertNotNull(
+            thrown,
+            "Unguarded getBackStackEntry<ChatList>() must throw while NavController is on AppLoading — this is the production crash we're guarding against"
+        )
+        kotlin.test.assertTrue(
+            thrown.message?.contains("back stack") == true,
+            "Expected back-stack IAE, got: ${thrown.message}"
+        )
+    }
+}

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/settings/SettingsUiTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/settings/SettingsUiTest.kt
@@ -16,7 +16,7 @@ class SettingsUiTest {
         setContent {
             MaterialTheme {
                 SettingsUi(
-                    uiState = SettingsUiState(appVersion = "1.0.0"),
+                    uiState = SettingsUiState(appVersion = "1.0.0", appBuild = "12345", appBuildDate = "2023-01-01"),
                     onAction = {},
                     onBackClick = {},
                     onNavigateToConnections = {},
@@ -34,7 +34,7 @@ class SettingsUiTest {
         setContent {
             MaterialTheme {
                 SettingsUi(
-                    uiState = SettingsUiState(appVersion = "1.0.0"),
+                    uiState = SettingsUiState(appVersion = "1.0.0", appBuild = "12345", appBuildDate = "2023-01-01"),
                     onAction = {},
                     onBackClick = {},
                     onNavigateToConnections = {},
@@ -56,7 +56,7 @@ class SettingsUiTest {
         setContent {
             MaterialTheme {
                 SettingsUi(
-                    uiState = SettingsUiState(appVersion = "2.5.3"),
+                    uiState = SettingsUiState(appVersion = "2.5.3", appBuild = "12345", appBuildDate = "2023-01-01"),
                     onAction = {},
                     onBackClick = {},
                     onNavigateToConnections = {},
@@ -76,9 +76,10 @@ class SettingsUiTest {
         setContent {
             MaterialTheme {
                 SettingsUi(
-                    uiState = SettingsUiState(appVersion = "1.0.0"),
+                    uiState = SettingsUiState(appVersion = "1.0.0", appBuild = "12345", appBuildDate = "2023-01-01"),
                     onAction = {},
                     onBackClick = {},
+                    onNavigateToConnections = {},
                     onNavigateToNotifications = { navigated = true },
                     onNavigateToAppearance = {},
                     onNavigateToHelp = {},
@@ -95,7 +96,7 @@ class SettingsUiTest {
         setContent {
             MaterialTheme {
                 SettingsUi(
-                    uiState = SettingsUiState(appVersion = "1.0.0"),
+                    uiState = SettingsUiState(appVersion = "1.0.0", appBuild = "12345", appBuildDate = "2023-01-01"),
                     onAction = {},
                     onBackClick = {},
                     onNavigateToConnections = {},
@@ -115,7 +116,7 @@ class SettingsUiTest {
         setContent {
             MaterialTheme {
                 SettingsUi(
-                    uiState = SettingsUiState(appVersion = "1.0.0"),
+                    uiState = SettingsUiState(appVersion = "1.0.0", appBuild = "12345", appBuildDate = "2023-01-01"),
                     onAction = { action ->
                         if (action is SettingsUiAction.LogoutClicked) {
                             loggedOut = true
@@ -139,7 +140,7 @@ class SettingsUiTest {
         setContent {
             MaterialTheme {
                 SettingsUi(
-                    uiState = SettingsUiState(appVersion = "1.0.0"),
+                    uiState = SettingsUiState(appVersion = "1.0.0", appBuild = "12345", appBuildDate = "2023-01-01"),
                     onAction = { action ->
                         if (action is SettingsUiAction.DeleteAccount) {
                             deleteClicked = true


### PR DESCRIPTION
Tapping a chat push from a fully-killed app crashed with:

    IllegalArgumentException: No destination with route o16 is on the
    NavController's back stack. The current destination is nv0 route=app-loading

Captured in homebase.log (2026-04-18T19:13:56.358, lines 8856-8887).

Root cause: a direct follow-on from PR #314
(fix-notification-tap-navigation-drop). #314 replaced the replay=0 SharedFlow in NotificationService / AppViewModel with a Channel(BUFFERED) so a cold-start OpenConversation event survives the subscriber-not-yet-attached window. That fix is correct on its own — but the downstream collector in AppNavHost drains the buffered event the instant it attaches, while NavController is still on Route.AppLoading (the AppLoading -> ChatList transition is driven by AppLoadingScreen.onNavigateToMainScreen on a subsequent recomposition). getBackStackEntry<Route.ChatList>() then throws, crashing the process.

Fix: gate the navigationEvents collector on Route.ChatList being present on the back stack before dispatching. currentBackStackEntryFlow emits whenever the current entry changes, so .first { hasRoute(Route.ChatList::class) } suspends on cold start until AppLoading transitions to ChatList, and returns immediately on warm paths where ChatList is already present.

Belt-and-suspenders: selectConversationOnChatList now returns Boolean and uses runCatching around getBackStackEntry so any future caller from a different nav context can't crash the app again.

Unrelated to PRs #318 / #320: both operate inside ConversationListUi's ListDetailPaneScaffold, which isn't mounted at crash time on cold start.

Tests (test-first):
- NotificationTapColdStartTest.cold_start_notification_tap_waits_for_chatlist_on_backstack drives a minimal NavHost(AppLoading -> ChatList), fires OpenConversation while on AppLoading, and verifies the event is held until ChatList is pushed, then applied to savedStateHandle.
- NotificationTapColdStartTest.unguarded_collector_reproduces_production_crash_on_cold_start is the negative control: same scenario without the flow gate, asserts IllegalArgumentException is thrown — proves the positive test actually exercises the cold-start race.

Drive-by: SettingsUiTest was failing to compile against current SettingsUiState / SettingsScreen signatures. Added the missing appBuild / appBuildDate / onNavigateToConnections args so the homebase-core jvmTest task can compile.