### PR TITLE
fix(chat): navigate on notification tap as soon as the conversation is in the local DB

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -513,7 +513,6 @@ class ConversationListViewModel(
                 .collect { (tap, convosState) ->
                     val resolved = resolveNotificationTap(
                         tap = tap,
-                        dataReady = convosState.dataReady,
                         conversationIds = convosState.items.map { it.id }.toSet(),
                     ) ?: return@collect
                     Logger.i(tag = "ConversationListViewModel") {
@@ -526,6 +525,33 @@ class ConversationListViewModel(
                     )
                     pendingNotificationTap.clearIfMatches(resolved.conversationId)
                 }
+        }
+
+        // Fast-path: when a notification tap arrives, kick a direct DB
+        // lookup for the target conversation off the Main dispatcher.
+        // ConversationStream.loadConversation runs one
+        // selectHomebaseFileByUnique against DriveMainIndex; if the file
+        // is in the local DB (which it usually is — the background sync
+        // that delivered the push wrote it), insertNewConversation /
+        // updateConversation mutates _conversations.items, which re-emits
+        // the StateFlow and lets the deferred resolver above fire
+        // immediately. Without this kick, the resolver waits for the
+        // full ConversationStream.start() enrichment pipeline (or, on a
+        // warm VM, for the next sync batch) — which is what made
+        // notification taps feel like they were gated on the drive-sync
+        // spinner. Dispatchers.IO so the kick can't be queued behind
+        // enrichWithUnreadCounts on Main.
+        viewModelScope.launch {
+            pendingNotificationTap.state.collect { tap ->
+                if (tap == null) return@collect
+                val convoId = tap.conversationId
+                val alreadyLoaded = conversationStream.conversations.value.items
+                    .any { it.id == convoId }
+                if (alreadyLoaded) return@collect
+                launch(Dispatchers.IO) {
+                    conversationStream.loadConversation(convoId)
+                }
+            }
         }
     }
 
@@ -2950,18 +2976,25 @@ internal fun synthesizeOwnerSession(
 /**
  * Decides whether a pending notification tap is ready to be resolved
  * against the current conversation list snapshot. Returns the tap
- * when the conversation list is ready AND contains the tap's
- * conversation id — caller then routes to the conversation + message.
- * Returns null when there's nothing to do yet (sync still pending).
+ * when the snapshot already contains the tap's conversation id —
+ * caller then routes to the conversation + message.
+ *
+ * No `dataReady` gate: a fast-path collector in the VM force-loads
+ * the tap's conversation directly from the local DB the moment a tap
+ * is set, so by the time the conversation appears in `items` we know
+ * it's locally available and safe to navigate to — even if
+ * `ConversationStream.start()` hasn't finished its full enrichment
+ * pipeline. The deferred fallback (sync delivers the conversation
+ * later) keeps working because `processConversationBatchIncrementally`
+ * also mutates `items`, which re-emits the StateFlow.
  *
  * Pure function so unit tests can exercise the resolution policy
  * without spinning up a VM.
  */
 internal fun resolveNotificationTap(
     tap: PendingNotificationTap.Tap?,
-    dataReady: Boolean,
     conversationIds: Set<Uuid>,
 ): PendingNotificationTap.Tap? {
-    if (tap == null || !dataReady) return null
+    if (tap == null) return null
     return tap.takeIf { conversationIds.contains(it.conversationId) }
 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/ConversationListPendingTapResolutionTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/ConversationListPendingTapResolutionTest.kt
@@ -12,11 +12,16 @@ import kotlin.uuid.Uuid
  * Locks down the resolution policy used by the VM's
  * pendingNotificationTap collector:
  *  - no tap → nothing to do
- *  - tap present but conversations not yet ready → wait
- *  - tap present, ready, conversation absent → still wait (next sync
- *    emit will try again)
- *  - tap present, ready, conversation present → hand back the tap so
- *    the caller fires selectConversation and clears
+ *  - tap present, conversation absent → still wait (next sync emit
+ *    will try again, and the VM's fast-path kick will have triggered
+ *    a direct DB load by then if the row exists locally)
+ *  - tap present, conversation present → hand back the tap so the
+ *    caller fires selectConversation and clears
+ *
+ * The previous `dataReady` gate is gone: the fast-path collector
+ * forces a direct DB load for the tap's conversation as soon as the
+ * tap is set, so the conversation showing up in `items` is itself
+ * proof that local data exists — `dataReady` would only add latency.
  */
 @OptIn(ExperimentalTime::class)
 class ConversationListPendingTapResolutionTest {
@@ -33,18 +38,6 @@ class ConversationListPendingTapResolutionTest {
         assertNull(
             resolveNotificationTap(
                 tap = null,
-                dataReady = true,
-                conversationIds = setOf(convoA),
-            )
-        )
-    }
-
-    @Test
-    fun notDataReady_returnsNull() {
-        assertNull(
-            resolveNotificationTap(
-                tap = tap(),
-                dataReady = false,
                 conversationIds = setOf(convoA),
             )
         )
@@ -52,11 +45,10 @@ class ConversationListPendingTapResolutionTest {
 
     @Test
     fun conversationAbsent_returnsNull() {
-        // Conversation hasn't synced yet — keep waiting.
+        // Conversation hasn't been loaded into items yet — keep waiting.
         assertNull(
             resolveNotificationTap(
                 tap = tap(),
-                dataReady = true,
                 conversationIds = setOf(convoB),
             )
         )
@@ -67,8 +59,21 @@ class ConversationListPendingTapResolutionTest {
         val t = tap()
         val result = resolveNotificationTap(
             tap = t,
-            dataReady = true,
             conversationIds = setOf(convoA, convoB),
+        )
+        assertEquals(t, result)
+    }
+
+    @Test
+    fun conversationPresent_resolvesEvenBeforeDataReady() {
+        // The fast-path DB lookup can insert the conversation into
+        // items before ConversationStream.start() has finished its
+        // enrichment passes. The resolver must not block on dataReady
+        // in that window — if items contains the id, navigate.
+        val t = tap()
+        val result = resolveNotificationTap(
+            tap = t,
+            conversationIds = setOf(convoA),
         )
         assertEquals(t, result)
     }
@@ -78,7 +83,6 @@ class ConversationListPendingTapResolutionTest {
         assertNull(
             resolveNotificationTap(
                 tap = tap(),
-                dataReady = true,
                 conversationIds = emptySet(),
             )
         )


### PR DESCRIPTION
When a chat notification was tapped, navigation to the target message was gated on
`conversationStream.conversations.dataReady` AND the conversation appearing in the
in-memory `items` list. In practice that gate didn't lift until the whole
`ConversationStream.start()` enrichment pipeline (including a 3.7 s
`enrichWithUnreadCounts` pass on cold start) and the next drive-sync cycle had
both finished — even when the message and conversation were already present in
the local SQLite DB from the background sync that delivered the push.

Two minimal changes, no new abstractions:

1. Add a fast-path collector in `ConversationListViewModel.init` that, on every
   non-null `pendingNotificationTap` emission, kicks
   `ConversationStream.loadConversation(conversationId)` on `Dispatchers.IO`.
   That existing function does a single `selectHomebaseFileByUnique` against
   `DriveMainIndex` and inserts/updates the row in `_conversations.items` if the
   file is locally available. Off Main so the kick can't be queued behind
   `enrichWithUnreadCounts`. Skips the kick when the conversation is already in
   `items` so we don't re-query on every recomposition-triggered re-emit.

2. Drop the `dataReady` parameter from `resolveNotificationTap`. With the
   fast-path above, the conversation appearing in `items` is itself proof that
   local data exists — `dataReady` would only add latency without adding safety.
   The deferred fallback path (sync delivers the conversation later →
   `processConversationBatchIncrementally` mutates `items` → resolver fires) is
   unchanged, as is the message-level retry inside `loadMessagesForConversation`
   that scrolls once the target message id appears in a `ChatMessagesData.Messages`
   emission. The 10 s `PendingNotificationTap` TTL still bounds an
   unresolvable tap.

Tests in `ConversationListPendingTapResolutionTest` updated for the new
`resolveNotificationTap` signature; added a case that pins down resolution
succeeding when the conversation is in `items` regardless of the prior
`dataReady` flag.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>