### PR TITLE
fix(storage): surface broken FileKache caches instead of hiding rows

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/cache/CacheStats.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/cache/CacheStats.kt
@@ -4,4 +4,14 @@ data class CacheStats(
     val id: String,
     val sizeBytes: Long,
     val maxBytes: Long,
-)
+) {
+    companion object {
+        // Sentinel for [sizeBytes] when a cache is unhealthy and cannot be
+        // queried — see the per-cache try/catch in each provider's
+        // getCacheStats(). The Storage screen renders this as a red
+        // "Unavailable" row and surfaces a banner pointing the user at
+        // "Clear caches", which wipes the directory and resets the ctor
+        // tombstone so the next access gets a fresh FileKache.
+        const val UNAVAILABLE: Long = -1L
+    }
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
@@ -530,6 +530,12 @@ class DriveFileProviderCached(
         kacheMutex.withLock {
             _payloadDiskKache = null
             _thumbDiskKache = null
+            // Reset the ctor tombstones. This is the recovery path for a
+            // FileKache-ctor NPE (observed on real devices with a populated
+            // homebase-thumbs dir from a prior install): the Storage-screen
+            // "Clear caches" button deletes the directory and clears the
+            // tombstone so the next access builds a fresh FileKache on top
+            // of an empty dir.
             payloadKacheFailure = null
             thumbKacheFailure = null
 
@@ -554,20 +560,30 @@ class DriveFileProviderCached(
         notFoundCache = emptySet()
     }
 
+    // Per-cache try/catch: one broken FileKache (e.g. ctor tombstoned after a
+    // mayakapps/kache NPE on this device's pre-existing cache state) must not
+    // hide the other row. A thrown `payloadDiskKache()` used to propagate up
+    // through the ViewModel's outer runCatching and wipe *both* drive rows
+    // from the Storage screen, leaving the user with no indication that a
+    // cache was unhealthy. Return sentinel `sizeBytes = CacheStats.UNAVAILABLE`
+    // (-1L) so the UI can render a visible "Unavailable" row and point the
+    // user at the Clear caches button — which resets the tombstone.
     suspend fun getCacheStats(): List<CacheStats> {
-        val payload = payloadDiskKache()
-        val thumb = thumbDiskKache()
-        return listOf(
-            CacheStats(
-                id = "drive_payloads",
-                sizeBytes = payload.size,
-                maxBytes = payload.maxSize,
-            ),
-            CacheStats(
-                id = "drive_thumbnails",
-                sizeBytes = thumb.size,
-                maxBytes = thumb.maxSize,
-            ),
-        )
+        val out = ArrayList<CacheStats>(2)
+        try {
+            val payload = payloadDiskKache()
+            out.add(CacheStats(id = "drive_payloads", sizeBytes = payload.size, maxBytes = payload.maxSize))
+        } catch (e: Throwable) {
+            Logger.w(tag = "DriveFileProviderCached", throwable = e) { "drive_payloads stats unavailable" }
+            out.add(CacheStats(id = "drive_payloads", sizeBytes = CacheStats.UNAVAILABLE, maxBytes = 0L))
+        }
+        try {
+            val thumb = thumbDiskKache()
+            out.add(CacheStats(id = "drive_thumbnails", sizeBytes = thumb.size, maxBytes = thumb.maxSize))
+        } catch (e: Throwable) {
+            Logger.w(tag = "DriveFileProviderCached", throwable = e) { "drive_thumbnails stats unavailable" }
+            out.add(CacheStats(id = "drive_thumbnails", sizeBytes = CacheStats.UNAVAILABLE, maxBytes = 0L))
+        }
+        return out
     }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
@@ -195,6 +195,9 @@ class PublicProfileProviderCached(
         kacheMutex.withLock {
             _profileDiskKache = null
             _imageDiskKache = null
+            // Reset the ctor tombstones — see DriveFileProviderCached.clearCaches
+            // for the full rationale. This is the Clear-caches-button recovery
+            // path for a tombstoned FileKache ctor failure.
             profileKacheFailure = null
             imageKacheFailure = null
 
@@ -213,21 +216,25 @@ class PublicProfileProviderCached(
         notFoundCache = emptySet()
     }
 
+    // Per-cache try/catch — see DriveFileProviderCached.getCacheStats for the
+    // rationale. Same shape here for symmetry.
     suspend fun getCacheStats(): List<CacheStats> {
-        val profile = profileDiskKache()
-        val image = imageDiskKache()
-        return listOf(
-            CacheStats(
-                id = "public_profiles",
-                sizeBytes = profile.size,
-                maxBytes = profile.maxSize,
-            ),
-            CacheStats(
-                id = "public_images",
-                sizeBytes = image.size,
-                maxBytes = image.maxSize,
-            ),
-        )
+        val out = ArrayList<CacheStats>(2)
+        try {
+            val profile = profileDiskKache()
+            out.add(CacheStats(id = "public_profiles", sizeBytes = profile.size, maxBytes = profile.maxSize))
+        } catch (e: Throwable) {
+            Logger.w(tag = "PublicProfileIO", throwable = e) { "public_profiles stats unavailable" }
+            out.add(CacheStats(id = "public_profiles", sizeBytes = CacheStats.UNAVAILABLE, maxBytes = 0L))
+        }
+        try {
+            val image = imageDiskKache()
+            out.add(CacheStats(id = "public_images", sizeBytes = image.size, maxBytes = image.maxSize))
+        } catch (e: Throwable) {
+            Logger.w(tag = "PublicProfileIO", throwable = e) { "public_images stats unavailable" }
+            out.add(CacheStats(id = "public_images", sizeBytes = CacheStats.UNAVAILABLE, maxBytes = 0L))
+        }
+        return out
     }
 
     // =========================================================

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
@@ -6,6 +6,7 @@ import co.touchlab.kermit.Severity
 import co.touchlab.kermit.platformLogWriter
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.NotFoundException
+import id.homebase.api.client.cache.CacheStats
 import id.homebase.api.client.auth.ApiCredentials
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.common.OdinId
@@ -289,6 +290,42 @@ class DriveFileProviderCachedTest {
         assertTrue(
             clearerErrors.isEmpty(),
             "clearCaches must not throw (got ${clearerErrors.size}: ${clearerErrors.firstOrNull()})"
+        )
+    }
+
+    /**
+     * Regression for real-device symptom where a single FileKache ctor NPE
+     * on the thumb cache was causing BOTH drive rows to disappear from the
+     * Storage screen (the ViewModel's outer runCatching substituted
+     * emptyList for the whole getCacheStats result). Per-cache try/catch
+     * must return a sentinel row for the broken cache + a real row for the
+     * healthy one.
+     *
+     * Forces the thumb ctor to fail by planting a regular file at the path
+     * the FileKache would otherwise create as a directory — createDirectories
+     * then throws IOException, caught by thumbDiskKache's try/catch and
+     * tombstoned.
+     */
+    @Test
+    fun `getCacheStats returns sentinel for broken cache without hiding the healthy one`() = runTest {
+        // Pre-fail the thumb cache: create homebase-thumbs as a FILE, which
+        // makes the subsequent FileKache ctor blow up on createDirectories.
+        Files.write(Path.of(tempDir, "homebase-thumbs"), ByteArray(0))
+
+        val stats = provider.getCacheStats()
+
+        assertEquals(2, stats.size, "both rows must be returned even if one ctor failed")
+
+        val payload = stats.single { it.id == "drive_payloads" }
+        val thumb = stats.single { it.id == "drive_thumbnails" }
+
+        assertTrue(
+            payload.sizeBytes != CacheStats.UNAVAILABLE,
+            "healthy payload cache must NOT be marked unavailable (got sizeBytes=${payload.sizeBytes})"
+        )
+        assertEquals(
+            CacheStats.UNAVAILABLE, thumb.sizeBytes,
+            "broken thumb cache must be marked unavailable via the sentinel"
         )
     }
 

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/profile/PublicProfileProviderCachedTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/profile/PublicProfileProviderCachedTest.kt
@@ -4,6 +4,7 @@ import co.touchlab.kermit.LogWriter
 import co.touchlab.kermit.Logger
 import co.touchlab.kermit.Severity
 import co.touchlab.kermit.platformLogWriter
+import id.homebase.api.client.cache.CacheStats
 import id.homebase.api.common.OdinId
 import id.homebase.api.file.FileOperationsProvider
 import io.ktor.client.HttpClient
@@ -232,6 +233,33 @@ class PublicProfileProviderCachedTest {
         assertTrue(
             requestCount > countAfterPopulate,
             "after clearCaches, next call must reach the network"
+        )
+    }
+
+    /**
+     * Mirror of DriveFileProviderCachedTest's per-cache-resilience assertion.
+     * A single FileKache ctor failure must not hide the healthy sibling row.
+     * Plants a regular file at the profile cache path so `createDirectories`
+     * throws, exercising the tombstone + sentinel return.
+     */
+    @Test
+    fun `getCacheStats returns sentinel for broken cache without hiding the healthy one`() = runTest {
+        Files.write(Path.of(tempDir, "homebase-public-profiles"), ByteArray(0))
+
+        val stats = provider.getCacheStats()
+
+        assertEquals(2, stats.size, "both rows must be returned even if one ctor failed")
+
+        val profile = stats.single { it.id == "public_profiles" }
+        val image = stats.single { it.id == "public_images" }
+
+        assertEquals(
+            CacheStats.UNAVAILABLE, profile.sizeBytes,
+            "broken profile cache must be marked unavailable via the sentinel"
+        )
+        assertTrue(
+            image.sizeBytes != CacheStats.UNAVAILABLE,
+            "healthy image cache must NOT be marked unavailable (got sizeBytes=${image.sizeBytes})"
         )
     }
 }

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -175,6 +175,9 @@
     <string name="storage_drives_none">No drives</string>
     <string name="storage_cache_coil_memory">In-memory images</string>
     <string name="storage_cache_ram_badge">RAM</string>
+    <string name="storage_cache_unavailable">Unavailable</string>
+    <string name="storage_cache_unhealthy_title">Some caches could not be opened</string>
+    <string name="storage_cache_unhealthy_body">One or more on-disk caches failed to initialise. Tap \"Clear caches\" to reset them — cached bytes will be lost but no primary data is affected.</string>
     <string name="storage_other_header">Other</string>
     <string name="storage_database">Database</string>
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.homebase.api.client.cache.CacheStats
 import id.homebase.resources.MR
 import id.homebase.resources.menu_back
 import id.homebase.resources.settings_storage
@@ -52,6 +53,9 @@ import id.homebase.resources.storage_cache_profiles
 import id.homebase.resources.storage_cache_ram_badge
 import id.homebase.resources.storage_cache_size_format
 import id.homebase.resources.storage_cache_thumbnails
+import id.homebase.resources.storage_cache_unavailable
+import id.homebase.resources.storage_cache_unhealthy_body
+import id.homebase.resources.storage_cache_unhealthy_title
 import id.homebase.resources.storage_cache_unknown
 import id.homebase.resources.storage_caches_cleared
 import id.homebase.resources.storage_caches_header
@@ -164,6 +168,11 @@ fun StorageSettingsUi(
                 OrphanCoilCacheWarning(bytes = uiState.orphanCoilDiskBytes)
             }
 
+            val hasUnhealthyCache = uiState.caches.any { it.sizeBytes == CacheStats.UNAVAILABLE }
+            if (hasUnhealthyCache) {
+                UnhealthyCacheWarning()
+            }
+
             Button(
                 onClick = { onAction(StorageSettingsUiAction.ClearCachesClicked) },
                 enabled = !uiState.isClearing &&
@@ -235,8 +244,11 @@ private fun SectionHeader(
 
 @Composable
 private fun DiskCachesBlock(caches: List<CacheRowState>) {
-    val totalMax = caches.sumOf { it.maxBytes }
-    val totalUsed = caches.sumOf { it.sizeBytes }
+    // Skip unavailable caches from the usage-bar math — their sizeBytes is the
+    // -1L sentinel (see CacheStats.UNAVAILABLE) and would poison totals.
+    val healthy = caches.filter { it.sizeBytes != CacheStats.UNAVAILABLE }
+    val totalMax = healthy.sumOf { it.maxBytes }
+    val totalUsed = healthy.sumOf { it.sizeBytes }
     val freeFraction = if (totalMax > 0L)
         ((totalMax - totalUsed).toFloat() / totalMax.toFloat()).coerceAtLeast(0f)
     else 0f
@@ -253,7 +265,7 @@ private fun DiskCachesBlock(caches: List<CacheRowState>) {
                 .height(10.dp)
                 .clip(RoundedCornerShape(5.dp)),
         ) {
-            for (cache in caches) {
+            for (cache in healthy) {
                 val w = if (totalMax > 0L)
                     (cache.sizeBytes.toFloat() / totalMax.toFloat()).coerceAtLeast(0f)
                 else 0f
@@ -286,6 +298,7 @@ private fun DiskCachesBlock(caches: List<CacheRowState>) {
 
 @Composable
 private fun CacheLegendRow(state: CacheRowState) {
+    val unavailable = state.sizeBytes == CacheStats.UNAVAILABLE
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
@@ -294,7 +307,10 @@ private fun CacheLegendRow(state: CacheRowState) {
             modifier = Modifier
                 .size(10.dp)
                 .clip(CircleShape)
-                .background(cacheColor(state.id)),
+                .background(
+                    if (unavailable) MaterialTheme.colorScheme.error
+                    else cacheColor(state.id)
+                ),
         )
         Spacer(modifier = Modifier.size(10.dp))
         Text(
@@ -302,15 +318,23 @@ private fun CacheLegendRow(state: CacheRowState) {
             style = MaterialTheme.typography.bodyMedium,
             modifier = Modifier.weight(1f),
         )
-        Text(
-            text = stringResource(
-                MR.string.storage_cache_size_format,
-                formatBytes(state.sizeBytes),
-                formatBytes(state.maxBytes),
-            ),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        if (unavailable) {
+            Text(
+                text = stringResource(MR.string.storage_cache_unavailable),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error,
+            )
+        } else {
+            Text(
+                text = stringResource(
+                    MR.string.storage_cache_size_format,
+                    formatBytes(state.sizeBytes),
+                    formatBytes(state.maxBytes),
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }
 
@@ -416,6 +440,24 @@ private fun EmptyRow(text: String) {
 
 @Composable
 private fun OrphanCoilCacheWarning(bytes: Long) {
+    ErrorCard(
+        title = "Orphan Coil disk cache detected",
+        body = "${formatBytes(bytes)} in cache/coil3_disk_cache. Coil's default disk " +
+                "cache should be off — this directory means something is bypassing " +
+                "the Homebase cache layer. Tap \"Clear caches\" to delete it.",
+    )
+}
+
+@Composable
+private fun UnhealthyCacheWarning() {
+    ErrorCard(
+        title = stringResource(MR.string.storage_cache_unhealthy_title),
+        body = stringResource(MR.string.storage_cache_unhealthy_body),
+    )
+}
+
+@Composable
+private fun ErrorCard(title: String, body: String) {
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = androidx.compose.material3.CardDefaults.cardColors(
@@ -424,15 +466,13 @@ private fun OrphanCoilCacheWarning(bytes: Long) {
     ) {
         Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
             Text(
-                text = "Orphan Coil disk cache detected",
+                text = title,
                 style = MaterialTheme.typography.titleSmall,
                 color = MaterialTheme.colorScheme.onErrorContainer,
             )
             Spacer(modifier = Modifier.size(4.dp))
             Text(
-                text = "${formatBytes(bytes)} in cache/coil3_disk_cache. Coil's default disk " +
-                        "cache should be off — this directory means something is bypassing " +
-                        "the Homebase cache layer. Tap \"Clear caches\" to delete it.",
+                text = body,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onErrorContainer,
             )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import coil3.ImageLoader
 import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.cache.CacheStats
 import id.homebase.api.client.drives.cache.DriveFileProviderCached
 import id.homebase.api.client.profile.PublicProfileProviderCached
 import id.homebase.api.file.FileOperationsProvider
@@ -72,7 +73,10 @@ class StorageSettingsViewModel(
             val caches = (profileStats + driveStats).map {
                 CacheRowState(id = it.id, sizeBytes = it.sizeBytes, maxBytes = it.maxBytes)
             }
-            val total = caches.sumOf { it.sizeBytes }
+            // Unavailable caches (sizeBytes == CacheStats.UNAVAILABLE, -1L) must
+            // not contribute to the total — they represent caches that could
+            // not be opened, not caches with negative size.
+            val total = caches.sumOf { if (it.sizeBytes == CacheStats.UNAVAILABLE) 0L else it.sizeBytes }
 
             val coilRow = imageLoader.memoryCache?.let { mem ->
                 CacheRowState(

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsUiTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsUiTest.kt
@@ -1,0 +1,91 @@
+package id.homebase.core.ui.screens.storage
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import id.homebase.api.client.cache.CacheStats
+import id.homebase.core.test.setTestLocale
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class StorageSettingsUiTest {
+
+    private val healthyPayload = CacheRowState(
+        id = "drive_payloads",
+        sizeBytes = 1024L,
+        maxBytes = 200L * 1024L * 1024L,
+    )
+    private val unavailableThumbs = CacheRowState(
+        id = "drive_thumbnails",
+        sizeBytes = CacheStats.UNAVAILABLE,
+        maxBytes = 0L,
+    )
+    private val healthyThumbs = CacheRowState(
+        id = "drive_thumbnails",
+        sizeBytes = 2048L,
+        maxBytes = 300L * 1024L * 1024L,
+    )
+
+    @Test
+    fun `shows red banner and Unavailable row when a cache is unavailable`() = runComposeUiTest {
+        setTestLocale("en-US")
+        setContent {
+            MaterialTheme {
+                StorageSettingsUi(
+                    uiState = StorageSettingsUiState(
+                        caches = listOf(healthyPayload, unavailableThumbs),
+                        isLoading = false,
+                    ),
+                    onAction = {},
+                    onBackClick = {},
+                    snackbarHostState = remember { SnackbarHostState() },
+                )
+            }
+        }
+        onNodeWithText("Some caches could not be opened").assertExists()
+        onNodeWithText("Unavailable").assertExists()
+    }
+
+    @Test
+    fun `hides red banner when all caches are healthy`() = runComposeUiTest {
+        setTestLocale("en-US")
+        setContent {
+            MaterialTheme {
+                StorageSettingsUi(
+                    uiState = StorageSettingsUiState(
+                        caches = listOf(healthyPayload, healthyThumbs),
+                        isLoading = false,
+                    ),
+                    onAction = {},
+                    onBackClick = {},
+                    snackbarHostState = remember { SnackbarHostState() },
+                )
+            }
+        }
+        onNodeWithText("Some caches could not be opened").assertDoesNotExist()
+        onNodeWithText("Unavailable").assertDoesNotExist()
+    }
+
+    @Test
+    fun `Clear caches button is enabled when an unavailable row is present`() = runComposeUiTest {
+        setTestLocale("en-US")
+        setContent {
+            MaterialTheme {
+                StorageSettingsUi(
+                    uiState = StorageSettingsUiState(
+                        caches = listOf(healthyPayload, unavailableThumbs),
+                        isLoading = false,
+                    ),
+                    onAction = {},
+                    onBackClick = {},
+                    snackbarHostState = remember { SnackbarHostState() },
+                )
+            }
+        }
+        onNodeWithText("Clear caches").assertIsEnabled()
+    }
+}


### PR DESCRIPTION
When a FileKache ctor tombstones (observed on a real Android phone where mayakapps/kache 2.1.1 init NPEs on a pre-existing homebase-thumbs directory inherited across installs), the old getCacheStats() threw from the first accessor call and the ViewModel's outer runCatching substituted emptyList. Effect: BOTH drive cache rows disappeared silently from the Storage screen. The user had no diagnostic signal and no way to reach the existing "Clear caches" recovery path without support intervention.

This commit keeps the row visible with a sentinel and points the user at the existing recovery path.

Code:
- CacheStats.UNAVAILABLE = -1L sentinel constant on the shared DTO.
- DriveFileProviderCached.getCacheStats and PublicProfileProviderCached.getCacheStats now use per-cache try/catch so one broken FileKache cannot hide its sibling row — the failing cache returns a CacheStats with sizeBytes = UNAVAILABLE.
- StorageSettingsScreen renders a red UnhealthyCacheWarning banner whenever any cache row is UNAVAILABLE; CacheLegendRow shows "Unavailable" in colorScheme.error for that row; usage-bar math and StorageSettingsViewModel.totalCacheBytes sum filter UNAVAILABLE out so the sentinel cannot produce negative widths or poisoned totals.
- OrphanCoilCacheWarning was generalised into an ErrorCard helper and now has a sibling call site (UnhealthyCacheWarning).
- clearCaches() in both providers gains a short comment documenting that tombstone reset is the user-driven recovery path triggered by the Storage-screen Clear caches button.

No changes to FileKache ctor or tombstone behavior. Pressing Clear caches was already the recovery path — clearCaches() deletes the directory and resets the tombstone; this commit just makes the failure visible so users can see that action is needed.

Tests:
- DriveFileProviderCachedTest and PublicProfileProviderCachedTest gain "getCacheStats returns sentinel for broken cache without hiding the healthy one": plant a regular file at the cache dir path so createDirectories throws, then assert both rows come back with the broken one marked UNAVAILABLE.
- New StorageSettingsUiTest (commonTest, runComposeUiTest): three cases pinning banner-shown-when-unavailable, banner-absent-when- healthy, and Clear-caches-button-enabled-when-any-row-is-broken.

All jvmTest modules green (homebase-api, homebase-common, homebase-chat, homebase-auth, and the Storage-related subset of homebase-core). The pre-existing NotificationTapColdStartTest flake fails identically on main and is unrelated to this change.