### PR TITLE
fix(cache): serialize FileKache lifecycle to end logout NPE race

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
@@ -57,24 +57,22 @@ class DriveFileProviderCached(
     private var _thumbDiskKache: FileKache? = null
     private val kacheMutex = Mutex()
 
-    private suspend fun payloadDiskKache(): FileKache {
-        _payloadDiskKache?.let { return it }
-        return kacheMutex.withLock {
-            _payloadDiskKache ?: FileKache(
-                    directory = "$directory/homebase-payloads",
-                    maxSize = 200L * 1024L * 1024L // 200MB
-            ).also { _payloadDiskKache = it }
-        }
+    // Always acquires kacheMutex — the previous lock-free fast path let a
+    // reader hand out a reference to a FileKache instance that clearCaches()
+    // was simultaneously disposing, producing a NPE inside FileKache's
+    // internals when the reader resumed and called .get() on it.
+    private suspend fun payloadDiskKache(): FileKache = kacheMutex.withLock {
+        _payloadDiskKache ?: FileKache(
+                directory = "$directory/homebase-payloads",
+                maxSize = 200L * 1024L * 1024L // 200MB
+        ).also { _payloadDiskKache = it }
     }
 
-    private suspend fun thumbDiskKache(): FileKache {
-        _thumbDiskKache?.let { return it }
-        return kacheMutex.withLock {
-            _thumbDiskKache ?: FileKache(
-                    directory = "$directory/homebase-thumbs",
-                    maxSize = 300L * 1024L * 1024L // 300MB
-            ).also { _thumbDiskKache = it }
-        }
+    private suspend fun thumbDiskKache(): FileKache = kacheMutex.withLock {
+        _thumbDiskKache ?: FileKache(
+                directory = "$directory/homebase-thumbs",
+                maxSize = 300L * 1024L * 1024L // 300MB
+        ).also { _thumbDiskKache = it }
     }
 
     // ================================================================
@@ -97,11 +95,7 @@ class DriveFileProviderCached(
         }
 
         // 2️⃣ Peek in disk cache and return result if it's there
-        payloadDiskKache().get(cacheKey)?.let { filePath ->
-            val (result, elapsed) = measureTimedValue { readBytesResponse(filePath) }
-            Logger.d(tag = "VideoIO") { "payload cache-hit: ${result.bytes.size} bytes in $elapsed key=$cacheKey" }
-            return result
-        }
+        readCachedPayloadOrLog(cacheKey)?.let { return it }
 
         // 2️⃣ Fetch from network but lock to make sure that we don't load the same
         // resource twice over the network
@@ -113,11 +107,7 @@ class DriveFileProviderCached(
             if (cacheKey in notFoundCache) {
                 return@withLock ByteApiResponse.EMPTY_404
             }
-            payloadDiskKache().get(cacheKey)?.let { filePath ->
-                val (result, elapsed) = measureTimedValue { readBytesResponse(filePath) }
-                Logger.d(tag = "VideoIO") { "payload cache-hit (post-lock): ${result.bytes.size} bytes in $elapsed key=$cacheKey" }
-                return@withLock result
-            }
+            readCachedPayloadOrLog(cacheKey)?.let { return@withLock it }
 
             // we allow up to 3 concurrent semaphore payloads over the network
             return payloadSemaphore.withPermit {
@@ -319,18 +309,35 @@ class DriveFileProviderCached(
 
     /**
      * Read a thumb from the disk cache. Returns null on cache miss OR when the
-     * cached file cannot be parsed (corrupted entry, truncated write, etc.) —
-     * the latter is logged as an error so the NPE/parse failure is visible
-     * instead of being swallowed into the retry loop above.
+     * cached file cannot be parsed (corrupted entry, truncated write, etc.) OR
+     * when the underlying FileKache throws (e.g. a concurrent clearCaches()
+     * on another thread). All exceptions are logged as errors so the caller
+     * can fall through to the network cleanly.
      */
     private suspend fun readCachedThumbOrLog(cacheKey: String): ByteApiResponse? {
-        val filePath = thumbDiskKache().get(cacheKey) ?: return null
         return try {
+            val filePath = thumbDiskKache().get(cacheKey) ?: return null
             val result = readBytesResponse(filePath)
             Logger.d(tag = "ThumbIO") { "thumb cache-hit: status=${result.status} ${result.bytes.size} bytes key=$cacheKey" }
             result
         } catch (e: Exception) {
-            Logger.e(tag = "ThumbIO", throwable = e) { "thumb cache-read FAILED key=$cacheKey path=$filePath" }
+            Logger.e(tag = "ThumbIO", throwable = e) { "thumb cache-read FAILED key=$cacheKey" }
+            null
+        }
+    }
+
+    /**
+     * Payload-cache analog of [readCachedThumbOrLog]. Defense-in-depth against
+     * FileKache internal errors and parse failures.
+     */
+    private suspend fun readCachedPayloadOrLog(cacheKey: String): ByteApiResponse? {
+        return try {
+            val filePath = payloadDiskKache().get(cacheKey) ?: return null
+            val (result, elapsed) = measureTimedValue { readBytesResponse(filePath) }
+            Logger.d(tag = "VideoIO") { "payload cache-hit: ${result.bytes.size} bytes in $elapsed key=$cacheKey" }
+            result
+        } catch (e: Exception) {
+            Logger.e(tag = "VideoIO", throwable = e) { "payload cache-read FAILED key=$cacheKey" }
             null
         }
     }
@@ -450,21 +457,32 @@ class DriveFileProviderCached(
         val thumbDir = "$directory/homebase-thumbs".toPath()
         val preloadDir = "$directory/hbvid_preload".toPath()
 
-        try {
-            _payloadDiskKache?.clear()
-            _thumbDiskKache?.clear()
-        } catch (e: Exception) {
-            Logger.w("Kache.clear() failed, falling back to manual delete", e)
+        // Serialised with the accessor functions: any in-flight payload/thumb
+        // reader either completed before we took the mutex (so its reference
+        // is no longer reachable from us) or is still waiting for it (so it
+        // will observe the post-teardown null and construct a fresh kache).
+        //
+        // We intentionally do NOT call FileKache.clear() — on at least one
+        // Android device that call raced with concurrent .get() calls and
+        // nulled internal FileKache state under a reader's feet, producing
+        // the `getClass() on null` NPE that fired 335× after logout.
+        // Deleting the directory directly achieves the same outcome and the
+        // next accessor reconstructs a clean FileKache on top of an empty dir.
+        kacheMutex.withLock {
+            _payloadDiskKache = null
+            _thumbDiskKache = null
+
             try {
-                fileSystem.delete(payloadDir, mustExist = false)
-                fileSystem.delete(thumbDir, mustExist = false)
-            } catch (deleteEx: Exception) {
-                Logger.w("Manual cache delete also failed", deleteEx)
+                fileSystem.deleteRecursively(payloadDir)
+            } catch (e: Exception) {
+                Logger.w(tag = "DriveFileProviderCached", throwable = e) { "payload cache dir delete failed" }
+            }
+            try {
+                fileSystem.deleteRecursively(thumbDir)
+            } catch (e: Exception) {
+                Logger.w(tag = "DriveFileProviderCached", throwable = e) { "thumb cache dir delete failed" }
             }
         }
-
-        _payloadDiskKache = null
-        _thumbDiskKache = null
 
         try {
             fileSystem.deleteRecursively(preloadDir)

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
@@ -16,9 +16,13 @@ import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.request.forms.InputProvider
 import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
 import java.io.DataOutputStream
 import java.io.IOException
 import java.nio.file.Files
@@ -252,6 +256,62 @@ class DriveFileProviderCachedTest {
         assertTrue(
             logCollector.hasError(tag = "ThumbIO", substring = "thumb cache-read FAILED"),
             "expected error log for cache-read corruption; got: ${logCollector.messages("ThumbIO")}"
+        )
+    }
+
+    /**
+     * Reproduces the Android NPE that fires 335× after logout: a concurrent
+     * `clearCaches()` on one thread races against in-flight `getThumbBytesRaw()`
+     * on another, poisoning the FileKache instance the reader is holding.
+     *
+     * Uses `runBlocking` (not `runTest`) — we need real parallelism across
+     * threads, which `runTest`'s virtual-time scheduler deliberately does
+     * not provide.
+     */
+    @Test
+    fun `concurrent clearCaches during thumb fetch does not propagate exceptions`() = runBlocking {
+        // Warm the cache so reads/writes are exercised (not just fresh inits).
+        provider.getThumbBytesRaw(driveId, fileId, key, 100, 100)
+
+        val iterations = 300
+        val fetcherErrors = mutableListOf<Throwable>()
+        val clearerErrors = mutableListOf<Throwable>()
+
+        val fetcher = async(Dispatchers.Default) {
+            repeat(iterations) {
+                try {
+                    provider.getThumbBytesRaw(driveId, fileId, key, 100, 100)
+                } catch (e: NotFoundException) {
+                    // Acceptable — the race window can return EMPTY_404 or
+                    // throw for a just-cleared cache under some code paths.
+                } catch (e: Throwable) {
+                    synchronized(fetcherErrors) { fetcherErrors += e }
+                }
+                yield()
+            }
+        }
+
+        val clearer = async(Dispatchers.Default) {
+            repeat(iterations) {
+                try {
+                    provider.clearCaches()
+                } catch (e: Throwable) {
+                    synchronized(clearerErrors) { clearerErrors += e }
+                }
+                yield()
+            }
+        }
+
+        awaitAll(fetcher, clearer)
+
+        assertTrue(
+            fetcherErrors.isEmpty(),
+            "fetcher must not see any unhandled exceptions while clearCaches runs " +
+                "(got ${fetcherErrors.size}: ${fetcherErrors.firstOrNull()})"
+        )
+        assertTrue(
+            clearerErrors.isEmpty(),
+            "clearCaches must not throw (got ${clearerErrors.size}: ${clearerErrors.firstOrNull()})"
         )
     }
 }


### PR DESCRIPTION


Root cause (pinned by yesterday's diagnostic logs): the thumb NPE that
fired 335x in a 60-second window, starting ~750ms after each logout, was
a data race on FileKache in DriveFileProviderCached.

- thumbDiskKache() / payloadDiskKache() had a lock-free fast path that
  handed out a reference to the live kache without holding kacheMutex.
- clearCaches() (run from YouAuthFlowManager.logout) called
  FileKache.clear() on those instances, also without the mutex, which
  nulled FileKache's internal state.
- A reader that had already dereferenced the field was left holding a
  poisoned instance. When it resumed and called .get(cacheKey) the
  FileKache lambda dereferenced a now-null internal field, producing
  the stock Android "getClass() on null" NPE.

The retry loop in HomebaseImageLoader then retried each failure 4x with
exponential backoff across ~90 in-flight convo_img thumbnails, which is
how one logout produced minutes of failing requests.

Changes:

- thumbDiskKache() / payloadDiskKache(): drop the fast path; always
  acquire kacheMutex. Uncontended in steady state and negligible next
  to disk I/O.
- clearCaches(): acquire kacheMutex for the whole teardown. Null the
  refs first, then deleteRecursively the two cache directories. Do NOT
  call FileKache.clear() — that is the call that poisons instances held
  by concurrent readers. The next accessor under the mutex reconstructs
  a clean kache on top of an empty dir.
- readCachedThumbOrLog(): widen try/catch to cover thumbDiskKache().get
  as well as readBytesResponse, so any FileKache internal error becomes
  a logged error + cache miss (caller falls through to network) instead
  of propagating.
- New readCachedPayloadOrLog() mirrors the thumb helper and is used at
  both payload cache-read sites in getPayloadBytesRaw.

Test: add "concurrent clearCaches during thumb fetch does not propagate
exceptions" — two coroutines on Dispatchers.Default, one calling
getThumbBytesRaw and the other clearCaches in a tight loop for 300
iterations. Uses runBlocking (not runTest) so the virtual-time
scheduler does not collapse the parallelism. Reliably reproduces the
NPE pre-fix; passes post-fix.

Verification:
  ./gradlew homebase-api:jvmTest homebase-chat:jvmTest \
    homebase-auth:jvmTest homebase-common:jvmTest

No behaviour change for non-logout code paths; no changes to
RetryHelper or HomebaseImageLoader.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>