### PR TITLE
leave group deadlock wip

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsViewModel.kt
@@ -86,9 +86,14 @@ class GroupSettingsViewModel(
                 viewModelScope.launch {
                     try {
                         uiState.value.conversation?.let { conversation ->
-                            uiState.value.currentOdinId?.let { _ ->
+                            uiState.value.currentOdinId?.let { currentUser ->
+                                val isSoleAdmin = conversation.isCurrentUserAdmin(currentUser)
+                                        && conversation.admins.size == 1
+                                val forceLocalOnly =
+                                    isSoleAdmin && !hasReachableNonAdmin(conversation)
                                 conversationService.leaveGroup(
-                                    conversationId = conversation.id
+                                    conversationId = conversation.id,
+                                    forceLocalOnly = forceLocalOnly
                                 )
                                 conversationStream.onConversationLeft(conversation.id)
                                 _uiState.update { it.copy(uiEvent = Back) }
@@ -104,7 +109,13 @@ class GroupSettingsViewModel(
             is GroupSettingsUiAction.LeaveGroupClicked -> {
                 uiState.value.conversation?.let { conversation ->
                     uiState.value.currentOdinId?.let { currentUser ->
-                        if (conversation.isCurrentUserAdmin(currentUser) && conversation.admins.size == 1 && conversation.isGroupConversation) {
+                        val isSoleAdmin = conversation.isCurrentUserAdmin(currentUser)
+                                && conversation.admins.size == 1
+                                && conversation.isGroupConversation
+                        // Only force the "choose new admin" dialog when there IS someone
+                        // reachable to promote. If the caller has no connected non-admin,
+                        // fall through to ConfirmLeave — leaveGroup will mark locally only.
+                        if (isSoleAdmin && hasReachableNonAdmin(conversation)) {
                             _uiState.update { it.copy(uiDialog = GroupSettingsUiDialog.LeaveChooseAdmin) }
                         } else {
                             _uiState.update { it.copy(uiDialog = GroupSettingsUiDialog.ConfirmLeave) }
@@ -195,6 +206,17 @@ class GroupSettingsViewModel(
 
     fun bottomSheetDismissed() {
         _uiState.update { it.copy(uiSheet = null) }
+    }
+
+    /**
+     * True when at least one loaded participant is both Connected (transit-reachable)
+     * and not already an admin — i.e. someone the sole admin could promote and hand off to.
+     */
+    private fun hasReachableNonAdmin(conversation: ConversationUiModel): Boolean {
+        return uiState.value.contacts.any { contact ->
+            contact.connectionState == ContactConnectionState.Connected &&
+                    !conversation.isCurrentUserAdmin(contact.odinId)
+        }
     }
 
     private fun loadData(conversation: ConversationUiModel) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -516,18 +516,25 @@ class ConversationService(
 
     }
 
-    suspend fun leaveGroup(conversationId: Uuid) {
+    /**
+     * @param forceLocalOnly caller has determined the group is isolated (no reachable
+     *  participant to receive distributed updates). Skips the admin-distribution protocol
+     *  and just flips [ChatProtocol.ConversationLeftTag] locally, matching the legacy-group
+     *  path. Also bypasses the sole-admin guard since there is no one to promote.
+     */
+    suspend fun leaveGroup(conversationId: Uuid, forceLocalOnly: Boolean = false) {
         val conversation = requireConversation(conversationId)
         val domain = credentialsManager.requireActiveDomain()
         val leaveFile = getConversationHomebaseFile(conversationId)
-        Logger.d { "leaveGroup START: conversationId=$conversationId isEncrypted=${leaveFile?.fileMetadata?.isEncrypted} aesKey=${leaveFile?.keyHeader?.aesKey?.unsafeBytes?.toBase64() ?: "NO FILE"}" }
+        Logger.d { "leaveGroup START: conversationId=$conversationId forceLocalOnly=$forceLocalOnly isEncrypted=${leaveFile?.fileMetadata?.isEncrypted} aesKey=${leaveFile?.keyHeader?.aesKey?.unsafeBytes?.toBase64() ?: "NO FILE"}" }
 
         if (!conversation.isGroupConversation) {
             throw IllegalStateException("Can only leave group conversations")
         }
 
-        if (conversation.isLegacyGroup) {
-            // Legacy groups don't support the full leave protocol — just mark locally
+        if (conversation.isLegacyGroup || forceLocalOnly) {
+            // Legacy groups don't support the full leave protocol, and isolated groups
+            // (no reachable participant) have nobody to distribute to — just mark locally.
             updateConversationTags(conversationId, dependencyUniqueId = conversationId) {
                 it + ChatProtocol.ConversationLeftTag
             }


### PR DESCRIPTION
ConversationService.leaveGroup (line 519) — new forceLocalOnly: Boolean = false param. When true (or for
  legacy groups), we skip the distributed protocol and just flip ConversationLeftTag locally. The
  sole-admin guard is bypassed in that branch since there's nobody to promote.

  GroupSettingsViewModel —
  - LeaveGroupClicked now only shows the LeaveChooseAdmin dead-end dialog when there's a reachable
  non-admin to promote. If you're the sole admin with no connected non-admin, it falls through to
  ConfirmLeave.
  - LeaveGroupConfirm computes forceLocalOnly = isSoleAdmin && !hasReachableNonAdmin and passes it to
  leaveGroup.
  - New hasReachableNonAdmin(conversation) helper reading from uiState.contacts (already populated with
  ContactConnectionState via ContactService).

  Admin picker (Option 1) — no change needed: GroupSettingsScreen.kt:264-310 already partitions
  participants and only offers the Make-Admin sheet for connected ones.

  Bug gates resolved:
  1. ✅ "Can't delete before leaving" — leaveGroup now succeeds in the isolated case → state becomes Left →
   deleteConversation passes its gate.
  2. ✅ "Can't leave before assigning admin" — sole-admin guard skipped when no reachable non-admin exists.
  3. ✅ "Can't assign to anyone" — picker already filters to connected; when the set is empty, leaving just
   works.

  Trade-off: remaining members' devices keep you as a stale participant (same as the legacy path). That's
  the expected cost when distribution isn't possible.