### PR TITLE
fix(chat): handle Android system back from search

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
@@ -54,7 +54,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.backhandler.BackHandler
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.text.font.FontWeight
@@ -89,7 +91,7 @@ import id.homebase.resources.search
 import org.jetbrains.compose.resources.stringResource
 import kotlin.uuid.Uuid
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
 fun ConversationListPane(
     uiState: ConversationListUiState,
@@ -114,6 +116,11 @@ fun ConversationListPane(
         if (uiState.isSearchActive) {
             focusRequesterSearch.requestFocus()
         }
+    }
+
+    @Suppress("DEPRECATION") BackHandler(enabled = uiState.isSearchActive) {
+        onUiAction(ConversationListUiAction.SearchBackClicked)
+        searchTextState.clearText()
     }
 
     BoxWithConstraints(modifier = Modifier.focusRequester(focusRequesterNone).focusable()) {


### PR DESCRIPTION
Tapping the search icon on the conversation list toggles an in-app search bar via local UI state (ConversationListUiState.isSearchActive), not a navigation destination. The only BackHandler on the screen was gated on `scaffoldNavigator.canNavigateBack(PopUntilContentChange)`, which on compact Android with no detail pane open evaluates to false. With no composable claiming the back event, Compose propagated it to the activity, which finished — the app quit instead of closing search.

Add a second BackHandler on ConversationListPane, enabled when `uiState.isSearchActive`, that fires the same action pair the X button on the search bar already runs: dispatch
`ConversationListUiAction.SearchBackClicked` and call `searchTextState.clearText()`. The handler lives on the pane (not the screen) because `searchTextState` is lexically scoped to the pane.

On tablet/large-screen layouts where both handlers can be enabled simultaneously, Compose's innermost-wins semantics mean the search handler takes precedence — closing the search UI the user just opened first is the expected UX.