### PR TITLE
fix(cache): guard disk cache to 2xx only; fix notFoundCache thread safety

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
@@ -49,7 +49,7 @@ class DriveFileProviderCached(
     // Immutable set — always replaced, never mutated in-place.
     // @Volatile ensures lock-free reads always see the latest reference.
     // Writes are serialized via notFoundCacheMutex (rare: only on 404 responses).
-    // Later we should cache 401,403,404,410, but not yet
+    // Only 404 (NotFoundException) is cached. Transient failures (5xx, network errors) are never cached.
     @Volatile private var notFoundCache: Set<String> = emptySet()
     private val notFoundCacheMutex = Mutex()
 
@@ -128,20 +128,17 @@ class DriveFileProviderCached(
                     Logger.d(tag = "VideoIO") { "payload network-fetch: ${networkResult.bytes.size} bytes in $elapsed key=$cacheKey" }
                     val result = networkResult
 
-                    if (result.status == 404) {
-                        // 404 case - cache that file doesn't exist in memory only
-                        notFoundCacheMutex.withLock { notFoundCache = notFoundCache + cacheKey }
-                        ByteApiResponse.EMPTY_404
-                    } else {
-                        // 3️⃣ Store to disk
-                        val (_, cacheWriteElapsed) = measureTimedValue {
-                            payloadDiskKache().put(cacheKey) { filePath ->
-                                writeBytesResponse(filePath, result)
-                            }
-                        }
-                        Logger.d(tag = "VideoIO") { "payload cache-write: ${result.bytes.size} bytes in $cacheWriteElapsed key=$cacheKey" }
-                        result
+                    // 3️⃣ Store to disk (only 200/206 can reach here — throwForFailure throws for everything else)
+                    check(result.status in 200..299) {
+                        "Unexpected non-2xx status ${result.status} reached disk cache write — not caching"
                     }
+                    val (_, cacheWriteElapsed) = measureTimedValue {
+                        payloadDiskKache().put(cacheKey) { filePath ->
+                            writeBytesResponse(filePath, result)
+                        }
+                    }
+                    Logger.d(tag = "VideoIO") { "payload cache-write: ${result.bytes.size} bytes in $cacheWriteElapsed key=$cacheKey" }
+                    result
                 } catch (e: NotFoundException) {
                     // 404 thrown by network layer — cache it so future calls skip the network
                     notFoundCacheMutex.withLock { notFoundCache = notFoundCache + cacheKey }
@@ -289,20 +286,17 @@ class DriveFileProviderCached(
                                     lastModified
                             )
 
-                    if (result.status == 404) {
-                        // 404 case - cache that file doesn't exist in memory only
-                        notFoundCacheMutex.withLock { notFoundCache = notFoundCache + cacheKey }
-                        ByteApiResponse.EMPTY_404
-                    } else {
-                        // 3️⃣ Store to disk; only allow one writer per GPT indicating
-                        // many writers can corrupt the journal file
-                        thumbnailKacheWriteMutex.withLock {
-                            thumbDiskKache().put(cacheKey) { filePath ->
-                                writeBytesResponse(filePath, result)
-                            }
-                        }
-                        result
+                    // 3️⃣ Store to disk (only 200/206 can reach here — throwForFailure throws for everything else).
+                    // Serialise writes to avoid corrupting FileKache's journal file.
+                    check(result.status in 200..299) {
+                        "Unexpected non-2xx status ${result.status} reached disk cache write — not caching"
                     }
+                    thumbnailKacheWriteMutex.withLock {
+                        thumbDiskKache().put(cacheKey) { filePath ->
+                            writeBytesResponse(filePath, result)
+                        }
+                    }
+                    result
                 } catch (e: NotFoundException) {
                     // 404 thrown by network layer — cache it so future calls skip the network
                     notFoundCacheMutex.withLock { notFoundCache = notFoundCache + cacheKey }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
@@ -10,6 +10,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsBytes
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
+import kotlin.concurrent.Volatile
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -31,7 +32,12 @@ class PublicProfileProviderCached(
 
     private val lock = Mutex()
     private val keyLocks = mutableMapOf<String, Mutex>()
-    private val notFoundCache = mutableSetOf<String>()
+
+    // Immutable set — always replaced, never mutated in-place.
+    // @Volatile ensures lock-free reads always see the latest reference.
+    // Writes are serialized via notFoundCacheMutex (rare: only on 404 responses).
+    @Volatile private var notFoundCache: Set<String> = emptySet()
+    private val notFoundCacheMutex = Mutex()
 
     private val profileDiskKache by lazy {
         runBlocking {
@@ -106,7 +112,7 @@ class PublicProfileProviderCached(
     suspend fun clearCaches() {
         profileDiskKache.clear()
         imageDiskKache.clear()
-        notFoundCache.clear()
+        notFoundCache = emptySet()
     }
 
     // =========================================================
@@ -170,7 +176,7 @@ class PublicProfileProviderCached(
                 }
 
                 404 -> {
-                    notFoundCache.add(cacheKey)
+                    notFoundCacheMutex.withLock { notFoundCache = notFoundCache + cacheKey }
                     null
                 }
 

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
@@ -1,0 +1,143 @@
+package id.homebase.api.client.drives.cache
+
+import id.homebase.api.client.NotFoundException
+import id.homebase.api.client.auth.ApiCredentials
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.SecureByteArray
+import id.homebase.api.file.FileOperationsProvider
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.forms.InputProvider
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import java.io.IOException
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.uuid.Uuid
+
+/**
+ * Verifies that [DriveFileProviderCached] only caches genuine 404 (NotFoundException) responses
+ * in its notFoundCache, and never caches transient failures such as network errors or 5xx responses.
+ */
+class DriveFileProviderCachedTest {
+
+    private var requestCount = 0
+    private var nextException: Exception? = null
+    private var nextStatus = HttpStatusCode.OK
+
+    private val mockEngine = MockEngine { _ ->
+        requestCount++
+        nextException?.let { e -> throw e }
+        respond("", nextStatus)
+    }
+
+    private val httpClient = HttpClient(mockEngine)
+    private val credentialsManager = CredentialsManager()
+    private var tempDir: String = ""
+    private lateinit var provider: DriveFileProviderCached
+
+    private val driveId = Uuid.parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    private val fileId  = Uuid.parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    private val key = "photo"
+
+    @BeforeTest
+    fun setup() = runBlocking {
+        tempDir = Files.createTempDirectory("hb-cache-test").toString()
+
+        credentialsManager.setActiveCredentials(
+            ApiCredentials.create(
+                domain = OdinId("frodobaggins.me"),
+                clientAccessToken = "test-token",
+                sharedSecret = SecureByteArray(ByteArray(32) { 0x01 })
+            )
+        )
+
+        provider = DriveFileProviderCached(
+            httpClient = httpClient,
+            credentialsManager = credentialsManager,
+            fileOperationsProvider = object : FileOperationsProvider {
+                override fun getCacheDirectory() = tempDir
+                override fun openFileInput(path: String): InputProvider = error("not used in tests")
+                override suspend fun readFileBytes(path: String): ByteArray = error("not used in tests")
+                override fun deleteTempFile(path: String) = false
+                override fun getFileSize(path: String) = 0L
+                override suspend fun writeBytesToTempFile(bytes: ByteArray, prefix: String, suffix: String): String = error("not used in tests")
+                override suspend fun writeStream(path: String, data: Flow<ByteArray>) = error("not used in tests")
+            }
+        )
+
+        requestCount = 0
+        nextException = null
+        nextStatus = HttpStatusCode.OK
+    }
+
+    @AfterTest
+    fun tearDown() {
+        httpClient.close()
+        runCatching {
+            Files.walk(java.nio.file.Path.of(tempDir))
+                .sorted(Comparator.reverseOrder())
+                .forEach { Files.deleteIfExists(it) }
+        }
+    }
+
+    @Test
+    fun `404 response is cached and subsequent call skips the network`() = runTest {
+        nextStatus = HttpStatusCode.NotFound
+
+        assertFailsWith<NotFoundException> {
+            provider.getThumbBytesRaw(driveId, fileId, key, 100, 100)
+        }
+        val countAfterFirst = requestCount
+
+        // Switch mock to return 200 — the notFoundCache should intercept before reaching network
+        nextStatus = HttpStatusCode.OK
+        val second = provider.getThumbBytesRaw(driveId, fileId, key, 100, 100)
+
+        assertEquals(countAfterFirst, requestCount, "notFoundCache must prevent a second network call for 404")
+        assertEquals(404, second.status, "Cached result should be EMPTY_404")
+    }
+
+    @Test
+    fun `network error is not cached — subsequent call retries and succeeds`() = runTest {
+        nextException = IOException("Network unavailable")
+
+        assertFailsWith<Exception> {
+            provider.getThumbBytesRaw(driveId, fileId, key, 100, 100)
+        }
+        val countAfterFirst = requestCount
+
+        // Restore connectivity
+        nextException = null
+        nextStatus = HttpStatusCode.OK
+        val second = provider.getThumbBytesRaw(driveId, fileId, key, 100, 100)
+
+        assertEquals(countAfterFirst + 1, requestCount, "IOException must not be cached — second call must reach the network")
+        assertEquals(200, second.status)
+    }
+
+    @Test
+    fun `500 server error is not cached — subsequent call retries and succeeds`() = runTest {
+        nextStatus = HttpStatusCode.InternalServerError
+
+        assertFailsWith<Exception> {
+            provider.getThumbBytesRaw(driveId, fileId, key, 100, 100)
+        }
+        val countAfterFirst = requestCount
+
+        // Server recovers
+        nextStatus = HttpStatusCode.OK
+        val second = provider.getThumbBytesRaw(driveId, fileId, key, 100, 100)
+
+        assertEquals(countAfterFirst + 1, requestCount, "500 must not be cached — second call must reach the network")
+        assertEquals(200, second.status)
+    }
+}


### PR DESCRIPTION
The notFoundCache in both DriveFileProviderCached and PublicProfileProviderCached is designed to short-circuit repeated requests for genuinely missing resources (404). Two bugs existed:

1. Dead-code 404 branch in DriveFileProviderCached getThumbBytesRawNetwork / getPayloadBytesRawNetwork only return a ByteApiResponse for HTTP 200/206 — all other statuses go through throwForFailure and arrive as thrown exceptions, never as a status code in the returned value. The `if (result.status == 404)` branch therefore could never execute. Its presence was misleading and created a false sense of safety: should throwForFailure ever let a non-2xx response slip through, the else-branch would silently cache it to disk forever.

   Fixed by removing the dead branch and replacing the else with an explicit `check(result.status in 200..299)` guard that makes the invariant clear and loud if it is ever violated.

2. Thread-unsafe notFoundCache in PublicProfileProviderCached The cache was a mutableSetOf<String>() (backed by LinkedHashSet), which is not thread-safe. The early-return reads on lines 125 and 140 happened outside the per-key mutex, while writes happened inside it, creating a window for concurrent read/write corruption.

   Fixed by adopting the same @Volatile + immutable-set-replacement pattern already used in DriveFileProviderCached: reads are lock-free via the volatile reference; writes are serialized through a dedicated notFoundCacheMutex.

Three regression tests added in DriveFileProviderCachedTest (jvmTest) confirming that 404 is cached, while network errors (IOException) and 5xx server errors are not cached and allow immediate retry.