### PR TITLE
perf(chat): batch admin-file lookups + cold-load timers

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DriveMainIndexWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DriveMainIndexWrapper.kt
@@ -67,6 +67,30 @@ class DriveMainIndexWrapper(
         return OdinSystemSerializer.deserialize<HomebaseFile>(row.jsonHeader)
     }
 
+    fun selectByIdentityAndDriveAndUniqueIds(
+        identityId: Uuid,
+        driveId: Uuid,
+        uniqueIds: Collection<Uuid>,
+    ): List<DriveMainIndex> {
+        if (uniqueIds.isEmpty()) return emptyList()
+        return delegate.selectByIdentityAndDriveAndUniqueIds(identityId, driveId, uniqueIds)
+            .executeAsList()
+    }
+
+    fun selectHomebaseFilesByUniqueIds(
+        identityId: Uuid,
+        driveId: Uuid,
+        uniqueIds: Collection<Uuid>,
+    ): List<HomebaseFile> {
+        if (uniqueIds.isEmpty()) return emptyList()
+        val rows = selectByIdentityAndDriveAndUniqueIds(identityId, driveId, uniqueIds)
+        val result = ArrayList<HomebaseFile>(rows.size)
+        for (row in rows) {
+            result.add(OdinSystemSerializer.deserialize<HomebaseFile>(row.jsonHeader))
+        }
+        return result
+    }
+
     fun selectByIdentityAndDriveAndGlobal(
         identityId: Uuid,
         driveId: Uuid,

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/DriveMainIndex.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/DriveMainIndex.sq
@@ -95,6 +95,13 @@ selectByIdentityAndDriveAndUnique:
 SELECT * FROM DriveMainIndex
 WHERE identityId = ? AND driveId = ? AND uniqueId = ?;
 
+-- Batch variant: look up many rows by uniqueId in one round-trip. Used by the
+-- chat overview cold-load to avoid N+1 admin-file queries when mapping each
+-- group conversation.
+selectByIdentityAndDriveAndUniqueIds:
+SELECT * FROM DriveMainIndex
+WHERE identityId = ? AND driveId = ? AND uniqueId IN ?;
+
 -- Select by identity and drive and file (get single row)
 selectByIdentityAndDriveAndGlobal:
 SELECT * FROM DriveMainIndex

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -176,6 +176,7 @@ class ConversationListViewModel(
         }
 
         viewModelScope.launch {
+            val vmInitMark = TimeSource.Monotonic.markNow()
             contactService.start()
             conversationStream.start()
             connectionService.start()
@@ -196,6 +197,31 @@ class ConversationListViewModel(
                     statusKnown = connections.isLoaded && requestsLoaded,
                 )
             }.distinctUntilChanged()
+
+            viewModelScope.launch {
+                conversationStream.conversations.first { it.dataReady }
+                Logger.i(tag = "ConvListPerf") {
+                    "combineSource firstEmit=conversations(dataReady) at ${vmInitMark.elapsedNow().inWholeMilliseconds}ms from vmInit"
+                }
+            }
+            viewModelScope.launch {
+                contactService.contacts.first { it.isNotEmpty() }
+                Logger.i(tag = "ConvListPerf") {
+                    "combineSource firstEmit=contacts(nonEmpty) at ${vmInitMark.elapsedNow().inWholeMilliseconds}ms from vmInit"
+                }
+            }
+            viewModelScope.launch {
+                ownerSessionRepository.user.first { it != null }
+                Logger.i(tag = "ConvListPerf") {
+                    "combineSource firstEmit=ownerSession(nonNull) at ${vmInitMark.elapsedNow().inWholeMilliseconds}ms from vmInit"
+                }
+            }
+            viewModelScope.launch {
+                connectionStatusFlow.first { it.statusKnown }
+                Logger.i(tag = "ConvListPerf") {
+                    "combineSource firstEmit=connectionStatus(known) at ${vmInitMark.elapsedNow().inWholeMilliseconds}ms from vmInit"
+                }
+            }
 
             combine(
                 conversationStream.conversations,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationAppDataJson.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationAppDataJson.kt
@@ -106,7 +106,44 @@ data class ConversationAdminInfo(
             val file = dbm.driveMainIndex.selectHomebaseFileByUnique(
                 c.getIdentityId(), chatDrive, adminUniqueId
             ) ?: return null
-            val content = file.fileMetadata.appData.content
+            return parseAdmins(file.fileMetadata.appData.content, conversationId)
+        }
+
+        /**
+         * Batched counterpart of [queryFromDb]. Resolves admin sets for many
+         * conversations in a single DB round-trip. Conversations whose admin
+         * file is missing, empty, or malformed are omitted from the returned
+         * map — callers should treat an absent key the same as `queryFromDb`
+         * returning `null` and apply their own fallback.
+         */
+        suspend fun queryBatchFromDb(
+            credentialsManager: CredentialsManager,
+            dbm: DatabaseManager,
+            chatDrive: Uuid,
+            conversationIds: Collection<Uuid>,
+        ): Map<Uuid, Set<OdinId>> {
+            if (conversationIds.isEmpty()) return emptyMap()
+            val c = credentialsManager.requireActiveCredentials()
+            val adminUniqueToConversation = HashMap<Uuid, Uuid>(conversationIds.size)
+            for (id in conversationIds) {
+                adminUniqueToConversation[ChatProtocol.getAdminFileUniqueId(id)] = id
+            }
+            val files = dbm.driveMainIndex.selectHomebaseFilesByUniqueIds(
+                c.getIdentityId(), chatDrive, adminUniqueToConversation.keys
+            )
+            val result = HashMap<Uuid, Set<OdinId>>(files.size)
+            for (file in files) {
+                val adminUniqueId = file.fileMetadata.appData.uniqueId ?: continue
+                val conversationId = adminUniqueToConversation[adminUniqueId] ?: continue
+                val admins = parseAdmins(file.fileMetadata.appData.content, conversationId)
+                if (admins != null) {
+                    result[conversationId] = admins
+                }
+            }
+            return result
+        }
+
+        private fun parseAdmins(content: String?, conversationId: Uuid): Set<OdinId>? {
             if (content.isNullOrEmpty()) return null
             return try {
                 val adminInfo = OdinSystemSerializer.deserialize<ConversationAdminInfo>(content)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMapper.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMapper.kt
@@ -21,6 +21,7 @@ import id.homebase.core.config.chatTargetDrive
 import id.homebase.core.image.HomebaseImageData
 import id.homebase.core.image.ImageSize
 import kotlin.io.encoding.Base64
+import kotlin.time.Clock
 import kotlin.uuid.Uuid
 
 class ConversationMapper(
@@ -33,10 +34,14 @@ class ConversationMapper(
 
     suspend fun mapToConversationUi(
         conversationFile: HomebaseFile,
-        lastMsg: HomebaseFile?
+        lastMsg: HomebaseFile?,
+        preloadedAdmins: Map<Uuid, Set<OdinId>>? = null,
     ): ConversationUiModel {
 
-        return try {
+        val startedAt = Clock.System.now().toEpochMilliseconds()
+        val rowId = conversationFile.fileMetadata.appData.uniqueId
+        try {
+            return try {
 
             val domain = credentialsManager.requireActiveDomain()
             val metadata = conversationFile.fileMetadata
@@ -89,7 +94,12 @@ class ConversationMapper(
 
             val admins: Set<OdinId> =
                 if (isAnyGroup) {
-                    queryAdmins(conversationId)
+                    val adminFileResult = if (preloadedAdmins != null) {
+                        preloadedAdmins[conversationId]
+                    } else {
+                        queryAdmins(conversationId)
+                    }
+                    adminFileResult
                     // Backward compat: fall back to conversation content, then originalAuthor
                         ?: (conversationData.adminData?.admins?.toSet())
                         ?: setOf(
@@ -190,6 +200,14 @@ class ConversationMapper(
                 fileUpdated = conversationFile.fileMetadata.updated.toInstant()
             )
         }
+        } finally {
+            val elapsed = Clock.System.now().toEpochMilliseconds() - startedAt
+            if (elapsed > 20) {
+                Logger.w(tag = "ConvListPerf") {
+                    "mapToConversationUi slow row=$rowId in ${elapsed}ms"
+                }
+            }
+        }
     }
 
     private suspend fun mapDeletedConversation(
@@ -231,7 +249,12 @@ class ConversationMapper(
     }
 
     private suspend fun queryAdmins(conversationId: Uuid): Set<OdinId>? {
-        return ConversationAdminInfo.queryFromDb(credentialsManager, dbm, chatDrive, conversationId)
+        val startedAt = Clock.System.now().toEpochMilliseconds()
+        val result = ConversationAdminInfo.queryFromDb(credentialsManager, dbm, chatDrive, conversationId)
+        Logger.i(tag = "ConvListPerf") {
+            "queryAdmins=${Clock.System.now().toEpochMilliseconds() - startedAt}ms groupId=$conversationId hit=${result != null}"
+        }
+        return result
     }
 
     private suspend fun buildConversationAvatarModel(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlin.time.Clock
 import kotlin.uuid.Uuid
 
 class ConversationStream(
@@ -448,6 +449,7 @@ class ConversationStream(
     }
 
     private suspend fun loadConversations() {
+        val startedAt = Clock.System.now().toEpochMilliseconds()
         val leftIds = _conversations.value.items
             .filter { it.conversationState == ConversationState.Left }
             .map { it.id }
@@ -457,6 +459,9 @@ class ConversationStream(
             if (convo.id in leftIds && convo.conversationState != ConversationState.Left)
                 convo.copy(conversationState = ConversationState.Left)
             else convo
+        }
+        Logger.i(tag = "ConvListPerf") {
+            "loadConversations end-to-end=${Clock.System.now().toEpochMilliseconds() - startedAt}ms items=${result.size}"
         }
         _conversations.value = ConversationsData(items = result)
     }
@@ -500,16 +505,17 @@ class ConversationStream(
     }
 
     suspend fun updateUnreadCounts() {
+        val startedAt = Clock.System.now().toEpochMilliseconds()
         val c = credentialsManager.requireActiveCredentials()
         val unread = dbm.chatReadCount.selectAllUnreadCount(c.getIdentityId(), c.domain)
         val unreadMap = unread.associate { it.conversationId to it.unreadCount.toInt() }
 
-        var changed = false
+        var changed = 0
 
         val updated = _conversations.value.items.map { convo ->
             val newCount = unreadMap[convo.id] ?: 0
             if (newCount != convo.unreadCount) {
-                changed = true
+                changed++
                 Logger.d("ConversationStream: unreadSync convo=${convo.id} ${convo.unreadCount}->${newCount}")
                 convo.copy(unreadCount = newCount)
             } else {
@@ -517,16 +523,37 @@ class ConversationStream(
             }
         }
 
-        if (changed) {
+        if (changed > 0) {
             _conversations.value = ConversationsData(items = updated)
+        }
+        Logger.i(tag = "ConvListPerf") {
+            "updateUnreadCounts=${Clock.System.now().toEpochMilliseconds() - startedAt}ms changedRows=$changed totalRows=${updated.size}"
         }
     }
 
     suspend fun fetchConversations(): List<ConversationUiModel> {
 
         val c = credentialsManager.requireActiveCredentials()
+        val queryStart = Clock.System.now().toEpochMilliseconds()
         val result = dbm.chatReadCount.selectAllConversationPlusLastMessage(c.getIdentityId())
-        return result.map { mapper.mapToConversationUi(it.conversation, it.message) }
+        val afterQuery = Clock.System.now().toEpochMilliseconds()
+        val conversationIds = ArrayList<Uuid>(result.size)
+        for (row in result) {
+            val id = row.conversation.fileMetadata.appData.uniqueId
+            if (id != null) conversationIds.add(id)
+        }
+        val adminMap = ConversationAdminInfo.queryBatchFromDb(
+            credentialsManager, dbm, chatDrive, conversationIds
+        )
+        val afterAdmins = Clock.System.now().toEpochMilliseconds()
+        val mapped = result.map {
+            mapper.mapToConversationUi(it.conversation, it.message, adminMap)
+        }
+        val afterMap = Clock.System.now().toEpochMilliseconds()
+        Logger.i(tag = "ConvListPerf") {
+            "fetchConversations: wrapperQueryPlusHeaderMap=${afterQuery - queryStart}ms batchAdmins=${afterAdmins - afterQuery}ms(hits=${adminMap.size}/${conversationIds.size}) outerMapToUi=${afterMap - afterAdmins}ms total=${afterMap - queryStart}ms items=${mapped.size}"
+        }
+        return mapped
 
     }
 

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/AdminQueryTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/AdminQueryTest.kt
@@ -559,6 +559,143 @@ class AdminQueryTest {
     // the same logic as ConversationMapper.queryAdmins(), we'll cover it after the refactor
     // extracts the shared logic into a testable unit.
 
+    // ---- Group 2b: ConversationAdminInfo.queryBatchFromDb() ----
+
+    @Test
+    fun queryBatchFromDb_emptyInput_returnsEmptyMap() = runTest {
+        createTestDatabaseManager().use { dbm ->
+            val cm = createTestCredentialsManager()
+            val result = ConversationAdminInfo.queryBatchFromDb(cm, dbm, chatDriveId, emptyList())
+            assertTrue(result.isEmpty())
+        }
+    }
+
+    @Test
+    fun queryBatchFromDb_returnsAdminsForAllPresentFiles() = runTest {
+        createTestDatabaseManager().use { dbm ->
+            val cm = createTestCredentialsManager()
+
+            val convo1 = Uuid.random()
+            val convo2 = Uuid.random()
+            val convo3 = Uuid.random()
+
+            insertFile(dbm, buildConversationFileJson(
+                fileId = Uuid.random(), uniqueId = convo1,
+                participants = listOf(testDomain, alice, bob),
+                originalAuthor = testDomain, isGroup = true
+            ))
+            insertFile(dbm, buildConversationFileJson(
+                fileId = Uuid.random(), uniqueId = convo2,
+                participants = listOf(testDomain, alice, bob),
+                originalAuthor = testDomain, isGroup = true
+            ))
+            insertFile(dbm, buildConversationFileJson(
+                fileId = Uuid.random(), uniqueId = convo3,
+                participants = listOf(testDomain, alice, bob),
+                originalAuthor = testDomain, isGroup = true
+            ))
+
+            insertFile(dbm, buildAdminFileJson(
+                fileId = Uuid.random(),
+                uniqueId = ChatProtocol.getAdminFileUniqueId(convo1),
+                groupId = convo1,
+                admins = listOf(alice),
+                originalAuthor = testDomain
+            ))
+            insertFile(dbm, buildAdminFileJson(
+                fileId = Uuid.random(),
+                uniqueId = ChatProtocol.getAdminFileUniqueId(convo2),
+                groupId = convo2,
+                admins = listOf(alice, bob),
+                originalAuthor = testDomain
+            ))
+            // convo3 intentionally has no admin file
+
+            val result = ConversationAdminInfo.queryBatchFromDb(
+                cm, dbm, chatDriveId, listOf(convo1, convo2, convo3)
+            )
+
+            assertEquals(2, result.size)
+            assertEquals(setOf(OdinId(alice)), result[convo1])
+            assertEquals(setOf(OdinId(alice), OdinId(bob)), result[convo2])
+            assertTrue(result[convo3] == null, "convo3 has no admin file — must be absent")
+        }
+    }
+
+    @Test
+    fun queryBatchFromDb_skipsCorruptAndEmptyAdminFiles() = runTest {
+        createTestDatabaseManager().use { dbm ->
+            val cm = createTestCredentialsManager()
+
+            val convoGood = Uuid.random()
+            val convoCorrupt = Uuid.random()
+            val convoEmpty = Uuid.random()
+
+            insertFile(dbm, buildAdminFileJson(
+                fileId = Uuid.random(),
+                uniqueId = ChatProtocol.getAdminFileUniqueId(convoGood),
+                groupId = convoGood,
+                admins = listOf(bob),
+                originalAuthor = testDomain
+            ))
+            insertFile(dbm, buildAdminFileJsonWithRawContent(
+                fileId = Uuid.random(),
+                uniqueId = ChatProtocol.getAdminFileUniqueId(convoCorrupt),
+                groupId = convoCorrupt,
+                rawContent = "not valid json",
+                originalAuthor = testDomain
+            ))
+            insertFile(dbm, buildAdminFileJsonWithRawContent(
+                fileId = Uuid.random(),
+                uniqueId = ChatProtocol.getAdminFileUniqueId(convoEmpty),
+                groupId = convoEmpty,
+                rawContent = "",
+                originalAuthor = testDomain
+            ))
+
+            val result = ConversationAdminInfo.queryBatchFromDb(
+                cm, dbm, chatDriveId, listOf(convoGood, convoCorrupt, convoEmpty)
+            )
+
+            assertEquals(1, result.size)
+            assertEquals(setOf(OdinId(bob)), result[convoGood])
+        }
+    }
+
+    @Test
+    fun queryBatchFromDb_matchesPerRowQueryResults() = runTest {
+        createTestDatabaseManager().use { dbm ->
+            val cm = createTestCredentialsManager()
+
+            val convo1 = Uuid.random()
+            val convo2 = Uuid.random()
+
+            insertFile(dbm, buildAdminFileJson(
+                fileId = Uuid.random(),
+                uniqueId = ChatProtocol.getAdminFileUniqueId(convo1),
+                groupId = convo1,
+                admins = listOf(alice, bob),
+                originalAuthor = testDomain
+            ))
+            insertFile(dbm, buildAdminFileJson(
+                fileId = Uuid.random(),
+                uniqueId = ChatProtocol.getAdminFileUniqueId(convo2),
+                groupId = convo2,
+                admins = listOf(bob),
+                originalAuthor = testDomain
+            ))
+
+            val singleRow1 = ConversationAdminInfo.queryFromDb(cm, dbm, chatDriveId, convo1)
+            val singleRow2 = ConversationAdminInfo.queryFromDb(cm, dbm, chatDriveId, convo2)
+            val batch = ConversationAdminInfo.queryBatchFromDb(
+                cm, dbm, chatDriveId, listOf(convo1, convo2)
+            )
+
+            assertEquals(singleRow1, batch[convo1])
+            assertEquals(singleRow2, batch[convo2])
+        }
+    }
+
     // ---- Group 3: Additional mapping correctness ----
 
     @Test


### PR DESCRIPTION
Indirect follow-up to the notification-tap work (PRs #326-#328). The instrumented trace from that branch showed that when a notification tap arrives, the visible delay before Detail renders is dominated by the chat-overview list reaching dataReady=true — not by navigation. Between the existing "Completed mapping" log and the first dataReady=true emit the trace has a 1-3 second opaque gap, hiding an N+1 admin-file query. This PR addresses that tail; it does not itself change navigation.

Two independent changes:

1) N+1 admin-file lookup -> single batch query
   - DriveMainIndex.sq: new selectByIdentityAndDriveAndUniqueIds (WHERE uniqueId IN ?) so callers can resolve many rows in one round-trip.
   - DriveMainIndexWrapper: selectByIdentityAndDriveAndUniqueIds + selectHomebaseFilesByUniqueIds (deserialized variant). Both short-circuit on empty input.
   - ConversationAdminInfo.queryBatchFromDb: companion method that builds the adminUniqueId->conversationId reverse map, fetches all admin files in one call, and returns a Map<conversationId, Set<OdinId>>. Parses via a shared private helper with the single-row path, so the fallback semantics for missing/empty/corrupt admin content stay identical.
   - ConversationMapper.mapToConversationUi gains an optional preloadedAdmins parameter (default null, backward-compatible for all other callers). Existing fallback chain (admin file -> conversationData.adminData -> originalAuthor) is preserved.
   - ConversationStream.fetchConversations pre-fetches the admin map once before the per-row map, replacing per-group DB calls on the cold-load path. With ~15 group conversations this removes ~15 round-trips from every first render of the list.

2) ConvListPerf timers (observability only, no behavior change)
   - ConversationStream: loadConversations end-to-end timer and updateUnreadCounts total timer.
   - ConversationStream.fetchConversations: split timing into wrapperQueryPlusHeaderMap / batchAdmins / outerMapToUi so the previously invisible post-"Completed mapping" gap is now measured.
   - ConversationMapper.mapToConversationUi: threshold-gated (>20ms) slow-row log, to surface only outliers. queryAdmins always-on timer kept so we can still see the single-row path cost when a caller doesn't preload.
   - ConversationListViewModel: four first-emit markers for the combine upstreams (conversations dataReady, contacts nonEmpty, ownerSession nonNull, connectionStatus known), each logged with elapsed time from vmInit. Pinpoints which upstream gates the first enriched emit.

Tests
   - AdminQueryTest gains 4 new cases: queryBatchFromDb_emptyInput_returnsEmptyMap, queryBatchFromDb_returnsAdminsForAllPresentFiles (3 convos, 2 with admin files -> third must be absent from the map), queryBatchFromDb_skipsCorruptAndEmptyAdminFiles, queryBatchFromDb_matchesPerRowQueryResults (parity vs queryFromDb).
   - homebase-chat:jvmTest + homebase-api:jvmTest: green (13 cases in AdminQueryTest, all existing cases still pass).

Next step: read the ConvListPerf trace on a cold-start repro to decide whether to also switch the first list emit to selectAllCoversations (the simple no-JOIN query) for an even earlier dataReady=true.