### PR TITLE
feat(defrag): real soft-delete check + live analyze scan visualization

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/HomebaseFile.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/HomebaseFile.kt
@@ -1,6 +1,7 @@
 package id.homebase.api.client.drives
 
 import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.drives.files.ArchivalStatus
 import id.homebase.api.client.drives.files.FileMetadata
 import id.homebase.api.serialization.UuidSerializer
 import kotlinx.serialization.Serializable
@@ -31,6 +32,13 @@ data class HomebaseFile(
             throw Exception("File is deleted.")
         }
     }
+
+    // Belt-and-suspenders: `fileState == Deleted` is the real/new marker; the
+    // older `archivalStatus == Removed` hack still appears on some rows. Both
+    // paths are treated as soft-deleted by every consumer in the codebase.
+    fun isSoftDeleted(): Boolean =
+        fileState == FileState.Deleted ||
+            fileMetadata.appData.archivalStatus == ArchivalStatus.Removed
 
     fun assertOriginalAuthor(odinId: OdinId) {
         val originalAuthor = fileMetadata.originalAuthor

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DriveMainIndexWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DriveMainIndexWrapper.kt
@@ -130,8 +130,30 @@ class DriveMainIndexWrapper(
     fun countByIdentityAndDrive(identityId: Uuid, driveId: Uuid): Long =
         delegate.countByIdentityAndDrive(identityId, driveId).executeAsOne()
 
-    fun selectSoftDeletedFileIds(identityId: Uuid, driveId: Uuid): List<Uuid> =
-        delegate.selectSoftDeletedFileIds(identityId, driveId).executeAsList()
+    /**
+     * Row shape for the Defragmenter's streaming scan — carries enough to call
+     * [HomebaseFile.isSoftDeleted] and to page forward by rowId.
+     */
+    data class PagedScanRow(val rowId: Long, val fileId: Uuid, val jsonHeader: String)
+
+    /**
+     * Keyset-paged scan of a drive's rows. Caller passes `sinceRowId = 0` on
+     * the first call and then `sinceRowId = lastRowIdOfPreviousChunk` on each
+     * subsequent call until an empty list is returned.
+     */
+    fun selectFileIdAndJsonByDriveSince(
+        identityId: Uuid,
+        driveId: Uuid,
+        sinceRowId: Long,
+        limit: Long,
+    ): List<PagedScanRow> = delegate.selectFileIdAndJsonByDriveSince(
+        identityId,
+        driveId,
+        sinceRowId,
+        limit,
+    ) { rowId, fileId, jsonHeader ->
+        PagedScanRow(rowId = rowId, fileId = fileId, jsonHeader = jsonHeader)
+    }.executeAsList()
 
     suspend fun upsertDriveMainIndex(
         identityId: Uuid,

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/DriveMainIndex.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/DriveMainIndex.sq
@@ -126,11 +126,15 @@ countByIdentityAndDrive:
 SELECT count(*) FROM DriveMainIndex
 WHERE identityId = ? AND driveId = ?;
 
--- Select fileIds of soft-deleted rows (archivalStatus = 2 = Removed).
--- Used by the Defragmenter screen to enumerate files awaiting hard delete.
-selectSoftDeletedFileIds:
-SELECT fileId FROM DriveMainIndex
-WHERE identityId = ? AND driveId = ? AND archivalStatus = 2;
+-- Page rows for a drive in rowId-ascending order, returning (rowId, fileId,
+-- jsonHeader). The Defragmenter scans these chunks and applies the
+-- HomebaseFile.isSoftDeleted() predicate in Kotlin; we can't filter on
+-- fileState in SQL because it lives inside jsonHeader, not as a column.
+selectFileIdAndJsonByDriveSince:
+SELECT rowId, fileId, jsonHeader FROM DriveMainIndex
+WHERE identityId = ? AND driveId = ? AND rowId > ?
+ORDER BY rowId
+LIMIT ?;
 
 -- Select all records - for TESTING
 selectAll:

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -3,11 +3,9 @@ package id.homebase.chat.services
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.auth.CredentialsManager
-import id.homebase.api.client.drives.FileState
 import id.homebase.api.client.drives.HomebaseFile
 import id.homebase.api.client.drives.QueryBatchSortField
 import id.homebase.api.client.drives.QueryBatchSortOrder
-import id.homebase.api.client.drives.files.ArchivalStatus
 import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.client.drives.query.QueryBatchCursor
 import id.homebase.api.client.eventbus.BackendEvent
@@ -404,8 +402,7 @@ class ChatMessageStream(
 
                 val versionTag = header.fileMetadata.versionTag ?: Uuid.NIL
                 val content = appData.content
-                val isDeleted = header.fileState == FileState.Deleted ||
-                        header.fileMetadata.appData.archivalStatus == ArchivalStatus.Removed
+                val isDeleted = header.isSoftDeleted()
 
                 if (isDeleted) {
                     val deletedUserDate = if (appData.userDate == null)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMapper.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMapper.kt
@@ -3,9 +3,7 @@ package id.homebase.chat.services.convo
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.auth.CredentialsManager
-import id.homebase.api.client.drives.FileState
 import id.homebase.api.client.drives.HomebaseFile
-import id.homebase.api.client.drives.files.ArchivalStatus
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.common.OdinId
 import id.homebase.api.common.time.UnixTimeUtc
@@ -87,8 +85,7 @@ class ConversationMapper(
 
                 val conversationId = appData.uniqueId ?: error("Missing uniqueId")
 
-                val isDeleted = conversationFile.fileState == FileState.Deleted
-                        || appData.archivalStatus == ArchivalStatus.Removed
+                val isDeleted = conversationFile.isSoftDeleted()
 
                 if (isDeleted) {
                     return mapDeletedConversation(conversationFile, domain)

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -215,7 +215,7 @@
     <string name="defragmenter_stat_elapsed">Elapsed: %1$s</string>
     <string name="defragmenter_stat_eta">Estimated: %1$s</string>
     <string name="defragmenter_status_idle">Ready to analyze</string>
-    <string name="defragmenter_status_analyzing">Analyzing drive…</string>
+    <string name="defragmenter_status_analyzing">Analyzing drive… %1$d of %2$d</string>
     <string name="defragmenter_status_ready">Analysis complete — ready to defragment</string>
     <string name="defragmenter_status_running">Defragmenting</string>
     <string name="defragmenter_status_paused">Paused</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterScreen.kt
@@ -176,6 +176,9 @@ private fun DefragmenterContent(
                 targetHighlights = state.targetHighlights,
                 frameTimeNanos = frameTimeNanos,
                 celebratoryProgress = celebratoryProgress,
+                analyzedUpto = if (state.phase is DefragmenterPhase.Analyzing)
+                    state.analyzedUpto else Int.MAX_VALUE,
+                scanHeadIndex = state.scanHeadIndex,
                 modifier = Modifier
                     .fillMaxSize()
                     .semantics {
@@ -185,8 +188,13 @@ private fun DefragmenterContent(
             )
         }
 
+        val barFraction = if (state.phase is DefragmenterPhase.Analyzing && state.analyzeTotal > 0) {
+            state.analyzedUpto.toFloat() / state.analyzeTotal.toFloat()
+        } else {
+            state.progressFraction
+        }
         Win98ProgressBar(
-            fraction = state.progressFraction,
+            fraction = barFraction,
             modifier = Modifier.fillMaxWidth(),
         )
 
@@ -228,7 +236,11 @@ private fun NarrowControls(state: DefragmenterUiState, onAction: (DefragmenterUi
 private fun StatsPanel(state: DefragmenterUiState, modifier: Modifier = Modifier) {
     val statusText = when (state.phase) {
         DefragmenterPhase.Idle -> stringResource(MR.string.defragmenter_status_idle)
-        DefragmenterPhase.Analyzing -> stringResource(MR.string.defragmenter_status_analyzing)
+        DefragmenterPhase.Analyzing -> stringResource(
+            MR.string.defragmenter_status_analyzing,
+            state.analyzedUpto,
+            state.analyzeTotal,
+        )
         DefragmenterPhase.Ready -> stringResource(MR.string.defragmenter_status_ready)
         DefragmenterPhase.Defragmenting -> stringResource(MR.string.defragmenter_status_running)
         DefragmenterPhase.Paused -> stringResource(MR.string.defragmenter_status_paused)
@@ -299,7 +311,9 @@ private fun ActionButtons(state: DefragmenterUiState, onAction: (DefragmenterUiA
             }
             Win98Button(
                 text = stringResource(MR.string.defragmenter_cancel),
-                enabled = phase is DefragmenterPhase.Defragmenting || phase is DefragmenterPhase.Paused,
+                enabled = phase is DefragmenterPhase.Defragmenting ||
+                    phase is DefragmenterPhase.Paused ||
+                    phase is DefragmenterPhase.Analyzing,
                 onClick = { onAction(DefragmenterUiAction.Cancel) },
             )
         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterUiState.kt
@@ -34,10 +34,19 @@ data class DefragmenterUiState(
     val progressFraction: Float = 0f,
     val elapsedMs: Long = 0L,
     val estRemainingMs: Long = 0L,
+    // Streaming-analyze progress. analyzedUpto is the exclusive upper bound of
+    // positions already scanned; analyzeTotal is the final grid size known
+    // after the Sized event.
+    val analyzedUpto: Int = 0,
+    val analyzeTotal: Int = 0,
 ) {
     /** True during Vacuuming and Complete — canvas tints filled blocks green. */
     val celebratory: Boolean
         get() = phase is DefragmenterPhase.Vacuuming || phase is DefragmenterPhase.Complete
+
+    /** Index of the cell the scan head is on, or null outside of Analyzing. */
+    val scanHeadIndex: Int?
+        get() = if (phase is DefragmenterPhase.Analyzing && analyzedUpto > 0) analyzedUpto - 1 else null
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -53,7 +62,9 @@ data class DefragmenterUiState(
             movesCompleted == other.movesCompleted &&
             progressFraction == other.progressFraction &&
             elapsedMs == other.elapsedMs &&
-            estRemainingMs == other.estRemainingMs
+            estRemainingMs == other.estRemainingMs &&
+            analyzedUpto == other.analyzedUpto &&
+            analyzeTotal == other.analyzeTotal
     }
 
     override fun hashCode(): Int {
@@ -64,6 +75,8 @@ data class DefragmenterUiState(
         result = 31 * result + movesCompleted.hashCode()
         result = 31 * result + progressFraction.hashCode()
         result = 31 * result + elapsedMs.hashCode()
+        result = 31 * result + analyzedUpto
+        result = 31 * result + analyzeTotal
         return result
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterViewModel.kt
@@ -4,9 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import id.homebase.core.ui.screens.defragmenter.model.BlockGrid
+import id.homebase.core.ui.screens.defragmenter.service.DefragAnalyzeEvent
 import id.homebase.core.ui.screens.defragmenter.service.DefragSource
 import id.homebase.core.ui.screens.defragmenter.service.DeletedFileRef
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -14,9 +14,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.time.TimeSource
@@ -68,36 +68,85 @@ class DefragmenterViewModel(
     private fun analyze() {
         analyzeJob?.cancel()
         analyzeJob = viewModelScope.launch {
-            _uiState.update { it.copy(phase = DefragmenterPhase.Analyzing) }
-            val analysis = source.analyze()
-            val grid = withContext(Dispatchers.Default) {
-                val gapIdx = IntArray(analysis.gapMap.size)
-                var i = 0
-                for (pos in analysis.gapMap.keys) {
-                    gapIdx[i++] = pos
-                }
-                BlockGrid.create(analysis.totalBlocks, gapIdx)
-            }
-            gapMap = analysis.gapMap
-            Logger.d(tag = tag) {
-                "Analyze complete: total=${grid.totalBlocks}, gaps=${grid.gapCount}"
-            }
-            resetCursors()
+            // Reset for a fresh scan; show empty grid immediately.
             _uiState.update {
                 it.copy(
-                    phase = DefragmenterPhase.Ready,
-                    grid = grid,
+                    phase = DefragmenterPhase.Analyzing,
+                    grid = BlockGrid.EMPTY,
                     gridVersion = it.gridVersion + 1,
-                    totalBlocks = grid.totalBlocks,
-                    initialGaps = grid.gapCount,
-                    gapsRemaining = grid.gapCount,
+                    totalBlocks = 0,
+                    initialGaps = 0,
+                    gapsRemaining = 0,
                     movesCompleted = 0L,
                     progressFraction = 0f,
                     elapsedMs = 0L,
                     estRemainingMs = 0L,
                     inFlight = emptyList(),
                     targetHighlights = IntArray(0),
+                    analyzedUpto = 0,
+                    analyzeTotal = 0,
                 )
+            }
+            val accGaps = HashMap<Int, DeletedFileRef>()
+            var liveGrid: BlockGrid = BlockGrid.EMPTY
+            source.analyze().collect { ev ->
+                when (ev) {
+                    is DefragAnalyzeEvent.Sized -> {
+                        liveGrid = BlockGrid.createEmpty(ev.totalBlocks)
+                        _uiState.update {
+                            it.copy(
+                                grid = liveGrid,
+                                gridVersion = it.gridVersion + 1,
+                                totalBlocks = ev.totalBlocks,
+                                analyzeTotal = ev.totalBlocks,
+                                analyzedUpto = 0,
+                            )
+                        }
+                    }
+
+                    is DefragAnalyzeEvent.Progress -> {
+                        val prev = _uiState.value.analyzedUpto
+                        // Flip non-gap positions in [prev, analyzedUpto) to filled.
+                        // Positions present in newGaps stay cleared (= gap).
+                        val grid = liveGrid
+                        if (grid !== BlockGrid.EMPTY) {
+                            for (pos in prev until ev.analyzedUpto) {
+                                if (!ev.newGaps.containsKey(pos)) {
+                                    grid.setFilled(pos, true)
+                                }
+                            }
+                        }
+                        if (ev.newGaps.isNotEmpty()) accGaps.putAll(ev.newGaps)
+                        _uiState.update {
+                            it.copy(
+                                analyzedUpto = ev.analyzedUpto,
+                                gridVersion = it.gridVersion + 1,
+                            )
+                        }
+                    }
+
+                    is DefragAnalyzeEvent.Done -> {
+                        gapMap = accGaps
+                        resetCursors()
+                        val grid = liveGrid
+                        val total = ev.totalBlocks
+                        Logger.d(tag = tag) {
+                            "Analyze complete: total=$total, gaps=${accGaps.size}"
+                        }
+                        _uiState.update {
+                            it.copy(
+                                phase = DefragmenterPhase.Ready,
+                                grid = grid,
+                                gridVersion = it.gridVersion + 1,
+                                totalBlocks = total,
+                                initialGaps = accGaps.size,
+                                gapsRemaining = accGaps.size,
+                                analyzedUpto = total,
+                                analyzeTotal = total,
+                            )
+                        }
+                    }
+                }
             }
         }
     }
@@ -135,6 +184,28 @@ class DefragmenterViewModel(
 
     private fun cancel() {
         val s = _uiState.value
+        if (s.phase is DefragmenterPhase.Analyzing) {
+            // Abort the in-progress scan and return to Idle. The partial
+            // grid/gap state is discarded — next Analyze starts fresh.
+            analyzeJob?.cancel()
+            analyzeJob = null
+            gapMap = emptyMap()
+            _uiState.update {
+                it.copy(
+                    phase = DefragmenterPhase.Idle,
+                    grid = BlockGrid.EMPTY,
+                    gridVersion = it.gridVersion + 1,
+                    totalBlocks = 0,
+                    initialGaps = 0,
+                    gapsRemaining = 0,
+                    analyzedUpto = 0,
+                    analyzeTotal = 0,
+                    inFlight = emptyList(),
+                    targetHighlights = IntArray(0),
+                )
+            }
+            return
+        }
         if (s.phase !is DefragmenterPhase.Defragmenting &&
             s.phase !is DefragmenterPhase.Paused &&
             s.phase !is DefragmenterPhase.Ready

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/model/BlockGrid.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/model/BlockGrid.kt
@@ -89,6 +89,16 @@ class BlockGrid(
     companion object {
         val EMPTY = BlockGrid(0, LongArray(0), 0)
 
+        /**
+         * Sized grid with every block marked as a gap. Used by the streaming
+         * Analyze flow: the UI starts empty and flips bits to filled as the
+         * scan head advances through the grid.
+         */
+        fun createEmpty(totalBlocks: Int): BlockGrid {
+            val wordCount = (totalBlocks + 63) ushr 6
+            return BlockGrid(totalBlocks, LongArray(wordCount), totalBlocks)
+        }
+
         fun create(totalBlocks: Int, softDeletedIndices: IntArray): BlockGrid {
             val wordCount = (totalBlocks + 63) ushr 6
             val bits = LongArray(wordCount)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/DefragSource.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/DefragSource.kt
@@ -1,33 +1,47 @@
 package id.homebase.core.ui.screens.defragmenter.service
 
+import kotlinx.coroutines.flow.Flow
 import kotlin.uuid.Uuid
 
 /**
  * Data backend for the Defragmenter screen.
  *
- * Analyze returns the current drive-index state compacted into one big linear
- * grid: total block count + a map of grid positions that are gaps (i.e. rows
- * whose `archivalStatus` is `Removed`, awaiting hard-delete on the server).
+ * [analyze] streams progress so the UI can render the scan as it happens: a
+ * [DefragAnalyzeEvent.Sized] with the final grid dimensions, zero or more
+ * [DefragAnalyzeEvent.Progress] chunks, and a terminal [DefragAnalyzeEvent.Done]
+ * carrying the final gap map.
  *
  * When a defrag animation commits a block into a gap, the ViewModel looks up
  * that gap in the map and calls [hardDelete] with the `fileId` of the file
  * that position represents.
  */
 interface DefragSource {
-    suspend fun analyze(): DefragAnalysis
+    fun analyze(): Flow<DefragAnalyzeEvent>
     suspend fun hardDelete(driveId: Uuid, fileId: Uuid): Boolean
 
     /** Compacts the SQLite database file (runs VACUUM). */
     suspend fun vacuum()
 }
 
-data class DefragAnalysis(
-    val totalBlocks: Int,
-    val gapMap: Map<Int, DeletedFileRef>,
-) {
-    companion object {
-        val EMPTY = DefragAnalysis(totalBlocks = 0, gapMap = emptyMap())
-    }
+sealed interface DefragAnalyzeEvent {
+    /** Emitted once after drive counts have been summed, before jsonHeader scan starts. */
+    data class Sized(val totalBlocks: Int) : DefragAnalyzeEvent
+
+    /**
+     * Emitted per scan chunk. [analyzedUpto] is the exclusive upper bound of
+     * positions that have now been examined. [newGaps] are gap positions
+     * discovered in this chunk only — the caller accumulates them.
+     */
+    data class Progress(
+        val analyzedUpto: Int,
+        val newGaps: Map<Int, DeletedFileRef>,
+    ) : DefragAnalyzeEvent
+
+    /** Terminal event: total and full accumulated gap map. */
+    data class Done(
+        val totalBlocks: Int,
+        val gapMap: Map<Int, DeletedFileRef>,
+    ) : DefragAnalyzeEvent
 }
 
 data class DeletedFileRef(val driveId: Uuid, val fileId: Uuid)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/LiveDefragSource.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/LiveDefragSource.kt
@@ -2,28 +2,34 @@ package id.homebase.core.ui.screens.defragmenter.service
 
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.HomebaseFile
 import id.homebase.api.client.drives.files.DriveFileProvider
+import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.DriveSyncManager
 import id.homebase.api.sync.database.DatabaseManager
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 import kotlin.concurrent.Volatile
-import kotlin.random.Random
 import kotlin.uuid.Uuid
 
 /**
  * Live DB/API-backed [DefragSource].
  *
- * Analyze walks every drive in [DriveSyncManager.driveStatuses], sums
- * `count(*)`, and fetches soft-deleted `fileId`s via the new
- * `selectSoftDeletedFileIds` SQL query. Each drive gets a contiguous range in
- * the grid; soft-deleted files are scattered to random positions within their
- * drive's range so the visualisation looks realistic rather than clumped at
- * the top of the grid.
+ * Analyze is a two-pass streaming scan:
+ *  1. Sum `count(*)` across every drive (cheap, indexed). Emit [Sized].
+ *  2. Per drive (sorted), keyset-page rows in rowId-ascending order. For each
+ *     row, deserialize `jsonHeader` and call [HomebaseFile.isSoftDeleted].
+ *     Gaps land at `offset + indexInDrive` in the global grid. After each
+ *     chunk emit [Progress]; emit [Done] at the end.
  *
  * Hard delete hits `POST /drives/{driveId}/files/{fileId}/hard-delete` via
- * [DriveFileProvider.hardDeleteFile]. Failures are logged but not retried —
- * this is a best-effort cleanup feature.
+ * [DriveFileProvider.hardDeleteFile]. On success we also delete the local
+ * `DriveMainIndex` row so the next analyze pass doesn't re-report it.
+ * Failures are logged but not retried — this is a best-effort cleanup.
  */
 class LiveDefragSource(
     private val driveSyncManager: DriveSyncManager,
@@ -39,29 +45,32 @@ class LiveDefragSource(
     @Volatile
     private var cachedIdentityId: Uuid? = null
 
-    override suspend fun analyze(): DefragAnalysis = withContext(Dispatchers.Default) {
+    override fun analyze(): Flow<DefragAnalyzeEvent> = flow {
         val identityId: Uuid = runCatching {
             credentialsManager.requireActiveCredentials().getIdentityId()
         }.getOrElse {
             Logger.w(tag = tag, throwable = it) { "no active credentials — cannot analyze" }
             cachedIdentityId = null
-            return@withContext DefragAnalysis.EMPTY
+            emit(DefragAnalyzeEvent.Done(totalBlocks = 0, gapMap = emptyMap()))
+            return@flow
         }
         cachedIdentityId = identityId
 
-        // Sort drives so grid assignment is stable across Analyze runs.
         val drives = driveSyncManager.driveStatuses.value.values
-            .map { it.driveId to it.label }
-            .sortedBy { it.first.toString() }
+            .map { it.driveId }
+            .sortedBy { it.toString() }
 
-        if (drives.isEmpty()) return@withContext DefragAnalysis.EMPTY
+        if (drives.isEmpty()) {
+            emit(DefragAnalyzeEvent.Done(totalBlocks = 0, gapMap = emptyMap()))
+            return@flow
+        }
 
         val mainIndex = databaseManager.driveMainIndex
-        val gapMap = HashMap<Int, DeletedFileRef>()
-        var totalBlocks = 0
-        val scatterRandom = Random.Default
 
-        for ((driveId, _) in drives) {
+        // Pass 1: count.
+        val driveSlots = ArrayList<DriveSlot>(drives.size)
+        var totalBlocks = 0
+        for (driveId in drives) {
             val count = runCatching { mainIndex.countByIdentityAndDrive(identityId, driveId) }
                 .getOrElse {
                     Logger.w(tag = tag, throwable = it) { "count failed for drive $driveId" }
@@ -70,38 +79,67 @@ class LiveDefragSource(
                 .coerceIn(0L, Int.MAX_VALUE.toLong() - totalBlocks)
                 .toInt()
             if (count == 0) continue
+            driveSlots.add(DriveSlot(driveId = driveId, offset = totalBlocks, count = count))
+            totalBlocks += count
+        }
+        emit(DefragAnalyzeEvent.Sized(totalBlocks = totalBlocks))
+        if (totalBlocks == 0) {
+            emit(DefragAnalyzeEvent.Done(totalBlocks = 0, gapMap = emptyMap()))
+            return@flow
+        }
 
-            val softIds = runCatching { mainIndex.selectSoftDeletedFileIds(identityId, driveId) }
-                .getOrElse {
-                    Logger.w(tag = tag, throwable = it) { "soft-delete enumeration failed for drive $driveId" }
+        // Pass 2: paged scan + deserialize.
+        val accGaps = HashMap<Int, DeletedFileRef>()
+        var cumulative = 0
+        for (slot in driveSlots) {
+            var sinceRowId = 0L
+            var indexInDrive = 0
+            while (indexInDrive < slot.count) {
+                val page = runCatching {
+                    mainIndex.selectFileIdAndJsonByDriveSince(
+                        identityId = identityId,
+                        driveId = slot.driveId,
+                        sinceRowId = sinceRowId,
+                        limit = PAGE_SIZE,
+                    )
+                }.getOrElse {
+                    Logger.w(tag = tag, throwable = it) {
+                        "page scan failed for drive=${slot.driveId} since=$sinceRowId"
+                    }
                     emptyList()
                 }
-                .take(count) // defensively clamp — can't have more gaps than rows.
+                if (page.isEmpty()) break
 
-            // Scatter softIds into random distinct positions inside this drive's
-            // grid range [offset, offset + count). Using a Fisher-Yates partial
-            // shuffle so each position is chosen exactly once.
-            val offset = totalBlocks
-            if (softIds.isNotEmpty()) {
-                val positions = IntArray(count) { it } // 0..count-1
-                for (i in 0 until softIds.size) {
-                    val j = i + scatterRandom.nextInt(count - i)
-                    val tmp = positions[i]
-                    positions[i] = positions[j]
-                    positions[j] = tmp
-                    val absPos = offset + positions[i]
-                    gapMap[absPos] = DeletedFileRef(driveId = driveId, fileId = softIds[i])
+                val chunkGaps = HashMap<Int, DeletedFileRef>()
+                for (row in page) {
+                    val header = runCatching {
+                        OdinSystemSerializer.deserialize<HomebaseFile>(row.jsonHeader)
+                    }.getOrNull()
+                    if (header != null && header.isSoftDeleted()) {
+                        val pos = slot.offset + indexInDrive
+                        chunkGaps[pos] = DeletedFileRef(driveId = slot.driveId, fileId = row.fileId)
+                    }
+                    indexInDrive += 1
+                    cumulative += 1
+                    sinceRowId = row.rowId
+                    if (indexInDrive >= slot.count) break
                 }
+                accGaps.putAll(chunkGaps)
+                emit(
+                    DefragAnalyzeEvent.Progress(
+                        analyzedUpto = cumulative,
+                        newGaps = chunkGaps,
+                    )
+                )
+                yield()
             }
-
-            totalBlocks += count
         }
 
         Logger.d(tag = tag) {
-            "analyze: totalBlocks=$totalBlocks, gaps=${gapMap.size} across ${drives.size} drive(s)"
+            "analyze: totalBlocks=$totalBlocks, gaps=${accGaps.size} across ${driveSlots.size} drive(s)"
         }
-        DefragAnalysis(totalBlocks = totalBlocks, gapMap = gapMap)
-    }
+        emit(DefragAnalyzeEvent.Done(totalBlocks = totalBlocks, gapMap = accGaps))
+    }.flowOn(Dispatchers.Default)
 
     override suspend fun hardDelete(driveId: Uuid, fileId: Uuid): Boolean {
         val remoteOk = runCatching {
@@ -134,6 +172,12 @@ class LiveDefragSource(
     }
 
     override suspend fun vacuum() {
-        databaseManager.vacuum()
+        withContext(Dispatchers.Default) { databaseManager.vacuum() }
+    }
+
+    private data class DriveSlot(val driveId: Uuid, val offset: Int, val count: Int)
+
+    private companion object {
+        const val PAGE_SIZE = 500L
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/ui/DefragGridCanvas.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/ui/DefragGridCanvas.kt
@@ -96,6 +96,14 @@ fun DefragGridCanvas(
     targetHighlights: IntArray,
     frameTimeNanos: Long,
     celebratoryProgress: Float = 0f,
+    // analyzedUpto = the exclusive upper bound of positions scanned so far.
+    // When equal to grid.totalBlocks (default), the whole grid is analyzed and
+    // no dim overlay is drawn. During Analyzing, positions >= analyzedUpto
+    // render as "unanalyzed" (flat dim) instead of as gaps.
+    analyzedUpto: Int = Int.MAX_VALUE,
+    // scanHeadIndex = index of the cell where the scan head currently is, or
+    // null outside of Analyzing. Draws a bright highlight overlay.
+    scanHeadIndex: Int? = null,
     modifier: Modifier = Modifier,
 ) {
     BoxWithConstraints(modifier = modifier) {
@@ -126,6 +134,9 @@ fun DefragGridCanvas(
                     targetHighlights = targetHighlights,
                     frameTimeNanos = frameTimeNanos,
                     celebratoryProgress = celebratoryProgress,
+                    totalBlocks = grid.totalBlocks,
+                    analyzedUpto = analyzedUpto,
+                    scanHeadIndex = scanHeadIndex,
                 )
             } else {
                 drawModern(
@@ -135,9 +146,73 @@ fun DefragGridCanvas(
                     targetHighlights = targetHighlights,
                     frameTimeNanos = frameTimeNanos,
                     celebratoryProgress = celebratoryProgress,
+                    totalBlocks = grid.totalBlocks,
+                    analyzedUpto = analyzedUpto,
+                    scanHeadIndex = scanHeadIndex,
                 )
             }
         }
+    }
+}
+
+/**
+ * Draws a flat dim rectangle over positions `[analyzedUpto, totalBlocks)`.
+ * O(rows) — one drawRect per grid row, not per cell.
+ */
+private fun DrawScope.drawUnanalyzedRegion(
+    layout: GridLayout,
+    totalBlocks: Int,
+    analyzedUpto: Int,
+    fill: Color,
+) {
+    if (analyzedUpto >= totalBlocks || totalBlocks <= 0) return
+    val cols = layout.cols
+    if (cols <= 0) return
+    val b = layout.blockSize
+    if (b <= 0f) return
+    val step = b + layout.gap
+    val startCol = analyzedUpto % cols
+    val startRow = analyzedUpto / cols
+    val lastIndex = totalBlocks - 1
+    val lastRow = lastIndex / cols
+    val lastColInLastRow = lastIndex % cols
+
+    // Partial row at startRow (may also be the last row).
+    val lastColInStartRow = if (startRow == lastRow) lastColInLastRow else cols - 1
+    if (startCol <= lastColInStartRow) {
+        val x = layout.offsetX + startCol * step
+        val y = layout.offsetY + startRow * step
+        val rowW = (lastColInStartRow - startCol + 1) * step - layout.gap
+        drawRect(color = fill, topLeft = Offset(x, y), size = Size(rowW, b))
+    }
+    // Full rows below startRow.
+    for (r in startRow + 1..lastRow) {
+        val lastColInRow = if (r == lastRow) lastColInLastRow else cols - 1
+        val x = layout.offsetX
+        val y = layout.offsetY + r * step
+        val rowW = (lastColInRow + 1) * step - layout.gap
+        drawRect(color = fill, topLeft = Offset(x, y), size = Size(rowW, b))
+    }
+}
+
+/** Bright single-cell overlay marking where the scan head is. */
+private fun DrawScope.drawScanHead(
+    layout: GridLayout,
+    totalBlocks: Int,
+    scanHeadIndex: Int?,
+) {
+    if (scanHeadIndex == null || scanHeadIndex < 0 || scanHeadIndex >= totalBlocks) return
+    val b = layout.blockSize
+    if (b <= 0f) return
+    val origin = layout.indexOffset(scanHeadIndex)
+    drawRect(color = Win98Palette.ScanHead, topLeft = origin, size = Size(b, b))
+    if (b >= 3f) {
+        drawRect(
+            color = Win98Palette.ScanHeadEdge,
+            topLeft = origin,
+            size = Size(b, b),
+            style = Stroke(width = max(1f, b * 0.1f)),
+        )
     }
 }
 
@@ -150,12 +225,21 @@ private fun DrawScope.drawModern(
     targetHighlights: IntArray,
     frameTimeNanos: Long,
     celebratoryProgress: Float,
+    totalBlocks: Int,
+    analyzedUpto: Int,
+    scanHeadIndex: Int?,
 ) {
     drawRect(
         brush = Brush.verticalGradient(
             listOf(Win98Palette.CanvasBackgroundTop, Win98Palette.CanvasBackground)
         ),
         size = size,
+    )
+    drawUnanalyzedRegion(
+        layout = layout,
+        totalBlocks = totalBlocks,
+        analyzedUpto = analyzedUpto,
+        fill = Win98Palette.UnanalyzedFill,
     )
     // Always draw the original-blue filled path. During the celebration,
     // paint a green copy over the left portion via clipRect — a vertical scan
@@ -170,6 +254,7 @@ private fun DrawScope.drawModern(
     }
     drawTargetHalos(targetHighlights, layout, frameTimeNanos)
     drawInFlightModern(inFlight, layout, frameTimeNanos)
+    drawScanHead(layout, totalBlocks, scanHeadIndex)
 }
 
 private fun buildFilledPath(grid: BlockGrid, layout: GridLayout): Path {
@@ -286,9 +371,18 @@ private fun DrawScope.drawClassic(
     targetHighlights: IntArray,
     frameTimeNanos: Long,
     celebratoryProgress: Float,
+    totalBlocks: Int,
+    analyzedUpto: Int,
+    scanHeadIndex: Int?,
 ) {
     // Solid black background — no gradient.
     drawRect(color = Win98Palette.ClassicBg, size = size)
+    drawUnanalyzedRegion(
+        layout = layout,
+        totalBlocks = totalBlocks,
+        analyzedUpto = analyzedUpto,
+        fill = Win98Palette.UnanalyzedFill,
+    )
 
     val b = layout.blockSize
     val sweepX = if (celebratoryProgress > 0f) celebratoryProgress * size.width else Float.NEGATIVE_INFINITY
@@ -345,6 +439,8 @@ private fun DrawScope.drawClassic(
             shadow = Win98Palette.ClassicMovingShadow,
         )
     }
+
+    drawScanHead(layout, totalBlocks, scanHeadIndex)
 }
 
 private fun DrawScope.drawClassicBlock(

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/ui/Win98Palette.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/ui/Win98Palette.kt
@@ -50,4 +50,14 @@ object Win98Palette {
     val ClassicGreenLight: Color = Color(0xFF50E850)
     val ClassicGreenShadow: Color = Color(0xFF004800)
     val GreenGlowEdge: Color = Color(0xFF00FF88)
+
+    // "Unanalyzed" palette — used during Analyzing for positions the scan
+    // head hasn't reached yet. Flat and unobtrusive so the scan head stands
+    // out as it sweeps across.
+    val UnanalyzedFill: Color = Color(0xFF2E2E2E)
+    val UnanalyzedEdge: Color = Color(0xFF1A1A1A)
+
+    // Scan-head highlight — the single bright cell at analyzedUpto - 1.
+    val ScanHead: Color = Color(0xFFFFFFE0)
+    val ScanHeadEdge: Color = Color(0xFFFFFFFF)
 }


### PR DESCRIPTION
Switch the Defragmenter from the OLD `archivalStatus = 2` SQL filter to the real soft-delete marker `HomebaseFile.fileState == FileState.Deleted`, and turn the (previously invisible) deserialization cost into a first-class "Analyzing disk…" sweep so the user sees blocks appear one-by-one as the scan head advances across the grid.

Soft-delete detection
- Add `HomebaseFile.isSoftDeleted()` (belt-and-suspenders: fileState==Deleted OR archivalStatus==Removed) next to `assertFileIsActive()`.
- Replace the manual OR in ChatMessageStream.kt and ConversationMapper.kt with the new helper; drop now-unused FileState/ArchivalStatus imports.

Streaming Analyze
- `DefragSource.analyze()` is now a `Flow<DefragAnalyzeEvent>` emitting Sized → repeated Progress → Done. The VM collects the flow, sizes the grid on Sized, flips filled bits per Progress chunk, and transitions to Ready on Done.
- `LiveDefragSource` does two passes: (1) sum count(*) across drives for the grid size; (2) keyset-page each drive's rows in rowId-ascending order via new `selectFileIdAndJsonByDriveSince` SQL (chunks of 500), deserialize each `jsonHeader`, apply `isSoftDeleted()`, emit Progress. Fisher-Yates gap scatter is gone — gaps now land at their real rowId position, which is more honest.
- `BlockGrid.createEmpty()` starts with every bit clear so the VM can progressively flip filled bits as the scan advances.

UI visualization
- `DefragmenterUiState` gains `analyzedUpto` + `analyzeTotal` and a derived `scanHeadIndex`.
- `DefragGridCanvas` accepts `analyzedUpto` + `scanHeadIndex`: positions beyond the scan head render as flat dim "unanalyzed" (new `Win98Palette.UnanalyzedFill`), and a single bright cell marks the current scan head. The unanalyzed overlay is O(rows), not O(cells).
- Status text: "Analyzing drive… N of M". Progress bar tracks analyzedUpto/analyzeTotal during scan.
- Cancel is enabled during Analyzing (aborts the coroutine and returns to Idle); Analyze/Start stay disabled until the scan completes.

Hard-delete key is unchanged — still `deleteBy(identityId, driveId, fileId)`, which matches the remote endpoint, the sync-ingest cleanup path, and the `(identityId, driveId, fileId)` UNIQUE constraint.

Verified: homebase-api, homebase-chat, homebase-core compile on JVM, Android, and iOS (iosSimulatorArm64). homebase-api + homebase-chat jvm test suites pass. Two homebase-core test failures in NotificationTapColdStartTest are pre-existing on the base branch and unrelated to this change.