### PR TITLE
Fix iOS camera crash on permission request

### DIFF
--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/CameraUtil.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/CameraUtil.native.kt
@@ -5,6 +5,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.compose.rememberCameraPickerLauncher
+import platform.AVFoundation.AVAuthorizationStatusAuthorized
+import platform.AVFoundation.AVAuthorizationStatusNotDetermined
+import platform.AVFoundation.AVCaptureDevice
+import platform.AVFoundation.AVMediaTypeAudio
+import platform.AVFoundation.AVMediaTypeVideo
+import platform.AVFoundation.authorizationStatusForMediaType
+import platform.AVFoundation.requestAccessForMediaType
 import platform.Foundation.NSURL
 import platform.UIKit.UIApplication
 import platform.UIKit.UIImagePickerController
@@ -13,6 +20,8 @@ import platform.UIKit.UIImagePickerControllerMediaURL
 import platform.UIKit.UIImagePickerControllerSourceType
 import platform.UIKit.UINavigationControllerDelegateProtocol
 import platform.darwin.NSObject
+import platform.darwin.dispatch_async
+import platform.darwin.dispatch_get_main_queue
 
 @Composable
 actual fun rememberCameraManager(onResult: (PlatformFile?) -> Unit): PlatformCameraManager {
@@ -22,7 +31,24 @@ actual fun rememberCameraManager(onResult: (PlatformFile?) -> Unit): PlatformCam
     return remember {
         object : PlatformCameraManager {
             override fun launch() {
-                launcher.launch()
+                val status = AVCaptureDevice.authorizationStatusForMediaType(AVMediaTypeVideo)
+                when (status) {
+                    AVAuthorizationStatusAuthorized -> launcher.launch()
+                    AVAuthorizationStatusNotDetermined -> {
+                        AVCaptureDevice.requestAccessForMediaType(AVMediaTypeVideo) { granted ->
+                            if (granted) {
+                                dispatch_async(dispatch_get_main_queue()) {
+                                    launcher.launch()
+                                }
+                            }
+                        }
+                    }
+                    else -> {
+                        NSURL.URLWithString(platform.UIKit.UIApplicationOpenSettingsURLString)?.let {
+                            UIApplication.sharedApplication.openURL(it, emptyMap<Any?, String>()) {}
+                        }
+                    }
+                }
             }
         }
     }
@@ -33,10 +59,55 @@ actual fun rememberVideoRecorderManager(onResult: (PlatformFile?) -> Unit): Plat
     val currentOnResult = rememberUpdatedState(onResult)
     return remember {
         object : PlatformVideoRecorderManager {
-            // Retained to prevent garbage collection while picker is presented
             private var delegate: VideoPickerDelegate? = null
 
             override fun launch() {
+                ensureCameraAndMicPermissions {
+                    presentVideoPicker()
+                }
+            }
+
+            private fun ensureCameraAndMicPermissions(onGranted: () -> Unit) {
+                val camStatus = AVCaptureDevice.authorizationStatusForMediaType(AVMediaTypeVideo)
+                when (camStatus) {
+                    AVAuthorizationStatusAuthorized -> ensureMicPermission(onGranted)
+                    AVAuthorizationStatusNotDetermined -> {
+                        AVCaptureDevice.requestAccessForMediaType(AVMediaTypeVideo) { granted ->
+                            if (granted) {
+                                ensureMicPermission(onGranted)
+                            }
+                        }
+                    }
+                    else -> {
+                        NSURL.URLWithString(platform.UIKit.UIApplicationOpenSettingsURLString)?.let {
+                            UIApplication.sharedApplication.openURL(it, emptyMap<Any?, String>()) {}
+                        }
+                    }
+                }
+            }
+
+            private fun ensureMicPermission(onGranted: () -> Unit) {
+                val micStatus = AVCaptureDevice.authorizationStatusForMediaType(AVMediaTypeAudio)
+                when (micStatus) {
+                    AVAuthorizationStatusAuthorized -> {
+                        dispatch_async(dispatch_get_main_queue()) { onGranted() }
+                    }
+                    AVAuthorizationStatusNotDetermined -> {
+                        AVCaptureDevice.requestAccessForMediaType(AVMediaTypeAudio) { granted ->
+                            if (granted) {
+                                dispatch_async(dispatch_get_main_queue()) { onGranted() }
+                            }
+                        }
+                    }
+                    else -> {
+                        NSURL.URLWithString(platform.UIKit.UIApplicationOpenSettingsURLString)?.let {
+                            UIApplication.sharedApplication.openURL(it, emptyMap<Any?, String>()) {}
+                        }
+                    }
+                }
+            }
+
+            private fun presentVideoPicker() {
                 val rootVC = UIApplication.sharedApplication.keyWindow?.rootViewController ?: return
 
                 val picker = UIImagePickerController()


### PR DESCRIPTION
## Summary
- iOS camera (photo and video) was crashing/dismissing immediately after the permission dialog because the picker launched before authorization was confirmed
- Added `AVCaptureDevice` permission checks before launching camera picker and video recorder in `CameraUtil.native.kt`
- Video recorder now also checks microphone permission before presenting `UIImagePickerController`
- If permission is denied, opens iOS Settings instead of silently failing

## Test plan
- [ ] Open chat → tap camera (first time) → grant permission → camera should open
- [ ] Open chat → tap video record (first time) → grant camera + mic permissions → recorder should open
- [ ] Deny camera permission in Settings → tap camera → should redirect to Settings
- [ ] Verify Android camera/video still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)