### PR TITLE
test(chat): pin deleteMessage recipients contract on the outbox row

### DIFF
--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTest.kt
@@ -1,10 +1,14 @@
 package id.homebase.chat.services
 
+import id.homebase.api.client.drives.files.DeleteLocalFilesByFileIdRequest
 import id.homebase.api.client.drives.files.DriveOutboxUploader
 import id.homebase.api.client.drives.files.SendReadReceiptByFileIdsOutboxRequest
+import id.homebase.api.common.OdinId
 import id.homebase.api.serialization.OdinSystemSerializer
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.uuid.Uuid
 import kotlinx.coroutines.test.runTest
@@ -187,6 +191,79 @@ class ChatMessageActionServiceTest {
 
             assertEquals(listOf(convoId), fixture.unreadCountEnricher.calls)
             assertEquals(listOf(convoId), fixture.localLastReadUpdater.calls.map { it.conversationId })
+        }
+    }
+
+    // ----- deleteMessage propagation contract -----
+    //
+    // Pins what `deleteMessage` puts on the outbox so that "Delete for everyone"
+    // carries the other participants as recipients (which is what tells the
+    // sync engine to fan the deletion out to peer drives), and "Delete for me"
+    // does NOT carry recipients. A regression on either side has been observed
+    // in the wild as "I deleted the message and the other person still sees it",
+    // so this is the cheap layer that catches it before runtime.
+
+    @Test
+    fun deleteMessage_deleteForEveryone_enqueuesDeleteRequestWithOtherParticipantsAsRecipients() = runTest {
+        ChatMessageActionServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val peer = "frodo.test"
+            val convoId = fixture.seedOneOnOneConversation(other = peer)
+            val fileId = Uuid.random()
+            val messageId = fixture.seedDeletableMessage(
+                conversationId = convoId,
+                senderDomain = fixture.testDomain,
+                fileId = fileId,
+            )
+
+            service.deleteMessage(messageId, deleteForEveryone = true)
+
+            val row = fixture.drainOutbox()
+                .single { it.uploadType == DriveOutboxUploader.DeleteFile }
+            val payload = OdinSystemSerializer.deserialize<DeleteLocalFilesByFileIdRequest>(
+                row.json.decodeToString()
+            )
+
+            val recipients = assertNotNull(
+                payload.recipients,
+                "recipients must not be null for 'Delete for everyone' — null means the sync engine won't fan the deletion out to peer drives",
+            )
+            assertEquals(
+                listOf(OdinId(peer)),
+                recipients,
+                "recipients must be the conversation participants minus self",
+            )
+            assertEquals(listOf(fileId), payload.fileIds)
+            assertEquals(false, payload.hardDelete)
+        }
+    }
+
+    @Test
+    fun deleteMessage_deleteForMe_enqueuesDeleteRequestWithoutRecipients() = runTest {
+        ChatMessageActionServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val peer = "frodo.test"
+            val convoId = fixture.seedOneOnOneConversation(other = peer)
+            val fileId = Uuid.random()
+            val messageId = fixture.seedDeletableMessage(
+                conversationId = convoId,
+                senderDomain = fixture.testDomain,
+                fileId = fileId,
+            )
+
+            service.deleteMessage(messageId, deleteForEveryone = false)
+
+            val row = fixture.drainOutbox()
+                .single { it.uploadType == DriveOutboxUploader.DeleteFile }
+            val payload = OdinSystemSerializer.deserialize<DeleteLocalFilesByFileIdRequest>(
+                row.json.decodeToString()
+            )
+
+            // "Delete for me" must NOT carry recipients — propagating it would
+            // unilaterally erase the message from the other participant's drive.
+            assertNull(payload.recipients, "recipients must be null for 'Delete for me'")
+            assertEquals(listOf(fileId), payload.fileIds)
+            assertEquals(false, payload.hardDelete)
         }
     }
 

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTest.kt
@@ -1,10 +1,14 @@
 package id.homebase.chat.services
 
+import id.homebase.api.client.CryptoHelper
+import id.homebase.api.client.drives.files.DeleteFilesBatchRequest
 import id.homebase.api.client.drives.files.DeleteLocalFilesByFileIdRequest
 import id.homebase.api.client.drives.files.DriveOutboxUploader
 import id.homebase.api.client.drives.files.SendReadReceiptByFileIdsOutboxRequest
 import id.homebase.api.common.OdinId
 import id.homebase.api.serialization.OdinSystemSerializer
+import io.ktor.http.HttpMethod
+import io.ktor.http.content.TextContent
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -264,6 +268,90 @@ class ChatMessageActionServiceTest {
             assertNull(payload.recipients, "recipients must be null for 'Delete for me'")
             assertEquals(listOf(fileId), payload.fileIds)
             assertEquals(false, payload.hardDelete)
+        }
+    }
+
+    // ----- deleteMessage WIRE-LEVEL contract -----
+    //
+    // The outbox-row tests above pin what we WRITE INTO the outbox. These tests
+    // pin what the DriveOutboxUploader actually puts ON THE WIRE when the row
+    // drains. The live propagation bug ("I delete-for-everyone, peer still sees
+    // it") could in principle live in any of: (a) outbox row JSON wrong, (b)
+    // dispatcher routes to the wrong uploader method, (c) wire DTO drops/renames
+    // recipients between DeleteLocalFilesByFileIdRequest and DeleteFilesBatchRequest,
+    // (d) endpoint URL changes. (a) is covered above; these tests cover (b)–(d)
+    // by capturing the actual HTTP request and decrypting its body.
+    //
+    // If both layers stay green and the live bug persists, the failure is
+    // server-side fan-out, not anything the client controls.
+
+    @Test
+    fun deleteMessage_deleteForEveryone_drainsOutboxToHttpRequestWithRecipientsOnTheWire() = runTest {
+        ChatMessageActionServiceTestFixture(captureHttp = true).use { fixture ->
+            val service = fixture.build(scope = this, outboxScope = backgroundScope)
+            val peer = "frodo.test"
+            val convoId = fixture.seedOneOnOneConversation(other = peer)
+            val fileId = Uuid.random()
+            val messageId = fixture.seedDeletableMessage(
+                conversationId = convoId,
+                senderDomain = fixture.testDomain,
+                fileId = fileId,
+            )
+
+            service.deleteMessage(messageId, deleteForEveryone = true)
+            fixture.drainOutboxAndAwaitHttp(this)
+
+            val request = fixture.capturedRequests.single()
+            assertEquals(HttpMethod.Post, request.method)
+            assertTrue(
+                request.url.encodedPath.endsWith("/files/delete-batch/by-file-id"),
+                "delete must POST to /files/delete-batch/by-file-id but went to ${request.url.encodedPath}",
+            )
+
+            // The body is encrypted with the shared secret — decrypt and assert
+            // the plaintext wire shape. A regression that drops `recipients`
+            // between the outbox DTO and the wire DTO produces null here.
+            val ciphertextJson = (request.body as TextContent).text
+            val payload: DeleteFilesBatchRequest =
+                CryptoHelper.decryptContent(ciphertextJson, fixture.sharedSecretBytes)
+
+            val req = payload.requests.single()
+            assertEquals(fileId, req.fileId)
+            val recipients = assertNotNull(
+                req.recipients,
+                "recipients must survive serialization onto the wire — null is the live-bug shape",
+            )
+            assertEquals(listOf(OdinId(peer)), recipients)
+        }
+    }
+
+    @Test
+    fun deleteMessage_deleteForMe_drainsOutboxToHttpRequestWithoutRecipientsOnTheWire() = runTest {
+        ChatMessageActionServiceTestFixture(captureHttp = true).use { fixture ->
+            val service = fixture.build(scope = this, outboxScope = backgroundScope)
+            val peer = "frodo.test"
+            val convoId = fixture.seedOneOnOneConversation(other = peer)
+            val fileId = Uuid.random()
+            val messageId = fixture.seedDeletableMessage(
+                conversationId = convoId,
+                senderDomain = fixture.testDomain,
+                fileId = fileId,
+            )
+
+            service.deleteMessage(messageId, deleteForEveryone = false)
+            fixture.drainOutboxAndAwaitHttp(this)
+
+            val request = fixture.capturedRequests.single()
+            val ciphertextJson = (request.body as TextContent).text
+            val payload: DeleteFilesBatchRequest =
+                CryptoHelper.decryptContent(ciphertextJson, fixture.sharedSecretBytes)
+
+            val req = payload.requests.single()
+            assertEquals(fileId, req.fileId)
+            // "Delete for me" must NOT carry recipients on the wire either —
+            // a future change that flips this would unilaterally fan a
+            // local-only delete out to the peer's drive.
+            assertNull(req.recipients, "recipients must be null on the wire for 'Delete for me'")
         }
     }
 

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
@@ -4,6 +4,7 @@ import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.auth.ApiCredentials
 import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.HomebaseFile
 import id.homebase.api.client.drives.files.reactions.DriveFileGroupReactionProvider
 import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.client.drives.cache.DriveFileProviderCached
@@ -14,12 +15,15 @@ import id.homebase.api.common.OdinId
 import id.homebase.api.common.SecureByteArray
 import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.sync.database.MainIndexMetaHelpers
 import id.homebase.api.sync.database.OdinDatabase
 import id.homebase.api.sync.database.Outbox
 import id.homebase.api.sync.database.OutboxSync
 import id.homebase.api.sync.database.OutboxUploader
 import id.homebase.chat.data.MessageUiModel
+import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.convo.ConversationService
 import id.homebase.chat.services.convo.LocalLastReadUpdater
 import id.homebase.chat.services.convo.UnreadCountEnricher
@@ -35,6 +39,7 @@ import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.test.TestScope
+import kotlin.time.Clock
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
 
@@ -172,6 +177,174 @@ class ChatMessageActionServiceTestFixture : AutoCloseable {
             hasMore = false,
         )
         return id
+    }
+
+    /**
+     * Seed a 1:1 conversation between [testDomain] and [other] into the in-memory
+     * DB so `conversationService.getConversation(convoId)` returns it with the
+     * expected participants list. Used by deleteMessage tests that need a real
+     * conversation row to compute recipients.
+     */
+    suspend fun seedOneOnOneConversation(
+        other: String,
+        conversationId: Uuid = Uuid.random(),
+    ): Uuid {
+        val fileId = Uuid.random()
+        val now = Clock.System.now().epochSeconds
+        val participants = listOf(testDomain, other)
+        val recipientsJson = participants.joinToString(",") { "\"$it\"" }
+        val contentJson = """{"title":"","version":1,"recipients":[$recipientsJson]}"""
+        val escaped = contentJson.replace("\"", "\\\"")
+        insertFile(
+            """{
+              "fileId": "$fileId",
+              "driveId": "$chatDriveId",
+              "fileState": "active",
+              "fileSystemType": "standard",
+              "serverFileIsEncrypted": "false",
+              "keyHeader": {
+                "iv": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+                "aesKey": {"bytes": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}
+              },
+              "fileMetadata": {
+                "globalTransitId": "${Uuid.random()}",
+                "created": ${now}000,
+                "updated": ${now}000,
+                "transitCreated": ${now}000,
+                "transitUpdated": 0,
+                "isEncrypted": false,
+                "senderOdinId": "$testDomain",
+                "originalAuthor": "$testDomain",
+                "appData": {
+                  "uniqueId": "$conversationId",
+                  "tags": null,
+                  "fileType": ${ChatProtocol.ConversationFileType},
+                  "dataType": 0,
+                  "groupId": null,
+                  "userDate": ${now}000,
+                  "content": "$escaped",
+                  "previewThumbnail": null,
+                  "archivalStatus": 0
+                },
+                "localAppData": null,
+                "referencedFile": null,
+                "reactionPreview": null,
+                "versionTag": "${Uuid.random()}",
+                "payloads": [],
+                "dataSource": null
+              },
+              "serverMetadata": {
+                "accessControlList": {
+                  "requiredSecurityGroup": "owner",
+                  "circleIdList": null,
+                  "odinIdList": null
+                },
+                "doNotIndex": false,
+                "allowDistribution": true,
+                "fileSystemType": "standard",
+                "fileByteCount": 100,
+                "originalRecipientCount": 1,
+                "transferHistory": null
+              },
+              "priority": 300,
+              "fileByteCount": 100
+            }"""
+        )
+        return conversationId
+    }
+
+    /**
+     * Seed a chat-message file row into DriveMainIndex AND register it with the
+     * fake messageLookup. Returns the message uniqueId.
+     *
+     * Both pieces are required because `ChatMessageActionService.deleteMessage`
+     * looks the message up via [MessageLookup] (for conversationId/authorship)
+     * AND independently resolves its fileId via QueryBatch over DriveMainIndex
+     * (`requireFileId(messageId)`).
+     */
+    suspend fun seedDeletableMessage(
+        conversationId: Uuid,
+        senderDomain: String = testDomain,
+        userDateMs: Long = 100L,
+        id: Uuid = Uuid.random(),
+        fileId: Uuid = Uuid.random(),
+    ): Uuid {
+        // 1) FakeMessageLookup record (so getMessage(id) returns non-null).
+        seedMessage(
+            conversationId = conversationId,
+            senderDomain = senderDomain,
+            userDateMs = userDateMs,
+            id = id,
+            fileId = fileId,
+        )
+
+        // 2) Real DriveMainIndex row keyed by uniqueId=id so requireFileId(id) finds it.
+        val now = Clock.System.now().epochSeconds
+        insertFile(
+            """{
+              "fileId": "$fileId",
+              "driveId": "$chatDriveId",
+              "fileState": "active",
+              "fileSystemType": "standard",
+              "serverFileIsEncrypted": "false",
+              "keyHeader": {
+                "iv": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+                "aesKey": {"bytes": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}
+              },
+              "fileMetadata": {
+                "globalTransitId": "${Uuid.random()}",
+                "created": ${userDateMs}000,
+                "updated": ${userDateMs}000,
+                "transitCreated": ${userDateMs}000,
+                "transitUpdated": 0,
+                "isEncrypted": false,
+                "senderOdinId": "$senderDomain",
+                "originalAuthor": "$senderDomain",
+                "appData": {
+                  "uniqueId": "$id",
+                  "tags": null,
+                  "fileType": ${ChatProtocol.MessageFileType},
+                  "dataType": 0,
+                  "groupId": "$conversationId",
+                  "userDate": ${userDateMs}000,
+                  "content": "",
+                  "previewThumbnail": null,
+                  "archivalStatus": 0
+                },
+                "localAppData": null,
+                "referencedFile": null,
+                "reactionPreview": null,
+                "versionTag": "${Uuid.random()}",
+                "payloads": [],
+                "dataSource": null
+              },
+              "serverMetadata": {
+                "accessControlList": {
+                  "requiredSecurityGroup": "owner",
+                  "circleIdList": null,
+                  "odinIdList": null
+                },
+                "doNotIndex": false,
+                "allowDistribution": true,
+                "fileSystemType": "standard",
+                "fileByteCount": 50,
+                "originalRecipientCount": 1,
+                "transferHistory": null
+              },
+              "priority": 300,
+              "fileByteCount": 50
+            }"""
+        )
+        return id
+    }
+
+    private suspend fun insertFile(jsonHeader: String) {
+        val header = OdinSystemSerializer.deserialize<HomebaseFile>(jsonHeader)
+        val processor = MainIndexMetaHelpers.HomebaseFileProcessor(dbm)
+        val record = processor.convertFileHeaderToDriveMainIndexRecord(
+            testIdentityId, chatDriveId, header
+        )
+        MainIndexMetaHelpers.upsertDriveMainIndex(dbm, record)
     }
 
     /**

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
@@ -5,10 +5,16 @@ import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.auth.ApiCredentials
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.client.drives.files.DeleteFileIdBatchResult
+import id.homebase.api.client.drives.files.DeleteFileResult
+import id.homebase.api.client.drives.files.DriveFileOperationsProvider
+import id.homebase.api.client.drives.files.DriveOutboxUploader
 import id.homebase.api.client.drives.files.reactions.DriveFileGroupReactionProvider
 import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.client.drives.cache.DriveFileProviderCached
 import id.homebase.api.client.drives.query.QueryBatchCursor
+import id.homebase.api.client.drives.upload.DriveUploadProvider
+import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.common.BatchResult
 import id.homebase.api.common.OdinId
@@ -34,11 +40,20 @@ import id.homebase.chat.services.convo.FakeStatusMessageSender
 import id.homebase.chat.services.outbox.OptimisticWriter
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
 import io.ktor.client.engine.mock.respondError
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlin.time.Clock
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
@@ -46,21 +61,43 @@ import kotlin.uuid.Uuid
 /**
  * Integration-ish fixture for ChatMessageActionService. Uses:
  *   - Real in-memory SQLite DB (so the outbox and ChatReadCount live in a real schema).
- *   - Real OutboxSync with setOnline(false) — enqueued rows stay in the DB for
- *     inspection, never uploaded. The stub uploader throws if something tries.
+ *   - Real OutboxSync with setOnline(false) by default — enqueued rows stay in
+ *     the DB for inspection, never uploaded. The stub uploader throws if
+ *     something tries.
  *   - FakeMessageLookup, FakeLocalLastReadUpdater, FakeUnreadCountEnricher — the
  *     three narrow seams the service under test depends on.
  *   - Real ConversationService is still passed to the ctor but markAsReadByFiles
  *     doesn't touch it.
  *
+ * Set [captureHttp] = true to switch to a wire-level mode: real
+ * [DriveOutboxUploader], capturing [MockEngine], `setOnline(true)`. The
+ * captured requests show up in [capturedRequests], and bodies can be decrypted
+ * via [sharedSecretBytes]. Use [drainOutboxAndAwaitHttp] to drive the outbox
+ * through to its HTTP call deterministically.
+ *
  * Use via `ChatMessageActionServiceTestFixture().use { fixture -> ... }` so the
  * in-memory DB is closed at the end of each test.
  */
-class ChatMessageActionServiceTestFixture : AutoCloseable {
+class ChatMessageActionServiceTestFixture(
+    private val captureHttp: Boolean = false,
+) : AutoCloseable {
 
     val testIdentityId: Uuid = Uuid.parse("7b1be23b-48bb-4304-bc7b-db5910c09a92")
     val chatDriveId: Uuid = Uuid.parse("9ff813af-f2d6-1e2f-9b9d-b189e72d1a11")
     val testDomain: String = "owner.test"
+
+    /**
+     * Outbound HTTP requests captured by the mock engine when `captureHttp = true`.
+     * Empty otherwise.
+     */
+    val capturedRequests: MutableList<HttpRequestData> = mutableListOf()
+
+    /**
+     * Shared-secret bytes the fixture's credentials use. Re-exposed so tests
+     * can decrypt request bodies via `CryptoHelper.decryptContent(...)`. Matches
+     * what [createCredentialsManager] sets up below.
+     */
+    val sharedSecretBytes: ByteArray = ByteArray(16)
 
     lateinit var dbm: DatabaseManager
         private set
@@ -77,16 +114,85 @@ class ChatMessageActionServiceTestFixture : AutoCloseable {
     lateinit var unreadCountEnricher: FakeUnreadCountEnricher
         private set
 
-    suspend fun build(scope: CoroutineScope = TestScope()): ChatMessageActionService {
+    suspend fun build(
+        scope: CoroutineScope = TestScope(),
+        outboxScope: CoroutineScope = scope,
+    ): ChatMessageActionService {
         dbm = createInMemoryDbm()
         credentialsManager = createCredentialsManager(testDomain)
         eventBus = EventBus()
+
+        // Two flavors of HTTP client:
+        //   - captureHttp=false (default): every request 500s. The fixture is
+        //     paired with ThrowingOutboxUploader + setOnline(false) so nothing
+        //     should hit the wire — the 500 is a loud signal if it does.
+        //   - captureHttp=true: requests are recorded into capturedRequests, and
+        //     the chat delete-batch endpoint returns a valid response so the
+        //     real DriveOutboxUploader's deleteFile path runs to completion.
+        val httpClient = if (captureHttp) {
+            HttpClient(MockEngine { request ->
+                capturedRequests += request
+                if (request.url.encodedPath.endsWith("/files/delete-batch/by-file-id")) {
+                    val body = OdinSystemSerializer.serialize(
+                        DeleteFileIdBatchResult(
+                            results = listOf(
+                                DeleteFileResult(
+                                    fileId = Uuid.NIL,
+                                    localFileDeleted = true,
+                                    localFileNotFound = false,
+                                )
+                            )
+                        )
+                    )
+                    respond(
+                        content = body,
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                } else {
+                    respondError(HttpStatusCode.InternalServerError)
+                }
+            })
+        } else {
+            HttpClient(MockEngine { _ ->
+                respondError(HttpStatusCode.InternalServerError)
+            })
+        }
+
+        val driveCache = DriveFileProviderCached(
+            httpClient,
+            credentialsManager,
+            NoopFileOperationsProvider(),
+        )
+        val fileProvider = DriveFileProvider(httpClient, credentialsManager, driveCache)
+        val reactionProvider = DriveFileGroupReactionProvider(httpClient, credentialsManager)
+
+        // captureHttp=true wires the REAL DriveOutboxUploader so we exercise the
+        // dispatcher (`when(uploadType) { DeleteFile -> deleteFile(...) }`) and
+        // the real DriveFileProvider.deleteFiles serialization. The other three
+        // providers are only on the constructor for the dispatcher's other
+        // branches; the DeleteFile branch only touches `fileProvider`.
+        val uploader: OutboxUploader = if (captureHttp) {
+            DriveOutboxUploader(
+                driveUploadProvider = DriveUploadProvider(
+                    httpClient,
+                    credentialsManager,
+                    NoopFileOperationsProvider(),
+                ),
+                fileProvider = fileProvider,
+                operationsProvider = DriveFileOperationsProvider(httpClient, credentialsManager),
+                reactionProvider = reactionProvider,
+            )
+        } else {
+            ThrowingOutboxUploader
+        }
+
         outboxSync = OutboxSync(
             databaseManager = dbm,
-            uploader = ThrowingOutboxUploader,
+            uploader = uploader,
             eventBus = eventBus,
-            scope = scope,
-        ).also { it.setOnline(false) }
+            scope = outboxScope,
+        ).also { it.setOnline(captureHttp) }
 
         messageLookup = FakeMessageLookup()
         localLastReadUpdater = FakeLocalLastReadUpdater()
@@ -113,31 +219,44 @@ class ChatMessageActionServiceTestFixture : AutoCloseable {
             conversationStream = FakeConversationLoader(),
         )
 
-        // reactionProvider and fileProvider are ctor-required but never invoked by
-        // markAsReadByFiles. Build them with a MockEngine that 500s any request so
-        // that if a future test reaches them, the failure is loud and clear rather
-        // than silent or NPE.
-        val httpClient = HttpClient(MockEngine { _ ->
-            respondError(HttpStatusCode.InternalServerError)
-        })
-        val driveCache = DriveFileProviderCached(
-            httpClient,
-            credentialsManager,
-            NoopFileOperationsProvider(),
-        )
-
         return ChatMessageActionService(
             conversationService = conversationService,
             localLastReadUpdater = localLastReadUpdater,
             unreadCountEnricher = unreadCountEnricher,
             messageLookup = messageLookup,
-            reactionProvider = DriveFileGroupReactionProvider(httpClient, credentialsManager),
+            reactionProvider = reactionProvider,
             credentialsManager = credentialsManager,
-            fileProvider = DriveFileProvider(httpClient, credentialsManager, driveCache),
+            fileProvider = fileProvider,
             dbm = dbm,
             outboxSync = outboxSync,
             optimisticWriter = optimisticWriter,
         )
+    }
+
+    /**
+     * Drain the outbox via the real OutboxSync workers and wait for the
+     * `Completed` event before returning. After this returns,
+     * [capturedRequests] reflects every HTTP call the drained rows produced.
+     *
+     * Mirrors the pattern from `OutboxSyncTest` — subscribe BEFORE `send()` so
+     * the test deterministically observes drain completion rather than relying
+     * on `advanceUntilIdle` alone.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    suspend fun drainOutboxAndAwaitHttp(testScope: TestScope) {
+        check(captureHttp) {
+            "drainOutboxAndAwaitHttp requires captureHttp = true; with the default fixture " +
+                    "the outbox is offline and the uploader throws on use"
+        }
+        val completed = testScope.async {
+            eventBus.events
+                .filterIsInstance<BackendEvent.OutboxEvent.Completed>()
+                .first()
+        }
+        testScope.testScheduler.runCurrent()
+        outboxSync.send()
+        testScope.advanceUntilIdle()
+        completed.await()
     }
 
     /**


### PR DESCRIPTION
Add two regression tests for ChatMessageActionService.deleteMessage that inspect the outbox row produced by each user action and assert what gets sent to peers vs. what stays local-only:

  - Delete for everyone -> outbox row must carry recipients = participants minus self. A null/empty here means the sync engine never fans the deletion out to peer drives, which manifests as "I deleted it but the other person still sees it".
  - Delete for me        -> outbox row must NOT carry recipients. Sending
    them would unilaterally erase the message from the peer's drive.

These tests exercise the full local pipeline (real in-memory SQLite, real OutboxSync with setOnline(false), real OptimisticWriter, real ConversationService) so a regression in any of: the participants resolution, the OptimisticWriter delete, or the
DeleteLocalFilesByFileIdRequest shape will break them.

To make this work, ChatMessageActionServiceTestFixture grows two seed helpers — seedOneOnOneConversation and seedDeletableMessage — plus a private insertFile that goes through MainIndexMetaHelpers, mirroring the JSON-based seed pattern already used in ConversationServiceTestFixture.

Note: these tests pin the in-app contract only. They confirm that recipients leave the client correctly, which means a separately-reported bug ("delete-for-everyone of an image does not propagate to peers") must live downstream of the outbox row — most likely the server-side batch delete endpoint not honoring the recipients fan-out, or a JSON shape mismatch on the wire. That is a follow-up investigation.


  - ChatMessageActionServiceTestFixture.kt: added an opt-in captureHttp = true mode that swaps the no-op MockEngine for a capturing one (records every
  HttpRequestData into capturedRequests, returns a valid DeleteFileIdBatchResult for the chat delete-batch endpoint), wires the real DriveOutboxUploader
  instead of the throwing stub, and sets outboxSync online. Added drainOutboxAndAwaitHttp(testScope) that subscribes to BackendEvent.OutboxEvent.Completed
  before send() for deterministic drain observation. Re-exposed sharedSecretBytes so tests can decrypt request bodies. Existing six tests untouched (they
  continue to use the default offline mode).
  - ChatMessageActionServiceTest.kt: added two wire-level tests — deleteMessage_deleteForEveryone_drainsOutboxToHttpRequestWithRecipientsOnTheWire and
  deleteMessage_deleteForMe_drainsOutboxToHttpRequestWithoutRecipientsOnTheWire. Both assert the URL ends in /files/delete-batch/by-file-id, decrypt the
  body via CryptoHelper.decryptContent into DeleteFilesBatchRequest, and pin the per-request recipients field on the wire ([OdinId("frodo.test")] for
  "everyone", null for "me").

  Both new tests pass against current main, which proves the client puts the right bytes on the wire — so the live propagation bug is downstream
  (server-side fan-out) and the next investigation step can move off the client.
