### PR TITLE
Defragmenter classifier and repair

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DriveMainIndexWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DriveMainIndexWrapper.kt
@@ -131,10 +131,20 @@ class DriveMainIndexWrapper(
         delegate.countByIdentityAndDrive(identityId, driveId).executeAsOne()
 
     /**
-     * Row shape for the Defragmenter's streaming scan — carries enough to call
-     * [HomebaseFile.isSoftDeleted] and to page forward by rowId.
+     * Row shape for the Defragmenter's streaming scan — carries enough to
+     *  - call [HomebaseFile.isSoftDeleted] from the deserialised jsonHeader,
+     *  - page forward by rowId,
+     *  - compare what's stored on the SQL side ([userDate], [archivalStatus])
+     *    against what the deserialised header says, so the classifier can
+     *    detect SQL/header drift without a second read.
      */
-    data class PagedScanRow(val rowId: Long, val fileId: Uuid, val jsonHeader: String)
+    data class PagedScanRow(
+        val rowId: Long,
+        val fileId: Uuid,
+        val userDate: Long,
+        val archivalStatus: Long,
+        val jsonHeader: String,
+    )
 
     /**
      * Keyset-paged scan of a drive's rows. Caller passes `sinceRowId = 0` on
@@ -151,8 +161,14 @@ class DriveMainIndexWrapper(
         driveId,
         sinceRowId,
         limit,
-    ) { rowId, fileId, jsonHeader ->
-        PagedScanRow(rowId = rowId, fileId = fileId, jsonHeader = jsonHeader)
+    ) { rowId, fileId, userDate, archivalStatus, jsonHeader ->
+        PagedScanRow(
+            rowId = rowId,
+            fileId = fileId,
+            userDate = userDate,
+            archivalStatus = archivalStatus,
+            jsonHeader = jsonHeader,
+        )
     }.executeAsList()
 
     suspend fun upsertDriveMainIndex(

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DriveMainIndexWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DriveMainIndexWrapper.kt
@@ -171,6 +171,32 @@ class DriveMainIndexWrapper(
         )
     }.executeAsList()
 
+    /**
+     * Defragmenter: re-project archivalStatus on a single row. Used by the
+     * repair pass to correct rows where the SQL projection has drifted from
+     * the header's soft-delete state.
+     */
+    suspend fun repairArchivalStatusByRowId(rowId: Long, archivalStatus: Long): Boolean {
+        return databaseManager.withWriteValue { db ->
+            db.driveMainIndexQueries
+                .repairArchivalStatusByRowId(archivalStatus, rowId)
+                .value > 0
+        }
+    }
+
+    /**
+     * Defragmenter: re-project userDate on a single row from the header's
+     * metadata.created fallback. Used by the repair pass to correct
+     * LegacyUserDateZero rows.
+     */
+    suspend fun repairUserDateByRowId(rowId: Long, userDate: Long): Boolean {
+        return databaseManager.withWriteValue { db ->
+            db.driveMainIndexQueries
+                .repairUserDateByRowId(userDate, rowId)
+                .value > 0
+        }
+    }
+
     suspend fun upsertDriveMainIndex(
         identityId: Uuid,
         driveId: Uuid,

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/DriveMainIndex.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/DriveMainIndex.sq
@@ -144,3 +144,16 @@ LIMIT ?;
 -- Select all records - for TESTING
 selectAll:
 SELECT * FROM DriveMainIndex;
+
+-- Defragmenter: re-project a row's archivalStatus column when the SQL value
+-- has drifted from what the deserialised jsonHeader says (the
+-- SoftDeleteArchivalMismatch case). Local-only — peers maintain their own
+-- projections from their own copies of the file.
+repairArchivalStatusByRowId:
+UPDATE DriveMainIndex SET archivalStatus = ? WHERE rowId = ?;
+
+-- Defragmenter: re-project a row's userDate column from the header's
+-- metadata.created fallback when appData.userDate was null and got stored as 0.
+-- Used by the repair pass to correct LegacyUserDateZero rows. Local-only.
+repairUserDateByRowId:
+UPDATE DriveMainIndex SET userDate = ? WHERE rowId = ?;

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/DriveMainIndex.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/DriveMainIndex.sq
@@ -126,12 +126,17 @@ countByIdentityAndDrive:
 SELECT count(*) FROM DriveMainIndex
 WHERE identityId = ? AND driveId = ?;
 
--- Page rows for a drive in rowId-ascending order, returning (rowId, fileId,
--- jsonHeader). The Defragmenter scans these chunks and applies the
--- HomebaseFile.isSoftDeleted() predicate in Kotlin; we can't filter on
--- fileState in SQL because it lives inside jsonHeader, not as a column.
+-- Page rows for a drive in rowId-ascending order, returning enough columns
+-- for the Defragmenter to (a) apply the HomebaseFile.isSoftDeleted() predicate
+-- (which lives inside jsonHeader, can't be filtered in SQL), and (b) detect
+-- known DriveMainIndex integrity issues without re-reading the row:
+--   * userDate=0 paired with non-null appData.userDate → legacy projection
+--   * archivalStatus mismatched against jsonHeader fileState → soft-delete drift
+-- The deserialised jsonHeader covers (a) and reveals appData.userDate; the SQL
+-- columns cover the projected/stored values so we can tell whether a repair
+-- UPDATE is actually needed.
 selectFileIdAndJsonByDriveSince:
-SELECT rowId, fileId, jsonHeader FROM DriveMainIndex
+SELECT rowId, fileId, userDate, archivalStatus, jsonHeader FROM DriveMainIndex
 WHERE identityId = ? AND driveId = ? AND rowId > ?
 ORDER BY rowId
 LIMIT ?;

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -221,6 +221,7 @@
     <string name="defragmenter_status_ready">Analysis complete — ready to defragment</string>
     <string name="defragmenter_status_running">Defragmenting</string>
     <string name="defragmenter_status_paused">Paused</string>
+    <string name="defragmenter_status_repairing">Repairing local index…</string>
     <string name="defragmenter_status_vacuuming">Optimizing database…</string>
     <string name="defragmenter_status_complete">Defragmentation complete</string>
     <string name="defragmenter_status_cancelled">Cancelled</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -30,7 +30,9 @@ import id.homebase.chat.services.LocalAttachmentContextStore
 import id.homebase.chat.services.PayloadBundleEncryptionService
 import id.homebase.chat.services.PayloadBundleEncryptor
 import id.homebase.chat.services.ShareSuggestionDonor
+import id.homebase.api.client.drives.HomebaseFile
 import id.homebase.chat.services.convo.ConversationLoader
+import id.homebase.chat.services.convo.ConversationMapper
 import id.homebase.chat.services.convo.ConversationService
 import id.homebase.chat.services.convo.ConversationStream
 import id.homebase.chat.services.convo.LocalLastReadUpdater
@@ -224,7 +226,39 @@ val appModule = module {
     singleOf(::ConnectionRequestService)
     singleOf(::NotificationActionBridge)
 
-    singleOf(::LiveDefragSource) bind DefragSource::class
+    single<DefragSource> {
+        // Probe for the Defragmenter's classifier: detects whether a
+        // conversation file (fileType=8888) is salvageable via
+        // ConversationMapper.mapToBasic. The mapper catches its own throws
+        // and returns a degraded `ConversationState.Invalid` model in that
+        // case, so we treat Invalid as the "unmappable" signal. An actual
+        // exception escaping the call (rare) is also treated as unmappable.
+        // ConversationMapper is a thin class with credentialsManager + dbm
+        // deps; we construct one here rather than wiring it into DI.
+        val mapper = ConversationMapper(
+            credentialsManager = get(),
+            dbm = get(),
+        )
+        val mapToBasicProbe: suspend (HomebaseFile) -> Throwable? = { file ->
+            try {
+                val ui = mapper.mapToBasic(file)
+                if (ui.conversationState == ConversationState.Invalid) {
+                    IllegalStateException("ConversationMapper returned Invalid state")
+                } else {
+                    null
+                }
+            } catch (t: Throwable) {
+                t
+            }
+        }
+        LiveDefragSource(
+            driveSyncManager = get(),
+            credentialsManager = get(),
+            databaseManager = get(),
+            driveFileProvider = get(),
+            mapToBasicProbe = mapToBasicProbe,
+        )
+    }
 
     viewModelOf(::AppViewModel)
     viewModelOf(::AppLoadingViewModel)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterScreen.kt
@@ -179,6 +179,7 @@ private fun DefragmenterContent(
                 analyzedUpto = if (state.phase is DefragmenterPhase.Analyzing)
                     state.analyzedUpto else Int.MAX_VALUE,
                 scanHeadIndex = state.scanHeadIndex,
+                cellStates = state.cellStates,
                 modifier = Modifier
                     .fillMaxSize()
                     .semantics {
@@ -263,6 +264,33 @@ private fun StatsPanel(state: DefragmenterUiState, modifier: Modifier = Modifier
             Win98Label(
                 stringResource(MR.string.defragmenter_stat_eta, formatDuration(state.estRemainingMs))
             )
+            // Per-issue tallies + colour swatches so the user can map block
+            // colour → meaning at a glance. Hidden when the count is zero so
+            // the panel doesn't grow until issues actually exist.
+            if (state.issueCountLegacyUserDateZero > 0) {
+                Win98Label(
+                    text = "Legacy userDate=0: ${state.issueCountLegacyUserDateZero}",
+                    color = Win98Palette.IssueLegacyUserDateZeroFill,
+                )
+            }
+            if (state.issueCountArchivalMismatch > 0) {
+                Win98Label(
+                    text = "Soft-delete drift: ${state.issueCountArchivalMismatch}",
+                    color = Win98Palette.IssueArchivalMismatchFill,
+                )
+            }
+            if (state.issueCountCorruptJson > 0) {
+                Win98Label(
+                    text = "Corrupt JSON: ${state.issueCountCorruptJson}",
+                    color = Win98Palette.IssueCorruptJsonFill,
+                )
+            }
+            if (state.issueCountUnmappableConvo > 0) {
+                Win98Label(
+                    text = "Unmappable conversation: ${state.issueCountUnmappableConvo}",
+                    color = Win98Palette.IssueUnmappableConvoFill,
+                )
+            }
         }
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterScreen.kt
@@ -59,6 +59,7 @@ import id.homebase.resources.defragmenter_status_complete
 import id.homebase.resources.defragmenter_status_idle
 import id.homebase.resources.defragmenter_status_paused
 import id.homebase.resources.defragmenter_status_ready
+import id.homebase.resources.defragmenter_status_repairing
 import id.homebase.resources.defragmenter_status_running
 import id.homebase.resources.defragmenter_status_vacuuming
 import id.homebase.resources.defragmenter_title_format
@@ -245,6 +246,7 @@ private fun StatsPanel(state: DefragmenterUiState, modifier: Modifier = Modifier
         DefragmenterPhase.Ready -> stringResource(MR.string.defragmenter_status_ready)
         DefragmenterPhase.Defragmenting -> stringResource(MR.string.defragmenter_status_running)
         DefragmenterPhase.Paused -> stringResource(MR.string.defragmenter_status_paused)
+        DefragmenterPhase.Repairing -> stringResource(MR.string.defragmenter_status_repairing)
         DefragmenterPhase.Vacuuming -> stringResource(MR.string.defragmenter_status_vacuuming)
         DefragmenterPhase.Complete -> stringResource(MR.string.defragmenter_status_complete)
         DefragmenterPhase.Cancelled -> stringResource(MR.string.defragmenter_status_cancelled)
@@ -341,7 +343,8 @@ private fun ActionButtons(state: DefragmenterUiState, onAction: (DefragmenterUiA
                 text = stringResource(MR.string.defragmenter_cancel),
                 enabled = phase is DefragmenterPhase.Defragmenting ||
                     phase is DefragmenterPhase.Paused ||
-                    phase is DefragmenterPhase.Analyzing,
+                    phase is DefragmenterPhase.Analyzing ||
+                    phase is DefragmenterPhase.Repairing,
                 onClick = { onAction(DefragmenterUiAction.Cancel) },
             )
         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterUiState.kt
@@ -39,6 +39,17 @@ data class DefragmenterUiState(
     // after the Sized event.
     val analyzedUpto: Int = 0,
     val analyzeTotal: Int = 0,
+    // Per-cell state codes (length == totalBlocks; default 0 = Healthy). Filled
+    // in by the analyze pipeline as classifier results arrive. The canvas reads
+    // this to pick the per-block fill colour. Mutated in place — gridVersion
+    // bumps trigger redraw. See model/CellStateCode.kt for the encoding.
+    val cellStates: ByteArray = ByteArray(0),
+    // Tally of non-Healthy classifier states for the stats panel. Updated on
+    // every Progress emit so the user sees counts climb during the scan.
+    val issueCountLegacyUserDateZero: Int = 0,
+    val issueCountArchivalMismatch: Int = 0,
+    val issueCountCorruptJson: Int = 0,
+    val issueCountUnmappableConvo: Int = 0,
 ) {
     /** True during Vacuuming and Complete — canvas tints filled blocks green. */
     val celebratory: Boolean
@@ -64,7 +75,12 @@ data class DefragmenterUiState(
             elapsedMs == other.elapsedMs &&
             estRemainingMs == other.estRemainingMs &&
             analyzedUpto == other.analyzedUpto &&
-            analyzeTotal == other.analyzeTotal
+            analyzeTotal == other.analyzeTotal &&
+            cellStates === other.cellStates &&
+            issueCountLegacyUserDateZero == other.issueCountLegacyUserDateZero &&
+            issueCountArchivalMismatch == other.issueCountArchivalMismatch &&
+            issueCountCorruptJson == other.issueCountCorruptJson &&
+            issueCountUnmappableConvo == other.issueCountUnmappableConvo
     }
 
     override fun hashCode(): Int {
@@ -77,6 +93,10 @@ data class DefragmenterUiState(
         result = 31 * result + elapsedMs.hashCode()
         result = 31 * result + analyzedUpto
         result = 31 * result + analyzeTotal
+        result = 31 * result + issueCountLegacyUserDateZero
+        result = 31 * result + issueCountArchivalMismatch
+        result = 31 * result + issueCountCorruptJson
+        result = 31 * result + issueCountUnmappableConvo
         return result
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterUiState.kt
@@ -8,6 +8,8 @@ sealed interface DefragmenterPhase {
     data object Ready : DefragmenterPhase
     data object Defragmenting : DefragmenterPhase
     data object Paused : DefragmenterPhase
+    /** Re-projecting local SQL columns for classifier-flagged rows. */
+    data object Repairing : DefragmenterPhase
     data object Vacuuming : DefragmenterPhase
     data object Complete : DefragmenterPhase
     data object Cancelled : DefragmenterPhase

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterViewModel.kt
@@ -8,8 +8,10 @@ import id.homebase.core.ui.screens.defragmenter.model.CELL_CORRUPT_JSON_HEADER
 import id.homebase.core.ui.screens.defragmenter.model.CELL_LEGACY_USERDATE_ZERO
 import id.homebase.core.ui.screens.defragmenter.model.CELL_SOFT_DELETE_ARCHIVAL_MISMATCH
 import id.homebase.core.ui.screens.defragmenter.model.CELL_UNMAPPABLE_CONVERSATION
+import id.homebase.core.ui.screens.defragmenter.model.CELL_HEALTHY
 import id.homebase.core.ui.screens.defragmenter.service.CellState
 import id.homebase.core.ui.screens.defragmenter.service.DefragAnalyzeEvent
+import id.homebase.core.ui.screens.defragmenter.service.DefragRepairEvent
 import id.homebase.core.ui.screens.defragmenter.service.DefragSource
 import id.homebase.core.ui.screens.defragmenter.service.DeletedFileRef
 import kotlinx.coroutines.Job
@@ -49,6 +51,7 @@ class DefragmenterViewModel(
     private var smoothedMovesPerSecond: Float = BASE_MOVES_PER_SECOND
 
     private var analyzeJob: Job? = null
+    private var repairJob: Job? = null
 
     // Maps grid position → file-to-hard-delete. Populated on Analyze; the
     // tick loop looks up the toIndex of each committed move here and fires
@@ -211,8 +214,15 @@ class DefragmenterViewModel(
         val s = _uiState.value
         if (s.phase !is DefragmenterPhase.Ready) return
         if (s.gapsRemaining == 0) {
-            // Nothing to animate — jump straight to vacuum+green finale.
-            enterVacuumAndComplete()
+            // No soft-deletes to compact. If the classifier flagged repair-eligible
+            // rows, run the repair pass (animates per-cell colour flips) before the
+            // vacuum/green finale. Otherwise jump straight to vacuum.
+            if (hasRepairTargets(s)) {
+                _uiState.update { it.copy(phase = DefragmenterPhase.Repairing) }
+                kickOffRepair()
+            } else {
+                enterVacuumAndComplete()
+            }
             return
         }
         runStartMark = TimeSource.Monotonic.markNow()
@@ -222,6 +232,9 @@ class DefragmenterViewModel(
         smoothedMovesPerSecond = BASE_MOVES_PER_SECOND
         _uiState.update { it.copy(phase = DefragmenterPhase.Defragmenting) }
     }
+
+    private fun hasRepairTargets(s: DefragmenterUiState): Boolean =
+        s.issueCountLegacyUserDateZero > 0 || s.issueCountArchivalMismatch > 0
 
     private fun pause() {
         val s = _uiState.value
@@ -263,6 +276,21 @@ class DefragmenterViewModel(
                     issueCountArchivalMismatch = 0,
                     issueCountCorruptJson = 0,
                     issueCountUnmappableConvo = 0,
+                )
+            }
+            return
+        }
+        if (s.phase is DefragmenterPhase.Repairing) {
+            // Stop the repair flow before flipping phase — the finally block
+            // in kickOffRepair checks phase before chaining to Vacuuming, so
+            // the order matters.
+            repairJob?.cancel()
+            repairJob = null
+            _uiState.update {
+                it.copy(
+                    phase = DefragmenterPhase.Cancelled,
+                    inFlight = emptyList(),
+                    targetHighlights = IntArray(0),
                 )
             }
             return
@@ -385,7 +413,11 @@ class DefragmenterViewModel(
             // Hard-delete any soft-deleted files that never got animated
             // (gaps whose grid bit is still 0 at defrag end).
             cleanupUnreachableGaps(grid)
-            DefragmenterPhase.Vacuuming
+            // If the classifier turned up repair-eligible rows, run the
+            // repair pass next so the user sees those cells flip colour
+            // before the vacuum/green sweep covers everything.
+            if (hasRepairTargets(state)) DefragmenterPhase.Repairing
+            else DefragmenterPhase.Vacuuming
         } else state.phase
 
         _uiState.update {
@@ -403,7 +435,75 @@ class DefragmenterViewModel(
             )
         }
 
-        if (reachedEnd) kickOffVacuum()
+        if (reachedEnd) {
+            if (phase is DefragmenterPhase.Repairing) kickOffRepair()
+            else kickOffVacuum()
+        }
+    }
+
+    /**
+     * Drive [DefragSource.repair] in the background. Each per-cell
+     * [DefragRepairEvent.Repaired] flips the matching cell's state byte to
+     * Healthy, decrements the issue tally, and bumps gridVersion so the
+     * canvas redraws. A small inter-event delay paces the animation so the
+     * user can see the colour transitions even when the underlying SQL
+     * UPDATEs are sub-millisecond. When the flow terminates we hand off to
+     * [kickOffVacuum] for the green finale.
+     */
+    private fun kickOffRepair() {
+        repairJob?.cancel()
+        repairJob = viewModelScope.launch {
+            try {
+                source.repair().collect { ev ->
+                    when (ev) {
+                        is DefragRepairEvent.Started -> Unit
+                        is DefragRepairEvent.Repaired -> applyRepaired(ev)
+                        is DefragRepairEvent.Done -> {
+                            Logger.d(tag = tag) {
+                                "Repair complete: analyzed=${ev.analyzed} " +
+                                        "repaired=${ev.repaired} " +
+                                        "(legacy=${ev.repairedLegacyUserDateZero} " +
+                                        "archival=${ev.repairedSoftDeleteArchivalMismatch}) " +
+                                        "skipped=${ev.skipped}"
+                            }
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                Logger.w(tag = tag, throwable = e) { "repair flow failed" }
+            } finally {
+                // Whether the flow completed normally or the user cancelled,
+                // only proceed to vacuum if we're still in Repairing — Cancel
+                // takes over to Cancelled and should NOT trigger vacuum.
+                if (_uiState.value.phase is DefragmenterPhase.Repairing) {
+                    kickOffVacuum()
+                }
+            }
+        }
+    }
+
+    private suspend fun applyRepaired(ev: DefragRepairEvent.Repaired) {
+        val state = _uiState.value
+        val states = state.cellStates
+        if (ev.position !in 0 until states.size) return
+        states[ev.position] = CELL_HEALTHY
+        _uiState.update {
+            when (ev.kind) {
+                DefragRepairEvent.RepairKind.LegacyUserDateZero -> it.copy(
+                    gridVersion = it.gridVersion + 1,
+                    issueCountLegacyUserDateZero =
+                        (it.issueCountLegacyUserDateZero - 1).coerceAtLeast(0),
+                )
+                DefragRepairEvent.RepairKind.SoftDeleteArchivalMismatch -> it.copy(
+                    gridVersion = it.gridVersion + 1,
+                    issueCountArchivalMismatch =
+                        (it.issueCountArchivalMismatch - 1).coerceAtLeast(0),
+                )
+            }
+        }
+        // Pace the visual flip so it's visible even when SQL UPDATEs return
+        // in microseconds. Skipped entirely on cancel — repairJob is cancelled.
+        delay(REPAIR_PER_CELL_PACING_MS)
     }
 
     /**
@@ -494,5 +594,10 @@ class DefragmenterViewModel(
         // Minimum time the "green + Vacuuming" finale is displayed, even if
         // VACUUM returns in under a second on tiny DBs.
         const val MIN_VACUUM_GREEN_MS: Long = 2_000L
+        // Per-cell delay during the repair animation so the issue→healthy
+        // colour flip is actually visible. The underlying SQL UPDATE is
+        // sub-millisecond on small Ns; without pacing the user would see
+        // every cell flip on the same frame.
+        const val REPAIR_PER_CELL_PACING_MS: Long = 200L
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterViewModel.kt
@@ -4,6 +4,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import id.homebase.core.ui.screens.defragmenter.model.BlockGrid
+import id.homebase.core.ui.screens.defragmenter.model.CELL_CORRUPT_JSON_HEADER
+import id.homebase.core.ui.screens.defragmenter.model.CELL_LEGACY_USERDATE_ZERO
+import id.homebase.core.ui.screens.defragmenter.model.CELL_SOFT_DELETE_ARCHIVAL_MISMATCH
+import id.homebase.core.ui.screens.defragmenter.model.CELL_UNMAPPABLE_CONVERSATION
+import id.homebase.core.ui.screens.defragmenter.service.CellState
 import id.homebase.core.ui.screens.defragmenter.service.DefragAnalyzeEvent
 import id.homebase.core.ui.screens.defragmenter.service.DefragSource
 import id.homebase.core.ui.screens.defragmenter.service.DeletedFileRef
@@ -85,17 +90,29 @@ class DefragmenterViewModel(
                     targetHighlights = IntArray(0),
                     analyzedUpto = 0,
                     analyzeTotal = 0,
+                    cellStates = ByteArray(0),
+                    issueCountLegacyUserDateZero = 0,
+                    issueCountArchivalMismatch = 0,
+                    issueCountCorruptJson = 0,
+                    issueCountUnmappableConvo = 0,
                 )
             }
             val accGaps = HashMap<Int, DeletedFileRef>()
             var liveGrid: BlockGrid = BlockGrid.EMPTY
+            var liveCellStates: ByteArray = ByteArray(0)
+            var legacyCount = 0
+            var archivalCount = 0
+            var corruptCount = 0
+            var unmappableCount = 0
             source.analyze().collect { ev ->
                 when (ev) {
                     is DefragAnalyzeEvent.Sized -> {
                         liveGrid = BlockGrid.createEmpty(ev.totalBlocks)
+                        liveCellStates = ByteArray(ev.totalBlocks) // default 0 = Healthy
                         _uiState.update {
                             it.copy(
                                 grid = liveGrid,
+                                cellStates = liveCellStates,
                                 gridVersion = it.gridVersion + 1,
                                 totalBlocks = ev.totalBlocks,
                                 analyzeTotal = ev.totalBlocks,
@@ -117,10 +134,42 @@ class DefragmenterViewModel(
                             }
                         }
                         if (ev.newGaps.isNotEmpty()) accGaps.putAll(ev.newGaps)
+                        // Stamp per-cell state codes for the canvas. SoftDeleted
+                        // is left at 0 — the gap representation already covers
+                        // it. Healthy is also 0 (the array default).
+                        val states = liveCellStates
+                        if (states.size == grid.totalBlocks) {
+                            for ((pos, state) in ev.newCells) {
+                                if (pos !in 0 until states.size) continue
+                                when (state) {
+                                    is CellState.LegacyUserDateZero -> {
+                                        states[pos] = CELL_LEGACY_USERDATE_ZERO
+                                        legacyCount++
+                                    }
+                                    is CellState.SoftDeleteArchivalMismatch -> {
+                                        states[pos] = CELL_SOFT_DELETE_ARCHIVAL_MISMATCH
+                                        archivalCount++
+                                    }
+                                    is CellState.CorruptJsonHeader -> {
+                                        states[pos] = CELL_CORRUPT_JSON_HEADER
+                                        corruptCount++
+                                    }
+                                    is CellState.UnmappableConversation -> {
+                                        states[pos] = CELL_UNMAPPABLE_CONVERSATION
+                                        unmappableCount++
+                                    }
+                                    is CellState.Healthy, is CellState.SoftDeleted -> Unit
+                                }
+                            }
+                        }
                         _uiState.update {
                             it.copy(
                                 analyzedUpto = ev.analyzedUpto,
                                 gridVersion = it.gridVersion + 1,
+                                issueCountLegacyUserDateZero = legacyCount,
+                                issueCountArchivalMismatch = archivalCount,
+                                issueCountCorruptJson = corruptCount,
+                                issueCountUnmappableConvo = unmappableCount,
                             )
                         }
                     }
@@ -131,18 +180,25 @@ class DefragmenterViewModel(
                         val grid = liveGrid
                         val total = ev.totalBlocks
                         Logger.d(tag = tag) {
-                            "Analyze complete: total=$total, gaps=${accGaps.size}"
+                            "Analyze complete: total=$total, gaps=${accGaps.size}, " +
+                                    "legacy=$legacyCount archival=$archivalCount " +
+                                    "corrupt=$corruptCount unmappable=$unmappableCount"
                         }
                         _uiState.update {
                             it.copy(
                                 phase = DefragmenterPhase.Ready,
                                 grid = grid,
+                                cellStates = liveCellStates,
                                 gridVersion = it.gridVersion + 1,
                                 totalBlocks = total,
                                 initialGaps = accGaps.size,
                                 gapsRemaining = accGaps.size,
                                 analyzedUpto = total,
                                 analyzeTotal = total,
+                                issueCountLegacyUserDateZero = legacyCount,
+                                issueCountArchivalMismatch = archivalCount,
+                                issueCountCorruptJson = corruptCount,
+                                issueCountUnmappableConvo = unmappableCount,
                             )
                         }
                     }
@@ -202,6 +258,11 @@ class DefragmenterViewModel(
                     analyzeTotal = 0,
                     inFlight = emptyList(),
                     targetHighlights = IntArray(0),
+                    cellStates = ByteArray(0),
+                    issueCountLegacyUserDateZero = 0,
+                    issueCountArchivalMismatch = 0,
+                    issueCountCorruptJson = 0,
+                    issueCountUnmappableConvo = 0,
                 )
             }
             return

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/model/CellStateCode.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/model/CellStateCode.kt
@@ -1,0 +1,22 @@
+package id.homebase.core.ui.screens.defragmenter.model
+
+/**
+ * Per-cell state ordinals used by the canvas to colour each filled block.
+ *
+ * Stored as a `ByteArray` of length [DefragmenterUiState.totalBlocks] so the
+ * canvas can look up a state by index in O(1) without a Map. `SoftDeleted` is
+ * NOT encoded here — soft-deletes are represented as gaps via
+ * [BlockGrid.isFilled] returning false, so the canvas already skips drawing
+ * them. The classifier cell types collapse to these codes:
+ *
+ *  - Healthy                    → [CELL_HEALTHY]
+ *  - LegacyUserDateZero         → [CELL_LEGACY_USERDATE_ZERO]
+ *  - SoftDeleteArchivalMismatch → [CELL_SOFT_DELETE_ARCHIVAL_MISMATCH]
+ *  - CorruptJsonHeader          → [CELL_CORRUPT_JSON_HEADER]
+ *  - UnmappableConversation     → [CELL_UNMAPPABLE_CONVERSATION]
+ */
+const val CELL_HEALTHY: Byte = 0
+const val CELL_LEGACY_USERDATE_ZERO: Byte = 1
+const val CELL_SOFT_DELETE_ARCHIVAL_MISMATCH: Byte = 2
+const val CELL_CORRUPT_JSON_HEADER: Byte = 3
+const val CELL_UNMAPPABLE_CONVERSATION: Byte = 4

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/DefragRowClassifier.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/DefragRowClassifier.kt
@@ -20,7 +20,7 @@ private const val MESSAGE_FILE_TYPE = 7878
 private const val CONVERSATION_FILE_TYPE = 8888
 
 /** `ArchivalStatus.Removed.value` — soft-delete marker on the SQL column. */
-private const val ARCHIVAL_STATUS_REMOVED = 2L
+internal const val ARCHIVAL_STATUS_REMOVED = 2L
 
 /**
  * Pure classifier for a [PagedScanRow]. Has no DB / network side effects;

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/DefragRowClassifier.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/DefragRowClassifier.kt
@@ -1,0 +1,152 @@
+package id.homebase.core.ui.screens.defragmenter.service
+
+import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.sync.database.DriveMainIndexWrapper.PagedScanRow
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import kotlin.uuid.Uuid
+
+/** Chat message file type (`appData.fileType` = 7878). */
+private const val MESSAGE_FILE_TYPE = 7878
+
+/** Chat conversation file type (`appData.fileType` = 8888). */
+private const val CONVERSATION_FILE_TYPE = 8888
+
+/** `ArchivalStatus.Removed.value` — soft-delete marker on the SQL column. */
+private const val ARCHIVAL_STATUS_REMOVED = 2L
+
+/**
+ * Pure classifier for a [PagedScanRow]. Has no DB / network side effects;
+ * given a row + driveId + the result of a (possibly throwing) conversation-mapper
+ * probe, decides which [CellState] the row maps to.
+ *
+ * Split from [LiveDefragSource] so it's unit-testable without spinning up a
+ * full DefragSource graph. The `mapToBasicProbe` is hoisted out to keep this
+ * file independent of homebase-chat — production wires `ConversationMapper.mapToBasic`
+ * via the lambda; tests can inject any probe.
+ */
+internal suspend fun classifyRow(
+    driveId: Uuid,
+    row: PagedScanRow,
+    /**
+     * Returns null if the conversation file maps cleanly; non-null
+     * (the throwable) when [ConversationMapper.mapToBasic] threw on this header.
+     * Only invoked for rows whose strict deserialise succeeded AND whose
+     * `appData.fileType == 8888`. May be null if the caller doesn't want to
+     * run the conversation-mapper probe at all (treats every conversation as
+     * Healthy from the classifier's point of view).
+     */
+    mapToBasicProbe: (suspend (HomebaseFile) -> Throwable?)? = null,
+): CellState {
+    // 1. Strict deserialise: failure → CorruptJsonHeader.
+    val header: HomebaseFile = try {
+        OdinSystemSerializer.deserialize(row.jsonHeader)
+    } catch (t: Throwable) {
+        return CellState.CorruptJsonHeader(
+            driveId = driveId,
+            fileId = row.fileId,
+            rowId = row.rowId,
+        )
+    }
+
+    val fileType = header.fileMetadata.appData.fileType ?: 0
+
+    // 2. Conversation file that mapToBasic refuses → UnmappableConversation.
+    if (fileType == CONVERSATION_FILE_TYPE && mapToBasicProbe != null) {
+        val mapperError = mapToBasicProbe(header)
+        if (mapperError != null) {
+            return CellState.UnmappableConversation(
+                driveId = driveId,
+                fileId = row.fileId,
+                rowId = row.rowId,
+            )
+        }
+    }
+
+    // 3. Soft-delete branches.
+    if (header.isSoftDeleted()) {
+        return if (fileType == MESSAGE_FILE_TYPE && row.archivalStatus != ARCHIVAL_STATUS_REMOVED) {
+            CellState.SoftDeleteArchivalMismatch(
+                driveId = driveId,
+                fileId = row.fileId,
+                rowId = row.rowId,
+            )
+        } else {
+            CellState.SoftDeleted(
+                ref = DeletedFileRef(driveId = driveId, fileId = row.fileId),
+            )
+        }
+    }
+
+    // 4. Legacy null-userDate (chat messages only).
+    if (
+        fileType == MESSAGE_FILE_TYPE &&
+        row.userDate == 0L &&
+        header.fileMetadata.appData.userDate == null &&
+        header.fileMetadata.created.milliseconds > 0L
+    ) {
+        return CellState.LegacyUserDateZero(
+            driveId = driveId,
+            fileId = row.fileId,
+            rowId = row.rowId,
+            createdMs = header.fileMetadata.created.milliseconds,
+        )
+    }
+
+    // 5. Default.
+    return CellState.Healthy
+}
+
+/**
+ * Build a [QuarantineCandidate] for a [CellState.CorruptJsonHeader] row,
+ * doing a lenient JsonElement pass to salvage whatever fields we can read
+ * from a partially-broken header. Always returns a non-null candidate —
+ * `fileId` and `rowId` come from the SQL row directly, so the prompt can
+ * always show *something* useful even if the JSON is fully unparseable.
+ */
+internal fun buildQuarantineCandidate(
+    driveId: Uuid,
+    row: PagedScanRow,
+    deserialiseError: Throwable?,
+): QuarantineCandidate {
+    val parsed: JsonElement? = try {
+        Json.parseToJsonElement(row.jsonHeader)
+    } catch (_: Throwable) {
+        null
+    }
+    val fileMetadata = (parsed as? JsonObject)?.get("fileMetadata") as? JsonObject
+    val appData = fileMetadata?.get("appData") as? JsonObject
+
+    fun JsonObject.string(field: String): String? =
+        (this[field] as? JsonPrimitive)?.contentOrNull?.takeIf { it.isNotEmpty() }
+
+    fun JsonObject.long(field: String): Long? =
+        (this[field] as? JsonPrimitive)?.longOrNull
+
+    fun JsonObject.int(field: String): Int? =
+        (this[field] as? JsonPrimitive)?.jsonPrimitive?.contentOrNull?.toIntOrNull()
+
+    fun JsonObject.uuid(field: String): Uuid? = string(field)?.let {
+        try { Uuid.parse(it) } catch (_: Throwable) { null }
+    }
+
+    return QuarantineCandidate(
+        driveId = driveId,
+        fileId = row.fileId,
+        rowId = row.rowId,
+        deserialiseError = deserialiseError?.message?.take(200),
+        senderOdinId = fileMetadata?.string("senderOdinId"),
+        originalAuthor = fileMetadata?.string("originalAuthor"),
+        createdMs = fileMetadata?.long("created"),
+        fileType = appData?.int("fileType"),
+        uniqueId = appData?.uuid("uniqueId"),
+        rawHeaderPrefix = row.jsonHeader.take(200),
+    )
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/DefragSource.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/DefragSource.kt
@@ -16,10 +16,13 @@ import kotlin.uuid.Uuid
  * When a defrag animation commits a block into a [CellState.SoftDeleted] cell,
  * the ViewModel calls [hardDelete] with the `fileId` that position represents.
  *
- * [repair] runs an integrity-fix pass that re-uploads chat-message files
- * (fileType=7878) carrying the legacy `userDate=0` shape or the
- * pre-fix soft-delete `archivalStatus` mismatch. Server-side via the outbox,
- * no peer redistribution. See the Defragmenter plan for the full predicate.
+ * [repair] runs an integrity-fix pass that re-projects local SQL columns
+ * for rows the classifier flagged as `LegacyUserDateZero` or
+ * `SoftDeleteArchivalMismatch`. Local-only: peers maintain their own
+ * projections from their own copies of the file, so no server round-trip
+ * is needed. Each successfully repaired row emits a per-cell
+ * [DefragRepairEvent.Repaired] so the UI can flip its colour back to
+ * Healthy one cell at a time.
  */
 interface DefragSource {
     fun analyze(): Flow<DefragAnalyzeEvent>
@@ -143,21 +146,31 @@ sealed interface DefragRepairEvent {
     /** Emitted once before the repair scan starts. */
     data class Started(val eligibleEstimate: Int) : DefragRepairEvent
 
-    /** Emitted per repair-chunk with running counters. */
-    data class Progress(
-        val analyzed: Int,
-        val enqueued: Int,
-        val skipped: Int,
+    /**
+     * Emitted per row successfully repaired. The UI uses this to flip the
+     * matching grid cell from its issue colour back to the healthy palette
+     * one at a time, mirroring the per-position emission cadence.
+     */
+    data class Repaired(
+        /** Position in the global grid, matching the analyze pass's cell map. */
+        val position: Int,
+        val driveId: Uuid,
+        val fileId: Uuid,
+        val rowId: Long,
+        val kind: RepairKind,
     ) : DefragRepairEvent
 
     /** Terminal event. */
     data class Done(
         val analyzed: Int,
-        val enqueued: Int,
-        val enqueuedLegacyUserDateZero: Int,
-        val enqueuedSoftDeleteArchivalMismatch: Int,
+        val repaired: Int,
+        val repairedLegacyUserDateZero: Int,
+        val repairedSoftDeleteArchivalMismatch: Int,
         val skipped: Int,
     ) : DefragRepairEvent
+
+    /** Which kind of repair was applied to a given row. */
+    enum class RepairKind { LegacyUserDateZero, SoftDeleteArchivalMismatch }
 }
 
 data class DeletedFileRef(val driveId: Uuid, val fileId: Uuid)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/DefragSource.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/DefragSource.kt
@@ -18,11 +18,12 @@ import kotlin.uuid.Uuid
  *
  * [repair] runs an integrity-fix pass that re-projects local SQL columns
  * for rows the classifier flagged as `LegacyUserDateZero` or
- * `SoftDeleteArchivalMismatch`. Local-only: peers maintain their own
- * projections from their own copies of the file, so no server round-trip
- * is needed. Each successfully repaired row emits a per-cell
- * [DefragRepairEvent.Repaired] so the UI can flip its colour back to
- * Healthy one cell at a time.
+ * `SoftDeleteArchivalMismatch`. **Local-only for now** — see the big TODO
+ * in [LiveDefragSource.repair] re: the server-side download-verify-patch-
+ * upload pass that's needed to make `SoftDeleteArchivalMismatch` repairs
+ * survive a logout/wipe-resync cycle. Each successfully repaired row
+ * emits a per-cell [DefragRepairEvent.Repaired] so the UI can flip its
+ * colour back to Healthy one cell at a time.
  */
 interface DefragSource {
     fun analyze(): Flow<DefragAnalyzeEvent>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/DefragSource.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/DefragSource.kt
@@ -8,15 +8,22 @@ import kotlin.uuid.Uuid
  *
  * [analyze] streams progress so the UI can render the scan as it happens: a
  * [DefragAnalyzeEvent.Sized] with the final grid dimensions, zero or more
- * [DefragAnalyzeEvent.Progress] chunks, and a terminal [DefragAnalyzeEvent.Done]
- * carrying the final gap map.
+ * [DefragAnalyzeEvent.Progress] chunks (each carrying per-position [CellState]
+ * for the rows scanned in that chunk), and a terminal [DefragAnalyzeEvent.Done]
+ * carrying the final cell map plus any [QuarantineCandidate]s the user should
+ * be prompted about.
  *
- * When a defrag animation commits a block into a gap, the ViewModel looks up
- * that gap in the map and calls [hardDelete] with the `fileId` of the file
- * that position represents.
+ * When a defrag animation commits a block into a [CellState.SoftDeleted] cell,
+ * the ViewModel calls [hardDelete] with the `fileId` that position represents.
+ *
+ * [repair] runs an integrity-fix pass that re-uploads chat-message files
+ * (fileType=7878) carrying the legacy `userDate=0` shape or the
+ * pre-fix soft-delete `archivalStatus` mismatch. Server-side via the outbox,
+ * no peer redistribution. See the Defragmenter plan for the full predicate.
  */
 interface DefragSource {
     fun analyze(): Flow<DefragAnalyzeEvent>
+    fun repair(): Flow<DefragRepairEvent>
     suspend fun hardDelete(driveId: Uuid, fileId: Uuid): Boolean
 
     /** Compacts the SQLite database file (runs VACUUM). */
@@ -29,19 +36,128 @@ sealed interface DefragAnalyzeEvent {
 
     /**
      * Emitted per scan chunk. [analyzedUpto] is the exclusive upper bound of
-     * positions that have now been examined. [newGaps] are gap positions
-     * discovered in this chunk only — the caller accumulates them.
+     * positions that have now been examined.
+     *
+     * [newCells] carries the [CellState] for each position discovered in this
+     * chunk only — the caller accumulates them into the full grid for colored
+     * rendering.
+     *
+     * [newGaps] is a backward-compat projection of [newCells] containing only
+     * the [CellState.SoftDeleted] entries. The existing soft-delete /
+     * hard-delete animation reads this directly without caring about the new
+     * states. New consumers should read [newCells] and project as needed.
      */
     data class Progress(
         val analyzedUpto: Int,
+        val newCells: Map<Int, CellState>,
         val newGaps: Map<Int, DeletedFileRef>,
     ) : DefragAnalyzeEvent
 
-    /** Terminal event: total and full accumulated gap map. */
+    /**
+     * Terminal event. [cellMap] is the full accumulated per-position state.
+     * [gapMap] is the soft-delete-only projection (backward compat — see
+     * [Progress.newGaps]).
+     *
+     * [corruptCandidates] are rows whose `jsonHeader` failed strict
+     * deserialisation; the UI walks these one at a time via the corrupt-JSON
+     * prompt flow so the user can choose to hard-delete or skip each one.
+     */
     data class Done(
         val totalBlocks: Int,
+        val cellMap: Map<Int, CellState>,
         val gapMap: Map<Int, DeletedFileRef>,
+        val corruptCandidates: List<QuarantineCandidate>,
     ) : DefragAnalyzeEvent
+}
+
+/**
+ * One scanned row's classification. Drives the Defragmenter grid colour and
+ * (for [LegacyUserDateZero] / [SoftDeleteArchivalMismatch]) determines whether
+ * a row gets re-uploaded by [DefragSource.repair].
+ *
+ * Evaluation order in the classifier (first match wins):
+ *  1. jsonHeader fails strict deserialise → [CorruptJsonHeader]
+ *  2. fileType=8888 + ConversationMapper.mapToBasic throws → [UnmappableConversation]
+ *  3. isSoftDeleted + archivalStatus drift → [SoftDeleteArchivalMismatch] (msg only)
+ *     else                                  → [SoftDeleted] (existing semantic)
+ *  4. fileType=7878 + userDate=0 + appData.userDate=null + created>0 → [LegacyUserDateZero]
+ *  5. otherwise → [Healthy]
+ */
+sealed interface CellState {
+    object Healthy : CellState
+
+    /** Soft-deleted (either via fileState or archivalStatus). UI: red. */
+    data class SoftDeleted(val ref: DeletedFileRef) : CellState
+
+    /** Soft-deleted in jsonHeader but `archivalStatus != Removed` in SQL. UI: orange. */
+    data class SoftDeleteArchivalMismatch(
+        val driveId: Uuid,
+        val fileId: Uuid,
+        val rowId: Long,
+    ) : CellState
+
+    /** Chat message with `appData.userDate = null` projected as 0. UI: amber. */
+    data class LegacyUserDateZero(
+        val driveId: Uuid,
+        val fileId: Uuid,
+        val rowId: Long,
+        val createdMs: Long,
+    ) : CellState
+
+    /** jsonHeader failed strict deserialise. UI: magenta. Drives the prompt. */
+    data class CorruptJsonHeader(
+        val driveId: Uuid,
+        val fileId: Uuid,
+        val rowId: Long,
+    ) : CellState
+
+    /** Conversation file (8888) where ConversationMapper.mapToBasic throws. UI: pink. */
+    data class UnmappableConversation(
+        val driveId: Uuid,
+        val fileId: Uuid,
+        val rowId: Long,
+    ) : CellState
+}
+
+/**
+ * Salvaged metadata for a [CellState.CorruptJsonHeader] row — populated via a
+ * lenient JSON-element pass when strict deserialisation has already failed.
+ * Best-effort: any field can be null if the JSON is too damaged to extract.
+ * `fileId` and `rowId` are always available because they're SQL columns on the
+ * row, not inside the (corrupt) JSON.
+ */
+data class QuarantineCandidate(
+    val driveId: Uuid,
+    val fileId: Uuid,
+    val rowId: Long,
+    val deserialiseError: String?,
+    val senderOdinId: String?,
+    val originalAuthor: String?,
+    val createdMs: Long?,
+    val fileType: Int?,
+    val uniqueId: Uuid?,
+    val rawHeaderPrefix: String,
+)
+
+sealed interface DefragRepairEvent {
+    /** Emitted once before the repair scan starts. */
+    data class Started(val eligibleEstimate: Int) : DefragRepairEvent
+
+    /** Emitted per repair-chunk with running counters. */
+    data class Progress(
+        val analyzed: Int,
+        val enqueued: Int,
+        val skipped: Int,
+    ) : DefragRepairEvent
+
+    /** Terminal event. */
+    data class Done(
+        val analyzed: Int,
+        val enqueued: Int,
+        val enqueuedLegacyUserDateZero: Int,
+        val enqueuedSoftDeleteArchivalMismatch: Int,
+        val skipped: Int,
+    ) : DefragRepairEvent
 }
 
 data class DeletedFileRef(val driveId: Uuid, val fileId: Uuid)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/LiveDefragSource.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/LiveDefragSource.kt
@@ -221,6 +221,44 @@ class LiveDefragSource(
      *
      * Each repair is one tiny SQL UPDATE; the reclassify+UPDATE per page
      * stays well under the page-scan latency.
+     *
+     * ────────────────────────────────────────────────────────────────────
+     * TODO(server-repair): the current implementation is LOCAL-ONLY.
+     *
+     *   Some classifier states are caused by inconsistencies on the
+     *   server-side file itself — notably [CellState.SoftDeleteArchivalMismatch],
+     *   which fires when a file's JSON has `fileState = deleted` but
+     *   `appData.archivalStatus != Removed`. The SQL projection faithfully
+     *   captures the inconsistent value, so a logout + resync from the
+     *   server will reproduce the same flagged state and the local UPDATE
+     *   we just applied is wiped.
+     *
+     *   The honest fix is download-verify-patch-upload:
+     *     1. GET the canonical header from the server by fileId.
+     *     2. Verify the inconsistency is still present (server may have
+     *        self-healed; skip if so).
+     *     3. Patch the JSON in place — for archivalStatus drift, set
+     *        `appData.archivalStatus = Removed` so the file is internally
+     *        consistent. Leave everything else identical.
+     *     4. PUT/UPDATE the file (UpdateFileByUniqueId-style — there is
+     *        existing outbox infrastructure). Server bumps versionTag,
+     *        distributes to peers via sync; their SQL projections heal too.
+     *
+     *   Caveats to design for before flipping the switch:
+     *     - Write authority: peer-authored files (most chat messages) we
+     *       can't update server-side; the server rejects. The pass would
+     *       have to skip those and report them as "needs_owner_repair".
+     *     - VersionTag bumps cascade as sync events to all peers. Pace
+     *       uploads (e.g. one per 100ms) so we don't thundering-herd.
+     *     - Encrypted payloads stay untouched — we only rewrite header
+     *       metadata, no re-encryption needed.
+     *     - Add a "verify on server" preflight that downloads a sample
+     *       and confirms the diagnosis before any write goes out.
+     *
+     *   Until that lands, keep this method local-only. The user explicitly
+     *   chose the conservative path so we don't risk corrupting server
+     *   data while the diagnosis logic is still bedding in.
+     * ────────────────────────────────────────────────────────────────────
      */
     override fun repair(): Flow<DefragRepairEvent> = flow {
         val identityId: Uuid = runCatching {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/LiveDefragSource.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/LiveDefragSource.kt
@@ -210,20 +210,185 @@ class LiveDefragSource(
         )
     }.flowOn(Dispatchers.Default)
 
+    /**
+     * Re-scans every drive in the same order/cadence as [analyze], applies the
+     * local-only repair for any [CellState.LegacyUserDateZero] /
+     * [CellState.SoftDeleteArchivalMismatch] row encountered, and emits one
+     * [DefragRepairEvent.Repaired] per successful UPDATE so the UI can flip
+     * cells back to Healthy as we go. CorruptJsonHeader and
+     * UnmappableConversation rows are not auto-repairable here — they need
+     * the prompt-driven hard-delete or upstream content fix.
+     *
+     * Each repair is one tiny SQL UPDATE; the reclassify+UPDATE per page
+     * stays well under the page-scan latency.
+     */
     override fun repair(): Flow<DefragRepairEvent> = flow {
-        // TODO(landing-3): re-scan, build UpdateFileByUniqueIdRequest for each
-        // LegacyUserDateZero / SoftDeleteArchivalMismatch row, enqueue via the
-        // outbox with no peer redistribution, and stream Progress/Done events.
-        // For now this is a no-op so the screen can render a Repair button
-        // that doesn't crash; landing-3 fills it in.
-        Logger.w(tag = tag) { "repair() not yet implemented (landing-3) — emitting empty Done" }
+        val identityId: Uuid = runCatching {
+            credentialsManager.requireActiveCredentials().getIdentityId()
+        }.getOrElse {
+            Logger.w(tag = tag, throwable = it) { "repair: no active credentials — skipping" }
+            emit(
+                DefragRepairEvent.Done(
+                    analyzed = 0,
+                    repaired = 0,
+                    repairedLegacyUserDateZero = 0,
+                    repairedSoftDeleteArchivalMismatch = 0,
+                    skipped = 0,
+                )
+            )
+            return@flow
+        }
+
+        val drives = driveSyncManager.driveStatuses.value.values
+            .map { it.driveId }
+            .sortedBy { it.toString() }
+        if (drives.isEmpty()) {
+            emit(
+                DefragRepairEvent.Done(
+                    analyzed = 0,
+                    repaired = 0,
+                    repairedLegacyUserDateZero = 0,
+                    repairedSoftDeleteArchivalMismatch = 0,
+                    skipped = 0,
+                )
+            )
+            return@flow
+        }
+
+        val mainIndex = databaseManager.driveMainIndex
+
+        // Pass 1: re-count + slot offsets, mirroring analyze() so positions
+        // emitted on Repaired line up with the UI's grid cell map.
+        val driveSlots = ArrayList<DriveSlot>(drives.size)
+        var totalBlocks = 0
+        for (driveId in drives) {
+            val count = runCatching { mainIndex.countByIdentityAndDrive(identityId, driveId) }
+                .getOrElse { 0L }
+                .coerceIn(0L, Int.MAX_VALUE.toLong() - totalBlocks)
+                .toInt()
+            if (count == 0) continue
+            driveSlots.add(DriveSlot(driveId = driveId, offset = totalBlocks, count = count))
+            totalBlocks += count
+        }
+
+        emit(DefragRepairEvent.Started(eligibleEstimate = -1))
+
+        var analyzed = 0
+        var repaired = 0
+        var repairedLegacy = 0
+        var repairedArchival = 0
+        var skipped = 0
+
+        for (slot in driveSlots) {
+            var sinceRowId = 0L
+            var indexInDrive = 0
+            while (indexInDrive < slot.count) {
+                val page = runCatching {
+                    mainIndex.selectFileIdAndJsonByDriveSince(
+                        identityId = identityId,
+                        driveId = slot.driveId,
+                        sinceRowId = sinceRowId,
+                        limit = PAGE_SIZE,
+                    )
+                }.getOrElse {
+                    Logger.w(tag = tag, throwable = it) {
+                        "repair page scan failed for drive=${slot.driveId} since=$sinceRowId"
+                    }
+                    emptyList()
+                }
+                if (page.isEmpty()) break
+
+                for (row in page) {
+                    val pos = slot.offset + indexInDrive
+                    val state = classifyRow(
+                        driveId = slot.driveId,
+                        row = row,
+                        mapToBasicProbe = mapToBasicProbe,
+                    )
+                    analyzed += 1
+                    when (state) {
+                        is CellState.SoftDeleteArchivalMismatch -> {
+                            val ok = runCatching {
+                                mainIndex.repairArchivalStatusByRowId(
+                                    rowId = row.rowId,
+                                    archivalStatus = ARCHIVAL_STATUS_REMOVED,
+                                )
+                            }.getOrElse {
+                                Logger.w(tag = tag, throwable = it) {
+                                    "repair archivalStatus failed rowId=${row.rowId}"
+                                }
+                                false
+                            }
+                            if (ok) {
+                                repaired += 1
+                                repairedArchival += 1
+                                emit(
+                                    DefragRepairEvent.Repaired(
+                                        position = pos,
+                                        driveId = slot.driveId,
+                                        fileId = row.fileId,
+                                        rowId = row.rowId,
+                                        kind = DefragRepairEvent.RepairKind.SoftDeleteArchivalMismatch,
+                                    )
+                                )
+                            } else {
+                                skipped += 1
+                            }
+                        }
+                        is CellState.LegacyUserDateZero -> {
+                            val ok = runCatching {
+                                mainIndex.repairUserDateByRowId(
+                                    rowId = row.rowId,
+                                    userDate = state.createdMs,
+                                )
+                            }.getOrElse {
+                                Logger.w(tag = tag, throwable = it) {
+                                    "repair userDate failed rowId=${row.rowId}"
+                                }
+                                false
+                            }
+                            if (ok) {
+                                repaired += 1
+                                repairedLegacy += 1
+                                emit(
+                                    DefragRepairEvent.Repaired(
+                                        position = pos,
+                                        driveId = slot.driveId,
+                                        fileId = row.fileId,
+                                        rowId = row.rowId,
+                                        kind = DefragRepairEvent.RepairKind.LegacyUserDateZero,
+                                    )
+                                )
+                            } else {
+                                skipped += 1
+                            }
+                        }
+                        is CellState.CorruptJsonHeader,
+                        is CellState.UnmappableConversation -> {
+                            // Not auto-repairable here.
+                            skipped += 1
+                        }
+                        is CellState.SoftDeleted, is CellState.Healthy -> Unit
+                    }
+                    indexInDrive += 1
+                    sinceRowId = row.rowId
+                    if (indexInDrive >= slot.count) break
+                }
+                yield()
+            }
+        }
+
+        Logger.i(tag = tag) {
+            "repair complete: analyzed=$analyzed repaired=$repaired " +
+                    "legacy=$repairedLegacy archival=$repairedArchival skipped=$skipped"
+        }
         emit(
             DefragRepairEvent.Done(
-                analyzed = 0,
-                enqueued = 0,
-                enqueuedLegacyUserDateZero = 0,
-                enqueuedSoftDeleteArchivalMismatch = 0,
-                skipped = 0,
+                analyzed = analyzed,
+                repaired = repaired,
+                repairedLegacyUserDateZero = repairedLegacy,
+                repairedSoftDeleteArchivalMismatch = repairedArchival,
+                skipped = skipped,
             )
         )
     }.flowOn(Dispatchers.Default)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/LiveDefragSource.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/LiveDefragSource.kt
@@ -4,7 +4,6 @@ import co.touchlab.kermit.Logger
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.drives.HomebaseFile
 import id.homebase.api.client.drives.files.DriveFileProvider
-import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.DriveSyncManager
 import id.homebase.api.sync.database.DatabaseManager
 import kotlinx.coroutines.Dispatchers
@@ -22,23 +21,32 @@ import kotlin.uuid.Uuid
  * Analyze is a two-pass streaming scan:
  *  1. Sum `count(*)` across every drive (cheap, indexed). Emit [Sized].
  *  2. Per drive (sorted), keyset-page rows in rowId-ascending order. For each
- *     row, deserialize `jsonHeader` and call [HomebaseFile.isSoftDeleted].
- *     Gaps land at `offset + indexInDrive` in the global grid. After each
- *     chunk emit [Progress]; emit [Done] at the end.
+ *     row, deserialize `jsonHeader` and run the classifier ([classifyRow]) to
+ *     decide which [CellState] the row maps to. Soft-deleted rows still
+ *     populate `newGaps`/`gapMap` for the existing hard-delete animation;
+ *     new consumers read the richer `newCells`/`cellMap`.
  *
  * Hard delete hits `POST /drives/{driveId}/files/{fileId}/hard-delete` via
  * [DriveFileProvider.hardDeleteFile]. On success we also delete the local
  * `DriveMainIndex` row so the next analyze pass doesn't re-report it.
  * Failures are logged but not retried — this is a best-effort cleanup.
+ *
+ * @param mapToBasicProbe Optional probe that returns null when a conversation
+ *   file (fileType=8888) maps cleanly via `ConversationMapper.mapToBasic`,
+ *   non-null when it throws. Production wires the real mapper through DI;
+ *   tests inject any predicate. Null disables the conversation-mapper check
+ *   entirely (rows are then always classified as Healthy on the conversation
+ *   axis).
  */
 class LiveDefragSource(
     private val driveSyncManager: DriveSyncManager,
     private val credentialsManager: CredentialsManager,
     private val databaseManager: DatabaseManager,
     private val driveFileProvider: DriveFileProvider,
+    private val mapToBasicProbe: (suspend (HomebaseFile) -> Throwable?)? = null,
 ) : DefragSource {
 
-    private val tag = "LiveDefragSource"
+    private val tag = "Defrag"
 
     // Cached from the most recent analyze() so hardDelete() can delete the
     // matching local row without re-fetching credentials on every call.
@@ -51,7 +59,14 @@ class LiveDefragSource(
         }.getOrElse {
             Logger.w(tag = tag, throwable = it) { "no active credentials — cannot analyze" }
             cachedIdentityId = null
-            emit(DefragAnalyzeEvent.Done(totalBlocks = 0, gapMap = emptyMap()))
+            emit(
+                DefragAnalyzeEvent.Done(
+                    totalBlocks = 0,
+                    cellMap = emptyMap(),
+                    gapMap = emptyMap(),
+                    corruptCandidates = emptyList(),
+                )
+            )
             return@flow
         }
         cachedIdentityId = identityId
@@ -61,7 +76,14 @@ class LiveDefragSource(
             .sortedBy { it.toString() }
 
         if (drives.isEmpty()) {
-            emit(DefragAnalyzeEvent.Done(totalBlocks = 0, gapMap = emptyMap()))
+            emit(
+                DefragAnalyzeEvent.Done(
+                    totalBlocks = 0,
+                    cellMap = emptyMap(),
+                    gapMap = emptyMap(),
+                    corruptCandidates = emptyList(),
+                )
+            )
             return@flow
         }
 
@@ -84,12 +106,27 @@ class LiveDefragSource(
         }
         emit(DefragAnalyzeEvent.Sized(totalBlocks = totalBlocks))
         if (totalBlocks == 0) {
-            emit(DefragAnalyzeEvent.Done(totalBlocks = 0, gapMap = emptyMap()))
+            emit(
+                DefragAnalyzeEvent.Done(
+                    totalBlocks = 0,
+                    cellMap = emptyMap(),
+                    gapMap = emptyMap(),
+                    corruptCandidates = emptyList(),
+                )
+            )
             return@flow
         }
 
-        // Pass 2: paged scan + deserialize.
+        // Pass 2: paged scan + classifier.
+        val accCells = HashMap<Int, CellState>()
         val accGaps = HashMap<Int, DeletedFileRef>()
+        val accCorrupt = ArrayList<QuarantineCandidate>()
+        // Cumulative per-state counters for the final summary.
+        val totals = StateCounters()
+        // Per-issue first-occurrence dedup, drive-scoped — so the log gets one
+        // detail line per (driveId, issueType) pair across the whole scan.
+        val firstSeen = HashSet<Pair<Uuid, String>>()
+
         var cumulative = 0
         for (slot in driveSlots) {
             var sinceRowId = 0L
@@ -110,24 +147,48 @@ class LiveDefragSource(
                 }
                 if (page.isEmpty()) break
 
+                val chunkCells = HashMap<Int, CellState>()
                 val chunkGaps = HashMap<Int, DeletedFileRef>()
+                val chunkCounters = StateCounters()
                 for (row in page) {
-                    val header = runCatching {
-                        OdinSystemSerializer.deserialize<HomebaseFile>(row.jsonHeader)
-                    }.getOrNull()
-                    if (header != null && header.isSoftDeleted()) {
-                        val pos = slot.offset + indexInDrive
-                        chunkGaps[pos] = DeletedFileRef(driveId = slot.driveId, fileId = row.fileId)
+                    val pos = slot.offset + indexInDrive
+                    val state = classifyRow(
+                        driveId = slot.driveId,
+                        row = row,
+                        mapToBasicProbe = mapToBasicProbe,
+                    )
+                    chunkCells[pos] = state
+                    chunkCounters.bump(state)
+                    if (state is CellState.SoftDeleted) {
+                        chunkGaps[pos] = state.ref
                     }
+                    if (state is CellState.CorruptJsonHeader) {
+                        // Build the prompt-ready candidate by re-running the
+                        // strict deserialise to capture the actual exception
+                        // message; lenient JSON pass extracts whatever salvageable
+                        // metadata it can.
+                        val err = runCatching {
+                            id.homebase.api.serialization.OdinSystemSerializer
+                                .deserialize<HomebaseFile>(row.jsonHeader)
+                        }.exceptionOrNull()
+                        accCorrupt.add(buildQuarantineCandidate(slot.driveId, row, err))
+                    }
+                    logFirstOccurrence(state, slot.driveId, row, firstSeen)
                     indexInDrive += 1
                     cumulative += 1
                     sinceRowId = row.rowId
                     if (indexInDrive >= slot.count) break
                 }
+                accCells.putAll(chunkCells)
                 accGaps.putAll(chunkGaps)
+                totals += chunkCounters
+                Logger.i(tag = tag) {
+                    "chunk drive=${slot.driveId} offset=${slot.offset} count=${page.size} ${chunkCounters.format()}"
+                }
                 emit(
                     DefragAnalyzeEvent.Progress(
                         analyzedUpto = cumulative,
+                        newCells = chunkCells,
                         newGaps = chunkGaps,
                     )
                 )
@@ -135,11 +196,111 @@ class LiveDefragSource(
             }
         }
 
-        Logger.d(tag = tag) {
-            "analyze: totalBlocks=$totalBlocks, gaps=${accGaps.size} across ${driveSlots.size} drive(s)"
+        Logger.i(tag = tag) {
+            "analyze complete: rows=$totalBlocks drives=${driveSlots.size} ${totals.format()} " +
+                    "repair_eligible=${totals.legacyUserDateZero + totals.softDeleteArchivalMismatch}"
         }
-        emit(DefragAnalyzeEvent.Done(totalBlocks = totalBlocks, gapMap = accGaps))
+        emit(
+            DefragAnalyzeEvent.Done(
+                totalBlocks = totalBlocks,
+                cellMap = accCells,
+                gapMap = accGaps,
+                corruptCandidates = accCorrupt,
+            )
+        )
     }.flowOn(Dispatchers.Default)
+
+    override fun repair(): Flow<DefragRepairEvent> = flow {
+        // TODO(landing-3): re-scan, build UpdateFileByUniqueIdRequest for each
+        // LegacyUserDateZero / SoftDeleteArchivalMismatch row, enqueue via the
+        // outbox with no peer redistribution, and stream Progress/Done events.
+        // For now this is a no-op so the screen can render a Repair button
+        // that doesn't crash; landing-3 fills it in.
+        Logger.w(tag = tag) { "repair() not yet implemented (landing-3) — emitting empty Done" }
+        emit(
+            DefragRepairEvent.Done(
+                analyzed = 0,
+                enqueued = 0,
+                enqueuedLegacyUserDateZero = 0,
+                enqueuedSoftDeleteArchivalMismatch = 0,
+                skipped = 0,
+            )
+        )
+    }.flowOn(Dispatchers.Default)
+
+    private fun logFirstOccurrence(
+        state: CellState,
+        driveId: Uuid,
+        row: id.homebase.api.sync.database.DriveMainIndexWrapper.PagedScanRow,
+        firstSeen: HashSet<Pair<Uuid, String>>,
+    ) {
+        val issueKey: String = when (state) {
+            is CellState.LegacyUserDateZero -> "legacy_userDate_zero"
+            is CellState.SoftDeleteArchivalMismatch -> "softdelete_archival_mismatch"
+            is CellState.CorruptJsonHeader -> "corrupt_jsonheader"
+            is CellState.UnmappableConversation -> "unmappable_conversation"
+            // Healthy and SoftDeleted are not "issues" — no per-occurrence detail line.
+            else -> return
+        }
+        if (!firstSeen.add(driveId to issueKey)) return
+        when (state) {
+            is CellState.LegacyUserDateZero -> Logger.w(tag = tag) {
+                "issue=legacy_userDate_zero drive=$driveId fileId=${row.fileId} " +
+                        "rowId=${row.rowId} created(ms)=${state.createdMs}"
+            }
+            is CellState.SoftDeleteArchivalMismatch -> Logger.w(tag = tag) {
+                "issue=softdelete_archival_mismatch drive=$driveId fileId=${row.fileId} " +
+                        "rowId=${row.rowId} archivalStatus=${row.archivalStatus}"
+            }
+            is CellState.CorruptJsonHeader -> Logger.w(tag = tag) {
+                "issue=corrupt_jsonheader drive=$driveId fileId=${row.fileId} " +
+                        "rowId=${row.rowId} header.take(120)=${row.jsonHeader.take(120)}"
+            }
+            is CellState.UnmappableConversation -> Logger.w(tag = tag) {
+                "issue=unmappable_conversation drive=$driveId fileId=${row.fileId} " +
+                        "rowId=${row.rowId}"
+            }
+            // Healthy and SoftDeleted are filtered out by the early-return above.
+            is CellState.Healthy, is CellState.SoftDeleted -> Unit
+        }
+    }
+
+    /** Per-state counters for chunk + summary logging. */
+    private class StateCounters {
+        var healthy = 0
+        var softDeleted = 0
+        var legacyUserDateZero = 0
+        var softDeleteArchivalMismatch = 0
+        var corruptJsonHeader = 0
+        var unmappableConversation = 0
+
+        fun bump(state: CellState) {
+            when (state) {
+                is CellState.Healthy -> healthy += 1
+                is CellState.SoftDeleted -> softDeleted += 1
+                is CellState.LegacyUserDateZero -> legacyUserDateZero += 1
+                is CellState.SoftDeleteArchivalMismatch -> softDeleteArchivalMismatch += 1
+                is CellState.CorruptJsonHeader -> corruptJsonHeader += 1
+                is CellState.UnmappableConversation -> unmappableConversation += 1
+            }
+        }
+
+        operator fun plusAssign(other: StateCounters) {
+            healthy += other.healthy
+            softDeleted += other.softDeleted
+            legacyUserDateZero += other.legacyUserDateZero
+            softDeleteArchivalMismatch += other.softDeleteArchivalMismatch
+            corruptJsonHeader += other.corruptJsonHeader
+            unmappableConversation += other.unmappableConversation
+        }
+
+        fun format(): String =
+            "healthy=$healthy soft_deleted=$softDeleted " +
+                    "legacy_userDate_zero=$legacyUserDateZero " +
+                    "softdelete_archival_mismatch=$softDeleteArchivalMismatch " +
+                    "corrupt_jsonheader=$corruptJsonHeader " +
+                    "unmappable_conversation=$unmappableConversation"
+    }
 
     override suspend fun hardDelete(driveId: Uuid, fileId: Uuid): Boolean {
         val remoteOk = runCatching {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/ui/DefragGridCanvas.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/ui/DefragGridCanvas.kt
@@ -19,6 +19,11 @@ import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.platform.LocalDensity
 import id.homebase.core.ui.screens.defragmenter.InFlightMove
 import id.homebase.core.ui.screens.defragmenter.model.BlockGrid
+import id.homebase.core.ui.screens.defragmenter.model.CELL_CORRUPT_JSON_HEADER
+import id.homebase.core.ui.screens.defragmenter.model.CELL_HEALTHY
+import id.homebase.core.ui.screens.defragmenter.model.CELL_LEGACY_USERDATE_ZERO
+import id.homebase.core.ui.screens.defragmenter.model.CELL_SOFT_DELETE_ARCHIVAL_MISMATCH
+import id.homebase.core.ui.screens.defragmenter.model.CELL_UNMAPPABLE_CONVERSATION
 import kotlin.math.ceil
 import kotlin.math.max
 import kotlin.math.min
@@ -104,6 +109,10 @@ fun DefragGridCanvas(
     // scanHeadIndex = index of the cell where the scan head currently is, or
     // null outside of Analyzing. Draws a bright highlight overlay.
     scanHeadIndex: Int? = null,
+    // Per-cell classifier-state codes (length == grid.totalBlocks; default 0
+    // = Healthy). Empty array = no per-cell colouring; everything renders in
+    // the healthy palette. See model/CellStateCode.kt for the encoding.
+    cellStates: ByteArray = ByteArray(0),
     modifier: Modifier = Modifier,
 ) {
     BoxWithConstraints(modifier = modifier) {
@@ -137,6 +146,7 @@ fun DefragGridCanvas(
                     totalBlocks = grid.totalBlocks,
                     analyzedUpto = analyzedUpto,
                     scanHeadIndex = scanHeadIndex,
+                    cellStates = cellStates,
                 )
             } else {
                 drawModern(
@@ -149,6 +159,7 @@ fun DefragGridCanvas(
                     totalBlocks = grid.totalBlocks,
                     analyzedUpto = analyzedUpto,
                     scanHeadIndex = scanHeadIndex,
+                    cellStates = cellStates,
                 )
             }
         }
@@ -228,6 +239,7 @@ private fun DrawScope.drawModern(
     totalBlocks: Int,
     analyzedUpto: Int,
     scanHeadIndex: Int?,
+    cellStates: ByteArray,
 ) {
     drawRect(
         brush = Brush.verticalGradient(
@@ -252,9 +264,43 @@ private fun DrawScope.drawModern(
         }
         return
     }
+    // Per-cell issue overlay — paint non-Healthy classifier states on top of
+    // the bulk healthy path. Issues are typically rare so per-cell drawRect
+    // overhead is negligible vs. the cached bulk path.
+    drawIssueOverlay(layout, cellStates, totalBlocks, analyzedUpto)
     drawTargetHalos(targetHighlights, layout, frameTimeNanos)
     drawInFlightModern(inFlight, layout, frameTimeNanos)
     drawScanHead(layout, totalBlocks, scanHeadIndex)
+}
+
+/**
+ * Walks [cellStates] and paints a solid issue-coloured rect over each
+ * non-Healthy cell. Used by both the modern overlay and as a fallback when
+ * cellStates is empty (no-op).
+ */
+private fun DrawScope.drawIssueOverlay(
+    layout: GridLayout,
+    cellStates: ByteArray,
+    totalBlocks: Int,
+    analyzedUpto: Int,
+) {
+    val b = layout.blockSize
+    if (b <= 0f) return
+    val limit = minOf(cellStates.size, totalBlocks, analyzedUpto)
+    if (limit <= 0) return
+    for (i in 0 until limit) {
+        val code = cellStates[i]
+        if (code == CELL_HEALTHY) continue
+        val color = when (code) {
+            CELL_LEGACY_USERDATE_ZERO -> Win98Palette.IssueLegacyUserDateZeroFill
+            CELL_SOFT_DELETE_ARCHIVAL_MISMATCH -> Win98Palette.IssueArchivalMismatchFill
+            CELL_CORRUPT_JSON_HEADER -> Win98Palette.IssueCorruptJsonFill
+            CELL_UNMAPPABLE_CONVERSATION -> Win98Palette.IssueUnmappableConvoFill
+            else -> continue
+        }
+        val origin = layout.indexOffset(i)
+        drawRect(color = color, topLeft = origin, size = Size(b, b))
+    }
 }
 
 private fun buildFilledPath(grid: BlockGrid, layout: GridLayout): Path {
@@ -374,6 +420,7 @@ private fun DrawScope.drawClassic(
     totalBlocks: Int,
     analyzedUpto: Int,
     scanHeadIndex: Int?,
+    cellStates: ByteArray,
 ) {
     // Solid black background — no gradient.
     drawRect(color = Win98Palette.ClassicBg, size = size)
@@ -389,9 +436,13 @@ private fun DrawScope.drawClassic(
     for (idx in filledIndices) {
         val origin = layout.indexOffset(idx)
         val green = origin.x + b * 0.5f < sweepX
-        val fill = if (green) Win98Palette.ClassicGreenFill else Win98Palette.ClassicBlockFill
-        val light = if (green) Win98Palette.ClassicGreenLight else Win98Palette.ClassicBlockLight
-        val shadow = if (green) Win98Palette.ClassicGreenShadow else Win98Palette.ClassicBlockShadow
+        // Pick the per-cell base palette from the classifier state code,
+        // then override with the celebratory green sweep when applicable.
+        val code: Byte = if (idx < cellStates.size) cellStates[idx] else CELL_HEALTHY
+        val basePalette = classicPaletteFor(code)
+        val fill = if (green) Win98Palette.ClassicGreenFill else basePalette.fill
+        val light = if (green) Win98Palette.ClassicGreenLight else basePalette.light
+        val shadow = if (green) Win98Palette.ClassicGreenShadow else basePalette.shadow
         drawClassicBlock(
             topLeft = origin,
             blockSize = b,
@@ -484,6 +535,43 @@ private fun DrawScope.drawClassicBlock(
         end = Offset(x + b - 0.5f, y + b),
         strokeWidth = 1f,
     )
+}
+
+/** Fill / bevel-light / bevel-shadow triple for one classifier state. */
+private class ClassicPalette(val fill: Color, val light: Color, val shadow: Color)
+
+private val HealthyClassicPalette = ClassicPalette(
+    fill = Win98Palette.ClassicBlockFill,
+    light = Win98Palette.ClassicBlockLight,
+    shadow = Win98Palette.ClassicBlockShadow,
+)
+private val LegacyClassicPalette = ClassicPalette(
+    fill = Win98Palette.IssueLegacyUserDateZeroFill,
+    light = Win98Palette.IssueLegacyUserDateZeroLight,
+    shadow = Win98Palette.IssueLegacyUserDateZeroShadow,
+)
+private val ArchivalMismatchClassicPalette = ClassicPalette(
+    fill = Win98Palette.IssueArchivalMismatchFill,
+    light = Win98Palette.IssueArchivalMismatchLight,
+    shadow = Win98Palette.IssueArchivalMismatchShadow,
+)
+private val CorruptJsonClassicPalette = ClassicPalette(
+    fill = Win98Palette.IssueCorruptJsonFill,
+    light = Win98Palette.IssueCorruptJsonLight,
+    shadow = Win98Palette.IssueCorruptJsonShadow,
+)
+private val UnmappableConvoClassicPalette = ClassicPalette(
+    fill = Win98Palette.IssueUnmappableConvoFill,
+    light = Win98Palette.IssueUnmappableConvoLight,
+    shadow = Win98Palette.IssueUnmappableConvoShadow,
+)
+
+private fun classicPaletteFor(code: Byte): ClassicPalette = when (code) {
+    CELL_LEGACY_USERDATE_ZERO -> LegacyClassicPalette
+    CELL_SOFT_DELETE_ARCHIVAL_MISMATCH -> ArchivalMismatchClassicPalette
+    CELL_CORRUPT_JSON_HEADER -> CorruptJsonClassicPalette
+    CELL_UNMAPPABLE_CONVERSATION -> UnmappableConvoClassicPalette
+    else -> HealthyClassicPalette
 }
 
 private fun buildFilledIndices(grid: BlockGrid): IntArray {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/ui/Win98Palette.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/ui/Win98Palette.kt
@@ -60,4 +60,35 @@ object Win98Palette {
     // Scan-head highlight — the single bright cell at analyzedUpto - 1.
     val ScanHead: Color = Color(0xFFFFFFE0)
     val ScanHeadEdge: Color = Color(0xFFFFFFFF)
+
+    // Per-issue palette — used to colour cells flagged by the Defragmenter
+    // classifier so the user can see at a glance which rows are damaged or
+    // legacy-shaped. One triple per state: fill (block body), light (top/left
+    // bevel in classic mode), shadow (bottom/right bevel in classic mode).
+    // For modern mode, only the fill is used (drawn as an overlay rect on
+    // top of the healthy bulk path).
+
+    // Amber — chat-message rows projected with userDate=0 that pre-date the
+    // metadata.created fallback. Eligible for repair via the outbox.
+    val IssueLegacyUserDateZeroFill: Color = Color(0xFFB87500)
+    val IssueLegacyUserDateZeroLight: Color = Color(0xFFFFC04A)
+    val IssueLegacyUserDateZeroShadow: Color = Color(0xFF6E4500)
+
+    // Orange — header reports soft-deleted but the SQL archivalStatus column
+    // wasn't kept in lock-step. Eligible for repair (re-projection).
+    val IssueArchivalMismatchFill: Color = Color(0xFFD05500)
+    val IssueArchivalMismatchLight: Color = Color(0xFFFF9050)
+    val IssueArchivalMismatchShadow: Color = Color(0xFF7A3000)
+
+    // Magenta — strict deserialise of jsonHeader failed; row needs the
+    // corrupt-JSON prompt flow to confirm hard-delete or skip.
+    val IssueCorruptJsonFill: Color = Color(0xFFC03070)
+    val IssueCorruptJsonLight: Color = Color(0xFFFF70B0)
+    val IssueCorruptJsonShadow: Color = Color(0xFF701840)
+
+    // Pink — conversation file (8888) where the mapper threw or returned
+    // ConversationState.Invalid. Not auto-repairable.
+    val IssueUnmappableConvoFill: Color = Color(0xFFE070A0)
+    val IssueUnmappableConvoLight: Color = Color(0xFFFFA8C8)
+    val IssueUnmappableConvoShadow: Color = Color(0xFF904060)
 }


### PR DESCRIPTION
Summary

  Turns the Defragmenter from a soft-delete-only compactor into a fuller storage-integrity tool. The analyze pass now classifies every row into one of six
  states, the grid paints each state in its own colour, and a new "Repair" phase between Defragment and Vacuum walks through repair-eligible cells one at a
  time, applying a local SQL fix and animating the colour flip back to healthy.

  Motivation

  Two recurring kinds of DriveMainIndex projection drift surface in real accounts (Frodo's, in particular):

  - SoftDeleteArchivalMismatch — file's JSON has fileState = deleted but appData.archivalStatus != Removed. The SQL archivalStatus column gets projected
  from appData.archivalStatus (MainIndexMeta.kt:113), so a soft-deleted file shows up as active per the SQL filter even though HomebaseFile.isSoftDeleted()
  correctly identifies it as deleted. Knock-on effects in unread-count queries and friends.
  - LegacyUserDateZero — chat messages with appData.userDate = null got their SQL userDate written as 0 until commit 10d3667c taught the projection to fall
  back to metadata.created. Existing rows pre-dating that fix are still 0, so message ordering and unread filters disagree with the in-memory list ordering.

  Until this PR these were invisible. The Defragmenter screen could see soft-deletes only, and "fixing" them meant the existing hard-delete sweep — the new
  states had no representation.

  What the user sees

  After Analyze:

  ┌─────────────┬────────────────────────────┬────────────────────────────────────────────────┐
  │   Colour    │           State            │                     Source                     │
  ├─────────────┼────────────────────────────┼────────────────────────────────────────────────┤
  │ Black/empty │ SoftDeleted                │ gap in the grid (existing)                     │
  ├─────────────┼────────────────────────────┼────────────────────────────────────────────────┤
  │ Navy/blue   │ Healthy                    │ every well-formed row                          │
  ├─────────────┼────────────────────────────┼────────────────────────────────────────────────┤
  │ Amber       │ LegacyUserDateZero         │ userDate=0 with non-null metadata.created      │
  ├─────────────┼────────────────────────────┼────────────────────────────────────────────────┤
  │ Orange      │ SoftDeleteArchivalMismatch │ header soft-deleted but SQL column out of sync │
  ├─────────────┼────────────────────────────┼────────────────────────────────────────────────┤
  │ Magenta     │ CorruptJsonHeader          │ strict deserialise of jsonHeader failed        │
  ├─────────────┼────────────────────────────┼────────────────────────────────────────────────┤
  │ Pink        │ UnmappableConversation     │ ConversationMapper.mapToBasic rejects the file │
  └─────────────┴────────────────────────────┴────────────────────────────────────────────────┘

  The stats panel shows live tallies in matching colours as the scan progresses, so it doubles as a legend. Rows are zero-suppressed.

  After Defragment:

  1. Existing compaction sweep moves filled blocks into soft-delete gaps, then hard-deletes the underlying files (unchanged behaviour).
  2. New Repairing phase: each repair-eligible cell flips back to navy/healthy at 200ms intervals. The pacing is a deliberate UX choice — the underlying SQL
   UPDATE is sub-millisecond, so without spacing the user wouldn't see anything.
  3. Existing vacuum + green-sweep finale.

  Cells that aren't auto-repairable (CorruptJsonHeader, UnmappableConversation, pink) stay their issue colour through the green sweep so they remain visible
   afterwards for follow-up.

  Service-side changes

  - DefragRowClassifier.kt (new) — pure, suspend, side-effect-free function classifyRow(driveId, row, mapToBasicProbe) that returns a CellState per
  PagedScanRow. First-match precedence: CorruptJsonHeader → UnmappableConversation → SoftDelete* → LegacyUserDateZero → Healthy. Split out from
  LiveDefragSource so it's unit-testable without spinning up the full graph and so it stays independent of homebase-chat.
  - buildQuarantineCandidate — lenient kotlinx.serialization.json.JsonElement pass that salvages whatever fields are still readable when strict deserialise
  has already failed, for the eventual prompt-driven hard-delete-or-skip flow.
  - DriveMainIndex.sq — selectFileIdAndJsonByDriveSince now also projects userDate and archivalStatus, so the classifier can compare what's stored against
  what the deserialised header says without a second read. New repairArchivalStatusByRowId and repairUserDateByRowId UPDATE-by-rowId statements.
  - DriveMainIndexWrapper.kt — PagedScanRow gains userDate + archivalStatus. Two new suspend helpers for the repair UPDATEs.
  - DefragSource.kt — Progress and Done events carry newCells / cellMap (rich CellState per position) alongside the existing soft-delete-only newGaps /
  gapMap projection (kept for backward compat with the existing animation). Done also carries corruptCandidates for the future prompt flow. New repair():
  Flow<DefragRepairEvent> with Started / Repaired(position, driveId, fileId, rowId, kind) / Done(repaired, repairedLegacyUserDateZero,
  repairedSoftDeleteArchivalMismatch, skipped).
  - LiveDefragSource.kt — analyze pass invokes classifyRow per row, accumulates per-state StateCounters, and emits the richer payloads.
  First-occurrence-per-(drive, issueType) detail logs surface a single example of each issue with rowId/fileId so a homebase.log capture is enough to start
  triage. repair() is real now: it re-runs the same paged scan, applies the matching local UPDATE per eligible row, and emits Repaired per success.
  Conservative skip for CorruptJsonHeader / UnmappableConversation.
  - AppModule.kt — wires mapToBasicProbe through DI using a fresh ConversationMapper(credentialsManager, dbm). ConversationMapper.mapToBasic already catches
   its own throws and returns ConversationState.Invalid; the probe treats Invalid as "unmappable", giving the classifier a clean signal without the
  homebase-chat module leaking into the classifier.

  UI / ViewModel changes

  - CellStateCode.kt (new) — byte-encoding constants. Stored as ByteArray on the UI state so the canvas can look up state per-index in O(1) without a Map.
  SoftDeleted is implicit (gap = bit cleared), so it's not encoded here.
  - Win98Palette.kt — four new fill / light / shadow triples sized for the classic-mode bevels: amber, orange, magenta, pink. Modern mode uses the fill only
   (overlay drawn on top of the cached bulk healthy path).
  - DefragmenterUiState.kt — cellStates: ByteArray (default 0 = Healthy), four issueCount* fields for the stats panel, new Repairing phase between
  Defragmenting and Vacuuming. Identity-stable mutation pattern matching the existing BlockGrid; gridVersion bumps drive redraw.
  - DefragmenterViewModel.kt — analyze stream stamps cellStates and bumps the issue tallies in place. New kickOffRepair() drives DefragSource.repair,
  applies each Repaired by flipping cellStates[position] = CELL_HEALTHY, decrementing the matching tally, and bumping gridVersion. REPAIR_PER_CELL_PACING_MS
   = 200ms keeps the animation visible. Cancel-while-repairing stops the coroutine cleanly so the finally-block doesn't chain into Vacuuming.
  - DefragGridCanvas.kt — accepts cellStates: ByteArray. Classic mode picks per-block fill/light/shadow from a small lookup keyed by code; the celebratory
  green sweep still overrides via the existing sweepX comparison so Vacuuming paints uniformly green. Modern mode renders the cached bulk healthy path
  first, then per-cell overlay rects for non-Healthy cells.
  - DefragmenterScreen.kt — passes state.cellStates to the canvas, exhausts the new Repairing branch in the status panel, and enables the Cancel button
  while repairing. Per-issue tally lines are zero-suppressed and coloured to match the block palette.
  - strings.xml — defragmenter_status_repairing = "Repairing local index…".

  Scope: local-only repair (for now)

  The repair pass writes to local SQL only. For LegacyUserDateZero that's correct and complete: the canonical file on the server is fine by design (legacy
  clients didn't carry userDate), and the post-10d3667c projection self-heals on logout/resync.

  For SoftDeleteArchivalMismatch the local fix doesn't survive a full logout-wipe-resync, because the inconsistency lives in the JSON itself:
  fileState=deleted paired with appData.archivalStatus != Removed will re-populate the SQL row to the same drift on the next sync. A // TODO(server-repair):
   block in LiveDefragSource.repair() documents the design for the proper fix — GET the canonical header, verify the inconsistency is still present, patch
  the JSON, PUT/UPDATE via outbox infrastructure — along with caveats (write authority on peer-authored files, versionTag thundering herd, payload
  encryption untouched). Held off explicitly until the diagnosis logic has bedded in so we don't risk writing bad data back to the server.

  Test plan

  - Run ./gradlew homebase-api:jvmTest homebase-chat:jvmTest homebase-common:jvmTest homebase-core:compileKotlinJvm desktopApp:compileKotlinJvm.
  - Run desktop app on Frodo. Click Analyze: expect 3 orange + 1 pink cells, matching the log line archival=3 corrupt=0 unmappable=1 repair_eligible=3.
  - Click Defragment. Expect status to flip to Repairing local index…, three orange cells turn navy at 200ms intervals (~600ms total), then the green sweep
  finishes. Pink cell stays pink through the sweep.
  - Cancel during Repairing: expect immediate stop, phase → Cancelled, no Vacuum kicked off, repair coroutine cleaned up.
  - Re-analyze a clean account: expect zero issue counts, mirrored=0 log lines, classic two-colour grid (filled/healthy + gaps/empty).
  - Confirm the existing soft-delete compaction + hard-delete sweep is unchanged on an account that has soft-deletes (gapMap / newGaps paths untouched).
