### PR TITLE
fix: make logout DB wipe uncancellable; reorder auth-state flip

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
@@ -7,6 +7,7 @@ import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.sync.database.DatabaseManager
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -20,6 +21,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlin.uuid.Uuid
 
 class DriveSyncManager(
@@ -203,10 +205,12 @@ class DriveSyncManager(
         _driveStatuses.update { emptyMap() }
     }
 
-    // Suspend so the caller (YouAuthFlowManager.logout) cannot race the next start():
-    // returning a Job would let login fire before the table wipes and the
-    // expectFreshCursors flag land.
-    suspend fun clearStorage() {
+    // Runs under NonCancellable because the typical caller is
+    // YouAuthFlowManager.logout() on SettingsViewModel.viewModelScope, and that scope is
+    // cancelled as soon as the auth-state flip to Unauthenticated tears the settings
+    // screen down. Without this, the wipe would be interrupted mid-flight and leave the
+    // KeyValue / Outbox / AppNotifications / ConnectionCache tables stale across logins.
+    suspend fun clearStorage() = withContext(NonCancellable) {
         val snapshot = driveSyncsMutex.withLock { driveSyncs.values.toList() }
 
         coroutineScope {
@@ -222,14 +226,10 @@ class DriveSyncManager(
         //  - Outbox         (pending uploads bound to drives we just wiped)
         //  - AppNotifications
         //  - ConnectionCache
-        try {
-            databaseManager.keyValue.deleteAll()
-            databaseManager.outbox.deleteAll()
-            databaseManager.appNotifications.deleteAllRows()
-            databaseManager.connectionCache.deleteAllRows()
-        } catch (e: Exception) {
-            Logger.e("DriveSyncManager.clearStorage: failed to wipe identity-scoped tables: ${e.message}", e)
-        }
+        databaseManager.keyValue.deleteAll()
+        databaseManager.outbox.deleteAll()
+        databaseManager.appNotifications.deleteAllRows()
+        databaseManager.connectionCache.deleteAllRows()
 
         // Signal the next start() that any cursor it finds is a bug.
         expectFreshCursors = true

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthFlowManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthFlowManager.kt
@@ -328,6 +328,7 @@ class YouAuthFlowManager(
 
     /** Logout and clear credentials. */
     suspend fun logout() {
+        // Notify the backend first — this needs valid credentials.
         try {
             val credentials = CredentialStorage.getCredentials()
             if (credentials != null) {
@@ -338,15 +339,20 @@ class YouAuthFlowManager(
             Logger.e(throwable = e, tag = TAG) { "Error during logout" }
         }
 
-        CredentialStorage.clearCredentials()
-        ShareAuthBridge.clearAuth()
-        _authState.value = YouAuthState.Unauthenticated
-        Logger.i(tag = TAG) { "User logged out" }
-
+        // Wipe all identity-scoped state BEFORE flipping _authState to Unauthenticated.
+        // Emitting Unauthenticated tears down the authenticated nav graph (and with it
+        // SettingsViewModel.viewModelScope, which is the coroutine currently running
+        // this logout). If we emit first, driveSyncManager.clearStorage() — and any
+        // other cache clears — get cancelled mid-flight, leaving stale DB rows behind.
         credentialsManager.removeActiveCredentials()
         driveSyncManager.clearStorage()
         driveFileProviderCached.clearCaches()
         publicProfileProviderCached.clearCaches()
+        CredentialStorage.clearCredentials()
+        ShareAuthBridge.clearAuth()
+
+        _authState.value = YouAuthState.Unauthenticated
+        Logger.i(tag = TAG) { "User logged out" }
     }
 
     /** Check if authentication is in progress. */

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncManagerTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncManagerTest.kt
@@ -13,10 +13,13 @@ import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpStatusCode
 import id.homebase.api.client.eventbus.BackendEvent
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -284,6 +287,69 @@ class DriveSyncManagerTest {
 
             assertTrue(emittedEvents.any { it is BackendEvent.SyncAllStopped && it.result is BackendEvent.SyncAllResult.Failure })
             job.cancel()
+        }
+        db.close()
+    }
+
+    @Test
+    fun clearStorageCompletesEvenWhenCallerScopeIsCancelled() {
+        val db = DatabaseManager { createInMemoryDatabase() }
+        runTest {
+            val manager = buildManager(db, buildCredentials(), EventBus(), backgroundScope)
+
+            // Seed each identity-scoped table so we can detect whether the wipe completed.
+            val identityId = Uuid.random()
+            db.keyValue.upsertValue(Uuid.random(), byteArrayOf(1, 2, 3))
+            db.outbox.insert(
+                driveId = Uuid.random(),
+                uniqueId = Uuid.random(),
+                dependencyUniqueId = null,
+                priority = 0,
+                uploadType = 0,
+                json = byteArrayOf(0),
+                filePaths = null,
+            )
+            db.appNotifications.insertNotification(
+                identityId = identityId,
+                notificationId = Uuid.random(),
+                unread = 1,
+                senderId = null,
+                timestamp = 0,
+                data = null,
+                created = 0,
+                modified = 0,
+            )
+            db.connectionCache.upsert(
+                identityId = identityId,
+                odinId = "frodo.shire.example",
+                status = "connected",
+                lastRefresh = 0,
+            )
+
+            // Sanity: every seed row is present before logout.
+            assertEquals(1L, db.outbox.count())
+            assertTrue(db.appNotifications.selectFirstPage(identityId, 10).isNotEmpty())
+            assertTrue(db.connectionCache.selectByIdentity(identityId).isNotEmpty())
+
+            // Simulate a caller (viewModelScope) that is cancelled while logout is running.
+            // Without withContext(NonCancellable), clearStorage() would throw and leave
+            // some of the identity-scoped tables populated.
+            val callerJob = Job()
+            val callerScope = CoroutineScope(callerJob)
+            val job = callerScope.launch { manager.clearStorage() }
+            callerJob.cancel()
+            advanceUntilIdle()
+            job.join()
+
+            assertEquals(0L, db.outbox.count(), "Outbox should be wiped even if caller cancelled")
+            assertTrue(
+                db.appNotifications.selectFirstPage(identityId, 10).isEmpty(),
+                "AppNotifications should be wiped even if caller cancelled"
+            )
+            assertTrue(
+                db.connectionCache.selectByIdentity(identityId).isEmpty(),
+                "ConnectionCache should be wiped even if caller cancelled"
+            )
         }
         db.close()
     }


### PR DESCRIPTION
Follow-up to #356. PR #356 introduced broad logout wiping (KeyValue, Outbox, AppNotifications, ConnectionCache) and a stale-cursor self-heal, but fresh desktop logs showed the wipe itself was getting cancelled mid-flight:

  Error: DriveSyncManager.clearStorage: failed to wipe identity-scoped
  tables: Job was cancelled
  kotlinx.coroutines.JobCancellationException: Job was cancelled

Root cause: SettingsViewModel.handleLogout() runs logout on viewModelScope. YouAuthFlowManager.logout() was flipping _authState to Unauthenticated *before* calling driveSyncManager.clearStorage() — and the auth-state flip immediately tore down the settings screen's nav graph, cancelling the very viewModelScope the wipe was running on. The catch(e: Exception) in clearStorage() then swallowed the CancellationException (CancellationException extends Exception in kotlinx.coroutines), logged it, and still set expectFreshCursors = true — leaving some tables populated while claiming a clean slate to the next login. Downstream symptom: UNIQUE-constraint violations on DriveMainIndex during the next sync.

Fix, two parts:

1. DriveSyncManager.clearStorage() now wraps its body in withContext(NonCancellable). The wipe must complete regardless of caller scope lifetime; NonCancellable is the idiomatic coroutine solution. The broad try/catch is removed — inside NonCancellable we cannot see CancellationException, and any real DB failure (disk full, corruption) should surface loudly rather than be silently suppressed while expectFreshCursors is set to true.

2. YouAuthFlowManager.logout() reorders steps so the DB wipe and cache clears run *before* _authState.value = Unauthenticated. Backend provider.logout() still runs first because it needs valid credentials. This is defense-in-depth on top of (1).

Regression test added in DriveSyncManagerTest: seeds each identity-scoped table, launches clearStorage() on a CoroutineScope(Job()), cancels the scope, asserts every table is empty after join(). Without the NonCancellable wrap this test fails.

Verified: homebase-api:jvmTest green (11/11 including new test); homebase-core / homebase-chat / homebase-common / homebase-auth compileKotlinJvm all green.

Refs #356.