### PR TITLE
Re-apply group-chat-fixes

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/connections/ConnectionIntroductionProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/connections/ConnectionIntroductionProvider.kt
@@ -12,7 +12,7 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 class ConnectionIntroductionProvider(
     httpClient: HttpClient,
     credentialsManager: CredentialsManager
-) : OdinApiProviderBase(httpClient, credentialsManager) {
+) : OdinApiProviderBase(httpClient, credentialsManager), IntroductionSender {
 
     companion object {
         private const val TAG = "ConnectionIntroductionProvider"
@@ -42,7 +42,7 @@ class ConnectionIntroductionProvider(
     // POST /introductions
     // ------------------------------------------------------------
 
-    suspend fun sendIntroductions(
+    override suspend fun sendIntroductions(
         group: IntroductionGroup
     ): IntroductionResult {
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/connections/IntroductionSender.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/connections/IntroductionSender.kt
@@ -1,0 +1,5 @@
+package id.homebase.api.client.connections
+
+interface IntroductionSender {
+    suspend fun sendIntroductions(group: IntroductionGroup): IntroductionResult
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
@@ -5,6 +5,7 @@ import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.api.client.identity.PublicIdentityRepository
 import id.homebase.api.client.connections.ConnectionIntroductionProvider
+import id.homebase.api.client.connections.IntroductionSender
 import id.homebase.api.client.connections.ConnectionNetworkProvider
 import id.homebase.api.client.connections.ConnectionRequestProvider
 import id.homebase.api.client.drives.cache.DriveFileProviderCached
@@ -36,6 +37,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val apiModule = module {
@@ -70,7 +72,7 @@ val apiModule = module {
 
     factoryOf(::ConnectionNetworkProvider)
     factoryOf(::ConnectionRequestProvider)
-    factoryOf(::ConnectionIntroductionProvider)
+    factoryOf(::ConnectionIntroductionProvider) bind IntroductionSender::class
     singleOf(::PublicProfileProviderCached)
     factoryOf(::PublicProfileProvider)
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
@@ -47,7 +47,7 @@ class ChatMessageSenderService(
     private val fileOperationsProvider: FileOperationsProvider,
     private val driveFileProvider: DriveFileProvider,
     private val shareSuggestionDonor: ShareSuggestionDonor = ShareSuggestionDonor(),
-) {
+) : id.homebase.chat.services.convo.StatusMessageSender {
     companion object {
         private const val TAG = "ChatMessageSenderService"
     }
@@ -120,13 +120,13 @@ class ChatMessageSenderService(
     }
 
 
-    suspend fun sendStatusMessage(
+    override suspend fun sendStatusMessage(
         messageUniqueId: Uuid,
         conversationId: Uuid,
         statusMessage: StatusMessageData,
-        previousMessageUniqueId: Uuid? = null,
-        payloadBundle: PayloadBundle? = null,
-        additionalRecipients: List<OdinId> = emptyList()
+        previousMessageUniqueId: Uuid?,
+        payloadBundle: PayloadBundle?,
+        additionalRecipients: List<OdinId>
     ): SendMessageResult = sendMessageInternal(
         messageUniqueId = messageUniqueId,
         conversationId = conversationId,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/PayloadBundleEncryptionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/PayloadBundleEncryptionService.kt
@@ -18,9 +18,9 @@ class PayloadBundleEncryptionService(
     private val fileOps: FileOperationsProvider,
     private val videoProcessor: VideoPayloadProcessor,
     private val eventBus: EventBus
-) {
+) : PayloadBundleEncryptor {
 
-    suspend fun encryptBundle(
+    override suspend fun encryptBundle(
         uniqueId: Uuid,
         bundle: PayloadBundle?,
         aesKey: SecureByteArray,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/PayloadBundleEncryptor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/PayloadBundleEncryptor.kt
@@ -1,0 +1,14 @@
+package id.homebase.chat.services
+
+import id.homebase.api.common.SecureByteArray
+import kotlinx.coroutines.CoroutineScope
+import kotlin.uuid.Uuid
+
+interface PayloadBundleEncryptor {
+    suspend fun encryptBundle(
+        uniqueId: Uuid,
+        bundle: PayloadBundle?,
+        aesKey: SecureByteArray,
+        scope: CoroutineScope
+    ): PayloadBundle
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -3,8 +3,8 @@ package id.homebase.chat.services.convo
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.auth.CredentialsManager
-import id.homebase.api.client.connections.ConnectionIntroductionProvider
 import id.homebase.api.client.connections.IntroductionGroup
+import id.homebase.api.client.connections.IntroductionSender
 import id.homebase.api.client.drives.FileSystemType
 import id.homebase.api.client.drives.HomebaseFile
 import id.homebase.api.client.drives.files.ArchivalStatus
@@ -30,10 +30,9 @@ import id.homebase.api.sync.database.OutboxSync
 import id.homebase.api.toBase64
 import id.homebase.chat.data.ConversationState
 import id.homebase.chat.data.ConversationUiModel
-import id.homebase.chat.services.ChatMessageSenderService
 import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.PayloadBundle
-import id.homebase.chat.services.PayloadBundleEncryptionService
+import id.homebase.chat.services.PayloadBundleEncryptor
 import id.homebase.chat.services.StatusMessage
 import id.homebase.chat.services.StatusMessageData
 import id.homebase.chat.services.XorIdUtil
@@ -44,14 +43,14 @@ import kotlin.uuid.Uuid
 
 class ConversationService(
     private val credentialsManager: CredentialsManager,
-    private val payloadBundleEncryptionService: PayloadBundleEncryptionService,
+    private val payloadBundleEncryptionService: PayloadBundleEncryptor,
     private val dbm: DatabaseManager,
-    private val introductionProvider: ConnectionIntroductionProvider,
+    private val introductionProvider: IntroductionSender,
     private val scope: CoroutineScope,
     private val outboxSync: OutboxSync,
-    private val chatMessageSenderService: ChatMessageSenderService,
+    private val chatMessageSenderService: StatusMessageSender,
     private val optimisticWriter: OptimisticWriter,
-    private val conversationStream: ConversationStream,
+    private val conversationStream: ConversationLoader,
 ) {
     private val chatDrive = chatTargetDrive.alias
 
@@ -459,7 +458,7 @@ class ConversationService(
                 previousMessageId = messageId
             }
 
-            trySendIntroductions(added, "$domain has added you to a group chat")
+            trySendIntroductions((current - domain).toList(), "You share a group chat with $domain")
         }
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationServiceCollaborators.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationServiceCollaborators.kt
@@ -1,0 +1,22 @@
+package id.homebase.chat.services.convo
+
+import id.homebase.api.common.OdinId
+import id.homebase.chat.services.PayloadBundle
+import id.homebase.chat.services.SendMessageResult
+import id.homebase.chat.services.StatusMessageData
+import kotlin.uuid.Uuid
+
+interface StatusMessageSender {
+    suspend fun sendStatusMessage(
+        messageUniqueId: Uuid,
+        conversationId: Uuid,
+        statusMessage: StatusMessageData,
+        previousMessageUniqueId: Uuid? = null,
+        payloadBundle: PayloadBundle? = null,
+        additionalRecipients: List<OdinId> = emptyList()
+    ): SendMessageResult
+}
+
+interface ConversationLoader {
+    suspend fun loadConversation(conversationId: Uuid)
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -48,7 +48,7 @@ class ConversationStream(
     private val cacheStorage: ShareCacheStorage,
     private val optimisticWriter: OptimisticWriter,
     private val outboxSync: OutboxSync,
-) {
+) : ConversationLoader {
 
     private val chatDrive = chatTargetDrive.alias
     private val _conversations = MutableStateFlow(ConversationsData(dataReady = false))
@@ -326,7 +326,7 @@ class ConversationStream(
         }
     }
 
-    suspend fun loadConversation(conversationId: Uuid) {
+    override suspend fun loadConversation(conversationId: Uuid) {
         val c = credentialsManager.requireActiveCredentials()
 
         val conversationFile = dbm.driveMainIndex.selectHomebaseFileByUnique(

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceCreateTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceCreateTest.kt
@@ -1,0 +1,245 @@
+package id.homebase.chat.services.convo
+
+import id.homebase.api.client.drives.files.ArchivalStatus
+import id.homebase.api.common.OdinId
+import id.homebase.chat.services.ChatProtocol
+import id.homebase.chat.services.StatusMessage
+import id.homebase.chat.services.XorIdUtil
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Tests for [ConversationService.createConversation] — 1:1 vs group branching,
+ * existing-file revival, participant validation, and the admin-file / introductions
+ * side-effects that belong to the group path.
+ */
+class ConversationServiceCreateTest {
+
+    @Test
+    fun createConversation_oneOnOne_usesDeterministicXorId_noAdminFile_noIntroductions() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+
+            val result = service.createConversation(
+                recipients = listOf(OdinId(alice)),
+                title = null,
+                payloadBundle = null,
+            )
+
+            val expectedId = XorIdUtil.getNewXorId(fixture.testDomain, alice)
+            assertEquals(expectedId, result.conversationId)
+            assertTrue(result.wasNewlyCreated)
+            assertTrue(
+                fixture.introductionSender.calls.isEmpty(),
+                "1:1 does not cross-introduce anyone"
+            )
+            assertFalse(
+                fixture.statusMessageSender.calls.any {
+                    it.statusMessage.statusMessage == StatusMessage.GroupConversationStarted
+                },
+                "GroupConversationStarted is only emitted for groups"
+            )
+        }
+    }
+
+    @Test
+    fun createConversation_group_createsAdminFile_sendsIntroductions_emitsGroupStartedStatus() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            val bob = "bob.test"
+
+            val result = service.createConversation(
+                recipients = listOf(OdinId(alice), OdinId(bob)),
+                title = "the fellowship",
+                payloadBundle = null,
+            )
+            assertTrue(result.wasNewlyCreated)
+
+            // Introductions to recipients (self excluded).
+            val intro = fixture.introductionSender.calls.single()
+            assertEquals(setOf(OdinId(alice), OdinId(bob)), intro.recipients.toSet())
+
+            // GroupConversationStarted status fired.
+            val started = fixture.statusMessageSender.calls.single {
+                it.statusMessage.statusMessage == StatusMessage.GroupConversationStarted
+            }
+            assertEquals(result.conversationId, started.conversationId)
+
+            // Admin file seeded in DB. uploadAdminFile goes through the outbox;
+            // we verify via direct DB lookup for the admin file's uniqueId.
+            val adminFile = fixture.getConversationFile(
+                ChatProtocol.getAdminFileUniqueId(result.conversationId)
+            )
+            // The admin file is only inserted locally via the optimisticWriter path —
+            // it is NOT guaranteed to be queryable here without a corresponding write.
+            // Instead, assert that an outbox row was enqueued for it.
+            assertTrue(
+                fixture.outboxRowCount() >= 2,
+                "expect at least 2 outbox rows: the conversation file upload + the admin file upload"
+            )
+        }
+    }
+
+    @Test
+    fun createConversation_existingHealthyFile_returnsWasNewlyCreatedFalse_andDoesNotRevive() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            val xorId = XorIdUtil.getNewXorId(fixture.testDomain, alice)
+            // Pre-seed a healthy 1:1 at the deterministic id.
+            fixture.seedOneOnOne(other = alice, conversationId = xorId)
+            val rowsBefore = fixture.outboxRowCount()
+
+            val result = service.createConversation(
+                recipients = listOf(OdinId(alice)),
+                title = null,
+                payloadBundle = null,
+            )
+
+            assertEquals(xorId, result.conversationId)
+            assertFalse(result.wasNewlyCreated)
+            assertEquals(
+                rowsBefore,
+                fixture.outboxRowCount(),
+                "healthy existing file should not revive ⇒ no new outbox rows"
+            )
+        }
+    }
+
+    @Test
+    fun createConversation_existingDeletedFile_revivesViaUpdate() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            val xorId = XorIdUtil.getNewXorId(fixture.testDomain, alice)
+            // Seed with archivalStatus=Removed ⇒ mapper reports Deleted ⇒ revive path.
+            fixture.seedOneOnOne(
+                other = alice,
+                conversationId = xorId,
+                archivalStatus = ArchivalStatus.Removed.value,
+            )
+            val rowsBefore = fixture.outboxRowCount()
+
+            val result = service.createConversation(
+                recipients = listOf(OdinId(alice)),
+                title = null,
+                payloadBundle = null,
+            )
+
+            assertEquals(xorId, result.conversationId)
+            assertFalse(result.wasNewlyCreated)
+            assertTrue(
+                fixture.outboxRowCount() > rowsBefore,
+                "revive should enqueue an UpdateFileByUniqueId request"
+            )
+        }
+    }
+
+    @Test
+    fun createConversation_emptyRecipients_throws() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+
+            val ex = assertFailsWith<IllegalArgumentException> {
+                service.createConversation(
+                    recipients = emptyList(),
+                    title = null,
+                    payloadBundle = null,
+                )
+            }
+            assertTrue(ex.message!!.contains("at least one recipient"))
+        }
+    }
+
+    @Test
+    fun createConversation_onlySelfInRecipients_throws() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+
+            val ex = assertFailsWith<IllegalArgumentException> {
+                service.createConversation(
+                    recipients = listOf(OdinId(fixture.testDomain)),
+                    title = null,
+                    payloadBundle = null,
+                )
+            }
+            assertTrue(ex.message!!.contains("at least one recipient"))
+        }
+    }
+
+    @Test
+    fun createConversation_duplicateRecipients_deduplicate_producesOneOnOne() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+
+            val result = service.createConversation(
+                recipients = listOf(OdinId(alice), OdinId(alice)),
+                title = null,
+                payloadBundle = null,
+            )
+
+            // Same id as a single-recipient 1:1
+            assertEquals(
+                XorIdUtil.getNewXorId(fixture.testDomain, alice),
+                result.conversationId,
+            )
+            assertTrue(
+                fixture.introductionSender.calls.isEmpty(),
+                "deduped 1:1 should not trigger introductions"
+            )
+        }
+    }
+
+    @Test
+    fun createConversation_recipientsListContainingSelf_stillCreatesOneOnOneWithOther() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+
+            val result = service.createConversation(
+                recipients = listOf(OdinId(fixture.testDomain), OdinId(alice)),
+                title = null,
+                payloadBundle = null,
+            )
+
+            assertEquals(
+                XorIdUtil.getNewXorId(fixture.testDomain, alice),
+                result.conversationId,
+                "self is filtered out, leaving a single normalized recipient ⇒ 1:1 id",
+            )
+        }
+    }
+
+    @Test
+    fun createConversation_group_conversationIdIsRandom_notXor() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            val bob = "bob.test"
+
+            val result = service.createConversation(
+                recipients = listOf(OdinId(alice), OdinId(bob)),
+                title = null,
+                payloadBundle = null,
+            )
+
+            // Groups don't use XOR ids — they get a fresh random one.
+            assertNotEquals(
+                XorIdUtil.getNewXorId(fixture.testDomain, alice),
+                result.conversationId
+            )
+            assertNotEquals(
+                XorIdUtil.getNewXorId(fixture.testDomain, bob),
+                result.conversationId
+            )
+        }
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceLeaveTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceLeaveTest.kt
@@ -1,0 +1,226 @@
+package id.homebase.chat.services.convo
+
+import id.homebase.api.common.OdinId
+import id.homebase.chat.services.ChatProtocol
+import id.homebase.chat.services.StatusMessage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Tests for the leave / rejoin flows on [ConversationService]:
+ *   - [ConversationService.leaveGroup]
+ *   - [ConversationService.acceptRejoin]
+ *   - [ConversationService.declineRejoin]
+ */
+class ConversationServiceLeaveTest {
+
+    // ---------- leaveGroup ----------
+
+    @Test
+    fun leaveGroup_happyPath_emitsMemberLeftStatus() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            val bob = "bob.test"
+            // testDomain is not the sole admin: alice is too.
+            val groupId = fixture.seedGroup(
+                others = listOf(alice, bob),
+                adminDomains = listOf(fixture.testDomain, alice),
+            )
+
+            service.leaveGroup(groupId)
+
+            val leaveStatus = fixture.statusMessageSender.calls.single {
+                it.statusMessage.statusMessage == StatusMessage.ConversationMemberLeft
+            }
+            assertEquals(OdinId(fixture.testDomain), leaveStatus.statusMessage.subject)
+            assertEquals(groupId, leaveStatus.conversationId)
+        }
+    }
+
+    @Test
+    fun leaveGroup_soleAdmin_throws() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val groupId = fixture.seedGroup(
+                others = listOf("alice.test"),
+                adminDomains = listOf(fixture.testDomain),
+            )
+
+            val ex = assertFailsWith<IllegalStateException> {
+                service.leaveGroup(groupId)
+            }
+            assertTrue(
+                ex.message!!.contains("only admin"),
+                "message should guide to assign another admin first"
+            )
+        }
+    }
+
+    @Test
+    fun leaveGroup_onOneOnOne_throws() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = fixture.seedOneOnOne(other = "alice.test")
+
+            val ex = assertFailsWith<IllegalStateException> {
+                service.leaveGroup(convoId)
+            }
+            assertTrue(ex.message!!.contains("group"))
+        }
+    }
+
+    @Test
+    fun leaveGroup_legacyGroup_shortCircuits_toTagOnly() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val groupId = fixture.seedLegacyGroup(
+                others = listOf("alice.test", "bob.test"),
+            )
+
+            service.leaveGroup(groupId)
+
+            // Legacy path: no status message, no admin-file update — just a local tag flip.
+            assertTrue(
+                fixture.statusMessageSender.calls.none {
+                    it.statusMessage.statusMessage == StatusMessage.ConversationMemberLeft
+                },
+                "legacy path should skip the leave status message"
+            )
+        }
+    }
+
+    @Test
+    fun leaveGroup_forceLocalOnly_shortCircuits_evenIfSoleAdmin() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            // testDomain is the ONLY admin — normally leaveGroup would throw, but
+            // forceLocalOnly bypasses the sole-admin guard.
+            val groupId = fixture.seedGroup(
+                others = listOf("alice.test"),
+                adminDomains = listOf(fixture.testDomain),
+            )
+
+            service.leaveGroup(groupId, forceLocalOnly = true)
+
+            // No distributed leave message — local tag flip only.
+            assertTrue(
+                fixture.statusMessageSender.calls.none {
+                    it.statusMessage.statusMessage == StatusMessage.ConversationMemberLeft
+                }
+            )
+        }
+    }
+
+    // ---------- acceptRejoin ----------
+
+    @Test
+    fun acceptRejoin_clearsLeftTag_onRejoinPending() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            // A group where self is a participant AND has the Left tag ⇒ RejoinPending.
+            val groupId = fixture.seedGroup(
+                others = listOf("alice.test", "bob.test"),
+                adminDomains = listOf("alice.test"),
+                localTags = listOf(ChatProtocol.ConversationLeftTag),
+            )
+
+            service.acceptRejoin(groupId)
+
+            // Nothing else emitted; the tag transform is a local-only op via optimistic writer.
+            assertTrue(
+                fixture.statusMessageSender.calls.isEmpty(),
+                "acceptRejoin is silent — no status messages",
+            )
+        }
+    }
+
+    @Test
+    fun acceptRejoin_whenNotRejoinPending_throws() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val groupId = fixture.seedGroup(
+                others = listOf("alice.test", "bob.test"),
+                adminDomains = listOf("alice.test"),
+                // no Left tag ⇒ Active, not RejoinPending
+            )
+
+            val ex = assertFailsWith<IllegalStateException> {
+                service.acceptRejoin(groupId)
+            }
+            assertTrue(ex.message!!.contains("RejoinPending"))
+        }
+    }
+
+    // ---------- declineRejoin ----------
+
+    @Test
+    fun declineRejoin_emitsDeclinedRejoinStatus_onRejoinPending() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val groupId = fixture.seedGroup(
+                others = listOf("alice.test", "bob.test"),
+                adminDomains = listOf("alice.test"),
+                localTags = listOf(ChatProtocol.ConversationLeftTag),
+            )
+
+            service.declineRejoin(groupId)
+
+            val declined = fixture.statusMessageSender.calls.single {
+                it.statusMessage.statusMessage == StatusMessage.ConversationMemberDeclinedRejoin
+            }
+            assertEquals(OdinId(fixture.testDomain), declined.statusMessage.subject)
+            assertEquals(groupId, declined.conversationId)
+        }
+    }
+
+    @Test
+    fun declineRejoin_whenNotRejoinPending_throws() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val groupId = fixture.seedGroup(
+                others = listOf("alice.test", "bob.test"),
+                adminDomains = listOf("alice.test"),
+            )
+
+            val ex = assertFailsWith<IllegalStateException> {
+                service.declineRejoin(groupId)
+            }
+            assertTrue(ex.message!!.contains("RejoinPending"))
+        }
+    }
+
+    @Test
+    fun declineRejoin_writesParticipantUpdate_andKeepsLeftTagLocally() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val groupId = fixture.seedGroup(
+                others = listOf("alice.test", "bob.test"),
+                adminDomains = listOf("alice.test"),
+                localTags = listOf(ChatProtocol.ConversationLeftTag),
+            )
+            val rowsBefore = fixture.outboxRowCount()
+
+            service.declineRejoin(groupId)
+
+            assertTrue(
+                fixture.outboxRowCount() > rowsBefore,
+                "declineRejoin should enqueue conversation update + tag update"
+            )
+            // It should NOT clear the Left tag (unlike acceptRejoin).
+            // We can't directly inspect the post-update optimistic tags without
+            // more fixture work, but we can confirm at least a status + update
+            // + tag enqueue sequence fired.
+            assertFalse(
+                fixture.statusMessageSender.calls.none {
+                    it.statusMessage.statusMessage == StatusMessage.ConversationMemberDeclinedRejoin
+                },
+                "decline-rejoin status message must fire"
+            )
+        }
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceLifecycleTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceLifecycleTest.kt
@@ -1,0 +1,405 @@
+package id.homebase.chat.services.convo
+
+import id.homebase.api.client.drives.files.ArchivalStatus
+import id.homebase.api.common.OdinId
+import id.homebase.chat.services.ChatProtocol
+import id.homebase.chat.services.PayloadBundle
+import id.homebase.chat.services.StatusMessage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Tests for the remaining lifecycle methods on [ConversationService]:
+ *   - updateConversation (title, photo)
+ *   - deleteConversation / clearConversation
+ *   - ensureNoteToSelfExists
+ *   - introduceEveryone
+ *   - archive / unarchive / pin / unpin (tag manipulation)
+ */
+class ConversationServiceLifecycleTest {
+
+    private val emptyPayloadBundle = PayloadBundle(
+        payloads = emptyList(),
+        thumbnails = emptyList(),
+        previewThumbs = emptyList(),
+    )
+
+    // ---------- updateConversation ----------
+
+    @Test
+    fun updateConversation_titleChange_emitsTitleUpdatedStatus() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val groupId = fixture.seedGroup(
+                others = listOf("alice.test"),
+                adminDomains = listOf(fixture.testDomain),
+                title = "old-title",
+            )
+
+            service.updateConversation(
+                conversationId = groupId,
+                title = "new-title",
+            )
+
+            assertTrue(
+                fixture.statusMessageSender.calls.any {
+                    it.statusMessage.statusMessage == StatusMessage.ConversationTitleUpdated
+                },
+                "title change should emit ConversationTitleUpdated",
+            )
+            assertFalse(
+                fixture.statusMessageSender.calls.any {
+                    it.statusMessage.statusMessage == StatusMessage.ConversationPhotoUpdated
+                },
+                "no payload ⇒ no photo-updated message",
+            )
+        }
+    }
+
+    @Test
+    fun updateConversation_photoChange_emitsPhotoUpdatedStatus() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val groupId = fixture.seedGroup(
+                others = listOf("alice.test"),
+                adminDomains = listOf(fixture.testDomain),
+                title = "keep-same",
+            )
+
+            service.updateConversation(
+                conversationId = groupId,
+                title = "keep-same", // unchanged ⇒ no title status
+                payloadBundle = emptyPayloadBundle,
+            )
+
+            assertTrue(
+                fixture.statusMessageSender.calls.any {
+                    it.statusMessage.statusMessage == StatusMessage.ConversationPhotoUpdated
+                }
+            )
+            assertFalse(
+                fixture.statusMessageSender.calls.any {
+                    it.statusMessage.statusMessage == StatusMessage.ConversationTitleUpdated
+                },
+                "title unchanged ⇒ no title-updated message",
+            )
+        }
+    }
+
+    @Test
+    fun updateConversation_titleAndPhoto_emitsBothStatusMessages() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val groupId = fixture.seedGroup(
+                others = listOf("alice.test"),
+                adminDomains = listOf(fixture.testDomain),
+                title = "old-title",
+            )
+
+            service.updateConversation(
+                conversationId = groupId,
+                title = "new-title",
+                payloadBundle = emptyPayloadBundle,
+            )
+
+            val kinds = fixture.statusMessageSender.calls.map { it.statusMessage.statusMessage }.toSet()
+            assertTrue(StatusMessage.ConversationTitleUpdated in kinds)
+            assertTrue(StatusMessage.ConversationPhotoUpdated in kinds)
+        }
+    }
+
+    @Test
+    fun updateConversation_noop_titleSameNoPayload_emitsNoStatusMessages() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val groupId = fixture.seedGroup(
+                others = listOf("alice.test"),
+                adminDomains = listOf(fixture.testDomain),
+                title = "unchanged",
+            )
+
+            service.updateConversation(
+                conversationId = groupId,
+                title = "unchanged",
+                payloadBundle = null,
+            )
+
+            assertTrue(
+                fixture.statusMessageSender.calls.isEmpty(),
+                "no observable change ⇒ no status messages",
+            )
+        }
+    }
+
+    @Test
+    fun updateConversation_onGroup_nonAdminCaller_throws() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val groupId = fixture.seedGroup(
+                others = listOf("alice.test"),
+                adminDomains = listOf("alice.test"),
+            )
+
+            val ex = assertFailsWith<IllegalStateException> {
+                service.updateConversation(
+                    conversationId = groupId,
+                    title = "whatever",
+                )
+            }
+            assertTrue(ex.message!!.contains("admin"))
+        }
+    }
+
+    // ---------- deleteConversation ----------
+
+    @Test
+    fun deleteConversation_group_inActiveState_throws() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val groupId = fixture.seedGroup(
+                others = listOf("alice.test"),
+                adminDomains = listOf(fixture.testDomain),
+                // active, not left/archived
+            )
+
+            val ex = assertFailsWith<IllegalStateException> {
+                service.deleteConversation(groupId)
+            }
+            assertTrue(ex.message!!.contains("leave the group"))
+        }
+    }
+
+    @Test
+    fun deleteConversation_group_inLeftState_succeeds_enqueuesDeleteAndMarksRemoved() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val groupId = fixture.seedGroup(
+                others = listOf("alice.test"),
+                adminDomains = listOf(fixture.testDomain),
+                localTags = listOf(ChatProtocol.ConversationLeftTag),
+            )
+            val rowsBefore = fixture.outboxRowCount()
+
+            service.deleteConversation(groupId)
+
+            // At least two enqueued ops: DeleteFilesByGroupId + UpdateFileByUniqueId (Removed).
+            assertTrue(
+                fixture.outboxRowCount() - rowsBefore >= 2,
+                "delete should enqueue DeleteFilesByGroupId AND a conversation update"
+            )
+        }
+    }
+
+    @Test
+    fun deleteConversation_group_inArchivedState_succeeds() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val groupId = fixture.seedGroup(
+                others = listOf("alice.test"),
+                adminDomains = listOf(fixture.testDomain),
+                localTags = listOf(ChatProtocol.ConversationArchivedTag),
+            )
+
+            // Should not throw.
+            service.deleteConversation(groupId)
+        }
+    }
+
+    @Test
+    fun deleteConversation_oneOnOne_inActiveState_succeeds() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = fixture.seedOneOnOne(other = "alice.test")
+
+            // 1:1 has no group-state guard — should not throw.
+            service.deleteConversation(convoId)
+        }
+    }
+
+    // ---------- clearConversation ----------
+
+    @Test
+    fun clearConversation_enqueuesDeleteOnly_doesNotMarkRemoved() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = fixture.seedOneOnOne(other = "alice.test")
+            val rowsBefore = fixture.outboxRowCount()
+
+            service.clearConversation(convoId)
+
+            // Exactly one outbox row — no secondary "mark removed" update.
+            assertEquals(
+                1L,
+                fixture.outboxRowCount() - rowsBefore,
+                "clearConversation enqueues just a DeleteFilesByGroupId request",
+            )
+        }
+    }
+
+    // ---------- ensureNoteToSelfExists ----------
+
+    @Test
+    fun ensureNoteToSelfExists_noExistingFile_createsFresh() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val rowsBefore = fixture.outboxRowCount()
+
+            service.ensureNoteToSelfExists()
+
+            assertTrue(
+                fixture.outboxRowCount() > rowsBefore,
+                "first-time note-to-self creation should enqueue an upload",
+            )
+        }
+    }
+
+    @Test
+    fun ensureNoteToSelfExists_existingActive_isNoop() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            // Seed a healthy note-to-self file.
+            fixture.seedOneOnOne(
+                other = fixture.testDomain, // same as self — note-to-self
+                conversationId = ChatProtocol.ConversationWithYourselfId,
+            )
+            val rowsBefore = fixture.outboxRowCount()
+
+            service.ensureNoteToSelfExists()
+
+            assertEquals(
+                rowsBefore,
+                fixture.outboxRowCount(),
+                "existing active note-to-self ⇒ no new enqueues",
+            )
+        }
+    }
+
+    @Test
+    fun ensureNoteToSelfExists_existingDeleted_revives() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            fixture.seedOneOnOne(
+                other = fixture.testDomain,
+                conversationId = ChatProtocol.ConversationWithYourselfId,
+                archivalStatus = ArchivalStatus.Removed.value,
+            )
+            val rowsBefore = fixture.outboxRowCount()
+
+            service.ensureNoteToSelfExists()
+
+            assertTrue(
+                fixture.outboxRowCount() > rowsBefore,
+                "deleted note-to-self should be revived via an update enqueue",
+            )
+        }
+    }
+
+    // ---------- introduceEveryone ----------
+
+    @Test
+    fun introduceEveryone_sendsToAllParticipantsExceptSelf_withCustomMessage() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            val bob = "bob.test"
+            val groupId = fixture.seedGroup(
+                others = listOf(alice, bob),
+                adminDomains = listOf(fixture.testDomain),
+            )
+
+            service.introduceEveryone(groupId, message = "Say hi 👋")
+
+            val call = fixture.introductionSender.calls.single()
+            // introduceEveryone passes the conversation's participant list verbatim —
+            // which includes self. That is the current behavior; this test locks it in.
+            assertEquals(
+                setOf(OdinId(fixture.testDomain), OdinId(alice), OdinId(bob)),
+                call.recipients.toSet()
+            )
+            assertEquals("Say hi 👋", call.message)
+        }
+    }
+
+    @Test
+    fun introduceEveryone_nullMessage_sendsEmptyStringMessage() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val groupId = fixture.seedGroup(
+                others = listOf("alice.test"),
+                adminDomains = listOf(fixture.testDomain),
+            )
+
+            service.introduceEveryone(groupId, message = null)
+
+            val call = fixture.introductionSender.calls.single()
+            assertEquals("", call.message)
+        }
+    }
+
+    // ---------- archive / unarchive / pin / unpin (tag flips) ----------
+    //
+    // All four route through updateConversationTags. We verify each writes an
+    // outbox row via the tag-update path.
+
+    @Test
+    fun archiveConversation_enqueuesTagUpdate() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = fixture.seedOneOnOne(other = "alice.test")
+            val before = fixture.outboxRowCount()
+
+            service.archiveConversation(convoId)
+
+            assertEquals(1L, fixture.outboxRowCount() - before)
+        }
+    }
+
+    @Test
+    fun unarchiveConversation_enqueuesTagUpdate() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = fixture.seedOneOnOne(
+                other = "alice.test",
+                localTags = listOf(ChatProtocol.ConversationArchivedTag),
+            )
+            val before = fixture.outboxRowCount()
+
+            service.unarchiveConversation(convoId)
+
+            assertEquals(1L, fixture.outboxRowCount() - before)
+        }
+    }
+
+    @Test
+    fun pinConversation_enqueuesTagUpdate() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = fixture.seedOneOnOne(other = "alice.test")
+            val before = fixture.outboxRowCount()
+
+            service.pinConversation(convoId)
+
+            assertEquals(1L, fixture.outboxRowCount() - before)
+        }
+    }
+
+    @Test
+    fun unpinConversation_enqueuesTagUpdate() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = fixture.seedOneOnOne(
+                other = "alice.test",
+                localTags = listOf(ChatProtocol.ConversationPinnedTag),
+            )
+            val before = fixture.outboxRowCount()
+
+            service.unpinConversation(convoId)
+
+            assertEquals(1L, fixture.outboxRowCount() - before)
+        }
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceRecoveryTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceRecoveryTest.kt
@@ -1,0 +1,232 @@
+package id.homebase.chat.services.convo
+
+import id.homebase.api.client.drives.files.ArchivalStatus
+import id.homebase.api.common.OdinId
+import id.homebase.chat.services.ChatProtocol
+import id.homebase.chat.services.XorIdUtil
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Tier-3 coverage for [ConversationService.recoverConversation] and the admin
+ * accessors ([ConversationService.getAdmins],
+ * [ConversationService.getConversationAdminHomebaseFile]).
+ */
+class ConversationServiceRecoveryTest {
+
+    // ---------- recoverConversation ----------
+
+    @Test
+    fun recoverConversation_noteToSelf_delegatesToEnsureNoteToSelfExists() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val rowsBefore = fixture.outboxRowCount()
+
+            service.recoverConversation(
+                conversationId = ChatProtocol.ConversationWithYourselfId,
+                originalAuthor = OdinId(fixture.testDomain),
+            )
+
+            // No existing note-to-self file ⇒ ensureNoteToSelfExists creates + pins.
+            assertTrue(
+                fixture.outboxRowCount() > rowsBefore,
+                "note-to-self recovery should enqueue a creation/pin",
+            )
+        }
+    }
+
+    @Test
+    fun recoverConversation_oneOnOne_existingActive_isNoOp() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            val xorId = XorIdUtil.getNewXorId(fixture.testDomain, alice)
+            fixture.seedOneOnOne(other = alice, conversationId = xorId)
+            val rowsBefore = fixture.outboxRowCount()
+
+            service.recoverConversation(
+                conversationId = xorId,
+                originalAuthor = OdinId(alice),
+            )
+
+            assertEquals(
+                rowsBefore,
+                fixture.outboxRowCount(),
+                "healthy active 1:1 needs no recovery ⇒ no new outbox rows",
+            )
+        }
+    }
+
+    @Test
+    fun recoverConversation_oneOnOne_existingDeleted_revivesViaUpdate() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            val xorId = XorIdUtil.getNewXorId(fixture.testDomain, alice)
+            fixture.seedOneOnOne(
+                other = alice,
+                conversationId = xorId,
+                archivalStatus = ArchivalStatus.Removed.value,
+            )
+            val rowsBefore = fixture.outboxRowCount()
+
+            service.recoverConversation(
+                conversationId = xorId,
+                originalAuthor = OdinId(alice),
+            )
+
+            assertTrue(
+                fixture.outboxRowCount() > rowsBefore,
+                "deleted 1:1 should be revived via an UpdateFileByUniqueId enqueue",
+            )
+        }
+    }
+
+    @Test
+    fun recoverConversation_oneOnOne_noFile_createsFresh() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            val xorId = XorIdUtil.getNewXorId(fixture.testDomain, alice)
+            val rowsBefore = fixture.outboxRowCount()
+
+            service.recoverConversation(
+                conversationId = xorId,
+                originalAuthor = OdinId(alice),
+            )
+
+            assertTrue(
+                fixture.outboxRowCount() > rowsBefore,
+                "no local file ⇒ writeConversationFile must enqueue a new-file upload",
+            )
+        }
+    }
+
+    @Test
+    fun recoverConversation_group_noFile_createsWithCallerAndOriginalAuthor() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            // Random uuid that does NOT match XorIdUtil(domain, alice) ⇒ group branch.
+            val groupId = Uuid.random()
+            val rowsBefore = fixture.outboxRowCount()
+
+            service.recoverConversation(
+                conversationId = groupId,
+                originalAuthor = OdinId(alice),
+            )
+
+            assertTrue(
+                fixture.outboxRowCount() > rowsBefore,
+                "group recovery with no file should enqueue a new group conversation",
+            )
+        }
+    }
+
+    // ---------- getAdmins ----------
+
+    @Test
+    fun getAdmins_returnsAdminsFromAdminFile_whenPresent() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            val bob = "bob.test"
+            val groupId = fixture.seedGroup(
+                others = listOf(alice, bob),
+                adminDomains = listOf(alice, bob),
+            )
+
+            val admins = service.getAdmins(groupId)
+
+            assertEquals(setOf(OdinId(alice), OdinId(bob)), admins)
+        }
+    }
+
+    @Test
+    fun getAdmins_fallsBackToOriginalAuthor_whenNoAdminFile() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            // seedGroup with seedAdminFile = false skips the dedicated admin file.
+            val groupId = fixture.seedGroup(
+                others = listOf(alice),
+                adminDomains = listOf(fixture.testDomain),
+                seedAdminFile = false,
+            )
+
+            val admins = service.getAdmins(groupId)
+
+            // originalAuthor on the seeded conversation is testDomain.
+            assertEquals(setOf(OdinId(fixture.testDomain)), admins)
+        }
+    }
+
+    // ---------- getConversationAdminHomebaseFile ----------
+
+    @Test
+    fun getConversationAdminHomebaseFile_returnsNull_whenNoAdminFile() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val groupId = fixture.seedGroup(
+                others = listOf("alice.test"),
+                adminDomains = listOf(fixture.testDomain),
+                seedAdminFile = false,
+            )
+
+            val adminFile = service.getConversationAdminHomebaseFile(groupId)
+
+            assertNull(adminFile)
+        }
+    }
+
+    @Test
+    fun getConversationAdminHomebaseFile_returnsFile_whenPresent() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val groupId = fixture.seedGroup(
+                others = listOf("alice.test"),
+                adminDomains = listOf(fixture.testDomain),
+                // seedAdminFile defaults to true
+            )
+
+            val adminFile = service.getConversationAdminHomebaseFile(groupId)
+
+            assertNotNull(adminFile)
+            assertEquals(
+                ChatProtocol.ConversationAdminFileType,
+                adminFile.fileMetadata.appData.fileType,
+            )
+        }
+    }
+
+    // ---------- small accessors ----------
+
+    @Test
+    fun getConversation_returnsNull_forUnknownId() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+
+            val result = service.getConversation(Uuid.random())
+
+            assertNull(result)
+        }
+    }
+
+    @Test
+    fun requireConversation_throws_forUnknownId() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+
+            val ex = assertFailsWith<IllegalStateException> {
+                service.requireConversation(Uuid.random())
+            }
+            assertTrue(ex.message!!.contains("No conversation"))
+        }
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceTest.kt
@@ -1,0 +1,292 @@
+package id.homebase.chat.services.convo
+
+import id.homebase.api.common.OdinId
+import id.homebase.chat.services.StatusMessage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Integration-ish tests for [ConversationService]. Uses an in-memory SQLite DB
+ * (via [ConversationServiceTestFixture]) for the mapper/outbox, and hand-written
+ * fakes for the network-shaped collaborators.
+ */
+class ConversationServiceTest {
+
+    @Test
+    fun updateGroupMembers_add_introducesEveryCurrentParticipantExceptSelf() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+
+            val alice = "alice.test"
+            val bob = "bob.test"
+            val charlie = "charlie.test"
+
+            val groupId = fixture.seedGroup(
+                others = listOf(alice, bob),
+                adminDomains = listOf(fixture.testDomain),
+            )
+
+            service.updateGroupMembers(
+                conversationId = groupId,
+                add = listOf(OdinId(charlie)),
+                remove = emptyList(),
+            )
+
+            // Introductions should go to the full post-update participant set minus
+            // self. Post our refactor: existing members (alice, bob) + newly added
+            // (charlie).
+            assertEquals(
+                1,
+                fixture.introductionSender.calls.size,
+                "expected one introductions call"
+            )
+            val group = fixture.introductionSender.calls.single()
+            assertEquals(
+                setOf(OdinId(alice), OdinId(bob), OdinId(charlie)),
+                group.recipients.toSet(),
+                "introductions must cross-introduce every non-self member, not just the newly added"
+            )
+            assertTrue(
+                group.recipients.none { it.domainName == fixture.testDomain },
+                "caller should never be in their own introduction list"
+            )
+        }
+    }
+
+    @Test
+    fun updateGroupMembers_add_sendsMemberAddedStatusReachingNewMember() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+
+            val alice = "alice.test"
+            val charlie = "charlie.test"
+
+            val groupId = fixture.seedGroup(
+                others = listOf(alice),
+                adminDomains = listOf(fixture.testDomain),
+            )
+
+            service.updateGroupMembers(
+                conversationId = groupId,
+                add = listOf(OdinId(charlie)),
+                remove = emptyList(),
+            )
+
+            val memberAddedCalls = fixture.statusMessageSender.calls.filter {
+                it.statusMessage.statusMessage == StatusMessage.ConversationMemberAdded
+            }
+            assertEquals(
+                1,
+                memberAddedCalls.size,
+                "one ConversationMemberAdded per newly added user"
+            )
+
+            val call = memberAddedCalls.single()
+            assertEquals(groupId, call.conversationId)
+            assertEquals(OdinId(charlie), call.statusMessage.subject)
+            assertTrue(
+                call.additionalRecipients.contains(OdinId(charlie)),
+                "newly added user must be in additionalRecipients so they receive the status message"
+            )
+        }
+    }
+
+    @Test
+    fun updateGroupMembers_remove_sendsMemberRemovedStatus_noIntroductions() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+
+            val alice = "alice.test"
+            val bob = "bob.test"
+
+            val groupId = fixture.seedGroup(
+                others = listOf(alice, bob),
+                adminDomains = listOf(fixture.testDomain),
+            )
+
+            service.updateGroupMembers(
+                conversationId = groupId,
+                add = emptyList(),
+                remove = listOf(OdinId(bob)),
+            )
+
+            // One status message about the removal...
+            val removedCalls = fixture.statusMessageSender.calls.filter {
+                it.statusMessage.statusMessage == StatusMessage.ConversationMemberRemoved
+            }
+            assertEquals(1, removedCalls.size)
+            assertEquals(OdinId(bob), removedCalls.single().statusMessage.subject)
+
+            // ...and no introductions, since no one was added.
+            assertTrue(
+                fixture.introductionSender.calls.isEmpty(),
+                "removal-only update should not trigger introductions"
+            )
+        }
+    }
+
+    @Test
+    fun updateGroupMembers_writesUpdateToOutbox() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+
+            val alice = "alice.test"
+            val charlie = "charlie.test"
+
+            val groupId = fixture.seedGroup(
+                others = listOf(alice),
+                adminDomains = listOf(fixture.testDomain),
+            )
+
+            val rowsBefore = fixture.outboxRowCount()
+
+            service.updateGroupMembers(
+                conversationId = groupId,
+                add = listOf(OdinId(charlie)),
+                remove = emptyList(),
+            )
+
+            assertTrue(
+                fixture.outboxRowCount() > rowsBefore,
+                "updateConversationInternal should enqueue at least one outbox row"
+            )
+        }
+    }
+
+    @Test
+    fun updateGroupMembers_removingAnAdmin_throws() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            val groupId = fixture.seedGroup(
+                others = listOf(alice),
+                // Both self and alice are admins.
+                adminDomains = listOf(fixture.testDomain, alice),
+            )
+
+            val ex = assertFailsWith<IllegalArgumentException> {
+                service.updateGroupMembers(
+                    conversationId = groupId,
+                    add = emptyList(),
+                    remove = listOf(OdinId(alice)),
+                )
+            }
+            assertTrue(
+                ex.message!!.contains("Cannot remove admins"),
+                "message should guide the caller to updateAdmins first: ${ex.message}"
+            )
+        }
+    }
+
+    @Test
+    fun updateGroupMembers_addAndRemove_inSingleCall_emitsBothStatusMessages_introducesOnlyPostUpdateSet() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            val bob = "bob.test"
+            val charlie = "charlie.test"
+            val groupId = fixture.seedGroup(
+                others = listOf(alice, bob),
+                adminDomains = listOf(fixture.testDomain),
+            )
+
+            service.updateGroupMembers(
+                conversationId = groupId,
+                add = listOf(OdinId(charlie)),
+                remove = listOf(OdinId(bob)),
+            )
+
+            // One Removed + one Added
+            val removed = fixture.statusMessageSender.calls.filter {
+                it.statusMessage.statusMessage == StatusMessage.ConversationMemberRemoved
+            }
+            val added = fixture.statusMessageSender.calls.filter {
+                it.statusMessage.statusMessage == StatusMessage.ConversationMemberAdded
+            }
+            assertEquals(1, removed.size)
+            assertEquals(OdinId(bob), removed.single().statusMessage.subject)
+            assertEquals(1, added.size)
+            assertEquals(OdinId(charlie), added.single().statusMessage.subject)
+
+            // Introductions sent to post-update participants (alice + charlie), NOT bob.
+            val intro = fixture.introductionSender.calls.single()
+            assertEquals(
+                setOf(OdinId(alice), OdinId(charlie)),
+                intro.recipients.toSet()
+            )
+        }
+    }
+
+    @Test
+    fun updateGroupMembers_addingAlreadyPresentUser_isNoOp() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            val groupId = fixture.seedGroup(
+                others = listOf(alice),
+                adminDomains = listOf(fixture.testDomain),
+            )
+
+            service.updateGroupMembers(
+                conversationId = groupId,
+                add = listOf(OdinId(alice)), // already a participant
+                remove = emptyList(),
+            )
+
+            val addedCalls = fixture.statusMessageSender.calls.filter {
+                it.statusMessage.statusMessage == StatusMessage.ConversationMemberAdded
+            }
+            assertTrue(
+                addedCalls.isEmpty(),
+                "re-adding an existing participant should not emit ConversationMemberAdded"
+            )
+            assertTrue(
+                fixture.introductionSender.calls.isEmpty(),
+                "no new participants ⇒ no introductions"
+            )
+        }
+    }
+
+    @Test
+    fun updateGroupMembers_nonAdminCaller_throws() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            val bob = "bob.test"
+            // testDomain is a participant but NOT an admin.
+            val groupId = fixture.seedGroup(
+                others = listOf(alice, bob),
+                adminDomains = listOf(alice),
+            )
+
+            val ex = assertFailsWith<IllegalStateException> {
+                service.updateGroupMembers(
+                    conversationId = groupId,
+                    add = listOf(OdinId("charlie.test")),
+                )
+            }
+            assertTrue(ex.message!!.contains("admin"))
+        }
+    }
+
+    @Test
+    fun updateGroupMembers_legacyGroup_throws() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val groupId = fixture.seedLegacyGroup(
+                others = listOf("alice.test", "bob.test")
+            )
+
+            val ex = assertFailsWith<IllegalStateException> {
+                service.updateGroupMembers(
+                    conversationId = groupId,
+                    add = listOf(OdinId("charlie.test")),
+                )
+            }
+            assertTrue(ex.message!!.contains("legacy"))
+        }
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceTestFixture.kt
@@ -1,0 +1,460 @@
+package id.homebase.chat.services.convo
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import id.homebase.api.client.auth.ApiCredentials
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.connections.IntroductionGroup
+import id.homebase.api.client.connections.IntroductionResult
+import id.homebase.api.client.connections.IntroductionSender
+import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.SecureByteArray
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.sync.database.MainIndexMetaHelpers
+import id.homebase.api.sync.database.OdinDatabase
+import id.homebase.api.sync.database.Outbox
+import id.homebase.api.sync.database.OutboxSync
+import id.homebase.api.sync.database.OutboxUploader
+import id.homebase.chat.services.ChatProtocol
+import id.homebase.chat.services.PayloadBundle
+import id.homebase.chat.services.PayloadBundleEncryptor
+import id.homebase.chat.services.SendMessageResult
+import id.homebase.chat.services.StatusMessageData
+import id.homebase.chat.services.outbox.OptimisticWriter
+import kotlin.time.Clock
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.TestScope
+
+/**
+ * Shared setup for ConversationService tests.
+ *
+ *   - Real in-memory SQLite DB (same pattern as [AdminQueryTest]).
+ *   - Real [OutboxSync] with `setOnline(false)` so enqueued rows land in the DB for
+ *     inspection but are never actually uploaded. The stub [OutboxUploader] throws
+ *     to catch accidental online paths in tests.
+ *   - Fake collaborators ([FakeStatusMessageSender], [FakeIntroductionSender],
+ *     [FakeConversationLoader], [FakePayloadBundleEncryptor]) record calls for
+ *     assertion — no network, no crypto, no coroutines they can leak.
+ *
+ * Use via `ConversationServiceTestFixture().use { fixture -> ... }` so the
+ * in-memory DB is closed at the end of each test.
+ */
+class ConversationServiceTestFixture : AutoCloseable {
+
+    // Fixed identityId — matches the hardcoded value in ApiCredentials.getIdentityId()
+    val testIdentityId: Uuid = Uuid.parse("7b1be23b-48bb-4304-bc7b-db5910c09a92")
+
+    // Chat drive alias from SystemDriveConstants.chatDrive
+    val chatDriveId: Uuid = Uuid.parse("9ff813af-f2d6-1e2f-9b9d-b189e72d1a11")
+
+    val testDomain: String = "owner.test"
+
+    lateinit var dbm: DatabaseManager
+        private set
+    lateinit var credentialsManager: CredentialsManager
+        private set
+    lateinit var eventBus: EventBus
+        private set
+    lateinit var outboxSync: OutboxSync
+        private set
+    lateinit var introductionSender: FakeIntroductionSender
+        private set
+    lateinit var statusMessageSender: FakeStatusMessageSender
+        private set
+    lateinit var conversationLoader: FakeConversationLoader
+        private set
+    lateinit var payloadEncryptor: FakePayloadBundleEncryptor
+        private set
+
+    suspend fun build(scope: CoroutineScope = TestScope()): ConversationService {
+        dbm = createInMemoryDbm()
+        credentialsManager = createCredentialsManager(testDomain)
+        eventBus = EventBus()
+        outboxSync = OutboxSync(
+            databaseManager = dbm,
+            uploader = ThrowingOutboxUploader,
+            eventBus = eventBus,
+            scope = scope
+        ).also { it.setOnline(false) } // never actually send
+
+        introductionSender = FakeIntroductionSender()
+        statusMessageSender = FakeStatusMessageSender()
+        conversationLoader = FakeConversationLoader()
+        payloadEncryptor = FakePayloadBundleEncryptor()
+
+        val optimisticWriter = OptimisticWriter(
+            credentialsManager = credentialsManager,
+            dbm = dbm,
+            eventBus = eventBus
+        )
+
+        return ConversationService(
+            credentialsManager = credentialsManager,
+            payloadBundleEncryptionService = payloadEncryptor,
+            dbm = dbm,
+            introductionProvider = introductionSender,
+            scope = scope,
+            outboxSync = outboxSync,
+            chatMessageSenderService = statusMessageSender,
+            optimisticWriter = optimisticWriter,
+            conversationStream = conversationLoader,
+        )
+    }
+
+    // ---------- DB seed helpers ----------
+
+    /**
+     * Seed a group conversation where [testDomain] is the admin. Participants include
+     * the caller ([testDomain]) plus every entry in [others].
+     *
+     * @param localTags tags written to localAppData — drive Left/Archived/Pinned state.
+     * @param archivalStatus 0=Active, 2=Removed. See [ArchivalStatus].
+     */
+    suspend fun seedGroup(
+        conversationId: Uuid = Uuid.random(),
+        others: List<String>,
+        adminDomains: List<String> = listOf(testDomain),
+        title: String = "",
+        localTags: List<Uuid> = emptyList(),
+        archivalStatus: Int = 0,
+        seedAdminFile: Boolean = true,
+    ): Uuid {
+        val participants = listOf(testDomain) + others
+        val adminDataJson =
+            """{"admins":[${adminDomains.joinToString(",") { "\"$it\"" }}]}"""
+        insertConversationFile(
+            fileId = Uuid.random(),
+            uniqueId = conversationId,
+            participants = participants,
+            originalAuthor = testDomain,
+            isGroup = true,
+            adminDataJson = adminDataJson,
+            title = title,
+            localTags = localTags,
+            archivalStatus = archivalStatus,
+        )
+
+        if (seedAdminFile) {
+            // Separate admin file (takes priority over adminData when read by
+            // ConversationAdminInfo.queryFromDb — see AdminQueryTest for details).
+            insertAdminFile(
+                fileId = Uuid.random(),
+                uniqueId = ChatProtocol.getAdminFileUniqueId(conversationId),
+                groupId = conversationId,
+                admins = adminDomains,
+                originalAuthor = testDomain
+            )
+        }
+        return conversationId
+    }
+
+    /** Seed a 1:1 conversation between [testDomain] and [other]. */
+    suspend fun seedOneOnOne(
+        other: String,
+        conversationId: Uuid = Uuid.random(),
+        localTags: List<Uuid> = emptyList(),
+        archivalStatus: Int = 0,
+    ): Uuid {
+        insertConversationFile(
+            fileId = Uuid.random(),
+            uniqueId = conversationId,
+            participants = listOf(testDomain, other),
+            originalAuthor = testDomain,
+            isGroup = false,
+            title = "",
+            localTags = localTags,
+            archivalStatus = archivalStatus,
+        )
+        return conversationId
+    }
+
+    /** A legacy (pre-tag) group — >2 participants but no ConversationGroupTag. */
+    suspend fun seedLegacyGroup(
+        others: List<String>,
+        conversationId: Uuid = Uuid.random(),
+    ): Uuid {
+        insertConversationFile(
+            fileId = Uuid.random(),
+            uniqueId = conversationId,
+            participants = listOf(testDomain) + others,
+            originalAuthor = testDomain,
+            isGroup = false, // no ConversationGroupTag → legacy
+            title = "",
+        )
+        return conversationId
+    }
+
+    fun outboxRowCount(): Long = dbm.outbox.count()
+
+    /**
+     * Drain the outbox (checkout everything eligible at real `now`) so callers can
+     * inspect what was enqueued. NOTE: this mutates `checkOutStamp`. Don't call it
+     * if you plan to run further service operations that might re-enqueue the same
+     * uniqueId, and don't rely on [outboxRowCount] afterwards — the rows are still
+     * there, just checked out.
+     */
+    suspend fun drainOutbox(): List<Outbox> {
+        val drained = mutableListOf<Outbox>()
+        while (true) {
+            val row = dbm.outbox.checkout() ?: break
+            drained += row
+        }
+        return drained
+    }
+
+    /** Load the current conversation HomebaseFile from the in-memory DB. */
+    suspend fun getConversationFile(conversationId: Uuid) =
+        dbm.driveMainIndex.selectHomebaseFileByUnique(
+            testIdentityId, chatDriveId, conversationId
+        )
+
+    override fun close() {
+        if (::dbm.isInitialized) dbm.close()
+    }
+
+    // ---------- internals ----------
+
+    private fun createInMemoryDbm(): DatabaseManager = DatabaseManager {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        OdinDatabase.Schema.create(driver)
+        driver
+    }
+
+    private suspend fun createCredentialsManager(domain: String): CredentialsManager {
+        val cm = CredentialsManager()
+        cm.setActiveCredentials(
+            ApiCredentials.create(
+                domain = OdinId(domain),
+                clientAccessToken = "test-token",
+                sharedSecret = SecureByteArray(ByteArray(16))
+            )
+        )
+        return cm
+    }
+
+    private suspend fun insertConversationFile(
+        fileId: Uuid,
+        uniqueId: Uuid,
+        participants: List<String>,
+        originalAuthor: String,
+        isGroup: Boolean,
+        adminDataJson: String? = null,
+        title: String = "",
+        archivalStatus: Int = 0,
+        localTags: List<Uuid> = emptyList(),
+    ) {
+        val now = Clock.System.now().epochSeconds
+        val recipientsJson = participants.joinToString(",") { "\"$it\"" }
+        val tagsField = if (isGroup) "[\"${ChatProtocol.ConversationGroupTag}\"]" else "null"
+        val adminDataField = if (adminDataJson != null) """, "adminData": $adminDataJson""" else ""
+        val contentJson =
+            """{"title":"$title","version":1,"recipients":[$recipientsJson]$adminDataField}"""
+        val escaped = contentJson.replace("\"", "\\\"")
+        val localAppDataField = if (localTags.isEmpty()) {
+            "null"
+        } else {
+            val tagList = localTags.joinToString(",") { "\"$it\"" }
+            """{"tags":[$tagList],"versionTag":"${Uuid.random()}","iv":null,"content":null,"readTime":null,"localReactions":null}"""
+        }
+
+        insertFile(
+            """{
+              "fileId": "$fileId",
+              "driveId": "$chatDriveId",
+              "fileState": "active",
+              "fileSystemType": "standard",
+              "serverFileIsEncrypted": "false",
+              "keyHeader": {
+                "iv": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+                "aesKey": {"bytes": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}
+              },
+              "fileMetadata": {
+                "globalTransitId": "${Uuid.random()}",
+                "created": ${now}000,
+                "updated": ${now}000,
+                "transitCreated": ${now}000,
+                "transitUpdated": 0,
+                "isEncrypted": false,
+                "senderOdinId": "$originalAuthor",
+                "originalAuthor": "$originalAuthor",
+                "appData": {
+                  "uniqueId": "$uniqueId",
+                  "tags": $tagsField,
+                  "fileType": ${ChatProtocol.ConversationFileType},
+                  "dataType": 0,
+                  "groupId": null,
+                  "userDate": ${now}000,
+                  "content": "$escaped",
+                  "previewThumbnail": null,
+                  "archivalStatus": $archivalStatus
+                },
+                "localAppData": $localAppDataField,
+                "referencedFile": null,
+                "reactionPreview": null,
+                "versionTag": "${Uuid.random()}",
+                "payloads": [],
+                "dataSource": null
+              },
+              "serverMetadata": {
+                "accessControlList": {
+                  "requiredSecurityGroup": "owner",
+                  "circleIdList": null,
+                  "odinIdList": null
+                },
+                "doNotIndex": false,
+                "allowDistribution": true,
+                "fileSystemType": "standard",
+                "fileByteCount": 100,
+                "originalRecipientCount": ${participants.size - 1},
+                "transferHistory": null
+              },
+              "priority": 300,
+              "fileByteCount": 100
+            }"""
+        )
+    }
+
+    private suspend fun insertAdminFile(
+        fileId: Uuid,
+        uniqueId: Uuid,
+        groupId: Uuid,
+        admins: List<String>,
+        originalAuthor: String,
+    ) {
+        val now = Clock.System.now().epochSeconds
+        val adminsJson = admins.joinToString(",") { "\"$it\"" }
+        val contentJson = """{"admins":[$adminsJson]}"""
+        val escaped = contentJson.replace("\"", "\\\"")
+
+        insertFile(
+            """{
+              "fileId": "$fileId",
+              "driveId": "$chatDriveId",
+              "fileState": "active",
+              "fileSystemType": "standard",
+              "serverFileIsEncrypted": "false",
+              "keyHeader": {
+                "iv": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+                "aesKey": {"bytes": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}
+              },
+              "fileMetadata": {
+                "globalTransitId": "${Uuid.random()}",
+                "created": ${now}000,
+                "updated": ${now}000,
+                "transitCreated": 0,
+                "transitUpdated": 0,
+                "isEncrypted": false,
+                "senderOdinId": "$originalAuthor",
+                "originalAuthor": "$originalAuthor",
+                "appData": {
+                  "uniqueId": "$uniqueId",
+                  "tags": null,
+                  "fileType": ${ChatProtocol.ConversationAdminFileType},
+                  "dataType": 0,
+                  "groupId": "$groupId",
+                  "userDate": ${now}000,
+                  "content": "$escaped",
+                  "previewThumbnail": null,
+                  "archivalStatus": 0
+                },
+                "localAppData": null,
+                "referencedFile": null,
+                "reactionPreview": null,
+                "versionTag": "${Uuid.random()}",
+                "payloads": [],
+                "dataSource": null
+              },
+              "serverMetadata": {
+                "accessControlList": {
+                  "requiredSecurityGroup": "owner",
+                  "circleIdList": null,
+                  "odinIdList": null
+                },
+                "doNotIndex": false,
+                "allowDistribution": true,
+                "fileSystemType": "standard",
+                "fileByteCount": 50,
+                "originalRecipientCount": 0,
+                "transferHistory": null
+              },
+              "priority": 300,
+              "fileByteCount": 50
+            }"""
+        )
+    }
+
+    private suspend fun insertFile(jsonHeader: String) {
+        val header = OdinSystemSerializer.deserialize<HomebaseFile>(jsonHeader)
+        val processor = MainIndexMetaHelpers.HomebaseFileProcessor(dbm)
+        val record = processor.convertFileHeaderToDriveMainIndexRecord(
+            testIdentityId, chatDriveId, header
+        )
+        MainIndexMetaHelpers.upsertDriveMainIndex(dbm, record)
+    }
+}
+
+// ---------- Test doubles ----------
+
+class FakeIntroductionSender : IntroductionSender {
+    val calls = mutableListOf<IntroductionGroup>()
+    override suspend fun sendIntroductions(group: IntroductionGroup): IntroductionResult {
+        calls += group
+        return IntroductionResult()
+    }
+}
+
+class FakeStatusMessageSender : StatusMessageSender {
+    data class Call(
+        val conversationId: Uuid,
+        val statusMessage: StatusMessageData,
+        val additionalRecipients: List<OdinId>,
+    )
+    val calls = mutableListOf<Call>()
+    override suspend fun sendStatusMessage(
+        messageUniqueId: Uuid,
+        conversationId: Uuid,
+        statusMessage: StatusMessageData,
+        previousMessageUniqueId: Uuid?,
+        payloadBundle: PayloadBundle?,
+        additionalRecipients: List<OdinId>,
+    ): SendMessageResult {
+        calls += Call(conversationId, statusMessage, additionalRecipients)
+        return SendMessageResult(messageUniqueId)
+    }
+}
+
+class FakeConversationLoader : ConversationLoader {
+    val loaded = mutableListOf<Uuid>()
+    override suspend fun loadConversation(conversationId: Uuid) {
+        loaded += conversationId
+    }
+}
+
+class FakePayloadBundleEncryptor : PayloadBundleEncryptor {
+    val calls = mutableListOf<Uuid>()
+    override suspend fun encryptBundle(
+        uniqueId: Uuid,
+        bundle: PayloadBundle?,
+        aesKey: SecureByteArray,
+        scope: CoroutineScope,
+    ): PayloadBundle {
+        calls += uniqueId
+        // Empty bundle regardless of input. Tests that need to assert payload contents
+        // should use a more specific fake or the real service.
+        return PayloadBundle(
+            payloads = emptyList(),
+            thumbnails = emptyList(),
+            previewThumbs = emptyList(),
+        )
+    }
+}
+
+/** Fails if the outbox ever tries to send — ensures tests stay offline. */
+private object ThrowingOutboxUploader : OutboxUploader {
+    override suspend fun upload(outboxRecord: Outbox, eventBus: EventBus) {
+        error("OutboxUploader.upload should never be called in tests (setOnline(false))")
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceUpdateAdminsTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceUpdateAdminsTest.kt
@@ -1,0 +1,179 @@
+package id.homebase.chat.services.convo
+
+import id.homebase.api.common.OdinId
+import id.homebase.chat.services.StatusMessage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Tests for [ConversationService.updateAdmins] — admin promotion/demotion,
+ * sole-admin guard, legacy-group rejection, and participant requirement.
+ */
+class ConversationServiceUpdateAdminsTest {
+
+    @Test
+    fun updateAdmins_add_emitsAdminAddedStatus() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            val bob = "bob.test"
+            val groupId = fixture.seedGroup(
+                others = listOf(alice, bob),
+                adminDomains = listOf(fixture.testDomain),
+            )
+
+            service.updateAdmins(
+                conversationId = groupId,
+                add = listOf(OdinId(alice)),
+            )
+
+            val adminAdded = fixture.statusMessageSender.calls.filter {
+                it.statusMessage.statusMessage == StatusMessage.ConversationAdminAdded
+            }
+            assertEquals(1, adminAdded.size)
+            assertEquals(OdinId(alice), adminAdded.single().statusMessage.subject)
+            // No introductions on admin changes.
+            assertTrue(fixture.introductionSender.calls.isEmpty())
+        }
+    }
+
+    @Test
+    fun updateAdmins_remove_emitsAdminRemovedStatus() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            val bob = "bob.test"
+            // Seed with two admins so removal still leaves at least one.
+            val groupId = fixture.seedGroup(
+                others = listOf(alice, bob),
+                adminDomains = listOf(fixture.testDomain, alice),
+            )
+
+            service.updateAdmins(
+                conversationId = groupId,
+                remove = listOf(OdinId(alice)),
+            )
+
+            val adminRemoved = fixture.statusMessageSender.calls.filter {
+                it.statusMessage.statusMessage == StatusMessage.ConversationAdminRemoved
+            }
+            assertEquals(1, adminRemoved.size)
+            assertEquals(OdinId(alice), adminRemoved.single().statusMessage.subject)
+        }
+    }
+
+    @Test
+    fun updateAdmins_addingNonParticipant_throws() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val groupId = fixture.seedGroup(
+                others = listOf("alice.test"),
+                adminDomains = listOf(fixture.testDomain),
+            )
+
+            val ex = assertFailsWith<IllegalArgumentException> {
+                service.updateAdmins(
+                    conversationId = groupId,
+                    add = listOf(OdinId("stranger.test")),
+                )
+            }
+            assertTrue(ex.message!!.contains("recipients"))
+        }
+    }
+
+    @Test
+    fun updateAdmins_removingSoleAdminSelf_throwsWithReplaceHint() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val groupId = fixture.seedGroup(
+                others = listOf("alice.test"),
+                adminDomains = listOf(fixture.testDomain),
+            )
+
+            val ex = assertFailsWith<IllegalStateException> {
+                service.updateAdmins(
+                    conversationId = groupId,
+                    remove = listOf(OdinId(fixture.testDomain)),
+                )
+            }
+            assertTrue(
+                ex.message!!.contains("replace you"),
+                "should surface the self-specific replace-hint: ${ex.message}"
+            )
+        }
+    }
+
+    @Test
+    fun updateAdmins_removingSoleAdminOther_throwsGenericMessage() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            // testDomain is NOT an admin here — but then testDomain can't even call
+            // updateAdmins (requireCallerIsGroupAdmin blocks). So to exercise the
+            // generic branch of the sole-admin guard we need: self is admin AND
+            // self is removing someone else who happens to be the only admin left
+            // after removal. That only works if someone else is the sole admin,
+            // which requires self NOT to be admin — contradiction with the caller
+            // gate. The guard is therefore practically unreachable today for
+            // non-self; we lock in the self-branch above and skip this scenario
+            // intentionally.
+            //
+            // Left as a stub to document the dead-code observation. Remove once
+            // the guard is restructured to something reachable.
+            val groupId = fixture.seedGroup(
+                others = listOf(alice),
+                adminDomains = listOf(fixture.testDomain, alice),
+            )
+            // Admins after remove would be [alice] — not empty — so no throw.
+            service.updateAdmins(
+                conversationId = groupId,
+                remove = listOf(OdinId(fixture.testDomain)),
+            )
+            // Sanity: we exited cleanly, no exception thrown, admin-removed status emitted.
+            assertTrue(fixture.statusMessageSender.calls.any {
+                it.statusMessage.statusMessage == StatusMessage.ConversationAdminRemoved
+            })
+        }
+    }
+
+    @Test
+    fun updateAdmins_nonAdminCaller_throws() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            val groupId = fixture.seedGroup(
+                others = listOf(alice),
+                adminDomains = listOf(alice),
+            )
+
+            val ex = assertFailsWith<IllegalStateException> {
+                service.updateAdmins(
+                    conversationId = groupId,
+                    add = listOf(OdinId(alice)),
+                )
+            }
+            assertTrue(ex.message!!.contains("admin"))
+        }
+    }
+
+    @Test
+    fun updateAdmins_legacyGroup_throws() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val groupId = fixture.seedLegacyGroup(
+                others = listOf("alice.test", "bob.test"),
+            )
+
+            val ex = assertFailsWith<IllegalStateException> {
+                service.updateAdmins(
+                    conversationId = groupId,
+                    add = listOf(OdinId("alice.test")),
+                )
+            }
+            assertTrue(ex.message!!.contains("legacy"))
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -23,9 +23,12 @@ import id.homebase.chat.services.LocalAttachmentContextStore
 import id.homebase.chat.services.ChatMessageSenderService
 import id.homebase.chat.services.ChatMessageStream
 import id.homebase.chat.services.PayloadBundleEncryptionService
+import id.homebase.chat.services.PayloadBundleEncryptor
 import id.homebase.chat.services.ShareSuggestionDonor
+import id.homebase.chat.services.convo.ConversationLoader
 import id.homebase.chat.services.convo.ConversationService
 import id.homebase.chat.services.convo.ConversationStream
+import id.homebase.chat.services.convo.StatusMessageSender
 import id.homebase.chat.services.convo.contact.ConnectionCacheRepository
 import id.homebase.chat.services.convo.contact.ConnectionService
 import id.homebase.chat.services.convo.contact.ContactService
@@ -57,6 +60,7 @@ import org.koin.core.module.Module
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.singleOf
 import org.koin.core.module.dsl.viewModelOf
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 val appModule = module {
@@ -106,7 +110,7 @@ val appModule = module {
     }
     singleOf(::BackgroundSyncOrchestrator)
 
-    factoryOf(::PayloadBundleEncryptionService)
+    factoryOf(::PayloadBundleEncryptionService) bind PayloadBundleEncryptor::class
     factoryOf(::OptimisticWriter)
 
     singleOf(::ShareConversationCacheWriter)
@@ -117,11 +121,11 @@ val appModule = module {
     singleOf(::ConnectionService)
     singleOf(::DriveContactService)
     singleOf(::ContactService)
-    singleOf(::ConversationStream)
+    singleOf(::ConversationStream) bind ConversationLoader::class
     singleOf(::ConversationService)
     singleOf(::ChatMessageStream)
     singleOf(::ShareSuggestionDonor)
-    singleOf(::ChatMessageSenderService)
+    singleOf(::ChatMessageSenderService) bind StatusMessageSender::class
     singleOf(::HomebaseImageLoader)
     singleOf(::ChatMessageActionService)
     singleOf(::NotificationService)


### PR DESCRIPTION
Re-applies the changes from #347 that were reverted in #348.

This is the revert-of-the-revert, containing the full content of the group-chat-fixes work as a single commit so it can be reviewed and merged cleanly onto post-revert main.

## Test plan
- [ ] CI green
- [ ] Smoke-test group chat flows