### PR TITLE
fix(cache): self-heal poisoned FileKache on internal NPE/ISE

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
@@ -148,6 +148,38 @@ class DriveFileProviderCached(
         }
     }
 
+    // Drop the live FileKache reference under the lifecycle mutex so the next
+    // accessor reconstructs from the on-disk journal. Use this only for
+    // exceptions that look like internal-state corruption (NPE, ISE) — observed
+    // on real Android devices where a single mayakapps/kache failure leaves
+    // the instance with a null internal sink/source and every subsequent
+    // get()/put() fires the same `getClass() on null` NPE for the rest of the
+    // session (90k+ identical errors in one user log). Not for IOException /
+    // disk-full, which are per-operation and recover on their own.
+    private fun isKacheInstanceCorrupt(e: Throwable): Boolean =
+            e is NullPointerException || e is IllegalStateException
+
+    // Internal so jvmTest can drive the recovery path directly. The on-disk
+    // journal survives — a fresh FileKache built over the same dir picks up
+    // existing entries.
+    internal suspend fun discardThumbKache() = kacheMutex.withLock {
+        if (_thumbDiskKache != null) {
+            Logger.w(tag = "DriveFileProviderCached") {
+                "discarding broken thumb FileKache — next access will reconstruct"
+            }
+            _thumbDiskKache = null
+        }
+    }
+
+    internal suspend fun discardPayloadKache() = kacheMutex.withLock {
+        if (_payloadDiskKache != null) {
+            Logger.w(tag = "DriveFileProviderCached") {
+                "discarding broken payload FileKache — next access will reconstruct"
+            }
+            _payloadDiskKache = null
+        }
+    }
+
     // ================================================================
     // -------------------- CACHED PAYLOAD METHODS --------------------
     // ================================================================
@@ -199,6 +231,7 @@ class DriveFileProviderCached(
                         // A write failure should not prevent the caller from getting the fetched bytes.
                         // Surface it loudly so we can spot corrupted journals or full disks.
                         Logger.e(tag = "PayloadIO", throwable = e) { "payload cache-write FAILED key=$cacheKey" }
+                        if (isKacheInstanceCorrupt(e)) discardPayloadKache()
                     }
                     result
                 } catch (e: NotFoundException) {
@@ -354,6 +387,7 @@ class DriveFileProviderCached(
                         // A write failure should not prevent the caller from getting the fetched bytes.
                         // Surface it loudly so we can spot corrupted journals or full disks.
                         Logger.e(tag = "ThumbIO", throwable = e) { "thumb cache-write FAILED key=$cacheKey" }
+                        if (isKacheInstanceCorrupt(e)) discardThumbKache()
                     }
                     result
                 } catch (e: NotFoundException) {
@@ -382,6 +416,7 @@ class DriveFileProviderCached(
             readBytesResponse(filePath)
         } catch (e: Exception) {
             Logger.e(tag = "ThumbIO", throwable = e) { "thumb cache-read FAILED key=$cacheKey" }
+            if (isKacheInstanceCorrupt(e)) discardThumbKache()
             null
         }
     }
@@ -397,6 +432,7 @@ class DriveFileProviderCached(
             result
         } catch (e: Exception) {
             Logger.e(tag = "PayloadIO", throwable = e) { "payload cache-read FAILED key=$cacheKey" }
+            if (isKacheInstanceCorrupt(e)) discardPayloadKache()
             null
         }
     }

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
@@ -330,6 +330,41 @@ class DriveFileProviderCachedTest {
     }
 
     /**
+     * Regression for an Android log where a single internal mayakapps/kache
+     * NPE poisoned the live FileKache instance and every subsequent
+     * `get()`/`put()` fired the same `getClass() on null` NPE for the rest of
+     * the session — 90k+ identical errors in one user log. The self-healing
+     * path nulls the bad reference under the lifecycle mutex so the next
+     * accessor reconstructs over the existing on-disk journal, recovering
+     * already-cached entries instead of needing a full re-download.
+     */
+    @Test
+    fun `discardThumbKache rebuilds cache and previously-cached bytes survive`() = runTest {
+        // Populate the cache so there's a live instance + on-disk journal.
+        provider.getThumbBytesRaw(driveId, fileId, key, 100, 100)
+        val countAfterPopulate = requestCount
+
+        // Same key reads from cache — no network — proving the live instance works.
+        provider.getThumbBytesRaw(driveId, fileId, key, 100, 100)
+        assertEquals(
+            countAfterPopulate, requestCount,
+            "warm read should hit the live cache (no extra network call)"
+        )
+
+        // Simulate the recovery path the new catch blocks invoke.
+        provider.discardThumbKache()
+
+        // Next call must succeed — a fresh FileKache reconstructs over the
+        // same directory and finds the existing entry. Network count must NOT
+        // change: the on-disk journal survives, so this is a cache hit.
+        provider.getThumbBytesRaw(driveId, fileId, key, 100, 100)
+        assertEquals(
+            countAfterPopulate, requestCount,
+            "after discard + reconstruct, the previously-cached entry must still serve from disk"
+        )
+    }
+
+    /**
      * Positive assertion: after clearCaches, the next fetch must actually
      * reach the network. Protects against a future regression where we e.g.
      * null the kache reference but forget to delete the on-disk directory.


### PR DESCRIPTION
Real-device log showed 90k+ identical NullPointerExceptions from mayakapps/kache internals on every thumb cache get/put for ~10 hours straight after the FileKache instance landed in a permanently broken state. Existing catch blocks logged the error but kept reusing the poisoned instance for the rest of the session.

Add discardThumbKache / discardPayloadKache helpers that null the live reference under kacheMutex so the next accessor reconstructs over the on-disk journal (cached entries survive). Wire them into the four read/write catch blocks, gated on NullPointerException / IllegalStateException only — IOException / disk-full are per-operation failures and must not trigger a reset.