### PR TITLE
fix: warm notification tap silently dropped when user is on Detail

### DIFF
--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
@@ -437,7 +437,12 @@ class NotificationService(
             }
 
             if (event != null) {
+                Logger.i(tag = "NotificationService") { "navigationEvent emit: $event" }
                 _navigationEvents.trySend(event)
+            } else {
+                Logger.w(tag = "NotificationService") {
+                    "No navigationEvent produced from click (appId unmatched?)"
+                }
             }
         } catch (e: Exception) {
             Logger.e(tag = "NotificationService") {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -45,6 +45,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.window.core.layout.WindowSizeClass
+import co.touchlab.kermit.Logger
 import id.homebase.api.youauth.YouAuthFlowManager
 import id.homebase.api.youauth.YouAuthState
 import id.homebase.auth.login.LoginScreen
@@ -165,14 +166,25 @@ fun AppNavHost(
             when (event) {
                 is NotificationNavigationEvent.OpenConversation -> {
                     val id = Uuid.parseOrNull(event.conversationId) ?: return@collect
-                    // Cold-start: NavController may still be on AppLoading while the
-                    // buffered event is drained. Wait for the AppLoading -> ChatList
-                    // transition before touching the ChatList saved state, otherwise
-                    // getBackStackEntry<Route.ChatList>() throws IllegalArgumentException.
-                    navController.currentBackStackEntryFlow
-                        .first { it.destination.hasRoute(Route.ChatList::class) }
-                    navController.selectConversationOnChatList(id, scrollToBottom = true)
-                    navController.popBackStack(Route.ChatList, inclusive = false)
+                    val topRoute = navController.currentBackStackEntry?.destination?.route
+                    Logger.i(tag = "AppNavHost") {
+                        "OpenConversation received: id=$id, currentDest=$topRoute"
+                    }
+                    // Gate on ChatList being *anywhere* in the back stack, not just
+                    // on top. Top-of-stack gating (currentBackStackEntryFlow) hangs
+                    // forever when the user is warm on Detail/Settings/etc. —
+                    // regression introduced by PR #322. currentBackStack returns
+                    // immediately here because ChatList sits underneath the current
+                    // top entry; the subsequent popBackStack pops back to it.
+                    val stack = navController.currentBackStack
+                        .first { stack -> stack.any { it.destination.hasRoute(Route.ChatList::class) } }
+                    Logger.i(tag = "AppNavHost") {
+                        "ChatList present in stack (size=${stack.size}), dispatching"
+                    }
+                    val ok = navController.selectConversationOnChatList(id, scrollToBottom = true)
+                    Logger.i(tag = "AppNavHost") { "selectConversationOnChatList result=$ok" }
+                    val popped = navController.popBackStack(Route.ChatList, inclusive = false)
+                    Logger.i(tag = "AppNavHost") { "popBackStack(ChatList)=$popped" }
                 }
                 is NotificationNavigationEvent.OpenUrl ->
                     uriHandler.openUrl(event.url)
@@ -581,7 +593,13 @@ fun AppNavHost(
 }
 
 private fun NavHostController.selectConversationOnChatList(conversationId: Uuid, scrollToBottom: Boolean = false): Boolean {
-    val entry = runCatching { getBackStackEntry<Route.ChatList>() }.getOrNull() ?: return false
+    val entry = runCatching { getBackStackEntry<Route.ChatList>() }.getOrNull()
+    if (entry == null) {
+        Logger.w(tag = "AppNavHost") {
+            "ChatList missing from stack — dropping pending conversation $conversationId"
+        }
+        return false
+    }
     entry.savedStateHandle["pendingConversationId"] = conversationId.toString()
     entry.savedStateHandle["pendingScrollToBottom"] = scrollToBottom
     return true

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppViewModel.kt
@@ -88,6 +88,7 @@ class AppViewModel(
     private fun collectNotificationEvents() {
         viewModelScope.launch {
             notificationService.navigationEvents.collect { event ->
+                Logger.i(tag = "AppViewModel") { "navigationEvent forwarded: $event" }
                 _navigationEvents.trySend(event)
             }
         }

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/navigation/NotificationTapColdStartTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/navigation/NotificationTapColdStartTest.kt
@@ -46,6 +46,9 @@ internal data object TestAppLoading
 @Serializable
 internal data object TestChatList
 
+@Serializable
+internal data object TestDetail
+
 @OptIn(ExperimentalTestApi::class)
 class NotificationTapColdStartTest {
 
@@ -157,6 +160,186 @@ class NotificationTapColdStartTest {
         kotlin.test.assertTrue(
             thrown.message?.contains("back stack") == true,
             "Expected back-stack IAE, got: ${thrown.message}"
+        )
+    }
+
+    /**
+     * Regression test for the warm-path drop captured in homebase.log lines 222+:
+     *
+     *   (MainActivity) Notification intent detected (conversation: b185a5ed-…)
+     *   — then silence; no navigation occurs.
+     *
+     * Scenario: app is warm, user is currently on a conversation Detail screen.
+     * A notification tap for a *different* conversation arrives.
+     *
+     * PR #322 gated the collector on
+     *   currentBackStackEntryFlow.first { it.destination.hasRoute(ChatList::class) }
+     * which checks the *top* back-stack entry. When the user is on Detail, that
+     * predicate never matches (top is Detail; ChatList sits underneath), so
+     * `first {}` suspends forever and the notification is silently dropped.
+     *
+     * The correct gate is membership in the back stack, not top-of-stack:
+     *   currentBackStack.first { stack -> stack.any { it.destination.hasRoute(ChatList::class) } }
+     * which returns immediately when ChatList is anywhere in the stack. The
+     * subsequent popBackStack(ChatList, inclusive=false) then brings ChatList
+     * back to the top, which reads pendingConversationId and routes.
+     */
+    @Test
+    fun warm_start_notification_tap_from_detail_navigates_via_chatlist() = runComposeUiTest {
+        val events = Channel<NotificationNavigationEvent>(Channel.BUFFERED)
+        val authReady = mutableStateOf(false)
+        val navigateToDetail = Channel<Unit>(Channel.BUFFERED)
+        var navControllerRef: androidx.navigation.NavHostController? = null
+
+        setContent {
+            val navController = rememberNavController()
+            navControllerRef = navController
+
+            LaunchedEffect(Unit) {
+                events.consumeAsFlow().collect { event ->
+                    if (event is NotificationNavigationEvent.OpenConversation) {
+                        val id = Uuid.parseOrNull(event.conversationId) ?: return@collect
+                        // The fix under test: wait for ChatList to be *anywhere*
+                        // in the stack, not for it to be the top entry.
+                        navController.currentBackStack
+                            .first { stack -> stack.any { it.destination.hasRoute(TestChatList::class) } }
+                        navController.getBackStackEntry<TestChatList>()
+                            .savedStateHandle["pendingConversationId"] = id.toString()
+                        navController.popBackStack(TestChatList, inclusive = false)
+                    }
+                }
+            }
+
+            LaunchedEffect(Unit) {
+                navigateToDetail.consumeAsFlow().collect {
+                    navController.navigate(TestDetail)
+                }
+            }
+
+            NavHost(navController, startDestination = TestAppLoading) {
+                composable<TestAppLoading> {
+                    LaunchedEffect(authReady.value) {
+                        if (authReady.value) {
+                            navController.navigate(TestChatList) {
+                                popUpTo(TestAppLoading) { inclusive = true }
+                            }
+                        }
+                    }
+                    Text("loading")
+                }
+                composable<TestChatList> { backStackEntry ->
+                    val pending by backStackEntry.savedStateHandle
+                        .getStateFlow<String?>("pendingConversationId", null)
+                        .collectAsState()
+                    Text("chatlist pending=${pending ?: "null"}")
+                }
+                composable<TestDetail> {
+                    Text("detail")
+                }
+            }
+        }
+
+        // Warm app up through to Detail.
+        authReady.value = true
+        waitForIdle()
+        navigateToDetail.trySend(Unit)
+        waitForIdle()
+        onNodeWithText("detail").assertExists()
+
+        // Notification tap arrives while on Detail. With the top-only gate this
+        // suspends forever; with the membership gate it proceeds immediately.
+        events.trySend(
+            NotificationNavigationEvent.OpenConversation(
+                "cc0577d2-2c92-4843-b08d-166e05ad4c19"
+            )
+        )
+        waitForIdle()
+
+        onNodeWithText("chatlist pending=cc0577d2-2c92-4843-b08d-166e05ad4c19")
+            .assertExists()
+        kotlin.test.assertNotNull(navControllerRef)
+    }
+
+    @Test
+    fun broken_top_only_gate_hangs_when_on_detail() = runComposeUiTest {
+        // Negative control: same warm-on-Detail scenario as the test above,
+        // but with the pre-fix top-only gate. Asserts that pendingConversationId
+        // is NOT applied to ChatList's savedStateHandle (the collector is
+        // suspended on `first{}` that can never match the top entry). If this
+        // test ever starts applying the pending id, the positive test above
+        // isn't actually exercising the regression.
+        val events = Channel<NotificationNavigationEvent>(Channel.BUFFERED)
+        val authReady = mutableStateOf(false)
+        val navigateToDetail = Channel<Unit>(Channel.BUFFERED)
+        var navControllerRef: androidx.navigation.NavHostController? = null
+
+        setContent {
+            val navController = rememberNavController()
+            navControllerRef = navController
+
+            LaunchedEffect(Unit) {
+                events.consumeAsFlow().collect { event ->
+                    if (event is NotificationNavigationEvent.OpenConversation) {
+                        val id = Uuid.parseOrNull(event.conversationId) ?: return@collect
+                        // The BROKEN top-only gate from PR #322.
+                        navController.currentBackStackEntryFlow
+                            .first { it.destination.hasRoute(TestChatList::class) }
+                        navController.getBackStackEntry<TestChatList>()
+                            .savedStateHandle["pendingConversationId"] = id.toString()
+                    }
+                }
+            }
+
+            LaunchedEffect(Unit) {
+                navigateToDetail.consumeAsFlow().collect {
+                    navController.navigate(TestDetail)
+                }
+            }
+
+            NavHost(navController, startDestination = TestAppLoading) {
+                composable<TestAppLoading> {
+                    LaunchedEffect(authReady.value) {
+                        if (authReady.value) {
+                            navController.navigate(TestChatList) {
+                                popUpTo(TestAppLoading) { inclusive = true }
+                            }
+                        }
+                    }
+                    Text("loading")
+                }
+                composable<TestChatList> {
+                    Text("chatlist")
+                }
+                composable<TestDetail> {
+                    Text("detail")
+                }
+            }
+        }
+
+        authReady.value = true
+        waitForIdle()
+        navigateToDetail.trySend(Unit)
+        waitForIdle()
+        onNodeWithText("detail").assertExists()
+
+        events.trySend(
+            NotificationNavigationEvent.OpenConversation(
+                "cc0577d2-2c92-4843-b08d-166e05ad4c19"
+            )
+        )
+        waitForIdle()
+
+        // With the broken gate the collector is suspended on `first {}` waiting
+        // for the top entry to be ChatList — which never happens while the user
+        // is on Detail. Peek directly into ChatList's savedStateHandle to prove
+        // the pending id was never written.
+        val controller = navControllerRef
+            ?: kotlin.test.fail("NavController not captured")
+        val chatListEntry = controller.getBackStackEntry<TestChatList>()
+        val pending = chatListEntry.savedStateHandle.get<String?>("pendingConversationId")
+        kotlin.test.assertNull(
+            pending,
+            "Broken top-only gate must leave pendingConversationId unset while user is on Detail — this is the warm-path regression we're guarding against"
         )
     }
 }


### PR DESCRIPTION
Continuation of PR #322 (fix-cold-start-notification-tap-crash, merged as fd42e080). PR #322 fixed the cold-start IllegalArgumentException by gating the notification collector in AppNavHost on
`currentBackStackEntryFlow.first { hasRoute(Route.ChatList::class) }`.

That gate is correct for cold-start (ChatList arrives later as the top entry) but regresses the warm path: `currentBackStackEntryFlow` is a StateFlow of the top-of-stack entry only. When the user is warm and currently on Detail/Settings/etc., the flow emits that top entry and the predicate never matches — ChatList sits underneath in the stack, not on top. The collector suspends forever and the tap is silently dropped.

Captured in homebase.log line 222+:
  (MainActivity) Notification intent detected (conversation: b185a5ed-…)
  — then silence, no navigation occurs. Diagnosable only by reading code
  because every hop between MainActivity and NavController was unlogged.

Fix: gate on membership in the back stack, not top-of-stack.
  navController.currentBackStack
      .first { stack -> stack.any { it.destination.hasRoute(Route.ChatList::class) } }
Returns immediately in both warm cases (user on ChatList or on Detail/Settings), still suspends correctly in cold-start (ChatList absent from stack until AppLoading -> ChatList transition). The subsequent popBackStack(Route.ChatList, inclusive = false) then pops back to ChatList, which reads pendingConversationId and routes.

Also adds Info-level logs at every hop on the intent -> navigation pipeline (NotificationService emit, AppViewModel forward, AppNavHost receive / gate pass / selectConversationOnChatList result / popBackStack result), so the next missed tap is greppable from homebase.log without re-reading source.

Tests:
- warm_start_notification_tap_from_detail_navigates_via_chatlist — positive regression test (validates the membership gate).
- broken_top_only_gate_hangs_when_on_detail — negative control that reproduces the pre-fix top-only gate and asserts the pending id is NOT applied, proving the positive test exercises the regression.
- Existing cold-start tests from PR #322 continue to pass.