### PR TITLE
Fix chat unread-count for self/deleted/Note-to-Self messages

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/ChatReadCountWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/ChatReadCountWrapper.kt
@@ -112,8 +112,14 @@ class ChatReadCountWrapper(
      * Get unread message count for a specific conversation
      * Note: This implementation is simplified and would need the generated SQLDelight queries
      */
-    fun selectUnreadCountForConversation(identityId: Uuid, groupId: Uuid): Long {
-        val result = delegate.selectUnreadCountForConversation(identityId, groupId).executeAsOneOrNull()
+    fun selectUnreadCountForConversation(
+        identityId: Uuid,
+        groupId: Uuid,
+        selfDomain: OdinId,
+    ): Long {
+        val result = delegate.selectUnreadCountForConversation(
+            identityId, groupId, selfDomain.domainName
+        ).executeAsOneOrNull()
 
         if (result == null)
             return 0

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/MainIndexMeta.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/MainIndexMeta.kt
@@ -112,7 +112,17 @@ object MainIndexMetaHelpers {
                 dataType = (header.fileMetadata.appData.dataType ?: 0).toLong(),
                 archivalStatus = (header.fileMetadata.appData.archivalStatus?.value ?: 0).toLong(),
                 historyStatus = 0L,
-                userDate = header.fileMetadata.appData.userDate ?: 0L,
+                // Fall back to `metadata.created` when appData.userDate is null —
+                // older Web/RN clients didn't always capture userDate, and the
+                // in-memory MessageUiModel mapper falls back to a server-stamped
+                // timestamp too (see ChatMessageStream.mapToMessageData). Storing
+                // 0 here would put those rows at the epoch, which makes any SQL
+                // filter on userDate (notably the unread-count queries) disagree
+                // with the in-memory list ordering. `created` is always set on
+                // real rows and is the same fallback the soft-delete branch in
+                // mapToMessageData uses, so we land on the same wall-clock time.
+                userDate = header.fileMetadata.appData.userDate
+                    ?: header.fileMetadata.created.milliseconds,
                 created = header.fileMetadata.created.milliseconds,
                 modified = header.fileMetadata.updated.milliseconds,
                 fileSystemType = 0L, // Default value

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ChatReadCount.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ChatReadCount.sq
@@ -54,7 +54,11 @@ LEFT JOIN ChatReadCount c ON d.groupId = c.groupId
 WHERE d.identityId = ?
   AND d.groupId = ?
   AND d.fileType = 7878 AND d.dataType = 0
-  AND (c.lastReadTime IS NULL OR d.userDate > c.lastReadTime);
+  AND (c.lastReadTime IS NULL OR d.userDate > c.lastReadTime)
+  AND d.originalAuthor IS NOT NULL
+  AND d.originalAuthor != ?
+  -- 2 = ArchivalStatus.Removed; soft-deleted messages don't count toward unread.
+  AND d.archivalStatus != 2;
 
 -- Return list of {groupId, unreadCount} for all chat conversations (8888)
 -- Will return (groupId, unread-count) for all Chat conversations with 1 or more unread messages.
@@ -77,7 +81,14 @@ WHERE d.identityId = ?
   AND d.dataType = 0
   AND (c.lastReadTime IS NULL OR d.userDate > c.lastReadTime)
   AND d.groupId IS NOT NULL
-  AND (d.originalAuthor IS NULL OR d.originalAuthor != ?)
+  -- NULL originalAuthor is treated as self: drive-sync echoes of your own
+  -- messages (and older self-authored rows) land with originalAuthor=NULL
+  -- because the server doesn't stamp it on self-messages. Counting them as
+  -- unread to yourself would be wrong.
+  AND d.originalAuthor IS NOT NULL
+  AND d.originalAuthor != ?
+  -- 2 = ArchivalStatus.Removed; soft-deleted messages don't count toward unread.
+  AND d.archivalStatus != 2
 GROUP BY d.groupId;
 
 

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/ChatReadCountWrapperTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/ChatReadCountWrapperTest.kt
@@ -13,6 +13,10 @@ import kotlin.uuid.Uuid
 
 class ChatReadCountWrapperTest {
 
+    // Mock data is seeded with originalAuthor="test.sender", so any other domain
+    // here behaves as "self != peer-author" — i.e., the messages count as unread.
+    private val selfDomain = OdinId("test.self")
+
     /**
      * Populates the database with mock test data:
      * - One conversation with no messages
@@ -280,15 +284,18 @@ class ChatReadCountWrapperTest {
             // FAILS HERE :
             val conv1Unread = wrapper.selectUnreadCountForConversation(
                 testData.identityId,
-                testData.convWithNoMessages.fileMetadata.appData.uniqueId!!
+                testData.convWithNoMessages.fileMetadata.appData.uniqueId!!,
+                selfDomain,
             )
             val conv2Unread = wrapper.selectUnreadCountForConversation(
                 testData.identityId,
-                testData.convWithOneMessage.first.fileMetadata.appData.uniqueId!!
+                testData.convWithOneMessage.first.fileMetadata.appData.uniqueId!!,
+                selfDomain,
             )
             val conv3Unread = wrapper.selectUnreadCountForConversation(
                 testData.identityId,
-                testData.convWithThreeMessages.first.fileMetadata.appData.uniqueId!!
+                testData.convWithThreeMessages.first.fileMetadata.appData.uniqueId!!,
+                selfDomain,
             )
 
             assertEquals(
@@ -317,7 +324,8 @@ class ChatReadCountWrapperTest {
 
             val conv3Unread = wrapper.selectUnreadCountForConversation(
                 testData.identityId,
-                testData.convWithThreeMessages.first.fileMetadata.appData.uniqueId!!
+                testData.convWithThreeMessages.first.fileMetadata.appData.uniqueId!!,
+                selfDomain,
             )
 
             // Should only count messages after the read time (only the 3rd message)
@@ -331,7 +339,7 @@ class ChatReadCountWrapperTest {
             val wrapper = dbm.chatReadCount
             val nonExistentGroupId = Uuid.random()
 
-            val unreadCount = wrapper.selectUnreadCountForConversation(Uuid.random(), nonExistentGroupId)
+            val unreadCount = wrapper.selectUnreadCountForConversation(Uuid.random(), nonExistentGroupId, selfDomain)
 
             assertEquals(
                 0L, unreadCount, "Non-existent conversation should have 0 unread"
@@ -443,7 +451,8 @@ class ChatReadCountWrapperTest {
             // Verify unread count changed
             val unreadCount = wrapper.selectUnreadCountForConversation(
                 testData.identityId,
-                testData.convWithOneMessage.first.fileMetadata.appData.uniqueId!!
+                testData.convWithOneMessage.first.fileMetadata.appData.uniqueId!!,
+                selfDomain,
             )
             assertEquals(
                 0L, unreadCount, "Should have 0 unread messages after setting read time"
@@ -475,7 +484,8 @@ class ChatReadCountWrapperTest {
             // messages)
             val unreadCount = wrapper.selectUnreadCountForConversation(
                 testData.identityId,
-                testData.convWithThreeMessages.first.fileMetadata.appData.uniqueId!!
+                testData.convWithThreeMessages.first.fileMetadata.appData.uniqueId!!,
+                selfDomain,
             )
             assertEquals(
                 0L, unreadCount, "Should have 0 unread messages after updating read time"
@@ -513,7 +523,8 @@ class ChatReadCountWrapperTest {
             // Verify it exists by checking unread count
             var unreadCount = wrapper.selectUnreadCountForConversation(
                 testData.identityId,
-                testData.convWithOneMessage.first.fileMetadata.appData.uniqueId!!
+                testData.convWithOneMessage.first.fileMetadata.appData.uniqueId!!,
+                selfDomain,
             )
             assertEquals(0L, unreadCount, "Should have 0 unread with read time set")
 
@@ -524,7 +535,8 @@ class ChatReadCountWrapperTest {
             // Verify it's gone - unread count should be back to original
             unreadCount = wrapper.selectUnreadCountForConversation(
                 testData.identityId,
-                testData.convWithOneMessage.first.fileMetadata.appData.uniqueId!!
+                testData.convWithOneMessage.first.fileMetadata.appData.uniqueId!!,
+                selfDomain,
             )
             assertEquals(
                 1L, unreadCount, "Should have 1 unread after deleting read time"
@@ -566,7 +578,8 @@ class ChatReadCountWrapperTest {
             // Verify unread count is back to original
             var unreadCount = wrapper.selectUnreadCountForConversation(
                 testData.identityId,
-                testData.convWithThreeMessages.first.fileMetadata.appData.uniqueId!!
+                testData.convWithThreeMessages.first.fileMetadata.appData.uniqueId!!,
+                selfDomain,
             )
             assertEquals(3L, unreadCount, "Should have 3 unread after deletion")
 
@@ -580,7 +593,8 @@ class ChatReadCountWrapperTest {
             // Verify new read time is effective
             unreadCount = wrapper.selectUnreadCountForConversation(
                 testData.identityId,
-                testData.convWithThreeMessages.first.fileMetadata.appData.uniqueId!!
+                testData.convWithThreeMessages.first.fileMetadata.appData.uniqueId!!,
+                selfDomain,
             )
             assertEquals(
                 0L, unreadCount, "Should have 0 unread after reinserting with new read time"

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/MainIndexMetaTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/MainIndexMetaTest.kt
@@ -107,6 +107,91 @@ class MainIndexMetaTest {
         }
     }
 
+    /**
+     * Regression test for the SQL/in-memory userDate clock divergence:
+     * older Web/RN clients sent messages without `appData.userDate`. The
+     * in-memory mapper falls back to a server-stamped timestamp, but
+     * the SQL projection used to store `0L` — leaving any unread-count
+     * filter on `userDate` permanently disagreeing with the message list
+     * order. The projection now falls back to `metadata.created`, which
+     * is always set on a real row.
+     */
+    @Test
+    fun convertFileHeader_fallsBackToCreated_whenAppDataUserDateIsNull() = runTest {
+        DatabaseManager({ createInMemoryDatabase() }).use { dbm ->
+            val identityId = Uuid.random()
+            val driveId = Uuid.random()
+            val fileId = Uuid.random()
+            val createdMs = 1_700_000_000_000L
+
+            val jsonHeader = """{
+                "fileId": "${fileId}",
+                "driveId": "${driveId}",
+                "fileState": "active",
+                "fileSystemType": "standard",
+                "serverFileIsEncrypted":"true",
+                "keyHeader" : {
+                    "iv" : [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+                    "aesKey" : {
+                      "bytes" : [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
+                    }
+                  },
+                "fileMetadata": {
+                    "globalTransitId": "52a491ac-9870-4d0c-94a1-1bf667393015",
+                    "created": $createdMs,
+                    "updated": $createdMs,
+                    "transitCreated": 0,
+                    "transitUpdated": 0,
+                    "serverFileIsEncrypted": true,
+                    "senderOdinId": "test.sender",
+                    "originalAuthor": "test.sender",
+                    "appData": {
+                        "uniqueId": "55d2e47e-ec86-f9b8-1e3d-d7bdeeb0527b",
+                        "tags": null,
+                        "fileType": 1,
+                        "dataType": 1,
+                        "groupId": null,
+                        "userDate": null,
+                        "content": "legacy message without userDate",
+                        "previewThumbnail": null,
+                        "archivalStatus": 0
+                    },
+                    "localAppData": null,
+                    "referencedFile": null,
+                    "reactionPreview": null,
+                    "versionTag": "1355aa19-2031-d800-403d-e8696a8be494",
+                    "payloads": [],
+                    "dataSource": null
+                },
+                "serverMetadata": {
+                    "accessControlList": {
+                        "requiredSecurityGroup": "owner",
+                        "circleIdList": null,
+                        "odinIdList": null
+                    },
+                    "doNotIndex": false,
+                    "allowDistribution": false,
+                    "fileSystemType": "standard",
+                    "fileByteCount": 1000,
+                    "originalRecipientCount": 0,
+                    "transferHistory": null
+                },
+                "priority": 300,
+                "fileByteCount": 1000
+            }"""
+
+            val header = OdinSystemSerializer.deserialize<HomebaseFile>(jsonHeader)
+            val processor = MainIndexMetaHelpers.HomebaseFileProcessor(dbm)
+            val record = processor.convertFileHeaderToDriveMainIndexRecord(identityId, driveId, header)
+
+            assertEquals(
+                createdMs,
+                record.userDate,
+                "SQL userDate must fall back to metadata.created when appData.userDate is null",
+            )
+        }
+    }
+
     @Test
     @Ignore // michael will fix
     fun testBaseUpsertEntryZapZapWithTags() = runTest {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -541,7 +541,7 @@ class ConversationListViewModel(
         // warm VM, for the next sync batch) — which is what made
         // notification taps feel like they were gated on the drive-sync
         // spinner. Dispatchers.IO so the kick can't be queued behind
-        // enrichWithUnreadCounts on Main.
+        // enrichAllConversationsWithUnreadCounts on Main.
         viewModelScope.launch {
             pendingNotificationTap.state.collect { tap ->
                 if (tap == null) return@collect

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -1120,7 +1120,7 @@ class ConversationListViewModel(
                 viewModelScope.launch {
                     try {
                         if (action.messageIds == null) {
-                            // TODO - mark all as read
+                            chatMessageActionService.markAllAsRead(action.conversationId)
                         } else {
                             chatMessageActionService.markAsReadByFiles(
                                 action.conversationId,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
@@ -152,6 +152,51 @@ class ChatMessageActionService(
         unreadCountEnricher.applyLocalAdvance(conversationId, newReadTime)
     }
 
+    /**
+     * Bulk "mark all as read" for an entire conversation. Advances local
+     * lastReadTime to the conversation's latest message timestamp.
+     *
+     * Deliberately does NOT enqueue read receipts — receipts are an
+     * "I actually read this" signal, and a bulk-dismiss action shouldn't
+     * impersonate that. The advance still propagates to other devices via
+     * `localLastReadUpdater.updateLocalLastReadTime` (which writes the
+     * conversation file's localAppData and the outbox syncs that).
+     *
+     * No-op if the conversation isn't in the in-memory list, or if its
+     * lastRead is already at or past the latest message.
+     */
+    suspend fun markAllAsRead(conversationId: Uuid) {
+        val convo = participantLookup.getConversationById(conversationId) ?: return
+        val newReadTime = convo.latestMessageTimestamp
+        if (newReadTime <= convo.lastRead) return
+
+        Logger.d(tag = TAG) {
+            "markAllAsRead convo=$conversationId advancing to ms=${newReadTime.toEpochMilliseconds()}"
+        }
+        dbm.chatReadCount.upsertLastReadTime(conversationId, UnixTimeUtc(newReadTime))
+        localLastReadUpdater.updateLocalLastReadTime(
+            conversationId,
+            UnixTimeUtc(newReadTime),
+        )
+        unreadCountEnricher.applyLocalAdvance(conversationId, newReadTime)
+
+        // Sanity check: after advancing lastRead to the conversation's latest
+        // message timestamp, the unread count should be 0. If not, there's a
+        // SQL/in-memory clock divergence — e.g. a message whose appData.userDate
+        // is greater than what enrichWithLastMessages reported as latestMessage-
+        // Timestamp (the in-memory mapper falls back to authorSpecificDate when
+        // appData.userDate is null, which can drift from the SQL d.userDate
+        // column). Logging it loudly so we can investigate.
+        val after = participantLookup.getConversationById(conversationId)
+        if (after != null && after.unreadCount > 0) {
+            Logger.w(tag = TAG) {
+                "markAllAsRead convo=$conversationId left unreadCount=${after.unreadCount} " +
+                        "after advancing lastRead to latestMessageTimestamp(ms)=" +
+                        "${newReadTime.toEpochMilliseconds()} — likely SQL/in-memory userDate divergence"
+            }
+        }
+    }
+
     private companion object {
         const val TAG = "MarkAsRead"
     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
@@ -68,72 +68,80 @@ class ChatMessageActionService(
                     "(excluded reasons: self-authored | already-read | deleted | pending-send)"
         }
 
-        if (unreadRecords.isEmpty()) {
+        // Local lastReadTime should advance to cover any non-deleted, non-pending message
+        // the user just viewed — even self-authored or already-receipted ones (e.g. Note-to-Self
+        // has no peer-eligible messages, but the user has clearly "read up to here").
+        val viewedRecords = batch.records.filter { !it.isDeleted && !it.isPendingSend }
+        if (viewedRecords.isEmpty()) {
             Logger.d(tag = TAG) {
-                "no eligible records — early return; convo=$conversationId no outbox row, no enrich"
+                "no viewed records — early return; convo=$conversationId no outbox row, no local advance"
             }
             return
         }
 
-        val newReadTime = unreadRecords.maxOf { it.userDate }
+        val newReadTime = viewedRecords.maxOf { it.userDate }
         Logger.d(tag = TAG) {
             "newReadTime(ms)=${newReadTime.toEpochMilliseconds()} " +
-                    "(max userDate over ${unreadRecords.size} eligible records)"
+                    "(max userDate over ${viewedRecords.size} viewed records, " +
+                    "${unreadRecords.size} receipt-eligible)"
         }
 
-        val fileIds = unreadRecords.map { it.fileId }
-        val enqueued = outboxSync.tryEnqueue(
-            request = SendReadReceiptByFileIdsOutboxRequest(
-                driveId = chatDrive,
-                fileIds = fileIds,
-            )
-        )
-        Logger.d(tag = TAG) {
-            "enqueue receipt: enqueued=$enqueued drive=$chatDrive fileIdsCount=${fileIds.size}"
-        }
-
-        if (enqueued) {
-            // Optimistic local upsert — the read-receipt send is now fire-and-forget
-            // via the outbox, so we can't gate this on a per-file server status.
-            // Local read state reflects what the user read locally; the outbox
-            // retries the server-side receipt delivery independently.
-            unreadRecords
-                .distinctBy { it.conversationId }
-                .forEach {
-                    Logger.d(tag = TAG) {
-                        "upsert chatReadCount.lastReadTime convo=${it.conversationId} ms=${newReadTime.toEpochMilliseconds()}"
-                    }
-                    dbm.chatReadCount.upsertLastReadTime(
-                        it.conversationId,
-                        UnixTimeUtc(newReadTime)
-                    )
-                }
-
-            Logger.d(tag = TAG) {
-                "→ localLastReadUpdater.updateLocalLastReadTime(convo=$conversationId, ms=${newReadTime.toEpochMilliseconds()})"
-            }
-            try {
-                localLastReadUpdater.updateLocalLastReadTime(
-                    conversationId,
-                    UnixTimeUtc(newReadTime)
+        // Send a read receipt only if there are receipt-eligible records. For
+        // Note-to-Self / all-self-authored views, we skip the outbox but still advance local state.
+        val enqueued = if (unreadRecords.isNotEmpty()) {
+            val fileIds = unreadRecords.map { it.fileId }
+            val ok = outboxSync.tryEnqueue(
+                request = SendReadReceiptByFileIdsOutboxRequest(
+                    driveId = chatDrive,
+                    fileIds = fileIds,
                 )
-                Logger.d(tag = TAG) { "← localLastReadUpdater returned ok" }
-            } catch (t: Throwable) {
-                Logger.e(throwable = t, tag = TAG) {
-                    "localLastReadUpdater THREW — likely the WIP TODO()s in ConversationService.updateLocalLastReadTime; " +
-                            "unreadCountEnricher will NOT run, UI unread count may stay stale"
-                }
-                throw t
+            )
+            Logger.d(tag = TAG) {
+                "enqueue receipt: enqueued=$ok drive=$chatDrive fileIdsCount=${fileIds.size}"
             }
-
-            Logger.d(tag = TAG) { "→ unreadCountEnricher.enrichConversationWithUnreadCounts(convo=$conversationId)" }
-            unreadCountEnricher.enrichConversationWithUnreadCounts(conversationId)
-            Logger.d(tag = TAG) { "← unreadCountEnricher returned" }
+            ok
         } else {
+            Logger.d(tag = TAG) {
+                "no receipt-eligible records — skipping outbox; advancing local read state only"
+            }
+            true
+        }
+
+        if (!enqueued) {
             Logger.w(tag = TAG) {
                 "outbox.tryEnqueue returned false — skipped DB upsert + enrich; convo=$conversationId"
             }
+            return
         }
+
+        // Optimistic local upsert — the read-receipt send is fire-and-forget via the outbox,
+        // so we can't gate this on a per-file server status. Local read state reflects what
+        // the user read locally; the outbox retries server-side receipt delivery independently.
+        Logger.d(tag = TAG) {
+            "upsert chatReadCount.lastReadTime convo=$conversationId ms=${newReadTime.toEpochMilliseconds()}"
+        }
+        dbm.chatReadCount.upsertLastReadTime(conversationId, UnixTimeUtc(newReadTime))
+
+        Logger.d(tag = TAG) {
+            "→ localLastReadUpdater.updateLocalLastReadTime(convo=$conversationId, ms=${newReadTime.toEpochMilliseconds()})"
+        }
+        try {
+            localLastReadUpdater.updateLocalLastReadTime(
+                conversationId,
+                UnixTimeUtc(newReadTime)
+            )
+            Logger.d(tag = TAG) { "← localLastReadUpdater returned ok" }
+        } catch (t: Throwable) {
+            Logger.e(throwable = t, tag = TAG) {
+                "localLastReadUpdater THREW — likely the WIP TODO()s in ConversationService.updateLocalLastReadTime; " +
+                        "unreadCountEnricher will NOT run, UI unread count may stay stale"
+            }
+            throw t
+        }
+
+        Logger.d(tag = TAG) { "→ unreadCountEnricher.enrichOneConversationWithUnreadCount(convo=$conversationId)" }
+        unreadCountEnricher.enrichOneConversationWithUnreadCount(conversationId)
+        Logger.d(tag = TAG) { "← unreadCountEnricher returned" }
     }
 
     private companion object {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
@@ -21,6 +21,7 @@ import id.homebase.api.sync.database.OutboxSync
 import id.homebase.api.sync.database.QueryBatch
 import id.homebase.chat.services.outbox.OptimisticWriter
 import id.homebase.api.client.drives.files.reactions.ReactionContent
+import id.homebase.chat.services.convo.ConversationParticipantLookup
 import id.homebase.chat.services.convo.ConversationService
 import id.homebase.chat.services.convo.LocalLastReadUpdater
 import id.homebase.chat.services.convo.UnreadCountEnricher
@@ -30,6 +31,7 @@ import kotlin.uuid.Uuid
 
 class ChatMessageActionService(
     private val conversationService: ConversationService,
+    private val participantLookup: ConversationParticipantLookup,
     private val localLastReadUpdater: LocalLastReadUpdater,
     private val unreadCountEnricher: UnreadCountEnricher,
     private val messageLookup: MessageLookup,
@@ -114,34 +116,40 @@ class ChatMessageActionService(
             return
         }
 
+        // Gate the local-state work on the in-memory lastRead. The conversation
+        // file's appdata.lastReadTime (mirrored as ConversationUiModel.lastRead)
+        // is the source of truth here; ChatReadCount is just its SQL-queryable
+        // index. Re-entering the same conversation typically lands here with
+        // newReadTime == priorLastRead — skipping spares us a SQL upsert, an
+        // appdata round-trip, and a COUNT-based enrich on every visit.
+        val priorLastRead = participantLookup.getConversationById(conversationId)?.lastRead
+        if (priorLastRead != null && newReadTime <= priorLastRead) {
+            Logger.d(tag = TAG) {
+                "newReadTime(ms)=${newReadTime.toEpochMilliseconds()} <= priorLastRead(ms)=${priorLastRead.toEpochMilliseconds()} — skipping upsert + enrich; convo=$conversationId"
+            }
+            return
+        }
+
         // Optimistic local upsert — the read-receipt send is fire-and-forget via the outbox,
         // so we can't gate this on a per-file server status. Local read state reflects what
         // the user read locally; the outbox retries server-side receipt delivery independently.
-        Logger.d(tag = TAG) {
-            "upsert chatReadCount.lastReadTime convo=$conversationId ms=${newReadTime.toEpochMilliseconds()}"
-        }
         dbm.chatReadCount.upsertLastReadTime(conversationId, UnixTimeUtc(newReadTime))
 
-        Logger.d(tag = TAG) {
-            "→ localLastReadUpdater.updateLocalLastReadTime(convo=$conversationId, ms=${newReadTime.toEpochMilliseconds()})"
-        }
         try {
             localLastReadUpdater.updateLocalLastReadTime(
                 conversationId,
                 UnixTimeUtc(newReadTime)
             )
-            Logger.d(tag = TAG) { "← localLastReadUpdater returned ok" }
         } catch (t: Throwable) {
             Logger.e(throwable = t, tag = TAG) {
-                "localLastReadUpdater THREW — likely the WIP TODO()s in ConversationService.updateLocalLastReadTime; " +
-                        "unreadCountEnricher will NOT run, UI unread count may stay stale"
+                "localLastReadUpdater THREW — unreadCountEnricher will NOT run, UI may stay stale"
             }
             throw t
         }
 
-        Logger.d(tag = TAG) { "→ unreadCountEnricher.enrichOneConversationWithUnreadCount(convo=$conversationId)" }
-        unreadCountEnricher.enrichOneConversationWithUnreadCount(conversationId)
-        Logger.d(tag = TAG) { "← unreadCountEnricher returned" }
+        // Synchronously patch in-memory lastRead + unreadCount so the UI
+        // updates without waiting for the BatchReceived round-trip.
+        unreadCountEnricher.applyLocalAdvance(conversationId, newReadTime)
     }
 
     private companion object {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
@@ -174,10 +174,18 @@ class ChatMessageActionService(
             "markAllAsRead convo=$conversationId advancing to ms=${newReadTime.toEpochMilliseconds()}"
         }
         dbm.chatReadCount.upsertLastReadTime(conversationId, UnixTimeUtc(newReadTime))
-        localLastReadUpdater.updateLocalLastReadTime(
-            conversationId,
-            UnixTimeUtc(newReadTime),
-        )
+        try {
+            localLastReadUpdater.updateLocalLastReadTime(
+                conversationId,
+                UnixTimeUtc(newReadTime),
+            )
+        } catch (t: Throwable) {
+            Logger.e(throwable = t, tag = TAG) {
+                "markAllAsRead localLastReadUpdater THREW — applyLocalAdvance will NOT run, " +
+                        "UI may stay stale; convo=$conversationId"
+            }
+            throw t
+        }
         unreadCountEnricher.applyLocalAdvance(conversationId, newReadTime)
 
         // Sanity check: after advancing lastRead to the conversation's latest

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -568,34 +568,6 @@ class ConversationStream(
      * fast first-paint path; every added cost here delays tap-to-render
      * latency on cold start.
      */
-    /**
-     * Catch ChatReadCount.lastReadTime up to the value carried in each
-     * conversation file's localAppData. Drive-sync of conversation files
-     * (cold load + peer-device echoes) updates DriveMainIndex but not
-     * ChatReadCount; this hook keeps the SQL-queryable index aligned with
-     * the file-of-record.
-     *
-     * Read prior + compare locally before issuing the upsert — the upsert's
-     * MAX(...) clause would also keep us from going backward, but it would
-     * still take a write lock on every cold-load row even when nothing
-     * actually needs updating. A cheap read avoids that.
-     */
-    private suspend fun mirrorLastReadIntoChatReadCount(files: List<HomebaseFile>) {
-        for (file in files) {
-            val uniqueId = file.fileMetadata.appData.uniqueId ?: continue
-            val raw = file.fileMetadata.localAppData?.content ?: continue
-            val localAppData = try {
-                OdinSystemSerializer.deserialize<ConversationLocalAppDataJson>(raw)
-            } catch (t: Throwable) {
-                continue
-            }
-            val incoming = localAppData.lastReadTime ?: continue
-            val prior = dbm.chatReadCount.selectLastReadTimeMs(uniqueId)
-            if (prior != null && prior >= incoming.milliseconds) continue
-            dbm.chatReadCount.upsertLastReadTime(uniqueId, incoming)
-        }
-    }
-
     private suspend fun loadBasicConversations() {
         val startedAt = Clock.System.now().toEpochMilliseconds()
         val c = credentialsManager.requireActiveCredentials()
@@ -634,6 +606,10 @@ class ConversationStream(
                     "(query=${afterQuery - startedAt}ms map=${Clock.System.now().toEpochMilliseconds() - afterQuery}ms) " +
                     "items=${basic.size}"
         }
+    }
+
+    private suspend fun mirrorLastReadIntoChatReadCount(files: List<HomebaseFile>) {
+        mirrorLastReadIntoChatReadCount(dbm, files)
     }
 
     /**
@@ -957,3 +933,38 @@ data class EnrichmentState(
      *  the unread counts from ChatReadCount. */
     val hasUnreadCounts: Boolean = false,
 )
+
+/**
+ * Catch `ChatReadCount.lastReadTime` up to the value carried in each
+ * conversation file's localAppData. Drive-sync of conversation files
+ * (cold load + peer-device echoes) updates `DriveMainIndex` but not
+ * `ChatReadCount`; this keeps the SQL-queryable index aligned with the
+ * file-of-record so `selectAllUnreadCount` reflects cross-device read
+ * advances on the next query.
+ *
+ * Read prior + compare locally before issuing the upsert — the upsert's
+ * `MAX(...)` clause would also keep us from going backward, but it would
+ * still take a write lock on every cold-load row even when nothing
+ * actually needs updating. A cheap read avoids that.
+ *
+ * Top-level for unit-testability without spinning up a full
+ * [ConversationStream] graph.
+ */
+internal suspend fun mirrorLastReadIntoChatReadCount(
+    dbm: DatabaseManager,
+    files: List<HomebaseFile>,
+) {
+    for (file in files) {
+        val uniqueId = file.fileMetadata.appData.uniqueId ?: continue
+        val raw = file.fileMetadata.localAppData?.content ?: continue
+        val localAppData = try {
+            OdinSystemSerializer.deserialize<ConversationLocalAppDataJson>(raw)
+        } catch (t: Throwable) {
+            continue
+        }
+        val incoming = localAppData.lastReadTime ?: continue
+        val prior = dbm.chatReadCount.selectLastReadTimeMs(uniqueId)
+        if (prior != null && prior >= incoming.milliseconds) continue
+        dbm.chatReadCount.upsertLastReadTime(uniqueId, incoming)
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -7,6 +7,7 @@ import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.common.OdinId
 import id.homebase.api.common.time.UnixTimeUtc
+import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.OutboxSync
 import id.homebase.api.util.truncateToCodePoints
@@ -392,6 +393,12 @@ class ConversationStream(
     private suspend fun processConversationBatchIncrementally(
         conversationFiles: List<HomebaseFile>
     ) {
+        // Drive-sync of a conversation file (cold-load or peer-device echo) writes
+        // only DriveMainIndex; ChatReadCount lags. selectAllUnreadCount uses
+        // ChatReadCount, so without this catch-up a conversation marked-read on
+        // another device keeps reporting non-zero unread on this one.
+        mirrorLastReadIntoChatReadCount(conversationFiles)
+
         // For each file in the batch, map to model (fetch last message from DB if needed)
         val incomingConversations =
             conversationFiles.map { file ->
@@ -561,6 +568,34 @@ class ConversationStream(
      * fast first-paint path; every added cost here delays tap-to-render
      * latency on cold start.
      */
+    /**
+     * Catch ChatReadCount.lastReadTime up to the value carried in each
+     * conversation file's localAppData. Drive-sync of conversation files
+     * (cold load + peer-device echoes) updates DriveMainIndex but not
+     * ChatReadCount; this hook keeps the SQL-queryable index aligned with
+     * the file-of-record.
+     *
+     * Read prior + compare locally before issuing the upsert — the upsert's
+     * MAX(...) clause would also keep us from going backward, but it would
+     * still take a write lock on every cold-load row even when nothing
+     * actually needs updating. A cheap read avoids that.
+     */
+    private suspend fun mirrorLastReadIntoChatReadCount(files: List<HomebaseFile>) {
+        for (file in files) {
+            val uniqueId = file.fileMetadata.appData.uniqueId ?: continue
+            val raw = file.fileMetadata.localAppData?.content ?: continue
+            val localAppData = try {
+                OdinSystemSerializer.deserialize<ConversationLocalAppDataJson>(raw)
+            } catch (t: Throwable) {
+                continue
+            }
+            val incoming = localAppData.lastReadTime ?: continue
+            val prior = dbm.chatReadCount.selectLastReadTimeMs(uniqueId)
+            if (prior != null && prior >= incoming.milliseconds) continue
+            dbm.chatReadCount.upsertLastReadTime(uniqueId, incoming)
+        }
+    }
+
     private suspend fun loadBasicConversations() {
         val startedAt = Clock.System.now().toEpochMilliseconds()
         val c = credentialsManager.requireActiveCredentials()
@@ -574,6 +609,12 @@ class ConversationStream(
 
         val files = dbm.chatReadCount.selectAllConversations(c.getIdentityId())
         val afterQuery = Clock.System.now().toEpochMilliseconds()
+
+        // Catch ChatReadCount up to whatever the conversation files say —
+        // necessary on cold load because mark-as-read advances from prior
+        // sessions on other devices may have synced into the file's localAppData
+        // without ever touching this device's ChatReadCount table.
+        mirrorLastReadIntoChatReadCount(files)
 
         val basic = files.map { file ->
             val ui = mapper.mapToBasic(file)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
+import kotlin.time.Instant
 import kotlin.uuid.Uuid
 
 class ConversationStream(
@@ -729,46 +730,27 @@ class ConversationStream(
     }
 
     /**
-     * Single-conversation variant of [enrichAllConversationsWithUnreadCounts] — patches the
-     * unread count for one conversation without re-scanning the whole list.
-     * Called from message-read actions after the local read timestamp is
-     * advanced for a specific conversation.
+     * Patch the in-memory entry for [conversationId] to reflect a successful
+     * mark-as-read advance: set lastRead to [newLastRead] and re-derive
+     * unreadCount from ChatReadCount. Single state emission so the UI sees both
+     * deltas at once. No-op if the conversation isn't in memory yet.
      */
-    override suspend fun enrichOneConversationWithUnreadCount(conversationId: Uuid) {
-        Logger.d(tag = "MarkAsRead") {
-            "ConversationStream.enrichOneConversationWithUnreadCount: enter convo=$conversationId"
-        }
+    override suspend fun applyLocalAdvance(conversationId: Uuid, newLastRead: Instant) {
+        val current = _conversations.value
+        val index = current.items.indexOfFirst { it.id == conversationId }
+        if (index < 0) return
+
         val c = credentialsManager.requireActiveCredentials()
         val newCount = dbm.chatReadCount
             .selectUnreadCountForConversation(c.getIdentityId(), conversationId, c.domain)
             .toInt()
-        Logger.d(tag = "MarkAsRead") {
-            "ConversationStream.enrichOneConversationWithUnreadCount: db newCount=$newCount convo=$conversationId"
-        }
-
-        val current = _conversations.value
-        val index = current.items.indexOfFirst { it.id == conversationId }
-        if (index < 0) {
-            Logger.w(tag = "MarkAsRead") {
-                "ConversationStream.enrichOneConversationWithUnreadCount: convo=$conversationId NOT FOUND in in-memory list (size=${current.items.size}) — UI badge will not update from this call"
-            }
-            return
-        }
 
         val convo = current.items[index]
-        if (convo.unreadCount == newCount) {
-            Logger.d(tag = "MarkAsRead") {
-                "ConversationStream.enrichOneConversationWithUnreadCount: convo=$conversationId no-op (unreadCount already $newCount)"
-            }
-            return
-        }
+        if (convo.lastRead == newLastRead && convo.unreadCount == newCount) return
 
-        Logger.d(tag = "MarkAsRead") {
-            "ConversationStream.enrichOneConversationWithUnreadCount: convo=$conversationId unread ${convo.unreadCount}->$newCount (publishing to StateFlow)"
-        }
-        Logger.d("ConversationStream: unreadSync convo=${conversationId} ${convo.unreadCount}->${newCount}")
+        Logger.d("ConversationStream: unreadSync convo=$conversationId ${convo.unreadCount}->$newCount")
         val updated = current.items.toMutableList().apply {
-            this[index] = convo.copy(unreadCount = newCount)
+            this[index] = convo.copy(lastRead = newLastRead, unreadCount = newCount)
         }
         _conversations.value = current.copy(items = updated)
     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -112,7 +112,7 @@ class ConversationStream(
             eventBus.events.collect { event ->
 
                 if (event is BackendEvent.ConnectionOnline) {
-                    enrichWithUnreadCounts()
+                    enrichAllConversationsWithUnreadCounts()
                     return@collect
                 }
 
@@ -699,7 +699,7 @@ class ConversationStream(
      *
      * Safe to defer, safe to skip, safe to retry.
      */
-    suspend fun enrichWithUnreadCounts() {
+    suspend fun enrichAllConversationsWithUnreadCounts() {
         val startedAt = Clock.System.now().toEpochMilliseconds()
         val c = credentialsManager.requireActiveCredentials()
         val unread = dbm.chatReadCount.selectAllUnreadCount(c.getIdentityId(), c.domain)
@@ -724,33 +724,33 @@ class ConversationStream(
         )
 
         Logger.i(tag = "ConvListPerf") {
-            "enrichWithUnreadCounts=${Clock.System.now().toEpochMilliseconds() - startedAt}ms changedRows=$changed totalRows=${current.items.size}"
+            "enrichAllConversationsWithUnreadCounts=${Clock.System.now().toEpochMilliseconds() - startedAt}ms changedRows=$changed totalRows=${current.items.size}"
         }
     }
 
     /**
-     * Single-conversation variant of [enrichWithUnreadCounts] — patches the
+     * Single-conversation variant of [enrichAllConversationsWithUnreadCounts] — patches the
      * unread count for one conversation without re-scanning the whole list.
      * Called from message-read actions after the local read timestamp is
      * advanced for a specific conversation.
      */
-    override suspend fun enrichConversationWithUnreadCounts(conversationId: Uuid) {
+    override suspend fun enrichOneConversationWithUnreadCount(conversationId: Uuid) {
         Logger.d(tag = "MarkAsRead") {
-            "ConversationStream.enrichConversationWithUnreadCounts: enter convo=$conversationId"
+            "ConversationStream.enrichOneConversationWithUnreadCount: enter convo=$conversationId"
         }
         val c = credentialsManager.requireActiveCredentials()
         val newCount = dbm.chatReadCount
-            .selectUnreadCountForConversation(c.getIdentityId(), conversationId)
+            .selectUnreadCountForConversation(c.getIdentityId(), conversationId, c.domain)
             .toInt()
         Logger.d(tag = "MarkAsRead") {
-            "ConversationStream.enrichConversationWithUnreadCounts: db newCount=$newCount convo=$conversationId"
+            "ConversationStream.enrichOneConversationWithUnreadCount: db newCount=$newCount convo=$conversationId"
         }
 
         val current = _conversations.value
         val index = current.items.indexOfFirst { it.id == conversationId }
         if (index < 0) {
             Logger.w(tag = "MarkAsRead") {
-                "ConversationStream.enrichConversationWithUnreadCounts: convo=$conversationId NOT FOUND in in-memory list (size=${current.items.size}) — UI badge will not update from this call"
+                "ConversationStream.enrichOneConversationWithUnreadCount: convo=$conversationId NOT FOUND in in-memory list (size=${current.items.size}) — UI badge will not update from this call"
             }
             return
         }
@@ -758,13 +758,13 @@ class ConversationStream(
         val convo = current.items[index]
         if (convo.unreadCount == newCount) {
             Logger.d(tag = "MarkAsRead") {
-                "ConversationStream.enrichConversationWithUnreadCounts: convo=$conversationId no-op (unreadCount already $newCount)"
+                "ConversationStream.enrichOneConversationWithUnreadCount: convo=$conversationId no-op (unreadCount already $newCount)"
             }
             return
         }
 
         Logger.d(tag = "MarkAsRead") {
-            "ConversationStream.enrichConversationWithUnreadCounts: convo=$conversationId unread ${convo.unreadCount}->$newCount (publishing to StateFlow)"
+            "ConversationStream.enrichOneConversationWithUnreadCount: convo=$conversationId unread ${convo.unreadCount}->$newCount (publishing to StateFlow)"
         }
         Logger.d("ConversationStream: unreadSync convo=${conversationId} ${convo.unreadCount}->${newCount}")
         val updated = current.items.toMutableList().apply {
@@ -796,7 +796,7 @@ class ConversationStream(
             // then admins (group-settings only), then unread counts.
             enrichWithLastMessages()
             enrichWithAdmins()
-            enrichWithUnreadCounts()
+            enrichAllConversationsWithUnreadCounts()
         }
 
         // Reactively update share cache when conversations or contacts change,
@@ -930,7 +930,7 @@ data class EnrichmentState(
     /** `true` once [ConversationStream.enrichWithAdmins] has resolved
      *  admin sets for group conversations. */
     val hasAdmins: Boolean = false,
-    /** `true` once [ConversationStream.enrichWithUnreadCounts] has applied
+    /** `true` once [ConversationStream.enrichAllConversationsWithUnreadCounts] has applied
      *  the unread counts from ChatReadCount. */
     val hasUnreadCounts: Boolean = false,
 )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -755,7 +755,13 @@ class ConversationStream(
     override suspend fun applyLocalAdvance(conversationId: Uuid, newLastRead: Instant) {
         val current = _conversations.value
         val index = current.items.indexOfFirst { it.id == conversationId }
-        if (index < 0) return
+        if (index < 0) {
+            Logger.w(tag = "MarkAsRead") {
+                "ConversationStream.applyLocalAdvance: convo=$conversationId NOT FOUND " +
+                        "in in-memory list (size=${current.items.size}) — UI badge will not update"
+            }
+            return
+        }
 
         val c = credentialsManager.requireActiveCredentials()
         val newCount = dbm.chatReadCount
@@ -960,6 +966,12 @@ internal suspend fun mirrorLastReadIntoChatReadCount(
         val localAppData = try {
             OdinSystemSerializer.deserialize<ConversationLocalAppDataJson>(raw)
         } catch (t: Throwable) {
+            // One bad row shouldn't poison cold-load — but make it visible
+            // instead of silent so we can investigate corrupted appdata.
+            Logger.w(throwable = t, tag = "ConversationStream") {
+                "mirrorLastReadIntoChatReadCount: failed to deserialise localAppData " +
+                        "for convo=$uniqueId — skipping row"
+            }
             continue
         }
         val incoming = localAppData.lastReadTime ?: continue

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/UnreadCountEnricher.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/UnreadCountEnricher.kt
@@ -10,5 +10,5 @@ import kotlin.uuid.Uuid
  * light. ConversationStream is the production implementation.
  */
 interface UnreadCountEnricher {
-    suspend fun enrichConversationWithUnreadCounts(conversationId: Uuid)
+    suspend fun enrichOneConversationWithUnreadCount(conversationId: Uuid)
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/UnreadCountEnricher.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/UnreadCountEnricher.kt
@@ -1,14 +1,21 @@
 package id.homebase.chat.services.convo
 
+import kotlin.time.Instant
 import kotlin.uuid.Uuid
 
 /**
- * Narrow seam for enriching a single conversation's unread count.
+ * Narrow seam for patching a single conversation's mark-as-read state into
+ * the in-memory ConversationStream.
  *
- * Lets callers like ChatMessageActionService depend on just this one method
- * rather than the full ConversationStream, which keeps their test fixtures
- * light. ConversationStream is the production implementation.
+ * Used by ChatMessageActionService after it advances ChatReadCount.lastReadTime,
+ * to immediately reflect the new lastRead and recomputed unreadCount in the UI
+ * without waiting for the conversation-file appdata round-trip via BatchReceived.
  */
 interface UnreadCountEnricher {
-    suspend fun enrichOneConversationWithUnreadCount(conversationId: Uuid)
+    /**
+     * Set [conversationId]'s [ConversationUiModel.lastRead] to [newLastRead] and
+     * recompute its [ConversationUiModel.unreadCount] from ChatReadCount in a
+     * single atomic state emission. No-op if the conversation isn't in memory.
+     */
+    suspend fun applyLocalAdvance(conversationId: Uuid, newLastRead: Instant)
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
@@ -9,6 +9,7 @@ import id.homebase.api.client.drives.FileSystemType
 import id.homebase.api.client.drives.HomebaseFile
 import id.homebase.api.client.drives.ServerMetadata
 import id.homebase.api.client.drives.files.AppFileMetaData
+import id.homebase.api.client.drives.files.ArchivalStatus
 import id.homebase.api.client.drives.files.FileMetadata
 import id.homebase.api.client.drives.files.LocalAppMetadata
 import id.homebase.api.client.drives.files.PayloadDescriptor
@@ -361,6 +362,10 @@ class OptimisticWriter(
                 appData = existingFile.fileMetadata.appData.copy(
                     content = "",
                     previewThumbnail = null,
+                    // Mirror the soft-delete into the SQL-queryable archivalStatus
+                    // column so unread-count queries can exclude this row without
+                    // having to deserialise the jsonHeader to read fileState.
+                    archivalStatus = ArchivalStatus.Removed,
                 )
             )
         )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -571,6 +571,15 @@ fun ConversationContent(
                                     )
                                 )
                             },
+                            onMarkAsRead = {
+                                showConversationMenu = false
+                                onUiAction(
+                                    ConversationListUiAction.MarkAsRead(
+                                        conversation.conversation.id,
+                                        messageIds = null,
+                                    )
+                                )
+                            },
                             onBlock = if (!conversation.conversation.isGroupConversation && !conversation.conversation.isWithSelf) {
                                 {
                                     showConversationMenu = false

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
@@ -534,10 +534,14 @@ fun ConversationLisContentItem(
                     onTogglePinClick = {
                         onUiAction(ConversationListUiAction.TogglePinConversation(listItem.conversation.conversation.id))
                     },
-//                    onMarkAsReadClick = {
-//                        onUiAction(ConversationListUiAction.MarkAsRead(listItem.conversation.conversation.id, listItem.conversation.conversation.la))
-//                    },
-                    onMarkAsReadClick = null, //no support for this
+                    onMarkAsReadClick = {
+                        onUiAction(
+                            ConversationListUiAction.MarkAsRead(
+                                listItem.conversation.conversation.id,
+                                messageIds = null,
+                            )
+                        )
+                    },
 
                     isSelected = listItem.conversation.conversation.id == selectedConversationId,
                 )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/Menu.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/Menu.kt
@@ -101,6 +101,7 @@ fun ConversationMenu(
     onArchive: () -> Unit,
     onClear: () -> Unit,
     onIntroduceEveryone: () -> Unit,
+    onMarkAsRead: (() -> Unit)? = null,
     onBlock: (() -> Unit)? = null,
 ) {
     DropdownMenu(
@@ -130,6 +131,16 @@ fun ConversationMenu(
             onClick = onSearch,
             text = { Text(text = stringResource(MR.string.search)) },
             leadingIcon = { Icon(imageVector = Icons.Filled.Search, contentDescription = null) })
+
+        if (onMarkAsRead != null) {
+            DropdownMenuItem(
+                onClick = onMarkAsRead,
+                text = { Text(text = stringResource(MR.string.chat_mark_all_as_read)) },
+                leadingIcon = {
+                    Icon(imageVector = Icons.Default.MarkChatRead, contentDescription = null)
+                },
+            )
+        }
 
         HorizontalDivider()
 

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTest.kt
@@ -408,4 +408,71 @@ class ChatMessageActionServiceTest {
             assertEquals(listOf(convoId), fixture.localLastReadUpdater.calls.map { it.conversationId })
         }
     }
+
+    // ----- markAllAsRead (bulk dismiss from menu) -----
+
+    @Test
+    fun markAllAsRead_advancesLastReadTimeToLatestMessageTimestamp() = runTest {
+        ChatMessageActionServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = Uuid.random()
+            val latest = kotlin.time.Instant.fromEpochMilliseconds(5_000L)
+            fixture.participantLookup.setLastRead(
+                conversationId = convoId,
+                lastRead = kotlin.time.Instant.fromEpochMilliseconds(1_000L),
+                latestMessageTimestamp = latest,
+            )
+
+            service.markAllAsRead(convoId)
+
+            // Local read pointer advanced to the conversation's latest message.
+            assertEquals(5_000L, fixture.dbm.chatReadCount.selectLastReadTimeMs(convoId))
+            assertEquals(
+                listOf(convoId to latest),
+                fixture.unreadCountEnricher.calls.map { it.conversationId to it.newLastRead },
+            )
+            assertEquals(
+                listOf(convoId),
+                fixture.localLastReadUpdater.calls.map { it.conversationId },
+            )
+            // Bulk dismiss must NOT impersonate per-message read receipts.
+            assertTrue(fixture.drainOutbox().isEmpty())
+        }
+    }
+
+    @Test
+    fun markAllAsRead_isNoOp_whenAlreadyAtLatest() = runTest {
+        ChatMessageActionServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = Uuid.random()
+            // lastRead == latestMessageTimestamp via the setLastRead default.
+            fixture.participantLookup.setLastRead(
+                conversationId = convoId,
+                lastRead = kotlin.time.Instant.fromEpochMilliseconds(5_000L),
+            )
+
+            service.markAllAsRead(convoId)
+
+            assertNull(fixture.dbm.chatReadCount.selectLastReadTimeMs(convoId))
+            assertTrue(fixture.unreadCountEnricher.calls.isEmpty())
+            assertTrue(fixture.localLastReadUpdater.calls.isEmpty())
+            assertTrue(fixture.drainOutbox().isEmpty())
+        }
+    }
+
+    @Test
+    fun markAllAsRead_isNoOp_whenConversationNotInMemory() = runTest {
+        ChatMessageActionServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = Uuid.random()
+            // No setLastRead call → fake returns null from getConversationById.
+
+            service.markAllAsRead(convoId)
+
+            assertNull(fixture.dbm.chatReadCount.selectLastReadTimeMs(convoId))
+            assertTrue(fixture.unreadCountEnricher.calls.isEmpty())
+            assertTrue(fixture.localLastReadUpdater.calls.isEmpty())
+            assertTrue(fixture.drainOutbox().isEmpty())
+        }
+    }
 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTest.kt
@@ -174,7 +174,7 @@ class ChatMessageActionServiceTest {
 
             service.markAsReadByFiles(convoId, listOf(id))
 
-            assertEquals(listOf(convoId), fixture.unreadCountEnricher.calls)
+            assertEquals(listOf(convoId), fixture.unreadCountEnricher.calls.map { it.conversationId })
             assertEquals(listOf(convoId), fixture.localLastReadUpdater.calls.map { it.conversationId })
         }
     }
@@ -359,7 +359,7 @@ class ChatMessageActionServiceTest {
 
             // But we did view the message, so local read state must advance.
             assertEquals(100L, fixture.dbm.chatReadCount.selectLastReadTimeMs(convoId))
-            assertEquals(listOf(convoId), fixture.unreadCountEnricher.calls)
+            assertEquals(listOf(convoId), fixture.unreadCountEnricher.calls.map { it.conversationId })
             assertEquals(listOf(convoId), fixture.localLastReadUpdater.calls.map { it.conversationId })
         }
     }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTest.kt
@@ -179,6 +179,51 @@ class ChatMessageActionServiceTest {
         }
     }
 
+    @Test
+    fun markAsReadByFiles_gateSkipsLocalAdvanceWhenInMemoryLastReadIsAlreadyAheadButReceiptsStillFire() = runTest {
+        // Reproduces the click-around-no-op scenario the in-memory gate is for:
+        // ConversationUiModel.lastRead is already ≥ max viewed userDate, so the
+        // upsert + appdata round-trip + enrich are redundant. Receipts for any
+        // peer-authored unread records must still go to the outbox — they're
+        // gated independently of the local read pointer.
+        ChatMessageActionServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = Uuid.random()
+            val peer = "alice.test"
+
+            // Two peer messages, max userDate 200. Both have localReadTimestamp=null
+            // so they're receipt-eligible.
+            val m1 = fixture.seedMessage(conversationId = convoId, senderDomain = peer, userDateMs = 100L)
+            val m2 = fixture.seedMessage(conversationId = convoId, senderDomain = peer, userDateMs = 200L)
+
+            // In-memory model is already past 200ms — gate should fire.
+            fixture.participantLookup.setLastRead(
+                convoId,
+                kotlin.time.Instant.fromEpochMilliseconds(200L),
+            )
+
+            service.markAsReadByFiles(convoId, listOf(m1, m2))
+
+            // Receipts still go: outbox carries both eligible fileIds.
+            val row = fixture.drainOutbox()
+                .single { it.uploadType == DriveOutboxUploader.SendReadReceiptByFileIds }
+            val payload = OdinSystemSerializer.deserialize<SendReadReceiptByFileIdsOutboxRequest>(
+                row.json.decodeToString()
+            )
+            val eligibleFileIds = fixture.messageLookup.records
+                .filter { it.id == m1 || it.id == m2 }
+                .map { it.fileId }
+                .toSet()
+            assertEquals(eligibleFileIds, payload.fileIds.toSet())
+
+            // Local-state work is skipped: ChatReadCount untouched, no local
+            // updater call, no enrich emission.
+            assertNull(fixture.dbm.chatReadCount.selectLastReadTimeMs(convoId))
+            assertTrue(fixture.localLastReadUpdater.calls.isEmpty())
+            assertTrue(fixture.unreadCountEnricher.calls.isEmpty())
+        }
+    }
+
     // ----- deleteMessage propagation contract -----
     //
     // Pins what `deleteMessage` puts on the outbox so that "Delete for everyone"

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTest.kt
@@ -20,10 +20,14 @@ import kotlinx.coroutines.test.runTest
 /**
  * Tests for [ChatMessageActionService.markAsReadByFiles].
  *
- * The load-bearing invariant: `newReadTime = unreadRecords.maxOf { it.userDate }`
- * must run **after** the filter (self-authored / already-read / deleted /
- * pending-send are excluded). A filtered-out record with a later userDate must
- * not leak into newReadTime or the upserted lastReadTime.
+ * Two distinct concerns:
+ *   - **Receipt outbox**: only peer-authored, unread, non-deleted, non-pending records
+ *     get a read receipt enqueued.
+ *   - **Local lastReadTime**: advances to cover anything the user has actually viewed —
+ *     including self-authored and already-read messages — so the unread count reflects
+ *     reality even in Note-to-Self conversations. Only deleted/pending-send records are
+ *     excluded from the date computation (deleted aren't shown; pending-send userDates
+ *     are unreliable).
  */
 class ChatMessageActionServiceTest {
 
@@ -98,21 +102,21 @@ class ChatMessageActionServiceTest {
     }
 
     @Test
-    fun markAsReadByFiles_pickMaxUserDate_ignoresFilteredOutRecordsEvenIfLater() = runTest {
+    fun markAsReadByFiles_pickMaxUserDate_excludesDeletedAndPendingButIncludesViewedSelfAndRead() = runTest {
         ChatMessageActionServiceTestFixture().use { fixture ->
             val service = fixture.build(scope = this)
             val convoId = Uuid.random()
             val peer = "alice.test"
             val self = fixture.testDomain
 
-            // Peer-authored, unread — eligible. Max is 200.
+            // Peer-authored, unread — eligible for receipt.
             val m1 = fixture.seedMessage(conversationId = convoId, senderDomain = peer, userDateMs = 100L)
             val m2 = fixture.seedMessage(conversationId = convoId, senderDomain = peer, userDateMs = 200L)
 
-            // Self-authored, userDate 500 — must NOT win.
+            // Self-authored, userDate 500 — viewed (advances local lastReadTime), not receipted.
             val mSelf = fixture.seedMessage(conversationId = convoId, senderDomain = self, userDateMs = 500L)
 
-            // Peer-authored but already-read, userDate 400 — must NOT win.
+            // Peer-authored but already-read, userDate 400 — viewed, not receipted.
             val mRead = fixture.seedMessage(
                 conversationId = convoId,
                 senderDomain = peer,
@@ -120,7 +124,7 @@ class ChatMessageActionServiceTest {
                 alreadyRead = true,
             )
 
-            // Peer-authored but deleted, userDate 700 — must NOT win.
+            // Peer-authored but deleted, userDate 700 — must NOT advance lastReadTime.
             val mDeleted = fixture.seedMessage(
                 conversationId = convoId,
                 senderDomain = peer,
@@ -128,7 +132,7 @@ class ChatMessageActionServiceTest {
                 isDeleted = true,
             )
 
-            // Peer-authored but pending-send, userDate 800 — must NOT win.
+            // Peer-authored but pending-send, userDate 800 — must NOT advance lastReadTime.
             val mPending = fixture.seedMessage(
                 conversationId = convoId,
                 senderDomain = peer,
@@ -139,12 +143,13 @@ class ChatMessageActionServiceTest {
             service.markAsReadByFiles(convoId, listOf(m1, m2, mSelf, mRead, mDeleted, mPending))
 
             assertEquals(
-                200L,
+                500L,
                 fixture.dbm.chatReadCount.selectLastReadTimeMs(convoId),
-                "newReadTime must be the max over filtered-in records only, not the whole batch",
+                "newReadTime must be the max over viewed records (excluding deleted/pending-send only) — " +
+                        "self-authored & already-read still mark 'I've read up to here'",
             )
 
-            // The outbox payload must only contain the eligible (m1, m2) fileIds.
+            // The outbox payload must only contain the receipt-eligible (m1, m2) fileIds.
             val row = fixture.drainOutbox()
                 .single { it.uploadType == DriveOutboxUploader.SendReadReceiptByFileIds }
             val payload = OdinSystemSerializer.deserialize<SendReadReceiptByFileIdsOutboxRequest>(
@@ -155,30 +160,6 @@ class ChatMessageActionServiceTest {
                 .map { it.fileId }
                 .toSet()
             assertEquals(eligibleFileIds, payload.fileIds.toSet())
-        }
-    }
-
-    @Test
-    fun markAsReadByFiles_sameNewReadTimeAppliedToAllDistinctConversations() = runTest {
-        ChatMessageActionServiceTestFixture().use { fixture ->
-            val service = fixture.build(scope = this)
-            val convoA = Uuid.random()
-            val convoB = Uuid.random()
-
-            val mA = fixture.seedMessage(
-                conversationId = convoA, senderDomain = "alice.test", userDateMs = 300L,
-            )
-            val mB = fixture.seedMessage(
-                conversationId = convoB, senderDomain = "bob.test", userDateMs = 500L,
-            )
-
-            service.markAsReadByFiles(convoA, listOf(mA, mB))
-
-            // Current behavior: newReadTime is the GLOBAL max across the batch (500)
-            // and the same value is applied to every distinct conversation. Pinning
-            // this so that a future per-conversation-max refactor is intentional.
-            assertEquals(500L, fixture.dbm.chatReadCount.selectLastReadTimeMs(convoA))
-            assertEquals(500L, fixture.dbm.chatReadCount.selectLastReadTimeMs(convoB))
         }
     }
 
@@ -356,14 +337,15 @@ class ChatMessageActionServiceTest {
     }
 
     @Test
-    fun markAsReadByFiles_noUnreadRecords_returnsEarlyWithNoSideEffects() = runTest {
+    fun markAsReadByFiles_onlySelfAuthored_skipsOutboxButAdvancesLocalReadState() = runTest {
         ChatMessageActionServiceTestFixture().use { fixture ->
             val service = fixture.build(scope = this)
             val convoId = Uuid.random()
 
-            // Only self-authored — all filtered out, unreadRecords ends up empty.
-            // Realistic: the scroll autoscan in ConversationMessagesPane can hand us
-            // a batch of ids where every record is self-authored or already-read.
+            // Only self-authored — nothing to receipt to a peer.
+            // Realistic: Note-to-Self conversations, where every visible message is
+            // self-authored. The local lastReadTime must still advance, otherwise the
+            // unread count sticks at whatever stale value the DB has.
             val id = fixture.seedMessage(
                 conversationId = convoId,
                 senderDomain = fixture.testDomain,
@@ -372,10 +354,13 @@ class ChatMessageActionServiceTest {
 
             service.markAsReadByFiles(convoId, listOf(id))
 
-            // Nothing to receipt — no outbox row, no local upsert, no enrichment.
+            // No peer to receipt to — outbox stays empty.
             assertTrue(fixture.drainOutbox().isEmpty())
-            assertTrue(fixture.unreadCountEnricher.calls.isEmpty())
-            assertTrue(fixture.localLastReadUpdater.calls.isEmpty())
+
+            // But we did view the message, so local read state must advance.
+            assertEquals(100L, fixture.dbm.chatReadCount.selectLastReadTimeMs(convoId))
+            assertEquals(listOf(convoId), fixture.unreadCountEnricher.calls)
+            assertEquals(listOf(convoId), fixture.localLastReadUpdater.calls.map { it.conversationId })
         }
     }
 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
@@ -113,6 +113,8 @@ class ChatMessageActionServiceTestFixture(
         private set
     lateinit var unreadCountEnricher: FakeUnreadCountEnricher
         private set
+    lateinit var participantLookup: FakeConversationParticipantLookup
+        private set
 
     suspend fun build(
         scope: CoroutineScope = TestScope(),
@@ -197,6 +199,7 @@ class ChatMessageActionServiceTestFixture(
         messageLookup = FakeMessageLookup()
         localLastReadUpdater = FakeLocalLastReadUpdater()
         unreadCountEnricher = FakeUnreadCountEnricher()
+        participantLookup = FakeConversationParticipantLookup()
 
         val optimisticWriter = OptimisticWriter(
             credentialsManager = credentialsManager,
@@ -221,7 +224,7 @@ class ChatMessageActionServiceTestFixture(
 
         return ChatMessageActionService(
             conversationService = conversationService,
-            participantLookup = FakeConversationParticipantLookup(),
+            participantLookup = participantLookup,
             localLastReadUpdater = localLastReadUpdater,
             unreadCountEnricher = unreadCountEnricher,
             messageLookup = messageLookup,
@@ -569,14 +572,35 @@ class FakeUnreadCountEnricher : UnreadCountEnricher {
 }
 
 /**
- * Tests don't seed a conversation list, so this fake always returns null —
- * which makes ChatMessageActionService.markAsReadByFiles skip the in-memory
- * lastRead gate and exercise the full upsert + enrich path the suite asserts.
+ * Default behaviour: returns null from `getConversationById`, so
+ * `ChatMessageActionService.markAsReadByFiles` skips the in-memory `lastRead`
+ * gate and exercises the full upsert + enrich path the rest of the suite
+ * asserts. Tests that want to exercise the gate can stash a stub model via
+ * [setLastRead] keyed by id.
  */
 class FakeConversationParticipantLookup :
     id.homebase.chat.services.convo.ConversationParticipantLookup {
+    private val conversations = mutableMapOf<Uuid, id.homebase.chat.data.ConversationUiModel>()
+
+    /** Stash a stub conversation whose `lastRead` is what the gate will compare against. */
+    fun setLastRead(conversationId: Uuid, lastRead: kotlin.time.Instant) {
+        conversations[conversationId] = id.homebase.chat.data.ConversationUiModel(
+            id = conversationId,
+            name = "",
+            lastMessage = "",
+            latestMessageTimestamp = lastRead,
+            avatarInitials = "",
+            avatarTiny = null,
+            lastRead = lastRead,
+            avatarModel = id.homebase.core.avatars.ConversationAvatarModel(
+                type = id.homebase.core.avatars.ConversationAvatarModel.Type.GroupFallback
+            ),
+            admins = emptySet(),
+        )
+    }
+
     override fun getConversationById(conversationId: Uuid):
-            id.homebase.chat.data.ConversationUiModel? = null
+            id.homebase.chat.data.ConversationUiModel? = conversations[conversationId]
 
     override suspend fun getRecipients(
         conversationId: Uuid,

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
@@ -582,13 +582,22 @@ class FakeConversationParticipantLookup :
     id.homebase.chat.services.convo.ConversationParticipantLookup {
     private val conversations = mutableMapOf<Uuid, id.homebase.chat.data.ConversationUiModel>()
 
-    /** Stash a stub conversation whose `lastRead` is what the gate will compare against. */
-    fun setLastRead(conversationId: Uuid, lastRead: kotlin.time.Instant) {
+    /**
+     * Stash a stub conversation whose `lastRead` and `latestMessageTimestamp`
+     * are what `markAsReadByFiles`'s gate / `markAllAsRead` will read.
+     * `latestMessageTimestamp` defaults to the same value as `lastRead`
+     * (the "fully read" case); pass it explicitly to simulate a backlog.
+     */
+    fun setLastRead(
+        conversationId: Uuid,
+        lastRead: kotlin.time.Instant,
+        latestMessageTimestamp: kotlin.time.Instant = lastRead,
+    ) {
         conversations[conversationId] = id.homebase.chat.data.ConversationUiModel(
             id = conversationId,
             name = "",
             lastMessage = "",
-            latestMessageTimestamp = lastRead,
+            latestMessageTimestamp = latestMessageTimestamp,
             avatarInitials = "",
             avatarTiny = null,
             lastRead = lastRead,

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
@@ -221,6 +221,7 @@ class ChatMessageActionServiceTestFixture(
 
         return ChatMessageActionService(
             conversationService = conversationService,
+            participantLookup = FakeConversationParticipantLookup(),
             localLastReadUpdater = localLastReadUpdater,
             unreadCountEnricher = unreadCountEnricher,
             messageLookup = messageLookup,
@@ -557,10 +558,30 @@ class FakeLocalLastReadUpdater : LocalLastReadUpdater {
 }
 
 class FakeUnreadCountEnricher : UnreadCountEnricher {
-    val calls = mutableListOf<Uuid>()
-    override suspend fun enrichOneConversationWithUnreadCount(conversationId: Uuid) {
-        calls += conversationId
+    data class Call(val conversationId: Uuid, val newLastRead: kotlin.time.Instant)
+    val calls = mutableListOf<Call>()
+    override suspend fun applyLocalAdvance(
+        conversationId: Uuid,
+        newLastRead: kotlin.time.Instant,
+    ) {
+        calls += Call(conversationId, newLastRead)
     }
+}
+
+/**
+ * Tests don't seed a conversation list, so this fake always returns null —
+ * which makes ChatMessageActionService.markAsReadByFiles skip the in-memory
+ * lastRead gate and exercise the full upsert + enrich path the suite asserts.
+ */
+class FakeConversationParticipantLookup :
+    id.homebase.chat.services.convo.ConversationParticipantLookup {
+    override fun getConversationById(conversationId: Uuid):
+            id.homebase.chat.data.ConversationUiModel? = null
+
+    override suspend fun getRecipients(
+        conversationId: Uuid,
+        additionalRecipients: List<id.homebase.api.common.OdinId>,
+    ): List<id.homebase.api.common.OdinId> = emptyList()
 }
 
 private object ThrowingOutboxUploader : OutboxUploader {

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
@@ -558,7 +558,7 @@ class FakeLocalLastReadUpdater : LocalLastReadUpdater {
 
 class FakeUnreadCountEnricher : UnreadCountEnricher {
     val calls = mutableListOf<Uuid>()
-    override suspend fun enrichConversationWithUnreadCounts(conversationId: Uuid) {
+    override suspend fun enrichOneConversationWithUnreadCount(conversationId: Uuid) {
         calls += conversationId
     }
 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationStreamMirrorTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationStreamMirrorTest.kt
@@ -1,0 +1,203 @@
+package id.homebase.chat.services.convo
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.common.time.UnixTimeUtc
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.sync.database.OdinDatabase
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Focused tests for [mirrorLastReadIntoChatReadCount] — the helper that
+ * keeps ChatReadCount in sync with each conversation file's
+ * localAppData.lastReadTime when those files arrive via cold-load or
+ * peer-device drive-sync.
+ */
+class ConversationStreamMirrorTest {
+
+    private lateinit var dbm: DatabaseManager
+
+    @BeforeTest
+    fun setup() {
+        dbm = DatabaseManager({
+            val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+            OdinDatabase.Schema.create(driver)
+            driver
+        })
+    }
+
+    @AfterTest
+    fun teardown() {
+        dbm.close()
+    }
+
+    @Test
+    fun mirror_advancesChatReadCount_whenFileIsNewer() = runTest {
+        val convoId = Uuid.random()
+        dbm.chatReadCount.upsertLastReadTime(convoId, UnixTimeUtc(999L))
+
+        mirrorLastReadIntoChatReadCount(dbm, listOf(stubFile(convoId, lastReadMs = 1_000L)))
+
+        assertEquals(1_000L, dbm.chatReadCount.selectLastReadTimeMs(convoId))
+    }
+
+    @Test
+    fun mirror_doesNothing_whenChatReadCountIsAlreadyAhead() = runTest {
+        val convoId = Uuid.random()
+        dbm.chatReadCount.upsertLastReadTime(convoId, UnixTimeUtc(2_000L))
+
+        mirrorLastReadIntoChatReadCount(dbm, listOf(stubFile(convoId, lastReadMs = 1_000L)))
+
+        assertEquals(2_000L, dbm.chatReadCount.selectLastReadTimeMs(convoId))
+    }
+
+    @Test
+    fun mirror_isNoOp_whenAlreadyEqual() = runTest {
+        val convoId = Uuid.random()
+        dbm.chatReadCount.upsertLastReadTime(convoId, UnixTimeUtc(1_000L))
+
+        mirrorLastReadIntoChatReadCount(dbm, listOf(stubFile(convoId, lastReadMs = 1_000L)))
+
+        assertEquals(1_000L, dbm.chatReadCount.selectLastReadTimeMs(convoId))
+    }
+
+    @Test
+    fun mirror_seedsFreshRow_whenNoChatReadCountYet() = runTest {
+        val convoId = Uuid.random()
+        assertNull(dbm.chatReadCount.selectLastReadTimeMs(convoId))
+
+        mirrorLastReadIntoChatReadCount(dbm, listOf(stubFile(convoId, lastReadMs = 1_000L)))
+
+        assertEquals(1_000L, dbm.chatReadCount.selectLastReadTimeMs(convoId))
+    }
+
+    @Test
+    fun mirror_skipsFile_whenLocalAppDataLastReadTimeIsNull() = runTest {
+        val convoId = Uuid.random()
+        dbm.chatReadCount.upsertLastReadTime(convoId, UnixTimeUtc(500L))
+
+        // localAppData.content present but lastReadTime field is null.
+        mirrorLastReadIntoChatReadCount(dbm, listOf(stubFile(convoId, lastReadMs = null)))
+
+        assertEquals(500L, dbm.chatReadCount.selectLastReadTimeMs(convoId))
+    }
+
+    @Test
+    fun mirror_skipsFile_whenLocalAppDataMissing() = runTest {
+        val convoId = Uuid.random()
+
+        // No localAppData block at all on the file.
+        mirrorLastReadIntoChatReadCount(dbm, listOf(stubFile(convoId, includeLocalAppData = false)))
+
+        assertNull(dbm.chatReadCount.selectLastReadTimeMs(convoId))
+    }
+
+    @Test
+    fun mirror_handlesBatchOfFiles() = runTest {
+        val a = Uuid.random()
+        val b = Uuid.random()
+        val c = Uuid.random()
+        dbm.chatReadCount.upsertLastReadTime(a, UnixTimeUtc(100L)) // behind file
+        dbm.chatReadCount.upsertLastReadTime(b, UnixTimeUtc(999L)) // ahead of file
+
+        mirrorLastReadIntoChatReadCount(
+            dbm,
+            listOf(
+                stubFile(a, lastReadMs = 200L),
+                stubFile(b, lastReadMs = 200L),
+                stubFile(c, lastReadMs = 200L),
+            )
+        )
+
+        assertEquals(200L, dbm.chatReadCount.selectLastReadTimeMs(a))
+        assertEquals(999L, dbm.chatReadCount.selectLastReadTimeMs(b))
+        assertEquals(200L, dbm.chatReadCount.selectLastReadTimeMs(c))
+    }
+
+    /**
+     * Build a minimal conversation HomebaseFile with [uniqueId] and an
+     * optional [lastReadMs] inside `localAppData`. Driven by JSON because
+     * HomebaseFile + nested types have a long required-field list and
+     * deserialising keeps the test surface small.
+     */
+    private fun stubFile(
+        uniqueId: Uuid,
+        lastReadMs: Long? = 0L,
+        includeLocalAppData: Boolean = true,
+    ): HomebaseFile {
+        val localAppDataJson: String = if (!includeLocalAppData) {
+            "null"
+        } else {
+            // ConversationLocalAppDataJson is @Serializable; serialise via
+            // OdinSystemSerializer so the wire format is exactly what the
+            // production deserialiser expects to parse back out.
+            val ladModel = ConversationLocalAppDataJson(
+                lastReadTime = lastReadMs?.let { UnixTimeUtc(it) }
+            )
+            val ladContent = OdinSystemSerializer.serialize(ladModel)
+            // The localAppData wrapper itself is a LocalAppMetadata with `content`
+            // carrying the JSON. We embed it as a JSON-escaped string.
+            val escaped = ladContent.replace("\\", "\\\\").replace("\"", "\\\"")
+            """{"tags": [], "iv": null, "content": "$escaped"}"""
+        }
+        val json = """{
+          "fileId": "${Uuid.random()}",
+          "driveId": "${Uuid.random()}",
+          "fileState": "active",
+          "fileSystemType": "standard",
+          "serverFileIsEncrypted": "false",
+          "keyHeader": {
+            "iv": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+            "aesKey": {"bytes": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}
+          },
+          "fileMetadata": {
+            "globalTransitId": "${Uuid.random()}",
+            "created": 0,
+            "updated": 0,
+            "isEncrypted": false,
+            "senderOdinId": "test.sender",
+            "originalAuthor": "test.sender",
+            "appData": {
+              "uniqueId": "$uniqueId",
+              "tags": null,
+              "fileType": 8888,
+              "dataType": 0,
+              "groupId": null,
+              "userDate": 0,
+              "content": null,
+              "previewThumbnail": null,
+              "archivalStatus": 0
+            },
+            "localAppData": $localAppDataJson,
+            "referencedFile": null,
+            "reactionPreview": null,
+            "versionTag": "${Uuid.random()}",
+            "payloads": [],
+            "dataSource": null
+          },
+          "serverMetadata": {
+            "accessControlList": {
+              "requiredSecurityGroup": "owner",
+              "circleIdList": null,
+              "odinIdList": null
+            },
+            "doNotIndex": false,
+            "allowDistribution": false,
+            "fileSystemType": "standard",
+            "fileByteCount": 100,
+            "originalRecipientCount": 0,
+            "transferHistory": null
+          },
+          "priority": 100,
+          "fileByteCount": 100
+        }"""
+        return OdinSystemSerializer.deserialize<HomebaseFile>(json)
+    }
+}


### PR DESCRIPTION
The unread badge had three independent bugs that combined to leave conversations stuck on inflated counts (e.g. 54 for Note-to-Self).

1. Self-authored messages with NULL originalAuthor were counted as unread to yourself. The server doesn't always stamp originalAuthor on self-authored messages echoed back via drive-sync, so the SQL filter `(originalAuthor IS NULL OR != domain)` let those rows through. Switch both unread queries to `originalAuthor IS NOT NULL AND != ?` — NULL is treated as self.

2. Soft-deleted messages kept counting toward unread because fileState lives inside the encrypted jsonHeader and isn't filterable in SQL. Fix: have OptimisticWriter.writeDelete also stamp archivalStatus = ArchivalStatus.Removed (the SQL-queryable column that isSoftDeleted() already accepts), and add `archivalStatus != 2` to the unread queries.

3. ChatMessageActionService.markAsReadByFiles early-returned without advancing local lastReadTime when no records were receipt-eligible (e.g. Note-to-Self, where every message is self-authored). Refactor so the receipt outbox and the local read-pointer advance are independent: skip the outbox when there's nothing to receipt, but still upsert lastReadTime over any non-deleted, non-pending viewed record. Also drop the vestigial multi-conversation distinctBy upsert loop — the function takes a single conversationId.

Bonus: selectUnreadCountForConversation gains the same originalAuthor filter as selectAllUnreadCount (it had none before, which is why enrichOneConversationWithUnreadCount kept reporting non-zero counts even after lastReadTime advanced).

Renames for clarity:
  enrichWithUnreadCounts          -> enrichAllConversationsWithUnreadCounts
  enrichConversationWithUnreadCounts -> enrichOneConversationWithUnreadCount

Tests updated to pin the new markAsReadByFiles semantics (viewed-vs- receiptable split) and the new 3-arg
ChatReadCountWrapper.selectUnreadCountForConversation signature.