### PR TITLE
build: silence AGP 9.2 `withHostTest` warning in all KMP modules

### DIFF
--- a/homebase-api/build.gradle.kts
+++ b/homebase-api/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
         compileSdk = libs.versions.android.targetSdk.get().toInt()
         minSdk = libs.versions.android.minSdk.get().toInt()
         androidResources.enable = true
+        withHostTest {}
     }
 
     jvm() {
@@ -145,6 +146,15 @@ kotlin {
         }
         jvmTest.dependencies {
             implementation(desktopDep)
+        }
+        // Android host tests run on the JVM with android.jar stubs — the real
+        // AndroidSqliteDriver would throw "Stub!" at runtime, so we use the
+        // JDBC driver the same way jvmMain does.
+        getByName("androidHostTest").dependencies {
+            implementation(libs.sqldelight.sqlite.driver.get().toString()) {
+                exclude(group = "org.xerial", module = "sqlite-jdbc")
+            }
+            implementation(libs.sqlite.jdbc.crypt)
         }
     }
 

--- a/homebase-api/src/androidHostTest/kotlin/id/homebase/api/sync/database/TestDatabaseHelper.androidHost.kt
+++ b/homebase-api/src/androidHostTest/kotlin/id/homebase/api/sync/database/TestDatabaseHelper.androidHost.kt
@@ -1,0 +1,13 @@
+package id.homebase.api.sync.database
+
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+
+// Android host-test runs on JVM with android.jar stubs, so the JDBC SQLite
+// driver (pure Java) is the right fit — AndroidSqliteDriver would throw
+// "Stub!" without a Robolectric-style runtime.
+actual fun createInMemoryDatabase(): SqlDriver {
+    val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+    OdinDatabase.Schema.create(driver)
+    return driver
+}

--- a/homebase-auth/build.gradle.kts
+++ b/homebase-auth/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
         namespace = "id.homebase.auth"
         compileSdk = libs.versions.android.targetSdk.get().toInt()
         minSdk = libs.versions.android.minSdk.get().toInt()
+        withHostTest {}
     }
 
     jvm()
@@ -84,4 +85,13 @@ kotlin {
             implementation(compose.desktop.currentOs)
         }
     }
+}
+
+// `withHostTest {}` is enabled above so AGP 9.2 stops warning about commonTest
+// with no Android host-test runner. Compose UI tests in commonTest use a
+// Skiko-backed implementation that doesn't compose against the mocked Android
+// host-test classpath, so disable the task until those tests are migrated
+// to jvmTest/.
+tasks.matching { it.name == "testAndroidHostTest" }.configureEach {
+    enabled = false
 }

--- a/homebase-chat/build.gradle.kts
+++ b/homebase-chat/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
         namespace = "id.homebase.chat"
         compileSdk = libs.versions.android.targetSdk.get().toInt()
         minSdk = libs.versions.android.minSdk.get().toInt()
+        withHostTest {}
     }
 
     jvm()
@@ -175,4 +176,13 @@ tasks.named("assemble") {
 // Also wire them up to the jvmJar task for good measure
 tasks.named("jvmJar") {
     finalizedBy(platformJarTasks)
+}
+
+// `withHostTest {}` is enabled above so AGP 9.2 stops warning about commonTest
+// with no Android host-test runner. Compose UI tests in commonTest use a
+// Skiko-backed implementation that doesn't compose against the mocked Android
+// host-test classpath, so disable the task until those tests are migrated
+// to jvmTest/.
+tasks.matching { it.name == "testAndroidHostTest" }.configureEach {
+    enabled = false
 }

--- a/homebase-common/build.gradle.kts
+++ b/homebase-common/build.gradle.kts
@@ -33,6 +33,7 @@ kotlin {
         compileSdk = libs.versions.android.targetSdk.get().toInt()
         minSdk = libs.versions.android.minSdk.get().toInt()
         androidResources.enable = true
+        withHostTest {}
     }
 
     jvm()
@@ -137,4 +138,12 @@ kotlin {
             }
         }
     }
+}
+// `withHostTest {}` is enabled above so AGP 9.2 stops warning about commonTest
+// with no Android host-test runner. Compose UI tests in commonTest use a
+// Skiko-backed implementation that doesn't compose against the mocked Android
+// host-test classpath, so disable the task until those tests are migrated
+// to jvmTest/.
+tasks.matching { it.name == "testAndroidHostTest" }.configureEach {
+    enabled = false
 }

--- a/homebase-core/build.gradle.kts
+++ b/homebase-core/build.gradle.kts
@@ -23,6 +23,7 @@ kotlin {
         namespace = "id.homebase.core"
         compileSdk = libs.versions.android.targetSdk.get().toInt()
         minSdk = libs.versions.android.minSdk.get().toInt()
+        withHostTest {}
     }
 
     jvm()
@@ -141,4 +142,14 @@ tasks.withType<Test>().configureEach {
             excludeTestsMatching("id.homebase.core.ui.navigation.NotificationTapColdStartTest.broken_top_only_gate_hangs_when_on_detail")
         }
     }
+}
+
+// `withHostTest {}` is enabled above so AGP 9.2 stops warning about commonTest
+// with no Android host-test runner. However, most commonTest files here use
+// `runComposeUiTest {}` (compose-ui-test), which resolves to a Skiko-backed
+// implementation on JVM but hits null-returning Android API stubs when run
+// against the mocked Android host-test classpath. Disable the task until
+// those tests are migrated to jvmTest/.
+tasks.matching { it.name == "testAndroidHostTest" }.configureEach {
+    enabled = false
 }


### PR DESCRIPTION
AGP 9.2 now warns that every KMP module with a `commonTest` source set but no Android host-test runner is missing coverage:

    WARNING: The 'commonTest' source directory exists, but android host
    tests are not enabled. To enable android host tests, add `withHostTest {}`
    to your android target configuration in the Gradle build file.

Enable `withHostTest {}` in homebase-api, homebase-auth, homebase-chat, homebase-common, and homebase-core to silence the warning and give the team a hook for future Android-classpath tests.

Caveat on the four UI modules (auth, chat, common, core): their `commonTest` is full of `runComposeUiTest {}` tests backed by Skiko on JVM. That implementation does not resolve against the mocked Android host-test classpath, and running the task produces dozens of NullPointerExceptions. Migrating Skiko tests into `jvmTest/` is a larger project than this cleanup deserves, so the `testAndroidHostTest` task is disabled in those four modules with an inline comment pointing at the follow-up. The compilation still runs, so the warning is gone and the door is open for future work.

homebase-api has no Compose UI tests — its 231-test `testAndroidHostTest` runs cleanly. It needed one small addition: an `androidHostTest/` actual for the `createInMemoryDatabase` expect declaration, which delegates to the same `JdbcSqliteDriver` the JVM implementation uses (the real `AndroidSqliteDriver` would hit android.jar stubs and throw at runtime). The JDBC driver dependency is wired via a new `androidHostTest.dependencies` block that mirrors `jvmMain`.

Pre-existing `NotificationTapColdStartTest` JVM failures are intentionally not touched — commit f4ee5ff7 documents them as known-broken in headless lifecycle environments and excludes them from CI. Respecting that decision.

Verified:
- `compileAndroidMain` across all five modules → no warnings.
- `homebase-api:testAndroidHostTest` → 231 tests, 0 failures.
- `testAndroidHostTest` SKIPPED for the other four modules (by design).
- `homebase-api:jvmTest`, `homebase-chat:jvmTest` → green.
- `compileKotlinIosSimulatorArm64` across all modules → green.