### PR TITLE
fix(logout): stop drive sync before clearing credentials

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
@@ -32,6 +32,8 @@ import id.homebase.api.video.VideoPrefetchDriveAccess
 import id.homebase.api.youauth.SecurityContextProvider
 import id.homebase.api.youauth.UsernameStorage
 import id.homebase.api.youauth.YouAuthFlowManager
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -43,7 +45,12 @@ import org.koin.dsl.module
 val apiModule = module {
     single { DatabaseManager.appDb }
 
-    single<CoroutineScope> { CoroutineScope(SupervisorJob() + Dispatchers.Default) }
+    single<CoroutineScope> {
+        val handler = CoroutineExceptionHandler { _, e ->
+            Logger.e(throwable = e, tag = "AppScope") { "Unhandled coroutine exception" }
+        }
+        CoroutineScope(SupervisorJob() + Dispatchers.Default + handler)
+    }
 
     // this creates the HttpClient
     single { HttpClientProvider.create() }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
@@ -119,7 +119,12 @@ class DriveSyncManager(
     }
 
     suspend fun start() {
-        val credentials = credentialsManager.requireActiveCredentials()
+        // getActiveCredentials() + null-check instead of requireActiveCredentials()
+        // so a logout race can't crash the caller. Not all callers try-catch this.
+        val credentials = credentialsManager.getActiveCredentials() ?: run {
+            Logger.w { "DriveSyncManager.start() skipped — no active credentials" }
+            return
+        }
         val identityId = credentials.getIdentityId()
 
         val freshLogin = expectFreshCursors

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthFlowManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthFlowManager.kt
@@ -345,6 +345,15 @@ class YouAuthFlowManager(
             Logger.e(throwable = e, tag = TAG) { "Error during logout" }
         }
 
+        // Tear down background work that reads credentials BEFORE nulling them.
+        // Cancels in-flight DriveSync jobs and empties driveSyncs so the retry
+        // scheduler in DriveSyncManager.init can't schedule new work against
+        // cleared credentials (was a source of uncaught
+        // IllegalStateException: No active credentials set). stop() is idempotent;
+        // AuthConnectionCoordinator.disconnect() will call it again when the
+        // authState flip below lands.
+        driveSyncManager.stop()
+
         // Wipe all identity-scoped state BEFORE flipping _authState to Unauthenticated.
         // Emitting Unauthenticated tears down the authenticated nav graph (and with it
         // SettingsViewModel.viewModelScope, which is the coroutine currently running

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -97,8 +97,15 @@ class AuthConnectionCoordinator(
 
     private fun loadProfile() {
         scope.launch {
-            val odinId = credentialsManager.requireActiveCredentials().domain
-            ownerSessionRepository.load(odinId)
+            // Use getActiveCredentials() rather than requireActiveCredentials() —
+            // a BackendEvent.ConnectionOnline racing with logout would otherwise
+            // throw IllegalStateException on a scope with no exception handler,
+            // crashing the process.
+            val credentials = credentialsManager.getActiveCredentials() ?: run {
+                Logger.d { "loadProfile: skipping — no active credentials" }
+                return@launch
+            }
+            ownerSessionRepository.load(credentials.domain)
         }
     }
 


### PR DESCRIPTION
An uncaught IllegalStateException("No active credentials set") was crashing the app on logout. Root cause: YouAuthFlowManager.logout() called credentialsManager.removeActiveCredentials() first and only triggered driveSyncManager.stop() later, indirectly, when the authState flip to Unauthenticated caused AuthConnectionCoordinator. disconnect() to fire. In that window, the DriveSyncManager retry scheduler and a late BackendEvent.ConnectionOnline handler kept calling requireActiveCredentials() against null credentials on scopes that had no exception handler, so the throw escaped to Thread.setDefaultUncaughtExceptionHandler and was logged by CrashLogger.

Changes:

- YouAuthFlowManager.logout(): call driveSyncManager.stop() before removeActiveCredentials(). stop() cancels in-flight DriveSync jobs and empties driveSyncs, so the retry scheduler's driveSyncs[event.driveId]?.sync() short-circuits to null. stop() is idempotent; AuthConnectionCoordinator.disconnect() will call it again when the authState flip lands.
- AuthConnectionCoordinator.loadProfile(): switch from requireActiveCredentials() to getActiveCredentials() + early return. Its scope has no SupervisorJob and no CoroutineExceptionHandler, so a logout race here would otherwise kill the whole coordinator scope.
- DriveSyncManager.start(): switch to getActiveCredentials() + early return. Not every future callsite will try-catch, so make the function safe to call with no active session.
- ApiModule.kt: add a CoroutineExceptionHandler to the app-level CoroutineScope. After the changes above no path should leak to it, but a future regression will now log via Kermit instead of crashing.