### PR TITLE
chore: log detail-pane render gate and conversationStream readiness

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -467,8 +467,14 @@ fun ConversationListUi(
             },
             detailPane = {
                 AnimatedPane {
+                    val contentKey = scaffoldNavigator.currentDestination?.contentKey
                     val conversation =
-                        uiState.activeConversations.find { it.conversation.id == scaffoldNavigator.currentDestination?.contentKey }
+                        uiState.activeConversations.find { it.conversation.id == contentKey }
+                    LaunchedEffect(contentKey, conversation != null) {
+                        Logger.i(tag = "ConversationListUi") {
+                            "detailPane render: contentKey=$contentKey, conversationFound=${conversation != null}, activeConversationsSize=${uiState.activeConversations.size}"
+                        }
+                    }
                     if (conversation != null) {
                         key(conversation.conversation.id) {
                             ConversationMessagesPane(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -220,6 +220,9 @@ class ConversationListViewModel(
                     )
                 })
             }.debounce(50).collect { (dataReady: Boolean, enriched: List<EnrichedConversationUiModel>) ->
+                Logger.i(tag = "ConversationListViewModel") {
+                    "conversationStream emit: dataReady=$dataReady enrichedCount=${enriched.size}"
+                }
                 if (dataReady) {
                     _uiState.update {
                         it.copy(


### PR DESCRIPTION
Second diagnostic commit on this branch. Builds on 0d25b1ef and PR #326 (fix-warm-notification-tap-from-detail, 6174caa2).

Static exploration of the cold-start path turned up a likely culprit for the "Detail doesn't appear until drive sync completes" symptom: the scaffold's detail pane in ConversationListScreen.kt:468 gates rendering of ConversationMessagesPane on `uiState.activeConversations.find { ... }` matching the scaffold's currentDestination.contentKey. If the conversation stream hasn't emitted dataReady=true yet (ConversationListViewModel.kt:222 debounced combine), activeConversations is empty and the pane renders EmptyDetailPane — even though selectedConversationId and the scaffold's navigation to Detail have already fired. Sync completing is what finally unblocks the conversation stream, making the conversation findable, and the pane finally shows content.

The three logs in 0d25b1ef cover the intent -> selectedConversationId path, but say nothing about whether the pane actually rendered the conversation afterward. These two fill that gap:

- ConversationListScreen.kt (detailPane lambda): a LaunchedEffect gated on (contentKey, conversation != null) logs "detailPane render: contentKey=..., conversationFound=..., activeConversationsSize=..." exactly when the pane first composes and again when the found-status transitions. No spam on recomposition.

- ConversationListViewModel.kt (debounced combine at line 222): log "conversationStream emit: dataReady=..., enrichedCount=..." on every tick, so we see the readiness transition and can correlate it with processIncrementalBatch and the detail-pane unblocking.

With these, a single cold-start repro should localize the block to one of three spans: the DB-read queue (slow `→ N messages in Yms`), the activeConversations render gate (fast read, long gap to conversationFound=true), or both.