### PR TITLE
fix(cache): harden FileKache construction against NPE poisoning

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
@@ -87,24 +87,55 @@ class DriveFileProviderCached(
 
     private var _payloadDiskKache: FileKache? = null
     private var _thumbDiskKache: FileKache? = null
+    @Volatile private var payloadKacheFailure: Throwable? = null
+    @Volatile private var thumbKacheFailure: Throwable? = null
     private val kacheMutex = Mutex()
 
     // Always acquires kacheMutex — the previous lock-free fast path let a
     // reader hand out a reference to a FileKache instance that clearCaches()
     // was simultaneously disposing, producing a NPE inside FileKache's
     // internals when the reader resumed and called .get() on it.
+    //
+    // createDirectories + tombstone on construction failure: observed on one
+    // real device that FileKache(…) itself throws `getClass() on null` from
+    // mayakapps/kache internals when the managed directory is missing.
+    // We pre-create the dir to avoid the library's fragile init path, and
+    // record any construction exception so we don't spam retries for the
+    // rest of the session. clearCaches() resets the tombstone.
     private suspend fun payloadDiskKache(): FileKache = kacheMutex.withLock {
-        _payloadDiskKache ?: FileKache(
-                directory = "$directory/homebase-payloads",
-                maxSize = 200L * 1024L * 1024L // 200MB
-        ).also { _payloadDiskKache = it }
+        _payloadDiskKache?.let { return@withLock it }
+        payloadKacheFailure?.let { throw it }
+
+        val dir = "$directory/homebase-payloads"
+        try {
+            fileSystem.createDirectories(dir.toPath())
+            FileKache(directory = dir, maxSize = 200L * 1024L * 1024L) // 200MB
+                    .also { _payloadDiskKache = it }
+        } catch (e: Throwable) {
+            Logger.e(tag = "DriveFileProviderCached", throwable = e) {
+                "FileKache construction FAILED (payload) — disabling disk cache for this session"
+            }
+            payloadKacheFailure = e
+            throw e
+        }
     }
 
     private suspend fun thumbDiskKache(): FileKache = kacheMutex.withLock {
-        _thumbDiskKache ?: FileKache(
-                directory = "$directory/homebase-thumbs",
-                maxSize = 300L * 1024L * 1024L // 300MB
-        ).also { _thumbDiskKache = it }
+        _thumbDiskKache?.let { return@withLock it }
+        thumbKacheFailure?.let { throw it }
+
+        val dir = "$directory/homebase-thumbs"
+        try {
+            fileSystem.createDirectories(dir.toPath())
+            FileKache(directory = dir, maxSize = 300L * 1024L * 1024L) // 300MB
+                    .also { _thumbDiskKache = it }
+        } catch (e: Throwable) {
+            Logger.e(tag = "DriveFileProviderCached", throwable = e) {
+                "FileKache construction FAILED (thumb) — disabling disk cache for this session"
+            }
+            thumbKacheFailure = e
+            throw e
+        }
     }
 
     // ================================================================
@@ -503,6 +534,8 @@ class DriveFileProviderCached(
         kacheMutex.withLock {
             _payloadDiskKache = null
             _thumbDiskKache = null
+            payloadKacheFailure = null
+            thumbKacheFailure = null
 
             try {
                 fileSystem.deleteRecursively(payloadDir)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
@@ -2,7 +2,6 @@ package id.homebase.api.client.drives.cache
 
 import co.touchlab.kermit.Logger
 import com.mayakapps.kache.FileKache
-import kotlin.time.measureTimedValue
 import id.homebase.api.client.ByteApiResponse
 import id.homebase.api.client.cache.CacheStats
 import id.homebase.api.client.KeyHeader
@@ -54,6 +53,13 @@ import okio.SYSTEM
  * lookups of deleted files skip the network. Transient failures
  * (5xx, network errors) are never cached.
  *
+ * Unlike [id.homebase.api.client.profile.PublicProfileProviderCached], this
+ * cache has no TTL or `Cache-Control` handling: drive file bytes are
+ * immutable at a given `(driveId, fileId, key, chunkStart, chunkLength,
+ * lastModified)` tuple, so the cacheKey itself is version-addressed.
+ * A new version lands under a new key, which gets fetched fresh; the old
+ * key ages out through LRU eviction.
+ *
  * Both FileKache instances are created lazily through mutex-gated
  * accessors; [clearCaches] deletes the directories recursively and nulls
  * the refs, so concurrent readers cannot end up with a disposed
@@ -75,6 +81,10 @@ class DriveFileProviderCached(
 
     private val thumbnailKacheWriteMutex = Mutex()
 
+    // TODO: unbounded growth — keyLocks gains one entry per unique cacheKey
+    //  ever touched and never drops any. Over a long session this leaks
+    //  memory. Same shape in PublicProfileProviderCached. Fix with a
+    //  weak-valued map or a periodic prune keyed on last-use timestamp.
     private val keyLocks = mutableMapOf<String, Mutex>()
     private val lock = Mutex()
 
@@ -175,22 +185,21 @@ class DriveFileProviderCached(
             // we allow up to 3 concurrent semaphore payloads over the network
             return payloadSemaphore.withPermit {
                 try {
-                    val (networkResult, elapsed) = measureTimedValue {
-                        delegate.getPayloadBytesRawNetwork(driveId, fileId, key, options, onDownloadProgress)
-                    }
-                    Logger.d(tag = "VideoIO") { "payload network-fetch: ${networkResult.bytes.size} bytes in $elapsed key=$cacheKey" }
-                    val result = networkResult
+                    val result = delegate.getPayloadBytesRawNetwork(driveId, fileId, key, options, onDownloadProgress)
 
                     // 3️⃣ Store to disk (only 200/206 can reach here — throwForFailure throws for everything else)
                     check(result.status in 200..299) {
                         "Unexpected non-2xx status ${result.status} reached disk cache write — not caching"
                     }
-                    val (_, cacheWriteElapsed) = measureTimedValue {
+                    try {
                         payloadDiskKache().put(cacheKey) { filePath ->
                             writeBytesResponse(filePath, result)
                         }
+                    } catch (e: Exception) {
+                        // A write failure should not prevent the caller from getting the fetched bytes.
+                        // Surface it loudly so we can spot corrupted journals or full disks.
+                        Logger.e(tag = "PayloadIO", throwable = e) { "payload cache-write FAILED key=$cacheKey" }
                     }
-                    Logger.d(tag = "VideoIO") { "payload cache-write: ${result.bytes.size} bytes in $cacheWriteElapsed key=$cacheKey" }
                     result
                 } catch (e: NotFoundException) {
                     // 404 thrown by network layer — cache it so future calls skip the network
@@ -198,6 +207,7 @@ class DriveFileProviderCached(
                     throw e
                 } catch (e: Exception) {
                     // For other errors (500, network issues, etc.), don't cache and rethrow
+                    Logger.w(tag = "PayloadIO") { "payload network-fetch FAILED (${e::class.simpleName}): ${e.message} key=$cacheKey" }
                     throw e
                 }
             }
@@ -230,25 +240,21 @@ class DriveFileProviderCached(
 
         val rangeResult = DriveFileHelpers.getRangeHeader(chunkStart, chunkLength)
 
-        val (decryptedBytes, decryptElapsed) =
-                measureTimedValue {
-                    if (rangeResult.updatedChunkStart != null) {
-                        val decrypted =
-                                delegate.decryptChunkedBytes(
-                                        raw.headers,
-                                        raw.bytes,
-                                        keyHeader,
-                                        startOffset = rangeResult.startOffset,
-                                        chunkStart = (chunkStart ?: 0).toInt()
-                                )
+        val decryptedBytes = if (rangeResult.updatedChunkStart != null) {
+            val decrypted =
+                    delegate.decryptChunkedBytes(
+                            raw.headers,
+                            raw.bytes,
+                            keyHeader,
+                            startOffset = rangeResult.startOffset,
+                            chunkStart = (chunkStart ?: 0).toInt()
+                    )
 
-                        val sliceEnd = chunkLength?.toInt() ?: decrypted.size
-                        decrypted.sliceArray(0 until minOf(sliceEnd, decrypted.size))
-                    } else {
-                        delegate.decryptBytes(keyHeader, raw.headers, raw.bytes)
-                    }
-                }
-        Logger.d(tag = "VideoIO") { "payload decrypt: ${raw.bytes.size} → ${decryptedBytes.size} bytes in $decryptElapsed" }
+            val sliceEnd = chunkLength?.toInt() ?: decrypted.size
+            decrypted.sliceArray(0 until minOf(sliceEnd, decrypted.size))
+        } else {
+            delegate.decryptBytes(keyHeader, raw.headers, raw.bytes)
+        }
 
         return BytesResponse(bytes = decryptedBytes, contentType = raw.contentType)
     }
@@ -303,10 +309,7 @@ class DriveFileProviderCached(
         val cacheKey = buildThumbCacheKey(driveId, fileId, payloadKey, width, height, lastModified)
 
         // 1️⃣ Check in-memory 404 cache first
-        if (cacheKey in notFoundCache) {
-            Logger.d(tag = "ThumbIO") { "thumb notFound-cache-hit key=$cacheKey" }
-            return ByteApiResponse.EMPTY_404
-        }
+        if (cacheKey in notFoundCache) return ByteApiResponse.EMPTY_404
 
         // 2️⃣ Peek in disk cache and return result if it's there
         readCachedThumbOrLog(cacheKey)?.let { return it }
@@ -335,9 +338,6 @@ class DriveFileProviderCached(
                                     height,
                                     lastModified
                             )
-                    Logger.d(tag = "ThumbIO") {
-                        "thumb network-fetch: status=${result.status} ${result.bytes.size} bytes contentType=${result.contentType} key=$cacheKey"
-                    }
 
                     // 3️⃣ Store to disk (only 200/206 can reach here — throwForFailure throws for everything else).
                     // Serialise writes to avoid corrupting FileKache's journal file.
@@ -350,7 +350,6 @@ class DriveFileProviderCached(
                                 writeBytesResponse(filePath, result)
                             }
                         }
-                        Logger.d(tag = "ThumbIO") { "thumb cache-write: ${result.bytes.size} bytes key=$cacheKey" }
                     } catch (e: Exception) {
                         // A write failure should not prevent the caller from getting the fetched bytes.
                         // Surface it loudly so we can spot corrupted journals or full disks.
@@ -380,9 +379,7 @@ class DriveFileProviderCached(
     private suspend fun readCachedThumbOrLog(cacheKey: String): ByteApiResponse? {
         return try {
             val filePath = thumbDiskKache().get(cacheKey) ?: return null
-            val result = readBytesResponse(filePath)
-            Logger.d(tag = "ThumbIO") { "thumb cache-hit: status=${result.status} ${result.bytes.size} bytes key=$cacheKey" }
-            result
+            readBytesResponse(filePath)
         } catch (e: Exception) {
             Logger.e(tag = "ThumbIO", throwable = e) { "thumb cache-read FAILED key=$cacheKey" }
             null
@@ -396,11 +393,10 @@ class DriveFileProviderCached(
     private suspend fun readCachedPayloadOrLog(cacheKey: String): ByteApiResponse? {
         return try {
             val filePath = payloadDiskKache().get(cacheKey) ?: return null
-            val (result, elapsed) = measureTimedValue { readBytesResponse(filePath) }
-            Logger.d(tag = "VideoIO") { "payload cache-hit: ${result.bytes.size} bytes in $elapsed key=$cacheKey" }
+            val result = readBytesResponse(filePath)
             result
         } catch (e: Exception) {
-            Logger.e(tag = "VideoIO", throwable = e) { "payload cache-read FAILED key=$cacheKey" }
+            Logger.e(tag = "PayloadIO", throwable = e) { "payload cache-read FAILED key=$cacheKey" }
             null
         }
     }
@@ -551,7 +547,9 @@ class DriveFileProviderCached(
 
         try {
             fileSystem.deleteRecursively(preloadDir)
-        } catch (_: Exception) {}
+        } catch (e: Exception) {
+            Logger.w(tag = "DriveFileProviderCached", throwable = e) { "hbvid_preload dir delete failed" }
+        }
 
         notFoundCache = emptySet()
     }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
@@ -30,19 +30,19 @@ import kotlin.time.Clock
  * Storage-screen rows:
  * - `public_profiles` — serialized [ProfileCard] JSON (display name, bio,
  *   links, email list, avatar URL, etc.). Directory
- *   `homebase-public-profiles`, cap 50 MB.
+ *   `homebase-public-profiles`, cap 10 MB.
  * - `public_images`   — raw avatar image bytes. Directory
  *   `homebase-public-images`, cap 200 MB.
  *
  * The split is deliberate, not incidental. Profile JSON is small (~1–10 KB)
- * and read on every ContactName render and notification hydration; avatar
- * bytes are an order of magnitude larger and sit behind Coil's in-memory
- * cache, so their disk hit rate is lower. A single merged FileKache would
- * let a burst of avatar loads evict the much smaller, much hotter profile
- * JSON under LRU pressure. Keeping them on separate caps (50 MB profiles,
- * 200 MB images) pins the small-hot tier. It also lets the two caps be
- * tuned independently and shows up as two distinct rows on the Storage
- * settings screen.
+ * and used as a sparse fallback for identities without a local contact-drive
+ * record — push senders, forward-sheet targets, unmet-peer [id.homebase.core.widget.ContactName]
+ * renders. Avatar bytes are an order of magnitude larger. A single merged
+ * FileKache would let a burst of avatar loads evict profile JSON entries
+ * under shared-pool LRU pressure; separate caps (10 MB profiles, 200 MB
+ * images) protect the small tier from the large one regardless of relative
+ * request rates. It also lets the two caps be tuned independently and
+ * shows up as two distinct rows on the Storage settings screen.
  *
  * A separate in-memory [notFoundCache] records 404 responses so repeated
  * lookups of missing identities skip the network. Transient failures
@@ -66,6 +66,10 @@ class PublicProfileProviderCached(
     private val directory = fileOperationsProvider.getCacheDirectory()
 
     private val lock = Mutex()
+    // TODO: unbounded growth — keyLocks gains one entry per unique cacheKey
+    //  ever touched and never drops any. Over a long session this leaks
+    //  memory. Same shape in DriveFileProviderCached. Fix with a
+    //  weak-valued map or a periodic prune keyed on last-use timestamp.
     private val keyLocks = mutableMapOf<String, Mutex>()
 
     // Immutable set — always replaced, never mutated in-place.
@@ -97,7 +101,7 @@ class PublicProfileProviderCached(
         val dir = "$directory/homebase-public-profiles"
         try {
             fileSystem.createDirectories(dir.toPath())
-            FileKache(directory = dir, maxSize = 50L * 1024L * 1024L)
+            FileKache(directory = dir, maxSize = 10L * 1024L * 1024L)
                 .also { _profileDiskKache = it }
         } catch (e: Throwable) {
             Logger.e(tag = "PublicProfileIO", throwable = e) {
@@ -296,7 +300,12 @@ class PublicProfileProviderCached(
                     null
                 }
 
-                else -> throw Exception("Fetch failed: ${response.status}")
+                else -> {
+                    Logger.w(tag = "PublicProfileIO") {
+                        "unexpected status=${response.status.value} key=$cacheKey"
+                    }
+                    throw Exception("Fetch failed: ${response.status}")
+                }
             }
         }
     }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
@@ -76,23 +76,54 @@ class PublicProfileProviderCached(
 
     private var _profileDiskKache: FileKache? = null
     private var _imageDiskKache: FileKache? = null
+    @Volatile private var profileKacheFailure: Throwable? = null
+    @Volatile private var imageKacheFailure: Throwable? = null
     private val kacheMutex = Mutex()
 
     // Always acquires kacheMutex — the previous `by lazy { runBlocking { ... } }`
     // handed out a permanent FileKache reference that a concurrent clearCaches()
     // could poison with .clear(). Mirrors DriveFileProviderCached post-fix.
+    //
+    // createDirectories + tombstone on construction failure: observed on one
+    // Android device that FileKache(…) throws `getClass() on null` from
+    // mayakapps/kache internals when the managed directory is missing.
+    // Pre-create the dir and tombstone the first construction exception so we
+    // don't spam retries for the rest of the session. clearCaches() resets
+    // the tombstone.
     private suspend fun profileDiskKache(): FileKache = kacheMutex.withLock {
-        _profileDiskKache ?: FileKache(
-            directory = "$directory/homebase-public-profiles",
-            maxSize = 50L * 1024L * 1024L
-        ).also { _profileDiskKache = it }
+        _profileDiskKache?.let { return@withLock it }
+        profileKacheFailure?.let { throw it }
+
+        val dir = "$directory/homebase-public-profiles"
+        try {
+            fileSystem.createDirectories(dir.toPath())
+            FileKache(directory = dir, maxSize = 50L * 1024L * 1024L)
+                .also { _profileDiskKache = it }
+        } catch (e: Throwable) {
+            Logger.e(tag = "PublicProfileIO", throwable = e) {
+                "FileKache construction FAILED (profile) — disabling disk cache for this session"
+            }
+            profileKacheFailure = e
+            throw e
+        }
     }
 
     private suspend fun imageDiskKache(): FileKache = kacheMutex.withLock {
-        _imageDiskKache ?: FileKache(
-            directory = "$directory/homebase-public-images",
-            maxSize = 200L * 1024L * 1024L
-        ).also { _imageDiskKache = it }
+        _imageDiskKache?.let { return@withLock it }
+        imageKacheFailure?.let { throw it }
+
+        val dir = "$directory/homebase-public-images"
+        try {
+            fileSystem.createDirectories(dir.toPath())
+            FileKache(directory = dir, maxSize = 200L * 1024L * 1024L)
+                .also { _imageDiskKache = it }
+        } catch (e: Throwable) {
+            Logger.e(tag = "PublicProfileIO", throwable = e) {
+                "FileKache construction FAILED (image) — disabling disk cache for this session"
+            }
+            imageKacheFailure = e
+            throw e
+        }
     }
 
     // =========================================================
@@ -160,6 +191,8 @@ class PublicProfileProviderCached(
         kacheMutex.withLock {
             _profileDiskKache = null
             _imageDiskKache = null
+            profileKacheFailure = null
+            imageKacheFailure = null
 
             try {
                 fileSystem.deleteRecursively(profileDir)

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
@@ -160,29 +160,6 @@ class DriveFileProviderCachedTest {
     }
 
     @Test
-    fun `thumb fetch emits ThumbIO breadcrumbs for network-fetch cache-write and cache-hit`() = runTest {
-        provider.getThumbBytesRaw(driveId, fileId, key, 100, 100)
-
-        assertTrue(
-            logCollector.hasMessage(tag = "ThumbIO", substring = "thumb network-fetch"),
-            "expected ThumbIO network-fetch breadcrumb; got: ${logCollector.messages("ThumbIO")}"
-        )
-        assertTrue(
-            logCollector.hasMessage(tag = "ThumbIO", substring = "thumb cache-write"),
-            "expected ThumbIO cache-write breadcrumb; got: ${logCollector.messages("ThumbIO")}"
-        )
-
-        // Second call must hit the disk cache and log accordingly.
-        logCollector.entries.clear()
-        provider.getThumbBytesRaw(driveId, fileId, key, 100, 100)
-
-        assertTrue(
-            logCollector.hasMessage(tag = "ThumbIO", substring = "thumb cache-hit"),
-            "expected ThumbIO cache-hit breadcrumb; got: ${logCollector.messages("ThumbIO")}"
-        )
-    }
-
-    @Test
     fun `poisoned cache entry with non-2xx status is visible in the decrypt failure log`() = runTest {
         // Populate the cache with a normal 200 response, then rewrite the on-disk
         // data file with a valid-format ByteApiResponse whose status is 500.

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/clipboard/ClipboardImageReceiverModifier.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/clipboard/ClipboardImageReceiverModifier.android.kt
@@ -31,11 +31,11 @@ actual fun clipboardImageReceiverModifier(onImagePasted: (ByteArray) -> Unit): M
                                 onImagePasted(bytes)
                                 true
                             } else {
-                                Logger.w("ClipboardImageReceiver") { "Failed to read bytes from URI: $uri" }
+                                Logger.w(tag = "ClipboardImageReceiver") { "Failed to read bytes from URI: $uri" }
                                 false
                             }
                         } catch (e: Exception) {
-                            Logger.e("ClipboardImageReceiver", e) { "Error reading pasted image" }
+                            Logger.e(throwable = e, tag = "ClipboardImageReceiver") { "Error reading pasted image" }
                             false
                         }
                     } else {

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/avatars/PublicAvatar.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/avatars/PublicAvatar.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil3.ImageLoader
 import coil3.compose.AsyncImagePainter
 import coil3.compose.SubcomposeAsyncImage
 import coil3.compose.SubcomposeAsyncImageContent
@@ -20,6 +21,7 @@ import id.homebase.api.common.OdinId
 import id.homebase.resources.MR
 import id.homebase.resources.avatar_public
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 
 @Composable
 fun PublicAvatar(
@@ -29,6 +31,13 @@ fun PublicAvatar(
     modifier: Modifier = Modifier
 ) {
     val imageUrl = "https://$odinId/pub/image"
+
+    // Defense in depth. SingletonImageLoader is also rewired to this
+    // instance in AppModule.{android,desktop,native}.kt, so a caller that
+    // forgets `imageLoader=` still lands on the configured loader. Passing
+    // explicitly here mirrors HomebaseImage.kt:82,146 and survives any
+    // future Coil upgrade that changes singleton resolution semantics.
+    val imageLoader: ImageLoader = koinInject()
 
     val clickableModifier =
         if (options.onClick != null) {
@@ -44,6 +53,7 @@ fun PublicAvatar(
 
     SubcomposeAsyncImage(
         model = imageUrl,
+        imageLoader = imageLoader,
         contentDescription = stringResource(MR.string.avatar_public),
         contentScale = options.contentScale,
         modifier = clickableModifier

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/PublicImageFetcher.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/PublicImageFetcher.kt
@@ -1,6 +1,7 @@
 package id.homebase.core.image
 
 import coil3.ImageLoader
+import coil3.Uri
 import coil3.decode.DataSource
 import coil3.decode.ImageSource
 import coil3.fetch.FetchResult
@@ -27,13 +28,42 @@ class PublicImageFetcher(
         )
     }
 
-    class Factory(private val provider: PublicProfileProvider) : Fetcher.Factory<String> {
-        override fun create(data: String, options: Options, imageLoader: ImageLoader): Fetcher? {
-            if (!data.contains("/pub/image")) return null
-            val odinId = OdinId(
-                data.removePrefix("https://").removeSuffix("/pub/image")
-            )
+    // Factory<Uri> — Coil 3 maps a String model to coil3.Uri BEFORE
+    // Fetcher-factory matching runs. A Factory<String> is therefore never
+    // polled for http(s) URLs (Coil sees only Uris at that stage), falls
+    // through to the built-in NetworkFetcher, and our cache layer is
+    // bypassed. Factory<Any> wasn't polled either (verified empirically —
+    // diagnostic logs showed Factory<Any>.create fired for custom data
+    // classes like HomebaseImageData but never for a mapped http Uri).
+    // Factory<Uri> is the correct type for http URL inputs.
+    class Factory(private val provider: PublicProfileProvider) : Fetcher.Factory<Uri> {
+        override fun create(data: Uri, options: Options, imageLoader: ImageLoader): Fetcher? {
+            val odinId = resolveOdinId(data) ?: return null
             return PublicImageFetcher(odinId, options, provider)
+        }
+    }
+
+    companion object {
+        /**
+         * Extracts the peer [OdinId] from a Coil request `data` parameter when
+         * it represents a public-image URL, or returns null otherwise.
+         *
+         * The `Any` parameter makes the helper directly testable with both
+         * [coil3.Uri] (production path, what Coil hands the Factory) and
+         * [String] (convenience in tests, avoids standing up a real Coil
+         * pipeline). Tested in `PublicImageFetcherFactoryTest` — keep this
+         * helper and its tests in sync if the URL shape changes.
+         */
+        internal fun resolveOdinId(data: Any): OdinId? {
+            val url = when (data) {
+                is Uri -> data.toString()
+                is String -> data
+                else -> return null
+            }
+            if (!url.contains("/pub/image")) return null
+            return OdinId(
+                url.removePrefix("https://").removeSuffix("/pub/image")
+            )
         }
     }
 }

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/image/PublicImageFetcherFactoryTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/image/PublicImageFetcherFactoryTest.kt
@@ -1,9 +1,12 @@
 package id.homebase.core.image
 
+import coil3.toUri
 import id.homebase.api.common.OdinId
+import id.homebase.core.image.PublicImageFetcher.Companion.resolveOdinId
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /** Tests for [PublicImageFetcher.Factory] URL matching and OdinId parsing logic */
@@ -49,5 +52,62 @@ class PublicImageFetcherFactoryTest {
         val url = "https://sub.frodo.digital/pub/image"
         val domain = url.removePrefix("https://").removeSuffix("/pub/image")
         assertEquals("sub.frodo.digital", OdinId(domain).toString())
+    }
+
+    // =========================================================
+    // Factory data-resolution — REGRESSION COVERAGE
+    //
+    // Coil 3 maps a String model to coil3.Uri BEFORE Fetcher-factory
+    // matching. A Factory<String> is therefore never polled for http(s)
+    // URLs — Coil only sees Uris at that stage, falls through to the
+    // built-in NetworkFetcher, and our cache layer is bypassed.
+    // Factory<Uri> + resolveOdinId() is the fix.
+    //
+    // resolveOdinId(data: Any) accepts both Uri (production path, what
+    // Coil hands us) and String (test convenience) so these tests can
+    // exercise both shapes without instantiating a real Coil pipeline.
+    //
+    // If any of these tests fail, the Factory match logic broke and the
+    // orphan-Coil warning on the Storage screen should start firing on
+    // the next run (red card + Logger.e from StorageSettingsViewModel).
+    // =========================================================
+
+    @Test
+    fun resolveOdinId_uriData_matches() {
+        val uri = "https://biggus.dickus.demo.rocks/pub/image".toUri()
+        assertEquals("biggus.dickus.demo.rocks", resolveOdinId(uri)?.toString())
+    }
+
+    @Test
+    fun resolveOdinId_stringData_matches() {
+        val odinId = resolveOdinId("https://frodo.digital/pub/image")
+        assertEquals("frodo.digital", odinId?.toString())
+    }
+
+    @Test
+    fun resolveOdinId_uriDataForProfileUrl_returnsNull() {
+        val uri = "https://frodo.digital/pub/profile".toUri()
+        assertNull(resolveOdinId(uri))
+    }
+
+    @Test
+    fun resolveOdinId_stringDataForProfileUrl_returnsNull() {
+        assertNull(resolveOdinId("https://frodo.digital/pub/profile"))
+    }
+
+    @Test
+    fun resolveOdinId_unsupportedDataType_returnsNull() {
+        // ByteArray, Int, Any — anything that isn't a Uri or String must be
+        // rejected without throwing, so the factory can cleanly fall through
+        // to other fetchers in Coil's registry.
+        assertNull(resolveOdinId(ByteArray(0)))
+        assertNull(resolveOdinId(42))
+        assertNull(resolveOdinId(Any()))
+    }
+
+    @Test
+    fun resolveOdinId_uriWithSubdomain_preservesOdinId() {
+        val uri = "https://sub.frodo.digital/pub/image".toUri()
+        assertEquals("sub.frodo.digital", resolveOdinId(uri)?.toString())
     }
 }

--- a/homebase-core/src/androidMain/kotlin/id/homebase/core/di/AppModule.android.kt
+++ b/homebase-core/src/androidMain/kotlin/id/homebase/core/di/AppModule.android.kt
@@ -2,6 +2,7 @@ package id.homebase.core.di
 
 import co.touchlab.kermit.Logger
 import coil3.ImageLoader
+import coil3.SingletonImageLoader
 import coil3.memory.MemoryCache
 import coil3.video.VideoFrameDecoder
 import id.homebase.api.file.AndroidFileOperationsProvider
@@ -53,7 +54,19 @@ actual fun platformModule(): Module = module {
                 .diskCache(null)
                 .build()
                 .also(::assertNoCoilDiskCache)
+                .also(::installAsCoilSingleton)
     }
+}
+
+// Rewire Coil's default SingletonImageLoader to our Koin-configured instance.
+// Without this, any SubcomposeAsyncImage / AsyncImage call that forgets the
+// `imageLoader=` argument falls back to Coil's auto-created singleton — a
+// separate loader with zero custom fetchers/keyers and a default 250 MB disk
+// cache (coil3_disk_cache). That path silently bypasses PublicImageFetcher
+// and stores avatar bytes unencrypted in a directory our Storage screen
+// cannot see.
+private fun installAsCoilSingleton(loader: ImageLoader) {
+    SingletonImageLoader.setSafe { loader }
 }
 
 private fun assertNoCoilDiskCache(loader: ImageLoader) {

--- a/homebase-core/src/androidMain/kotlin/id/homebase/core/ui/screens/feed/PlatformWebView.android.kt
+++ b/homebase-core/src/androidMain/kotlin/id/homebase/core/ui/screens/feed/PlatformWebView.android.kt
@@ -19,7 +19,6 @@ actual fun PlatformWebView(
         onCreated = { nativeWebView ->
             // Enable DOM storage (localStorage) — disabled by default on Android WebView
             nativeWebView.settings.domStorageEnabled = true
-            nativeWebView.settings.databaseEnabled = true
         },
         onDispose = {},
     )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsScreen.kt
@@ -160,6 +160,10 @@ fun StorageSettingsUi(
                 }
             }
 
+            if (uiState.orphanCoilDiskBytes > 0L) {
+                OrphanCoilCacheWarning(bytes = uiState.orphanCoilDiskBytes)
+            }
+
             Button(
                 onClick = { onAction(StorageSettingsUiAction.ClearCachesClicked) },
                 enabled = !uiState.isClearing &&
@@ -407,6 +411,32 @@ private fun EmptyRow(text: String) {
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+    }
+}
+
+@Composable
+private fun OrphanCoilCacheWarning(bytes: Long) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = androidx.compose.material3.CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+        ),
+    ) {
+        Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+            Text(
+                text = "Orphan Coil disk cache detected",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+            )
+            Spacer(modifier = Modifier.size(4.dp))
+            Text(
+                text = "${formatBytes(bytes)} in cache/coil3_disk_cache. Coil's default disk " +
+                        "cache should be off — this directory means something is bypassing " +
+                        "the Homebase cache layer. Tap \"Clear caches\" to delete it.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+            )
+        }
     }
 }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsUiState.kt
@@ -8,6 +8,14 @@ data class StorageSettingsUiState(
     val drives: List<DriveRowState> = emptyList(),
     val totalCacheBytes: Long = 0L,
     val databaseSizeBytes: Long = 0L,
+    // Size of any leftover `coil3_disk_cache` directory. Should always be 0 in
+    // a correctly-configured build (we disable Coil's default disk cache and
+    // rewire the SingletonImageLoader to our instance). Non-zero means
+    // something is bypassing our cache layer — either a stale install from
+    // before the SingletonImageLoader was wired (the user can press "Clear
+    // caches" to delete it) or a regression that reintroduced Coil's default
+    // disk cache somewhere. Rendered as a red warning row.
+    val orphanCoilDiskBytes: Long = 0L,
     val isLoading: Boolean = true,
     val isClearing: Boolean = false,
     val uiEvent: StorageSettingsUiEvent? = null,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsViewModel.kt
@@ -7,6 +7,7 @@ import coil3.ImageLoader
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.drives.cache.DriveFileProviderCached
 import id.homebase.api.client.profile.PublicProfileProviderCached
+import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.sync.DriveSyncManager
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.DatabaseSizeProbe
@@ -17,6 +18,10 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.SYSTEM
 import kotlin.uuid.Uuid
 
 class StorageSettingsViewModel(
@@ -27,7 +32,10 @@ class StorageSettingsViewModel(
     private val databaseManager: DatabaseManager,
     private val imageLoader: ImageLoader,
     private val databaseSizeProbe: DatabaseSizeProbe,
+    private val fileOperationsProvider: FileOperationsProvider,
 ) : ViewModel() {
+
+    private val fileSystem = FileSystem.SYSTEM
 
     private val _uiState = MutableStateFlow(StorageSettingsUiState())
     val uiState: StateFlow<StorageSettingsUiState> = _uiState.asStateFlow()
@@ -84,6 +92,10 @@ class StorageSettingsViewModel(
 
             val driveRows = loadDriveRows()
 
+            val orphanCoilBytes = withContext(Dispatchers.Default) {
+                probeOrphanCoilDiskCache()
+            }
+
             _uiState.update {
                 it.copy(
                     caches = caches,
@@ -91,10 +103,47 @@ class StorageSettingsViewModel(
                     drives = driveRows,
                     totalCacheBytes = total,
                     databaseSizeBytes = dbSize,
+                    orphanCoilDiskBytes = orphanCoilBytes,
                     isLoading = false,
                 )
             }
         }
+    }
+
+    /**
+     * Measure the size of Coil's default disk cache directory (`coil3_disk_cache`)
+     * if it exists. In a correctly-configured build this is always 0 — we set
+     * `.diskCache(null)` on our ImageLoader and wire the SingletonImageLoader
+     * to that instance, so nothing should write there. A non-zero value means
+     * either a leftover directory from an older build or a regression that
+     * reintroduced Coil's default disk cache somewhere. Logged loudly so the
+     * anomaly is visible in logs too.
+     */
+    private fun probeOrphanCoilDiskCache(): Long {
+        return runCatching {
+            val path = "${fileOperationsProvider.getCacheDirectory()}/coil3_disk_cache".toPath()
+            if (!fileSystem.exists(path)) return@runCatching 0L
+            val total = directorySizeBytes(path)
+            if (total > 0L) {
+                Logger.e(tag = "StorageSettings") {
+                    "orphan coil3_disk_cache detected: $total bytes at $path — " +
+                        "Coil's default disk cache should be off and the directory should be empty/deleted"
+                }
+            }
+            total
+        }.getOrElse {
+            Logger.w(tag = "StorageSettings", throwable = it) { "orphan coil disk probe failed" }
+            0L
+        }
+    }
+
+    private fun directorySizeBytes(dir: Path): Long {
+        var total = 0L
+        for (child in fileSystem.list(dir)) {
+            val meta = fileSystem.metadata(child)
+            total += if (meta.isDirectory) directorySizeBytes(child) else (meta.size ?: 0L)
+        }
+        return total
     }
 
     private suspend fun loadDriveRows(): List<DriveRowState> {
@@ -134,6 +183,10 @@ class StorageSettingsViewModel(
                 .onFailure { Logger.w(tag = "StorageSettings", throwable = it) { "drive clearCaches failed" } }
             runCatching { imageLoader.memoryCache?.clear() }
                 .onFailure { Logger.w(tag = "StorageSettings", throwable = it) { "coil memory clear failed" } }
+            runCatching {
+                val orphan = "${fileOperationsProvider.getCacheDirectory()}/coil3_disk_cache".toPath()
+                if (fileSystem.exists(orphan)) fileSystem.deleteRecursively(orphan)
+            }.onFailure { Logger.w(tag = "StorageSettings", throwable = it) { "orphan coil disk clear failed" } }
             _uiState.update { it.copy(isClearing = false, uiEvent = StorageSettingsUiEvent.CachesCleared) }
             load()
         }

--- a/homebase-core/src/jvmMain/kotlin/id/homebase/core/di/AppModule.desktop.kt
+++ b/homebase-core/src/jvmMain/kotlin/id/homebase/core/di/AppModule.desktop.kt
@@ -3,6 +3,7 @@ package id.homebase.core.di
 import co.touchlab.kermit.Logger
 import coil3.ImageLoader
 import coil3.PlatformContext
+import coil3.SingletonImageLoader
 import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.file.JvmFileOperationsProvider
 import id.homebase.api.sync.database.DatabaseSizeProbe
@@ -47,7 +48,17 @@ actual fun platformModule(): Module = module {
                 .diskCache(null)
                 .build()
                 .also(::assertNoCoilDiskCache)
+                .also(::installAsCoilSingleton)
     }
+}
+
+// See AppModule.android.kt for the full rationale. tl;dr: SubcomposeAsyncImage
+// without an explicit `imageLoader=` falls back to Coil's auto-created
+// singleton — a loader with zero of our custom fetchers and a default disk
+// cache. Rewiring the singleton to our Koin-configured instance closes that
+// leak globally.
+private fun installAsCoilSingleton(loader: ImageLoader) {
+    SingletonImageLoader.setSafe { loader }
 }
 
 private fun assertNoCoilDiskCache(loader: ImageLoader) {

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/di/AppModule.native.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/di/AppModule.native.kt
@@ -3,6 +3,7 @@ package id.homebase.core.di
 import co.touchlab.kermit.Logger
 import coil3.ImageLoader
 import coil3.PlatformContext
+import coil3.SingletonImageLoader
 import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.file.IOSFileOperationsProvider
 import id.homebase.api.sync.database.DatabaseSizeProbe
@@ -48,7 +49,17 @@ actual fun platformModule(): Module = module {
                 .diskCache(null)
                 .build()
                 .also(::assertNoCoilDiskCache)
+                .also(::installAsCoilSingleton)
     }
+}
+
+// See AppModule.android.kt for the full rationale. tl;dr: SubcomposeAsyncImage
+// without an explicit `imageLoader=` falls back to Coil's auto-created
+// singleton — a loader with zero of our custom fetchers and a default disk
+// cache. Rewiring the singleton to our Koin-configured instance closes that
+// leak globally.
+private fun installAsCoilSingleton(loader: ImageLoader) {
+    SingletonImageLoader.setSafe { loader }
 }
 
 private fun assertNoCoilDiskCache(loader: ImageLoader) {


### PR DESCRIPTION
Two problems, one branch

  1. FileKache constructor NPE poisoning (original fix)

  On one real Android device every thumb load and the Storage screen's drive cache rows failed with the same NullPointerException thrown from inside
  mayakapps/kache's FileKache(...) constructor:

  NullPointerException: getClass() on a null object reference
    at ... (kache internals: journal reader init)
    at DriveFileProviderCached.thumbDiskKache
    at DriveFileProviderCached.getCacheStats / readCachedThumbOrLog

  Because the constructor threw, the .also { _thumbDiskKache = it } never ran. _thumbDiskKache stayed null, every subsequent call re-entered the same
  construction path and threw again, and the cache stayed poisoned for the rest of the process. The Storage screen silently dropped the drive rows
  (runCatching caught the NPE and substituted emptyList).

  Fix applied symmetrically to DriveFileProviderCached (payload + thumb) and PublicProfileProviderCached (profile + image):

  - Pre-create the managed directory with fileSystem.createDirectories before invoking FileKache(...), so the library's init path doesn't land on a missing
  tree.
  - Catch Throwable from the constructor, log Logger.e once, and record the failure in a new @Volatile Throwable? tombstone field so subsequent accessor
  calls rethrow immediately instead of retrying.
  - Reset the tombstones inside clearCaches() under the same kacheMutex that nulls the kache refs, so a logout/login cycle gets a fresh attempt.

  Public had the same latent shape (same constructor pattern on a possibly-missing directory) — fixed preemptively.

  2. Coil avatar cache silently bypassed, leaking unencrypted to orphan directory

  During verification of the FileKache fix the user observed that homebase-public-images/files/ on the emulator read as 0 bytes on disk — yet avatars loaded
   instantly with no network spinners after pressing "Clear caches". Investigation uncovered a second, independent bug: we had two ImageLoader instances on
  device.

  - Koin-configured ImageLoader (AppModule.{android,desktop,native}.kt) — registers PublicImageFetcher/HomebaseImageFetcher, .diskCache(null) disables
  Coil's default disk cache, relies on PublicProfileProviderCached for encrypted disk caching.
  - Coil's auto-created SingletonImageLoader — zero custom fetchers/keyers, default 250 MB disk cache at cache/coil3_disk_cache. Never configured by us.

  Any SubcomposeAsyncImage / AsyncImage call that omits imageLoader= falls back to the singleton. PublicAvatar.kt was such a caller — every /pub/image
  request routed through Coil's built-in NetworkFetcher, bypassing PublicImageFetcher entirely and caching raw bytes unencrypted to coil3_disk_cache (845 KB
   of avatar data in a directory the Storage screen couldn't see). Meanwhile our public_images FileKache was genuinely empty.

  A second subtlety: the PublicImageFetcher.Factory declared itself Fetcher.Factory<String>. Coil 3 maps a String model to coil3.Uri before Fetcher-factory
  matching runs, so Factory<String> was never polled for http URLs — Coil only sees Uris at that stage, fell through to the built-in NetworkFetcher, and our
   cache layer was bypassed even for any caller that did pass imageLoader= explicitly.

  Three-layer defense:

  1. Per-composable — PublicAvatar now injects the Koin ImageLoader via koinInject() and passes it explicitly to SubcomposeAsyncImage. Mirrors
  HomebaseImage.kt.
  2. Global — SingletonImageLoader.setSafe { loader } in all three AppModule.* platform files rewires Coil's auto-created singleton to our configured
  instance, so any future caller that forgets imageLoader= still lands on the right loader.
  3. Observability + cleanup — StorageSettingsViewModel probes cache/coil3_disk_cache size on every Storage-screen load; if non-zero, logs Logger.e and
  renders a red warning card. "Clear caches" deletes the orphan directory.

  Factory<String> → Factory<Uri> with an Any-typed resolveOdinId companion helper (so tests can pass String without standing up a real Coil pipeline). 6
  regression tests in PublicImageFetcherFactoryTest lock the type choice against future "simplification".

  3. Consistency + observability alignment between cache providers

  Consistency audit between PublicProfileProviderCached and DriveFileProviderCached revealed drift:

  - Payload cache-write errors now swallow + Logger.e (were propagating, failing the caller even after a successful network fetch). Matches thumb and
  public.
  - Payload network-fetch failures now Logger.w before rethrow. Matches thumb.
  - VideoIO log tag → PayloadIO — the payload cache stores any attachment bytes (images, audio, PDFs, videos), not just video; the old tag was misleading.
  - DriveFileProviderCached class KDoc documents why there is no TTL / Cache-Control handling: the cacheKey is version-addressed via lastModified, so new
  versions land under new keys and old ones age out via LRU. (Public needs TTL because /pub/profile content is version-free.)
  - hbvid_preload cleanup now logs Logger.w on failure instead of silent catch (_: Exception) {}.
  - public_profiles FileKache cap reduced 50 MB → 10 MB after confirming it's a sparse fallback path (profile JSON comes from the local contact drive;
  /pub/profile is hit only for push senders, forward-sheet targets, and unmet-peer ContactName renders — never during routine conversation scrolling).
  - TODO comments added on both classes' unbounded keyLocks map (grows per unique cacheKey ever touched, never drops; follow-up ticket to replace with a
  weak-valued map or last-use prune).

  4. Logging audit

  Removed 16 Logger.d entries across both cache providers that were firing on every hot path (cache-hit, notFound-cache-hit, cache-write, network-fetch,
  decrypt). On a scrolling-conversation-list session these produced dozens of lines per second — the signal-to-noise ratio in homebase.log was unusable.
  Kept every Logger.w/Logger.e — they're already gated on rare, actionable conditions. Unwrapped three measureTimedValue blocks whose timings were only
  consumed by the dropped logs.

  5. Compile-warning cleanup

  - ClipboardImageReceiverModifier.android.kt — Kermit deprecation: switched to named tag = … / throwable = … overload.
  - PlatformWebView.android.kt — dropped deprecated WebSettings.databaseEnabled = true. It controlled WebSQL, which has been removed from Android WebView;
  the flag is a no-op on modern versions.

  Verification

  - ./gradlew :homebase-common:jvmTest — 12 tests pass (6 new regression tests for resolveOdinId).
  - ./gradlew :homebase-api:compileKotlinJvm — clean.
  - ./gradlew :homebase-chat:compileKotlinJvm — clean.
  - Emulator run confirmed: homebase-public-images/files populates with real avatar bytes on conversation scroll; coil3_disk_cache is absent (deleted by
  Clear Caches); the red warning card fires when the orphan directory is artificially reintroduced; Storage-screen cache rows include both drive providers
  after a logout/login cycle.
