### PR TITLE
Diagnose(thumb): surface NPE context in retry + cache logs, add regression tests

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/RetryHelper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/RetryHelper.kt
@@ -111,13 +111,15 @@ suspend fun <T> withRetryResult(
 
             if (attempt < config.maxRetries) {
                 Logger.w(tag = logTag) {
-                    "Attempt ${attempt + 1}/${config.maxRetries + 1} failed: ${e.message}, retrying in ${currentDelay}ms"
+                    "Attempt ${attempt + 1}/${config.maxRetries + 1} failed (${e::class.simpleName}): ${e.message}, retrying in ${currentDelay}ms"
                 }
                 delay(currentDelay)
                 currentDelay = (currentDelay * config.backoffMultiplier).toLong()
                     .coerceAtMost(config.maxDelayMs)
             } else {
-                Logger.e(tag = logTag) { "All ${config.maxRetries + 1} attempts failed: ${e.message}" }
+                Logger.e(tag = logTag, throwable = e) {
+                    "All ${config.maxRetries + 1} attempts failed (${e::class.simpleName}): ${e.message}"
+                }
             }
         }
     }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
@@ -251,13 +251,12 @@ class DriveFileProviderCached(
 
         // 1️⃣ Check in-memory 404 cache first
         if (cacheKey in notFoundCache) {
+            Logger.d(tag = "ThumbIO") { "thumb notFound-cache-hit key=$cacheKey" }
             return ByteApiResponse.EMPTY_404
         }
 
         // 2️⃣ Peek in disk cache and return result if it's there
-        thumbDiskKache().get(cacheKey)?.let { filePath ->
-            return readBytesResponse(filePath)
-        }
+        readCachedThumbOrLog(cacheKey)?.let { return it }
 
         // 2️⃣ Fetch from network but lock to make sure that we don't load the same
         // resource twice over the network
@@ -269,9 +268,7 @@ class DriveFileProviderCached(
             if (cacheKey in notFoundCache) {
                 return@withLock ByteApiResponse.EMPTY_404
             }
-            thumbDiskKache().get(cacheKey)?.let { filePath ->
-                return@withLock readBytesResponse(filePath)
-            }
+            readCachedThumbOrLog(cacheKey)?.let { return@withLock it }
 
             // we allow up to 30 concurrent semaphore thumbnails over the network
             return thumbnailSemaphore.withPermit {
@@ -285,16 +282,26 @@ class DriveFileProviderCached(
                                     height,
                                     lastModified
                             )
+                    Logger.d(tag = "ThumbIO") {
+                        "thumb network-fetch: status=${result.status} ${result.bytes.size} bytes contentType=${result.contentType} key=$cacheKey"
+                    }
 
                     // 3️⃣ Store to disk (only 200/206 can reach here — throwForFailure throws for everything else).
                     // Serialise writes to avoid corrupting FileKache's journal file.
                     check(result.status in 200..299) {
                         "Unexpected non-2xx status ${result.status} reached disk cache write — not caching"
                     }
-                    thumbnailKacheWriteMutex.withLock {
-                        thumbDiskKache().put(cacheKey) { filePath ->
-                            writeBytesResponse(filePath, result)
+                    try {
+                        thumbnailKacheWriteMutex.withLock {
+                            thumbDiskKache().put(cacheKey) { filePath ->
+                                writeBytesResponse(filePath, result)
+                            }
                         }
+                        Logger.d(tag = "ThumbIO") { "thumb cache-write: ${result.bytes.size} bytes key=$cacheKey" }
+                    } catch (e: Exception) {
+                        // A write failure should not prevent the caller from getting the fetched bytes.
+                        // Surface it loudly so we can spot corrupted journals or full disks.
+                        Logger.e(tag = "ThumbIO", throwable = e) { "thumb cache-write FAILED key=$cacheKey" }
                     }
                     result
                 } catch (e: NotFoundException) {
@@ -303,10 +310,29 @@ class DriveFileProviderCached(
                     throw e
                 } catch (e: Exception) {
                     // For other errors (500, network issues, etc.), don't cache and rethrow
+                    Logger.w(tag = "ThumbIO") { "thumb network-fetch FAILED (${e::class.simpleName}): ${e.message} key=$cacheKey" }
                     throw e
                 }
             }
         } // Mutex.lock
+    }
+
+    /**
+     * Read a thumb from the disk cache. Returns null on cache miss OR when the
+     * cached file cannot be parsed (corrupted entry, truncated write, etc.) —
+     * the latter is logged as an error so the NPE/parse failure is visible
+     * instead of being swallowed into the retry loop above.
+     */
+    private suspend fun readCachedThumbOrLog(cacheKey: String): ByteApiResponse? {
+        val filePath = thumbDiskKache().get(cacheKey) ?: return null
+        return try {
+            val result = readBytesResponse(filePath)
+            Logger.d(tag = "ThumbIO") { "thumb cache-hit: status=${result.status} ${result.bytes.size} bytes key=$cacheKey" }
+            result
+        } catch (e: Exception) {
+            Logger.e(tag = "ThumbIO", throwable = e) { "thumb cache-read FAILED key=$cacheKey path=$filePath" }
+            null
+        }
     }
 
     suspend fun getThumbBytesDecrypted(
@@ -330,7 +356,21 @@ class DriveFileProviderCached(
 
         if (raw.status == 404) throw NotFoundException()
 
-        val decryptedBytes = delegate.decryptBytes(keyHeader, raw.headers, raw.bytes)
+        val payloadEncryptedHeader = raw.headers["payloadencrypted"]
+        val decryptedBytes = try {
+            delegate.decryptBytes(keyHeader, raw.headers, raw.bytes)
+        } catch (e: Exception) {
+            // Single most likely NPE site when the cache is poisoned with a
+            // non-2xx response from the pre-61ebe154 code path. Keep context
+            // so the log pins the bad key.
+            Logger.e(tag = "ThumbIO", throwable = e) {
+                "thumb decrypt FAILED (${e::class.simpleName}): status=${raw.status} " +
+                    "bytes=${raw.bytes.size} contentType=${raw.contentType} " +
+                    "payloadEncrypted=$payloadEncryptedHeader drive=$driveId file=$fileId " +
+                    "key=$payloadKey size=${width}x$height lastMod=$lastModified"
+            }
+            throw e
+        }
 
         return BytesResponse(bytes = decryptedBytes, contentType = raw.contentType)
     }

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
@@ -1,5 +1,10 @@
 package id.homebase.api.client.drives.cache
 
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Severity
+import co.touchlab.kermit.platformLogWriter
+import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.NotFoundException
 import id.homebase.api.client.auth.ApiCredentials
 import id.homebase.api.client.auth.CredentialsManager
@@ -14,13 +19,16 @@ import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import java.io.DataOutputStream
 import java.io.IOException
 import java.nio.file.Files
+import java.nio.file.Path
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 import kotlin.uuid.Uuid
 
 /**
@@ -43,6 +51,8 @@ class DriveFileProviderCachedTest {
     private val credentialsManager = CredentialsManager()
     private var tempDir: String = ""
     private lateinit var provider: DriveFileProviderCached
+
+    private val logCollector = CollectingLogWriter()
 
     private val driveId = Uuid.parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
     private val fileId  = Uuid.parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
@@ -77,6 +87,9 @@ class DriveFileProviderCachedTest {
         requestCount = 0
         nextException = null
         nextStatus = HttpStatusCode.OK
+
+        logCollector.entries.clear()
+        Logger.setLogWriters(listOf(logCollector))
     }
 
     @AfterTest
@@ -87,6 +100,7 @@ class DriveFileProviderCachedTest {
                 .sorted(Comparator.reverseOrder())
                 .forEach { Files.deleteIfExists(it) }
         }
+        Logger.setLogWriters(listOf(platformLogWriter()))
     }
 
     @Test
@@ -140,4 +154,136 @@ class DriveFileProviderCachedTest {
         assertEquals(countAfterFirst + 1, requestCount, "500 must not be cached — second call must reach the network")
         assertEquals(200, second.status)
     }
+
+    @Test
+    fun `thumb fetch emits ThumbIO breadcrumbs for network-fetch cache-write and cache-hit`() = runTest {
+        provider.getThumbBytesRaw(driveId, fileId, key, 100, 100)
+
+        assertTrue(
+            logCollector.hasMessage(tag = "ThumbIO", substring = "thumb network-fetch"),
+            "expected ThumbIO network-fetch breadcrumb; got: ${logCollector.messages("ThumbIO")}"
+        )
+        assertTrue(
+            logCollector.hasMessage(tag = "ThumbIO", substring = "thumb cache-write"),
+            "expected ThumbIO cache-write breadcrumb; got: ${logCollector.messages("ThumbIO")}"
+        )
+
+        // Second call must hit the disk cache and log accordingly.
+        logCollector.entries.clear()
+        provider.getThumbBytesRaw(driveId, fileId, key, 100, 100)
+
+        assertTrue(
+            logCollector.hasMessage(tag = "ThumbIO", substring = "thumb cache-hit"),
+            "expected ThumbIO cache-hit breadcrumb; got: ${logCollector.messages("ThumbIO")}"
+        )
+    }
+
+    @Test
+    fun `poisoned cache entry with non-2xx status is visible in the decrypt failure log`() = runTest {
+        // Populate the cache with a normal 200 response, then rewrite the on-disk
+        // data file with a valid-format ByteApiResponse whose status is 500.
+        // Such entries should not exist post-61ebe154 (the write-guard blocks them),
+        // but pre-fix code paths could have produced them — so a user upgrading
+        // past the fix might still carry one on disk. This test documents the
+        // failure mode and pins the diagnostic log to the right context.
+        val thumbDir = Path.of(tempDir, "homebase-thumbs")
+        val filesBefore = snapshotFiles(thumbDir)
+
+        provider.getThumbBytesRaw(driveId, fileId, key, 100, 100)
+
+        val dataFiles = snapshotFiles(thumbDir) - filesBefore
+        assertTrue(dataFiles.isNotEmpty(), "populate step should have written at least one data file")
+
+        // 13 bytes is deliberately not a multiple of the AES block size so
+        // decryptUsingKeyHeader fails loudly instead of returning garbage.
+        val poisonedPayload = ByteArray(13) { 0xAB.toByte() }
+        for (file in dataFiles) {
+            DataOutputStream(Files.newOutputStream(file)).use { out ->
+                out.writeInt(500)                     // status
+                out.writeInt("text/html".length)      // contentType length
+                out.writeBytes("text/html")           // contentType (ascii => utf8)
+                out.writeByte(1)                      // payloadEncrypted = true
+                out.write(poisonedPayload)            // "encrypted" payload
+            }
+        }
+        logCollector.entries.clear()
+
+        val keyHeader = KeyHeader.newRandom16()
+        // Using the decrypted entry point — this is what loadThumbnail calls.
+        assertFailsWith<Exception> {
+            provider.getThumbBytesDecrypted(driveId, fileId, key, keyHeader, 100, 100)
+        }
+
+        assertTrue(
+            logCollector.hasError(tag = "ThumbIO", substring = "thumb decrypt FAILED"),
+            "expected decrypt FAILED error log; got: ${logCollector.messages("ThumbIO")}"
+        )
+        assertTrue(
+            logCollector.messages("ThumbIO").any { it.contains("status=500") },
+            "error log must include the poisoned status for triage; got: ${logCollector.messages("ThumbIO")}"
+        )
+        assertTrue(
+            logCollector.messages("ThumbIO").any { it.contains("contentType=text/html") },
+            "error log must include the poisoned contentType for triage; got: ${logCollector.messages("ThumbIO")}"
+        )
+    }
+
+    @Test
+    fun `corrupted disk cache entry is logged and call falls through to the network`() = runTest {
+        // Populate the thumb cache with a real 200 response.
+        provider.getThumbBytesRaw(driveId, fileId, key, 100, 100)
+        val countAfterPopulate = requestCount
+
+        // Truncate every file under the thumb cache dir to simulate a corrupted
+        // on-disk entry (short read in readBytesResponse => EOFException / NPE).
+        val thumbDir = Path.of(tempDir, "homebase-thumbs")
+        Files.walk(thumbDir).use { stream ->
+            stream.filter { Files.isRegularFile(it) }.forEach { Files.write(it, ByteArray(0)) }
+        }
+        logCollector.entries.clear()
+
+        val second = provider.getThumbBytesRaw(driveId, fileId, key, 100, 100)
+
+        assertEquals(200, second.status, "caller should still receive bytes via network fallback")
+        assertTrue(
+            requestCount > countAfterPopulate,
+            "corrupted cache must fall through to the network"
+        )
+        assertTrue(
+            logCollector.hasError(tag = "ThumbIO", substring = "thumb cache-read FAILED"),
+            "expected error log for cache-read corruption; got: ${logCollector.messages("ThumbIO")}"
+        )
+    }
+}
+
+/** Snapshot every regular file under [dir] (recursively), skipping FileKache's journal. */
+private fun snapshotFiles(dir: Path): Set<Path> {
+    if (!Files.exists(dir)) return emptySet()
+    return Files.walk(dir).use { stream ->
+        stream
+            .filter { Files.isRegularFile(it) }
+            .filter { !it.fileName.toString().startsWith("journal") }
+            .toList()
+            .toSet()
+    }
+}
+
+/** Kermit LogWriter that captures entries for test assertions. */
+private class CollectingLogWriter : LogWriter() {
+    data class Entry(val severity: Severity, val tag: String, val message: String, val throwable: Throwable?)
+
+    val entries: MutableList<Entry> = mutableListOf()
+
+    override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
+        entries += Entry(severity, tag, message, throwable)
+    }
+
+    fun hasMessage(tag: String, substring: String): Boolean =
+        entries.any { it.tag == tag && it.message.contains(substring) }
+
+    fun hasError(tag: String, substring: String): Boolean =
+        entries.any { it.tag == tag && it.severity == Severity.Error && it.message.contains(substring) }
+
+    fun messages(tag: String): List<String> =
+        entries.filter { it.tag == tag }.map { "[${it.severity}] ${it.message}" }
 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
@@ -9,6 +9,8 @@ import id.homebase.api.file.FileOperationsProvider
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.extension
 import io.github.vinceglb.filekit.mimeType
+import kotlinx.coroutines.CancellationException
+import kotlin.uuid.Uuid
 
 /** Image data container */
 // TODO: Rename to memoryImage?
@@ -43,13 +45,15 @@ class HomebaseImageLoader(
         // Content types that don't need thumbnails (render as-is)
         val THUMBLESS_CONTENT_TYPES = setOf("image/svg+xml", "image/gif")
 
-        // Default retry configuration for image loading
+        // Default retry configuration for image loading.
+        // retryOn unwraps the RuntimeException wrapper produced below so the real
+        // cause (e.g. NotFoundException) still short-circuits retries.
         val DEFAULT_RETRY_CONFIG = RetryConfig(
             maxRetries = 3,
             initialDelayMs = 500L,
             maxDelayMs = 5000L,
             backoffMultiplier = 2.0,
-            retryOn = { e -> e !is NotFoundException }
+            retryOn = { e -> (e.cause ?: e) !is NotFoundException }
         )
     }
 
@@ -94,15 +98,32 @@ class HomebaseImageLoader(
 
         // Fetch from server with retry
         return withRetry(retryConfig, TAG) {
-            val response = driveFileProvider.getThumbBytesDecrypted(
-                driveId = data.driveId,
-                fileId = data.fileId,
-                payloadKey = data.payloadKey,
-                keyHeader = data.keyHeader,
-                width = targetSize.pixelWidth,
-                height = targetSize.pixelHeight,
-                lastModified = data.lastModified,
-            ) ?: return@withRetry null
+            val response = try {
+                driveFileProvider.getThumbBytesDecrypted(
+                    driveId = data.driveId,
+                    fileId = data.fileId,
+                    payloadKey = data.payloadKey,
+                    keyHeader = data.keyHeader,
+                    width = targetSize.pixelWidth,
+                    height = targetSize.pixelHeight,
+                    lastModified = data.lastModified,
+                )
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                throw RuntimeException(
+                    buildImageLoadFailureMessage(
+                        kind = "thumb",
+                        driveId = data.driveId,
+                        fileId = data.fileId,
+                        payloadKey = data.payloadKey,
+                        size = targetSize,
+                        lastModified = data.lastModified,
+                        causeClass = e::class.simpleName
+                    ),
+                    e
+                )
+            } ?: return@withRetry null
 
             CachedImage(
                 bytes = response.bytes, contentType = response.contentType, size = targetSize
@@ -126,12 +147,29 @@ class HomebaseImageLoader(
 
         // Fetch from server with retry
         return withRetry(retryConfig, TAG) {
-            val response = driveFileProvider.getPayloadBytesDecrypted(
-                driveId = data.driveId,
-                fileId = data.fileId,
-                key = data.payloadKey,
-                keyHeader = data.keyHeader
-            ) ?: return@withRetry null
+            val response = try {
+                driveFileProvider.getPayloadBytesDecrypted(
+                    driveId = data.driveId,
+                    fileId = data.fileId,
+                    key = data.payloadKey,
+                    keyHeader = data.keyHeader
+                )
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                throw RuntimeException(
+                    buildImageLoadFailureMessage(
+                        kind = "payload",
+                        driveId = data.driveId,
+                        fileId = data.fileId,
+                        payloadKey = data.payloadKey,
+                        size = null,
+                        lastModified = data.lastModified,
+                        causeClass = e::class.simpleName
+                    ),
+                    e
+                )
+            } ?: return@withRetry null
 
             CachedImage(
                 bytes = response.bytes,
@@ -140,6 +178,25 @@ class HomebaseImageLoader(
             )
         }
     }
+}
+
+/**
+ * Request-level context string appended to image-load failures so the retry
+ * log identifies which drive/file/size failed. Shared by [HomebaseImageLoader]
+ * and covered by unit tests.
+ */
+internal fun buildImageLoadFailureMessage(
+    kind: String,
+    driveId: Uuid,
+    fileId: Uuid,
+    payloadKey: String,
+    size: ImageSize?,
+    lastModified: Long?,
+    causeClass: String?,
+): String {
+    val sizeStr = size?.let { "${it.pixelWidth}x${it.pixelHeight}" } ?: "full"
+    return "$kind load failed drive=$driveId file=$fileId key=$payloadKey " +
+        "size=$sizeStr lastMod=$lastModified cause=$causeClass"
 }
 
 /** Load pending/local file from filesystem */

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/image/HomebaseImageLoaderTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/image/HomebaseImageLoaderTest.kt
@@ -86,4 +86,44 @@ class HomebaseImageLoaderTest {
         assertTrue(HomebaseImageLoader.THUMBLESS_CONTENT_TYPES.contains("image/svg+xml"))
         assertTrue(HomebaseImageLoader.THUMBLESS_CONTENT_TYPES.contains("image/gif"))
     }
+
+    @Test
+    fun `buildImageLoadFailureMessage includes drive file key size and cause for thumbs`() {
+        val drive = Uuid.parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        val file = Uuid.parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+        val msg = buildImageLoadFailureMessage(
+            kind = "thumb",
+            driveId = drive,
+            fileId = file,
+            payloadKey = "photo",
+            size = ImageSize(320, 320),
+            lastModified = 1776703690500L,
+            causeClass = "NullPointerException"
+        )
+
+        assertTrue(msg.startsWith("thumb load failed"), "kind should be first: $msg")
+        assertTrue(msg.contains("drive=$drive"), "missing drive: $msg")
+        assertTrue(msg.contains("file=$file"), "missing file: $msg")
+        assertTrue(msg.contains("key=photo"), "missing payload key: $msg")
+        assertTrue(msg.contains("size=320x320"), "missing size: $msg")
+        assertTrue(msg.contains("lastMod=1776703690500"), "missing lastModified: $msg")
+        assertTrue(msg.contains("cause=NullPointerException"), "missing cause: $msg")
+    }
+
+    @Test
+    fun `buildImageLoadFailureMessage renders full size when size is null`() {
+        val drive = Uuid.random()
+        val file = Uuid.random()
+        val msg = buildImageLoadFailureMessage(
+            kind = "payload",
+            driveId = drive,
+            fileId = file,
+            payloadKey = "photo",
+            size = null,
+            lastModified = null,
+            causeClass = "IOException"
+        )
+        assertTrue(msg.contains("size=full"), "null size must render as full: $msg")
+        assertTrue(msg.contains("lastMod=null"), "null lastModified must render as null: $msg")
+    }
 }


### PR DESCRIPTION
Since 61ebe154 (cache 2xx-only guard + notFoundCache thread-safety fix),
users have been seeing repeated HomebaseImageLoader retry spam ending in
"All 4 attempts failed: Attempt to invoke virtual method
'java.lang.Class java.lang.Object.getClass()' on a null object reference"
— a stock Android-runtime NPE with no stack trace, no cache key, no
drive/file identifiers, and no indication of which layer (cache read /
network fetch / decrypt) failed. Without that context we cannot tell
which thumbs fail, nor where in the pipeline they fail.

This change is diagnostic only — no behavior changes, no defensive
guards, no cache wipe. The goal is that the next reproduction log
pins the failure to a single layer and a single request.

RetryHelper
- Final-failure log now passes `throwable = e` so Kermit prints the
  stack trace (previously only e.message was logged).
- Per-attempt and final log lines include `e::class.simpleName` so an
  NPE can be distinguished from IllegalStateException / IOException
  without needing the trace.

HomebaseImageLoader
- loadThumbnail and loadFullPayload wrap the provider call so any
  exception is rethrown with request context: drive, file, payloadKey,
  pixel size, lastModified, and the cause class name.
- The original exception is preserved as `cause`, and
  DEFAULT_RETRY_CONFIG.retryOn is updated to unwrap it so
  NotFoundException still short-circuits retries as before.
- The message builder is extracted as an `internal` top-level helper
  (buildImageLoadFailureMessage) to make the context format unit-
  testable without mocking DriveFileProvider.

DriveFileProviderCached (thumb path only; payload path already had
VideoIO breadcrumbs)
- New ThumbIO breadcrumbs on notFound-cache-hit, disk cache-hit,
  network-fetch (including status, byte count, contentType),
  cache-write, network-fetch FAILED.
- readCachedThumbOrLog wraps readBytesResponse in try/catch: a
  corrupted or truncated on-disk entry is now logged with the cache
  key and treated as a miss (falls through to network) instead of
  being swallowed into the retry loop.
- The cache-write put(...) block is wrapped in try/catch: a journal
  corruption or disk-full error is logged loudly but no longer
  prevents the caller from receiving the fetched bytes.
- getThumbBytesDecrypted wraps delegate.decryptBytes in try/catch,
  logging status, bytes size, contentType, payloadencrypted flag, and
  drive/file/key/size/lastModified before rethrowing. This is the
  single most likely NPE site if the cache holds poisoned entries
  written by the pre-61ebe154 code path.

Tests
- DriveFileProviderCachedTest gets a Kermit LogWriter test double
  (CollectingLogWriter) and three new cases:
    * thumb fetch emits ThumbIO breadcrumbs for network-fetch,
      cache-write, and cache-hit
    * a corrupted on-disk cache entry (zero-length data file) is
      logged and falls through to the network
    * a poisoned cache entry with status=500, payloadencrypted=true,
      and misaligned bytes surfaces through the new decrypt-failure
      log with status and contentType context — documenting the
      failure mode that a pre-fix upgrade could have left on disk.
- HomebaseImageLoaderTest gets two cases for buildImageLoadFailureMessage
  covering both sized (thumb) and unsized (full payload) requests.

Does not reproduce the exact Android-runtime NPE in a jvmTest —
ByteApiResponse is fully non-nullable and decryptBytes cannot produce
that specific error message from a pure JVM run. The purpose here is
to make sure that when the NPE next fires on a device, the log
contains the stack trace and the request context needed to localize
it. Once we have that, the follow-up PR can target the real fix
(likely one of: poisoned cache eviction, Ktor/OkHttp response guard,
or a defensive read-side status check).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>