### PR TITLE
fix(logout): DROP tables on wipe, clear Coil caches

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
@@ -58,7 +58,9 @@ val apiModule = module {
     single<OutboxUploader> { DriveOutboxUploader(get(), get(), get(), get()) }
     singleOf(::OutboxSync)
 
-    singleOf(::YouAuthFlowManager)
+    // YouAuthFlowManager is bound in homebase-core's AppModule where the platform
+    // singletons (ImageLoader, FileOperationsProvider) needed by its
+    // clearPlatformCaches hook are available. See homebase-core/.../AppModule.kt.
 
     single { UsernameStorage() }
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
@@ -53,13 +53,11 @@ class DriveSync(
     }
 
 
-    // Wipe drive-scoped synced data on logout. Identity-scoped tables (KeyValue, Outbox,
-    // AppNotifications, ConnectionCache) are wiped once at the DriveSyncManager level.
-    suspend fun clearStorage() {
-        databaseManager.driveMainIndex.deleteAll()
-        databaseManager.driveTagIndex.deleteAll()
-        databaseManager.driveLocalTagIndex.deleteAll()
-        databaseManager.chatReadCount.deleteAll()
+    // Reset in-memory sync state on logout. Every SQL table this drive touches is
+    // wiped centrally by DatabaseManager.wipeAndRecreate(), so this method only has
+    // to zero the cursor we hold in memory — without this the next session would
+    // resume from a stale QueryBatchCursor that no longer matches on-disk rows.
+    fun resetInMemoryState() {
         cursor = null
     }
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
@@ -8,7 +8,6 @@ import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.sync.database.DatabaseManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -213,28 +212,18 @@ class DriveSyncManager(
     suspend fun clearStorage() = withContext(NonCancellable) {
         val snapshot = driveSyncsMutex.withLock { driveSyncs.values.toList() }
 
-        coroutineScope {
-            snapshot
-                .map { sync -> launch { sync.clearStorage() } }
-                .joinAll()
-        }
+        // Zero per-drive in-memory state (cursor fields) before the SQL wipe so no
+        // DriveSync can lazily re-materialize a cursor from a row that's about to be
+        // dropped.
+        snapshot.forEach { it.resetInMemoryState() }
 
-        // Wipe identity-scoped tables once, after every per-drive clear has finished.
-        // Anything stored here is tied to the logged-out identity and must not leak
-        // into the next session.
-        //  - KeyValue       (sync cursors — the reason this method exists)
-        //  - Outbox         (pending uploads bound to drives we just wiped)
-        //  - AppNotifications
-        //  - ConnectionCache
-        databaseManager.keyValue.deleteAll()
-        databaseManager.outbox.deleteAll()
-        databaseManager.appNotifications.deleteAllRows()
-        databaseManager.connectionCache.deleteAllRows()
-
-        // Reclaim the disk space from the large DELETEs above. Logout is rare and
-        // already a "please wait" moment — paying the VACUUM cost here keeps login and
-        // normal operation fast.
-        databaseManager.vacuum()
+        // One DROP + CREATE + VACUUM of every table in OdinDatabase. Replaces the
+        // previous per-table deleteAll() chain, which was observed leaving Outbox
+        // rows across logout/login with their retry counters intact. DROP is the
+        // unforgeable variant — open transactions, stale caches, and stray driver
+        // references can't carry rows across it. Verification probes inside
+        // wipeAndRecreate() log an error if either of those loopholes actually fires.
+        databaseManager.wipeAndRecreate()
 
         // Signal the next start() that any cursor it finds is a bug.
         expectFreshCursors = true

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
@@ -79,6 +79,20 @@ class DatabaseManager(driverProvider: () -> SqlDriver) : AutoCloseable {
         private lateinit var instance: DatabaseManager
         val appDb: DatabaseManager get() = instance
 
+        // Single source of truth for every table in OdinDatabase. If a new table is
+        // added to the schema, add it here or wipeAndRecreate() will silently skip it
+        // on logout — exactly the class of bug that leaks Outbox rows across sessions.
+        internal val TABLE_NAMES = listOf(
+            "AppNotifications",
+            "ChatReadCount",
+            "ConnectionCache",
+            "DriveLocalTagIndex",
+            "DriveMainIndex",
+            "DriveTagIndex",
+            "KeyValue",
+            "Outbox"
+        )
+
         suspend fun initialize(driverProvider: () -> SqlDriver) {
             if (::instance.isInitialized) throw IllegalStateException("Already initialized")
 
@@ -87,27 +101,9 @@ class DatabaseManager(driverProvider: () -> SqlDriver) : AutoCloseable {
             val version = instance.driveMainIndex.getSchemaVersion()
 
             if (version < DATABASE_VERSION) {
-                val logger = Logger.withTag("DatabaseManager")
-                logger.i { "Schema version $version < $DATABASE_VERSION — wiping tables" }
-                wipeTables(instance.driver)
-                OdinDatabase.Schema.create(instance.driver)
-                logger.i { "Tables recreated after wipe" }
-            }
-        }
-
-        private fun wipeTables(driver: SqlDriver) {
-            val tables = listOf(
-                "AppNotifications",
-                "ChatReadCount",
-                "ConnectionCache",
-                "DriveLocalTagIndex",
-                "DriveMainIndex",
-                "DriveTagIndex",
-                "KeyValue",
-                "Outbox"
-            )
-            tables.forEach { table ->
-                driver.execute(null, "DROP TABLE IF EXISTS $table;", 0)
+                Logger.withTag("DatabaseManager")
+                    .i { "Schema version $version < $DATABASE_VERSION — wiping tables" }
+                instance.wipeAndRecreate()
             }
         }
     }
@@ -184,11 +180,77 @@ class DatabaseManager(driverProvider: () -> SqlDriver) : AutoCloseable {
         block(database)
     }
 
-    // VACUUM rewrites the entire DB file, reclaiming space freed by large DELETEs
-    // (e.g. the logout wipe). Must run outside a transaction and with exclusive access
-    // to the DB, so we run it on dbDispatcher like every other write path.
-    suspend fun vacuum() = withContext(dbDispatcher) {
+    // Nuke every table and rebuild the schema from scratch. Used on logout (via
+    // DriveSyncManager.clearStorage) and on schema-version bump (via initialize).
+    //
+    // DROP TABLE is used instead of DELETE FROM because DROP is an unforgeable
+    // guarantee: after it returns, the rows cannot survive an open transaction,
+    // a stale cache, or a stray driver reference. DELETE has bitten us — the
+    // Outbox has been observed to keep rows across logout/login with their retry
+    // counters intact, meaning some deleteAll() was either racing another writer
+    // or hitting a different driver instance. DROP + CREATE + VACUUM on a single
+    // driver, inside the one-at-a-time dbDispatcher, removes all of those loopholes.
+    //
+    // Two verification probes run alongside the wipe and log an error if they fire:
+    //   1. After DROP: counting rows on the table must throw "no such table". If
+    //      the SELECT succeeds, DROP didn't take effect (wrong driver, or something
+    //      caught the exception silently).
+    //   2. After CREATE: the row count must be zero. If it's not, something wrote
+    //      to the freshly recreated table before we finished — usually a caller
+    //      still running with stale credentials.
+    suspend fun wipeAndRecreate() = withContext(dbDispatcher) {
+        val log = Logger.withTag("DatabaseManager")
+
+        TABLE_NAMES.forEach { table ->
+            driver.execute(null, "DROP TABLE IF EXISTS $table;", 0)
+        }
+
+        // Probe 1: after DROP every SELECT must throw.
+        TABLE_NAMES.forEach { table ->
+            val stillThere = runCatching {
+                driver.executeQuery(
+                    identifier = null,
+                    sql = "SELECT COUNT(*) FROM $table",
+                    mapper = { cursor ->
+                        cursor.next()
+                        QueryResult.Value(cursor.getLong(0) ?: 0L)
+                    },
+                    parameters = 0,
+                ).value
+            }.getOrNull()
+            if (stillThere != null) {
+                log.e { "wipeAndRecreate: table '$table' still queryable after DROP (rows=$stillThere) — wipe did not take effect" }
+            }
+        }
+
+        OdinDatabase.Schema.create(driver)
+
+        // Probe 2: after CREATE every table must be empty.
+        TABLE_NAMES.forEach { table ->
+            val count = runCatching {
+                driver.executeQuery(
+                    identifier = null,
+                    sql = "SELECT COUNT(*) FROM $table",
+                    mapper = { cursor ->
+                        cursor.next()
+                        QueryResult.Value(cursor.getLong(0) ?: 0L)
+                    },
+                    parameters = 0,
+                ).value
+            }.getOrElse { e ->
+                log.e(e) { "wipeAndRecreate: could not count '$table' after CREATE" }
+                -1L
+            }
+            if (count > 0L) {
+                log.e { "wipeAndRecreate: table '$table' has $count rows after wipe — something re-inserted mid-wipe" }
+            }
+        }
+
+        // Reclaim the pages freed by DROP. VACUUM must run outside any transaction;
+        // dbDispatcher has the single-writer slot so we're safe here.
         driver.execute(identifier = null, sql = "VACUUM", parameters = 0)
+
+        log.i { "wipeAndRecreate: completed (${TABLE_NAMES.size} tables)" }
     }
 
     override fun close() {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthFlowManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthFlowManager.kt
@@ -76,6 +76,12 @@ class YouAuthFlowManager(
     private val httpClient: HttpClient,
     private val driveFileProviderCached: DriveFileProviderCached,
     private val publicProfileProviderCached: PublicProfileProviderCached,
+    // Platform-level cache teardown invoked during logout, alongside the per-cache
+    // clearCaches() calls below. Injected from the module that owns platform
+    // singletons (homebase-core) so this class doesn't have to depend on coil3 or
+    // on FileOperationsProvider directly. Default no-op keeps existing tests and
+    // any construction path that doesn't care about platform caches working.
+    private val clearPlatformCaches: suspend () -> Unit = {},
 ) {
     private val _authState = MutableStateFlow<YouAuthState>(YouAuthState.Initializing)
     val authState: StateFlow<YouAuthState> = _authState.asStateFlow()
@@ -348,6 +354,12 @@ class YouAuthFlowManager(
         driveSyncManager.clearStorage()
         driveFileProviderCached.clearCaches()
         publicProfileProviderCached.clearCaches()
+        // Platform caches (Coil memory cache, orphan coil3_disk_cache dir, anything
+        // else the app-level module wants to flush). Wrapped in runCatching so a
+        // failing hook can't block the authState flip that follows — we'd rather
+        // log out with a stale Coil entry than get stuck half-authenticated.
+        runCatching { clearPlatformCaches() }
+            .onFailure { Logger.e(throwable = it, tag = TAG) { "clearPlatformCaches failed" } }
         CredentialStorage.clearCredentials()
         ShareAuthBridge.clearAuth()
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -1,8 +1,15 @@
 package id.homebase.core.di
 
+import co.touchlab.kermit.Logger
+import coil3.ImageLoader
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.di.apiModule
+import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.sync.DriveSyncManager
+import id.homebase.api.youauth.YouAuthFlowManager
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import okio.SYSTEM
 import id.homebase.auth.login.LoginViewModel
 import id.homebase.chat.addgroupmembers.AddGroupMembersViewModel
 import id.homebase.chat.archivedconversations.ArchivedConversationsViewModel
@@ -75,6 +82,48 @@ val appModule = module {
     single {
         DriveSyncManager(get(), get(), get(), get(), get(),
             syncLabeledDrives.associate { it.drive.alias to it.label })
+    }
+
+    // Bound here rather than in homebase-api's ApiModule because the logout hook
+    // needs platform singletons (Coil ImageLoader, FileOperationsProvider) that
+    // don't exist at the homebase-api layer. The hook clears every cache that
+    // outlives the identity:
+    //   - Coil in-memory image cache: avatars and thumbnails decoded for the
+    //     outgoing user must not leak to the next login on the same machine.
+    //   - Orphan coil3_disk_cache directory: our ImageLoader sets diskCache(null),
+    //     but if a regression ever re-enables it, or a prior install populated
+    //     it, we want logout to clean it up. Matches StorageSettingsViewModel's
+    //     "Clear caches" button behaviour.
+    // DriveFileProviderCached and PublicProfileProviderCached already delete
+    // their encrypted disk directories in their own clearCaches(), which
+    // YouAuthFlowManager.logout() invokes immediately before this hook.
+    single {
+        val imageLoader: ImageLoader = get()
+        val fileOps: FileOperationsProvider = get()
+        val fileSystem = FileSystem.SYSTEM
+        YouAuthFlowManager(
+            driveSyncManager = get(),
+            credentialsManager = get(),
+            httpClient = get(),
+            driveFileProviderCached = get(),
+            publicProfileProviderCached = get(),
+            clearPlatformCaches = {
+                runCatching { imageLoader.memoryCache?.clear() }
+                    .onFailure {
+                        Logger.w(tag = "YouAuthFlowManager", throwable = it) {
+                            "coil memory cache clear failed on logout"
+                        }
+                    }
+                runCatching {
+                    val orphan = "${fileOps.getCacheDirectory()}/coil3_disk_cache".toPath()
+                    if (fileSystem.exists(orphan)) fileSystem.deleteRecursively(orphan)
+                }.onFailure {
+                    Logger.w(tag = "YouAuthFlowManager", throwable = it) {
+                        "orphan coil disk cache delete failed on logout"
+                    }
+                }
+            },
+        )
     }
 
     single {


### PR DESCRIPTION
Investigating a desktop log that showed Outbox rows (including their retry counters at attempt=9/20) surviving a clean logout/login cycle. The previous clearStorage() path used per-wrapper deleteAll() calls plus a trailing vacuum(), with the table list duplicated across three sites (DatabaseManager.wipeTables, DriveSync.clearStorage, DriveSyncManager.clearStorage). DELETE has too many loopholes for this job — open transactions, stale prepared-statement caches, or a stray driver reference anywhere will carry rows across it.

Changes:

- DatabaseManager: introduce a single TABLE_NAMES companion constant as the source of truth for every OdinDatabase table, and a new wipeAndRecreate() that DROPs, re-creates, and VACUUMs all tables in one pass. DROP invalidates prepared statements and snapshots, so no concurrent reader can resurrect a wiped row. Two verification probes log loudly if the wipe fails to take effect: one between DROP and CREATE asserting SELECT throws "no such table", and one after CREATE asserting every table is empty. If either fires, the log will name the table and row count, pointing straight at the offending caller. initialize() now routes the schema-version-bump path through wipeAndRecreate() too, so both logout and upgrade share one implementation.

- DriveSync.clearStorage is renamed to resetInMemoryState() and shrinks to `cursor = null`. SQL-state teardown is now centralized.

- DriveSyncManager.clearStorage becomes: per-drive in-memory reset, then one wipeAndRecreate() call. Six deleteAll/deleteAllRows/vacuum calls collapse to one.

- YouAuthFlowManager.logout() gains a clearPlatformCaches hook wired from homebase-core's AppModule. Closes a privacy gap on multi-user machines: Coil's in-memory image cache was previously never cleared on logout, so avatars and thumbnails decoded for the outgoing user could render for the next user. The hook also deletes any orphan coil3_disk_cache directory as defence-in-depth against a regression that re-enables Coil's disk cache. Failures in the hook are logged, not propagated — logout still completes.

- YouAuthFlowManager's Koin binding moves from homebase-api's ApiModule to homebase-core's AppModule so the hook can reference ImageLoader and FileOperationsProvider, which don't exist at the api layer.

Verification: existing DriveSyncManagerTest.clearStorageCompletesEven- WhenCallerScopeIsCancelled still passes (seeds rows, cancels the caller scope mid-logout, asserts the wipe completed). All Outbox, CursorSync, and DatabaseManager tests pass. JVM compile clean across homebase-api and homebase-core.