### PR TITLE
fix(outbox): drop terminal 400s; demote null-userDate logs

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveOutboxUploader.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveOutboxUploader.kt
@@ -46,6 +46,19 @@ class DriveOutboxUploader(
             }
         } catch (e: ClientException) {
             if (e.status == 400) {
+                // Self-recipient: the outbox item's recipient list contains the
+                // logged-in identity. The server will reject this forever, so drop
+                // the row rather than scheduling 20 retries. Title-match because the
+                // server returns errorCode=UnhandledScenario for this case; there's
+                // no dedicated enum value. Mirrors the VersionTagMismatch pattern
+                // below: return normally and OutboxSync deletes the row.
+                if (e.message?.startsWith("Cannot transfer to yourself") == true) {
+                    Logger.w(
+                        "$TAG upload: dropping outbox item ${outboxRecord.uniqueId} " +
+                                "uploadType=${outboxRecord.uploadType} — terminal: ${e.message}"
+                    )
+                    return
+                }
                 when (e.errorCode) {
                     OdinClientErrorCode.VersionTagMismatch -> {
                         Logger.w(
@@ -100,7 +113,16 @@ class DriveOutboxUploader(
         // from a previous install), convert the failed UploadNewFile into an
         // UpdateFileByUniqueId so the client's fresh content lands on the server.
         } catch (e: ClientException) {
-            if (e.status == 400 && e.errorCode == OdinClientErrorCode.ExistingFileWithUniqueId) {
+            // Route through retryAsUpdate whenever the server reports the uniqueId
+            // already exists. The proper errorCode is ExistingFileWithUniqueId, but
+            // the server also reports this condition as errorCode=UnhandledScenario
+            // with title "File already exists with ClientUniqueId: [...]" — the
+            // title match is a defensive fallback for that case. Without it the
+            // recovery path is skipped and the outbox retries for 20 attempts.
+            val isExistingFileConflict = e.status == 400 && (
+                    e.errorCode == OdinClientErrorCode.ExistingFileWithUniqueId ||
+                            e.message?.startsWith("File already exists with ClientUniqueId") == true)
+            if (isExistingFileConflict) {
                 Logger.w(
                     "$TAG uploadNewFile: uniqueId=${request.metadata.appData.uniqueId} " +
                             "got ExistingFileWithUniqueId (server already has this file) — " +

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -483,7 +483,14 @@ class ChatMessageStream(
                             authorSpecificDate
                         } else {
                             if (appData.userDate == null) {
-                                Logger.w {
+                                // Debug-level: legacy messages from older web/RN clients
+                                // that never captured userDate. Fallback to the
+                                // server-stamped authorSpecificDate is correct; no
+                                // action is required. Logged because when debugging
+                                // display-time issues it's useful to identify which
+                                // messages took the fallback path. Was Warn; demoted
+                                // to Debug because it fires ~4k times per login.
+                                Logger.d {
                                     "Message (uid: ${appData.uniqueId}) with no version and not edited has null userDate. " +
                                         "using authorSpecificDate. See file: https://${domain}/owner/drives/9ff813aff2d61e2f9b9db189e72d1a11_66ea8355ae4155c39b5a719166b510e3/${appData.uniqueId}"
                                 }
@@ -494,8 +501,8 @@ class ChatMessageStream(
 
                     } else {
                         if (appData.userDate == null) {
-                            Logger.w { "Message (uid: ${appData.uniqueId}) with version ${messageAppData.version} has null userDate. using authorSpecificDate" }
-                            Logger.w { "See File here: https://${domain}/owner/drives/9ff813aff2d61e2f9b9db189e72d1a11_66ea8355ae4155c39b5a719166b510e3/${appData.uniqueId}" }
+                            Logger.d { "Message (uid: ${appData.uniqueId}) with version ${messageAppData.version} has null userDate. using authorSpecificDate" }
+                            Logger.d { "See File here: https://${domain}/owner/drives/9ff813aff2d61e2f9b9db189e72d1a11_66ea8355ae4155c39b5a719166b510e3/${appData.uniqueId}" }
                             authorSpecificDate
                         } else
                             UnixTimeUtc(appData.userDate!!)


### PR DESCRIPTION
Two follow-ups from the logout-wipe log review. Both fall out of mis-categorised server errors and one benign fallback path that together dominate the log on every login.

DriveOutboxUploader
-------------------
On login, the outbox retries two permanent 400 conditions for 20 attempts each with exponential backoff, drowning the log:

  "Cannot transfer to yourself; what's the point?"
  "File already exists with ClientUniqueId: [...]"

Both are reported by the server as errorCode=UnhandledScenario (raw: null), so the existing errorCode-based branches don't fire and the generic "will retry" branch runs instead. Fixed by matching on the title text as a defensive fallback:

- upload() gets a new branch for "Cannot transfer to yourself" that follows the VersionTagMismatch pattern: log Warn once, return normally, and OutboxSync deletes the row on the way out. The enqueue itself is a bug (items whose only recipient is the logged-in identity shouldn't be queued in the first place) but that belongs in whichever service is building the recipient list — stopping the noise here is still the right move.

- uploadNewFile()'s existing ExistingFileWithUniqueId recovery is widened to also match by title when errorCode is absent. The recovery path (retryAsUpdate) is unchanged — fetch the server file's versionTag and convert the UploadNewFile into an UpdateFileByUniqueId so the client's fresh content isn't lost. Previously this recovery never fired for the common case where the server omits errorCode.

No new unit tests. DriveOutboxUploader has no existing unit tests and mocking its collaborators (DriveUploadProvider with a live HttpClient, DriveFileProvider, etc.) is a significant amount of scaffolding for a string-match change that mirrors a well-established sibling pattern. Verification is via desktop log inspection on a real logout/login cycle.

ChatMessageStream
-----------------
~4,600 Warn lines per login shaped like:

  Warn: Message (uid: ...) with no version and not edited has null
        userDate. using authorSpecificDate. See file: ...

The hypothesis that these were soft-deleted messages was wrong — soft-deleted items (FileState.Deleted or ArchivalStatus.Removed) return early at line 441 with a "Deleted File" placeholder, never reaching this code path. The warning fires on *active* legacy messages whose author (older web/React-Native client) didn't capture userDate when the message was created; the fallback to authorSpecificDate (server-stamped created / transitCreated) is correct and always produces a valid date.

Demoted all three Logger.w call sites to Logger.d. The "See file" URL is preserved so the debug-level signal remains useful when chasing display-time issues; it just no longer drowns the Warn channel on every login.

Verification
------------
- homebase-api:jvmTest + homebase-chat:jvmTest both pass with --rerun-tasks on this branch.
- Desktop run + logout/login should show:
  * zero "Failed upload ... retry in N seconds" lines for either title — they're either dropped (terminal) or converted to retryAsUpdate log lines
  * zero "Message (uid: ...) ... null userDate" Warn lines — visible only at Debug severity now
  * net login-log size drop of >4,000 lines vs. the previous run