### PR TITLE
feat: VACUUM DB on logout and add blocking "erasing data" overlay

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
@@ -231,6 +231,11 @@ class DriveSyncManager(
         databaseManager.appNotifications.deleteAllRows()
         databaseManager.connectionCache.deleteAllRows()
 
+        // Reclaim the disk space from the large DELETEs above. Logout is rare and
+        // already a "please wait" moment — paying the VACUUM cost here keeps login and
+        // normal operation fast.
+        databaseManager.vacuum()
+
         // Signal the next start() that any cursor it finds is a bug.
         expectFreshCursors = true
     }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
@@ -184,6 +184,13 @@ class DatabaseManager(driverProvider: () -> SqlDriver) : AutoCloseable {
         block(database)
     }
 
+    // VACUUM rewrites the entire DB file, reclaiming space freed by large DELETEs
+    // (e.g. the logout wipe). Must run outside a transaction and with exclusive access
+    // to the DB, so we run it on dbDispatcher like every other write path.
+    suspend fun vacuum() = withContext(dbDispatcher) {
+        driver.execute(identifier = null, sql = "VACUUM", parameters = 0)
+    }
+
     override fun close() {
         driver.close()
         logger.i { "Database closed" }

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -166,6 +166,7 @@
     <string name="settings_help">Help</string>
     <string name="settings_storage">Storage</string>
     <string name="settings_logout">Log out</string>
+    <string name="settings_logout_in_progress">Erasing all your encrypted data</string>
     <string name="settings_delete_account">Delete my account</string>
 
     <!-- Storage screen -->

--- a/homebase-core/build.gradle.kts
+++ b/homebase-core/build.gradle.kts
@@ -70,6 +70,7 @@ kotlin {
             implementation(libs.jetbrains.compose.material3)
             implementation(libs.jetbrains.compose.material.icons.extended)
             implementation(libs.jetbrains.compose.material3.adaptive)
+            implementation(libs.jetbrains.compose.ui.backhandler)
             implementation(libs.jetbrains.compose.ui.tooling.preview)
             implementation(libs.androidx.lifecycle.viewmodelCompose)
             implementation(libs.androidx.lifecycle.runtimeCompose)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsScreen.kt
@@ -1,6 +1,8 @@
 package id.homebase.core.ui.screens.settings
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,6 +15,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.ui.backhandler.BackHandler
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.HelpOutline
 import androidx.compose.material.icons.automirrored.outlined.Logout
@@ -34,12 +38,14 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
@@ -74,6 +80,7 @@ import id.homebase.resources.settings_delete_account_dialog_text
 import id.homebase.resources.settings_delete_account_dialog_title
 import id.homebase.resources.settings_help
 import id.homebase.resources.settings_logout
+import id.homebase.resources.settings_logout_in_progress
 import id.homebase.resources.settings_notifications
 import id.homebase.resources.settings_notifications_active
 import id.homebase.resources.settings_notifications_issue
@@ -138,16 +145,62 @@ fun SettingsScreen(
         }
     }
 
-    SettingsUi(
-        uiState = uiState,
-        onAction = viewModel::onAction,
-        onBackClick = onBackClick,
-        onNavigateToConnections = onNavigateToConnections,
-        onNavigateToNotifications = onNavigateToNotifications,
-        onNavigateToAppearance = onNavigateToAppearance,
-        onNavigateToStorage = onNavigateToStorage,
-        onNavigateToHelp = onNavigateToHelp
-    )
+    Box(modifier = Modifier.fillMaxSize()) {
+        SettingsUi(
+            uiState = uiState,
+            onAction = viewModel::onAction,
+            onBackClick = onBackClick,
+            onNavigateToConnections = onNavigateToConnections,
+            onNavigateToNotifications = onNavigateToNotifications,
+            onNavigateToAppearance = onNavigateToAppearance,
+            onNavigateToStorage = onNavigateToStorage,
+            onNavigateToHelp = onNavigateToHelp
+        )
+
+        if (uiState.isLoggingOut) {
+            LogoutOverlay()
+        }
+    }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+private fun LogoutOverlay() {
+    // Swallow the system back gesture so the user can't navigate mid-wipe.
+    @Suppress("DEPRECATION")
+    BackHandler(enabled = true) { /* no-op */ }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.6f))
+            // Absorb every tap so the underlying Settings row never receives it.
+            .pointerInput(Unit) {
+                awaitPointerEventScope {
+                    while (true) { awaitPointerEvent() }
+                }
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        Surface(
+            shape = MaterialTheme.shapes.large,
+            tonalElevation = 8.dp,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ) {
+            Column(
+                modifier = Modifier.padding(horizontal = 32.dp, vertical = 24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                CircularProgressIndicator()
+                Text(
+                    text = stringResource(MR.string.settings_logout_in_progress),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+        }
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsUiState.kt
@@ -6,6 +6,7 @@ enum class NotificationVerificationStatus { CHECKING, OK, ERROR }
 
 data class SettingsUiState(
     val isLoading: Boolean = false,
+    val isLoggingOut: Boolean = false,
     val appName: String = "Homebase Chat",
     val appVersion: String,
     val appBuild: String,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsViewModel.kt
@@ -106,6 +106,11 @@ class SettingsViewModel(
     }
 
     private fun handleLogout() {
+        // Guard against a second tap while logout is in progress — the overlay is the
+        // primary defence, but the VM is the authoritative one-in-flight gate.
+        if (_uiState.value.isLoggingOut) return
+        _uiState.update { it.copy(isLoggingOut = true) }
+
         viewModelScope.launch {
             LoggerConfig.purgeLogs()
             notificationService.deleteToken()


### PR DESCRIPTION
Follow-up to the logout-wipe hardening on branch
harden-logout-wipe-noncancellable. That work made the wipe correct; this commit finishes the UX around it — the wipe is slow (~5s on a 30k row DB) and the app was leaving the user staring at an unresponsive Settings screen with every button still clickable.

VACUUM on logout
----------------
After clearStorage() empties DriveMainIndex / DriveTagIndex / DriveLocalTagIndex / ChatReadCount / KeyValue / Outbox / AppNotifications / ConnectionCache, the SQLite file still owns the pages from those ~30k rows. Without VACUUM they sit as free-list pages until the next identity's data fills them back in. We'd rather pay the rewrite cost on a rare logout than make every login / daily op slower.

- DatabaseManager: new suspend vacuum() that runs VACUUM via the driver on the write dispatcher. Runs outside a transaction (VACUUM requires that).
- DriveSyncManager.clearStorage(): calls vacuum() as the last step inside the NonCancellable block, after the tables are empty and before the expectFreshCursors flag is set.

Blocking logout overlay
-----------------------
The 5–6 second wipe used to be invisible: the user could double-click Logout, tap other rows, or navigate away mid-wipe. Not catastrophic since the wipe is NonCancellable, but the UI was lying about what was happening.

- SettingsUiState: new isLoggingOut Boolean.
- SettingsViewModel.handleLogout(): early-return if already logging out, then flips the flag before launching the logout coroutine. The flag is authoritative — the overlay is defence-in-depth.
- SettingsScreen: new LogoutOverlay composable layered over SettingsUi in a Box when isLoggingOut is true. 60% scrim, central Surface with a CircularProgressIndicator and the string "Erasing all your encrypted data" (new compose resource settings_logout_in_progress). pointerInput absorbs taps, BackHandler absorbs system back so the user can't navigate mid-wipe.

- homebase-core/build.gradle.kts: adds the jetbrains.compose.ui.backhandler dep — required for androidx.compose.ui.backhandler.BackHandler in commonMain (already present in homebase-chat).

Verification
------------
- homebase-api:jvmTest green (11/11, existing logout regression test still passes).
- homebase-core / homebase-chat / homebase-common / homebase-auth compileKotlinJvm all green.
- Manual: tested prior commit's wipe behaviour via fresh desktop log; post-logout first-login now completes without the UNIQUE-constraint / early-abort / stale-cursor symptoms that motivated this work.

Refs #356.