### PR TITLE
feat(storage): add Storage settings screen with caches, drives, Coil memory, DB size

### DIFF
--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/sync/database/DatabaseSizeProbe.android.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/sync/database/DatabaseSizeProbe.android.kt
@@ -1,0 +1,21 @@
+package id.homebase.api.sync.database
+
+import android.content.Context
+import java.io.File
+
+class AndroidDatabaseSizeProbe(private val context: Context) : DatabaseSizeProbe {
+    override fun sizeBytes(): Long {
+        val dbFile = context.getDatabasePath("odin-2.db")
+        val dir = dbFile.parentFile ?: return if (dbFile.exists()) dbFile.length() else 0L
+        var total = 0L
+        for (suffix in DB_SUFFIXES) {
+            val f = File(dir, "odin-2.db$suffix")
+            if (f.exists()) total += f.length()
+        }
+        return total
+    }
+
+    private companion object {
+        val DB_SUFFIXES = arrayOf("", "-wal", "-shm", "-journal")
+    }
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/cache/CacheStats.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/cache/CacheStats.kt
@@ -1,0 +1,7 @@
+package id.homebase.api.client.cache
+
+data class CacheStats(
+    val id: String,
+    val sizeBytes: Long,
+    val maxBytes: Long,
+)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
@@ -28,6 +28,37 @@ import okio.FileSystem
 import okio.Path.Companion.toPath
 import okio.SYSTEM
 
+/**
+ * Disk-backed, encrypted cache for authenticated drive file bytes. Wraps
+ * [DriveFileHttpProvider] so callers get transparent read-through caching
+ * for payloads and thumbnails.
+ *
+ * Two underlying [com.mayakapps.kache.FileKache] instances back the two
+ * Storage-screen rows:
+ * - `drive_payloads`   — media payload bytes (attachments). Directory
+ *   `homebase-payloads`, cap 200 MB. Fetches are gated by
+ *   [payloadSemaphore] (1 concurrent network request).
+ * - `drive_thumbnails` — thumbnail bytes. Directory `homebase-thumbs`,
+ *   cap 300 MB. Fetches are gated by [thumbnailSemaphore] (30 concurrent).
+ *
+ * The payload/thumbnail split follows the same "small-hot vs large-cold"
+ * stratification as PublicProfileProviderCached — thumbnails render on
+ * every gallery scroll, so they are kept on their own cap where a burst
+ * of full-payload fetches cannot evict them.
+ *
+ * Bytes are AES-CBC-encrypted on the wire and written encrypted to disk;
+ * the [KeyHeader] is *not* persisted to the cache, so a copy of the cache
+ * directory alone yields no plaintext.
+ *
+ * A separate in-memory [notFoundCache] records 404 responses so repeated
+ * lookups of deleted files skip the network. Transient failures
+ * (5xx, network errors) are never cached.
+ *
+ * Both FileKache instances are created lazily through mutex-gated
+ * accessors; [clearCaches] deletes the directories recursively and nulls
+ * the refs, so concurrent readers cannot end up with a disposed
+ * FileKache reference — they re-create it on next access.
+ */
 class DriveFileProviderCached(
         httpClient: HttpClient,
         credentialsManager: CredentialsManager,

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
@@ -4,6 +4,7 @@ import co.touchlab.kermit.Logger
 import com.mayakapps.kache.FileKache
 import kotlin.time.measureTimedValue
 import id.homebase.api.client.ByteApiResponse
+import id.homebase.api.client.cache.CacheStats
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.NotFoundException
 import id.homebase.api.client.auth.CredentialsManager
@@ -489,5 +490,22 @@ class DriveFileProviderCached(
         } catch (_: Exception) {}
 
         notFoundCache = emptySet()
+    }
+
+    suspend fun getCacheStats(): List<CacheStats> {
+        val payload = payloadDiskKache()
+        val thumb = thumbDiskKache()
+        return listOf(
+            CacheStats(
+                id = "drive_payloads",
+                sizeBytes = payload.size,
+                maxBytes = payload.maxSize,
+            ),
+            CacheStats(
+                id = "drive_thumbnails",
+                sizeBytes = thumb.size,
+                maxBytes = thumb.maxSize,
+            ),
+        )
     }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
@@ -2,6 +2,7 @@ package id.homebase.api.client.profile
 
 import co.touchlab.kermit.Logger
 import com.mayakapps.kache.FileKache
+import id.homebase.api.client.cache.CacheStats
 import id.homebase.api.common.OdinId
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.file.FileOperationsProvider
@@ -139,6 +140,23 @@ class PublicProfileProviderCached(
         }
 
         notFoundCache = emptySet()
+    }
+
+    suspend fun getCacheStats(): List<CacheStats> {
+        val profile = profileDiskKache()
+        val image = imageDiskKache()
+        return listOf(
+            CacheStats(
+                id = "public_profiles",
+                sizeBytes = profile.size,
+                maxBytes = profile.maxSize,
+            ),
+            CacheStats(
+                id = "public_images",
+                sizeBytes = image.size,
+                maxBytes = image.maxSize,
+            ),
+        )
     }
 
     // =========================================================

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
@@ -20,6 +20,40 @@ import okio.Path.Companion.toPath
 import okio.SYSTEM
 import kotlin.time.Clock
 
+/**
+ * Disk-backed cache for a peer identity's *public* profile data — the
+ * unauthenticated JSON and avatar image served at `https://{odinId}/pub/profile`
+ * and `https://{odinId}/pub/image`. Both endpoints are public HTTPS, so their
+ * responses are stored on disk unencrypted.
+ *
+ * Two underlying [com.mayakapps.kache.FileKache] instances back the two
+ * Storage-screen rows:
+ * - `public_profiles` — serialized [ProfileCard] JSON (display name, bio,
+ *   links, email list, avatar URL, etc.). Directory
+ *   `homebase-public-profiles`, cap 50 MB.
+ * - `public_images`   — raw avatar image bytes. Directory
+ *   `homebase-public-images`, cap 200 MB.
+ *
+ * The split is deliberate, not incidental. Profile JSON is small (~1–10 KB)
+ * and read on every ContactName render and notification hydration; avatar
+ * bytes are an order of magnitude larger and sit behind Coil's in-memory
+ * cache, so their disk hit rate is lower. A single merged FileKache would
+ * let a burst of avatar loads evict the much smaller, much hotter profile
+ * JSON under LRU pressure. Keeping them on separate caps (50 MB profiles,
+ * 200 MB images) pins the small-hot tier. It also lets the two caps be
+ * tuned independently and shows up as two distinct rows on the Storage
+ * settings screen.
+ *
+ * A separate in-memory [notFoundCache] records 404 responses so repeated
+ * lookups of missing identities skip the network. Transient failures
+ * (5xx, network errors) are never cached.
+ *
+ * Both FileKache instances are created lazily through mutex-gated accessors
+ * so that [clearCaches] cannot race with a reader: clears delete the
+ * directory recursively and null the refs, and readers re-create the
+ * FileKache on next access. See also [id.homebase.api.client.drives.cache.DriveFileProviderCached]
+ * which follows the same lifecycle pattern.
+ */
 class PublicProfileProviderCached(
     private val httpClient: HttpClient,
     fileOperationsProvider: FileOperationsProvider

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseSizeProbe.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseSizeProbe.kt
@@ -1,0 +1,5 @@
+package id.homebase.api.sync.database
+
+interface DatabaseSizeProbe {
+    fun sizeBytes(): Long
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DriveMainIndexWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DriveMainIndexWrapper.kt
@@ -127,6 +127,9 @@ class DriveMainIndexWrapper(
 
     fun countAll(): Long = delegate.countAll().executeAsOne()
 
+    fun countByIdentityAndDrive(identityId: Uuid, driveId: Uuid): Long =
+        delegate.countByIdentityAndDrive(identityId, driveId).executeAsOne()
+
     suspend fun upsertDriveMainIndex(
         identityId: Uuid,
         driveId: Uuid,

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/DriveMainIndex.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/DriveMainIndex.sq
@@ -121,6 +121,11 @@ WHERE identityId = ? AND driveId = ? AND fileId = ?;
 countAll:
 SELECT count(*) FROM DriveMainIndex;
 
+-- Count records for a specific identity + drive (used by Storage settings)
+countByIdentityAndDrive:
+SELECT count(*) FROM DriveMainIndex
+WHERE identityId = ? AND driveId = ?;
+
 -- Select all records - for TESTING
 selectAll:
 SELECT * FROM DriveMainIndex;

--- a/homebase-api/src/jvmMain/kotlin/id/homebase/api/sync/database/DatabaseSizeProbe.jvm.kt
+++ b/homebase-api/src/jvmMain/kotlin/id/homebase/api/sync/database/DatabaseSizeProbe.jvm.kt
@@ -1,0 +1,20 @@
+package id.homebase.api.sync.database
+
+import id.homebase.api.file.JvmFileSystemUtil
+import java.io.File
+
+class JvmDatabaseSizeProbe : DatabaseSizeProbe {
+    override fun sizeBytes(): Long {
+        val dbDir = File(JvmFileSystemUtil.getAppDataDirectory(), "database")
+        var total = 0L
+        for (suffix in DB_SUFFIXES) {
+            val f = File(dbDir, "odin-2.db$suffix")
+            if (f.exists()) total += f.length()
+        }
+        return total
+    }
+
+    private companion object {
+        val DB_SUFFIXES = arrayOf("", "-wal", "-shm", "-journal")
+    }
+}

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/sync/database/DatabaseSizeProbe.native.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/sync/database/DatabaseSizeProbe.native.kt
@@ -1,0 +1,25 @@
+package id.homebase.api.sync.database
+
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSFileSize
+import platform.Foundation.NSHomeDirectory
+
+class NativeDatabaseSizeProbe : DatabaseSizeProbe {
+    override fun sizeBytes(): Long {
+        val dir = "${NSHomeDirectory()}/databases"
+        val fileManager = NSFileManager.defaultManager
+        var total = 0L
+        for (suffix in DB_SUFFIXES) {
+            val path = "$dir/odin-2.db$suffix"
+            if (!fileManager.fileExistsAtPath(path)) continue
+            val attrs = fileManager.attributesOfItemAtPath(path, null) ?: continue
+            val size = (attrs[NSFileSize] as? Number)?.toLong() ?: 0L
+            total += size
+        }
+        return total
+    }
+
+    private companion object {
+        val DB_SUFFIXES = arrayOf("", "-wal", "-shm", "-journal")
+    }
+}

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -154,8 +154,29 @@
     <string name="settings_profile_info">Profile Info</string>
     <string name="settings_security_setup">Security Setup</string>
     <string name="settings_help">Help</string>
+    <string name="settings_storage">Storage</string>
     <string name="settings_logout">Log out</string>
     <string name="settings_delete_account">Delete my account</string>
+
+    <!-- Storage screen -->
+    <string name="storage_caches_header">Caches</string>
+    <string name="storage_drives_header">Drives</string>
+    <string name="storage_cache_profiles">Public profiles</string>
+    <string name="storage_cache_profile_images">Profile images</string>
+    <string name="storage_cache_payloads">Media payloads</string>
+    <string name="storage_cache_thumbnails">Thumbnails</string>
+    <string name="storage_cache_unknown">Other</string>
+    <string name="storage_cache_size_format">%1$s / %2$s</string>
+    <string name="storage_drive_count_format">%1$d items</string>
+    <string name="storage_total_cache_format">Total: %1$s</string>
+    <string name="storage_clear_caches">Clear caches</string>
+    <string name="storage_caches_cleared">Caches cleared</string>
+    <string name="storage_caches_none">No caches</string>
+    <string name="storage_drives_none">No drives</string>
+    <string name="storage_cache_coil_memory">In-memory images</string>
+    <string name="storage_cache_ram_badge">RAM</string>
+    <string name="storage_other_header">Other</string>
+    <string name="storage_database">Database</string>
 
     <!-- Help screen -->
     <string name="help_support_center">Support Center</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
@@ -82,6 +82,10 @@ sealed class Route {
     data object Help : Route()
 
     @Serializable
+    @SerialName("storage-settings")
+    data object StorageSettings : Route()
+
+    @Serializable
     @SerialName("connections")
     data object Connections : Route()
 

--- a/homebase-core/src/androidMain/kotlin/id/homebase/core/di/AppModule.android.kt
+++ b/homebase-core/src/androidMain/kotlin/id/homebase/core/di/AppModule.android.kt
@@ -1,10 +1,13 @@
 package id.homebase.core.di
 
+import co.touchlab.kermit.Logger
 import coil3.ImageLoader
 import coil3.memory.MemoryCache
 import coil3.video.VideoFrameDecoder
 import id.homebase.api.file.AndroidFileOperationsProvider
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.sync.database.AndroidDatabaseSizeProbe
+import id.homebase.api.sync.database.DatabaseSizeProbe
 import id.homebase.core.audio.AndroidAudioPlayer
 import id.homebase.core.audio.AndroidAudioRecorder
 import id.homebase.core.audio.AndroidWaveFormGenerator
@@ -33,7 +36,8 @@ actual fun platformModule(): Module = module {
     single<AudioRecorder> { AndroidAudioRecorder(androidContext()) }
     single<AudioPlayer> { AndroidAudioPlayer() }
     single<AudioWaveFormGenerator> { AndroidWaveFormGenerator() }
-    single {
+    single<DatabaseSizeProbe> { AndroidDatabaseSizeProbe(androidContext()) }
+    single(createdAtStart = true) {
         ImageLoader.Builder(androidContext())
                 .components {
                     add(HomebaseImageKeyer())
@@ -47,5 +51,16 @@ actual fun platformModule(): Module = module {
                     .build()
             }
                 .build()
+                .also(::assertNoCoilDiskCache)
+    }
+}
+
+private fun assertNoCoilDiskCache(loader: ImageLoader) {
+    val disk = loader.diskCache
+    if (disk != null) {
+        Logger.e(tag = "ImageLoader") {
+            "Unexpected Coil disk cache enabled (max=${disk.maxSize} bytes). " +
+                    "DriveFileProviderCached handles encrypted disk caching; Coil's disk cache must stay off."
+        }
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -52,6 +52,7 @@ import id.homebase.core.ui.screens.home.HomeViewModel
 import id.homebase.core.ui.screens.loading.AppLoadingViewModel
 import id.homebase.core.ui.screens.notifications.NotificationSettingsViewModel
 import id.homebase.core.ui.screens.settings.SettingsViewModel
+import id.homebase.core.ui.screens.storage.StorageSettingsViewModel
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.singleOf
@@ -146,6 +147,7 @@ val appModule = module {
     viewModelOf(::SettingsViewModel)
     viewModelOf(::NotificationSettingsViewModel)
     viewModelOf(::AppearanceSettingsViewModel)
+    viewModelOf(::StorageSettingsViewModel)
     viewModelOf(::HelpViewModel)
     viewModelOf(::ConnectionsViewModel)
     viewModelOf(::ConnectRequestViewModel)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -76,6 +76,7 @@ import id.homebase.core.ui.screens.home.HomeScreen
 import id.homebase.core.ui.screens.loading.AppLoadingScreen
 import id.homebase.core.ui.screens.notifications.NotificationSettingsScreen
 import id.homebase.core.ui.screens.settings.SettingsScreen
+import id.homebase.core.ui.screens.storage.StorageSettingsScreen
 import id.homebase.core.ui.screens.widget.RichTextExample
 import id.homebase.core.util.buildNotificationUrl
 import id.homebase.core.util.getUriHandler
@@ -542,6 +543,9 @@ fun AppNavHost(
                                 onNavigateToAppearance = {
                                     navController.navigate(Route.AppearanceSettings)
                                 },
+                                onNavigateToStorage = {
+                                    navController.navigate(Route.StorageSettings)
+                                },
                                 onNavigateToHelp = {
                                     navController.navigate(Route.Help)
                                 },
@@ -582,6 +586,14 @@ fun AppNavHost(
                     composable<Route.Help> {
                         if (isAuthenticated) {
                             HelpScreen(
+                                viewModel = koinViewModel(),
+                                onBackClick = { navController.popBackStack() })
+                        }
+                    }
+
+                    composable<Route.StorageSettings> {
+                        if (isAuthenticated) {
+                            StorageSettingsScreen(
                                 viewModel = koinViewModel(),
                                 onBackClick = { navController.popBackStack() })
                         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.People
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Security
+import androidx.compose.material.icons.outlined.Storage
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -79,6 +80,7 @@ import id.homebase.resources.settings_notifications_issue
 import id.homebase.resources.settings_open_owner_console
 import id.homebase.resources.settings_profile_info
 import id.homebase.resources.settings_security_setup
+import id.homebase.resources.settings_storage
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -88,6 +90,7 @@ fun SettingsScreen(
     onNavigateToConnections: () -> Unit,
     onNavigateToNotifications: () -> Unit,
     onNavigateToAppearance: () -> Unit,
+    onNavigateToStorage: () -> Unit,
     onNavigateToHelp: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -142,6 +145,7 @@ fun SettingsScreen(
         onNavigateToConnections = onNavigateToConnections,
         onNavigateToNotifications = onNavigateToNotifications,
         onNavigateToAppearance = onNavigateToAppearance,
+        onNavigateToStorage = onNavigateToStorage,
         onNavigateToHelp = onNavigateToHelp
     )
 }
@@ -155,6 +159,7 @@ fun SettingsUi(
     onNavigateToConnections: () -> Unit,
     onNavigateToNotifications: () -> Unit,
     onNavigateToAppearance: () -> Unit,
+    onNavigateToStorage: () -> Unit,
     onNavigateToHelp: () -> Unit,
 ) {
     val scrollState = rememberScrollState()
@@ -287,6 +292,13 @@ fun SettingsUi(
             )
             Spacer(modifier = Modifier.height(8.dp))
             SettingsItemAction(
+                modifier = Modifier.testTag("storageButton"),
+                imageVector = Icons.Outlined.Storage,
+                text = stringResource(MR.string.settings_storage),
+                onClick = onNavigateToStorage
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            SettingsItemAction(
                 modifier = Modifier.testTag("helpButton"),
                 imageVector = Icons.AutoMirrored.Outlined.HelpOutline,
                 text = stringResource(MR.string.settings_help),
@@ -344,6 +356,7 @@ fun SettingsUiPreview() {
             onNavigateToConnections = {},
             onNavigateToNotifications = {},
             onNavigateToAppearance = {},
+            onNavigateToStorage = {},
             onNavigateToHelp = {}
         )
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/FormatBytes.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/FormatBytes.kt
@@ -1,0 +1,25 @@
+package id.homebase.core.ui.screens.storage
+
+import kotlin.math.abs
+
+private const val KB = 1024.0
+private const val MB = KB * 1024.0
+private const val GB = MB * 1024.0
+
+internal fun formatBytes(bytes: Long): String {
+    val absBytes = abs(bytes)
+    return when {
+        absBytes < KB -> "$bytes B"
+        absBytes < MB -> formatUnit(bytes / KB, "KB")
+        absBytes < GB -> formatUnit(bytes / MB, "MB")
+        else -> formatUnit(bytes / GB, "GB")
+    }
+}
+
+private fun formatUnit(value: Double, suffix: String): String {
+    val rounded = (value * 10).toLong() / 10.0
+    val whole = rounded.toLong()
+    val tenths = ((rounded - whole) * 10).toLong()
+    val tenthsAbs = if (tenths < 0) -tenths else tenths
+    return "$whole.$tenthsAbs $suffix"
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsScreen.kt
@@ -1,0 +1,343 @@
+package id.homebase.core.ui.screens.storage
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ChevronLeft
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.homebase.resources.MR
+import id.homebase.resources.menu_back
+import id.homebase.resources.settings_storage
+import id.homebase.resources.storage_cache_coil_memory
+import id.homebase.resources.storage_cache_payloads
+import id.homebase.resources.storage_cache_profile_images
+import id.homebase.resources.storage_cache_profiles
+import id.homebase.resources.storage_cache_ram_badge
+import id.homebase.resources.storage_cache_size_format
+import id.homebase.resources.storage_cache_thumbnails
+import id.homebase.resources.storage_cache_unknown
+import id.homebase.resources.storage_caches_cleared
+import id.homebase.resources.storage_caches_header
+import id.homebase.resources.storage_caches_none
+import id.homebase.resources.storage_clear_caches
+import id.homebase.resources.storage_database
+import id.homebase.resources.storage_drive_count_format
+import id.homebase.resources.storage_drives_header
+import id.homebase.resources.storage_drives_none
+import id.homebase.resources.storage_other_header
+import id.homebase.resources.storage_total_cache_format
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun StorageSettingsScreen(
+    viewModel: StorageSettingsViewModel,
+    onBackClick: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val cachesClearedMessage = stringResource(MR.string.storage_caches_cleared)
+
+    LaunchedEffect(uiState.uiEvent) {
+        when (uiState.uiEvent) {
+            null -> {}
+            StorageSettingsUiEvent.CachesCleared -> {
+                viewModel.eventConsumed()
+                snackbarHostState.showSnackbar(cachesClearedMessage)
+            }
+        }
+    }
+
+    StorageSettingsUi(
+        uiState = uiState,
+        onAction = viewModel::onAction,
+        onBackClick = onBackClick,
+        snackbarHostState = snackbarHostState,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StorageSettingsUi(
+    uiState: StorageSettingsUiState,
+    onAction: (StorageSettingsUiAction) -> Unit,
+    onBackClick: () -> Unit,
+    snackbarHostState: SnackbarHostState,
+) {
+    val scrollState = rememberScrollState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(MR.string.settings_storage)) },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(
+                            imageVector = Icons.Default.ChevronLeft,
+                            contentDescription = stringResource(MR.string.menu_back)
+                        )
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(innerPadding)
+                .padding(innerPadding)
+                .padding(horizontal = 16.dp)
+                .verticalScroll(scrollState),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            SectionHeader(
+                title = stringResource(MR.string.storage_caches_header),
+                trailing = {
+                    Text(
+                        text = stringResource(
+                            MR.string.storage_total_cache_format,
+                            formatBytes(uiState.totalCacheBytes),
+                        ),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+            )
+
+            Card(modifier = Modifier.fillMaxWidth()) {
+                if (uiState.caches.isEmpty() && uiState.coilMemoryCache == null) {
+                    EmptyRow(text = stringResource(MR.string.storage_caches_none))
+                } else {
+                    Column {
+                        uiState.caches.forEachIndexed { index, cache ->
+                            if (index > 0) {
+                                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                            }
+                            CacheRow(state = cache)
+                        }
+                        uiState.coilMemoryCache?.let { coil ->
+                            if (uiState.caches.isNotEmpty()) {
+                                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                            }
+                            CacheRow(state = coil, isMemory = true)
+                        }
+                    }
+                }
+            }
+
+            Button(
+                onClick = { onAction(StorageSettingsUiAction.ClearCachesClicked) },
+                enabled = !uiState.isClearing &&
+                        (uiState.caches.isNotEmpty() || uiState.coilMemoryCache != null),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (uiState.isClearing) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                } else {
+                    Text(stringResource(MR.string.storage_clear_caches))
+                }
+            }
+
+            SectionHeader(title = stringResource(MR.string.storage_drives_header))
+
+            Card(modifier = Modifier.fillMaxWidth()) {
+                if (uiState.drives.isEmpty()) {
+                    EmptyRow(text = stringResource(MR.string.storage_drives_none))
+                } else {
+                    Column {
+                        uiState.drives.forEachIndexed { index, drive ->
+                            if (index > 0) {
+                                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                            }
+                            DriveRow(state = drive)
+                        }
+                    }
+                }
+            }
+
+            SectionHeader(title = stringResource(MR.string.storage_other_header))
+
+            Card(modifier = Modifier.fillMaxWidth()) {
+                SimpleSizeRow(
+                    label = stringResource(MR.string.storage_database),
+                    sizeBytes = uiState.databaseSizeBytes,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(
+    title: String,
+    trailing: (@Composable () -> Unit)? = null,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        if (trailing != null) {
+            trailing()
+        }
+    }
+}
+
+@Composable
+private fun CacheRow(state: CacheRowState, isMemory: Boolean = false) {
+    val fraction = if (state.maxBytes <= 0L) 0f
+    else (state.sizeBytes.toFloat() / state.maxBytes.toFloat()).coerceIn(0f, 1f)
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = stringResource(cacheLabelRes(state.id)),
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+                if (isMemory) {
+                    Spacer(modifier = Modifier.size(8.dp))
+                    Text(
+                        text = stringResource(MR.string.storage_cache_ram_badge),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            Text(
+                text = stringResource(
+                    MR.string.storage_cache_size_format,
+                    formatBytes(state.sizeBytes),
+                    formatBytes(state.maxBytes),
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Spacer(modifier = Modifier.height(6.dp))
+        LinearProgressIndicator(
+            progress = { fraction },
+            modifier = Modifier.fillMaxWidth(),
+            drawStopIndicator = {},
+        )
+    }
+}
+
+@Composable
+private fun SimpleSizeRow(label: String, sizeBytes: Long) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Text(
+            text = formatBytes(sizeBytes),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun DriveRow(state: DriveRowState) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = state.label,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Text(
+            text = stringResource(MR.string.storage_drive_count_format, state.itemCount),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun EmptyRow(text: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 16.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+private fun cacheLabelRes(id: String): StringResource = when (id) {
+    "public_profiles" -> MR.string.storage_cache_profiles
+    "public_images" -> MR.string.storage_cache_profile_images
+    "drive_payloads" -> MR.string.storage_cache_payloads
+    "drive_thumbnails" -> MR.string.storage_cache_thumbnails
+    StorageSettingsViewModel.COIL_MEMORY_ID -> MR.string.storage_cache_coil_memory
+    else -> MR.string.storage_cache_unknown
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsUiState.kt
@@ -1,0 +1,35 @@
+package id.homebase.core.ui.screens.storage
+
+import kotlin.uuid.Uuid
+
+data class StorageSettingsUiState(
+    val caches: List<CacheRowState> = emptyList(),
+    val coilMemoryCache: CacheRowState? = null,
+    val drives: List<DriveRowState> = emptyList(),
+    val totalCacheBytes: Long = 0L,
+    val databaseSizeBytes: Long = 0L,
+    val isLoading: Boolean = true,
+    val isClearing: Boolean = false,
+    val uiEvent: StorageSettingsUiEvent? = null,
+)
+
+data class CacheRowState(
+    val id: String,
+    val sizeBytes: Long,
+    val maxBytes: Long,
+)
+
+data class DriveRowState(
+    val driveId: Uuid,
+    val label: String,
+    val itemCount: Long,
+)
+
+sealed interface StorageSettingsUiAction {
+    data object Refresh : StorageSettingsUiAction
+    data object ClearCachesClicked : StorageSettingsUiAction
+}
+
+sealed interface StorageSettingsUiEvent {
+    data object CachesCleared : StorageSettingsUiEvent
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsViewModel.kt
@@ -1,0 +1,145 @@
+package id.homebase.core.ui.screens.storage
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
+import coil3.ImageLoader
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.cache.DriveFileProviderCached
+import id.homebase.api.client.profile.PublicProfileProviderCached
+import id.homebase.api.sync.DriveSyncManager
+import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.sync.database.DatabaseSizeProbe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.uuid.Uuid
+
+class StorageSettingsViewModel(
+    private val publicProfileProviderCached: PublicProfileProviderCached,
+    private val driveFileProviderCached: DriveFileProviderCached,
+    private val driveSyncManager: DriveSyncManager,
+    private val credentialsManager: CredentialsManager,
+    private val databaseManager: DatabaseManager,
+    private val imageLoader: ImageLoader,
+    private val databaseSizeProbe: DatabaseSizeProbe,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(StorageSettingsUiState())
+    val uiState: StateFlow<StorageSettingsUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun onAction(action: StorageSettingsUiAction) {
+        when (action) {
+            StorageSettingsUiAction.Refresh -> load()
+            StorageSettingsUiAction.ClearCachesClicked -> clearCaches()
+        }
+    }
+
+    fun eventConsumed() {
+        _uiState.update { it.copy(uiEvent = null) }
+    }
+
+    private fun load() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+
+            val profileStats = runCatching { publicProfileProviderCached.getCacheStats() }
+                .getOrElse {
+                    Logger.w(tag = "StorageSettings", throwable = it) { "profile cache stats failed" }
+                    emptyList()
+                }
+            val driveStats = runCatching { driveFileProviderCached.getCacheStats() }
+                .getOrElse {
+                    Logger.w(tag = "StorageSettings", throwable = it) { "drive cache stats failed" }
+                    emptyList()
+                }
+            val caches = (profileStats + driveStats).map {
+                CacheRowState(id = it.id, sizeBytes = it.sizeBytes, maxBytes = it.maxBytes)
+            }
+            val total = caches.sumOf { it.sizeBytes }
+
+            val coilRow = imageLoader.memoryCache?.let { mem ->
+                CacheRowState(
+                    id = COIL_MEMORY_ID,
+                    sizeBytes = mem.size,
+                    maxBytes = mem.maxSize,
+                )
+            }
+
+            val dbSize = withContext(Dispatchers.Default) {
+                runCatching { databaseSizeProbe.sizeBytes() }
+                    .getOrElse {
+                        Logger.w(tag = "StorageSettings", throwable = it) { "database size probe failed" }
+                        0L
+                    }
+            }
+
+            val driveRows = loadDriveRows()
+
+            _uiState.update {
+                it.copy(
+                    caches = caches,
+                    coilMemoryCache = coilRow,
+                    drives = driveRows,
+                    totalCacheBytes = total,
+                    databaseSizeBytes = dbSize,
+                    isLoading = false,
+                )
+            }
+        }
+    }
+
+    private suspend fun loadDriveRows(): List<DriveRowState> {
+        val identityId: Uuid = runCatching {
+            credentialsManager.requireActiveCredentials().getIdentityId()
+        }.getOrElse {
+            Logger.w(tag = "StorageSettings", throwable = it) { "no active credentials — cannot load drive counts" }
+            return emptyList()
+        }
+
+        val drives = driveSyncManager.driveStatuses.value.values
+            .map { it.driveId to it.label }
+            .sortedBy { it.second }
+
+        return withContext(Dispatchers.Default) {
+            val rows = ArrayList<DriveRowState>(drives.size)
+            for ((driveId, label) in drives) {
+                val count = runCatching {
+                    databaseManager.driveMainIndex.countByIdentityAndDrive(identityId, driveId)
+                }.getOrElse {
+                    Logger.w(tag = "StorageSettings", throwable = it) { "drive count failed for $driveId" }
+                    0L
+                }
+                rows.add(DriveRowState(driveId = driveId, label = label, itemCount = count))
+            }
+            rows
+        }
+    }
+
+    private fun clearCaches() {
+        if (_uiState.value.isClearing) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isClearing = true) }
+            runCatching { publicProfileProviderCached.clearCaches() }
+                .onFailure { Logger.w(tag = "StorageSettings", throwable = it) { "profile clearCaches failed" } }
+            runCatching { driveFileProviderCached.clearCaches() }
+                .onFailure { Logger.w(tag = "StorageSettings", throwable = it) { "drive clearCaches failed" } }
+            runCatching { imageLoader.memoryCache?.clear() }
+                .onFailure { Logger.w(tag = "StorageSettings", throwable = it) { "coil memory clear failed" } }
+            _uiState.update { it.copy(isClearing = false, uiEvent = StorageSettingsUiEvent.CachesCleared) }
+            load()
+        }
+    }
+
+    companion object {
+        const val COIL_MEMORY_ID: String = "coil_memory"
+    }
+}

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/settings/SettingsUiTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/settings/SettingsUiTest.kt
@@ -23,6 +23,7 @@ class SettingsUiTest {
                     onNavigateToConnections = {},
                     onNavigateToNotifications = {},
                     onNavigateToAppearance = {},
+                    onNavigateToStorage = {},
                     onNavigateToHelp = {},
                 )
             }
@@ -41,6 +42,7 @@ class SettingsUiTest {
                     onNavigateToConnections = {},
                     onNavigateToNotifications = {},
                     onNavigateToAppearance = {},
+                    onNavigateToStorage = {},
                     onNavigateToHelp = {},
                 )
             }
@@ -64,6 +66,7 @@ class SettingsUiTest {
                     onNavigateToConnections = {},
                     onNavigateToNotifications = {},
                     onNavigateToAppearance = {},
+                    onNavigateToStorage = {},
                     onNavigateToHelp = {},
                 )
             }
@@ -84,6 +87,7 @@ class SettingsUiTest {
                     onNavigateToConnections = {},
                     onNavigateToNotifications = { navigated = true },
                     onNavigateToAppearance = {},
+                    onNavigateToStorage = {},
                     onNavigateToHelp = {},
                 )
             }
@@ -104,6 +108,7 @@ class SettingsUiTest {
                     onNavigateToConnections = {},
                     onNavigateToNotifications = {},
                     onNavigateToAppearance = { navigated = true },
+                    onNavigateToStorage = {},
                     onNavigateToHelp = {},
                 )
             }
@@ -128,6 +133,7 @@ class SettingsUiTest {
                     onNavigateToConnections = {},
                     onNavigateToNotifications = {},
                     onNavigateToAppearance = {},
+                    onNavigateToStorage = {},
                     onNavigateToHelp = {},
                 )
             }
@@ -152,6 +158,7 @@ class SettingsUiTest {
                     onNavigateToConnections = {},
                     onNavigateToNotifications = {},
                     onNavigateToAppearance = {},
+                    onNavigateToStorage = {},
                     onNavigateToHelp = {},
                 )
             }

--- a/homebase-core/src/jvmMain/kotlin/id/homebase/core/di/AppModule.desktop.kt
+++ b/homebase-core/src/jvmMain/kotlin/id/homebase/core/di/AppModule.desktop.kt
@@ -1,9 +1,12 @@
 package id.homebase.core.di
 
+import co.touchlab.kermit.Logger
 import coil3.ImageLoader
 import coil3.PlatformContext
 import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.file.JvmFileOperationsProvider
+import id.homebase.api.sync.database.DatabaseSizeProbe
+import id.homebase.api.sync.database.JvmDatabaseSizeProbe
 import id.homebase.core.audio.AudioPlayer
 import id.homebase.core.audio.AudioRecorder
 import id.homebase.core.audio.AudioWaveFormGenerator
@@ -31,7 +34,8 @@ actual fun platformModule(): Module = module {
     single<AudioRecorder> { JvmAudioRecorder() }
     single<AudioPlayer> { JvmAudioPlayer() }
     single<AudioWaveFormGenerator> { JvmWaveFormGenerator() }
-    single {
+    single<DatabaseSizeProbe> { JvmDatabaseSizeProbe() }
+    single(createdAtStart = true) {
         // Note: No disk cache - DriveFileProviderCached handles encrypted disk caching
         // Coil's memory cache is still enabled by default for fast UI redraws
         ImageLoader.Builder(PlatformContext.INSTANCE)
@@ -41,5 +45,16 @@ actual fun platformModule(): Module = module {
                     add(PublicImageFetcher.Factory(get()))
                 }
                 .build()
+                .also(::assertNoCoilDiskCache)
+    }
+}
+
+private fun assertNoCoilDiskCache(loader: ImageLoader) {
+    val disk = loader.diskCache
+    if (disk != null) {
+        Logger.e(tag = "ImageLoader") {
+            "Unexpected Coil disk cache enabled (max=${disk.maxSize} bytes). " +
+                    "DriveFileProviderCached handles encrypted disk caching; Coil's disk cache must stay off."
+        }
     }
 }

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/di/AppModule.native.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/di/AppModule.native.kt
@@ -1,9 +1,12 @@
 package id.homebase.core.di
 
+import co.touchlab.kermit.Logger
 import coil3.ImageLoader
 import coil3.PlatformContext
 import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.file.IOSFileOperationsProvider
+import id.homebase.api.sync.database.DatabaseSizeProbe
+import id.homebase.api.sync.database.NativeDatabaseSizeProbe
 import id.homebase.core.audio.AudioPlayer
 import id.homebase.core.audio.AudioRecorder
 import id.homebase.core.audio.AudioWaveFormGenerator
@@ -33,7 +36,8 @@ actual fun platformModule(): Module = module {
     single<AudioPlayer> { IOSAudioPlayer() }
     single<AudioWaveFormGenerator> { IOSWaveFormGenerator() }
 
-    single {
+    single<DatabaseSizeProbe> { NativeDatabaseSizeProbe() }
+    single(createdAtStart = true) {
         ImageLoader.Builder(PlatformContext.INSTANCE)
                 .components {
                     add(HomebaseImageKeyer())
@@ -42,5 +46,16 @@ actual fun platformModule(): Module = module {
                     add(PublicImageFetcher.Factory(get()))
                 }
                 .build()
+                .also(::assertNoCoilDiskCache)
+    }
+}
+
+private fun assertNoCoilDiskCache(loader: ImageLoader) {
+    val disk = loader.diskCache
+    if (disk != null) {
+        Logger.e(tag = "ImageLoader") {
+            "Unexpected Coil disk cache enabled (max=${disk.maxSize} bytes). " +
+                    "DriveFileProviderCached handles encrypted disk caching; Coil's disk cache must stay off."
+        }
     }
 }


### PR DESCRIPTION
New Settings -> Storage screen showing per-cache disk usage, per-drive record counts, Coil's in-memory image cache, and the SQLite database file size. Includes a "Clear caches" button that empties the four FileKache caches and Coil's memory cache in one action. DB size is display-only -- clearing the DB would be destructive.

Additions:
- Route.StorageSettings + AppNavHost wiring
- Menu entry in SettingsScreen between Appearance and Help
- getCacheStats() on PublicProfileProviderCached + DriveFileProviderCached
- countByIdentityAndDrive() on DriveMainIndexWrapper + DriveMainIndex.sq
- DatabaseSizeProbe interface with androidMain / jvmMain / nativeMain actuals that sum odin-2.db plus its wal/shm/journal sidecars
- StorageSettingsViewModel / UiState / Screen under homebase-core
- Cold-start assertion in each platform module that Coil's ImageLoader must not have a disk cache (error-logged via Kermit; createdAtStart = true to fire at app launch rather than on first image load -- the drive payload/thumb caches are handled by DriveFileProviderCached and Coil must not duplicate them)
- LinearProgressIndicator rows hide Material 3's stop-indicator dot so the numeric size label is the only readout