### PR TITLE
First code pass for supporting Desktop notifications

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ composeMultiplatform = "1.10.3"
 composeHotReload = "1.1.0-rc01"
 composenativetray = "1.2.0"
 composenativewebview = "1.0.0-beta-01"
+nucleus = "1.14.1"
 conveyor = "2.0"
 ffmpegKit = "1.0"
 vlcj = "4.8.2"
@@ -171,6 +172,10 @@ kache-file = { module = "com.mayakapps.kache:file-kache", version.ref = "kache" 
 kache = { module = "com.mayakapps.kache:kache", version.ref = "kache" }
 composenativetray = { module = "io.github.kdroidfilter:composenativetray", version.ref = "composenativetray" }
 composenativewebview = { module = "io.github.kdroidfilter:composewebview", version.ref = "composenativewebview" }
+nucleus-notification-common = { module = "io.github.kdroidfilter:nucleus.notification-common", version.ref = "nucleus" }
+nucleus-notification-windows = { module = "io.github.kdroidfilter:nucleus.notification-windows", version.ref = "nucleus" }
+nucleus-notification-macos = { module = "io.github.kdroidfilter:nucleus.notification-macos", version.ref = "nucleus" }
+nucleus-notification-linux = { module = "io.github.kdroidfilter:nucleus.notification-linux", version.ref = "nucleus" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/homebase-common/build.gradle.kts
+++ b/homebase-common/build.gradle.kts
@@ -121,6 +121,10 @@ kotlin {
         jvmMain.dependencies {
             implementation(libs.ktor.client.cio)
             implementation(libs.kotlinx.io.core.jvm)
+            implementation(libs.nucleus.notification.common)
+            implementation(libs.nucleus.notification.windows)
+            implementation(libs.nucleus.notification.macos)
+            implementation(libs.nucleus.notification.linux)
         }
     }
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationClickRouter.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationClickRouter.kt
@@ -1,0 +1,19 @@
+package id.homebase.core.notifications
+
+import com.mmk.kmpnotifier.notification.PayloadData
+
+/**
+ * Bridge used by platform notification backends (e.g. Nucleus on JVM) to deliver
+ * click events back into [NotificationService] without requiring direct DI.
+ *
+ * [NotificationService] sets [handler] during init; platform displayers invoke
+ * [onClick] on notification activation.
+ */
+object NotificationClickRouter {
+    @Volatile
+    var handler: ((PayloadData) -> Unit)? = null
+
+    fun onClick(data: PayloadData) {
+        handler?.invoke(data)
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationClickRouter.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationClickRouter.kt
@@ -1,6 +1,7 @@
 package id.homebase.core.notifications
 
 import com.mmk.kmpnotifier.notification.PayloadData
+import kotlin.concurrent.Volatile
 
 /**
  * Bridge used by platform notification backends (e.g. Nucleus on JVM) to deliver

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
@@ -317,14 +317,18 @@ class NotificationService(
                 if (isAppInForeground) {
                     // Show in-app banner instead of system notification
                     _inAppNotificationEvents.tryEmit(richData)
-                } else if (Platform.osName == "Android") {
-                    // Android: display rich notification from app code (no service extension)
-                    if (shouldAlert) lastAlertMark = TimeSource.Monotonic.markNow()
-                    showRichNotification(richData)
-                    BadgeManager.increment()
-                } else {
+                } else if (Platform.osName.contains("iOS", ignoreCase = true) ||
+                    Platform.osName.contains("iPadOS", ignoreCase = true)
+                ) {
                     // iOS: Notification Service Extension handles background display;
                     // posting here would create a duplicate notification.
+                    BadgeManager.increment()
+                } else {
+                    // Android + Desktop (Windows/macOS/Linux): display rich notification
+                    // from app code. On desktop this routes through Nucleus via
+                    // RichNotificationDisplayer.
+                    if (shouldAlert) lastAlertMark = TimeSource.Monotonic.markNow()
+                    showRichNotification(richData)
                     BadgeManager.increment()
                 }
             } catch (e: Exception) {

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
@@ -94,6 +94,8 @@ class NotificationService(
                 if (id != null) conversationMessageCounts.remove(id.toString())
             }
         }
+        // Route clicks from platform backends (Nucleus on JVM) back to this service.
+        NotificationClickRouter.handler = { data -> handleNotificationClicked(data) }
     }
 
     /** Clears the accumulated message count for a conversation (e.g. on mark-as-read). */

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/notifications/NucleusNotificationAdapter.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/notifications/NucleusNotificationAdapter.kt
@@ -6,9 +6,14 @@ import id.homebase.api.file.JvmFileSystemUtil
 import io.github.kdroidfilter.nucleus.notification.common.NotificationManager
 import io.github.kdroidfilter.nucleus.notification.common.NotificationResult
 import io.github.kdroidfilter.nucleus.notification.common.notification
+import io.github.kdroidfilter.nucleus.notification.windows.ShortcutPolicy
+import io.github.kdroidfilter.nucleus.notification.windows.WindowsNotificationCenter
 import java.io.File
 import java.security.MessageDigest
 import java.util.concurrent.ConcurrentHashMap
+
+private const val DESKTOP_AUMID = "id.homebase.chat.desktop"
+private const val DESKTOP_APP_NAME = "Homebase Chat"
 
 /**
  * JVM-only adapter that wraps the Nucleus cross-platform notification API
@@ -84,6 +89,7 @@ internal class NucleusNotificationAdapter private constructor() {
          * can fall back to KMPNotifier.
          */
         fun createOrNull(): NucleusNotificationAdapter? = try {
+            initializeWindowsIfApplicable()
             NotificationManager.initialize()
             if (!NotificationManager.isAvailable()) {
                 Logger.i(tag = "NucleusNotificationAdapter") {
@@ -98,6 +104,41 @@ internal class NucleusNotificationAdapter private constructor() {
                 "Nucleus initialisation failed: ${e.message}"
             }
             null
+        }
+
+        /**
+         * Windows toasts require an installed app whose AUMID is bound to a Start Menu
+         * shortcut. Unpackaged Java apps (e.g. dev-mode `./gradlew desktopApp:run`) have
+         * no such shortcut, so Nucleus's default policy (`REQUIRE_NO_CREATE` in dev
+         * mode) lets `send()` succeed while WinRT silently drops the toast.
+         *
+         * We force [ShortcutPolicy.REQUIRE_CREATE] with an explicit AUMID so a Start
+         * Menu shortcut is created once on first run; subsequent runs reuse it and
+         * toasts render.
+         *
+         * Harmless no-op on macOS/Linux — [WindowsNotificationCenter.isAvailable]
+         * returns false when the native bridge hasn't loaded.
+         */
+        private fun initializeWindowsIfApplicable() {
+            val osName = System.getProperty("os.name")?.lowercase().orEmpty()
+            if (!osName.contains("windows")) return
+            try {
+                if (!WindowsNotificationCenter.isAvailable) {
+                    Logger.w(tag = "NucleusNotificationAdapter") {
+                        "Windows native bridge not available — skipping explicit AUMID init"
+                    }
+                    return
+                }
+                WindowsNotificationCenter.initialize(
+                    aumid = DESKTOP_AUMID,
+                    appName = DESKTOP_APP_NAME,
+                    shortcutPolicy = ShortcutPolicy.REQUIRE_CREATE,
+                )
+            } catch (e: Throwable) {
+                Logger.w(tag = "NucleusNotificationAdapter") {
+                    "WindowsNotificationCenter.initialize threw: ${e.message}"
+                }
+            }
         }
     }
 }

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/notifications/NucleusNotificationAdapter.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/notifications/NucleusNotificationAdapter.kt
@@ -1,0 +1,103 @@
+package id.homebase.core.notifications
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.browser.DesktopAppFocusManager
+import id.homebase.api.file.JvmFileSystemUtil
+import io.github.kdroidfilter.nucleus.notification.common.NotificationManager
+import io.github.kdroidfilter.nucleus.notification.common.NotificationResult
+import io.github.kdroidfilter.nucleus.notification.common.notification
+import java.io.File
+import java.security.MessageDigest
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * JVM-only adapter that wraps the Nucleus cross-platform notification API
+ * (Windows toast / macOS user notification / Linux libnotify).
+ *
+ * Avatar bytes passed in [RichNotificationData.senderImageBytes] are written
+ * once per sender-hash to a temp file under the app data directory; Nucleus
+ * requires a filesystem path, not in-memory bytes.
+ */
+internal class NucleusNotificationAdapter private constructor() {
+
+    private val avatarCache = ConcurrentHashMap<String, String>()
+    private val cacheDir: File = File(JvmFileSystemUtil.getAppDataDirectory(), "notification-cache").apply {
+        if (!exists()) mkdirs()
+    }
+
+    fun show(data: RichNotificationData) {
+        try {
+            val largeImage = data.senderImageBytes?.let(::cachedAvatarPath)
+            val result = notification(
+                title = data.title,
+                message = data.body,
+                largeImage = largeImage,
+                onActivated = {
+                    DesktopAppFocusManager.requestFocus()
+                    NotificationClickRouter.onClick(data.payloadData)
+                },
+                onFailed = {
+                    Logger.w(tag = "NucleusNotificationAdapter") {
+                        "Nucleus reported delivery failure for notification '${data.title}'"
+                    }
+                },
+            ).send()
+            if (result is NotificationResult.Failure) {
+                Logger.w(tag = "NucleusNotificationAdapter") {
+                    "Send failed: ${result.reason}"
+                }
+            }
+        } catch (e: Exception) {
+            Logger.e(tag = "NucleusNotificationAdapter") {
+                "Failed to show notification: ${e.message}"
+            }
+        }
+    }
+
+    private fun cachedAvatarPath(bytes: ByteArray): String? {
+        return try {
+            val digest = MessageDigest.getInstance("SHA-1").digest(bytes)
+            val key = digest.joinToString("") { "%02x".format(it) }
+            avatarCache[key]?.let { existing ->
+                if (File(existing).exists()) return existing
+            }
+            val file = File(cacheDir, "$key.png")
+            if (!file.exists()) {
+                file.writeBytes(bytes)
+            }
+            val path = file.absolutePath
+            avatarCache[key] = path
+            path
+        } catch (e: Exception) {
+            Logger.w(tag = "NucleusNotificationAdapter") {
+                "Failed to cache avatar: ${e.message}"
+            }
+            null
+        }
+    }
+
+    companion object {
+        /**
+         * Attempts to construct the adapter and eagerly initialise Nucleus.
+         * Returns null if the platform has no notification backend available
+         * (e.g. a headless Linux box with no notification daemon) so callers
+         * can fall back to KMPNotifier.
+         */
+        fun createOrNull(): NucleusNotificationAdapter? = try {
+            NotificationManager.initialize()
+            if (!NotificationManager.isAvailable()) {
+                Logger.i(tag = "NucleusNotificationAdapter") {
+                    "Nucleus reports no platform dispatcher available — falling back"
+                }
+                null
+            } else {
+                NucleusNotificationAdapter()
+            }
+        } catch (e: Exception) {
+            Logger.w(tag = "NucleusNotificationAdapter") {
+                "Nucleus initialisation failed: ${e.message}"
+            }
+            null
+        }
+    }
+}

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/notifications/NucleusNotificationAdapter.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/notifications/NucleusNotificationAdapter.kt
@@ -6,14 +6,9 @@ import id.homebase.api.file.JvmFileSystemUtil
 import io.github.kdroidfilter.nucleus.notification.common.NotificationManager
 import io.github.kdroidfilter.nucleus.notification.common.NotificationResult
 import io.github.kdroidfilter.nucleus.notification.common.notification
-import io.github.kdroidfilter.nucleus.notification.windows.ShortcutPolicy
-import io.github.kdroidfilter.nucleus.notification.windows.WindowsNotificationCenter
 import java.io.File
 import java.security.MessageDigest
 import java.util.concurrent.ConcurrentHashMap
-
-private const val DESKTOP_AUMID = "id.homebase.chat.desktop"
-private const val DESKTOP_APP_NAME = "Homebase Chat"
 
 /**
  * JVM-only adapter that wraps the Nucleus cross-platform notification API
@@ -89,7 +84,6 @@ internal class NucleusNotificationAdapter private constructor() {
          * can fall back to KMPNotifier.
          */
         fun createOrNull(): NucleusNotificationAdapter? = try {
-            initializeWindowsIfApplicable()
             NotificationManager.initialize()
             if (!NotificationManager.isAvailable()) {
                 Logger.i(tag = "NucleusNotificationAdapter") {
@@ -104,41 +98,6 @@ internal class NucleusNotificationAdapter private constructor() {
                 "Nucleus initialisation failed: ${e.message}"
             }
             null
-        }
-
-        /**
-         * Windows toasts require an installed app whose AUMID is bound to a Start Menu
-         * shortcut. Unpackaged Java apps (e.g. dev-mode `./gradlew desktopApp:run`) have
-         * no such shortcut, so Nucleus's default policy (`REQUIRE_NO_CREATE` in dev
-         * mode) lets `send()` succeed while WinRT silently drops the toast.
-         *
-         * We force [ShortcutPolicy.REQUIRE_CREATE] with an explicit AUMID so a Start
-         * Menu shortcut is created once on first run; subsequent runs reuse it and
-         * toasts render.
-         *
-         * Harmless no-op on macOS/Linux — [WindowsNotificationCenter.isAvailable]
-         * returns false when the native bridge hasn't loaded.
-         */
-        private fun initializeWindowsIfApplicable() {
-            val osName = System.getProperty("os.name")?.lowercase().orEmpty()
-            if (!osName.contains("windows")) return
-            try {
-                if (!WindowsNotificationCenter.isAvailable) {
-                    Logger.w(tag = "NucleusNotificationAdapter") {
-                        "Windows native bridge not available — skipping explicit AUMID init"
-                    }
-                    return
-                }
-                WindowsNotificationCenter.initialize(
-                    aumid = DESKTOP_AUMID,
-                    appName = DESKTOP_APP_NAME,
-                    shortcutPolicy = ShortcutPolicy.REQUIRE_CREATE,
-                )
-            } catch (e: Throwable) {
-                Logger.w(tag = "NucleusNotificationAdapter") {
-                    "WindowsNotificationCenter.initialize threw: ${e.message}"
-                }
-            }
         }
     }
 }

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/notifications/RichNotificationDisplayer.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/notifications/RichNotificationDisplayer.jvm.kt
@@ -1,21 +1,29 @@
 package id.homebase.core.notifications
 
 import com.mmk.kmpnotifier.notification.NotifierManager
-import kotlin.random.Random
 
 /**
- * Desktop fallback — delegates to KMPNotifier's LocalNotifier.
- * Desktop platforms (macOS/Windows/Linux) don't support rich notification styles.
+ * Desktop displayer — prefers the Nucleus cross-platform notification backend
+ * (Windows toast / macOS user notification / Linux libnotify). Falls back to
+ * KMPNotifier's LocalNotifier if Nucleus is unavailable on this platform
+ * (e.g. headless Linux with no notification daemon).
  */
 actual class RichNotificationDisplayer actual constructor() {
 
+    private val nucleus: NucleusNotificationAdapter? = NucleusNotificationAdapter.createOrNull()
+
     actual fun show(data: RichNotificationData) {
+        val adapter = nucleus
+        if (adapter != null) {
+            adapter.show(data)
+            return
+        }
         val notifier = NotifierManager.getLocalNotifier()
         notifier.notify(
             id = data.notificationId,
             title = data.title,
             body = data.body,
-            payloadData = data.payloadData
+            payloadData = data.payloadData,
         )
     }
 }

--- a/homebase-core/src/jvmMain/kotlin/id/homebase/core/di/AppModule.desktop.kt
+++ b/homebase-core/src/jvmMain/kotlin/id/homebase/core/di/AppModule.desktop.kt
@@ -19,6 +19,7 @@ import id.homebase.core.gallery.PlatformGalleryManager
 import id.homebase.core.image.HomebaseImageFetcher
 import id.homebase.core.image.HomebaseImageKeyer
 import id.homebase.core.image.PublicImageFetcher
+import id.homebase.core.notifications.DesktopChatNotificationBridge
 import id.homebase.core.settings.createSettings
 import id.homebase.core.share.ShareCacheStorage
 import id.homebase.core.util.JvmPlatformInfo
@@ -36,6 +37,14 @@ actual fun platformModule(): Module = module {
     single<AudioPlayer> { JvmAudioPlayer() }
     single<AudioWaveFormGenerator> { JvmWaveFormGenerator() }
     single<DatabaseSizeProbe> { JvmDatabaseSizeProbe() }
+    single(createdAtStart = true) {
+        DesktopChatNotificationBridge(
+            eventBus = get(),
+            notificationService = get(),
+            credentialsManager = get(),
+            scope = get(),
+        ).also { it.start() }
+    }
     single(createdAtStart = true) {
         // Note: No disk cache - DriveFileProviderCached handles encrypted disk caching
         // Coil's memory cache is still enabled by default for fast UI redraws

--- a/homebase-core/src/jvmMain/kotlin/id/homebase/core/notifications/DesktopChatNotificationBridge.kt
+++ b/homebase-core/src/jvmMain/kotlin/id/homebase/core/notifications/DesktopChatNotificationBridge.kt
@@ -1,0 +1,131 @@
+package id.homebase.core.notifications
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.eventbus.BackendEvent
+import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.util.truncateToCodePoints
+import id.homebase.chat.services.ChatMessageStream
+import id.homebase.chat.services.ChatProtocol
+import id.homebase.core.config.AppConfig
+import id.homebase.core.config.chatTargetDrive
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.launch
+import kotlin.time.Clock
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+private const val BODY_PREVIEW_MAX_CODEPOINTS = 200
+
+/**
+ * JVM-only bridge that turns inbound chat messages (delivered via the websocket /
+ * sync event bus) into local OS notifications. Android and iOS receive push
+ * notifications from FCM/APNs and go through [NotificationService.onFcmMessageReceived]
+ * — desktop has no push channel, so this bridge fabricates the same payload shape
+ * from live messages so the rest of the notification pipeline (foreground suppression,
+ * in-app banner, per-conversation count summary, chime cooldown, click navigation)
+ * is shared across all platforms.
+ */
+class DesktopChatNotificationBridge(
+    private val eventBus: EventBus,
+    private val notificationService: NotificationService,
+    private val credentialsManager: CredentialsManager,
+    private val scope: CoroutineScope,
+) {
+    private val chatAppIdDashed: String = Uuid.parse(AppConfig.APP_ID).toString()
+    private val chatDriveId: Uuid = chatTargetDrive.alias
+
+    @Volatile
+    private var started: Boolean = false
+
+    /** Messages with `created` before this instant are treated as replay and skipped. */
+    @Volatile
+    private var freshnessFloor: Instant = Instant.DISTANT_PAST
+
+    fun start() {
+        if (started) return
+        started = true
+        freshnessFloor = Clock.System.now()
+        Logger.i(tag = "DesktopChatNotificationBridge") {
+            "Started (freshnessFloor=$freshnessFloor)"
+        }
+        scope.launch {
+            eventBus.events
+                .filterIsInstance<BackendEvent.DriveEvent.BatchReceived>()
+                .filter { it.driveId == chatDriveId }
+                .collect { event -> handleBatch(event) }
+        }
+    }
+
+    private suspend fun handleBatch(event: BackendEvent.DriveEvent.BatchReceived) {
+        val domain = try {
+            credentialsManager.requireActiveDomain()
+        } catch (e: Exception) {
+            Logger.d(tag = "DesktopChatNotificationBridge") {
+                "No active domain, skipping batch: ${e.message}"
+            }
+            return
+        }
+
+        val floor = freshnessFloor
+        for (file in event.batchData) {
+            if (file.fileMetadata.appData.fileType != ChatProtocol.MessageFileType) continue
+            val message = try {
+                ChatMessageStream.mapToMessageData(file, credentialsManager)
+            } catch (e: Exception) {
+                Logger.w(tag = "DesktopChatNotificationBridge") {
+                    "Failed to map message: ${e.message}"
+                }
+                null
+            } ?: continue
+
+            if (message.isDeleted || message.isStatusMessage || message.isPendingSend) continue
+            if (message.isAuthoredBy(domain)) continue
+            if (message.created < floor) continue
+
+            val senderId = message.originalAuthor?.domainName ?: continue
+            val payload = buildSyntheticPayload(
+                senderId = senderId,
+                conversationId = message.conversationId,
+                createdEpochMs = message.created.toEpochMilliseconds(),
+                body = message.content,
+            )
+            val json = try {
+                OdinSystemSerializer.serialize(payload)
+            } catch (e: Exception) {
+                Logger.w(tag = "DesktopChatNotificationBridge") {
+                    "Serialization failed: ${e.message}"
+                }
+                continue
+            }
+            notificationService.onFcmMessageReceived(
+                title = null,
+                body = null,
+                data = mapOf("data" to json),
+            )
+        }
+    }
+
+    private fun buildSyntheticPayload(
+        senderId: String,
+        conversationId: Uuid,
+        createdEpochMs: Long,
+        body: String,
+    ): PushNotification {
+        val preview = body.truncateToCodePoints(BODY_PREVIEW_MAX_CODEPOINTS)
+        return PushNotification(
+            senderId = senderId,
+            created = createdEpochMs,
+            options = PushNotificationPayloadOptions(
+                appId = chatAppIdDashed,
+                typeId = conversationId.toString(),
+                unEncryptedMessage = preview,
+                silent = false,
+            ),
+            appDisplayName = AppConfig.APP_NAME,
+        )
+    }
+}


### PR DESCRIPTION
  Desktop OS-level notifications (Windows / macOS / Linux)

  Adds native desktop toast / user-notification support for inbound chat messages, leveraging the https://github.com/kdroidFilter/Nucleus
  (io.github.kdroidfilter:nucleus.notification-*:1.14.1). When a new chat message arrives via the websocket and the app window is unfocused, the OS now
  raises a native notification (Windows toast / macOS User Notification / Linux libnotify). Clicking the notification brings the window to front and
  navigates to the conversation.

  What changed

  New components (JVM-only, in homebase-common + homebase-core)

  - NucleusNotificationAdapter (homebase-common/jvmMain) — wraps Nucleus's cross-platform NotificationManager + notification { … } DSL. Handles
  sender-avatar filesystem caching (Nucleus requires a path, not in-memory bytes). Degrades to null if no platform dispatcher is available (e.g. headless
  Linux with no notification daemon), so the displayer falls back to the existing KMPNotifier LocalNotifier.
  - DesktopChatNotificationBridge (homebase-core/jvmMain) — subscribes to EventBus for BackendEvent.DriveEvent.BatchReceived on the chat drive, decodes each
   new message via ChatMessageStream.mapToMessageData, filters out self-authored / deleted / status / pending / historical messages, and synthesises a
  PushNotification JSON payload passed into NotificationService.onFcmMessageReceived. This reuses the full existing pipeline (foreground suppression, in-app
   banner, per-conversation count summary, 15-minute chime cooldown) rather than building a parallel one.
  - NotificationClickRouter (homebase-common/commonMain) — tiny singleton that bridges Nucleus click callbacks back into
  NotificationService.handleNotificationClicked without requiring DI in the displayer. Uses @Volatile from kotlin.concurrent for K/N compatibility.

  Modifications

  - RichNotificationDisplayer.jvm.kt — prefers Nucleus when available; falls back to KMPNotifier's LocalNotifier otherwise.
  - NotificationService.handleIncomingPayload — the display branch previously treated Android as special (else if (Platform.osName == "Android")) and
  dropped desktop backgrounded messages into the iOS-only badge-only path. Invert the condition: iOS is now the explicit special-case (it has a Notification
   Service Extension handling background display), and Android + Desktop share the showRichNotification path.
  - AppModule.desktop.kt — registers DesktopChatNotificationBridge as single(createdAtStart = true) so it starts listening at app launch.
  - gradle/libs.versions.toml + homebase-common/build.gradle.kts — adds Nucleus common + Windows + macOS + Linux artifacts to jvmMain.dependencies.

  Per-platform behaviour

  ┌───────────────────────────────────────────────┬────────────────────────────────┬────────────────────────────────┬──────────────────┐
  │                   Platform                    │ In-app banner (window focused) │  OS toast (window unfocused)   │ Click → navigate │
  ├───────────────────────────────────────────────┼────────────────────────────────┼────────────────────────────────┼──────────────────┤
  │ Android                                       │ ✅ (existing)                  │ ✅ (existing)                  │ ✅ (existing)    │
  ├───────────────────────────────────────────────┼────────────────────────────────┼────────────────────────────────┼──────────────────┤
  │ iOS                                           │ ✅ (existing)                  │ ✅ (via NSE, existing)         │ ✅ (existing)    │
  ├───────────────────────────────────────────────┼────────────────────────────────┼────────────────────────────────┼──────────────────┤
  │ macOS (dev + installed)                       │ ✅                             │ ✅ Nucleus → User Notification │ ✅               │
  ├───────────────────────────────────────────────┼────────────────────────────────┼────────────────────────────────┼──────────────────┤
  │ Linux (dev + installed, daemon running)       │ ✅                             │ ✅ Nucleus → libnotify         │ ✅               │
  ├───────────────────────────────────────────────┼────────────────────────────────┼────────────────────────────────┼──────────────────┤
  │ Windows (Conveyor-installed)                  │ ✅                             │ ✅ Nucleus → WinRT toast       │ ✅               │
  ├───────────────────────────────────────────────┼────────────────────────────────┼────────────────────────────────┼──────────────────┤
  │ Windows (dev-mode / ./gradlew desktopApp:run) │ ✅                             │ ⚠️ See limitations below       │ n/a              │
  └───────────────────────────────────────────────┴────────────────────────────────┴────────────────────────────────┴──────────────────┘

  Known limitations

  Windows dev-mode toasts don't display. WinRT requires a Start Menu shortcut bound to the process's AUMID before it will render toast popups.
  Conveyor-installed builds have this; unpackaged JVM processes launched via Gradle / Android Studio don't.

  We briefly tried forcing Nucleus's ShortcutPolicy.REQUIRE_CREATE to auto-create the shortcut in dev mode. That worked for toasts but had a bad
  side-effect: Nucleus's SetCurrentProcessExplicitAppUserModelID call rebinds the taskbar icon to the created shortcut's icon, which in dev mode points at
  java.exe / the JetBrains bootstrap loader and shows their icon instead of the Homebase icon. Reverting restored the icon at the cost of dev-mode Windows
  toasts.

  Workaround for dev-mode Windows testing: build and install a Conveyor build (./gradlew desktopApp:packageDistributionForCurrentOS or similar) once; its
  proper Start Menu shortcut makes toasts render.

  Follow-ups (not in this PR)

  - Conveyor AUMID alignment. When testing Conveyor-installed builds on Windows, confirm Nucleus resolves the same AUMID as Conveyor's rdns-name
  (id.homebase.feed.dev / id.homebase.feed). If it doesn't, either install the Nucleus Gradle plugin with the correct nucleus-app.properties, or set
  System.setProperty("nucleus.app.aumid", "<rdns-name>") in Main.kt before lazy init.
  - macOS permission dialog UX. First-run Nucleus sends on macOS will surface the system Notification permission prompt (bundled .app required — bare JVM
  launches silently fail the prompt). No code change needed.
  - Linux notification daemon requirement. Desktops without a daemon (minimal i3/sway etc.) will see NotificationManager.isAvailable() == false and fall
  through to KMPNotifier (essentially a no-op on Linux). Worth a line in release notes.

  Test plan

  - JVM / Android compiles: ./gradlew :homebase-common:compileKotlinJvm :homebase-common:compileAndroidMain
  - iOS compiles: ./gradlew :homebase-common:compileKotlinIosArm64 (fixed the @Volatile → kotlin.concurrent.Volatile import for K/N)
  - Desktop app runs and shows correct Homebase icon in Windows taskbar
  - Windows Action Center log confirms bridge fires (FCM message received → Display path: rich notification → showRichNotification)
  - macOS dev build — toast appears, click routes to conversation
  - Linux dev build with GNOME/KDE daemon — toast appears
  - Conveyor-installed Windows build — toast appears in Action Center + as popup

  ---
  Note for your machine: delete %APPDATA%\Microsoft\Windows\Start Menu\Programs\Homebase Chat.lnk (if still there from the REQUIRE_CREATE experiment) before
   pulling and relaunching — otherwise Windows keeps resolving the old AUMID to the stale shortcut and the icon won't look right.

  Also — the revert commit (22da2fb7) is committed locally but not yet pushed. Let me know when to git push origin desktop-notifications.
