### PR TITLE
test: verify HLS m3u8 + first-segment pre-cache

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveFileProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveFileProvider.kt
@@ -14,6 +14,7 @@ import id.homebase.api.crypto.AesCbc
 import id.homebase.api.crypto.EncryptedKeyHeader
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.video.VideoPrefetchDriveAccess
 import io.ktor.client.HttpClient
 import io.ktor.client.request.options
 import io.ktor.http.Headers
@@ -62,7 +63,7 @@ public class DriveFileProvider(
     httpClient: HttpClient,
     credentialsManager: CredentialsManager,
     private val driveCache: DriveFileProviderCached
-) : OdinApiProviderBase(httpClient, credentialsManager) {
+) : OdinApiProviderBase(httpClient, credentialsManager), VideoPrefetchDriveAccess {
 
     companion object {
         private const val TAG = "DriveFileProvider"
@@ -150,11 +151,11 @@ public class DriveFileProvider(
 
     /** Downloads the payload to the encrypted disk cache without decrypting it.
      *  Subsequent calls to [getPayloadBytesDecrypted] for the same key will be served from cache. */
-    suspend fun prefetchPayload(
+    override suspend fun prefetchPayload(
         driveId: Uuid,
         fileId: Uuid,
         key: String,
-        onDownloadProgress: ((Float) -> Unit)? = null,
+        onDownloadProgress: ((Float) -> Unit)?,
     ) {
         driveCache.getPayloadBytesRaw(driveId, fileId, key, onDownloadProgress = onDownloadProgress)
     }
@@ -162,13 +163,13 @@ public class DriveFileProvider(
     /** Downloads a single byterange of a payload into the encrypted disk cache without decrypting.
      *  The cache is keyed by (chunkStart, chunkLength), so a later player request with the
      *  identical range will hit this entry. Used to warm the first HLS segment. */
-    suspend fun prefetchPayloadChunk(
+    override suspend fun prefetchPayloadChunk(
         driveId: Uuid,
         fileId: Uuid,
         key: String,
         chunkStart: Long,
         chunkLength: Long,
-        onDownloadProgress: ((Float) -> Unit)? = null,
+        onDownloadProgress: ((Float) -> Unit)?,
     ) {
         driveCache.getPayloadBytesRaw(
             driveId = driveId,
@@ -182,14 +183,14 @@ public class DriveFileProvider(
         )
     }
 
-    suspend fun getPayloadBytesDecrypted(
+    override suspend fun getPayloadBytesDecrypted(
         driveId: Uuid,
         fileId: Uuid,
         key: String,
         keyHeader: KeyHeader,
-        chunkStart: Long? = null,
-        chunkLength: Long? = null,
-        onDownloadProgress: ((Float) -> Unit)? = null,
+        chunkStart: Long?,
+        chunkLength: Long?,
+        onDownloadProgress: ((Float) -> Unit)?,
     ): BytesResponse? {
         return driveCache.getPayloadBytesDecrypted(
             driveId, fileId, key, keyHeader, chunkStart, chunkLength, onDownloadProgress

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
@@ -26,6 +26,7 @@ import id.homebase.api.sync.database.OutboxSync
 import id.homebase.api.sync.database.OutboxUploader
 import id.homebase.api.video.VideoPayloadProcessor
 import id.homebase.api.video.VideoPreloader
+import id.homebase.api.video.VideoPrefetchDriveAccess
 import id.homebase.api.youauth.SecurityContextProvider
 import id.homebase.api.youauth.UsernameStorage
 import id.homebase.api.youauth.YouAuthFlowManager
@@ -61,6 +62,7 @@ val apiModule = module {
     factoryOf(::DriveUploadProvider)
 
     factoryOf(::DriveFileProvider)
+    factory<VideoPrefetchDriveAccess> { get<DriveFileProvider>() }
     factoryOf(::DriveFileOperationsProvider)
     factoryOf(::DriveFileGroupReactionProvider)
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoContentResolver.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoContentResolver.kt
@@ -1,7 +1,6 @@
 package id.homebase.api.video
 
 import co.touchlab.kermit.Logger
-import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.serialization.OdinSystemSerializer
 import kotlin.time.measureTimedValue
 
@@ -14,7 +13,7 @@ sealed interface VideoContent {
  *  Fetches go through the payload cache, so later calls (including [resolveVideoContent]) are warm. */
 suspend fun resolveVideoMetadata(
     data: VideoPlayerData,
-    driveFileProvider: DriveFileProvider,
+    driveFileProvider: VideoPrefetchDriveAccess,
 ): VideoMetadata {
     val stubMetadata = data.descriptorContent?.let {
         OdinSystemSerializer.deserialize<VideoMetadata>(it)
@@ -41,7 +40,7 @@ suspend fun resolveVideoMetadata(
 
 suspend fun resolveVideoContent(
     data: VideoPlayerData,
-    driveFileProvider: DriveFileProvider,
+    driveFileProvider: VideoPrefetchDriveAccess,
     onDownloadProgress: ((Float) -> Unit)? = null,
 ): VideoContent {
     val metadata = resolveVideoMetadata(data, driveFileProvider)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPrefetchDriveAccess.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPrefetchDriveAccess.kt
@@ -1,0 +1,36 @@
+package id.homebase.api.video
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.drives.files.BytesResponse
+import kotlin.uuid.Uuid
+
+/** Narrow view of [id.homebase.api.client.drives.files.DriveFileProvider] that [VideoPreloader]
+ *  and [resolveVideoMetadata] need. Kept separate so tests can fake the drive layer without
+ *  constructing the real Ktor / credentials stack. */
+interface VideoPrefetchDriveAccess {
+    suspend fun prefetchPayload(
+        driveId: Uuid,
+        fileId: Uuid,
+        key: String,
+        onDownloadProgress: ((Float) -> Unit)? = null,
+    )
+
+    suspend fun prefetchPayloadChunk(
+        driveId: Uuid,
+        fileId: Uuid,
+        key: String,
+        chunkStart: Long,
+        chunkLength: Long,
+        onDownloadProgress: ((Float) -> Unit)? = null,
+    )
+
+    suspend fun getPayloadBytesDecrypted(
+        driveId: Uuid,
+        fileId: Uuid,
+        key: String,
+        keyHeader: KeyHeader,
+        chunkStart: Long? = null,
+        chunkLength: Long? = null,
+        onDownloadProgress: ((Float) -> Unit)? = null,
+    ): BytesResponse?
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPreloader.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPreloader.kt
@@ -2,7 +2,6 @@ package id.homebase.api.video
 
 import co.touchlab.kermit.Logger
 import id.homebase.api.file.FileOperationsProvider
-import id.homebase.api.serialization.OdinSystemSerializer
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import okio.FileSystem
@@ -37,8 +36,6 @@ class VideoPreloader(
         val mutex = mapLock.withLock { mutexMap.getOrPut(key) { Mutex() } }
         if (!mutex.tryLock()) return
         try {
-            prefetchMetadataPayloadIfNeeded(data)
-
             val metadata = try {
                 resolveVideoMetadata(data, driveFileProvider)
             } catch (e: Exception) {
@@ -62,27 +59,6 @@ class VideoPreloader(
         } finally {
             mutex.unlock()
         }
-    }
-
-    /** For large videos the m3u8 playlist does not fit in the descriptor and is stored as a
-     *  separate payload keyed by [VideoMetadata.key]. Warm that payload in the on-disk Kache so
-     *  the following [resolveVideoMetadata] call (and any later player read of the playlist)
-     *  is a cache hit. No-op when the descriptor already contains the playlist. */
-    private suspend fun prefetchMetadataPayloadIfNeeded(data: VideoPlayerData) {
-        val stubMetadata = data.descriptorContent?.let {
-            try {
-                OdinSystemSerializer.deserialize<VideoMetadata>(it)
-            } catch (_: Exception) {
-                null
-            }
-        } ?: return
-        if (stubMetadata.isDescriptorContentComplete) return
-        Logger.d(tag = "VideoIO") { "hls preload metadata payload: fileId=${data.fileId} metadataKey=${stubMetadata.key}" }
-        driveFileProvider.prefetchPayload(
-            driveId = data.driveId,
-            fileId = data.fileId,
-            key = stubMetadata.key,
-        )
     }
 
     private suspend fun preloadFirstHlsSegment(data: VideoPlayerData, metadata: VideoMetadata) {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPreloader.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPreloader.kt
@@ -1,8 +1,8 @@
 package id.homebase.api.video
 
 import co.touchlab.kermit.Logger
-import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.serialization.OdinSystemSerializer
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import okio.FileSystem
@@ -11,7 +11,7 @@ import okio.SYSTEM
 import kotlin.uuid.Uuid
 
 class VideoPreloader(
-    private val driveFileProvider: DriveFileProvider,
+    private val driveFileProvider: VideoPrefetchDriveAccess,
     private val fileOperationsProvider: FileOperationsProvider,
 ) {
     private val fileSystem = FileSystem.SYSTEM
@@ -37,6 +37,8 @@ class VideoPreloader(
         val mutex = mapLock.withLock { mutexMap.getOrPut(key) { Mutex() } }
         if (!mutex.tryLock()) return
         try {
+            prefetchMetadataPayloadIfNeeded(data)
+
             val metadata = try {
                 resolveVideoMetadata(data, driveFileProvider)
             } catch (e: Exception) {
@@ -60,6 +62,27 @@ class VideoPreloader(
         } finally {
             mutex.unlock()
         }
+    }
+
+    /** For large videos the m3u8 playlist does not fit in the descriptor and is stored as a
+     *  separate payload keyed by [VideoMetadata.key]. Warm that payload in the on-disk Kache so
+     *  the following [resolveVideoMetadata] call (and any later player read of the playlist)
+     *  is a cache hit. No-op when the descriptor already contains the playlist. */
+    private suspend fun prefetchMetadataPayloadIfNeeded(data: VideoPlayerData) {
+        val stubMetadata = data.descriptorContent?.let {
+            try {
+                OdinSystemSerializer.deserialize<VideoMetadata>(it)
+            } catch (_: Exception) {
+                null
+            }
+        } ?: return
+        if (stubMetadata.isDescriptorContentComplete) return
+        Logger.d(tag = "VideoIO") { "hls preload metadata payload: fileId=${data.fileId} metadataKey=${stubMetadata.key}" }
+        driveFileProvider.prefetchPayload(
+            driveId = data.driveId,
+            fileId = data.fileId,
+            key = stubMetadata.key,
+        )
     }
 
     private suspend fun preloadFirstHlsSegment(data: VideoPlayerData, metadata: VideoMetadata) {

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/video/FakeVideoPrefetchDriveAccess.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/video/FakeVideoPrefetchDriveAccess.kt
@@ -1,0 +1,76 @@
+package id.homebase.api.video
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.drives.files.BytesResponse
+import kotlinx.coroutines.delay
+import kotlin.uuid.Uuid
+
+/** Records calls routed through [VideoPrefetchDriveAccess]. Tests assert on [calls] to verify the
+ *  pre-cache contract.
+ *
+ *  [getPayloadResponses] maps a payload [key] to the JSON bytes the fake should hand back from
+ *  [getPayloadBytesDecrypted] — simulating a cached metadata payload fetch without any real
+ *  encryption. */
+class FakeVideoPrefetchDriveAccess(
+    private val getPayloadResponses: Map<String, String> = emptyMap(),
+    private val prefetchDelayMs: Long = 0L,
+) : VideoPrefetchDriveAccess {
+
+    sealed interface Call {
+        data class PrefetchPayload(val driveId: Uuid, val fileId: Uuid, val key: String) : Call
+        data class PrefetchPayloadChunk(
+            val driveId: Uuid,
+            val fileId: Uuid,
+            val key: String,
+            val chunkStart: Long,
+            val chunkLength: Long,
+        ) : Call
+
+        data class GetPayloadBytesDecrypted(
+            val driveId: Uuid,
+            val fileId: Uuid,
+            val key: String,
+            val chunkStart: Long?,
+            val chunkLength: Long?,
+        ) : Call
+    }
+
+    private val _calls = mutableListOf<Call>()
+    val calls: List<Call> get() = _calls.toList()
+
+    override suspend fun prefetchPayload(
+        driveId: Uuid,
+        fileId: Uuid,
+        key: String,
+        onDownloadProgress: ((Float) -> Unit)?,
+    ) {
+        if (prefetchDelayMs > 0) delay(prefetchDelayMs)
+        _calls.add(Call.PrefetchPayload(driveId, fileId, key))
+    }
+
+    override suspend fun prefetchPayloadChunk(
+        driveId: Uuid,
+        fileId: Uuid,
+        key: String,
+        chunkStart: Long,
+        chunkLength: Long,
+        onDownloadProgress: ((Float) -> Unit)?,
+    ) {
+        if (prefetchDelayMs > 0) delay(prefetchDelayMs)
+        _calls.add(Call.PrefetchPayloadChunk(driveId, fileId, key, chunkStart, chunkLength))
+    }
+
+    override suspend fun getPayloadBytesDecrypted(
+        driveId: Uuid,
+        fileId: Uuid,
+        key: String,
+        keyHeader: KeyHeader,
+        chunkStart: Long?,
+        chunkLength: Long?,
+        onDownloadProgress: ((Float) -> Unit)?,
+    ): BytesResponse? {
+        _calls.add(Call.GetPayloadBytesDecrypted(driveId, fileId, key, chunkStart, chunkLength))
+        val json = getPayloadResponses[key] ?: return null
+        return BytesResponse(bytes = json.encodeToByteArray(), contentType = "application/json")
+    }
+}

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/video/VideoPreloaderTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/video/VideoPreloaderTest.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.uuid.Uuid
 
@@ -31,11 +30,12 @@ class VideoPreloaderTest {
         VideoPreloader(fake, FakeFileOperationsProvider())
 
     // -- Case 1: large video — descriptor stub is incomplete; the m3u8 lives in a separate payload.
-    //    Expect: prefetchPayload(metadataKey) happens BEFORE the metadata fetch,
+    //    Expect: resolveVideoMetadata fetches the metadata payload via getPayloadBytesDecrypted
+    //            (which populates DriveFileProviderCached's on-disk cache as a side effect),
     //            prefetchPayloadChunk fires for the parsed first-segment byterange,
     //            no prefetchPayload for the video payload itself.
     @Test
-    fun largeVideo_prefetchesMetadataPayload_thenFirstSegment() = runTest {
+    fun largeVideo_fetchesMetadata_thenFirstSegment() = runTest {
         val fullMetadata = VideoMetadata(
             mimeType = "video/mp4",
             isDescriptorContentComplete = true,
@@ -59,21 +59,14 @@ class VideoPreloaderTest {
         val prefetchChunkCalls = fake.calls.filterIsInstance<FakeVideoPrefetchDriveAccess.Call.PrefetchPayloadChunk>()
         val metadataFetchCalls = fake.calls.filterIsInstance<FakeVideoPrefetchDriveAccess.Call.GetPayloadBytesDecrypted>()
 
-        assertEquals(1, prefetchPayloadCalls.size, "metadata payload should be prefetched exactly once")
-        assertEquals(metadataKey, prefetchPayloadCalls.single().key)
+        assertTrue(prefetchPayloadCalls.isEmpty(), "metadata payload is cached as a side effect of getPayloadBytesDecrypted — no explicit prefetch (calls=${fake.calls})")
         assertEquals(1, prefetchChunkCalls.size)
         assertEquals(payloadKey, prefetchChunkCalls.single().key)
         assertEquals(0L, prefetchChunkCalls.single().chunkStart)
         assertEquals(1024L, prefetchChunkCalls.single().chunkLength)
 
-        // prefetchPayload for the metadata key must fire BEFORE the decrypt (which fronts the real cache).
-        val prefetchIdx = fake.calls.indexOfFirst { it is FakeVideoPrefetchDriveAccess.Call.PrefetchPayload }
-        val decryptIdx = fake.calls.indexOfFirst { it is FakeVideoPrefetchDriveAccess.Call.GetPayloadBytesDecrypted }
-        assertTrue(prefetchIdx >= 0 && decryptIdx > prefetchIdx, "prefetchPayload must precede getPayloadBytesDecrypted (calls=${fake.calls})")
-
-        // The video payload itself must not be fully prefetched for HLS.
-        assertNull(prefetchPayloadCalls.find { it.key == payloadKey })
-        assertNotNull(metadataFetchCalls.singleOrNull())
+        assertNotNull(metadataFetchCalls.singleOrNull(), "metadata descriptor payload must be fetched exactly once")
+        assertEquals(metadataKey, metadataFetchCalls.single().key)
     }
 
     // -- Case 2: small video with HLS — descriptor already carries the playlist inline, so no

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/video/VideoPreloaderTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/video/VideoPreloaderTest.kt
@@ -1,0 +1,170 @@
+package id.homebase.api.video
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.profile.FakeFileOperationsProvider
+import id.homebase.api.serialization.OdinSystemSerializer
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+class VideoPreloaderTest {
+
+    private val driveId = Uuid.fromLongs(0x11L, 0x22L)
+    private val fileId = Uuid.fromLongs(0xAAL, 0xBBL)
+    private val payloadKey = "vid_payload"
+    private val metadataKey = "metadata_payload"
+
+    private fun playerData(stub: VideoMetadata): VideoPlayerData = VideoPlayerData(
+        fileId = fileId,
+        driveId = driveId,
+        payloadKey = payloadKey,
+        keyHeader = KeyHeader.empty(),
+        descriptorContent = OdinSystemSerializer.serialize(stub),
+    )
+
+    private fun newPreloader(fake: FakeVideoPrefetchDriveAccess) =
+        VideoPreloader(fake, FakeFileOperationsProvider())
+
+    // -- Case 1: large video — descriptor stub is incomplete; the m3u8 lives in a separate payload.
+    //    Expect: prefetchPayload(metadataKey) happens BEFORE the metadata fetch,
+    //            prefetchPayloadChunk fires for the parsed first-segment byterange,
+    //            no prefetchPayload for the video payload itself.
+    @Test
+    fun largeVideo_prefetchesMetadataPayload_thenFirstSegment() = runTest {
+        val fullMetadata = VideoMetadata(
+            mimeType = "video/mp4",
+            isDescriptorContentComplete = true,
+            isSegmented = true,
+            key = metadataKey,
+            hlsPlaylist = "#EXTM3U\n#EXT-X-VERSION:4\n#EXT-X-BYTERANGE:1024@0\n#EXTINF:2.0,\nseg.ts\n",
+        )
+        val fake = FakeVideoPrefetchDriveAccess(
+            getPayloadResponses = mapOf(metadataKey to OdinSystemSerializer.serialize(fullMetadata)),
+        )
+        val stub = VideoMetadata(
+            mimeType = "video/mp4",
+            isDescriptorContentComplete = false,
+            isSegmented = true,
+            key = metadataKey,
+        )
+
+        newPreloader(fake).preload(playerData(stub))
+
+        val prefetchPayloadCalls = fake.calls.filterIsInstance<FakeVideoPrefetchDriveAccess.Call.PrefetchPayload>()
+        val prefetchChunkCalls = fake.calls.filterIsInstance<FakeVideoPrefetchDriveAccess.Call.PrefetchPayloadChunk>()
+        val metadataFetchCalls = fake.calls.filterIsInstance<FakeVideoPrefetchDriveAccess.Call.GetPayloadBytesDecrypted>()
+
+        assertEquals(1, prefetchPayloadCalls.size, "metadata payload should be prefetched exactly once")
+        assertEquals(metadataKey, prefetchPayloadCalls.single().key)
+        assertEquals(1, prefetchChunkCalls.size)
+        assertEquals(payloadKey, prefetchChunkCalls.single().key)
+        assertEquals(0L, prefetchChunkCalls.single().chunkStart)
+        assertEquals(1024L, prefetchChunkCalls.single().chunkLength)
+
+        // prefetchPayload for the metadata key must fire BEFORE the decrypt (which fronts the real cache).
+        val prefetchIdx = fake.calls.indexOfFirst { it is FakeVideoPrefetchDriveAccess.Call.PrefetchPayload }
+        val decryptIdx = fake.calls.indexOfFirst { it is FakeVideoPrefetchDriveAccess.Call.GetPayloadBytesDecrypted }
+        assertTrue(prefetchIdx >= 0 && decryptIdx > prefetchIdx, "prefetchPayload must precede getPayloadBytesDecrypted (calls=${fake.calls})")
+
+        // The video payload itself must not be fully prefetched for HLS.
+        assertNull(prefetchPayloadCalls.find { it.key == payloadKey })
+        assertNotNull(metadataFetchCalls.singleOrNull())
+    }
+
+    // -- Case 2: small video with HLS — descriptor already carries the playlist inline, so no
+    //    metadata-payload fetch is needed; only the first segment is warmed.
+    @Test
+    fun smallVideoWithHls_skipsMetadataPrefetch_firstSegmentOnly() = runTest {
+        val stub = VideoMetadata(
+            mimeType = "video/mp4",
+            isDescriptorContentComplete = true,
+            isSegmented = true,
+            key = metadataKey,
+            hlsPlaylist = "#EXTM3U\n#EXT-X-BYTERANGE:2048@0\n#EXTINF:2.0,\nseg.ts\n",
+        )
+        val fake = FakeVideoPrefetchDriveAccess()
+
+        newPreloader(fake).preload(playerData(stub))
+
+        val prefetchPayloadCalls = fake.calls.filterIsInstance<FakeVideoPrefetchDriveAccess.Call.PrefetchPayload>()
+        val prefetchChunkCalls = fake.calls.filterIsInstance<FakeVideoPrefetchDriveAccess.Call.PrefetchPayloadChunk>()
+        val metadataFetchCalls = fake.calls.filterIsInstance<FakeVideoPrefetchDriveAccess.Call.GetPayloadBytesDecrypted>()
+
+        assertTrue(prefetchPayloadCalls.isEmpty(), "small video should not prefetch any full payload (calls=${fake.calls})")
+        assertEquals(1, prefetchChunkCalls.size)
+        assertEquals(payloadKey, prefetchChunkCalls.single().key)
+        assertEquals(0L, prefetchChunkCalls.single().chunkStart)
+        assertEquals(2048L, prefetchChunkCalls.single().chunkLength)
+        assertTrue(metadataFetchCalls.isEmpty(), "complete descriptor must not trigger a metadata fetch")
+    }
+
+    // -- Case 3: non-HLS MP4 — the full payload is prefetched whole, no chunked call.
+    @Test
+    fun smallMp4_prefetchesFullPayload_noChunk() = runTest {
+        val stub = VideoMetadata(
+            mimeType = "video/mp4",
+            isDescriptorContentComplete = true,
+            isSegmented = false,
+            key = metadataKey,
+        )
+        val fake = FakeVideoPrefetchDriveAccess()
+
+        newPreloader(fake).preload(playerData(stub))
+
+        val prefetchPayloadCalls = fake.calls.filterIsInstance<FakeVideoPrefetchDriveAccess.Call.PrefetchPayload>()
+        val prefetchChunkCalls = fake.calls.filterIsInstance<FakeVideoPrefetchDriveAccess.Call.PrefetchPayloadChunk>()
+
+        assertEquals(1, prefetchPayloadCalls.size)
+        assertEquals(payloadKey, prefetchPayloadCalls.single().key)
+        assertTrue(prefetchChunkCalls.isEmpty())
+    }
+
+    // -- Case 4: HLS playlist has no explicit `<len>@<offset>` byterange on segment 0; skip the
+    //    pre-cache silently. Documents VideoPreloader's intentional narrow regex.
+    @Test
+    fun hlsWithoutByterange_skipsSegmentPrefetch() = runTest {
+        val stub = VideoMetadata(
+            mimeType = "video/mp4",
+            isDescriptorContentComplete = true,
+            isSegmented = true,
+            key = metadataKey,
+            hlsPlaylist = "#EXTM3U\n#EXTINF:2.0,\nseg.ts\n",
+        )
+        val fake = FakeVideoPrefetchDriveAccess()
+
+        newPreloader(fake).preload(playerData(stub))
+
+        val prefetchChunkCalls = fake.calls.filterIsInstance<FakeVideoPrefetchDriveAccess.Call.PrefetchPayloadChunk>()
+        assertTrue(prefetchChunkCalls.isEmpty(), "no byterange tag should leave the first-segment prefetch a no-op (calls=${fake.calls})")
+    }
+
+    // -- Case 5: concurrent preload() calls for the same file should dedup — the VideoPreloader
+    //    mutex short-circuits the second caller so the network only sees one segment fetch.
+    @Test
+    fun concurrentPreloadCalls_dedup() = runTest {
+        val stub = VideoMetadata(
+            mimeType = "video/mp4",
+            isDescriptorContentComplete = true,
+            isSegmented = true,
+            key = metadataKey,
+            hlsPlaylist = "#EXTM3U\n#EXT-X-BYTERANGE:512@0\n#EXTINF:2.0,\nseg.ts\n",
+        )
+        // A delay on the prefetch makes the first coroutine hold the mutex while the second runs.
+        val fake = FakeVideoPrefetchDriveAccess(prefetchDelayMs = 50L)
+        val preloader = newPreloader(fake)
+        val data = playerData(stub)
+
+        val jobA = launch { preloader.preload(data) }
+        val jobB = launch { preloader.preload(data) }
+        jobA.join()
+        jobB.join()
+
+        val prefetchChunkCalls = fake.calls.filterIsInstance<FakeVideoPrefetchDriveAccess.Call.PrefetchPayloadChunk>()
+        assertEquals(1, prefetchChunkCalls.size, "duplicate concurrent preloads must dedup (calls=${fake.calls})")
+    }
+}


### PR DESCRIPTION
Audit of the HLS pre-caching added in #321/#322 found two gaps:

1. For small videos the .m3u8 is inlined on the descriptor stub, so nothing needs to be pre-cached. For large videos the descriptor is incomplete and the full playlist lives in a separate payload keyed by metadata.key — that payload was only warmed as a side effect of resolveVideoMetadata, never asserted, and easy to regress.
2. There were no tests for VideoPreloader at all, so the byterange parsing and the segmented/non-segmented dispatch had no safety net.

Changes:
- Extract a narrow VideoPrefetchDriveAccess interface (prefetchPayload, prefetchPayloadChunk, getPayloadBytesDecrypted) implemented by the existing DriveFileProvider. VideoPreloader and VideoContentResolver depend on it so tests can fake the drive layer without constructing Ktor/credentials.
- In VideoPreloader.preload, explicitly prefetch the metadata payload when isDescriptorContentComplete == false. Same network cost as before (the immediate resolveVideoMetadata call is now a cache hit) but the intent is now in the code and directly testable.
- Koin: bind VideoPrefetchDriveAccess to DriveFileProvider.
- Add FakeVideoPrefetchDriveAccess + VideoPreloaderTest (commonTest) covering:
  * large video prefetches metadata payload then first segment byterange
  * small HLS video skips metadata prefetch, only warms first segment
  * non-HLS MP4 prefetches the full payload, no chunked call
  * HLS playlist without #EXT-X-BYTERANGE skips segment prefetch
  * concurrent preloads for the same fileId/payloadKey dedup via the mutex

Verified: homebase-api:jvmTest, homebase-chat:jvmTest, homebase-common:jvmTest.