### PR TITLE
chore: log pendingConversationId -> selectedConversationId timing

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -370,6 +370,9 @@ class ConversationListViewModel(
         messageId: Uuid? = null,
         scrollToBottom: Boolean = false
     ) {
+        Logger.i(tag = "ConversationListViewModel") {
+            "selectConversation id=$conversationId scrollToBottom=$scrollToBottom"
+        }
         // Check for pending shared content (from iOS share extension or other handoff)
         viewModelScope.launch {
             processPendingSharedContent(conversationId)
@@ -1895,6 +1898,9 @@ class ConversationListViewModel(
         val loadStart = TimeSource.Monotonic.markNow()
 
         val hasCachedMessages = chatMessageStream.hasCachedMessages(conversationId)
+        Logger.i(tag = "ConversationListViewModel") {
+            "loadMessagesForConversation id=$conversationId hasCached=$hasCachedMessages"
+        }
 
         _messagesUiState.update {
             it.copy(scrollPosition = null, isLoadingMessages = !hasCachedMessages)
@@ -1999,6 +2005,9 @@ class ConversationListViewModel(
                                 )
                             }
 
+                            Logger.i(tag = "ConversationListViewModel") {
+                                "selectedConversationId flip id=$conversationId messageCount=${messages.size}"
+                            }
                             _uiState.value = _uiState.value.copy(
                                 selectedConversationId = conversationId,
                             )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -339,6 +339,9 @@ fun AppNavHost(
                             LaunchedEffect(pendingConversationId) {
                                 pendingConversationId?.let { idStr ->
                                     Uuid.parseOrNull(idStr)?.let {
+                                        Logger.i(tag = "AppNavHost") {
+                                            "ChatList observed pendingConversationId=$idStr, calling selectConversation"
+                                        }
                                         conversationListViewModel.selectConversation(it, scrollToBottom = pendingScrollToBottom)
                                         backStackEntry.savedStateHandle["pendingConversationId"] = null
                                         backStackEntry.savedStateHandle["pendingScrollToBottom"] = false


### PR DESCRIPTION
Diagnostic logs only — no behavior change. Follow-up to PR #326 (fix-warm-notification-tap-from-detail, 6174caa2) which instrumented the MainActivity -> NavController hop but left the ChatList VM path silent.

After PR #326 shipped, a separate cold-start symptom surfaced: tap a push on a killed app, land on ChatList, and Detail does not appear until the drive-sync spinner stops. It's unclear whether the scaffold actually swaps to Detail early (showing an empty pane until sync delivers messages) or something is gating the `selectedConversationId` flip on sync finishing. Static reading suggests empty-Detail-until-populated (the load path is local DB only), but the pipeline has enough async plumbing that runtime evidence is needed to be sure.

Adds three Info logs, tag-namespaced so the full chain is greppable from homebase.log:

- AppNavHost: ChatList composable's LaunchedEffect(pendingConversationId) now logs "ChatList observed pendingConversationId=..., calling selectConversation" immediately before it calls into the VM.
- ConversationListViewModel.selectConversation: entry log with the conversation id and scrollToBottom.
- ConversationListViewModel.loadMessagesForConversation: entry log with hasCachedMessages, and a "selectedConversationId flip" log at the moment the scaffold-swap trigger is written (line ~2008).

Combined with PR #326's AppNavHost collector logs and the existing ChatMessageStream / ConversationListUi / ChatMessageStream batch logs, the full cold-start intent -> detail-pane-rendered path is now visible from a single log. Comparing timestamps against
`ChatMessageStream: processIncrementalBatch` (sync delivery) will answer whether the swap happens early (visual coincidence) or is genuinely gated on sync.