### PR TITLE
Group heal tooling and outbox-chain serialization for chat sends

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsScreen.kt
@@ -1,27 +1,39 @@
 package id.homebase.chat.groupsettings
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.ChevronLeft
 import androidx.compose.material.icons.filled.DoNotDisturbOn
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.Healing
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.KeyOff
 import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.ui.Alignment
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
@@ -36,16 +48,24 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.homebase.api.common.OdinId
 import id.homebase.chat.createconversation.ContactItem
 import id.homebase.chat.services.convo.contact.ContactConnectionState
 import id.homebase.chat.widget.AvatarNameDisplay
 import id.homebase.chat.widget.ErrorInfoItem
 import id.homebase.chat.widget.LoadingListItem
+import id.homebase.core.avatars.AvatarOptions
+import id.homebase.core.avatars.ContactAvatar
 import id.homebase.core.avatars.ConversationAvatarModel
+import id.homebase.core.widget.ContactName
 import id.homebase.core.widget.DialogButtons
 import id.homebase.core.widget.DialogCard
 import id.homebase.core.widget.DialogText
@@ -56,7 +76,14 @@ import id.homebase.resources.MR
 import id.homebase.resources.cancel
 import id.homebase.resources.chat_group_add_members
 import id.homebase.resources.chat_group_admin
+import id.homebase.resources.chat_group_admin_file_delivered
+import id.homebase.resources.chat_group_admin_file_problem
 import id.homebase.resources.chat_group_choose_new_admin
+import id.homebase.resources.chat_group_heal
+import id.homebase.resources.chat_group_heal_completed
+import id.homebase.resources.chat_group_heal_completed_nothing
+import id.homebase.resources.chat_group_main_file_delivered
+import id.homebase.resources.chat_group_main_file_problem
 import id.homebase.resources.chat_group_choose_new_admin_disclaimer
 import id.homebase.resources.chat_group_leave
 import id.homebase.resources.chat_group_leave_disclaimer
@@ -93,6 +120,8 @@ fun GroupSettingsScreen(
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
     val uriHandler = LocalUriHandler.current
+    val healCompletedMessage = stringResource(MR.string.chat_group_heal_completed)
+    val healCompletedNothingMessage = stringResource(MR.string.chat_group_heal_completed_nothing)
 
     when (val event = uiState.uiEvent) {
         is GroupSettingsUiEvent.Back -> {
@@ -123,6 +152,16 @@ fun GroupSettingsScreen(
         is GroupSettingsUiEvent.OpenUrl -> {
             viewModel.eventConsumed()
             uriHandler.openUri(event.url)
+        }
+
+        is GroupSettingsUiEvent.HealCompleted -> {
+            viewModel.eventConsumed()
+            val message = if (event.mainHealed || event.adminHealed) {
+                healCompletedMessage
+            } else {
+                healCompletedNothingMessage
+            }
+            scope.launch { snackbarHostState.showSnackbar(message = message) }
         }
 
         null -> {}
@@ -269,7 +308,7 @@ fun GroupSettingsUi(
                         }
 
                     items(connectedContacts, key = { it.odinId.domainName }) { contact ->
-                        ContactItem(
+                        GroupParticipantRow(
                             name = contact.name,
                             subTitle = contact.odinId.domainName,
                             annotation = if (conversation.isCurrentUserAdmin(contact.odinId)) stringResource(
@@ -277,11 +316,15 @@ fun GroupSettingsUi(
                             ) else null,
                             avatarInitials = contact.avatarInitials,
                             odinId = contact.odinId,
-                            onContactClick = {
+                            onClick = {
                                 onUiAction(
                                     GroupSettingsUiAction.ShowMemberSheet(contact)
                                 )
                             },
+                            mainStatus = uiState.mainFileTransfer?.get(contact.odinId),
+                            adminStatus = uiState.adminFileTransfer?.get(contact.odinId),
+                            showMainColumn = uiState.mainFileTransfer != null,
+                            showAdminColumn = uiState.adminFileTransfer != null,
                         )
                     }
 
@@ -294,18 +337,31 @@ fun GroupSettingsUi(
                             )
                         }
                         items(notConnectedContacts, key = { it.odinId.domainName }) { contact ->
-                            ContactItem(
+                            GroupParticipantRow(
                                 name = contact.name,
                                 subTitle = contact.odinId.domainName,
                                 annotation = stringResource(MR.string.connect),
                                 annotationColor = MaterialTheme.colorScheme.primary,
                                 avatarInitials = contact.avatarInitials,
                                 odinId = contact.odinId,
-                                onContactClick = {
+                                onClick = {
                                     onUiAction(
                                         GroupSettingsUiAction.ConnectToIdentity(contact.odinId)
                                     )
                                 },
+                                mainStatus = uiState.mainFileTransfer?.get(contact.odinId),
+                                adminStatus = uiState.adminFileTransfer?.get(contact.odinId),
+                                showMainColumn = uiState.mainFileTransfer != null,
+                                showAdminColumn = uiState.adminFileTransfer != null,
+                            )
+                        }
+                    }
+                    if (uiState.canHeal) {
+                        item {
+                            HorizontalDivider()
+                            HealGroupButton(
+                                isHealing = uiState.isHealing,
+                                onClick = { onUiAction(GroupSettingsUiAction.HealGroupClicked) }
                             )
                         }
                     }
@@ -535,5 +591,149 @@ fun GroupSettingsSheets(
                 }
             }
         }
+    }
+}
+
+/**
+ * GroupSettings-only participant row. Mirrors the shared [ContactItem] layout but inlines
+ * the per-file delivery indicators next to the name (the indicators are a diagnostic aid
+ * specific to this screen and don't belong on the shared widget).
+ */
+@Composable
+private fun GroupParticipantRow(
+    name: String,
+    subTitle: String?,
+    annotation: String?,
+    annotationColor: Color? = null,
+    avatarInitials: String,
+    odinId: OdinId,
+    onClick: () -> Unit,
+    mainStatus: RecipientFileStatus?,
+    adminStatus: RecipientFileStatus?,
+    showMainColumn: Boolean,
+    showAdminColumn: Boolean,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 20.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        ContactAvatar(
+            odinId = odinId,
+            profileImageData = null,
+            initials = avatarInitials,
+            options = AvatarOptions(
+                size = 28.dp,
+                fontSize = 12.sp,
+            ),
+            sharedTransitionScope = null,
+            animatedVisibilityScope = null
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                ContactName(
+                    odinId = odinId,
+                    knownName = name,
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f, fill = false)
+                )
+                if (showMainColumn || showAdminColumn) {
+                    Spacer(modifier = Modifier.width(8.dp))
+                    if (showMainColumn) {
+                        TransferStatusIcon(
+                            mainStatus,
+                            stringResource(MR.string.chat_group_main_file_delivered),
+                            stringResource(MR.string.chat_group_main_file_problem),
+                        )
+                    }
+                    if (showMainColumn && showAdminColumn) {
+                        Spacer(modifier = Modifier.width(2.dp))
+                    }
+                    if (showAdminColumn) {
+                        TransferStatusIcon(
+                            adminStatus,
+                            stringResource(MR.string.chat_group_admin_file_delivered),
+                            stringResource(MR.string.chat_group_admin_file_problem),
+                        )
+                    }
+                }
+            }
+            subTitle?.let {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = subTitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+        annotation?.let {
+            Text(
+                text = annotation,
+                style = MaterialTheme.typography.labelSmall,
+                color = annotationColor ?: LocalContentColor.current,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TransferStatusIcon(
+    status: RecipientFileStatus?,
+    okDescription: String,
+    problemDescription: String,
+) {
+    val size = 12.dp
+    when (status) {
+        RecipientFileStatus.Ok -> Icon(
+            imageVector = Icons.Default.Check,
+            contentDescription = okDescription,
+            tint = LocalContentColor.current.copy(alpha = 0.55f),
+            modifier = Modifier.size(size)
+        )
+        is RecipientFileStatus.Problem -> Icon(
+            imageVector = Icons.Default.ErrorOutline,
+            contentDescription = problemDescription,
+            tint = MaterialTheme.colorScheme.error,
+            modifier = Modifier.size(size)
+        )
+        null -> Spacer(modifier = Modifier.size(size))
+    }
+}
+
+@Composable
+private fun HealGroupButton(
+    isHealing: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .clickable(enabled = !isHealing, onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 20.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (isHealing) {
+            CircularProgressIndicator(modifier = Modifier.size(20.dp))
+        } else {
+            Icon(
+                imageVector = Icons.Default.Healing,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp)
+            )
+        }
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(
+            text = stringResource(MR.string.chat_group_heal),
+            style = MaterialTheme.typography.bodyLarge,
+        )
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsUiAction.kt
@@ -15,4 +15,5 @@ sealed interface GroupSettingsUiAction {
     data class RemoveAdmin(val contact: ContactUiModel, val skipConfirmation: Boolean = false) : GroupSettingsUiAction
     data class RemoveFromGroup(val contact: ContactUiModel, val skipConfirmation: Boolean = false) : GroupSettingsUiAction
     data class ConnectToIdentity(val odinId: OdinId) : GroupSettingsUiAction
+    data object HealGroupClicked : GroupSettingsUiAction
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsUiState.kt
@@ -1,10 +1,12 @@
 package id.homebase.chat.groupsettings
 
 import androidx.compose.runtime.Immutable
+import id.homebase.api.client.drives.files.TransferStatus
 import id.homebase.api.common.OdinId
 import id.homebase.chat.data.ContactUiModel
 import id.homebase.chat.data.ConversationUiModel
 import kotlin.uuid.Uuid
+import org.jetbrains.compose.resources.StringResource
 
 @Immutable
 data class GroupSettingsUiState(
@@ -14,10 +16,24 @@ data class GroupSettingsUiState(
     val isCurrentUserGroupAdmin: Boolean = false,
     val isLegacyGroup: Boolean = false,
     val contacts: List<ContactUiModel> = listOf(),
+    /** Per-recipient transfer state for the main conversation file. null = caller is not
+     *  the original author and the column should be hidden. */
+    val mainFileTransfer: Map<OdinId, RecipientFileStatus>? = null,
+    /** Per-recipient transfer state for the admin file. null = column hidden (see above). */
+    val adminFileTransfer: Map<OdinId, RecipientFileStatus>? = null,
+    val isHealing: Boolean = false,
     val uiEvent: GroupSettingsUiEvent? = null,
     val uiDialog: GroupSettingsUiDialog? = null,
     val uiSheet: GroupSettingsUiSheet? = null,
-)
+) {
+    val canHeal: Boolean get() = mainFileTransfer != null || adminFileTransfer != null
+}
+
+@Immutable
+sealed interface RecipientFileStatus {
+    data object Ok : RecipientFileStatus
+    data class Problem(val rawStatus: TransferStatus, val detailRes: StringResource?) : RecipientFileStatus
+}
 
 sealed interface GroupSettingsUiEvent {
     data object Back : GroupSettingsUiEvent
@@ -26,6 +42,7 @@ sealed interface GroupSettingsUiEvent {
     data class ShowAddMembers(val conversationId: String) : GroupSettingsUiEvent
     data class ShowEditGroup(val conversationId: String) : GroupSettingsUiEvent
     data class OpenUrl(val url: String) : GroupSettingsUiEvent
+    data class HealCompleted(val mainHealed: Boolean, val adminHealed: Boolean) : GroupSettingsUiEvent
 }
 
 sealed interface GroupSettingsUiDialog {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsViewModel.kt
@@ -381,11 +381,18 @@ class GroupSettingsViewModel(
             val results = history?.history?.results ?: emptyList()
             results.associate { entry: RecipientTransferHistoryEntry ->
                 val odinId = OdinId(entry.recipient)
-                val status = if (
-                    entry.latestTransferStatus == TransferStatus.Delivered &&
-                    !entry.isInOutbox &&
-                    !TransferStatus.isFailedStatus(entry.latestTransferStatus)
-                ) {
+                // Match the per-message status mapping in
+                // ChatDeliveryStatus.toChatDeliveryStatus: when the latest known
+                // status is Delivered, that wins over `isInOutbox`. Right after
+                // pressing "Heal group" we re-enqueue the file, so the server
+                // briefly returns `latestTransferStatus = Delivered` (from the
+                // prior successful send) AND `isInOutbox = true` (because we
+                // just kicked it back into the outbox). Treating that combo as
+                // a Problem produced a misleading "PROBLEM(Delivered)" log
+                // entry and a transient red icon for ~180ms after each heal.
+                // The recipient is fine — the file has been delivered before
+                // and is currently being redistributed.
+                val status = if (entry.latestTransferStatus == TransferStatus.Delivered) {
                     RecipientFileStatus.Ok
                 } else {
                     RecipientFileStatus.Problem(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsViewModel.kt
@@ -328,7 +328,8 @@ class GroupSettingsViewModel(
 
         Logger.d {
             "loadTransferHistory: ${conversation.id} mainAuthored=${mainTransfer != null} mainEntries=${mainTransfer?.size} " +
-                    "adminAuthored=${adminTransfer != null} adminEntries=${adminTransfer?.size}"
+                    "adminAuthored=${adminTransfer != null} adminEntries=${adminTransfer?.size} " +
+                    "main=${renderTransferMap(mainTransfer)} admin=${renderTransferMap(adminTransfer)}"
         }
 
         _uiState.update {
@@ -339,26 +340,27 @@ class GroupSettingsViewModel(
         }
     }
 
+    private fun renderTransferMap(map: Map<OdinId, RecipientFileStatus>?): String {
+        if (map == null) return "<column hidden — caller is not author>"
+        if (map.isEmpty()) return "<no recipients in transfer history>"
+        return map.entries.joinToString(prefix = "{", postfix = "}") { (recipient, status) ->
+            val s = when (status) {
+                RecipientFileStatus.Ok -> "OK"
+                is RecipientFileStatus.Problem -> "PROBLEM(${status.rawStatus})"
+            }
+            "$recipient=$s"
+        }
+    }
+
     /**
      * Logs the per-recipient status of both group files in a single multi-line entry.
      * Called before and after a heal so the diff is easy to read in homebase.log when
      * diagnosing "I clicked heal but recipient X still doesn't have it".
      */
     private fun logTransferSnapshot(label: String, conversationId: Uuid, state: GroupSettingsUiState) {
-        fun renderMap(map: Map<OdinId, RecipientFileStatus>?): String {
-            if (map == null) return "<column hidden — caller is not author>"
-            if (map.isEmpty()) return "<no recipients in transfer history>"
-            return map.entries.joinToString(prefix = "{", postfix = "}") { (recipient, status) ->
-                val s = when (status) {
-                    RecipientFileStatus.Ok -> "OK"
-                    is RecipientFileStatus.Problem -> "PROBLEM(${status.rawStatus})"
-                }
-                "$recipient=$s"
-            }
-        }
         Logger.i {
             "GroupSettings: $label snapshot conversationId=$conversationId " +
-                    "main=${renderMap(state.mainFileTransfer)} admin=${renderMap(state.adminFileTransfer)}"
+                    "main=${renderTransferMap(state.mainFileTransfer)} admin=${renderTransferMap(state.adminFileTransfer)}"
         }
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsViewModel.kt
@@ -6,6 +6,11 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.client.drives.files.DriveFileProvider
+import id.homebase.api.client.drives.files.RecipientTransferHistoryEntry
+import id.homebase.api.client.drives.files.TransferStatus
+import id.homebase.api.common.OdinId
 import id.homebase.chat.data.ContactUiModel
 import id.homebase.chat.data.ConversationUiModel
 import id.homebase.chat.groupsettings.GroupSettingsUiEvent.Back
@@ -17,6 +22,8 @@ import id.homebase.chat.services.convo.ConversationService
 import id.homebase.chat.services.convo.ConversationStream
 import id.homebase.chat.services.convo.contact.ContactConnectionState
 import id.homebase.chat.services.convo.contact.ContactService
+import id.homebase.chat.services.toErrorDetailRes
+import id.homebase.core.config.chatTargetDrive
 import id.homebase.core.ui.navigation.Route
 import id.homebase.core.util.buildConnectToIdentityUrl
 import id.homebase.core.util.initials
@@ -34,6 +41,7 @@ class GroupSettingsViewModel(
     private val conversationService: ConversationService,
     private val contactService: ContactService,
     private val credentialsManager: CredentialsManager,
+    private val driveFileProvider: DriveFileProvider,
 ) : ViewModel() {
 
     val route = savedStateHandle.toRoute<Route.GroupSettings>()
@@ -194,6 +202,40 @@ class GroupSettingsViewModel(
                     _uiState.update { it.copy(uiEvent = GroupSettingsUiEvent.OpenUrl(url)) }
                 }
             }
+
+            is GroupSettingsUiAction.HealGroupClicked -> {
+                val conversation = uiState.value.conversation ?: return
+                if (uiState.value.isHealing) return
+                _uiState.update { it.copy(isHealing = true) }
+                viewModelScope.launch {
+                    try {
+                        Logger.i("GroupSettings: heal requested for ${conversation.id}")
+                        logTransferSnapshot("BEFORE heal", conversation.id, uiState.value)
+                        val result = conversationService.healGroupDistribution(conversation.id)
+                        Logger.i("GroupSettings: heal result for ${conversation.id} mainHealed=${result.mainHealed} adminHealed=${result.adminHealed}")
+                        // Re-load transfer history so the user sees outbox/sending state immediately
+                        loadTransferHistory(conversation)
+                        logTransferSnapshot("AFTER heal", conversation.id, uiState.value)
+                        _uiState.update {
+                            it.copy(
+                                isHealing = false,
+                                uiEvent = GroupSettingsUiEvent.HealCompleted(
+                                    mainHealed = result.mainHealed,
+                                    adminHealed = result.adminHealed,
+                                )
+                            )
+                        }
+                    } catch (e: Exception) {
+                        Logger.e("GroupSettings: heal failed for ${conversation.id}", e)
+                        _uiState.update {
+                            it.copy(
+                                isHealing = false,
+                                uiEvent = Error("Failed to heal group: ${e.message ?: "unknown error"}")
+                            )
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -247,10 +289,113 @@ class GroupSettingsViewModel(
                         isLoading = false,
                     )
                 }
+
+                if (conversation.isGroupConversation && !conversation.isLegacyGroup) {
+                    loadTransferHistory(conversation)
+                }
             } catch (e: Exception) {
                 Logger.e("Failed to load conversation", e)
                 _uiState.update { it.copy(isLoading = false) }
             }
+        }
+    }
+
+    /**
+     * For each of the two group files (main conversation + admin), fetches the per-recipient
+     * transfer-history if (and only if) the current user is the original author of that file.
+     * Mirrors the loader in [id.homebase.chat.messageinfo.MessageInfoViewModel] — same call,
+     * same status mapping. Result is exposed in [GroupSettingsUiState.mainFileTransfer] /
+     * [GroupSettingsUiState.adminFileTransfer]; null map = column hidden in the UI.
+     */
+    private suspend fun loadTransferHistory(conversation: ConversationUiModel) {
+        val domain = credentialsManager.requireActiveDomain()
+
+        val mainFile = try {
+            conversationService.getConversationHomebaseFile(conversation.id)
+        } catch (e: Exception) {
+            Logger.w(throwable = e) { "loadTransferHistory: failed to load main file ${conversation.id}" }
+            null
+        }
+        val adminFile = try {
+            conversationService.getConversationAdminHomebaseFile(conversation.id)
+        } catch (e: Exception) {
+            Logger.w(throwable = e) { "loadTransferHistory: failed to load admin file ${conversation.id}" }
+            null
+        }
+
+        val mainTransfer = fetchTransferIfAuthor("main", domain, mainFile)
+        val adminTransfer = fetchTransferIfAuthor("admin", domain, adminFile)
+
+        Logger.d {
+            "loadTransferHistory: ${conversation.id} mainAuthored=${mainTransfer != null} mainEntries=${mainTransfer?.size} " +
+                    "adminAuthored=${adminTransfer != null} adminEntries=${adminTransfer?.size}"
+        }
+
+        _uiState.update {
+            it.copy(
+                mainFileTransfer = mainTransfer,
+                adminFileTransfer = adminTransfer,
+            )
+        }
+    }
+
+    /**
+     * Logs the per-recipient status of both group files in a single multi-line entry.
+     * Called before and after a heal so the diff is easy to read in homebase.log when
+     * diagnosing "I clicked heal but recipient X still doesn't have it".
+     */
+    private fun logTransferSnapshot(label: String, conversationId: Uuid, state: GroupSettingsUiState) {
+        fun renderMap(map: Map<OdinId, RecipientFileStatus>?): String {
+            if (map == null) return "<column hidden — caller is not author>"
+            if (map.isEmpty()) return "<no recipients in transfer history>"
+            return map.entries.joinToString(prefix = "{", postfix = "}") { (recipient, status) ->
+                val s = when (status) {
+                    RecipientFileStatus.Ok -> "OK"
+                    is RecipientFileStatus.Problem -> "PROBLEM(${status.rawStatus})"
+                }
+                "$recipient=$s"
+            }
+        }
+        Logger.i {
+            "GroupSettings: $label snapshot conversationId=$conversationId " +
+                    "main=${renderMap(state.mainFileTransfer)} admin=${renderMap(state.adminFileTransfer)}"
+        }
+    }
+
+    private suspend fun fetchTransferIfAuthor(
+        label: String,
+        currentUser: OdinId,
+        file: HomebaseFile?
+    ): Map<OdinId, RecipientFileStatus>? {
+        if (file == null) return null
+        val author = file.fileMetadata.originalAuthor ?: file.fileMetadata.senderOdinId
+        if (author != currentUser) {
+            Logger.d { "loadTransferHistory: skipping $label — caller=$currentUser is not author=$author" }
+            return null
+        }
+
+        return try {
+            val history = driveFileProvider.getTransferHistory(chatTargetDrive.alias, file.fileId)
+            val results = history?.history?.results ?: emptyList()
+            results.associate { entry: RecipientTransferHistoryEntry ->
+                val odinId = OdinId(entry.recipient)
+                val status = if (
+                    entry.latestTransferStatus == TransferStatus.Delivered &&
+                    !entry.isInOutbox &&
+                    !TransferStatus.isFailedStatus(entry.latestTransferStatus)
+                ) {
+                    RecipientFileStatus.Ok
+                } else {
+                    RecipientFileStatus.Problem(
+                        rawStatus = entry.latestTransferStatus,
+                        detailRes = entry.latestTransferStatus.toErrorDetailRes()
+                    )
+                }
+                odinId to status
+            }
+        } catch (e: Exception) {
+            Logger.w(throwable = e) { "loadTransferHistory: getTransferHistory($label) failed for fileId=${file.fileId}" }
+            null
         }
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
@@ -28,10 +28,12 @@ import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.OutboxSync
 import id.homebase.chat.data.ConversationState
 import id.homebase.chat.services.chat.ChatMessageSizer
-import id.homebase.chat.services.convo.ConversationStream
+import id.homebase.chat.services.convo.ConversationParticipantLookup
 import id.homebase.chat.services.outbox.OptimisticWriter
 import id.homebase.core.config.chatTargetDrive
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.JsonPrimitive
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
@@ -39,10 +41,10 @@ import kotlin.uuid.Uuid
 
 class ChatMessageSenderService(
     private val outboxSync: OutboxSync,
-    private val conversationStream: ConversationStream,
+    private val conversationStream: ConversationParticipantLookup,
     private val payloadBundleEncryptionService: PayloadBundleEncryptionService,
     private val scope: CoroutineScope,
-    private val chatMessageStream: ChatMessageStream,
+    private val chatMessageStream: MessageLookup,
     private val optimisticWriter: OptimisticWriter,
     private val fileOperationsProvider: FileOperationsProvider,
     private val driveFileProvider: DriveFileProvider,
@@ -53,6 +55,22 @@ class ChatMessageSenderService(
     }
 
     private val chatDrive = chatTargetDrive.alias
+
+    /**
+     * In-memory tracker of the last outbox-enqueued message uniqueId per conversation.
+     * Used to chain each new message behind the previous one when the caller doesn't
+     * supply a [previousMessageUniqueId], so offline pile-ups release in send order
+     * rather than fanning out in parallel the moment the conversation file drains.
+     *
+     * Lifetime: per service instance. After app restart, the map is empty — pending
+     * outbox rows already carry their persisted deps, so the chain among already-
+     * queued messages survives restart; only the link between pre-restart and
+     * post-restart messages resets, which is acceptable (post-restart messages
+     * fall back to chaining on the conversation file id, which the queued ones
+     * also depended on transitively).
+     */
+    private val lastEnqueuedPerConversation = mutableMapOf<Uuid, Uuid>()
+    private val lastEnqueuedMutex = Mutex()
 
     suspend fun sendNewMessage(
         messageUniqueId: Uuid,
@@ -214,16 +232,40 @@ class ChatMessageSenderService(
         )
         // Outbox enqueue is the success gate — once accepted, the message
         // will be delivered regardless of what happens after.
+        //
+        // Determine the outbox dependency:
+        //   1. If the caller supplied an explicit previousMessageUniqueId, use it.
+        //   2. Otherwise, chain on the last message we enqueued in THIS conversation
+        //      (in-memory tracker) so messages typed while offline release in send
+        //      order rather than fanning out in parallel the moment the conversation
+        //      file drains.
+        //   3. If this is the first message we enqueue in the conversation since the
+        //      service started, fall back to the conversation file's uniqueId. For a
+        //      brand-new conversation the conversation file is still in the outbox,
+        //      so the message waits — closes the orphan-recovery race on the
+        //      recipient side. For an active conversation the conversation file row
+        //      is gone, so the dep resolves immediately via the `NOT EXISTS` guard
+        //      in the outbox checkout SQL — no overhead.
+        val effectiveDep = previousMessageUniqueId
+            ?: lastEnqueuedMutex.withLock { lastEnqueuedPerConversation[conversationId] }
+            ?: conversationId
         val enqueued = outboxSync.tryEnqueue(
             request,
             priority = 1,
-            dependencyUniqueId = previousMessageUniqueId,
+            dependencyUniqueId = effectiveDep,
         )
 
         if (!enqueued) {
             error("Failed to send chat message")
         }
-        Logger.d(tag = TAG) { "sendMessageInternal: outbox enqueued message=$messageUniqueId" }
+        // Record this message as the new chain tail for the conversation. Done after
+        // a successful enqueue so a failure doesn't leave a dangling pointer that
+        // future messages would chain to a never-enqueued id (which `NOT EXISTS`
+        // would resolve immediately, undoing the chain).
+        lastEnqueuedMutex.withLock {
+            lastEnqueuedPerConversation[conversationId] = messageUniqueId
+        }
+        Logger.d(tag = TAG) { "sendMessageInternal: outbox enqueued message=$messageUniqueId dep=$effectiveDep" }
 
         // Best-effort optimistic write — makes the message appear in the chat
         // stream immediately. If it fails, the outbox delivery + sync will

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
@@ -42,7 +42,7 @@ import kotlin.uuid.Uuid
 class ChatMessageSenderService(
     private val outboxSync: OutboxSync,
     private val conversationStream: ConversationParticipantLookup,
-    private val payloadBundleEncryptionService: PayloadBundleEncryptionService,
+    private val payloadBundleEncryptionService: PayloadBundleEncryptor,
     private val scope: CoroutineScope,
     private val chatMessageStream: MessageLookup,
     private val optimisticWriter: OptimisticWriter,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -156,7 +156,7 @@ class ChatMessageStream(
         return mapToMessageData(messageFile, credentialsManager, ::resolveDisplayName)
     }
 
-    suspend fun getMessageFile(messageId: Uuid): HomebaseFile? {
+    override suspend fun getMessageFile(messageId: Uuid): HomebaseFile? {
         val c = credentialsManager.requireActiveCredentials()
         return dbm.driveMainIndex.selectHomebaseFileByUnique(
             c.getIdentityId(),
@@ -284,7 +284,7 @@ class ChatMessageStream(
         )
     }
 
-    suspend fun loadFullMessage(conversationId: Uuid, messageId: Uuid): String? {
+    override suspend fun loadFullMessage(conversationId: Uuid, messageId: Uuid): String? {
 
         val header = getMessage(messageId) ?: return null
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/MessageLookup.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/MessageLookup.kt
@@ -1,15 +1,23 @@
 package id.homebase.chat.services
 
+import id.homebase.api.client.drives.HomebaseFile
 import id.homebase.api.common.BatchResult
 import id.homebase.chat.data.MessageUiModel
 import kotlin.uuid.Uuid
 
 /**
  * Narrow read-side seam over ChatMessageStream. Keeps ChatMessageActionService
- * buildable in tests without the full message-stream collaborator graph
- * (ContactService, DriveFileProvider, EventBus subscribers, scope).
+ * and ChatMessageSenderService buildable in tests without the full
+ * message-stream collaborator graph (ContactService, DriveFileProvider,
+ * EventBus subscribers, scope).
  */
 interface MessageLookup {
     suspend fun getMessage(messageId: Uuid): MessageUiModel?
     suspend fun getMessages(messageIds: List<Uuid>): BatchResult<MessageUiModel>
+    /** Server-side header file for a message. Used by edit/reply paths to
+     *  resolve the underlying [HomebaseFile] when we need its versionTag. */
+    suspend fun getMessageFile(messageId: Uuid): HomebaseFile?
+    /** For messages whose content was offloaded to a payload (over the
+     *  in-header size budget), read the full text back. */
+    suspend fun loadFullMessage(conversationId: Uuid, messageId: Uuid): String?
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -1161,11 +1161,21 @@ class ConversationService(
             fileSystemType = FileSystemType.Standard,
         )
 
-        val enqueued = outboxSync.tryEnqueue(request)
+        // Chain the admin file behind the main conversation file so it is not released
+        // from the local outbox until the conversation file's upload to our own server
+        // has been acknowledged. Without this, the conversation file and the admin file
+        // race in parallel through Transit, and recipients can see the admin file land
+        // before the conversation file — which used to push them into the orphan-recovery
+        // path and create stale placeholders. (See Shelly's Apr 19 log on conversation
+        // 0e684619 for the original failure mode.) The dependency does NOT enforce
+        // ordering across the recipient's network — Transit distribution is still
+        // parallel — but it removes the local-outbox half of the race, which is the
+        // half we control.
+        val enqueued = outboxSync.tryEnqueue(request, dependencyUniqueId = conversationId)
         if (!enqueued) {
             Logger.w { "uploadAdminFile: outbox enqueue returned false for $conversationId — likely UNIQUE conflict on adminUniqueId=$adminUniqueId; the file was NOT scheduled for upload" }
         } else {
-            Logger.d { "uploadAdminFile: enqueued upload for adminUniqueId=$adminUniqueId" }
+            Logger.d { "uploadAdminFile: enqueued upload for adminUniqueId=$adminUniqueId dependencyUniqueId=$conversationId" }
         }
     }
 
@@ -1244,11 +1254,16 @@ class ConversationService(
             unecryptedMetadata = metadata
         )
 
-        val enqueued = outboxSync.tryEnqueue(request)
+        // Same chaining as uploadAdminFile — the admin file's update should not race
+        // ahead of the conversation file in the local outbox. Even when the admin file
+        // is updated standalone (admin add/remove), chaining behind the conversation
+        // file is benign: the conversation file's outbox row, if any, drains first,
+        // otherwise the dependency resolves immediately.
+        val enqueued = outboxSync.tryEnqueue(request, dependencyUniqueId = conversationId)
         if (!enqueued) {
             Logger.w { "updateAdminFile: outbox enqueue returned false for $conversationId — likely UNIQUE conflict on adminUniqueId=$adminUniqueId (something already pending); the update was NOT scheduled" }
         } else {
-            Logger.d { "updateAdminFile: enqueued update for adminUniqueId=$adminUniqueId versionTag=${existingFile.fileMetadata.versionTag}" }
+            Logger.d { "updateAdminFile: enqueued update for adminUniqueId=$adminUniqueId versionTag=${existingFile.fileMetadata.versionTag} dependencyUniqueId=$conversationId" }
         }
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -1013,7 +1013,7 @@ class ConversationService(
         )
     }
 
-    private suspend fun getConversationHomebaseFile(conversationId: Uuid): HomebaseFile? {
+    suspend fun getConversationHomebaseFile(conversationId: Uuid): HomebaseFile? {
         val c = credentialsManager.requireActiveCredentials()
         return dbm.driveMainIndex.selectHomebaseFileByUnique(c.getIdentityId(), chatDrive, conversationId)
     }
@@ -1022,6 +1022,92 @@ class ConversationService(
         val c = credentialsManager.requireActiveCredentials()
         val adminUniqueId = ChatProtocol.getAdminFileUniqueId(conversationId)
         return dbm.driveMainIndex.selectHomebaseFileByUnique(c.getIdentityId(), chatDrive, adminUniqueId)
+    }
+
+    /**
+     * Manually re-distribute the group files (main conversation file + admin file) to all
+     * current participants, for any of those files the caller authored. This is a recovery
+     * aid for groups where one or more recipients did not receive (or lost) the original
+     * group file. Per-file authorship is checked individually — the caller may have
+     * authored only one of the two and the other will be left untouched.
+     *
+     * Each step is debug-logged so a failure can be diagnosed in homebase.log.
+     */
+    suspend fun healGroupDistribution(conversationId: Uuid): HealGroupResult {
+        val conversation = requireConversation(conversationId)
+        if (!conversation.isGroupConversation) {
+            throw IllegalStateException("healGroupDistribution: not a group conversation $conversationId")
+        }
+
+        val domain = credentialsManager.requireActiveDomain()
+        val recipients = conversation.participants.filterNot { it == domain }.distinct()
+
+        Logger.i { "healGroupDistribution: START conversationId=$conversationId domain=$domain participants=${conversation.participants} recipients=$recipients admins=${conversation.admins}" }
+
+        var mainHealed = false
+        var adminHealed = false
+
+        // Main conversation file
+        val mainFile = getConversationHomebaseFile(conversationId)
+        if (mainFile == null) {
+            Logger.w { "healGroupDistribution: no local main conversation file for $conversationId — skipping main" }
+        } else {
+            val mainAuthor = mainFile.fileMetadata.originalAuthor ?: mainFile.fileMetadata.senderOdinId
+            val mainPending = mainFile.fileMetadata.localAppData?.tags?.contains(ChatProtocol.isPendingSendTag) == true
+            Logger.d { "healGroupDistribution: main file fileId=${mainFile.fileId} sender=${mainFile.fileMetadata.senderOdinId} originalAuthor=${mainFile.fileMetadata.originalAuthor} resolvedAuthor=$mainAuthor versionTag=${mainFile.fileMetadata.versionTag} isPending=$mainPending localTags=${mainFile.fileMetadata.localAppData?.tags}" }
+            if (mainAuthor == domain) {
+                try {
+                    Logger.i { "healGroupDistribution: redistributing main conversation file $conversationId to recipients=$recipients" }
+                    updateConversationInternal(
+                        conversationId = conversationId,
+                        title = conversation.name,
+                        participants = conversation.participants,
+                        distribute = true
+                    )
+                    mainHealed = true
+                    Logger.i { "healGroupDistribution: main conversation file enqueued for redistribute $conversationId" }
+                } catch (t: Throwable) {
+                    Logger.e("healGroupDistribution: main conversation file redistribute FAILED for $conversationId", t)
+                    throw t
+                }
+            } else {
+                Logger.d { "healGroupDistribution: skipping main — caller is not the original author (author=$mainAuthor, caller=$domain)" }
+            }
+        }
+
+        // Admin file
+        val adminFile = getConversationAdminHomebaseFile(conversationId)
+        if (adminFile == null) {
+            Logger.w { "healGroupDistribution: no local admin file for $conversationId — skipping admin" }
+        } else {
+            val adminAuthor = adminFile.fileMetadata.originalAuthor ?: adminFile.fileMetadata.senderOdinId
+            val adminPending = adminFile.fileMetadata.localAppData?.tags?.contains(ChatProtocol.isPendingSendTag) == true
+            Logger.d { "healGroupDistribution: admin file fileId=${adminFile.fileId} sender=${adminFile.fileMetadata.senderOdinId} originalAuthor=${adminFile.fileMetadata.originalAuthor} resolvedAuthor=$adminAuthor versionTag=${adminFile.fileMetadata.versionTag} isPending=$adminPending localTags=${adminFile.fileMetadata.localAppData?.tags}" }
+            if (adminAuthor == domain) {
+                try {
+                    Logger.i { "healGroupDistribution: redistributing admin file $conversationId admins=${conversation.admins} recipients=$recipients" }
+                    updateAdminFile(
+                        conversationId = conversationId,
+                        admins = conversation.admins.toList(),
+                        recipients = recipients
+                    )
+                    adminHealed = true
+                    Logger.i { "healGroupDistribution: admin file enqueued for redistribute $conversationId" }
+                } catch (t: Throwable) {
+                    Logger.e("healGroupDistribution: admin file redistribute FAILED for $conversationId", t)
+                    throw t
+                }
+            } else {
+                Logger.d { "healGroupDistribution: skipping admin — caller is not the original author (author=$adminAuthor, caller=$domain)" }
+            }
+        }
+
+        Logger.i { "healGroupDistribution: DONE conversationId=$conversationId mainHealed=$mainHealed adminHealed=$adminHealed" }
+        return HealGroupResult(mainHealed = mainHealed, adminHealed = adminHealed)
+    }
+
+    data class HealGroupResult(val mainHealed: Boolean, val adminHealed: Boolean) {
+        val didAnything: Boolean get() = mainHealed || adminHealed
     }
 
     /** Reads the admin list from the dedicated admin file, falling back to originalAuthor. */
@@ -1075,7 +1161,12 @@ class ConversationService(
             fileSystemType = FileSystemType.Standard,
         )
 
-        outboxSync.tryEnqueue(request)
+        val enqueued = outboxSync.tryEnqueue(request)
+        if (!enqueued) {
+            Logger.w { "uploadAdminFile: outbox enqueue returned false for $conversationId — likely UNIQUE conflict on adminUniqueId=$adminUniqueId; the file was NOT scheduled for upload" }
+        } else {
+            Logger.d { "uploadAdminFile: enqueued upload for adminUniqueId=$adminUniqueId" }
+        }
     }
 
     /** Updates an existing admin file (or creates one if it doesn't exist yet). */
@@ -1153,7 +1244,12 @@ class ConversationService(
             unecryptedMetadata = metadata
         )
 
-        outboxSync.tryEnqueue(request)
+        val enqueued = outboxSync.tryEnqueue(request)
+        if (!enqueued) {
+            Logger.w { "updateAdminFile: outbox enqueue returned false for $conversationId — likely UNIQUE conflict on adminUniqueId=$adminUniqueId (something already pending); the update was NOT scheduled" }
+        } else {
+            Logger.d { "updateAdminFile: enqueued update for adminUniqueId=$adminUniqueId versionTag=${existingFile.fileMetadata.versionTag}" }
+        }
     }
 
     override suspend fun updateLocalLastReadTime(conversationId: Uuid, newLastReadTime: UnixTimeUtc) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -156,10 +156,17 @@ class ConversationService(
         if (isGroup) {
             trySendIntroductions(normalizedRecipients, "$domain has added you to a group chat")
 
+            // Serialize: conversation file → admin file → status message. Chaining the
+            // status message off the admin file (rather than off the conversation file
+            // directly) avoids a fan-out parallel where both the admin file and the
+            // status message would release the moment the conversation file is
+            // acknowledged at our own server, then race through Transit in any order.
+            // With this chain, recipients see the conversation file, then the admin
+            // file, then the "group started" status message — strict order on our side.
             chatMessageSenderService.sendStatusMessage(
                 messageUniqueId = Uuid.random(),
                 conversationId = newConversationId,
-                previousMessageUniqueId = newConversationId,
+                previousMessageUniqueId = ChatProtocol.getAdminFileUniqueId(newConversationId),
                 statusMessage = StatusMessageData(
                     statusMessage = StatusMessage.GroupConversationStarted,
                     subject = null
@@ -349,7 +356,11 @@ class ConversationService(
             recipients = recipients.filterNot { it == domain }
         )
 
-        var previousMessageId: Uuid? = null
+        // Serialize the status messages behind the admin-file update so the admin file
+        // lands on each recipient first, then the "X is now admin" / "X is no longer
+        // admin" status messages in their original order. Without this initial dep,
+        // the first status message would race the admin-file update through Transit.
+        var previousMessageId: Uuid? = ChatProtocol.getAdminFileUniqueId(conversationId)
         add.forEach { user ->
             val messageId = Uuid.random()
             chatMessageSenderService.sendStatusMessage(
@@ -429,11 +440,16 @@ class ConversationService(
 
         val normalized = (current + domain).distinct()
 
+        // Chain the conversation-file update behind the last "X was removed" status
+        // message so peers see the removed-status before the participant change lands.
+        // If there were no removals, previousMessageId is null and the update has no
+        // upstream dep — same as before.
         updateConversationInternal(
             conversationId = conversationId,
             title = conversation.name,
             participants = normalized,
-            additionalDistributionRecipients = removed.toList()
+            additionalDistributionRecipients = removed.toList(),
+            dependencyUniqueId = previousMessageId,
         )
 
         // tell the group who was added after we update the conversation so

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationServiceCollaborators.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationServiceCollaborators.kt
@@ -20,3 +20,19 @@ interface StatusMessageSender {
 interface ConversationLoader {
     suspend fun loadConversation(conversationId: Uuid)
 }
+
+/**
+ * Narrow read-only view of conversation participant state, exposed so that
+ * services that need to look up "who is in this conversation" don't have to
+ * depend on the full [ConversationStream] (which carries a heavy graph of
+ * dependencies and can't be subclassed in tests).
+ *
+ * Implemented by [ConversationStream]; faked in test fixtures.
+ */
+interface ConversationParticipantLookup {
+    fun getConversationById(conversationId: Uuid): id.homebase.chat.data.ConversationUiModel?
+    suspend fun getRecipients(
+        conversationId: Uuid,
+        additionalRecipients: List<OdinId> = emptyList()
+    ): List<OdinId>
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -48,7 +48,7 @@ class ConversationStream(
     private val cacheStorage: ShareCacheStorage,
     private val optimisticWriter: OptimisticWriter,
     private val outboxSync: OutboxSync,
-) : ConversationLoader, UnreadCountEnricher {
+) : ConversationLoader, UnreadCountEnricher, ConversationParticipantLookup {
 
     private val chatDrive = chatTargetDrive.alias
     private val _conversations = MutableStateFlow(ConversationsData(dataReady = false))
@@ -819,7 +819,7 @@ class ConversationStream(
         }
     }
 
-    fun getConversationById(conversationId: Uuid): ConversationUiModel? {
+    override fun getConversationById(conversationId: Uuid): ConversationUiModel? {
         return _conversations.value.items.firstOrNull { it.id == conversationId }
     }
 
@@ -833,9 +833,9 @@ class ConversationStream(
         )
     }
 
-    suspend fun getRecipients(
+    override suspend fun getRecipients(
         conversationId: Uuid,
-        additionalRecipients: List<OdinId> = emptyList()
+        additionalRecipients: List<OdinId>
     ): List<OdinId> {
 
         val domain = credentialsManager.requireActiveDomain()

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
@@ -537,6 +537,12 @@ class FakeMessageLookup : MessageLookup {
             cursor = QueryBatchCursor(),
         )
     }
+
+    override suspend fun getMessageFile(messageId: Uuid): id.homebase.api.client.drives.HomebaseFile? =
+        error("FakeMessageLookup.getMessageFile not exercised by tests using this fixture")
+
+    override suspend fun loadFullMessage(conversationId: Uuid, messageId: Uuid): String? =
+        error("FakeMessageLookup.loadFullMessage not exercised by tests using this fixture")
 }
 
 class FakeLocalLastReadUpdater : LocalLastReadUpdater {

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceOutboxOrderingTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceOutboxOrderingTest.kt
@@ -1,0 +1,148 @@
+package id.homebase.chat.services
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Static-shape tests for [ChatMessageSenderService.sendMessageInternal]'s
+ * outbox dependency wiring. The service maintains an in-memory map of the
+ * last-enqueued message per conversation so that pile-ups (offline use) drain
+ * in send order rather than fanning out in parallel as soon as the
+ * conversation file is acknowledged.
+ *
+ * The chain semantics asserted here:
+ *   - Caller-supplied `previousMessageUniqueId` is honored verbatim.
+ *   - When the caller passes null AND the service has previously enqueued a
+ *     message in this conversation, the new message chains on that prior id.
+ *   - When the caller passes null AND there is no prior message in this
+ *     conversation, the new message chains on the conversation file's
+ *     uniqueId — which closes the orphan-recovery race on the recipient side
+ *     for brand-new conversations.
+ *   - Tracking is per-conversation: a new conversation starts a fresh chain.
+ */
+class ChatMessageSenderServiceOutboxOrderingTest {
+
+    @Test
+    fun firstMessageInBrandNewConversation_chainsOnConversationId() = runTest {
+        ChatMessageSenderServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val conversationId = fixture.seedConversation(others = listOf("alice.test"))
+            // Simulate "createConversation just enqueued the conversation file
+            // and it's still pending" by inserting a row at uniqueId=conversationId.
+            fixture.enqueuePendingConversationFileRow(conversationId)
+
+            val messageId = Uuid.random()
+            service.sendNewMessage(
+                messageUniqueId = messageId,
+                conversationId = conversationId,
+                messageText = "hi",
+                previousMessageUniqueId = null,
+                payloadBundle = null,
+            )
+
+            val rows = fixture.drainOutboxInDependencyOrder()
+            val messageRow = rows.single { it.uniqueId == messageId }
+            assertEquals(
+                conversationId,
+                messageRow.dependencyUniqueId,
+                "first message in a brand-new conversation must chain on the conversation file"
+            )
+        }
+    }
+
+    @Test
+    fun secondAndThirdMessages_chainOnPreviousMessage_evenAcrossOfflinePileUp() = runTest {
+        ChatMessageSenderServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val conversationId = fixture.seedConversation(others = listOf("alice.test"))
+            fixture.enqueuePendingConversationFileRow(conversationId)
+
+            // User offline. Three messages typed in a row.
+            val m1 = Uuid.random()
+            val m2 = Uuid.random()
+            val m3 = Uuid.random()
+            service.sendNewMessage(m1, conversationId, "one", previousMessageUniqueId = null, payloadBundle = null)
+            service.sendNewMessage(m2, conversationId, "two", previousMessageUniqueId = null, payloadBundle = null)
+            service.sendNewMessage(m3, conversationId, "three", previousMessageUniqueId = null, payloadBundle = null)
+
+            val rows = fixture.drainOutboxInDependencyOrder()
+            val r1 = rows.single { it.uniqueId == m1 }
+            val r2 = rows.single { it.uniqueId == m2 }
+            val r3 = rows.single { it.uniqueId == m3 }
+
+            assertEquals(
+                conversationId, r1.dependencyUniqueId,
+                "M1 chains on the conversation file (no prior message in this conversation yet)"
+            )
+            assertEquals(
+                m1, r2.dependencyUniqueId,
+                "M2 chains on M1 — preserves send order through the local outbox during offline pile-up"
+            )
+            assertEquals(
+                m2, r3.dependencyUniqueId,
+                "M3 chains on M2 — same"
+            )
+        }
+    }
+
+    @Test
+    fun explicitPreviousMessageUniqueId_overridesTheFallback() = runTest {
+        ChatMessageSenderServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val conversationId = fixture.seedConversation(others = listOf("alice.test"))
+
+            val explicitPrev = Uuid.random()
+            val messageId = Uuid.random()
+            service.sendNewMessage(
+                messageUniqueId = messageId,
+                conversationId = conversationId,
+                messageText = "hi",
+                previousMessageUniqueId = explicitPrev,
+                payloadBundle = null,
+            )
+
+            val rows = fixture.drainOutboxInDependencyOrder()
+            val messageRow = rows.single { it.uniqueId == messageId }
+            assertEquals(
+                explicitPrev,
+                messageRow.dependencyUniqueId,
+                "explicit caller-supplied previousMessageUniqueId must win over the fallback"
+            )
+        }
+    }
+
+    @Test
+    fun chainsAreTrackedPerConversation_notCrossContaminated() = runTest {
+        ChatMessageSenderServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val conversationA = fixture.seedConversation(others = listOf("alice.test"))
+            val conversationB = fixture.seedConversation(others = listOf("bob.test"))
+
+            // First message in A.
+            val a1 = Uuid.random()
+            service.sendNewMessage(a1, conversationA, "hi A", previousMessageUniqueId = null, payloadBundle = null)
+            // First message in B — must NOT chain on a1 (different conversation).
+            val b1 = Uuid.random()
+            service.sendNewMessage(b1, conversationB, "hi B", previousMessageUniqueId = null, payloadBundle = null)
+            // Second message in A — chains on a1.
+            val a2 = Uuid.random()
+            service.sendNewMessage(a2, conversationA, "hi A2", previousMessageUniqueId = null, payloadBundle = null)
+            // Second message in B — chains on b1.
+            val b2 = Uuid.random()
+            service.sendNewMessage(b2, conversationB, "hi B2", previousMessageUniqueId = null, payloadBundle = null)
+
+            val rows = fixture.drainOutboxInDependencyOrder()
+            val rA1 = rows.single { it.uniqueId == a1 }
+            val rB1 = rows.single { it.uniqueId == b1 }
+            val rA2 = rows.single { it.uniqueId == a2 }
+            val rB2 = rows.single { it.uniqueId == b2 }
+
+            assertEquals(conversationA, rA1.dependencyUniqueId, "A1 chains on conversation A")
+            assertEquals(conversationB, rB1.dependencyUniqueId, "B1 chains on conversation B")
+            assertEquals(a1, rA2.dependencyUniqueId, "A2 chains on A1 (same conversation), not on B1")
+            assertEquals(b1, rB2.dependencyUniqueId, "B2 chains on B1 (same conversation), not on A2")
+        }
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceTestFixture.kt
@@ -52,7 +52,7 @@ import kotlin.uuid.Uuid
  *     a non-null instance.
  *   - Real [DriveFileProvider] backed by a [MockEngine] that returns 500 for
  *     every request. Construction requires it; the send path doesn't call it.
- *   - [NoopFileOperationsProvider] — only invoked for over-budget messages,
+ *   - [SenderNoopFileOperationsProvider] — only invoked for over-budget messages,
  *     and the tests stay under the budget so it's never reached.
  *
  * Use via `ChatMessageSenderServiceTestFixture().use { fixture -> ... }` so
@@ -84,7 +84,7 @@ class ChatMessageSenderServiceTestFixture : AutoCloseable {
 
         outboxSync = OutboxSync(
             databaseManager = dbm,
-            uploader = ThrowingOutboxUploader,
+            uploader = SenderThrowingOutboxUploader,
             eventBus = eventBus,
             scope = scope,
         ).also { it.setOnline(false) }
@@ -106,7 +106,7 @@ class ChatMessageSenderServiceTestFixture : AutoCloseable {
         val driveCache = DriveFileProviderCached(
             httpClient,
             credentialsManager,
-            NoopFileOperationsProvider(),
+            SenderNoopFileOperationsProvider(),
         )
         val driveFileProvider = DriveFileProvider(httpClient, credentialsManager, driveCache)
 
@@ -117,7 +117,7 @@ class ChatMessageSenderServiceTestFixture : AutoCloseable {
             scope = scope,
             chatMessageStream = FakeMessageLookup(),
             optimisticWriter = optimisticWriter,
-            fileOperationsProvider = NoopFileOperationsProvider(),
+            fileOperationsProvider = SenderNoopFileOperationsProvider(),
             driveFileProvider = driveFileProvider,
             shareSuggestionDonor = ShareSuggestionDonor(),
         )
@@ -253,9 +253,9 @@ class SeedableConversationLookup(private val testDomain: String) : ConversationP
     }
 }
 
-private class NoopFileOperationsProvider : FileOperationsProvider {
+private class SenderNoopFileOperationsProvider : FileOperationsProvider {
     private fun nope(): Nothing =
-        error("NoopFileOperationsProvider: no file IO expected in chain-shape tests")
+        error("SenderNoopFileOperationsProvider: no file IO expected in chain-shape tests")
 
     override fun openFileInput(path: String) = nope()
     override suspend fun readFileBytes(path: String) = nope()
@@ -266,7 +266,7 @@ private class NoopFileOperationsProvider : FileOperationsProvider {
     override suspend fun writeStream(path: String, data: Flow<ByteArray>) = nope()
 }
 
-private object ThrowingOutboxUploader : OutboxUploader {
+private object SenderThrowingOutboxUploader : OutboxUploader {
     override suspend fun upload(outboxRecord: Outbox, eventBus: EventBus) {
         error("OutboxUploader.upload should never be called in tests (setOnline(false))")
     }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceTestFixture.kt
@@ -1,0 +1,273 @@
+package id.homebase.chat.services
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import id.homebase.api.client.auth.ApiCredentials
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.cache.DriveFileProviderCached
+import id.homebase.api.client.drives.files.DriveFileProvider
+import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.SecureByteArray
+import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.sync.database.OdinDatabase
+import id.homebase.api.sync.database.Outbox
+import id.homebase.api.sync.database.OutboxSync
+import id.homebase.api.sync.database.OutboxUploader
+import id.homebase.chat.data.ConversationState
+import id.homebase.chat.data.ConversationUiModel
+import id.homebase.chat.services.convo.ConversationParticipantLookup
+import id.homebase.chat.services.convo.FakePayloadBundleEncryptor
+import id.homebase.chat.services.outbox.OptimisticWriter
+import id.homebase.core.avatars.ConversationAvatarModel
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respondError
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.test.TestScope
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * Fixture for [ChatMessageSenderService] focused on the static-shape contract
+ * of `sendMessageInternal`'s outbox enqueue: the resulting `(uniqueId,
+ * dependencyUniqueId)` row, given the caller's `previousMessageUniqueId` and
+ * the in-memory per-conversation chain tracker the service maintains.
+ *
+ * Wiring choices:
+ *   - Real in-memory SQLite DB + real [OutboxSync] with `setOnline(false)`,
+ *     same pattern as [id.homebase.chat.services.convo.ConversationServiceTestFixture].
+ *     Outbox rows are inspectable via [drainOutbox] / [drainOutboxInDependencyOrder].
+ *   - Real [OptimisticWriter] (writes to the in-memory DB).
+ *   - Fake [ConversationParticipantLookup] ([SeedableConversationLookup]) so
+ *     tests can pre-register a conversation and its recipients without paying
+ *     the cost of constructing a real [id.homebase.chat.services.convo.ConversationStream].
+ *   - Fake [PayloadBundleEncryptor] returning empty bundles — the tests use
+ *     plain text messages that fit in the file header (`buildMessageContentAndBundle`
+ *     short-circuits before any payload work).
+ *   - [FakeMessageLookup] for `chatMessageStream` — the new chain-related code path
+ *     in `sendMessageInternal` does not call it, but the constructor requires
+ *     a non-null instance.
+ *   - Real [DriveFileProvider] backed by a [MockEngine] that returns 500 for
+ *     every request. Construction requires it; the send path doesn't call it.
+ *   - [NoopFileOperationsProvider] — only invoked for over-budget messages,
+ *     and the tests stay under the budget so it's never reached.
+ *
+ * Use via `ChatMessageSenderServiceTestFixture().use { fixture -> ... }` so
+ * the in-memory DB is closed at the end of each test.
+ */
+class ChatMessageSenderServiceTestFixture : AutoCloseable {
+
+    val testIdentityId: Uuid = Uuid.parse("7b1be23b-48bb-4304-bc7b-db5910c09a92")
+    val chatDriveId: Uuid = Uuid.parse("9ff813af-f2d6-1e2f-9b9d-b189e72d1a11")
+    val testDomain: String = "owner.test"
+
+    lateinit var dbm: DatabaseManager
+        private set
+    lateinit var credentialsManager: CredentialsManager
+        private set
+    lateinit var eventBus: EventBus
+        private set
+    lateinit var outboxSync: OutboxSync
+        private set
+    lateinit var conversationLookup: SeedableConversationLookup
+        private set
+    lateinit var payloadEncryptor: FakePayloadBundleEncryptor
+        private set
+
+    suspend fun build(scope: CoroutineScope = TestScope()): ChatMessageSenderService {
+        dbm = createInMemoryDbm()
+        credentialsManager = createCredentialsManager(testDomain)
+        eventBus = EventBus()
+
+        outboxSync = OutboxSync(
+            databaseManager = dbm,
+            uploader = ThrowingOutboxUploader,
+            eventBus = eventBus,
+            scope = scope,
+        ).also { it.setOnline(false) }
+
+        conversationLookup = SeedableConversationLookup(testDomain)
+        payloadEncryptor = FakePayloadBundleEncryptor()
+
+        val optimisticWriter = OptimisticWriter(
+            credentialsManager = credentialsManager,
+            dbm = dbm,
+            eventBus = eventBus,
+        )
+
+        // Real DriveFileProvider with an HTTP client that 500s every request.
+        // The send path doesn't call into it; this is just to satisfy the ctor.
+        val httpClient = HttpClient(MockEngine { _ ->
+            respondError(HttpStatusCode.InternalServerError)
+        })
+        val driveCache = DriveFileProviderCached(
+            httpClient,
+            credentialsManager,
+            NoopFileOperationsProvider(),
+        )
+        val driveFileProvider = DriveFileProvider(httpClient, credentialsManager, driveCache)
+
+        return ChatMessageSenderService(
+            outboxSync = outboxSync,
+            conversationStream = conversationLookup,
+            payloadBundleEncryptionService = payloadEncryptor,
+            scope = scope,
+            chatMessageStream = FakeMessageLookup(),
+            optimisticWriter = optimisticWriter,
+            fileOperationsProvider = NoopFileOperationsProvider(),
+            driveFileProvider = driveFileProvider,
+            shareSuggestionDonor = ShareSuggestionDonor(),
+        )
+    }
+
+    /**
+     * Register a conversation so [ChatMessageSenderService] sees a non-null
+     * [ConversationUiModel] when it queries `conversationStream.getConversationById`.
+     * Recipients are everything except [testDomain].
+     */
+    fun seedConversation(
+        conversationId: Uuid = Uuid.random(),
+        others: List<String>,
+        isGroup: Boolean = others.size > 1,
+    ): Uuid {
+        val participants = listOf(testDomain) + others
+        conversationLookup.register(
+            ConversationUiModel(
+                id = conversationId,
+                name = "test",
+                lastMessage = "",
+                latestMessageTimestamp = Instant.fromEpochMilliseconds(0),
+                admins = setOf(OdinId(testDomain)),
+                unreadCount = 0,
+                avatarTiny = null,
+                avatarInitials = "",
+                avatarUrl = "",
+                participants = participants.map { OdinId(it) },
+                lastRead = Instant.fromEpochMilliseconds(0),
+                avatarModel = ConversationAvatarModel(type = ConversationAvatarModel.Type.GroupFallback),
+                isGroup = isGroup,
+                conversationState = ConversationState.Active,
+            )
+        )
+        return conversationId
+    }
+
+    /**
+     * Insert a synthetic outbox row with `uniqueId = conversationId` and no
+     * dependency, simulating the conversation-file row that
+     * `ConversationService.createConversation` would have enqueued. Tests use
+     * this to verify "the message waits for the conversation row" without
+     * standing up the full [ConversationService] graph.
+     *
+     * The row is inserted via the real [outboxSync.tryEnqueue] using a minimal
+     * [DeleteFilesByGroupIdOutboxRequest] — type doesn't matter for the chain
+     * test (the checkout SQL only cares about the uniqueId / dependencyUniqueId
+     * pair), and this request doesn't require encryption or attached payloads.
+     */
+    suspend fun enqueuePendingConversationFileRow(conversationId: Uuid) {
+        outboxSync.tryEnqueue(
+            id.homebase.api.client.drives.files.DeleteFilesByGroupIdOutboxRequest(
+                driveId = chatDriveId,
+                groupIds = listOf(conversationId),
+            ),
+        )
+    }
+
+    fun outboxRowCount(): Long = dbm.outbox.count()
+
+    /**
+     * Drain checked-out rows. Same caveat as the helper in
+     * `ConversationServiceTestFixture`: rows whose `dependencyUniqueId` still
+     * exists in the table won't surface — use [drainOutboxInDependencyOrder]
+     * for chained enqueues.
+     */
+    suspend fun drainOutbox(): List<Outbox> {
+        val drained = mutableListOf<Outbox>()
+        while (true) {
+            val row = dbm.outbox.checkout() ?: break
+            drained += row
+        }
+        return drained
+    }
+
+    /**
+     * Drain ALL rows by checkout-and-delete in a loop, surfacing rows in
+     * dependency order (head first). Use to assert chain shape.
+     */
+    suspend fun drainOutboxInDependencyOrder(): List<Outbox> {
+        val drained = mutableListOf<Outbox>()
+        while (true) {
+            val row = dbm.outbox.checkout() ?: break
+            drained += row
+            dbm.outbox.deleteByRowId(row.rowId)
+        }
+        return drained
+    }
+
+    override fun close() {
+        if (::dbm.isInitialized) dbm.close()
+    }
+
+    private fun createInMemoryDbm(): DatabaseManager = DatabaseManager({
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        OdinDatabase.Schema.create(driver)
+        driver
+    })
+
+    private suspend fun createCredentialsManager(domain: String): CredentialsManager {
+        val cm = CredentialsManager()
+        cm.setActiveCredentials(
+            ApiCredentials.create(
+                domain = OdinId(domain),
+                clientAccessToken = "test-token",
+                sharedSecret = SecureByteArray(ByteArray(16)),
+            )
+        )
+        return cm
+    }
+}
+
+// ---------- Test doubles (local to this fixture) ----------
+
+class SeedableConversationLookup(private val testDomain: String) : ConversationParticipantLookup {
+    private val conversations = mutableMapOf<Uuid, ConversationUiModel>()
+
+    fun register(conversation: ConversationUiModel) {
+        conversations[conversation.id] = conversation
+    }
+
+    override fun getConversationById(conversationId: Uuid): ConversationUiModel? =
+        conversations[conversationId]
+
+    override suspend fun getRecipients(
+        conversationId: Uuid,
+        additionalRecipients: List<OdinId>,
+    ): List<OdinId> {
+        val conversation = conversations[conversationId] ?: return emptyList()
+        return (conversation.participants + additionalRecipients)
+            .filter { it.domainName != testDomain }
+            .distinct()
+    }
+}
+
+private class NoopFileOperationsProvider : FileOperationsProvider {
+    private fun nope(): Nothing =
+        error("NoopFileOperationsProvider: no file IO expected in chain-shape tests")
+
+    override fun openFileInput(path: String) = nope()
+    override suspend fun readFileBytes(path: String) = nope()
+    override fun deleteTempFile(path: String) = nope()
+    override fun getCacheDirectory(): String = System.getProperty("java.io.tmpdir") ?: "/tmp"
+    override fun getFileSize(path: String) = nope()
+    override suspend fun writeBytesToTempFile(bytes: ByteArray, prefix: String, suffix: String) = nope()
+    override suspend fun writeStream(path: String, data: Flow<ByteArray>) = nope()
+}
+
+private object ThrowingOutboxUploader : OutboxUploader {
+    override suspend fun upload(outboxRecord: Outbox, eventBus: EventBus) {
+        error("OutboxUploader.upload should never be called in tests (setOnline(false))")
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceOutboxOrderingTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceOutboxOrderingTest.kt
@@ -1,0 +1,265 @@
+package id.homebase.chat.services.convo
+
+import id.homebase.api.common.OdinId
+import id.homebase.chat.services.ChatProtocol
+import id.homebase.chat.services.StatusMessage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Static-shape tests for the outbox dependency chain that [ConversationService]
+ * produces. Each test asserts the `(uniqueId, dependencyUniqueId)` tuples of the
+ * outbox rows that result from a single service call, plus the
+ * `previousMessageUniqueId` values passed to [FakeStatusMessageSender] for any
+ * status messages emitted along the way.
+ *
+ * Why these tests exist: recent refactors serialized three flows
+ * ([ConversationService.createConversation], [ConversationService.updateAdmins],
+ * [ConversationService.updateGroupMembers]) so each step in a group mutation
+ * waits for the previous one in the local outbox. Without coverage, a future
+ * edit could quietly turn the chain back into a fan-out (e.g. by removing a
+ * `dependencyUniqueId = …` argument or dropping a `previousMessageUniqueId`
+ * thread-through), and recipients could see the admin file or a status message
+ * land before the conversation file — the failure mode that produced the
+ * orphan-recovery placeholder bug.
+ *
+ * Out of scope: whether [id.homebase.api.sync.database.OutboxSync] actually
+ * releases items in dependency order at runtime (that's its own contract,
+ * tested in homebase-api), and whether the server-side Transit protocol
+ * preserves the chain across identities (integration concern).
+ */
+class ConversationServiceOutboxOrderingTest {
+
+    @Test
+    fun createConversation_group_chainsConversationThenAdminThenStatus() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            val bob = "bob.test"
+
+            val result = service.createConversation(
+                recipients = listOf(OdinId(alice), OdinId(bob)),
+                title = "the fellowship",
+                payloadBundle = null,
+            )
+
+            val conversationId = result.conversationId
+            val adminUniqueId = ChatProtocol.getAdminFileUniqueId(conversationId)
+
+            val rows = fixture.drainOutboxInDependencyOrder()
+            val convoRow = rows.single { it.uniqueId == conversationId }
+            val adminRow = rows.single { it.uniqueId == adminUniqueId }
+
+            assertNull(
+                convoRow.dependencyUniqueId,
+                "conversation file is the chain head — must not depend on anything"
+            )
+            assertEquals(
+                conversationId,
+                adminRow.dependencyUniqueId,
+                "admin file outbox row must depend on the conversation file"
+            )
+
+            val started = fixture.statusMessageSender.calls.single {
+                it.statusMessage.statusMessage == StatusMessage.GroupConversationStarted
+            }
+            assertEquals(
+                adminUniqueId,
+                started.previousMessageUniqueId,
+                "GroupConversationStarted must chain off the admin file, not the conversation file"
+            )
+        }
+    }
+
+    @Test
+    fun createConversation_oneToOne_doesNotEnqueueAdminFile_andNoStatusMessage() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+
+            val result = service.createConversation(
+                recipients = listOf(OdinId(alice)),
+                title = null,
+                payloadBundle = null,
+            )
+
+            val adminUniqueId = ChatProtocol.getAdminFileUniqueId(result.conversationId)
+            val rows = fixture.drainOutboxInDependencyOrder()
+
+            assertTrue(
+                rows.none { it.uniqueId == adminUniqueId },
+                "1:1 must not enqueue an admin file"
+            )
+            assertTrue(
+                fixture.statusMessageSender.calls.isEmpty(),
+                "1:1 must not emit a GroupConversationStarted status message"
+            )
+        }
+    }
+
+    @Test
+    fun updateAdmins_chainsStatusMessagesAfterAdminFile() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            val bob = "bob.test"
+            // testDomain + alice are admins so removing alice still leaves one admin (testDomain)
+            // and adding bob is valid (bob is a participant).
+            val groupId = fixture.seedGroup(
+                others = listOf(alice, bob),
+                adminDomains = listOf(fixture.testDomain, alice),
+            )
+            val adminUniqueId = ChatProtocol.getAdminFileUniqueId(groupId)
+
+            service.updateAdmins(
+                conversationId = groupId,
+                add = listOf(OdinId(bob)),
+                remove = listOf(OdinId(alice)),
+            )
+
+            val rows = fixture.drainOutboxInDependencyOrder()
+            val adminRow = rows.single { it.uniqueId == adminUniqueId }
+            assertEquals(
+                groupId,
+                adminRow.dependencyUniqueId,
+                "admin file update must chain off the conversation file"
+            )
+
+            val calls = fixture.statusMessageSender.calls
+            assertEquals(2, calls.size, "expect one ConversationAdminAdded + one ConversationAdminRemoved")
+            assertEquals(
+                adminUniqueId,
+                calls[0].previousMessageUniqueId,
+                "first admin-status message must chain off the admin file"
+            )
+            assertEquals(
+                calls[0].messageUniqueId,
+                calls[1].previousMessageUniqueId,
+                "second admin-status message must chain off the first one"
+            )
+        }
+    }
+
+    @Test
+    fun updateGroupMembers_serializesRemovedThenConversationUpdateThenAdded() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"   // will be removed
+            val bob = "bob.test"       // will be removed
+            val carol = "carol.test"   // stays
+            val dave = "dave.test"     // will be added
+            val groupId = fixture.seedGroup(
+                others = listOf(alice, bob, carol),
+                adminDomains = listOf(fixture.testDomain),
+            )
+
+            service.updateGroupMembers(
+                conversationId = groupId,
+                remove = listOf(OdinId(alice), OdinId(bob)),
+                add = listOf(OdinId(dave)),
+            )
+
+            val rows = fixture.drainOutboxInDependencyOrder()
+            val convoUpdateRow = rows.single { it.uniqueId == groupId }
+            val calls = fixture.statusMessageSender.calls
+            assertEquals(3, calls.size, "expect 2 ConversationMemberRemoved + 1 ConversationMemberAdded")
+
+            // Removed messages chain head → tail
+            assertNull(
+                calls[0].previousMessageUniqueId,
+                "first removed-status starts the chain (no upstream dep — pre-existing behavior)"
+            )
+            assertEquals(
+                calls[0].messageUniqueId,
+                calls[1].previousMessageUniqueId,
+                "second removed-status chains off the first"
+            )
+
+            // Conversation update waits for the trailing removed-status
+            assertEquals(
+                calls[1].messageUniqueId,
+                convoUpdateRow.dependencyUniqueId,
+                "conversation update must wait for the last removed-status message"
+            )
+
+            // Added messages chain off the conversation update
+            assertEquals(
+                groupId,
+                calls[2].previousMessageUniqueId,
+                "first added-status must chain off the conversation file update"
+            )
+        }
+    }
+
+    @Test
+    fun updateGroupMembers_noRemovals_conversationUpdateHasNullDependency() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            val bob = "bob.test"
+            val groupId = fixture.seedGroup(
+                others = listOf(alice),
+                adminDomains = listOf(fixture.testDomain),
+            )
+
+            service.updateGroupMembers(
+                conversationId = groupId,
+                remove = emptyList(),
+                add = listOf(OdinId(bob)),
+            )
+
+            val rows = fixture.drainOutboxInDependencyOrder()
+            val convoUpdateRow = rows.single { it.uniqueId == groupId }
+            assertNull(
+                convoUpdateRow.dependencyUniqueId,
+                "with no removals, the conversation update has no upstream dep " +
+                        "(regression guard for the new dependencyUniqueId = previousMessageId line)"
+            )
+
+            val calls = fixture.statusMessageSender.calls
+            assertEquals(1, calls.size, "only the added-status message")
+            assertEquals(
+                groupId,
+                calls[0].previousMessageUniqueId,
+                "added-status must chain off the conversation file update"
+            )
+        }
+    }
+
+    @Test
+    fun updateGroupMembers_onlyRemovals_chainTerminatesAtConversationUpdate() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val alice = "alice.test"
+            val bob = "bob.test"
+            val groupId = fixture.seedGroup(
+                others = listOf(alice, bob),
+                adminDomains = listOf(fixture.testDomain),
+            )
+
+            service.updateGroupMembers(
+                conversationId = groupId,
+                remove = listOf(OdinId(bob)),
+                add = emptyList(),
+            )
+
+            val calls = fixture.statusMessageSender.calls
+            assertEquals(1, calls.size, "one removed-status, no added-status")
+            assertNull(
+                calls[0].previousMessageUniqueId,
+                "first removed-status starts the chain"
+            )
+
+            val rows = fixture.drainOutboxInDependencyOrder()
+            val convoUpdateRow = rows.single { it.uniqueId == groupId }
+            assertEquals(
+                calls[0].messageUniqueId,
+                convoUpdateRow.dependencyUniqueId,
+                "conversation update must wait for the trailing removed-status message"
+            )
+        }
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceTestFixture.kt
@@ -195,12 +195,37 @@ class ConversationServiceTestFixture : AutoCloseable {
      * if you plan to run further service operations that might re-enqueue the same
      * uniqueId, and don't rely on [outboxRowCount] afterwards — the rows are still
      * there, just checked out.
+     *
+     * **Caveat for dependency-chained enqueues**: the `checkout` SQL hides any row
+     * whose `dependencyUniqueId` still exists in the table, so this only returns
+     * the chain-head when callers enqueue with deps. Use
+     * [drainOutboxInDependencyOrder] when you need every row of a chain.
      */
     suspend fun drainOutbox(): List<Outbox> {
         val drained = mutableListOf<Outbox>()
         while (true) {
             val row = dbm.outbox.checkout() ?: break
             drained += row
+        }
+        return drained
+    }
+
+    /**
+     * Drain ALL outbox rows by repeatedly checking out the next eligible row and
+     * then deleting it, which unblocks any rows that depended on it. Returns the
+     * rows in dependency order (chain head first). Use this when asserting the
+     * `(uniqueId, dependencyUniqueId)` shape of a chained enqueue (e.g. group
+     * creation, admin update + status messages, member-change flows).
+     *
+     * Like [drainOutbox], this is destructive — the rows are removed from the
+     * table after the call returns.
+     */
+    suspend fun drainOutboxInDependencyOrder(): List<Outbox> {
+        val drained = mutableListOf<Outbox>()
+        while (true) {
+            val row = dbm.outbox.checkout() ?: break
+            drained += row
+            dbm.outbox.deleteByRowId(row.rowId)
         }
         return drained
     }
@@ -408,8 +433,10 @@ class FakeIntroductionSender : IntroductionSender {
 
 class FakeStatusMessageSender : StatusMessageSender {
     data class Call(
+        val messageUniqueId: Uuid,
         val conversationId: Uuid,
         val statusMessage: StatusMessageData,
+        val previousMessageUniqueId: Uuid?,
         val additionalRecipients: List<OdinId>,
     )
     val calls = mutableListOf<Call>()
@@ -421,7 +448,13 @@ class FakeStatusMessageSender : StatusMessageSender {
         payloadBundle: PayloadBundle?,
         additionalRecipients: List<OdinId>,
     ): SendMessageResult {
-        calls += Call(conversationId, statusMessage, additionalRecipients)
+        calls += Call(
+            messageUniqueId = messageUniqueId,
+            conversationId = conversationId,
+            statusMessage = statusMessage,
+            previousMessageUniqueId = previousMessageUniqueId,
+            additionalRecipients = additionalRecipients,
+        )
         return SendMessageResult(messageUniqueId)
     }
 }

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -366,6 +366,13 @@
     <string name="chat_group_rejoin_pending_description">You were re-added to this group</string>
     <string name="chat_group_rejoin_accept">Rejoin</string>
     <string name="chat_group_rejoin_decline">Decline</string>
+    <string name="chat_group_main_file_delivered">Group file delivered</string>
+    <string name="chat_group_main_file_problem">Group file delivery problem</string>
+    <string name="chat_group_admin_file_delivered">Admin file delivered</string>
+    <string name="chat_group_admin_file_problem">Admin file delivery problem</string>
+    <string name="chat_group_heal">Heal group</string>
+    <string name="chat_group_heal_completed">Re-distributing group files…</string>
+    <string name="chat_group_heal_completed_nothing">Nothing to redistribute (you didn\'t author the group files).</string>
 
     <!-- 1:1 connection state banner (shown in place of the message composer) -->
     <string name="chat_not_connected_description">You're not connected.</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -206,6 +206,7 @@ val appModule = module {
     singleOf(::ContactService)
     singleOf(::ConversationStream) bind ConversationLoader::class
     single<UnreadCountEnricher> { get<ConversationStream>() }
+    single<id.homebase.chat.services.convo.ConversationParticipantLookup> { get<ConversationStream>() }
     singleOf(::ConversationService)
     single<LocalLastReadUpdater> { get<ConversationService>() }
     singleOf(::ChatMessageStream)


### PR DESCRIPTION
 Description

  ## Summary

  Two related strands shipped together on this branch:

  1. **Diagnostic + recovery tooling** for the "recipient didn't receive my group" bug class:
     per-recipient delivery indicators on the Group Settings screen, a "Heal group" button
     for the original author, and richer logging so a stuck case can be traced through both
     peers' `homebase.log` files.
  2. **Outbox dependency-chain serialization** for chat sends so that the conversation file,
     the admin file, status messages, and user-typed messages release through the local
     outbox in strict order rather than fanning out the moment an ancestor is acknowledged.
     Closes the local-outbox half of the orphan-recovery race that produced Shelly's stuck
     placeholder on conversation `0e684619` (Apr 19 log timeline analyzed in commit
     `8dedb8f3`).

  ## Background — the bug we were chasing

  A recipient ("Shelly") in a 4-person group conversation showed only `[creator, self]` as
  participants on her phone, despite the desktop app's transfer-history reporting all three
  recipients as `Delivered=OK`. Pre-`3d09be30` (Apr 24) orphan-recovery wrote a 2-person
  placeholder to her local DB when the first message arrived 11 ms ahead of the conversation
  file in her drive sync; the placeholder shadowed the real conversation file and persisted
  through every subsequent sync. The Apr 24 patches removed the server-write side-effect and
  fixed the upsert-guard for new orphans, but the **upstream race** — admin file and message
  arriving in batch 1, conversation file in batch 2 — was still possible. This branch
  serializes the local outbox so the race can no longer happen on the sender side.

  ## Changes

  ### Diagnostic and recovery tooling (commits `07c0031e`, `ec0a9eb0`)

  - **Per-recipient delivery indicators on Group Settings.** Up to two small grey check
    icons appear inline next to each participant's name — one per group file the current
    user authored (main conversation file + admin file). Red `ErrorOutline` if the server
    reports anything other than `Delivered`. Hidden entirely if the current user didn't
    author either file. Reuses the existing `MessageInfoViewModel` transfer-history loader
    pattern (`driveFileProvider.getTransferHistory(chatTargetDrive.alias, fileId)` with the
    same status mapping).
  - **"Heal group" button** at the bottom of Group Settings. Visible only if the current
    user authored at least one of the two group files. Tap → service redistributes the
    file(s) the user authored to all current participants via `updateConversationInternal` /
    `updateAdminFile`. Result snackbar; `isHealing` spinner during the call.
  - **`ConversationService.healGroupDistribution(conversationId)`** — public entry on the
    service. Per-file authorship check (`fileMetadata.originalAuthor ?: senderOdinId ==
    domain`); skips files the user didn't author; full debug logging at every step
    (versionTag, isPending, recipients, enqueue result).
  - **Logging gaps closed.** `uploadAdminFile` and `updateAdminFile` previously discarded
    the `outboxSync.tryEnqueue` boolean; now they `Logger.w` when enqueue returns false
    (UNIQUE conflict / silent drop). `loadTransferHistory` in the ViewModel now logs
    per-recipient state, not just counts, so a `BEFORE heal` / `AFTER heal` snapshot is a
    diff in the log.

  ### Outbox dependency-chain serialization

  #### Service-driven enqueues (commits `8dedb8f3`, `ec78284b`)

  `ConversationService` now produces a strictly-serial chain in three places:

  1. **`createConversation` (group path):** conversation file (no dep) → admin file (dep =
     `conversationId`) → `GroupConversationStarted` status (dep =
     `ChatProtocol.getAdminFileUniqueId(conversationId)`). Previously the admin file had no
     dep at all and the status message chained directly off the conversation file, so admin
     + status raced once the conversation file was acknowledged.
  2. **`updateAdmins`:** admin-file update row (dep = `conversationId`); first
     add/remove-status message seeded with `previousMessageUniqueId =
     adminFileUniqueId`; subsequent status messages chain on the previous one's id.
  3. **`updateGroupMembers`:** trailing removed-status messages → conversation-file update
     (dep = last removed-status `messageId`, or null when there are no removals) → added-
     status messages chain on `conversationId` (existing behavior, preserved).

  #### User-typed messages (commit `b439b3b9`)

  `ChatMessageSenderService.sendMessageInternal` now maintains an in-memory
  `Map<conversationId, lastEnqueuedMessageId>` (mutex-guarded) and falls back through three
  levels when the caller passes `previousMessageUniqueId = null` (which is the common
  case from `ConversationListViewModel.addMessage` and friends):

  effectiveDep = previousMessageUniqueId           // explicit caller wins
    ?: lastEnqueuedPerConversation[conversationId]  // chain on prior in this convo
    ?: conversationId                                // first message in convo: chain on convo file

  This means three messages typed in airplane mode release through the local outbox as
  `A → B → C`, in send order, rather than fanning out in parallel the moment the
  conversation file drains. The `NOT EXISTS` guard in the outbox `checkout` SQL means the
  fallback to `conversationId` resolves immediately for active conversations (the
  conversation file row is gone), so there is no overhead in the common case.

  ### Refactor (commit `b439b3b9`)

  To make `ChatMessageSenderService` testable in isolation, two narrow read-side seams were
  extracted:

  - **`ConversationParticipantLookup`** (new) — `getConversationById` + `getRecipients`.
    Implemented by `ConversationStream`; the sender now depends on the interface.
  - **`MessageLookup`** (existing) extended with `getMessageFile` and `loadFullMessage` so
    the sender's edit/reply paths can also be mocked. `ChatMessageStream` already implements
    `MessageLookup`; the two new methods are marked `override`.
  - DI binding added: `single<ConversationParticipantLookup> { get<ConversationStream>() }`.

  No behavioral change to production wiring — Koin resolves the same singleton.

  ## Tests

  - **`ConversationServiceOutboxOrderingTest`** (new in `380b4a39`) — six static-shape tests
    on the chain produced by `createConversation` (1:1 and group), `updateAdmins`, and
    `updateGroupMembers` (full flow, no removals, only removals). Uses the existing
    `ConversationServiceTestFixture` plus a new `drainOutboxInDependencyOrder()` helper that
    iteratively checks-out-and-deletes so chained rows surface (the existing `drainOutbox`
    only returns chain heads).
  - **`FakeStatusMessageSender`** extended in the same fixture to record `messageUniqueId`
    and `previousMessageUniqueId`. Backwards-compatible: existing tests read only the
    preserved fields.
  - **`ChatMessageSenderServiceOutboxOrderingTest`** (new in `b439b3b9`) — four tests on
    the per-message chain in `sendMessageInternal`:
    1. First message in a brand-new conversation chains on `conversationId`.
    2. Three sequential messages with `previousMessageUniqueId = null` chain on each
       other (`B.dep == A.uniqueId`, `C.dep == B.uniqueId`) — the airplane-mode pile-up
       case.
    3. Caller-supplied `previousMessageUniqueId` overrides the in-memory fallback.
    4. Chains are tracked per-conversation — sends to two parallel conversations don't
       cross-contaminate.
  - **`ChatMessageSenderServiceTestFixture`** (new) — minimal fixture mirroring the
    `ConversationServiceTestFixture` pattern: real offline `OutboxSync` + in-memory
    SQLite + real `OptimisticWriter`; fakes for `ConversationParticipantLookup`,
    `MessageLookup`, `PayloadBundleEncryptor`; `MockEngine`-backed `HttpClient` for the
    `DriveFileProvider` that the send path doesn't actually touch.

  ## Known caveats

  - **App restart with pending chained messages.** The in-memory `lastEnqueuedPerConversation`
    map is cleared on restart; pending outbox rows still carry their persisted deps and
    drain in order among themselves, but a new message after restart starts a fresh chain
    (fallback to `conversationId`). Realistically only matters if the user is offline
    through a restart.
  - **Truly concurrent sends from two coroutines** for the same conversation could read
    the same predecessor under the current mutex granularity (lock wraps map read and map
    write separately, not the entire enqueue). Sequential sends — the common case via
    `viewModelScope.launch` from `addMessage` — are unaffected.
  - **Existing stuck conversations** (e.g. Shelly's `0e684619`) are not auto-fixed by this
    change. Pressing "Heal group" from the original author's app is the empirical
    recovery path; whether it succeeds depends on whether the recipient's server accepts
    Michael's `UpdateFileByUniqueId` despite the local placeholder having a
    recipient-minted `versionTag`. Untested at the server protocol level.
