### PR TITLE
fix: wipe identity-scoped DB state on logout to prevent stale sync cursor

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
@@ -33,7 +33,8 @@ class DriveSync(
     private val driveQueryProvider: DriveQueryProvider, // TODO: <- can we get rid of this?
     private val databaseManager: DatabaseManager,
     private val eventBus: EventBus,
-    scope: CoroutineScope? = null
+    scope: CoroutineScope? = null,
+    expectFreshCursor: Boolean = false,
 ) {
     // Background work is Network and DB bound, so using IO
     private val scope = scope ?: CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -47,21 +48,18 @@ class DriveSync(
     //TODO: Consider having a (readable) "last modified" which holds the largest timestamp of last-modified
 
     init {
-        // Load cursor from database
         val cursorStorage = CursorStorage(databaseManager, driveId)
-        cursor = cursorStorage.loadCursor()
+        cursor = cursorStorage.loadCursor(expectFresh = expectFreshCursor)
     }
 
 
-    // Wipe all synced data on logout — nothing should survive for security
+    // Wipe drive-scoped synced data on logout. Identity-scoped tables (KeyValue, Outbox,
+    // AppNotifications, ConnectionCache) are wiped once at the DriveSyncManager level.
     suspend fun clearStorage() {
         databaseManager.driveMainIndex.deleteAll()
         databaseManager.driveTagIndex.deleteAll()
         databaseManager.driveLocalTagIndex.deleteAll()
         databaseManager.chatReadCount.deleteAll()
-        databaseManager.keyValue.deleteByKey(driveId)
-        val cursorStorage = CursorStorage(databaseManager, driveId)
-        cursorStorage.deleteCursor()
         cursor = null
     }
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
@@ -7,7 +7,7 @@ import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.sync.database.DatabaseManager
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -36,6 +36,10 @@ class DriveSyncManager(
     private var driveSyncs: Map<Uuid, DriveSync> = emptyMap()
     private val driveSyncsMutex = Mutex()
     @kotlin.concurrent.Volatile private var isRunning = false
+
+    // Set by clearStorage(), consumed by the next start(). Lets a freshly constructed
+    // DriveSync detect and loudly complain if a cursor survived logout.
+    @kotlin.concurrent.Volatile private var expectFreshCursors = false
 
     private val _driveStatuses = MutableStateFlow<Map<Uuid, DriveStatus>>(emptyMap())
     val driveStatuses: StateFlow<Map<Uuid, DriveStatus>> = _driveStatuses.asStateFlow()
@@ -117,6 +121,9 @@ class DriveSyncManager(
         val credentials = credentialsManager.requireActiveCredentials()
         val identityId = credentials.getIdentityId()
 
+        val freshLogin = expectFreshCursors
+        expectFreshCursors = false
+
         drives.forEach { (driveId, label) ->
             val alreadyExists = driveSyncsMutex.withLock { driveSyncs.containsKey(driveId) }
             if (alreadyExists) {
@@ -131,7 +138,8 @@ class DriveSyncManager(
                     driveQueryProvider = driveQueryProvider,
                     databaseManager = databaseManager,
                     eventBus = eventBus,
-                    scope = scope
+                    scope = scope,
+                    expectFreshCursor = freshLogin,
                 )
             }.onSuccess { sync ->
                 driveSyncsMutex.withLock { driveSyncs = driveSyncs + (driveId to sync) }
@@ -195,16 +203,35 @@ class DriveSyncManager(
         _driveStatuses.update { emptyMap() }
     }
 
-    fun clearStorage(): Job {
-        val snapshot = driveSyncs.values.toList()
-        return scope.launch {
+    // Suspend so the caller (YouAuthFlowManager.logout) cannot race the next start():
+    // returning a Job would let login fire before the table wipes and the
+    // expectFreshCursors flag land.
+    suspend fun clearStorage() {
+        val snapshot = driveSyncsMutex.withLock { driveSyncs.values.toList() }
+
+        coroutineScope {
             snapshot
-                .map { sync ->
-                    launch {
-                        sync.clearStorage()
-                    }
-                }
+                .map { sync -> launch { sync.clearStorage() } }
                 .joinAll()
         }
+
+        // Wipe identity-scoped tables once, after every per-drive clear has finished.
+        // Anything stored here is tied to the logged-out identity and must not leak
+        // into the next session.
+        //  - KeyValue       (sync cursors — the reason this method exists)
+        //  - Outbox         (pending uploads bound to drives we just wiped)
+        //  - AppNotifications
+        //  - ConnectionCache
+        try {
+            databaseManager.keyValue.deleteAll()
+            databaseManager.outbox.deleteAll()
+            databaseManager.appNotifications.deleteAllRows()
+            databaseManager.connectionCache.deleteAllRows()
+        } catch (e: Exception) {
+            Logger.e("DriveSyncManager.clearStorage: failed to wipe identity-scoped tables: ${e.message}", e)
+        }
+
+        // Signal the next start() that any cursor it finds is a bug.
+        expectFreshCursors = true
     }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/AppNotificationsWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/AppNotificationsWrapper.kt
@@ -106,4 +106,8 @@ class AppNotificationsWrapper(
             delegate.deleteByNotificationId(identityId, notificationId).value
         }
     }
+
+    suspend fun deleteAllRows(): Long {
+        return databaseManager.withWriteValue { db -> delegate.deleteAllRows().value }
+    }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/ConnectionCacheWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/ConnectionCacheWrapper.kt
@@ -52,4 +52,10 @@ class ConnectionCacheWrapper(
             delegate.deleteAllByIdentity(identityId)
         }
     }
+
+    suspend fun deleteAllRows() {
+        databaseManager.withWrite {
+            delegate.deleteAllRows()
+        }
+    }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/CursorStorage.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/CursorStorage.kt
@@ -1,5 +1,6 @@
 package id.homebase.api.sync.database
 
+import co.touchlab.kermit.Logger
 import id.homebase.api.client.drives.query.QueryBatchCursor
 import kotlin.uuid.Uuid
 
@@ -17,11 +18,27 @@ class CursorStorage(
     // should be calculated on init() here
 
     /**
-     * Load QueryBatchCursor for the predefined cursor Guid
-     * Returns null if no cursor is found in the database
+     * Load QueryBatchCursor for the predefined cursor Guid.
+     * Returns null if no cursor is found in the database.
+     *
+     * @param expectFresh set by callers who know this is the first load after logout.
+     *   If a cursor is found anyway, log an error (logout should have wiped it) and
+     *   discard it so the next sync starts from scratch instead of silently resuming
+     *   from a stale position. The underlying row is not deleted here; the next
+     *   saveCursor() will overwrite it, or DriveSyncManager.clearStorage() already
+     *   wipes the whole KeyValue table.
      */
-    fun loadCursor(): QueryBatchCursor? {
-        return databaseManager.keyValue.selectByKey(driveId)?.let { QueryBatchCursor.fromJson(it.data_.decodeToString()) }
+    fun loadCursor(expectFresh: Boolean = false): QueryBatchCursor? {
+        val cursor = databaseManager.keyValue.selectByKey(driveId)?.let {
+            QueryBatchCursor.fromJson(it.data_.decodeToString())
+        }
+        if (expectFresh && cursor != null) {
+            Logger.e(
+                "Stale cursor survived logout for drive=$driveId cursor=${cursor.toJson().take(200)} — discarding"
+            )
+            return null
+        }
+        return cursor
     }
     
     /**

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/KeyValueWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/KeyValueWrapper.kt
@@ -42,4 +42,8 @@ class KeyValueWrapper(
     ): Boolean {
         return databaseManager.withWriteValue { delegate.deleteByKey(key).value > 0 }
     }
+
+    suspend fun deleteAll(): Long {
+        return databaseManager.withWriteValue { delegate.deleteAll().value }
+    }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxWrapper.kt
@@ -105,4 +105,8 @@ class OutboxWrapper(
             delegate.deleteBy(driveId, uniqueId).value
         }
     }
+
+    suspend fun deleteAll(): Long {
+        return databaseManager.withWriteValue { delegate.deleteAll().value }
+    }
 }

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/AppNotifications.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/AppNotifications.sq
@@ -49,3 +49,7 @@ WHERE identityId = ?;
 deleteByNotificationId:
 DELETE FROM AppNotifications
 WHERE identityId = ? AND notificationId = ?;
+
+-- Wipe the entire table (used on logout).
+deleteAllRows:
+DELETE FROM AppNotifications;

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ConnectionCache.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ConnectionCache.sq
@@ -37,3 +37,7 @@ WHERE identityId = ? AND status = ?;
 deleteAllByIdentity:
 DELETE FROM ConnectionCache
 WHERE identityId = ?;
+
+-- Wipe the entire table (used on logout).
+deleteAllRows:
+DELETE FROM ConnectionCache;

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/KeyValue.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/KeyValue.sq
@@ -22,3 +22,7 @@ WHERE key = ?;
 deleteByKey:
 DELETE FROM KeyValue
 WHERE key = ?;
+
+-- Wipe the entire table (used on logout).
+deleteAll:
+DELETE FROM KeyValue;

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/Outbox.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/Outbox.sq
@@ -98,3 +98,7 @@ WHERE checkOutStamp = ?;
 -- Get count
 count:
 SELECT count(*) FROM Outbox;
+
+-- Wipe the entire table (used on logout).
+deleteAll:
+DELETE FROM Outbox;

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/CursorSyncTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/CursorSyncTest.kt
@@ -125,6 +125,63 @@ class CursorSyncTest {
     }
 
     @Test
+    fun testLoadCursor_expectFreshButCursorExists_returnsNull() = runTest {
+        DatabaseManager { createInMemoryDatabase() }.use { dbm ->
+            val cursorStorage = CursorStorage(dbm, Uuid.random())
+            cursorStorage.saveCursor(
+                QueryBatchCursor(
+                    paging = TimeRowCursor(UnixTimeUtc(1704067200000L), 12345L),
+                    stop = null,
+                    next = null,
+                )
+            )
+
+            // Sanity: cursor is there under a normal load.
+            assertNotNull(cursorStorage.loadCursor(), "precondition: cursor saved")
+
+            // Fresh-login load must discard it rather than silently resume.
+            assertNull(
+                cursorStorage.loadCursor(expectFresh = true),
+                "stale cursor must not be returned on fresh login",
+            )
+        }
+    }
+
+    @Test
+    fun testLoadCursor_expectFreshAndNoCursor_returnsNullWithoutLogging() = runTest {
+        DatabaseManager { createInMemoryDatabase() }.use { dbm ->
+            val cursorStorage = CursorStorage(dbm, Uuid.random())
+            // No cursor saved — expectFresh=true is the normal, quiet path.
+            assertNull(cursorStorage.loadCursor(expectFresh = true))
+        }
+    }
+
+    @Test
+    fun testKeyValueDeleteAll_wipesEveryCursor() = runTest {
+        DatabaseManager { createInMemoryDatabase() }.use { dbm ->
+            // Two different drives each holding a cursor, mirroring what the app has at
+            // logout time (chat + contact + feed drives each write their own KV row).
+            val cursor = QueryBatchCursor(
+                paging = TimeRowCursor(UnixTimeUtc(1704067200000L), 1L),
+                stop = null,
+                next = null,
+            )
+            val storageA = CursorStorage(dbm, Uuid.random())
+            val storageB = CursorStorage(dbm, Uuid.random())
+            storageA.saveCursor(cursor)
+            storageB.saveCursor(cursor)
+            assertNotNull(storageA.loadCursor(), "precondition: cursor A saved")
+            assertNotNull(storageB.loadCursor(), "precondition: cursor B saved")
+
+            // This is what DriveSyncManager.clearStorage() calls on logout.
+            dbm.keyValue.deleteAll()
+
+            assertNull(storageA.loadCursor(), "cursor A must be gone after deleteAll")
+            assertNull(storageB.loadCursor(), "cursor B must be gone after deleteAll")
+        }
+    }
+
+    @Test
     fun testDeleteCursor() = runTest {
         DatabaseManager { createInMemoryDatabase() }.use { dbm -> // Create a QueryBatchCursor with all fields populated
             // Create and save a cursor


### PR DESCRIPTION
Symptom
=======
On Desktop, after logout + re-login, the chat drive's initial sync stopped
after ~741 records (two QueryBatch pages of 500 + 241) even though ~30k
records existed on the server. Every subsequent sync only pulled 1-7
record pushes, and the DB topped out around 4.3k rows.

Root cause
==========
DriveSync.clearStorage() only deleted a single KeyValue row per drive
(keyValue.deleteByKey(driveId)). If a KeyValue row ever survived logout
- for instance from a crash, or from a prior clearStorage() that missed
one - it was picked back up on the next login in DriveSync.init{} via
CursorStorage.loadCursor(). The server then replied hasMoreRows=false on
the second page because the stale cursor's `stop` boundary was already
past the data, and the loop exited at DriveSync.kt:188.

Fix
===
- DriveSync.clearStorage() is now narrowed to drive-scoped tables only.
- DriveSyncManager.clearStorage() wipes every identity-scoped table in
  one shot after the per-drive fan-out:
    * KeyValue         (the actual cursor bug)
    * Outbox           (pending uploads bound to the wiped drives)
    * AppNotifications (would otherwise render for the new identity)
    * ConnectionCache  (same risk)
  It is now `suspend fun` rather than returning a Job, so callers cannot
  race the next start(). YouAuthFlowManager.logout() is already suspend
  so the call site is unchanged.
- New SQLDelight statements + wrapper methods:
    * KeyValue.deleteAll
    * Outbox.deleteAll
    * AppNotifications.deleteAllRows
    * ConnectionCache.deleteAllRows
  Existing identity-scoped variants are kept because other code paths
  use them.
- CursorStorage.loadCursor(expectFresh = false) gains a parameter: when
  set by the post-logout path it logs `Logger.e("Stale cursor survived
  logout ...")` and returns null, self-healing the symptom if the wipe
  above ever misses something. DriveSyncManager plumbs the flag via a
  @Volatile expectFreshCursors member that is set at the end of
  clearStorage() and consumed (and reset) at the top of the next start().

Pagination termination (hasMoreRows) is deliberately left unchanged -
hasMoreRows is the authoritative signal and the adaptive batchSize
(50..1000) means short pages are the normal steady state.

Outbox note
===========
outbox.deleteAll() on logout discards any pending uploads/messages
queued under the outgoing identity. Defaulting to "wipe" is the safer
choice for a security-sensitive app; revisit separately if offline
queueing across logout is desired.

Tests
=====
CursorSyncTest gains three cases covering the new behaviour:
- loadCursor(expectFresh=true) with a pre-seeded row returns null.
- loadCursor(expectFresh=true) with no row is the quiet happy path.
- keyValue.deleteAll() wipes cursors for every drive in one call.

./gradlew homebase-api:jvmTest green; downstream modules compile.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>