### PR TITLE
fix(chat): stop search-highlight crash on long markdown messages

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -41,9 +41,10 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.Placeable
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLayoutResult
-import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -183,31 +184,28 @@ fun MessageBubbleRaw(
 
     val deletedText = stringResource(MR.string.chat_message_deleted)
     val textState =
-        remember(message.isDeleted, message.content, searchQuery, isCurrentSearchResult) {
+        remember(message.isDeleted, message.content) {
             RichTextState()
                 .applyDefaultStyling(linkColor = if (sentByYou) DarkColors.Primary else LightColors.Primary)
                 .applyMarkDownContent(if (message.isDeleted) deletedText else message.content)
-                .also { state ->
-                    if (searchQuery.isNotEmpty()) {
-                        val plainText = state.annotatedString.text
-                        val lowerQuery = searchQuery.lowercase()
-                        val lowerText = plainText.lowercase()
-                        var startIndex = 0
-                        while (true) {
-                            val idx = lowerText.indexOf(lowerQuery, startIndex)
-                            if (idx == -1) break
-                            val highlightColor = if (isCurrentSearchResult)
-                                Color(0xFFFF8C00).copy(alpha = 0.6f)
-                            else
-                                Color(0xFFFFEB3B).copy(alpha = 0.5f)
-                            state.addSpanStyle(
-                                spanStyle = SpanStyle(background = highlightColor),
-                                TextRange(idx, idx + lowerQuery.length)
-                            )
-                            startIndex = idx + lowerQuery.length
-                        }
-                    }
-                }
+        }
+    // When a search query is active we render a plain AnnotatedString instead of RichText,
+    // so that the string the highlight offsets are computed against is exactly the string
+    // being drawn. RichTextState can reassemble its annotatedString to a different length
+    // at layout time (markdown tokens), which would leave stale SpanStyle ranges and crash
+    // String.subSequence during draw.
+    val highlightedText: AnnotatedString? =
+        remember(message.isDeleted, message.content, searchQuery, isCurrentSearchResult) {
+            if (message.isDeleted) return@remember null
+            val highlightColor = if (isCurrentSearchResult)
+                Color(0xFFFF8C00).copy(alpha = 0.6f)
+            else
+                Color(0xFFFFEB3B).copy(alpha = 0.5f)
+            buildSearchHighlightedText(
+                plain = message.content,
+                searchQuery = searchQuery,
+                highlightColor = highlightColor,
+            )
         }
 
     val shape = remember {
@@ -369,6 +367,13 @@ fun MessageBubbleRaw(
                                         onTextLayout = { textLayoutResult = it },
                                         fontSize = size,
                                         style = MaterialTheme.typography.displaySmall,
+                                        color = contentColor
+                                    )
+                                } else if (highlightedText != null) {
+                                    Text(
+                                        text = highlightedText,
+                                        onTextLayout = { textLayoutResult = it },
+                                        style = MaterialTheme.typography.bodyLarge,
                                         color = contentColor
                                     )
                                 } else {
@@ -609,6 +614,38 @@ fun MessageBubbleRaw(
                     }
                 }
             }
+        }
+    }
+}
+
+/**
+ * Build an [AnnotatedString] that highlights every case-insensitive occurrence of
+ * [searchQuery] inside [plain] with a background [highlightColor]. Returns null when
+ * the query is empty or produces no matches, so the caller can decide whether to skip
+ * the highlight code path entirely.
+ *
+ * Every produced span end is clamped to `plain.length`. This is an invariant the
+ * renderer relies on: a span whose end exceeds the drawn string triggers
+ * `String.subSequence` inside Compose's text layout and crashes the main thread.
+ */
+internal fun buildSearchHighlightedText(
+    plain: String,
+    searchQuery: String,
+    highlightColor: Color,
+): AnnotatedString? {
+    if (searchQuery.isEmpty()) return null
+    val lowerQuery = searchQuery.lowercase()
+    val lowerText = plain.lowercase()
+    if (!lowerText.contains(lowerQuery)) return null
+    return buildAnnotatedString {
+        append(plain)
+        var startIndex = 0
+        while (true) {
+            val idx = lowerText.indexOf(lowerQuery, startIndex)
+            if (idx == -1) break
+            val endIdx = (idx + lowerQuery.length).coerceAtMost(plain.length)
+            addStyle(SpanStyle(background = highlightColor), idx, endIdx)
+            startIndex = endIdx
         }
     }
 }

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/SearchHighlightTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/SearchHighlightTest.kt
@@ -1,0 +1,65 @@
+package id.homebase.chat.widget
+
+import androidx.compose.ui.graphics.Color
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SearchHighlightTest {
+
+    private val color = Color.Yellow
+
+    @Test
+    fun emptyQueryReturnsNull() {
+        assertNull(buildSearchHighlightedText("hello world", "", color))
+    }
+
+    @Test
+    fun noMatchReturnsNull() {
+        assertNull(buildSearchHighlightedText("hello world", "zzz", color))
+    }
+
+    @Test
+    fun caseInsensitiveMatch() {
+        val result = buildSearchHighlightedText("Monday Monday", "mon", color)!!
+        assertEquals("Monday Monday", result.text)
+        val ranges = result.spanStyles
+        assertEquals(2, ranges.size)
+        assertEquals(0, ranges[0].start); assertEquals(3, ranges[0].end)
+        assertEquals(7, ranges[1].start); assertEquals(10, ranges[1].end)
+    }
+
+    @Test
+    fun allRangesFitWithinPlainText_forLongMarkdownMessage() {
+        // The original crash happened at length=4253 with end=4321 — span end
+        // exceeded drawn string length. Build a realistic long markdown body
+        // and assert the invariant that every produced SpanStyle has
+        // end <= text.length and start in [0, end].
+        val body = buildString {
+            append("# Heading\n\n")
+            repeat(40) { append("- list item with `code` and **bold** and _italic_ Mon\n") }
+            repeat(60) { append("This is a long paragraph with Monday somewhere inside.\n") }
+        }
+        val result = buildSearchHighlightedText(body, "Mon", color)!!
+        val plainLen = result.text.length
+        assertTrue(plainLen > 4000, "sanity: body is expected to be large, was $plainLen")
+        for (range in result.spanStyles) {
+            assertTrue(
+                range.end <= plainLen,
+                "end=${range.end} exceeds plainLen=$plainLen"
+            )
+            assertTrue(range.start in 0..range.end)
+        }
+    }
+
+    @Test
+    fun matchAtVeryEndOfString() {
+        // Regression for the exact shape of the crash: a match whose end index
+        // equals plain.length must land exactly at plain.length, never past it.
+        val body = "x".repeat(4250) + "Mon"
+        val result = buildSearchHighlightedText(body, "Mon", color)!!
+        val last = result.spanStyles.last()
+        assertEquals(body.length, last.end)
+    }
+}


### PR DESCRIPTION
Typing a search query in the chat search box would crash the app while drawing any message bubble whose rendered length shrank relative to its markdown source. The main-thread exception was
StringIndexOutOfBoundsException: begin 4223, end 4321, length 4253 raised from String.subSequence inside Compose's TextLayout during dispatchDraw — killing the whole activity.

Root cause: MessageBubbleRaw built a RichTextState via setMarkdown(message.content), then for each search match added a SpanStyle range using offsets read off state.annotatedString.text. The richeditor library rebuilds its annotatedString at layout time; for long markdown messages (lists, code, links, blockquotes) the drawn string is shorter than the one we indexed against, so a span with end
> rendered length trips subSequence at draw time.

Fix: stop mutating the RichTextState for search highlighting. When searchQuery is non-empty, build a plain AnnotatedString from message.content with highlight SpanStyle ranges added via a procedural while-loop, and render it through Text(...) instead of RichText(...). The string used to index matches is the exact string Compose will draw. Markdown styling is sacrificed only while a search is active, which matches the UX expectation for search results.

The highlight builder is extracted into a pure internal function buildSearchHighlightedText(plain, searchQuery, highlightColor) so the index-vs-render invariant is unit-testable. The helper defensively clamps every span end to plain.length.

Regression coverage: homebase-chat/.../widget/SearchHighlightTest asserts empty-query, no-match, case-insensitive multi-match, match at the very end of the string, and — most importantly — that every span produced for a ~4 kB markdown body has end <= text.length, the exact invariant whose violation produced the original crash.