### PR TITLE
follow-up #350: harden MessageSearchItem + unicode string audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,22 @@ writing or modifying any screen/composable, verify:
 - UiState should be a flat `data class` with `_uiState.update { }` pattern
 - One-time events (navigation, snackbar) should use separate `SharedFlow`, not stored in UiState
 
+## Strings & Unicode
+
+User-entered text (messages, descriptions, names, link previews) can contain emoji and other
+non-BMP characters that Kotlin `String` stores as UTF-16 surrogate pairs. Chopping such a
+string with `take(n)`, `substring(0, n)`, `dropLast`, `subSequence`, etc. can split a
+surrogate pair in half and produce a lone surrogate that breaks rendering and downstream
+serialization.
+
+- To truncate user content to a length budget, use `String.truncateToCodePoints(n)` from
+  `id.homebase.api.util.StringExtensions` — it advances past surrogate pairs.
+- For avatar initials from a display name, use `String.initials()` from
+  `id.homebase.core.util.StringExtensions` — it splits on whitespace and returns
+  first-of-first + first-of-last uppercased. Do not write `name.take(2).uppercase()`.
+- `take`/`substring` remain correct for known-ASCII content: URLs, hex/base64, UUIDs,
+  device tokens, byte arrays.
+
 ## Adding New Top-Level Features (Add-on Apps)
 
 When adding a self-contained feature that surfaces as an icon in the bottom navigation bar

--- a/androidApp/src/main/kotlin/id/homebase/feed/share/SharePickerScreen.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/SharePickerScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.api.client.auth.OwnerSessionRepository
+import id.homebase.api.util.truncateToCodePoints
 import id.homebase.resources.MR
 import id.homebase.resources.share_picker_next
 import id.homebase.resources.share_picker_send
@@ -408,7 +409,7 @@ private fun SharedContentPreview(
     Column(modifier = modifier) {
         if (sharedContent.hasText) {
             Text(
-                text = sharedContent.text!!.take(200),
+                text = sharedContent.text!!.truncateToCodePoints(200),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 3,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsViewModel.kt
@@ -19,6 +19,7 @@ import id.homebase.chat.services.convo.contact.ContactConnectionState
 import id.homebase.chat.services.convo.contact.ContactService
 import id.homebase.core.ui.navigation.Route
 import id.homebase.core.util.buildConnectToIdentityUrl
+import id.homebase.core.util.initials
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -231,7 +232,7 @@ class GroupSettingsViewModel(
                             id = Uuid.random(),
                             odinId = odinId,
                             name = odinId.domainName,
-                            avatarInitials = odinId.domainName.take(2).uppercase(),
+                            avatarInitials = odinId.domainName.initials(),
                             connectionState = ContactConnectionState.NotConnected
                         )
                     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/LinkPreviewPayloadBuilder.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/LinkPreviewPayloadBuilder.kt
@@ -6,6 +6,7 @@ import id.homebase.api.client.link.LinkPreview
 import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.image.createThumbnails
 import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.util.truncateToCodePoints
 import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.PayloadBundle
 import kotlin.io.encoding.Base64
@@ -83,7 +84,7 @@ object LinkPreviewPayloadBuilder {
             imageWidth = if (hasImage) linkPreview.imageWidth else null,
             imageHeight = if (hasImage) linkPreview.imageHeight else null,
             description = if (maxDescLen != null) {
-                linkPreview.description.take(maxDescLen)
+                linkPreview.description.truncateToCodePoints(maxDescLen)
             } else {
                 linkPreview.description
             },

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -115,6 +115,7 @@ import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.ContactAvatar
 import id.homebase.core.avatars.ConversationAvatar
 import id.homebase.core.util.dismissKeyboardOnTap
+import id.homebase.core.util.initials
 import id.homebase.core.util.isDesktop
 import id.homebase.core.util.isWeb
 import id.homebase.core.util.keyboardAsState
@@ -1333,7 +1334,7 @@ private fun ConnectIdentityRow(
         ContactAvatar(
             odinId = odinId,
             profileImageData = null,
-            initials = resolvedName.take(2).uppercase(),
+            initials = resolvedName.initials(),
             options = AvatarOptions(size = 36.dp, fontSize = 14.sp),
             sharedTransitionScope = null,
             animatedVisibilityScope = null,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageSearchItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageSearchItem.kt
@@ -26,6 +26,7 @@ import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.ContactAvatar
 import id.homebase.core.avatars.FallbackAvatar
 import id.homebase.core.util.applyDefaultStyling
+import id.homebase.core.util.applyMarkDownContent
 import id.homebase.core.util.formatTimestamp
 import id.homebase.core.util.initials
 import kotlin.time.Instant
@@ -41,7 +42,7 @@ fun MessageSearchItem(
 ) {
     // See ConversationItem.kt ConversationMessagePreview for why remember is required here
     val textState = remember(message) {
-        RichTextState().applyDefaultStyling().also { it.setMarkdown(message) }
+        RichTextState().applyDefaultStyling().applyMarkDownContent(message)
     }
     Row(
         modifier = Modifier

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ReplyPreviewBar.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ReplyPreviewBar.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import id.homebase.api.client.KeyHeader
+import id.homebase.api.util.truncateToCodePoints
 import id.homebase.chat.data.MessageUiModel
 import id.homebase.chat.services.ChatProtocol
 import id.homebase.core.config.chatTargetDrive
@@ -95,7 +96,7 @@ fun ReplyPreviewBar(message: MessageUiModel, onDismiss: () -> Unit, modifier: Mo
         hasMultiplePayloads = hasMultiplePayloads,
     )
 
-    val previewText = contentLabel?.text ?: message.content.take(80)
+    val previewText = contentLabel?.text ?: message.content.truncateToCodePoints(80)
 
     Surface(
         modifier = modifier.fillMaxWidth(),

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/MessageSearchItemTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/MessageSearchItemTest.kt
@@ -1,0 +1,54 @@
+package id.homebase.chat.widget
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.time.Instant
+
+@OptIn(ExperimentalTestApi::class)
+class MessageSearchItemTest {
+
+    @Test
+    fun rendersSimpleMarkdownMessage() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                MessageSearchItem(
+                    memberName = "Alice",
+                    message = "Hello **world**",
+                    contactOdinId = null,
+                    timestamp = Instant.fromEpochMilliseconds(0),
+                    onClick = {},
+                    onContactClick = {},
+                )
+            }
+        }
+        onNodeWithText("Alice").assertExists()
+    }
+
+    // Regression: the search-results row used to call setMarkdown() directly,
+    // which throws StringIndexOutOfBoundsException inside the markdown parser
+    // for certain inputs (see RichTextRenderingTest for the exact input). The
+    // fix routes the call through applyMarkDownContent(), which catches the
+    // parser blow-up and falls back to plain text. This test composes the
+    // widget with that same known-problematic input and asserts composition
+    // does not throw.
+    @Test
+    fun rendersWithoutCrashing_forParserBreakingMarkdown() = runComposeUiTest {
+        val problematic = "gg\n\n  gg"
+        setContent {
+            MaterialTheme {
+                MessageSearchItem(
+                    memberName = "Bob",
+                    message = problematic,
+                    contactOdinId = null,
+                    timestamp = Instant.fromEpochMilliseconds(0),
+                    onClick = {},
+                    onContactClick = {},
+                )
+            }
+        }
+        onNodeWithText("Bob").assertExists()
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/EmojiSummary.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/EmojiSummary.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
+import id.homebase.core.util.initials
 
 
 @Composable
@@ -141,7 +142,7 @@ fun EmojiSummary(
                             contentAlignment = Alignment.Center
                         ) {
                             Text(
-                                text = user.user.take(2).uppercase(),
+                                text = user.user.initials(),
                                 color = Color.White,
                                 fontSize = 12.sp
                             )

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/InAppNotificationBanner.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/InAppNotificationBanner.kt
@@ -25,6 +25,7 @@ import id.homebase.api.common.OdinId
 import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.PublicAvatar
 import id.homebase.core.notifications.RichNotificationData
+import id.homebase.core.util.initials
 
 /**
  * Signal-style in-app notification banner displayed at the top of the screen.
@@ -61,7 +62,7 @@ fun InAppNotificationBanner(
                     // Sender avatar (circular, loaded via URL)
                     PublicAvatar(
                         odinId = OdinId(notification.senderId),
-                        initials = notification.senderName.take(2),
+                        initials = notification.senderName.initials(),
                         options = AvatarOptions(size = 40.dp),
                     )
 


### PR DESCRIPTION
Follow-up to PR #350 (fix-search-highlight-crash). That PR fixed the StringIndexOutOfBoundsException in MessageBubbleRaw when the user searched for "Mon" inside long markdown messages. The same underlying bug class (non-BMP chars in user content interacting with index-based string operations) turned out to have two more fallout sites that are addressed here.

1. MessageSearchItem second crash fix homebase-chat/.../widget/MessageSearchItem.kt calls setMarkdown on arbitrary user-entered content. For pathological input the markdown parser throws inside org.intellij.markdown.ASTUtil — this reproduced when a "Mon" search result surfaced the same ~4 kB message from #350 in the left-pane results list. Fixed by routing through applyMarkDownContent (already used elsewhere), which catches the parser blow-up and falls back to setText.

   Added commonTest regression test MessageSearchItemTest with a parser-breaking markdown input; verified it fails on the pre-fix code (StringIndexOutOfBoundsException at composition) and passes on the fix.

2. Unicode-safe string chopping audit Scanned the repo for .take/.substring/.drop/etc. and replaced seven unsafe call sites on user-entered text:

   - SharePickerScreen.kt, LinkPreviewPayloadBuilder.kt, ReplyPreviewBar.kt — .take(N) on message/description/shared text swapped for truncateToCodePoints(N) (already the helper-of-record, used by ConversationStream, ConversationUiModel, ConversationListViewModel, ChatMessageSizer).
   - InAppNotificationBanner.kt, ConversationContent.kt, EmojiSummary.kt, GroupSettingsViewModel.kt — .take(2).uppercase() for avatar initials swapped for the existing String.initials() extension, which splits on whitespace and uppercases.

   Bucket C call sites (hex, base64, UUIDs, URLs, device tokens,
   byte-array prefix checks, list-of-object .take) were explicitly
   classified as safe and left alone.

3. CLAUDE.md note Added a short "Strings & Unicode" section after "UI & Design Quality" documenting the two helpers and when to reach for each, so future work doesn't reintroduce the pattern.

Verified:
- ./gradlew :homebase-chat:compileKotlinJvm :homebase-common:compileKotlinJvm :androidApp:compileDebugKotlin — all clean.
- ./gradlew homebase-chat:jvmTest homebase-common:jvmTest homebase-api:jvmTest — all green.
- Reverting the MessageSearchItem one-liner makes the new regression test fail with the exact exception class it guards.