### PR TITLE
Several gallery / media optimization experiments at once

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
@@ -27,7 +27,6 @@ import co.touchlab.kermit.Logger
 import com.mohamedrejeb.richeditor.model.RichTextState
 import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.api.file.FileOperationsProvider
-import id.homebase.api.video.FFmpegUtils
 import id.homebase.api.youauth.YouAuthFlowManager
 import id.homebase.api.youauth.YouAuthState
 import id.homebase.chat.conversationlist.AttachmentPendingFile
@@ -427,19 +426,19 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
         return null
     }
 
-    private suspend fun convertToAttachmentFiles(files: List<SharedFile>): List<AttachmentPendingFile> {
+    private fun convertToAttachmentFiles(files: List<SharedFile>): List<AttachmentPendingFile> {
         return files.map { sharedFile ->
             val platformFile = PlatformFile(java.io.File(sharedFile.path))
             when {
                 sharedFile.mimeType.startsWith("image/") ->
                     AttachmentPendingFile.FileImage(Uuid.random(), platformFile)
-                sharedFile.mimeType.startsWith("video/") -> {
-                    val thumbnailPath = FFmpegUtils.grabThumbnail(sharedFile.path)
-                    val thumbnailBytes = thumbnailPath?.let {
-                        java.io.File(it).readBytes()
-                    }
-                    AttachmentPendingFile.FileVideo(Uuid.random(), platformFile, thumbnailBytes)
-                }
+                sharedFile.mimeType.startsWith("video/") ->
+                    // Editor renders the poster via Coil's VideoFrameDecoder when bytes
+                    // are null; the upload pipeline extracts its own thumbnails from the
+                    // file path inside VideoPayloadProcessor. So we don't need to do any
+                    // synchronous extraction here — that was the slowest part of opening
+                    // the share preview for big videos.
+                    AttachmentPendingFile.FileVideo(Uuid.random(), platformFile, thumbnailBytes = null)
                 else ->
                     AttachmentPendingFile.File(Uuid.random(), platformFile)
             }

--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/file/AndroidFileOperationsProvider.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/file/AndroidFileOperationsProvider.kt
@@ -36,6 +36,44 @@ class AndroidFileOperationsProvider(
         }
     }
 
+    override fun readFileAsFlow(path: String, chunkSize: Int): kotlinx.coroutines.flow.Flow<ByteArray> =
+        kotlinx.coroutines.flow.flow {
+            val stream = if (path.startsWith("content://") || path.startsWith("content:")) {
+                context.contentResolver.openInputStream(path.toUri())
+                    ?: throw IllegalArgumentException("Unable to open content URI: $path")
+            } else {
+                File(path).inputStream()
+            }
+            stream.use {
+                val buf = ByteArray(chunkSize)
+                while (true) {
+                    val n = it.read(buf, 0, buf.size)
+                    if (n <= 0) break
+                    emit(buf.copyOf(n))
+                }
+            }
+        }
+
+    override suspend fun readFileHeaderBytes(path: String, maxBytes: Int): ByteArray =
+        withContext(Dispatchers.IO) {
+            val stream = if (path.startsWith("content://") || path.startsWith("content:")) {
+                context.contentResolver.openInputStream(path.toUri())
+                    ?: throw IllegalArgumentException("Unable to open content URI: $path")
+            } else {
+                File(path).inputStream()
+            }
+            stream.use {
+                val buf = ByteArray(maxBytes)
+                var off = 0
+                while (off < maxBytes) {
+                    val n = it.read(buf, off, maxBytes - off)
+                    if (n <= 0) break
+                    off += n
+                }
+                if (off == maxBytes) buf else buf.copyOf(off)
+            }
+        }
+
     override fun deleteTempFile(path: String): Boolean {
         return runCatching {
             if (path.startsWith("content://") || path.startsWith("content:")) {

--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/video/VideoThumbnailExtractor.android.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/video/VideoThumbnailExtractor.android.kt
@@ -1,0 +1,88 @@
+package id.homebase.api.video
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.media.MediaMetadataRetriever
+import android.os.Build
+import android.os.CancellationSignal
+import android.util.Log
+import android.util.Size
+import androidx.core.net.toUri
+import id.homebase.api.ActivityProvider
+import java.io.ByteArrayOutputStream
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+actual object VideoThumbnailExtractor {
+    private const val TAG = "VideoThumbnailExtractor"
+    private const val TARGET_PX = 640
+    private const val JPEG_QUALITY = 80
+
+    actual suspend fun extractPosterFrame(videoPath: String): ByteArray? =
+        withContext(Dispatchers.IO) {
+            val context = ActivityProvider.requireActivity().applicationContext
+            val isContentUri = videoPath.startsWith("content://") || videoPath.startsWith("content:")
+
+            if (isContentUri) {
+                tryLoadThumbnail(context, videoPath)?.let { return@withContext it }
+                tryMediaMetadataRetrieverForUri(context, videoPath)?.let { return@withContext it }
+            } else {
+                tryMediaMetadataRetrieverForPath(videoPath)?.let { return@withContext it }
+            }
+
+            null
+        }
+
+    private fun tryLoadThumbnail(context: Context, contentUri: String): ByteArray? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return null
+        return try {
+            val bitmap = context.contentResolver.loadThumbnail(
+                contentUri.toUri(),
+                Size(TARGET_PX, TARGET_PX),
+                CancellationSignal(),
+            )
+            bitmap.toJpegBytes().also { bitmap.recycle() }
+        } catch (e: Exception) {
+            Log.d(TAG, "loadThumbnail failed for $contentUri: ${e.message}")
+            null
+        }
+    }
+
+    private fun tryMediaMetadataRetrieverForUri(context: Context, contentUri: String): ByteArray? {
+        val retriever = MediaMetadataRetriever()
+        return try {
+            retriever.setDataSource(context, contentUri.toUri())
+            retriever.frameAtZero()?.let { it.toJpegBytes().also { _ -> it.recycle() } }
+        } catch (e: Exception) {
+            Log.d(TAG, "MMR(uri) failed for $contentUri: ${e.message}")
+            null
+        } finally {
+            retriever.runCatching { release() }
+        }
+    }
+
+    private fun tryMediaMetadataRetrieverForPath(filePath: String): ByteArray? {
+        val file = File(filePath)
+        if (!file.exists()) return null
+        val retriever = MediaMetadataRetriever()
+        return try {
+            retriever.setDataSource(filePath)
+            retriever.frameAtZero()?.let { it.toJpegBytes().also { _ -> it.recycle() } }
+        } catch (e: Exception) {
+            Log.d(TAG, "MMR(path) failed for $filePath: ${e.message}")
+            null
+        } finally {
+            retriever.runCatching { release() }
+        }
+    }
+
+    private fun MediaMetadataRetriever.frameAtZero(): Bitmap? =
+        getFrameAtTime(0, MediaMetadataRetriever.OPTION_CLOSEST_SYNC)
+
+    private fun Bitmap.toJpegBytes(): ByteArray {
+        val out = ByteArrayOutputStream()
+        compress(Bitmap.CompressFormat.JPEG, JPEG_QUALITY, out)
+        return out.toByteArray()
+    }
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/crypto/AesCbc.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/crypto/AesCbc.kt
@@ -67,14 +67,18 @@ object AesCbc {
     private const val BLOCK_SIZE = 16
 
     /**
-     * Stream encrypt data with AES-CBC. Assumes each chunk (apart from last one) is a multiple of
-     * 16 bytes.
+     * Stream encrypt data with AES-CBC + PKCS7 padding. Accepts a [dataStream] of any chunk
+     * shape — the function buffers internally so callers don't need to align their producer
+     * to the AES block size.
      *
-     * The algorithm:
-     * 1. For each chunk, encrypt using the previous block as IV (or initial IV for first chunk)
-     * 2. Remove the padding block from each chunk except the last
-     * 3. Store the last encrypted block to use as IV for next chunk
-     * 4. On final chunk, re-add the padding for proper stream termination
+     * The output ciphertext is byte-identical to [encrypt] applied to the concatenation of
+     * all incoming chunks: same CBC chaining, same single PKCS7 pad block at the end.
+     *
+     * Algorithm: keep a [carry] buffer of unprocessed bytes (always < 2 * BLOCK_SIZE). On
+     * each incoming chunk, peel off the largest block-aligned prefix that still leaves at
+     * least one block in carry, encrypt + emit that prefix (stripping the cipher's PKCS7
+     * pad block since the input is aligned), and roll the chain IV. On flow end, encrypt
+     * whatever's left in carry — the cipher applies the final PKCS7 padding for us.
      *
      * @param dataStream Flow of byte arrays representing the data stream
      * @param key Encryption key
@@ -92,32 +96,32 @@ object AesCbc {
         val aesKey = aes.keyDecoder().decodeFromByteArray(AES.Key.Format.RAW, key)
         val cipher = aesKey.cipher()
 
-        var lastBlock: ByteArray? = null
-        var lastPadding: ByteArray? = null
+        var carry = ByteArray(0)
+        var chainIv = iv
 
-        dataStream.collect { chunk ->
-            // Encrypt with iv or previous block as iv
-            val currentIv = lastBlock ?: iv
-            val encrypted = cipher.encryptWithIv(currentIv, chunk)
-
-            // Get padding (last BLOCK_SIZE bytes)
-            lastPadding = encrypted.copyOfRange(encrypted.size - BLOCK_SIZE, encrypted.size)
-
-            // Remove padding from output
-            val removedPadding = encrypted.copyOfRange(0, encrypted.size - BLOCK_SIZE)
-
-            // Get last block for next iteration's IV
-            lastBlock =
-                    removedPadding.copyOfRange(
-                            removedPadding.size - BLOCK_SIZE,
-                            removedPadding.size
-                    )
-
-            send(removedPadding)
+        dataStream.collect { incoming ->
+            if (incoming.isEmpty()) return@collect
+            val combined = if (carry.isEmpty()) incoming else carry + incoming
+            // Hold back at least BLOCK_SIZE bytes so the eventual final emit is always
+            // ≥ BLOCK_SIZE — required because we strip a PKCS7 pad block from each
+            // mid-stream encryption, which would underflow if the chunk were too small.
+            val processSize = ((combined.size - BLOCK_SIZE) / BLOCK_SIZE) * BLOCK_SIZE
+            if (processSize > 0) {
+                val toEncrypt = combined.copyOfRange(0, processSize)
+                val encrypted = cipher.encryptWithIv(chainIv, toEncrypt)
+                // Strip the PKCS7 pad block (always exactly BLOCK_SIZE since input is aligned).
+                val streamed = encrypted.copyOfRange(0, encrypted.size - BLOCK_SIZE)
+                chainIv = streamed.copyOfRange(streamed.size - BLOCK_SIZE, streamed.size)
+                carry = combined.copyOfRange(processSize, combined.size)
+                send(streamed)
+            } else {
+                carry = combined
+            }
         }
 
-        // Re-add last padding to have a clear end of the stream
-        lastPadding?.let { send(it) }
+        // Final emit: encrypt whatever's left in carry (0..N bytes) — the cipher's own
+        // PKCS7 padding produces the trailing block(s).
+        send(cipher.encryptWithIv(chainIv, carry))
     }
 
     /** Stream encrypt data with AES-CBC using SecureByteArray key. */

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/FileOperationsProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/FileOperationsProvider.kt
@@ -2,10 +2,35 @@ package id.homebase.api.file
 
 import io.ktor.client.request.forms.InputProvider
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 
 interface FileOperationsProvider {
     fun openFileInput(path: String): InputProvider
     suspend fun readFileBytes(path: String): ByteArray
+
+    /**
+     * Read [path] as a stream of byte chunks (default 64 KB). Lets callers process large
+     * files (video encryption, hash, upload) without allocating the full payload at once.
+     *
+     * The default implementation falls back to [readFileBytes] and emits a single chunk —
+     * no streaming benefit, but no regression for platforms that haven't bothered to
+     * override. Android and JVM provide proper streaming.
+     */
+    fun readFileAsFlow(path: String, chunkSize: Int = DEFAULT_HEADER_BYTES): Flow<ByteArray> = flow {
+        emit(readFileBytes(path))
+    }
+
+    /**
+     * Read at most [maxBytes] from the start of [path]. Designed for cheap header peeks
+     * (image dimensions, MIME sniffing) where loading the full asset would waste RAM.
+     *
+     * The default implementation reads everything and slices — platforms with cheap
+     * streaming I/O (Android, JVM) are expected to override.
+     */
+    suspend fun readFileHeaderBytes(path: String, maxBytes: Int = DEFAULT_HEADER_BYTES): ByteArray {
+        val all = readFileBytes(path)
+        return if (all.size <= maxBytes) all else all.copyOf(maxBytes)
+    }
 
     fun deleteTempFile(path: String): Boolean
     fun getCacheDirectory(): String
@@ -28,4 +53,8 @@ interface FileOperationsProvider {
      * by copying it to a temp file. On platforms without content URIs, returns [path] unchanged.
      */
     suspend fun resolveToFilePath(path: String): String = path
+
+    companion object {
+        const val DEFAULT_HEADER_BYTES: Int = 64 * 1024
+    }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/image/ImageHeaderParser.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/image/ImageHeaderParser.kt
@@ -1,0 +1,131 @@
+package id.homebase.api.image
+
+/**
+ * Header-only image-size reader. Parses the first ~64 KB of an image file to extract its
+ * pixel dimensions without decoding the entire payload.
+ *
+ * Supports JPEG (SOF0–SOF15), PNG (IHDR), GIF (LSD), and WebP (VP8 / VP8L / VP8X).
+ * Returns null for formats we can't parse incrementally (e.g. HEIC) — callers should
+ * fall back to [ImageUtils.getNaturalSize] in that case.
+ */
+object ImageHeaderParser {
+
+    fun parse(header: ByteArray): ImageSize? {
+        if (header.size < 12) return null
+        return when {
+            isJpeg(header) -> parseJpeg(header)
+            isPng(header) -> parsePng(header)
+            isGif(header) -> parseGif(header)
+            isWebp(header) -> parseWebp(header)
+            else -> null
+        }
+    }
+
+    private fun isJpeg(b: ByteArray) = b[0] == 0xFF.toByte() && b[1] == 0xD8.toByte()
+
+    private fun isPng(b: ByteArray) =
+        b[0] == 0x89.toByte() && b[1] == 0x50.toByte() && b[2] == 0x4E.toByte() &&
+            b[3] == 0x47.toByte() && b[4] == 0x0D.toByte() && b[5] == 0x0A.toByte() &&
+            b[6] == 0x1A.toByte() && b[7] == 0x0A.toByte()
+
+    private fun isGif(b: ByteArray) =
+        b[0] == 'G'.code.toByte() && b[1] == 'I'.code.toByte() && b[2] == 'F'.code.toByte() &&
+            b[3] == '8'.code.toByte() && (b[4] == '7'.code.toByte() || b[4] == '9'.code.toByte()) &&
+            b[5] == 'a'.code.toByte()
+
+    private fun isWebp(b: ByteArray) =
+        b[0] == 'R'.code.toByte() && b[1] == 'I'.code.toByte() && b[2] == 'F'.code.toByte() &&
+            b[3] == 'F'.code.toByte() && b[8] == 'W'.code.toByte() && b[9] == 'E'.code.toByte() &&
+            b[10] == 'B'.code.toByte() && b[11] == 'P'.code.toByte()
+
+    // JPEG: walk segments looking for SOF0..SOF15, skipping DHT (C4), JPG (C8), DAC (CC).
+    private fun parseJpeg(b: ByteArray): ImageSize? {
+        var i = 2 // past SOI
+        while (i + 8 < b.size) {
+            // Skip fill bytes (0xFF padding before next marker)
+            while (i < b.size && b[i] == 0xFF.toByte()) i++
+            if (i >= b.size) return null
+            val marker = b[i].toInt() and 0xFF
+            i++
+            // SOFx (excluding DHT 0xC4, JPG 0xC8, DAC 0xCC)
+            if (marker in 0xC0..0xCF && marker != 0xC4 && marker != 0xC8 && marker != 0xCC) {
+                if (i + 6 >= b.size) return null
+                // segment length (2 bytes, big-endian, includes itself)
+                // skip length (2) + sample precision (1)
+                val height = ((b[i + 3].toInt() and 0xFF) shl 8) or (b[i + 4].toInt() and 0xFF)
+                val width = ((b[i + 5].toInt() and 0xFF) shl 8) or (b[i + 6].toInt() and 0xFF)
+                if (width <= 0 || height <= 0) return null
+                return ImageSize(width, height)
+            }
+            // Other marker — skip its segment
+            if (marker == 0xD8 || marker == 0xD9) return null // SOI/EOI without SOF
+            if (i + 1 >= b.size) return null
+            val segLen = ((b[i].toInt() and 0xFF) shl 8) or (b[i + 1].toInt() and 0xFF)
+            if (segLen < 2) return null
+            i += segLen
+        }
+        return null
+    }
+
+    // PNG: IHDR chunk starts immediately after the 8-byte signature. Width @16, height @20,
+    // both big-endian 32-bit.
+    private fun parsePng(b: ByteArray): ImageSize? {
+        if (b.size < 24) return null
+        val width = readBigEndianInt(b, 16)
+        val height = readBigEndianInt(b, 20)
+        return if (width > 0 && height > 0) ImageSize(width, height) else null
+    }
+
+    // GIF: width @6, height @8, both little-endian 16-bit.
+    private fun parseGif(b: ByteArray): ImageSize? {
+        if (b.size < 10) return null
+        val width = (b[6].toInt() and 0xFF) or ((b[7].toInt() and 0xFF) shl 8)
+        val height = (b[8].toInt() and 0xFF) or ((b[9].toInt() and 0xFF) shl 8)
+        return if (width > 0 && height > 0) ImageSize(width, height) else null
+    }
+
+    // WebP: chunk at offset 12 is "VP8 ", "VP8L", or "VP8X". Extract width/height
+    // depending on chunk type.
+    private fun parseWebp(b: ByteArray): ImageSize? {
+        if (b.size < 30) return null
+        val chunk = b.copyOfRange(12, 16).decodeToString()
+        return when (chunk) {
+            "VP8 " -> {
+                // Lossy: width @26, height @28 (14-bit each, mask out top 2 bits)
+                if (b.size < 30) return null
+                val w = ((b[26].toInt() and 0xFF) or ((b[27].toInt() and 0x3F) shl 8))
+                val h = ((b[28].toInt() and 0xFF) or ((b[29].toInt() and 0x3F) shl 8))
+                if (w > 0 && h > 0) ImageSize(w, h) else null
+            }
+            "VP8L" -> {
+                // Lossless: 14-bit width-1 and height-1 packed @21..24
+                if (b.size < 25) return null
+                val b0 = b[21].toInt() and 0xFF
+                val b1 = b[22].toInt() and 0xFF
+                val b2 = b[23].toInt() and 0xFF
+                val b3 = b[24].toInt() and 0xFF
+                val w = ((b1 and 0x3F) shl 8 or b0) + 1
+                val h = ((b3 and 0x0F) shl 10 or (b2 shl 2) or ((b1 and 0xC0) shr 6)) + 1
+                if (w > 0 && h > 0) ImageSize(w, h) else null
+            }
+            "VP8X" -> {
+                // Extended: canvas width-1 @24 (24-bit LE), height-1 @27 (24-bit LE)
+                if (b.size < 30) return null
+                val w = ((b[24].toInt() and 0xFF) or
+                    ((b[25].toInt() and 0xFF) shl 8) or
+                    ((b[26].toInt() and 0xFF) shl 16)) + 1
+                val h = ((b[27].toInt() and 0xFF) or
+                    ((b[28].toInt() and 0xFF) shl 8) or
+                    ((b[29].toInt() and 0xFF) shl 16)) + 1
+                if (w > 0 && h > 0) ImageSize(w, h) else null
+            }
+            else -> null
+        }
+    }
+
+    private fun readBigEndianInt(b: ByteArray, off: Int): Int =
+        ((b[off].toInt() and 0xFF) shl 24) or
+            ((b[off + 1].toInt() and 0xFF) shl 16) or
+            ((b[off + 2].toInt() and 0xFF) shl 8) or
+            (b[off + 3].toInt() and 0xFF)
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPayloadProcessor.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPayloadProcessor.kt
@@ -5,10 +5,12 @@ import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.drives.files.PayloadFile
 import id.homebase.api.client.drives.files.ThumbnailFile
 import id.homebase.api.client.drives.upload.EmbeddedThumb
+import id.homebase.api.crypto.AesCbc
 import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.image.createThumbnails
 import id.homebase.api.serialization.OdinSystemSerializer
 import io.ktor.utils.io.core.toByteArray
+import kotlin.uuid.Uuid
 
 
 class VideoPayloadProcessor(
@@ -220,18 +222,21 @@ class VideoPayloadProcessor(
         )
     }
 
-    private suspend fun encryptVideoFile(
+    internal suspend fun encryptVideoFile(
         inputPath: String,
         keyHeader: KeyHeader
     ): String {
-        val bytes = fileOperationsProvider.readFileBytes(inputPath)
-        val encrypted = keyHeader.encryptDataAes(bytes)
-
-        return fileOperationsProvider.writeBytesToTempFile(
-            encrypted,
-            "video-encrypted",
-            ".bin"
+        val outputPath =
+            "${fileOperationsProvider.getCacheDirectory()}/video-encrypted-${Uuid.random()}.bin"
+        fileOperationsProvider.writeStream(
+            path = outputPath,
+            data = AesCbc.streamEncryptWithCbc(
+                dataStream = fileOperationsProvider.readFileAsFlow(inputPath),
+                key = keyHeader.aesKey,
+                iv = keyHeader.iv,
+            ),
         )
+        return outputPath
     }
 
     private suspend fun detectVideoCodec(filePath: String): String {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoThumbnailExtractor.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoThumbnailExtractor.kt
@@ -1,0 +1,17 @@
+package id.homebase.api.video
+
+/**
+ * Fast poster-frame extractor for videos.
+ *
+ * Returns JPEG bytes directly so callers don't need to dance through a temp file +
+ * readFileBytes + delete. Each platform picks the cheapest pipeline available; the
+ * expensive [FFmpegUtils.grabThumbnail] path is only used as a last resort.
+ */
+expect object VideoThumbnailExtractor {
+    /**
+     * Extract a poster frame from [videoPath]. On Android this may be a `content://` URI
+     * (preferred — avoids the full file copy that [FFmpegUtils.grabThumbnail] requires).
+     * Returns JPEG bytes or null if extraction failed.
+     */
+    suspend fun extractPosterFrame(videoPath: String): ByteArray?
+}

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/crypto/AesCbcTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/crypto/AesCbcTest.kt
@@ -339,4 +339,60 @@ class AesCbcTest {
             AesCbc.streamDecryptWithCbc(dataStream, key, iv).toList()
         }
     }
+
+    // ========================================================================
+    // Arbitrary chunk shape — pins the fix for the previously-broken contract
+    // (every chunk had to be a multiple of 16 bytes, which crashed for sub-block
+    // tails and could silently produce wrong ciphertext for unaligned chunks).
+    // ========================================================================
+
+    private suspend fun assertStreamMatchesBulk(
+        plaintext: ByteArray,
+        chunks: List<ByteArray>,
+    ) {
+        val key = ByteArrayUtil.getRndByteArray(16)
+        val iv = ByteArrayUtil.getRndByteArray(16)
+
+        val streamed = mutableListOf<ByteArray>()
+        AesCbc.streamEncryptWithCbc(flowOf(*chunks.toTypedArray()), key, iv).toList(streamed)
+        val streamedBytes = streamed.fold(ByteArray(0)) { acc, b -> acc + b }
+        val bulkBytes = AesCbc.encrypt(plaintext, key, iv)
+        assertEquals(bulkBytes.contentToString(), streamedBytes.contentToString())
+    }
+
+    @Test
+    fun streamEncrypt_singleSubBlockChunk_matchesBulk() = runTest {
+        listOf(1, 7, 15).forEach { size ->
+            val plaintext = ByteArray(size) { (it + 1).toByte() }
+            assertStreamMatchesBulk(plaintext, listOf(plaintext))
+        }
+    }
+
+    @Test
+    fun streamEncrypt_unalignedFinalChunk_matchesBulk() = runTest {
+        listOf(1, 7, 15).forEach { tailSize ->
+            val head = ByteArray(65536) { it.toByte() }
+            val tail = ByteArray(tailSize) { (0xFF - it).toByte() }
+            assertStreamMatchesBulk(head + tail, listOf(head, tail))
+        }
+    }
+
+    @Test
+    fun streamEncrypt_unalignedSourceChunks_matchesBulk() = runTest {
+        // No individual chunk is block-aligned, and they cross multiple block
+        // boundaries — exercises the carry buffer's combine-and-peel logic.
+        val a = ByteArray(17) { it.toByte() }
+        val b = ByteArray(17) { (it + 17).toByte() }
+        val c = ByteArray(17) { (it + 34).toByte() }
+        assertStreamMatchesBulk(a + b + c, listOf(a, b, c))
+    }
+
+    @Test
+    fun streamEncrypt_emptyChunkInMiddle_matchesBulk() = runTest {
+        // Defensive: producers may emit empty chunks. They must be skipped without
+        // affecting chaining.
+        val a = ByteArray(16) { it.toByte() }
+        val b = ByteArray(16) { (it + 16).toByte() }
+        assertStreamMatchesBulk(a + b, listOf(a, ByteArray(0), b))
+    }
 }

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/image/ImageHeaderParserTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/image/ImageHeaderParserTest.kt
@@ -1,0 +1,72 @@
+package id.homebase.api.image
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ImageHeaderParserTest {
+
+    @Test
+    fun jpegSof0Returns800x600() {
+        // Minimal JPEG: SOI + APP0 (skipped) + SOF0 with 800x600
+        val app0 = byteArrayOf(
+            0xFF.toByte(), 0xE0.toByte(),
+            0x00, 0x10, // length 16
+            'J'.code.toByte(), 'F'.code.toByte(), 'I'.code.toByte(), 'F'.code.toByte(), 0x00,
+            0x01, 0x01, 0x00, 0x00, 0x48, 0x00, 0x48, 0x00, 0x00,
+        )
+        val sof = byteArrayOf(
+            0xFF.toByte(), 0xC0.toByte(),
+            0x00, 0x11, // length 17
+            0x08, // precision
+            0x02.toByte(), 0x58.toByte(), // height = 600
+            0x03.toByte(), 0x20.toByte(), // width = 800
+            0x03, // components
+            0x01, 0x22, 0x00,
+            0x02, 0x11, 0x01,
+            0x03, 0x11, 0x01,
+        )
+        val header = byteArrayOf(0xFF.toByte(), 0xD8.toByte()) + app0 + sof
+
+        val size = ImageHeaderParser.parse(header)
+        assertEquals(ImageSize(800, 600), size)
+    }
+
+    @Test
+    fun pngIhdrReturnsCorrectSize() {
+        val sig = byteArrayOf(
+            0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+        )
+        // IHDR: 4 bytes length(=13), 4 bytes type, 4 bytes width, 4 bytes height, ...
+        val ihdr = byteArrayOf(
+            0x00, 0x00, 0x00, 0x0D,
+            'I'.code.toByte(), 'H'.code.toByte(), 'D'.code.toByte(), 'R'.code.toByte(),
+            0x00, 0x00, 0x04.toByte(), 0x00.toByte(), // width = 1024
+            0x00, 0x00, 0x03.toByte(), 0x00.toByte(), // height = 768
+            0x08, 0x06, 0x00, 0x00, 0x00,
+        )
+        assertEquals(ImageSize(1024, 768), ImageHeaderParser.parse(sig + ihdr))
+    }
+
+    @Test
+    fun gifReturnsLittleEndianSize() {
+        val header = byteArrayOf(
+            'G'.code.toByte(), 'I'.code.toByte(), 'F'.code.toByte(),
+            '8'.code.toByte(), '9'.code.toByte(), 'a'.code.toByte(),
+            0x40, 0x00, // width = 64
+            0x80.toByte(), 0x00, // height = 128
+            0x00, 0x00,
+        )
+        assertEquals(ImageSize(64, 128), ImageHeaderParser.parse(header))
+    }
+
+    @Test
+    fun unknownFormatReturnsNull() {
+        assertNull(ImageHeaderParser.parse(ByteArray(64) { 0x42 }))
+    }
+
+    @Test
+    fun tooShortReturnsNull() {
+        assertNull(ImageHeaderParser.parse(byteArrayOf(0xFF.toByte(), 0xD8.toByte())))
+    }
+}

--- a/homebase-api/src/jvmMain/java/id/homebase/api/video/VideoThumbnailExtractor.jvm.kt
+++ b/homebase-api/src/jvmMain/java/id/homebase/api/video/VideoThumbnailExtractor.jvm.kt
@@ -1,0 +1,16 @@
+package id.homebase.api.video
+
+import java.io.File
+
+actual object VideoThumbnailExtractor {
+    actual suspend fun extractPosterFrame(videoPath: String): ByteArray? {
+        val thumbPath = FFmpegUtils.grabThumbnail(videoPath) ?: return null
+        return try {
+            File(thumbPath).readBytes()
+        } catch (_: Exception) {
+            null
+        } finally {
+            runCatching { File(thumbPath).delete() }
+        }
+    }
+}

--- a/homebase-api/src/jvmMain/kotlin/id/homebase/api/file/JvmFileOperationsProvider.kt
+++ b/homebase-api/src/jvmMain/kotlin/id/homebase/api/file/JvmFileOperationsProvider.kt
@@ -16,6 +16,32 @@ class JvmFileOperationsProvider : FileOperationsProvider {
     override suspend fun readFileBytes(path: String): ByteArray =
         withContext(Dispatchers.IO) { File(path).readBytes() }
 
+    override fun readFileAsFlow(path: String, chunkSize: Int): kotlinx.coroutines.flow.Flow<ByteArray> =
+        kotlinx.coroutines.flow.flow {
+            File(path).inputStream().use { stream ->
+                val buf = ByteArray(chunkSize)
+                while (true) {
+                    val n = stream.read(buf, 0, buf.size)
+                    if (n <= 0) break
+                    emit(buf.copyOf(n))
+                }
+            }
+        }
+
+    override suspend fun readFileHeaderBytes(path: String, maxBytes: Int): ByteArray =
+        withContext(Dispatchers.IO) {
+            File(path).inputStream().use { stream ->
+                val buf = ByteArray(maxBytes)
+                var off = 0
+                while (off < maxBytes) {
+                    val n = stream.read(buf, off, maxBytes - off)
+                    if (n <= 0) break
+                    off += n
+                }
+                if (off == maxBytes) buf else buf.copyOf(off)
+            }
+        }
+
     override fun deleteTempFile(path: String): Boolean {
         val file = File(path)
 

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/video/VideoPayloadProcessorStreamEncryptTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/video/VideoPayloadProcessorStreamEncryptTest.kt
@@ -1,0 +1,83 @@
+package id.homebase.api.video
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.file.JvmFileOperationsProvider
+import java.io.File
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Locks down the streaming AES path used by [VideoPayloadProcessor.encryptVideoFile].
+ *
+ * The risk being protected against: if the streaming encrypt produces ciphertext
+ * different from the bulk [KeyHeader.encryptDataAes] path, every uploaded video would
+ * be silently corrupted on the wire. Manual playback testing on a phone catches the
+ * symptom but not at CI time — these tests do.
+ */
+class VideoPayloadProcessorStreamEncryptTest {
+
+    @Test
+    fun encryptVideoFile_matchesBulkEncrypt_atVariousSizes() = runTest {
+        // Sizes deliberately span the AES block (16) and read-chunk (65536) boundaries
+        // because the new readFileAsFlow + alignedForCbc logic is what could go wrong here.
+        // Specifically tests sizes that produce a sub-block tail (mod 65536 ∈ [1..15]) —
+        // those are the production-corrupting cases the streaming wrapper has to handle.
+        val sizes = listOf(
+            1,                         // below block size — bulk-encrypt fallback
+            15,                        // also below block size
+            16,                        // exactly one AES block
+            17,
+            65535,
+            65536,                     // exactly one chunk
+            65537,                     // chunk + 1 byte (the 1-byte tail used to crash)
+            65536 + 7,                 // chunk + sub-block tail
+            5 * 1024 * 1024 + 7,       // typical largeish video + sub-block tail
+        )
+        val provider = JvmFileOperationsProvider()
+        val processor = VideoPayloadProcessor(provider)
+        val key = KeyHeader.newRandom16()
+
+        for (size in sizes) {
+            val plaintext = ByteArray(size).also { Random.nextBytes(it) }
+            val inputPath = provider.writeBytesToTempFile(plaintext, "stream_in_", ".bin")
+
+            try {
+                val outputPath = processor.encryptVideoFile(inputPath, key)
+
+                val bulkCipher = key.encryptDataAes(plaintext)
+                val streamCipher = File(outputPath).readBytes()
+
+                assertContentEquals(
+                    bulkCipher,
+                    streamCipher,
+                    "Ciphertext mismatch at size=$size — streaming path is incompatible with bulk path",
+                )
+                provider.deleteTempFile(outputPath)
+            } finally {
+                provider.deleteTempFile(inputPath)
+            }
+        }
+    }
+
+    @Test
+    fun encryptVideoFile_roundTripsThroughDecrypt() = runTest {
+        val provider = JvmFileOperationsProvider()
+        val processor = VideoPayloadProcessor(provider)
+        val key = KeyHeader.newRandom16()
+        val plaintext = ByteArray(5 * 1024 * 1024 + 123).also { Random.nextBytes(it) }
+        val inputPath = provider.writeBytesToTempFile(plaintext, "rt_in_", ".bin")
+
+        try {
+            val outputPath = processor.encryptVideoFile(inputPath, key)
+            val cipherBytes = File(outputPath).readBytes()
+            val decrypted = key.decrypt(cipherBytes)
+            assertContentEquals(plaintext, decrypted)
+            provider.deleteTempFile(outputPath)
+        } finally {
+            provider.deleteTempFile(inputPath)
+        }
+    }
+
+}

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/video/VideoThumbnailExtractor.native.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/video/VideoThumbnailExtractor.native.kt
@@ -1,0 +1,26 @@
+package id.homebase.api.video
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.Foundation.NSData
+import platform.Foundation.NSFileManager
+import platform.Foundation.dataWithContentsOfFile
+import platform.posix.memcpy
+
+@OptIn(ExperimentalForeignApi::class)
+actual object VideoThumbnailExtractor {
+    actual suspend fun extractPosterFrame(videoPath: String): ByteArray? {
+        val thumbPath = FFmpegUtils.grabThumbnail(videoPath) ?: return null
+        return try {
+            val data = NSData.dataWithContentsOfFile(thumbPath) ?: return null
+            val bytes = ByteArray(data.length.toInt())
+            bytes.usePinned { pinned -> memcpy(pinned.addressOf(0), data.bytes, data.length) }
+            bytes
+        } catch (_: Exception) {
+            null
+        } finally {
+            runCatching { NSFileManager.defaultManager.removeItemAtPath(thumbPath, null) }
+        }
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -29,6 +29,7 @@ import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.util.truncateToCodePoints
 import id.homebase.api.video.FFmpegUtils
 import id.homebase.api.video.VideoMetadata
+import id.homebase.api.video.VideoThumbnailExtractor
 import id.homebase.chat.conversationlist.ConversationListUiDialog.DeleteMessage
 import id.homebase.chat.conversationlist.ConversationListUiDialog.DiscardDraft
 import id.homebase.chat.conversationlist.ConversationListUiEvent.NavigateBack
@@ -110,11 +111,15 @@ import io.github.vinceglb.filekit.write
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
+import id.homebase.core.localization.TranslationUtil
+import id.homebase.resources.chat_attach_file_failed
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -189,6 +194,46 @@ class ConversationListViewModel(
     val messageInputTextState = RichTextState().applyDefaultStyling()
     private var currentConversationJob: Job? = null
     private var pendingMessageId: Uuid? = null
+
+    // Tracks in-flight video thumbnail extraction per pending attachment so the editor can
+    // open instantly (Signal-style) while the FFmpeg/MediaMetadataRetriever poster work
+    // happens in the background. The send path awaits these so the message envelope still
+    // ships a poster frame.
+    private val pendingThumbnails = mutableMapOf<Uuid, Deferred<ByteArray?>>()
+
+    private fun extractThumbnailAsync(attachmentId: Uuid, videoPath: String) {
+        val deferred = viewModelScope.async {
+            runCatching { VideoThumbnailExtractor.extractPosterFrame(videoPath) }.getOrNull()
+        }
+        pendingThumbnails[attachmentId] = deferred
+        viewModelScope.launch {
+            val bytes = try {
+                deferred.await()
+            } catch (_: CancellationException) {
+                null
+            }
+            pendingThumbnails.remove(attachmentId)
+            if (bytes == null) return@launch
+            _messagesUiState.update { state ->
+                val overlay = state.fullScreenOverlay as? FullScreenOverlay.AttachmentData
+                    ?: return@update state
+                if (overlay.attachments.none { it.attachmentId == attachmentId }) return@update state
+                val updated = overlay.attachments.map { a ->
+                    if (a is AttachmentPendingFile.FileVideo && a.attachmentId == attachmentId) {
+                        a.copy(thumbnailBytes = bytes)
+                    } else a
+                }
+                state.copy(fullScreenOverlay = overlay.copy(attachments = updated))
+            }
+        }
+    }
+
+    private suspend fun ensureThumbnail(file: AttachmentPendingFile.FileVideo): AttachmentPendingFile.FileVideo {
+        if (file.thumbnailBytes != null) return file
+        val pending = pendingThumbnails.remove(file.attachmentId) ?: return file
+        val bytes = runCatching { pending.await() }.getOrNull()
+        return if (bytes != null) file.copy(thumbnailBytes = bytes) else file
+    }
 
     init {
         viewModelScope.launch {
@@ -1134,26 +1179,11 @@ class ConversationListViewModel(
                             val ct = it.mimeType()?.toString()
                                 ?: detectContentTypeFromExtensionOrHint(it.name)
                             when {
-                                ct.startsWith("video/") -> {
-                                    val thumbnailBytes = try {
-                                        val resolvedPath =
-                                            fileOperationsProvider.resolveToFilePath(it.toString())
-                                        val thumbPath = FFmpegUtils.grabThumbnail(resolvedPath)
-                                        if (thumbPath != null) {
-                                            val bytes =
-                                                fileOperationsProvider.readFileBytes(thumbPath)
-                                            fileOperationsProvider.deleteTempFile(thumbPath)
-                                            bytes
-                                        } else null
-                                    } catch (_: Exception) {
-                                        null
-                                    }
-                                    AttachmentPendingFile.FileVideo(
-                                        Uuid.generateV7(),
-                                        it,
-                                        thumbnailBytes
-                                    )
-                                }
+                                ct.startsWith("video/") -> AttachmentPendingFile.FileVideo(
+                                    Uuid.generateV7(),
+                                    it,
+                                    thumbnailBytes = null,
+                                )
 
                                 action.isImage || ct.startsWith("image/") -> AttachmentPendingFile.FileImage(
                                     Uuid.generateV7(),
@@ -1187,11 +1217,22 @@ class ConversationListViewModel(
                                 fullScreenOverlay = newOverlay,
                             )
                         }
+
+                        // Editor is now visible — extract thumbnails in the background and
+                        // patch the pending FileVideo entries when they complete.
+                        newFiles.forEach { f ->
+                            if (f is AttachmentPendingFile.FileVideo) {
+                                extractThumbnailAsync(f.attachmentId, f.file.toString())
+                            }
+                        }
                     } catch (e: Exception) {
                         Logger.e("Failed to attach file(s)", e)
                         sendEvent(
                             ShowErrorMessage(
-                                "Failed to attach file(s): ${e.message}"
+                                TranslationUtil.getString(
+                                    MR.string.chat_attach_file_failed,
+                                    e.message ?: ""
+                                )
                             )
                         )
                     }
@@ -1203,22 +1244,10 @@ class ConversationListViewModel(
                     try {
                         val newFiles = action.files.map {
                             if (it.mimeType.startsWith("video/")) {
-                                val thumbnailBytes = try {
-                                    val resolvedPath =
-                                        fileOperationsProvider.resolveToFilePath(it.file.toString())
-                                    val thumbPath = FFmpegUtils.grabThumbnail(resolvedPath)
-                                    if (thumbPath != null) {
-                                        val bytes = fileOperationsProvider.readFileBytes(thumbPath)
-                                        fileOperationsProvider.deleteTempFile(thumbPath)
-                                        bytes
-                                    } else null
-                                } catch (_: Exception) {
-                                    null
-                                }
                                 AttachmentPendingFile.FileVideo(
                                     Uuid.generateV7(),
                                     it.file,
-                                    thumbnailBytes
+                                    thumbnailBytes = null,
                                 )
                             } else {
                                 AttachmentPendingFile.Gallery(Uuid.generateV7(), it)
@@ -1248,11 +1277,22 @@ class ConversationListViewModel(
                                 fullScreenOverlay = newOverlay,
                             )
                         }
+
+                        // Editor visible — kick off thumbnail extraction in parallel, using
+                        // the gallery URI directly (no resolveToFilePath copy).
+                        newFiles.zip(action.files).forEach { (pending, gallery) ->
+                            if (pending is AttachmentPendingFile.FileVideo) {
+                                extractThumbnailAsync(pending.attachmentId, gallery.file.toString())
+                            }
+                        }
                     } catch (e: Exception) {
                         Logger.e("Failed to attach file(s)", e)
                         sendEvent(
                             ShowErrorMessage(
-                                "Failed to attach file(s): ${e.message}"
+                                TranslationUtil.getString(
+                                    MR.string.chat_attach_file_failed,
+                                    e.message ?: ""
+                                )
                             )
                         )
                     }
@@ -2570,8 +2610,14 @@ class ConversationListViewModel(
     ) {
         val sentAt = UnixTimeUtc.now()
         viewModelScope.launch {
+            // If any FileVideo entries still have a thumbnail extraction in flight (the
+            // user hit Send before the background poster task finished), wait on it once
+            // so the message envelope ships with a poster frame.
+            val resolvedFiles = files.map { f ->
+                if (f is AttachmentPendingFile.FileVideo) ensureThumbnail(f) else f
+            }
             val attachments = mutableListOf<AttachmentInput>()
-            files.forEach { attachment ->
+            resolvedFiles.forEach { attachment ->
                 when (attachment) {
                     is AttachmentPendingFile.File -> {
                         attachments.add(
@@ -2680,7 +2726,7 @@ class ConversationListViewModel(
             // aspect for free; for images we compute aspect asynchronously below and
             // re-put once we have it — avoids blocking the placeholder on image I/O.
             val imagePathsToRefine = mutableListOf<Pair<String, String>>()
-            files.forEachIndexed { index, file ->
+            resolvedFiles.forEachIndexed { index, file ->
                 val payloadKey = "${ChatProtocol.PAYLOAD_KEY_MESSAGE_WEB}$index"
                 val ctx: LocalAttachmentContext? = when (file) {
                     is AttachmentPendingFile.FileVideo -> {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -23,6 +23,7 @@ import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.client.link.LinkPreview
 import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.image.ImageHeaderParser
 import id.homebase.api.image.ImageUtils
 import id.homebase.api.image.convertHeicToJpeg
 import id.homebase.api.serialization.OdinSystemSerializer
@@ -2763,13 +2764,16 @@ class ConversationListViewModel(
                 }
             }
 
-            // Refine image aspect ratios off the main path.
+            // Refine image aspect ratios off the main path. Try a header-only parser
+            // first so we don't allocate the full image bytes just to read width/height;
+            // fall back to the full-bytes decoder for formats we can't sniff (e.g. HEIC).
             if (imagePathsToRefine.isNotEmpty()) {
                 viewModelScope.launch {
                     imagePathsToRefine.forEach { (payloadKey, path) ->
                         val aspect = runCatching {
-                            val bytes = fileOperationsProvider.readFileBytes(path)
-                            val size = ImageUtils.getNaturalSize(bytes)
+                            val header = fileOperationsProvider.readFileHeaderBytes(path)
+                            val size = ImageHeaderParser.parse(header)
+                                ?: ImageUtils.getNaturalSize(fileOperationsProvider.readFileBytes(path))
                             if (size.pixelWidth > 0 && size.pixelHeight > 0)
                                 size.pixelWidth.toFloat() / size.pixelHeight.toFloat()
                             else null

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/AttachmentOptions.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/AttachmentOptions.kt
@@ -3,6 +3,7 @@ package id.homebase.chat.widget
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -16,6 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -35,11 +37,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -51,8 +52,8 @@ import androidx.compose.ui.unit.dp
 import coil3.ImageLoader
 import coil3.compose.AsyncImage
 import id.homebase.api.isIos
+import id.homebase.core.gallery.GalleryCache
 import id.homebase.core.gallery.GalleryImage
-import id.homebase.core.gallery.PlatformGalleryManager
 import id.homebase.core.gallery.rememberGalleryPermissionState
 import id.homebase.core.ui.theme.Dimens
 import id.homebase.core.util.isMobile
@@ -66,7 +67,6 @@ import id.homebase.resources.chat_no_gallery_items
 import id.homebase.resources.chat_select_more_photos
 import id.homebase.resources.go_to_settings
 import id.homebase.resources.manage
-import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 
@@ -98,15 +98,12 @@ fun AttachmentGallery(
     if (isMobile()) {
         // Get ImageLoader with HomebaseImageFetcher from Koin DI
         val imageLoader: ImageLoader = koinInject()
-        val scope = rememberCoroutineScope()
-        val galleryLoader = koinInject<PlatformGalleryManager>()
-        val galleryItems = remember { mutableStateListOf<GalleryImage>() }
+        val galleryCache = koinInject<GalleryCache>()
+        val galleryItems by galleryCache.items.collectAsStateWithLifecycle()
         val galleryPermissionState = rememberGalleryPermissionState(
             onGalleryPermissionGranted = {
-                scope.launch {
-                    galleryItems.clear()
-                    galleryItems.addAll(galleryLoader.fetchGalleryImages())
-                }
+                // Permission flipped on — kick the cache to refresh now that we can read.
+                galleryCache.refresh()
             }
         )
 
@@ -143,8 +140,7 @@ fun AttachmentGallery(
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
 
-                        items(galleryItems.size) { index ->
-                            val galleryImage = galleryItems[index]
+                        items(galleryItems, key = { it.id }) { galleryImage ->
                             Box(
                                 contentAlignment = Alignment.Center
                             ) {
@@ -164,6 +160,20 @@ fun AttachmentGallery(
                                         contentDescription = null,
                                         tint = Color.White.copy(alpha = 0.85f)
                                     )
+                                    val duration = galleryImage.durationMs
+                                    if (duration != null && duration > 0) {
+                                        Text(
+                                            text = formatDuration(duration),
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = Color.White,
+                                            modifier = Modifier
+                                                .align(Alignment.BottomEnd)
+                                                .padding(6.dp)
+                                                .clip(RoundedCornerShape(4.dp))
+                                                .background(Color.Black.copy(alpha = 0.55f))
+                                                .padding(horizontal = 6.dp, vertical = 2.dp),
+                                        )
+                                    }
                                 }
                             }
                         }
@@ -271,6 +281,18 @@ fun AttachmentOptions(
 //                }
 //            }
         }
+    }
+}
+
+private fun formatDuration(durationMs: Long): String {
+    val totalSeconds = durationMs / 1000
+    val hours = totalSeconds / 3600
+    val minutes = (totalSeconds % 3600) / 60
+    val seconds = totalSeconds % 60
+    return if (hours > 0) {
+        "$hours:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}"
+    } else {
+        "${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}"
     }
 }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenAttachmentEditor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenAttachmentEditor.kt
@@ -54,7 +54,6 @@ import com.mohamedrejeb.richeditor.model.RichTextState
 import id.homebase.chat.conversationlist.AttachmentPendingFile
 import id.homebase.chat.conversationlist.FullScreenOverlay
 import id.homebase.chat.widget.video.LocalVideoPlayerSurface
-import id.homebase.core.image.HomebaseImageData
 import id.homebase.resources.MR
 import id.homebase.resources.chat_message_add_gallery_image
 import id.homebase.resources.chat_message_remove_gallery_image
@@ -129,7 +128,7 @@ fun FullScreenAttachmentEditor(
                     is AttachmentPendingFile.FileImage -> {
                         AsyncImage(
                             imageLoader = imageLoader,
-                            model = HomebaseImageData.pending(attachment.file.toString()),
+                            model = attachment.file.toString(),
                             contentDescription = null,
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -140,6 +139,10 @@ fun FullScreenAttachmentEditor(
                     is AttachmentPendingFile.FileVideo -> {
                         var isPlaying by remember(attachment.attachmentId) { mutableStateOf(false) }
                         var firstFrameRendered by remember(attachment.attachmentId) { mutableStateOf(false) }
+                        // Show a Coil-decoded poster whenever we don't yet have the
+                        // pre-extracted bytes — Coil's VideoFrameDecoder pulls a frame
+                        // straight from the URI without our FFmpeg + temp-file dance.
+                        val posterModel: Any = attachment.thumbnailBytes ?: attachment.file.toString()
                         Box(
                             modifier = Modifier
                                 .fillMaxSize()
@@ -155,27 +158,13 @@ fun FullScreenAttachmentEditor(
                                 )
                             }
                             if (!firstFrameRendered) {
-                                if (attachment.thumbnailBytes != null) {
-                                    AsyncImage(
-                                        imageLoader = imageLoader,
-                                        model = attachment.thumbnailBytes,
-                                        contentDescription = null,
-                                        modifier = Modifier.fillMaxWidth(),
-                                        contentScale = ContentScale.Fit
-                                    )
-                                } else {
-                                    Box(
-                                        modifier = Modifier.fillMaxSize(),
-                                        contentAlignment = Alignment.Center
-                                    ) {
-                                        Icon(
-                                            Icons.Default.PlayCircle,
-                                            contentDescription = null,
-                                            modifier = Modifier.size(96.dp),
-                                            tint = MaterialTheme.colorScheme.onSurface
-                                        )
-                                    }
-                                }
+                                AsyncImage(
+                                    imageLoader = imageLoader,
+                                    model = posterModel,
+                                    contentDescription = null,
+                                    modifier = Modifier.fillMaxWidth(),
+                                    contentScale = ContentScale.Fit
+                                )
                                 Icon(
                                     Icons.Default.PlayCircle,
                                     contentDescription = null,
@@ -190,7 +179,7 @@ fun FullScreenAttachmentEditor(
                     is AttachmentPendingFile.Gallery -> {
                         AsyncImage(
                             imageLoader = imageLoader,
-                            model = HomebaseImageData.pending(attachment.image.thumbnailUri ?: attachment.image.file.toString()),
+                            model = attachment.image.thumbnailUri ?: attachment.image.file.toString(),
                             contentDescription = null,
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -256,8 +245,8 @@ fun FullScreenAttachmentEditor(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                items(data.attachments) { attachment ->
-                    val isSelected = data.attachments[pagerState.currentPage] == attachment
+                items(data.attachments, key = { it.attachmentId }) { attachment ->
+                    val isSelected = data.attachments[pagerState.currentPage].attachmentId == attachment.attachmentId
                     Box(
                         modifier = Modifier
                             .size(60.dp)
@@ -269,7 +258,10 @@ fun FullScreenAttachmentEditor(
                             )
                             .clickable {
                                 scope.launch {
-                                    pagerState.animateScrollToPage(data.attachments.indexOf(attachment))
+                                    val idx = data.attachments.indexOfFirst {
+                                        it.attachmentId == attachment.attachmentId
+                                    }
+                                    if (idx >= 0) pagerState.animateScrollToPage(idx)
                                 }
                             }
                     ) {
@@ -285,7 +277,7 @@ fun FullScreenAttachmentEditor(
                             is AttachmentPendingFile.FileImage -> {
                                 AsyncImage(
                                     imageLoader = imageLoader,
-                                    model = HomebaseImageData.pending(attachment.file.toString()),
+                                    model = attachment.file.toString(),
                                     contentDescription = null,
                                     modifier = Modifier.fillMaxSize(),
                                     contentScale = ContentScale.Crop
@@ -296,15 +288,13 @@ fun FullScreenAttachmentEditor(
                                     modifier = Modifier.fillMaxSize(),
                                     contentAlignment = Alignment.Center
                                 ) {
-                                    if (attachment.thumbnailBytes != null) {
-                                        AsyncImage(
-                                            imageLoader = imageLoader,
-                                            model = attachment.thumbnailBytes,
-                                            contentDescription = null,
-                                            modifier = Modifier.fillMaxSize(),
-                                            contentScale = ContentScale.Crop
-                                        )
-                                    }
+                                    AsyncImage(
+                                        imageLoader = imageLoader,
+                                        model = attachment.thumbnailBytes ?: attachment.file.toString(),
+                                        contentDescription = null,
+                                        modifier = Modifier.fillMaxSize(),
+                                        contentScale = ContentScale.Crop
+                                    )
                                     Icon(
                                         Icons.Default.PlayCircle,
                                         contentDescription = null,
@@ -315,7 +305,7 @@ fun FullScreenAttachmentEditor(
                             is AttachmentPendingFile.Gallery -> {
                                 AsyncImage(
                                     imageLoader = imageLoader,
-                                    model = HomebaseImageData.pending(attachment.image.thumbnailUri ?: attachment.image.file.toString()),
+                                    model = attachment.image.thumbnailUri ?: attachment.image.file.toString(),
                                     contentDescription = null,
                                     modifier = Modifier.fillMaxSize(),
                                     contentScale = ContentScale.Crop

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/clipboard/ClipboardImageReceiverModifier.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/clipboard/ClipboardImageReceiverModifier.android.kt
@@ -24,6 +24,18 @@ actual fun clipboardImageReceiverModifier(onImagePasted: (ByteArray) -> Unit): M
                     val uri = item.uri
                     if (uri != null) {
                         try {
+                            // TODO(perf): Stream the URI directly to a temp file instead of
+                            // allocating the full image as a ByteArray here. Today this round-trips:
+                            // URI → byte[] → callback → VM.writeBytesToTempFile(bytes) → PlatformFile,
+                            // costing one ~5–10 MB allocation per paste. Fixing it requires changing
+                            // the (ByteArray) -> Unit callback contract in clipboardImageReceiverModifier
+                            // (expect + 4 actuals), the AttachClipboardImage UiAction, and the
+                            // onPasteImage hook in MessageInputBar / ConversationContent — touched in
+                            // too many spots for the marginal one-off-per-paste win, deferred for now.
+                            // When fixing: have the modifier copy the URI to a temp file via
+                            // FileOperationsProvider and pass the resulting path. The URI is bound to
+                            // the Compose contentReceiver scope and may be invalid by the time the VM
+                            // coroutine runs.
                             val bytes = context.contentResolver
                                 .openInputStream(uri)
                                 ?.use { it.readBytes() }

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/gallery/AndroidGalleryManager.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/gallery/AndroidGalleryManager.kt
@@ -1,59 +1,103 @@
 package id.homebase.core.gallery
 
-import  android.content.ContentUris
+import android.content.ContentResolver
+import android.content.ContentUris
 import android.content.Context
+import android.os.Build
+import android.os.Bundle
 import android.provider.MediaStore
 import io.github.vinceglb.filekit.PlatformFile
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-class AndroidGalleryManager(val context: Context): PlatformGalleryManager {
-    override suspend fun fetchGalleryImages(limit: Int): List<GalleryImage> = withContext(Dispatchers.IO) {
-        val images = queryMediaStore(collectionUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
-        val videos = queryMediaStore(collectionUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI)
-        (images + videos)
-            .sortedByDescending { it.dateAdded }
-            .take(limit)
-    }
+class AndroidGalleryManager(val context: Context) : PlatformGalleryManager {
 
-    private fun queryMediaStore(collectionUri: android.net.Uri): List<GalleryImage> {
-        val idColumn = MediaStore.MediaColumns._ID
-        val dateColumn = MediaStore.MediaColumns.DATE_ADDED
-        val mimeColumn = MediaStore.MediaColumns.MIME_TYPE
-        val bucketColumn = MediaStore.MediaColumns.BUCKET_DISPLAY_NAME
-        val displayNameColumn = MediaStore.MediaColumns.DISPLAY_NAME
+    private val collectionUri = MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL)
 
-        val results = mutableListOf<GalleryImage>()
-        val projection = arrayOf(idColumn, dateColumn, mimeColumn, bucketColumn, displayNameColumn)
-        context.contentResolver.query(
-            collectionUri,
-            projection,
-            null,
-            null,
-            "$dateColumn DESC"
-        )?.use { cursor ->
-            val idIdx = cursor.getColumnIndexOrThrow(idColumn)
-            val dateIdx = cursor.getColumnIndexOrThrow(dateColumn)
-            val mimeIdx = cursor.getColumnIndexOrThrow(mimeColumn)
-            val bucketIdx = cursor.getColumnIndexOrThrow(bucketColumn)
-            val displayNameIdx = cursor.getColumnIndexOrThrow(displayNameColumn)
+    private val projection = arrayOf(
+        MediaStore.Files.FileColumns._ID,
+        MediaStore.Files.FileColumns.MEDIA_TYPE,
+        MediaStore.Files.FileColumns.MIME_TYPE,
+        MediaStore.Files.FileColumns.DATE_ADDED,
+        MediaStore.Files.FileColumns.DISPLAY_NAME,
+        MediaStore.Files.FileColumns.BUCKET_DISPLAY_NAME,
+        MediaStore.Files.FileColumns.WIDTH,
+        MediaStore.Files.FileColumns.HEIGHT,
+        MediaStore.Files.FileColumns.DURATION,
+    )
 
-            while (cursor.moveToNext()) {
-                val id = cursor.getLong(idIdx)
-                val uri = ContentUris.withAppendedId(collectionUri, id).toString()
-                results.add(
-                    GalleryImage(
-                        id = id.toString(),
-                        file = PlatformFile(uri),
-                        thumbnailUri = uri,
-                        dateAdded = cursor.getLong(dateIdx),
-                        mimeType = cursor.getString(mimeIdx) ?: "",
-                        galleryName = cursor.getString(bucketIdx) ?: "",
-                        fileName = cursor.getString(displayNameIdx) ?: "",
-                    )
+    override suspend fun fetchGalleryImages(limit: Int): List<GalleryImage> =
+        withContext(Dispatchers.IO) {
+            val args = Bundle().apply {
+                putString(
+                    ContentResolver.QUERY_ARG_SQL_SELECTION,
+                    "${MediaStore.Files.FileColumns.MEDIA_TYPE} IN (?, ?)",
                 )
+                putStringArray(
+                    ContentResolver.QUERY_ARG_SQL_SELECTION_ARGS,
+                    arrayOf(
+                        MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE.toString(),
+                        MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO.toString(),
+                    ),
+                )
+                putStringArray(
+                    ContentResolver.QUERY_ARG_SORT_COLUMNS,
+                    arrayOf(MediaStore.Files.FileColumns.DATE_ADDED),
+                )
+                putInt(
+                    ContentResolver.QUERY_ARG_SORT_DIRECTION,
+                    ContentResolver.QUERY_SORT_DIRECTION_DESCENDING,
+                )
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    putInt(ContentResolver.QUERY_ARG_LIMIT, limit)
+                }
+            }
+
+            val cursor = context.contentResolver.query(collectionUri, projection, args, null)
+                ?: return@withContext emptyList()
+
+            cursor.use { c ->
+                val idIdx = c.getColumnIndexOrThrow(MediaStore.Files.FileColumns._ID)
+                val typeIdx = c.getColumnIndexOrThrow(MediaStore.Files.FileColumns.MEDIA_TYPE)
+                val mimeIdx = c.getColumnIndexOrThrow(MediaStore.Files.FileColumns.MIME_TYPE)
+                val dateIdx = c.getColumnIndexOrThrow(MediaStore.Files.FileColumns.DATE_ADDED)
+                val displayIdx = c.getColumnIndexOrThrow(MediaStore.Files.FileColumns.DISPLAY_NAME)
+                val bucketIdx = c.getColumnIndexOrThrow(MediaStore.Files.FileColumns.BUCKET_DISPLAY_NAME)
+                val widthIdx = c.getColumnIndexOrThrow(MediaStore.Files.FileColumns.WIDTH)
+                val heightIdx = c.getColumnIndexOrThrow(MediaStore.Files.FileColumns.HEIGHT)
+                val durationIdx = c.getColumnIndexOrThrow(MediaStore.Files.FileColumns.DURATION)
+
+                val results = ArrayList<GalleryImage>(c.count.coerceAtMost(limit))
+                while (c.moveToNext() && results.size < limit) {
+                    val id = c.getLong(idIdx)
+                    val mediaType = c.getInt(typeIdx)
+                    val isVideo = mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO
+                    val collectionForItem = if (isVideo) {
+                        MediaStore.Video.Media.EXTERNAL_CONTENT_URI
+                    } else {
+                        MediaStore.Images.Media.EXTERNAL_CONTENT_URI
+                    }
+                    val uri = ContentUris.withAppendedId(collectionForItem, id).toString()
+                    val mime = c.getString(mimeIdx)
+                        ?: if (isVideo) "video/*" else "image/*"
+                    val duration = if (isVideo) c.getLong(durationIdx).takeIf { it > 0 } else null
+
+                    results.add(
+                        GalleryImage(
+                            id = id.toString(),
+                            file = PlatformFile(uri),
+                            thumbnailUri = uri,
+                            dateAdded = c.getLong(dateIdx),
+                            mimeType = mime,
+                            galleryName = c.getString(bucketIdx) ?: "",
+                            fileName = c.getString(displayIdx) ?: "",
+                            durationMs = duration,
+                            width = c.getInt(widthIdx),
+                            height = c.getInt(heightIdx),
+                        )
+                    )
+                }
+                results
             }
         }
-        return results
-    }
 }

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -416,6 +416,7 @@
     <string name="chat_message_delete_for_me">Delete for me</string>
     <string name="chat_message_options">Message options</string>
     <string name="chat_message_attachment_options">Attachment options</string>
+    <string name="chat_attach_file_failed">Failed to attach file(s): %s</string>
     <string name="chat_message_camera">Camera</string>
     <string name="chat_message_take_photo">Take photo</string>
     <string name="chat_message_record_video">Record video</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/gallery/GalleryCache.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/gallery/GalleryCache.kt
@@ -1,0 +1,60 @@
+package id.homebase.core.gallery
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
+
+/**
+ * Application-scoped cache of recent device gallery items.
+ *
+ * Reopening the picker should be instant: rather than re-querying MediaStore/Photos
+ * on every sheet open, we keep the last result around and refresh it lazily when the
+ * platform reports a library change (registered by the DI module per-platform).
+ */
+@OptIn(FlowPreview::class)
+class GalleryCache(
+    private val manager: PlatformGalleryManager,
+    private val limit: Int = DEFAULT_LIMIT,
+) {
+    private val _items = MutableStateFlow<List<GalleryImage>>(emptyList())
+    val items: StateFlow<List<GalleryImage>> = _items.asStateFlow()
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val refreshTrigger = MutableSharedFlow<Unit>(
+        replay = 0,
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    init {
+        scope.launch {
+            refreshTrigger
+                .onStart { emit(Unit) }
+                .debounce(REFRESH_DEBOUNCE_MS)
+                .collectLatest {
+                    runCatching { manager.fetchGalleryImages(limit) }
+                        .onSuccess { _items.value = it }
+                }
+        }
+    }
+
+    /** Coalesced refresh; safe to call from any thread, multiple times rapidly. */
+    fun refresh() {
+        refreshTrigger.tryEmit(Unit)
+    }
+
+    companion object {
+        const val DEFAULT_LIMIT = 100
+        private const val REFRESH_DEBOUNCE_MS = 250L
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/gallery/PlatformGalleryManager.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/gallery/PlatformGalleryManager.kt
@@ -16,6 +16,9 @@ data class GalleryImage(
     val mimeType: String,
     val fileName: String,
     val galleryName: String,
+    val durationMs: Long? = null,
+    val width: Int = 0,
+    val height: Int = 0,
 ) {
     fun isVideo(): Boolean {
         return mimeType.startsWith("video/")

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/gallery/IOSGalleryLibraryObserver.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/gallery/IOSGalleryLibraryObserver.kt
@@ -1,0 +1,26 @@
+package id.homebase.core.gallery
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Photos.PHChange
+import platform.Photos.PHPhotoLibrary
+import platform.Photos.PHPhotoLibraryChangeObserverProtocol
+import platform.darwin.NSObject
+
+/**
+ * Bridges PHPhotoLibrary change notifications into [GalleryCache.refresh] so reopening
+ * the picker after the user adds/removes a photo shows the latest gallery state.
+ *
+ * Held by the Koin singleton scope so the observer outlives any composables.
+ */
+@OptIn(ExperimentalForeignApi::class)
+class IOSGalleryLibraryObserver(private val cache: GalleryCache) :
+    NSObject(), PHPhotoLibraryChangeObserverProtocol {
+
+    init {
+        PHPhotoLibrary.sharedPhotoLibrary().registerChangeObserver(this)
+    }
+
+    override fun photoLibraryDidChange(changeInstance: PHChange) {
+        cache.refresh()
+    }
+}

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/gallery/IOSGalleryManager.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/gallery/IOSGalleryManager.kt
@@ -1,58 +1,48 @@
 package id.homebase.core.gallery
 
 import io.github.vinceglb.filekit.PlatformFile
+import kotlin.math.roundToLong
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import platform.Foundation.NSSortDescriptor
 import platform.Foundation.timeIntervalSince1970
 import platform.Photos.PHAsset
-import platform.Photos.PHAssetCollection
-import platform.Photos.PHAssetCollectionTypeAlbum
 import platform.Photos.PHAssetMediaTypeImage
 import platform.Photos.PHAssetMediaTypeVideo
 import platform.Photos.PHAssetResource
 import platform.Photos.PHFetchOptions
 
-class IOSGalleryManager: PlatformGalleryManager {
-    override suspend fun fetchGalleryImages(limit: Int): List<GalleryImage> = withContext(Dispatchers.Main) {
-          val fetchOptions = PHFetchOptions().apply {
-            sortDescriptors = listOf(
-                NSSortDescriptor("creationDate", false)
+class IOSGalleryManager : PlatformGalleryManager {
+    override suspend fun fetchGalleryImages(limit: Int): List<GalleryImage> =
+        withContext(Dispatchers.Default) {
+            val fetchOptions = PHFetchOptions().apply {
+                sortDescriptors = listOf(NSSortDescriptor("creationDate", false))
+                fetchLimit = limit.toULong()
+            }
+
+            val images = processFetchResult(
+                PHAsset.fetchAssetsWithMediaType(PHAssetMediaTypeImage, fetchOptions),
+                "image/*",
             )
-            fetchLimit = limit.toULong()
+            val videos = processFetchResult(
+                PHAsset.fetchAssetsWithMediaType(PHAssetMediaTypeVideo, fetchOptions),
+                "video/*",
+            )
+
+            (images + videos)
+                .sortedByDescending { it.dateAdded }
+                .take(limit)
         }
 
-        // Fetch images
-        val imageFetchResult = PHAsset.fetchAssetsWithMediaType(
-            PHAssetMediaTypeImage,
-            fetchOptions
-        )
-
-        // Fetch videos
-        val videoFetchResult = PHAsset.fetchAssetsWithMediaType(
-            PHAssetMediaTypeVideo,
-            fetchOptions
-        )
-
-        // Process images
-        val images = processFetchResult(imageFetchResult, "image/*")
-
-        // Process videos
-        val videos = processFetchResult(videoFetchResult, "video/*")
-
-        // Combine and sort by date, then take the limit
-        (images + videos)
-            .sortedByDescending { it.dateAdded }
-            .take(limit)
-    }
-
-    private fun processFetchResult(fetchResult: platform.Photos.PHFetchResult, mimeType: String): List<GalleryImage> {
-        val items = mutableListOf<GalleryImage>()
+    private fun processFetchResult(
+        fetchResult: platform.Photos.PHFetchResult,
+        mimeType: String,
+    ): List<GalleryImage> {
+        val items = ArrayList<GalleryImage>(fetchResult.count.toInt())
 
         for (i in 0 until fetchResult.count.toInt()) {
             val asset = fetchResult.objectAtIndex(i.toULong()) as PHAsset
 
-            // Get the file name from asset resources
             val resources = PHAssetResource.assetResourcesForAsset(asset)
             val fileName = if (resources.isNotEmpty()) {
                 (resources.first() as? PHAssetResource)?.originalFilename ?: "unknown"
@@ -60,27 +50,28 @@ class IOSGalleryManager: PlatformGalleryManager {
                 "unknown"
             }
 
-            // Get the album/collection name
-            val collections = PHAssetCollection.fetchAssetCollectionsContainingAsset(
-                asset,
-                PHAssetCollectionTypeAlbum,
-                null
-            )
-            val galleryName = if (collections.count > 0u) {
-                (collections.objectAtIndex(0u) as? PHAssetCollection)?.localizedTitle ?: ""
-            } else {
-                ""
-            }
+            val isVideo = asset.mediaType == PHAssetMediaTypeVideo
+            val durationMs = if (isVideo && asset.duration > 0.0) {
+                (asset.duration * 1000.0).roundToLong()
+            } else null
 
-            items.add(GalleryImage(
-                id = asset.localIdentifier,
-                file = PlatformFile(asset.localIdentifier),
-                thumbnailUri = "ph://${asset.localIdentifier}",
-                dateAdded = asset.creationDate?.timeIntervalSince1970?.toLong() ?: 0L,
-                mimeType = mimeType,
-                fileName = fileName,
-                galleryName = galleryName,
-            ))
+            items.add(
+                GalleryImage(
+                    id = asset.localIdentifier,
+                    file = PlatformFile(asset.localIdentifier),
+                    thumbnailUri = "ph://${asset.localIdentifier}",
+                    dateAdded = asset.creationDate?.timeIntervalSince1970?.toLong() ?: 0L,
+                    mimeType = mimeType,
+                    fileName = fileName,
+                    // Album-membership lookup (PHAssetCollection.fetchAssetCollectionsContainingAsset)
+                    // used to run here per-asset — that was 50× a slow Photos round-trip on every
+                    // picker open and the value wasn't displayed anywhere. Drop it.
+                    galleryName = "",
+                    durationMs = durationMs,
+                    width = asset.pixelWidth.toInt(),
+                    height = asset.pixelHeight.toInt(),
+                )
+            )
         }
 
         return items

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/image/PHAssetFetcher.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/image/PHAssetFetcher.kt
@@ -10,96 +10,130 @@ import coil3.fetch.FetchResult
 import coil3.fetch.Fetcher
 import coil3.fetch.ImageFetchResult
 import coil3.request.Options
+import coil3.size.Dimension
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.usePinned
 import kotlinx.coroutines.suspendCancellableCoroutine
+import platform.CoreGraphics.CGSizeMake
+import platform.Foundation.NSData
 import platform.Photos.PHAsset
+import platform.Photos.PHAssetMediaTypeVideo
+import platform.Photos.PHImageContentModeAspectFill
 import platform.Photos.PHImageManager
 import platform.Photos.PHImageRequestOptions
 import platform.Photos.PHImageRequestOptionsDeliveryModeHighQualityFormat
+import platform.UIKit.UIImage
+import platform.UIKit.UIImageJPEGRepresentation
 import platform.posix.memcpy
 import kotlin.coroutines.resume
 
 /**
- * Coil Fetcher for loading iOS PHAsset images using the Photos framework.
+ * Coil Fetcher for loading iOS PHAsset thumbnails / images.
  *
- * This fetcher handles URIs with the format: "ph://localIdentifier"
- * where localIdentifier is the PHAsset's localIdentifier string.
+ * Accepts URIs of the form `ph://localIdentifier`. For images, uses the binary asset
+ * data path (preserves orientation). For VIDEO assets, uses requestImageForAsset which
+ * extracts a representative frame — `requestImageDataAndOrientationForAsset` returns
+ * nothing for videos.
  */
 class PHAssetFetcher(
     private val data: String,
-    private val options: Options
+    private val options: Options,
 ) : Fetcher {
 
     @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
     override suspend fun fetch(): FetchResult? {
-        // Extract the local identifier from the URI
-        println("PHAssetFetcher.fetch() called with data: $data")
-        val localIdentifier = if (data.startsWith("ph://")) {
-            data.removePrefix("ph://")
-        } else {
-            data
-        }
+        val localIdentifier = data.removePrefix("ph://")
 
-        // Fetch the PHAsset
         val fetchResult = PHAsset.fetchAssetsWithLocalIdentifiers(
             listOf(localIdentifier),
-            options = null
+            options = null,
         )
-
-        if (fetchResult.count == 0uL) {
-            return null
-        }
-
+        if (fetchResult.count == 0uL) return null
         val asset = fetchResult.firstObject as? PHAsset ?: return null
 
-        // Request the image from PHImageManager
-        val imageData = suspendCancellableCoroutine { continuation ->
+        val isVideo = asset.mediaType == PHAssetMediaTypeVideo
+        return if (isVideo) {
+            fetchVideoFrame(asset)
+        } else {
+            fetchImageData(asset)
+        }
+    }
+
+    @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+    private suspend fun fetchImageData(asset: PHAsset): FetchResult? {
+        val nsData = suspendCancellableCoroutine<NSData?> { continuation ->
             val requestOptions = PHImageRequestOptions().apply {
                 setNetworkAccessAllowed(true)
-                setResizeMode(PHImageRequestOptionsDeliveryModeHighQualityFormat)
+                setDeliveryMode(PHImageRequestOptionsDeliveryModeHighQualityFormat)
                 setSynchronous(false)
             }
 
             PHImageManager.defaultManager().requestImageDataAndOrientationForAsset(
                 asset,
-                options = requestOptions
-            ) { data, _, _, info ->
+                options = requestOptions,
+            ) { d, _, _, info ->
                 if (continuation.isActive) {
                     val isDegraded = info?.get(platform.Photos.PHImageResultIsDegradedKey) as? Boolean ?: false
-
-                    // On a physical device, this might be called with a null 'data'
-                    // first if the asset is downloading from iCloud.
-                    if (data != null) {
-                        continuation.resume(data)
-                    } else if (!isDegraded) {
-                        // If it's not degraded and data is still null, the fetch failed.
-                        continuation.resume(null)
-                    }
+                    if (d != null) continuation.resume(d)
+                    else if (!isDegraded) continuation.resume(null)
                 }
             }
+        } ?: return null
+
+        return imageFromNSData(nsData)
+    }
+
+    @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+    private suspend fun fetchVideoFrame(asset: PHAsset): FetchResult? {
+        // Pick the best target size from the Coil request — falls back to a sane
+        // thumbnail size if the layout hasn't measured yet.
+        val targetSize = run {
+            val w = (options.size.width as? Dimension.Pixels)?.px?.toDouble() ?: 640.0
+            val h = (options.size.height as? Dimension.Pixels)?.px?.toDouble() ?: 640.0
+            CGSizeMake(w, h)
         }
 
-        if (imageData == null) {
-            return null
-        }
+        val uiImage = suspendCancellableCoroutine<UIImage?> { continuation ->
+            val requestOptions = PHImageRequestOptions().apply {
+                setNetworkAccessAllowed(true)
+                setDeliveryMode(PHImageRequestOptionsDeliveryModeHighQualityFormat)
+                setSynchronous(false)
+            }
 
-        // Convert NSData to ByteArray
-        val bytes = ByteArray(imageData.length.toInt())
+            PHImageManager.defaultManager().requestImageForAsset(
+                asset = asset,
+                targetSize = targetSize,
+                contentMode = PHImageContentModeAspectFill,
+                options = requestOptions,
+            ) { image, info ->
+                if (continuation.isActive) {
+                    val isDegraded = info?.get(platform.Photos.PHImageResultIsDegradedKey) as? Boolean ?: false
+                    if (image != null) continuation.resume(image)
+                    else if (!isDegraded) continuation.resume(null)
+                }
+            }
+        } ?: return null
+
+        // Convert UIImage → JPEG bytes → Skia Image. We pay one JPEG encode per frame
+        // so the rest of the Coil pipeline can decode like any other image.
+        val jpegData = UIImageJPEGRepresentation(uiImage, 0.85) ?: return null
+        return imageFromNSData(jpegData)
+    }
+
+    @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+    private fun imageFromNSData(nsData: NSData): FetchResult {
+        val bytes = ByteArray(nsData.length.toInt())
         bytes.usePinned { pinned ->
-            memcpy(pinned.addressOf(0), imageData.bytes, imageData.length)
+            memcpy(pinned.addressOf(0), nsData.bytes, nsData.length)
         }
-
-        // Convert ByteArray to Skia Image to ImageBitmap to Coil Image
         val skiaImage = org.jetbrains.skia.Image.makeFromEncoded(bytes)
         val imageBitmap = skiaImage.toComposeImageBitmap()
-
         return ImageFetchResult(
             image = imageBitmap.asSkiaBitmap().asImage(),
             isSampled = false,
-            dataSource = DataSource.DISK
+            dataSource = DataSource.DISK,
         )
     }
 
@@ -107,19 +141,17 @@ class PHAssetFetcher(
         override fun create(
             data: Any,
             options: Options,
-            imageLoader: ImageLoader
+            imageLoader: ImageLoader,
         ): Fetcher? {
-            if (data !is Uri) {
-                return null
+            // Accept both Coil Uri and bare String models — the editor passes the URI
+            // straight through (no HomebaseImageData wrapper) for pending local items.
+            val uri = when (data) {
+                is Uri -> data.toString()
+                is String -> data
+                else -> return null
             }
-            val uri = data.toString()
-            // Only handle URIs starting with "ph://" or PHAsset localIdentifiers
-            if (!uri.startsWith("ph://") && !uri.contains("/L0/")) {
-                return null
-            }
+            if (!uri.startsWith("ph://") && !uri.contains("/L0/")) return null
             return PHAssetFetcher(uri, options)
         }
     }
 }
-
-

--- a/homebase-core/src/androidMain/kotlin/id/homebase/core/di/AppModule.android.kt
+++ b/homebase-core/src/androidMain/kotlin/id/homebase/core/di/AppModule.android.kt
@@ -16,6 +16,7 @@ import id.homebase.core.audio.AudioPlayer
 import id.homebase.core.audio.AudioRecorder
 import id.homebase.core.audio.AudioWaveFormGenerator
 import id.homebase.core.gallery.AndroidGalleryManager
+import id.homebase.core.gallery.GalleryCache
 import id.homebase.core.gallery.PlatformGalleryManager
 import id.homebase.core.image.HomebaseImageFetcher
 import id.homebase.core.image.HomebaseImageKeyer
@@ -35,6 +36,26 @@ actual fun platformModule(): Module = module {
     single { ShareCacheStorage(androidContext()) }
     single { createSettings(androidContext()) }
     single<PlatformGalleryManager> { AndroidGalleryManager(androidContext()) }
+    single(createdAtStart = true) {
+        val cache = GalleryCache(get<PlatformGalleryManager>())
+        // Refresh whenever the system reports new gallery items. The observer lives
+        // for the Application lifetime, mirroring the Koin singleton scope.
+        val resolver = androidContext().contentResolver
+        val handler = android.os.Handler(android.os.Looper.getMainLooper())
+        val observer = object : android.database.ContentObserver(handler) {
+            override fun onChange(selfChange: Boolean) {
+                cache.refresh()
+            }
+        }
+        resolver.registerContentObserver(
+            android.provider.MediaStore.Files.getContentUri(
+                android.provider.MediaStore.VOLUME_EXTERNAL
+            ),
+            true,
+            observer,
+        )
+        cache
+    }
     single<PlatformInfo> { AndroidPlatformInfo(androidContext()) }
     single<AudioRecorder> { AndroidAudioRecorder(androidContext()) }
     single<AudioPlayer> { AndroidAudioPlayer() }

--- a/homebase-core/src/jvmMain/kotlin/id/homebase/core/di/AppModule.desktop.kt
+++ b/homebase-core/src/jvmMain/kotlin/id/homebase/core/di/AppModule.desktop.kt
@@ -14,6 +14,7 @@ import id.homebase.core.audio.AudioWaveFormGenerator
 import id.homebase.core.audio.JvmAudioPlayer
 import id.homebase.core.audio.JvmAudioRecorder
 import id.homebase.core.audio.JvmWaveFormGenerator
+import id.homebase.core.gallery.GalleryCache
 import id.homebase.core.gallery.JvmGalleryManager
 import id.homebase.core.gallery.PlatformGalleryManager
 import id.homebase.core.image.HomebaseImageFetcher
@@ -34,6 +35,7 @@ actual fun platformModule(): Module = module {
     single { ShareCacheStorage() }
     single { createSettings() }
     single<PlatformGalleryManager> { JvmGalleryManager() }
+    single { GalleryCache(get<PlatformGalleryManager>()) }
     single<PlatformInfo> { JvmPlatformInfo() }
     single<AudioRecorder> { JvmAudioRecorder() }
     single<AudioPlayer> { JvmAudioPlayer() }

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/di/AppModule.native.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/di/AppModule.native.kt
@@ -14,6 +14,8 @@ import id.homebase.core.audio.AudioWaveFormGenerator
 import id.homebase.core.audio.IOSAudioPlayer
 import id.homebase.core.audio.IOSAudioRecorder
 import id.homebase.core.audio.IOSWaveFormGenerator
+import id.homebase.core.gallery.GalleryCache
+import id.homebase.core.gallery.IOSGalleryLibraryObserver
 import id.homebase.core.gallery.IOSGalleryManager
 import id.homebase.core.gallery.PlatformGalleryManager
 import id.homebase.core.image.HomebaseImageFetcher
@@ -34,6 +36,10 @@ actual fun platformModule(): Module = module {
     single { ShareCacheStorage() }
     single { createSettings() }
     single<PlatformGalleryManager> { IOSGalleryManager() }
+    single { GalleryCache(get<PlatformGalleryManager>()) }
+    // Held as its own singleton so PHPhotoLibrary's weak observer reference is
+    // backed by something with Application-scoped lifetime.
+    single(createdAtStart = true) { IOSGalleryLibraryObserver(get<GalleryCache>()) }
     single<PlatformInfo> { IOSPlatformInfo() }
     single<AudioRecorder> { IOSAudioRecorder() }
     single<AudioPlayer> { IOSAudioPlayer() }


### PR DESCRIPTION
  Summary of what shipped

  - Editor opens instantly on selection. ConversationListViewModel.AttachGalleryItem and AttachPlatformFile now build FileVideo(thumbnailBytes = null) synchronously and
  _messagesUiState.update fires before any thumbnail work. A child coroutine extracts the poster off-path and patches the overlay state by attachmentId. The send path awaits the
  per-attachmentId Deferred so the message envelope still ships a poster frame.
  - New Android extractor at homebase-api/.../VideoThumbnailExtractor.android.kt: ContentResolver.loadThumbnail(uri, Size(640,640)) → MediaMetadataRetriever(context, uri) → returns JPEG
  bytes. Both paths skip the full content:// → cacheDir copy that the FFmpeg fallback required. JVM/native actuals still delegate to FFmpegUtils.grabThumbnail (used only on Desktop file
  picks today).
  - Editor renders the URI through Coil's VideoFrameDecoder when bytes aren't ready. FullScreenAttachmentEditor uses attachment.thumbnailBytes ?: attachment.file.toString(). Removed the
  duplicate centered PlayCircle 96dp. Thumbnail strip got key = { it.attachmentId }, equality compares by id, indexOf → indexOfFirst. Local pending URIs now bypass
  HomebaseImageData.pending(...) so Coil's native MediaStore/file decoders stream + downsample (no full-bytes round-trip).
  - AndroidGalleryManager is one MediaStore.Files query projecting DURATION, WIDTH, HEIGHT, sorted server-side, capped via QUERY_ARG_LIMIT on API 30+. GalleryImage carries durationMs /
  width / height.
  - AttachmentGallery picker now uses stable key = { it.id } and shows a duration overlay on video tiles.
  - GalleryCache Koin singleton (commonMain) holds a StateFlow<List<GalleryImage>>, debounced refresh. Android registers a ContentObserver on MediaStore.Files; iOS registers
  IOSGalleryLibraryObserver : PHPhotoLibraryChangeObserver. The picker reads galleryCache.items via collectAsStateWithLifecycle() so reopens are instant.
  - iOS perf: IOSGalleryManager runs on Dispatchers.Default, drops the per-asset PHAssetCollection.fetchAssetCollectionsContainingAsset call (50× round-trip on every open). PHAssetFetcher
  now branches on PHAssetMediaTypeVideo and uses requestImageForAsset(targetSize, AspectFill, ...) so video tiles actually render — previously they were blank because
  requestImageDataAndOrientationForAsset returns nothing for videos.
  - Misc: localized the attach-failure string via MR.string.chat_attach_file_failed + TranslationUtil.

Round 2 of Signal-style media-perf work — removes the remaining places
where the app loaded entire image/video bytes into a Kotlin ByteArray
when a URI / file path / stream would do. Also fixes a corruption-class
bug in AesCbc.streamEncryptWithCbc that the new tests uncovered.

Three user-visible changes plus one shared-API fix:

1. Share-intent preview opens instantly for large videos. Previously
   ShareReceiverActivity.convertToAttachmentFiles ran FFmpeg + readBytes
   synchronously before the share preview UI could render. Editor now
   renders the poster from the URI via Coil's VideoFrameDecoder, so we
   pass thumbnailBytes = null and skip the blocking work entirely.

2. Aspect-ratio detection for sent photos reads ~64 KB of header instead
   of the full file. New ImageHeaderParser handles JPEG / PNG / GIF /
   WebP; falls back to ImageUtils.getNaturalSize for HEIC. New
   FileOperationsProvider.readFileHeaderBytes(maxBytes) does the partial
   read with platform-specific streaming on Android + JVM.

3. Video upload encryption (encryptVideoFile) now streams through AES
   instead of materialising the full ciphertext on the heap. Was ~10 MB
   peak for a sub-5 MB video; now constant ~64 KB. Uses new
   FileOperationsProvider.readFileAsFlow(chunkSize) helper.

4. AesCbc.streamEncryptWithCbc now accepts arbitrary chunk shapes.

The bug: the previous implementation crashed with
ArrayIndexOutOfBoundsException whenever any chunk was smaller than the
AES block size — e.g., any video whose total size mod 65536 fell in
[1..15]. The fix maintains an internal carry buffer, peels off
block-aligned prefixes, and lets the cipher's PKCS7 produce the trailing
block(s) at flow end. Output is byte-identical to encryptDataAes for any
input shape.

Initially the alignment workaround leaked into three call sites; user
review pointed out (correctly) that the fix belonged inside the
streaming function. After consolidation, encryptVideoFile is a clean
two-line pipeline and readFileAsFlow is a plain read-emit loop with no
references to AES alignment.

Tests added:
- AesCbcTest: 4 cases for sub-block input, unaligned final chunk,
  unaligned source chunks, and empty middle chunks. All assert byte
  equality with the bulk encrypt path.
- VideoPayloadProcessorStreamEncryptTest (new file): end-to-end coverage
  at the encryptVideoFile boundary across 9 sizes including the
  previously-crashing ones, plus a roundtrip-decrypt test.
- ImageHeaderParserTest (new file): JPEG SOF0, PNG IHDR, GIF, unknown
  format, too-short input.

streamDecryptWithCbc is untouched; existing decrypt callers in
DriveFileProviderCached / DriveFileHttpProvider continue to consume
ciphertext that's bit-equivalent to before.
