### PR TITLE
fix(di): use single { } for PendingNotificationTap so default args apply

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -208,7 +208,11 @@ val appModule = module {
     singleOf(::ChatMessageSenderService) bind StatusMessageSender::class
     singleOf(::HomebaseImageLoader)
     singleOf(::ChatMessageActionService)
-    singleOf(::PendingNotificationTap)
+    // singleOf(::PendingNotificationTap) would force Koin to resolve every
+    // constructor parameter from the container — including the Duration TTL
+    // and the CoroutineScope, which are intentionally Kotlin-default args.
+    // Use the explicit lambda form so the defaults take effect.
+    single { PendingNotificationTap() }
     singleOf(::NotificationService)
     singleOf(::ConnectionRequestService)
     singleOf(::NotificationActionBridge)


### PR DESCRIPTION
The TTL refactor (9f615143) gave PendingNotificationTap a Duration and CoroutineScope on its constructor with Kotlin default values. The DI binding was still `singleOf(::PendingNotificationTap)`, which makes Koin ignore Kotlin defaults and try to resolve every parameter from the container. With no Duration registered, startup failed with NoDefinitionFoundException for kotlin.time.Duration, cascading through NotificationService and DesktopChatNotificationBridge and crashing `./gradlew desktopApp:jvmRun` at Koin eager-instance creation.

Switching to `single { PendingNotificationTap() }` invokes the constructor with zero args so DEFAULT_TTL (10s) and the self-owned scope take effect — the production behavior the class was designed for.