### PR TITLE
feat: receive localReactions; dedupe ReactionContent

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/FileMetadata.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/FileMetadata.kt
@@ -54,7 +54,8 @@ data class LocalAppMetadata(
     val versionTag: Uuid? = null,
     val iv: String? = null,
     val content: String? = null,
-    val readTime: UnixTimeUtc? = null
+    val readTime: UnixTimeUtc? = null,
+    val localReactions: List<String>? = null,
 )
 
 /** Reaction entry for both comments and summary reactions */

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/reactions/ReactionContent.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/reactions/ReactionContent.kt
@@ -1,0 +1,6 @@
+package id.homebase.api.client.drives.files.reactions
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ReactionContent(val emoji: String)

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/client/drives/files/reactions/ReactionContractTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/client/drives/files/reactions/ReactionContractTest.kt
@@ -1,0 +1,47 @@
+@file:OptIn(ExperimentalUuidApi::class)
+
+package id.homebase.api.client.drives.files.reactions
+
+import id.homebase.api.client.drives.files.LocalAppMetadata
+import id.homebase.api.serialization.OdinSystemSerializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.uuid.ExperimentalUuidApi
+
+class ReactionContractTest {
+
+    @Test
+    fun reactionContentRoundTripsThroughOdinSystemSerializer() {
+        val encoded = OdinSystemSerializer.serialize(ReactionContent(emoji = "❤️"))
+        assertEquals("""{"emoji":"❤️"}""", encoded)
+
+        val decoded = OdinSystemSerializer.deserialize<ReactionContent>("""{"emoji":"🚀"}""")
+        assertEquals("🚀", decoded.emoji)
+    }
+
+    @Test
+    fun localAppMetadataTolerates_missingLocalReactions() {
+        val decoded = OdinSystemSerializer.deserialize<LocalAppMetadata>("{}")
+        assertNull(decoded.localReactions)
+    }
+
+    @Test
+    fun localAppMetadataTolerates_explicitNullLocalReactions() {
+        val decoded = OdinSystemSerializer.deserialize<LocalAppMetadata>(
+            """{"localReactions": null}"""
+        )
+        assertNull(decoded.localReactions)
+    }
+
+    @Test
+    fun localAppMetadataPreservesLocalReactionsAsRawJsonStrings() {
+        val decoded = OdinSystemSerializer.deserialize<LocalAppMetadata>(
+            """{"localReactions": ["{\"emoji\":\"❤️\"}", "{\"emoji\":\"🚀\"}"]}"""
+        )
+        assertEquals(
+            listOf("""{"emoji":"❤️"}""", """{"emoji":"🚀"}"""),
+            decoded.localReactions
+        )
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/MessageUiModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/MessageUiModel.kt
@@ -9,6 +9,7 @@ import id.homebase.api.common.OdinId
 import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.chat.services.MessageAppData
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
 
@@ -30,6 +31,10 @@ data class MessageUiModel(
 
     /** The timestamp when this file was marked as read for current user's identity */
     val localReadTimestamp: UnixTimeUtc? = null,
+
+    /** Raw JSON-encoded reactions the current identity has applied to this
+     *  message (mirrors server `localAppData.localReactions`). */
+    val ownReactions: ImmutableList<String> = persistentListOf(),
 
     val isEdited: Boolean = false,
     val messageAppData: MessageAppData, // TODO: Should we copy these up into the message?

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/ReactionContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/ReactionContent.kt
@@ -1,8 +1,0 @@
-package id.homebase.chat.data
-
-import kotlinx.serialization.Serializable
-
-@Serializable
-data class ReactionContent(
-    val emoji: String
-)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
@@ -22,7 +22,7 @@ import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.OutboxSync
 import id.homebase.api.sync.database.QueryBatch
 import id.homebase.chat.services.outbox.OptimisticWriter
-import id.homebase.chat.data.ReactionContent
+import id.homebase.api.client.drives.files.reactions.ReactionContent
 import id.homebase.chat.services.convo.ConversationService
 import id.homebase.chat.services.convo.ConversationStream
 import id.homebase.core.config.chatTargetDrive

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -395,6 +395,9 @@ class ChatMessageStream(
                     ?: false
 
             val localReadTimestamp = metadata.localAppData?.readTime
+            val ownReactions = metadata.localAppData?.localReactions
+                .orEmpty()
+                .toPersistentList()
 
             try {
                 require(appData.fileType == ChatProtocol.MessageFileType)
@@ -421,6 +424,7 @@ class ChatMessageStream(
                         originalAuthor = metadata.originalAuthor,
                         displayName = metadata.originalAuthor?.domainName ?: "",
                         localReadTimestamp = localReadTimestamp,
+                        ownReactions = ownReactions,
                         isEdited = false,
                         content = "Deleted File",
                         messageAppData = MessageAppData(),
@@ -513,6 +517,7 @@ class ChatMessageStream(
                     displayName = displayName,
                     isEdited = messageAppData.isEdited,
                     localReadTimestamp = localReadTimestamp,
+                    ownReactions = ownReactions,
                     messageAppData = messageAppData,
                     reactionPreview = metadata.reactionPreview,
                     previewThumbnail = metadata.appData.previewThumbnail,
@@ -544,6 +549,7 @@ class ChatMessageStream(
                         displayName = metadata.originalAuthor?.domainName ?: "",
                         messageAppData = MessageAppData(),
                         localReadTimestamp = localReadTimestamp,
+                        ownReactions = ownReactions,
                         reactionPreview = metadata.reactionPreview,
                         previewThumbnail = metadata.appData.previewThumbnail,
                         payloads = metadata.payloads?.toPersistentList(),

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageStreamMapperTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageStreamMapperTest.kt
@@ -1,0 +1,174 @@
+@file:OptIn(ExperimentalUuidApi::class)
+
+package id.homebase.chat.services
+
+import id.homebase.api.client.auth.ApiCredentials
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.SecureByteArray
+import id.homebase.api.serialization.OdinSystemSerializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Covers the `ChatMessageStream.mapToMessageData` path that populates
+ * `MessageUiModel.ownReactions` from `fileMetadata.localAppData.localReactions`.
+ *
+ * Three branches in the mapper construct a `MessageUiModel`
+ * (normal / deleted / catch-fallback); these tests exercise the first two.
+ */
+class ChatMessageStreamMapperTest {
+
+    private val testDomain = "owner.test"
+
+    private suspend fun createTestCredentialsManager(): CredentialsManager {
+        val cm = CredentialsManager()
+        cm.setActiveCredentials(
+            ApiCredentials.create(
+                domain = OdinId(testDomain),
+                clientAccessToken = "test-token",
+                sharedSecret = SecureByteArray(ByteArray(16))
+            )
+        )
+        return cm
+    }
+
+    private val sampleLocalReactionsJson =
+        """["{\"emoji\":\"❤️\"}", "{\"emoji\":\"🚀\"}"]"""
+
+    private val expectedOwnReactions =
+        listOf("""{"emoji":"❤️"}""", """{"emoji":"🚀"}""")
+
+    /**
+     * Builds a minimal chat-message HomebaseFile JSON.
+     *
+     * @param localAppDataJson JSON object literal (e.g. `{"localReactions":[...]}`)
+     *        or `null` to emit `"localAppData": null`.
+     * @param fileState `"active"` or `"deleted"`.
+     */
+    private fun buildChatMessageHeader(
+        localAppDataJson: String?,
+        fileState: String = "active"
+    ): HomebaseFile {
+        val now = Clock.System.now().epochSeconds
+        val messageContent =
+            """{"message":"hi","deliveryStatus":20,"isEdited":false,"version":1}"""
+        val escapedContent = messageContent.replace("\"", "\\\"")
+        val localAppDataField = localAppDataJson ?: "null"
+
+        val jsonHeader = """{
+            "fileId": "${Uuid.random()}",
+            "driveId": "${Uuid.random()}",
+            "fileState": "$fileState",
+            "fileSystemType": "standard",
+            "serverFileIsEncrypted": false,
+            "keyHeader": {
+                "iv": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+                "aesKey": {"bytes": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}
+            },
+            "fileMetadata": {
+                "globalTransitId": "${Uuid.random()}",
+                "created": ${now}000,
+                "updated": ${now}000,
+                "transitCreated": ${now}000,
+                "transitUpdated": 0,
+                "isEncrypted": false,
+                "senderOdinId": "sender.test",
+                "originalAuthor": "sender.test",
+                "appData": {
+                    "uniqueId": "${Uuid.random()}",
+                    "tags": null,
+                    "fileType": ${ChatProtocol.MessageFileType},
+                    "dataType": 0,
+                    "groupId": "${Uuid.random()}",
+                    "userDate": ${now}000,
+                    "content": "$escapedContent",
+                    "previewThumbnail": null,
+                    "archivalStatus": 0
+                },
+                "localAppData": $localAppDataField,
+                "referencedFile": null,
+                "reactionPreview": null,
+                "versionTag": "${Uuid.random()}",
+                "payloads": [],
+                "dataSource": null
+            },
+            "serverMetadata": {
+                "accessControlList": {
+                    "requiredSecurityGroup": "owner",
+                    "circleIdList": null,
+                    "odinIdList": null
+                },
+                "doNotIndex": false,
+                "allowDistribution": true,
+                "fileSystemType": "standard",
+                "fileByteCount": 100,
+                "originalRecipientCount": 0,
+                "transferHistory": null
+            },
+            "priority": 300,
+            "fileByteCount": 100
+        }"""
+
+        return OdinSystemSerializer.deserialize<HomebaseFile>(jsonHeader)
+    }
+
+    @Test
+    fun mapToMessageData_propagatesLocalReactionsIntoOwnReactions() = runTest {
+        val cm = createTestCredentialsManager()
+        val header = buildChatMessageHeader(
+            localAppDataJson = """{"localReactions": $sampleLocalReactionsJson}"""
+        )
+
+        val result = ChatMessageStream.mapToMessageData(header, cm)
+
+        assertNotNull(result)
+        assertEquals(expectedOwnReactions, result.ownReactions.toList())
+    }
+
+    @Test
+    fun mapToMessageData_ownReactionsEmpty_whenLocalAppDataIsAbsent() = runTest {
+        val cm = createTestCredentialsManager()
+        val header = buildChatMessageHeader(localAppDataJson = null)
+
+        val result = ChatMessageStream.mapToMessageData(header, cm)
+
+        assertNotNull(result)
+        assertTrue(result.ownReactions.isEmpty())
+    }
+
+    @Test
+    fun mapToMessageData_ownReactionsEmpty_whenLocalReactionsIsExplicitNull() = runTest {
+        val cm = createTestCredentialsManager()
+        val header = buildChatMessageHeader(
+            localAppDataJson = """{"localReactions": null}"""
+        )
+
+        val result = ChatMessageStream.mapToMessageData(header, cm)
+
+        assertNotNull(result)
+        assertTrue(result.ownReactions.isEmpty())
+    }
+
+    @Test
+    fun mapToMessageData_ownReactionsPropagatedOnDeletedBranch() = runTest {
+        val cm = createTestCredentialsManager()
+        val header = buildChatMessageHeader(
+            localAppDataJson = """{"localReactions": $sampleLocalReactionsJson}""",
+            fileState = "deleted"
+        )
+
+        val result = ChatMessageStream.mapToMessageData(header, cm)
+
+        assertNotNull(result)
+        assertTrue(result.isDeleted)
+        assertEquals(expectedOwnReactions, result.ownReactions.toList())
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionList.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionList.kt
@@ -27,12 +27,12 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import id.homebase.api.client.drives.files.ReactionSummary
+import id.homebase.api.client.drives.files.reactions.ReactionContent
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.resources.MR
 import id.homebase.resources.chat_message_emoji_options
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.serialization.Serializable
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -59,9 +59,6 @@ fun ReactionList(
         }
     }
 }
-
-@Serializable
-data class ReactionContent(val emoji: String)
 
 private fun extractEmoji(reactionContent: String): String? {
     return try {


### PR DESCRIPTION
- Add optional `localReactions: List<String>?` to `LocalAppMetadata`. Tolerates absent / explicit-null / populated server responses via the existing `OdinSystemSerializer` config.
- Plumb the field through `ChatMessageStream.mapToMessageData` into a new `MessageUiModel.ownReactions: ImmutableList<String>`, covering all three `MessageUiModel(...)` construction sites (normal, deleted, fallback). Sets the stage for highlighting the current user's reactions in the UI.
- Move the shared `ReactionContent` wire DTO down to `homebase-api` next to `ToggleReactionRequest`, removing both the duplicate class in `homebase-chat` and the inline private copy in `ReactionList.kt`. One class, one serializer, used by both the write and read paths.
- Add contract tests: `ReactionContractTest` pins serialization and tolerance of the new field; `ChatMessageStreamMapperTest` pins `ownReactions` propagation across all branches of the mapper.