### PR TITLE
Fix stale notification replay auto-navigating into wrong conversation

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
@@ -20,8 +20,11 @@ import com.mmk.kmpnotifier.notification.NotifierManager
 import id.homebase.api.ActivityProvider
 import id.homebase.api.youauth.YouAuthFlowManager
 import id.homebase.core.App
+import id.homebase.core.notifications.NotificationIntentDecision
 import id.homebase.core.notifications.NotificationService
 import id.homebase.core.notifications.RichNotificationDisplayer
+import id.homebase.core.notifications.decideNotificationIntent
+import id.homebase.core.notifications.isReplayedFromHistory
 import id.homebase.core.settings.ThemeState
 import id.homebase.core.settings.UserPreferences
 import io.github.vinceglb.filekit.FileKit
@@ -136,29 +139,41 @@ class MainActivity : AppCompatActivity() {
      * Extracts the payload data from intent extras and routes via NotificationService.
      */
     private fun handleNotificationIntent(intent: Intent) {
-        // Check for our always-present marker extra (works for all notification types,
-        // not just chat notifications that carry a conversationId)
-        if (!intent.getBooleanExtra(RichNotificationDisplayer.EXTRA_NOTIFICATION_TAP, false)) return
+        val isMarked = intent.getBooleanExtra(RichNotificationDisplayer.EXTRA_NOTIFICATION_TAP, false)
+        val payload = intent.extras?.let { extras ->
+            buildMap<String, Any> {
+                for (key in extras.keySet()) {
+                    @Suppress("DEPRECATION") extras.get(key)?.let { put(key, it) }
+                }
+            }
+        } ?: emptyMap()
 
-        val conversationId = intent.getStringExtra(
-            RichNotificationDisplayer.EXTRA_NOTIFICATION_CONVERSATION_ID
-        )
-        Logger.i(tag = "MainActivity") {
-            "Notification intent detected (conversation: $conversationId)"
+        when (val decision = decideNotificationIntent(intent.flags, isMarked, payload)) {
+            NotificationIntentDecision.Skip -> {
+                // The replay case — Android resumed the activity from recents and
+                // handed back the original launching Intent (with stale extras).
+                // We log it specifically because the symptom from homebase.log
+                // 2026-05-01 08:05:49 was a stale tap auto-navigating the user.
+                if (isReplayedFromHistory(intent.flags) && isMarked) {
+                    Logger.i(tag = "MainActivity") {
+                        "Skipping replayed notification intent (FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY set)"
+                    }
+                }
+            }
+            is NotificationIntentDecision.Process -> {
+                val conversationId = intent.getStringExtra(
+                    RichNotificationDisplayer.EXTRA_NOTIFICATION_CONVERSATION_ID
+                )
+                Logger.i(tag = "MainActivity") {
+                    "Notification intent detected (conversation: $conversationId)"
+                }
+                notificationService.handleNotificationClicked(decision.payload)
+            }
         }
-
-        // Build PayloadData map from intent extras (RichNotificationDisplayer puts all
-        // original notification payload entries as extras)
-        val extras = intent.extras ?: return
-        val payloadData = mutableMapOf<String, Any>()
-        for (key in extras.keySet()) {
-            @Suppress("DEPRECATION")
-            extras.get(key)?.let { payloadData[key] = it }
-        }
-
-        notificationService.handleNotificationClicked(payloadData)
 
         // Clear the notification extras so we don't re-handle on config change
+        // within this same activity instance (process death + recents resume is
+        // covered by the FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY check above).
         intent.removeExtra(RichNotificationDisplayer.EXTRA_NOTIFICATION_TAP)
         intent.removeExtra(RichNotificationDisplayer.EXTRA_NOTIFICATION_CONVERSATION_ID)
         intent.removeExtra("data")

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ColdStartDetailGuard.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ColdStartDetailGuard.kt
@@ -1,0 +1,77 @@
+package id.homebase.chat.conversationlist
+
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
+import androidx.compose.material3.adaptive.navigation.BackNavigationBehavior
+import androidx.compose.material3.adaptive.navigation.ThreePaneScaffoldNavigator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.uuid.Uuid
+
+/**
+ * How long the guard waits for drive-sync to land a conversation referenced by
+ * a `rememberSaveable`-restored Detail destination before popping the pane
+ * scaffold back to List. Long enough that a sync about to land doesn't lose
+ * its rendering window; short enough that the user doesn't sit on the
+ * "select a conversation" empty pane noticeably.
+ */
+internal val COLD_START_DETAIL_GRACE = 800.milliseconds
+
+/**
+ * Cold-start guard for the chat list's `ListDetailPaneScaffold`.
+ *
+ * The pane scaffold's destination history is `rememberSaveable`-backed and
+ * survives process death. After Android process death + recents resume, on
+ * phone (single-pane), the scaffold can re-mount with a Detail destination
+ * whose `contentKey` references a conversation that hasn't yet been loaded
+ * by drive sync. The user sees the EmptyDetailPane ("select a conversation")
+ * full-screen until the conversation appears or some other path navigates
+ * away — observed at 2+ seconds in homebase.log around 2026-05-01 08:05:49.
+ *
+ * This guard gives drive sync [COLD_START_DETAIL_GRACE] to land the target,
+ * then pops back to List if the conversation still isn't present. Two-pane
+ * mode is exempted because Detail-without-selection is legitimate UX there.
+ *
+ * **Keying note.** The effect re-keys on the derived [Boolean]
+ * `isRestoredConvLoaded`, NOT on the underlying conversation set. Drive-sync
+ * arrives in chunks during cold-start; each chunk produces a new collection,
+ * which would reset the timer if we keyed on it directly. Keying on the
+ * Boolean means the effect re-launches only when the target conversation
+ * actually appears in the set (`false` → `true`), at which point the
+ * early-return prevents the pop — exactly the desired behavior.
+ */
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+@Composable
+internal fun ColdStartDetailGuard(
+    scaffoldNavigator: ThreePaneScaffoldNavigator<Uuid>,
+    loadedConversationIds: Set<Uuid>,
+    maxHorizontalPartitions: Int,
+) {
+    val restoredDetailKey = scaffoldNavigator.currentDestination
+        ?.takeIf { it.pane == ListDetailPaneScaffoldRole.Detail }
+        ?.contentKey
+    val isRestoredConvLoaded =
+        restoredDetailKey != null && restoredDetailKey in loadedConversationIds
+
+    LaunchedEffect(restoredDetailKey, isRestoredConvLoaded, maxHorizontalPartitions) {
+        if (maxHorizontalPartitions > 1) return@LaunchedEffect
+        if (restoredDetailKey == null) return@LaunchedEffect
+        if (isRestoredConvLoaded) return@LaunchedEffect
+        delay(COLD_START_DETAIL_GRACE)
+        // Re-check after the wait. If the conversation landed during the delay
+        // the keying flip would have cancelled this coroutine — this re-read
+        // defends against the small race where the cancellation hasn't yet
+        // reached us when we resume.
+        if (restoredDetailKey !in loadedConversationIds &&
+            scaffoldNavigator.currentDestination?.pane == ListDetailPaneScaffoldRole.Detail
+        ) {
+            Logger.i(tag = "ConversationListUi") {
+                "Detail pane restored with unloaded conversation $restoredDetailKey — popping to List"
+            }
+            scaffoldNavigator.navigateBack(BackNavigationBehavior.PopUntilContentChange)
+        }
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -658,6 +658,17 @@ fun ConversationListUi(
         }
     }
 
+    // Cold-start guard against the pane scaffold's rememberSaveable-restored Detail
+    // destination outliving its conversation. See ColdStartDetailGuard's KDoc.
+    val loadedConversationIds = remember(uiState.activeConversations) {
+        uiState.activeConversations.mapTo(hashSetOf()) { it.conversation.id }
+    }
+    ColdStartDetailGuard(
+        scaffoldNavigator = scaffoldNavigator,
+        loadedConversationIds = loadedConversationIds,
+        maxHorizontalPartitions = scaffoldDirective.maxHorizontalPartitions,
+    )
+
     val partitions = scaffoldDirective.maxHorizontalPartitions
     LaunchedEffect(partitions) {
         if (partitions > 1) {

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/conversationlist/ColdStartDetailGuardTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/conversationlist/ColdStartDetailGuardTest.kt
@@ -1,0 +1,252 @@
+package id.homebase.chat.conversationlist
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.layout.AnimatedPane
+import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffold
+import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
+import androidx.compose.material3.adaptive.layout.PaneScaffoldDirective
+import androidx.compose.material3.adaptive.layout.ThreePaneScaffoldDestinationItem
+import androidx.compose.material3.adaptive.navigation.ThreePaneScaffoldNavigator
+import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaffoldNavigator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.uuid.Uuid
+
+/**
+ * Compose UI tests for [ColdStartDetailGuard].
+ *
+ * These tests drive `mainClock.advanceTimeBy(...)` to advance both Compose
+ * frames and the LaunchedEffect's `delay(...)` together — `runComposeUiTest`'s
+ * test dispatcher is tied to `mainClock`, so a single advance moves both.
+ *
+ * The regression target for this whole branch is the `unrelatedConvsAddedDuringWait_stillPopsAfterGrace`
+ * case: an earlier version keyed the LaunchedEffect on the entire activeConversations
+ * list, so each drive-sync chunk reset the timer and the pop never fired during
+ * a typical cold-start.
+ */
+@OptIn(ExperimentalTestApi::class, ExperimentalMaterial3AdaptiveApi::class)
+class ColdStartDetailGuardTest {
+
+    private val convX = Uuid.parse("aaaaaaaa-0000-0000-0000-000000000001")
+    private val convY = Uuid.parse("aaaaaaaa-0000-0000-0000-000000000002")
+    private val convZ = Uuid.parse("aaaaaaaa-0000-0000-0000-000000000003")
+    private val convW = Uuid.parse("aaaaaaaa-0000-0000-0000-000000000004")
+
+    private fun compactDirective() = PaneScaffoldDirective(
+        maxHorizontalPartitions = 1,
+        horizontalPartitionSpacerSize = 0.dp,
+        maxVerticalPartitions = 1,
+        verticalPartitionSpacerSize = 0.dp,
+        defaultPanePreferredWidth = 360.dp,
+        excludedBounds = emptyList(),
+    )
+
+    private fun expandedDirective() = PaneScaffoldDirective(
+        maxHorizontalPartitions = 2,
+        horizontalPartitionSpacerSize = 0.dp,
+        maxVerticalPartitions = 1,
+        verticalPartitionSpacerSize = 0.dp,
+        defaultPanePreferredWidth = 360.dp,
+        excludedBounds = emptyList(),
+    )
+
+    /**
+     * Test host. Mirrors the production wiring: rememberListDetailPaneScaffoldNavigator
+     * starts at Detail(initialDetailKey) so we simulate the rememberSaveable
+     * restoration of a Detail destination across process death without actually
+     * tearing down a process. Exposes the navigator via [navigatorRef] for
+     * assertion.
+     */
+    @Composable
+    private fun TestHost(
+        directive: PaneScaffoldDirective,
+        initialDetailKey: Uuid?,
+        loadedIds: MutableState<Set<Uuid>>,
+        navigatorRef: MutableState<ThreePaneScaffoldNavigator<Uuid>?>,
+    ) {
+        val initialHistory = remember {
+            buildList {
+                add(ThreePaneScaffoldDestinationItem(ListDetailPaneScaffoldRole.List))
+                if (initialDetailKey != null) {
+                    add(
+                        ThreePaneScaffoldDestinationItem(
+                            ListDetailPaneScaffoldRole.Detail,
+                            initialDetailKey,
+                        )
+                    )
+                }
+            }
+        }
+        val scaffoldNavigator = rememberListDetailPaneScaffoldNavigator<Uuid>(
+            scaffoldDirective = directive,
+            initialDestinationHistory = initialHistory,
+        )
+        navigatorRef.value = scaffoldNavigator
+
+        ColdStartDetailGuard(
+            scaffoldNavigator = scaffoldNavigator,
+            loadedConversationIds = loadedIds.value,
+            maxHorizontalPartitions = directive.maxHorizontalPartitions,
+        )
+
+        ListDetailPaneScaffold(
+            directive = directive,
+            scaffoldState = scaffoldNavigator.scaffoldState,
+            listPane = { AnimatedPane { Text("list") } },
+            detailPane = {
+                AnimatedPane {
+                    val key = scaffoldNavigator.currentDestination?.contentKey
+                    Text("detail=${key?.toString() ?: "null"}")
+                }
+            },
+        )
+    }
+
+    @Test
+    fun unloadedConv_popsAfterGrace() = runComposeUiTest {
+        mainClock.autoAdvance = false
+        val loaded = mutableStateOf<Set<Uuid>>(emptySet())
+        val navigatorRef = mutableStateOf<ThreePaneScaffoldNavigator<Uuid>?>(null)
+
+        setContent {
+            MaterialTheme {
+                TestHost(
+                    directive = compactDirective(),
+                    initialDetailKey = convX,
+                    loadedIds = loaded,
+                    navigatorRef = navigatorRef,
+                )
+            }
+        }
+        mainClock.advanceTimeBy(50)  // initial composition + LaunchedEffect launch
+
+        // Sanity: scaffold is on Detail before the grace expires.
+        assertEquals(
+            ListDetailPaneScaffoldRole.Detail,
+            navigatorRef.value?.currentDestination?.pane,
+        )
+
+        // Cross the 800 ms threshold; effect should pop back to List.
+        mainClock.advanceTimeBy(900)
+        assertNotEquals(
+            ListDetailPaneScaffoldRole.Detail,
+            navigatorRef.value?.currentDestination?.pane,
+            "guard should have popped back to List after grace",
+        )
+    }
+
+    @Test
+    fun convLoadsBeforeGrace_doesNotPop() = runComposeUiTest {
+        mainClock.autoAdvance = false
+        val loaded = mutableStateOf<Set<Uuid>>(emptySet())
+        val navigatorRef = mutableStateOf<ThreePaneScaffoldNavigator<Uuid>?>(null)
+
+        setContent {
+            MaterialTheme {
+                TestHost(
+                    directive = compactDirective(),
+                    initialDetailKey = convX,
+                    loadedIds = loaded,
+                    navigatorRef = navigatorRef,
+                )
+            }
+        }
+        mainClock.advanceTimeBy(400)  // partway through the grace
+
+        // Drive sync lands convX → keying flips, in-flight delay cancels.
+        loaded.value = setOf(convX)
+        mainClock.advanceTimeBy(1000)  // well past grace; nothing should pop
+
+        assertEquals(
+            ListDetailPaneScaffoldRole.Detail,
+            navigatorRef.value?.currentDestination?.pane,
+            "loading the target conversation must cancel the pop",
+        )
+        assertEquals(
+            convX,
+            navigatorRef.value?.currentDestination?.contentKey,
+        )
+    }
+
+    /**
+     * Regression test for the keying bug fixed in this commit: keying directly
+     * on `activeConversations` reset the 800 ms timer every time drive sync
+     * landed an unrelated conversation. With chunks arriving every ~250 ms the
+     * timer would never elapse. Keying on the derived `isRestoredConvLoaded`
+     * Boolean means unrelated conversations don't reset the timer.
+     */
+    @Test
+    fun unrelatedConvsAddedDuringWait_stillPopsAfterGrace() = runComposeUiTest {
+        mainClock.autoAdvance = false
+        val loaded = mutableStateOf<Set<Uuid>>(emptySet())
+        val navigatorRef = mutableStateOf<ThreePaneScaffoldNavigator<Uuid>?>(null)
+
+        setContent {
+            MaterialTheme {
+                TestHost(
+                    directive = compactDirective(),
+                    initialDetailKey = convX,  // never loaded
+                    loadedIds = loaded,
+                    navigatorRef = navigatorRef,
+                )
+            }
+        }
+        mainClock.advanceTimeBy(50)
+
+        // Three drive-sync chunks within the grace window, none of them convX.
+        mainClock.advanceTimeBy(200); loaded.value = setOf(convY)
+        mainClock.advanceTimeBy(200); loaded.value = setOf(convY, convZ)
+        mainClock.advanceTimeBy(200); loaded.value = setOf(convY, convZ, convW)
+        // Cumulative ~650 ms; nothing should have popped yet.
+        assertEquals(
+            ListDetailPaneScaffoldRole.Detail,
+            navigatorRef.value?.currentDestination?.pane,
+        )
+
+        // Cross the 800 ms boundary. Pre-fix this would not have popped because
+        // each chunk reset the timer. Post-fix the timer kept ticking.
+        mainClock.advanceTimeBy(300)
+        assertNotEquals(
+            ListDetailPaneScaffoldRole.Detail,
+            navigatorRef.value?.currentDestination?.pane,
+            "unrelated conv chunks must not reset the grace timer",
+        )
+    }
+
+    @Test
+    fun twoPaneMode_doesNotPop() = runComposeUiTest {
+        mainClock.autoAdvance = false
+        val loaded = mutableStateOf<Set<Uuid>>(emptySet())
+        val navigatorRef = mutableStateOf<ThreePaneScaffoldNavigator<Uuid>?>(null)
+
+        setContent {
+            MaterialTheme {
+                TestHost(
+                    directive = expandedDirective(),
+                    initialDetailKey = convX,
+                    loadedIds = loaded,
+                    navigatorRef = navigatorRef,
+                )
+            }
+        }
+        mainClock.advanceTimeBy(2_000)  // way past grace
+
+        // Two-pane mode legitimately shows Detail without a matching conversation.
+        assertEquals(
+            ListDetailPaneScaffoldRole.Detail,
+            navigatorRef.value?.currentDestination?.pane,
+            "two-pane mode must not pop the empty Detail",
+        )
+    }
+
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
@@ -616,6 +616,53 @@ class NotificationService(
 }
 
 /**
+ * Mirrors Android's `Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY` bit. Callers
+ * pass `intent.flags`; a non-zero AND means the Intent comes from the recents
+ * history stack (launcher resume after process death) rather than a fresh
+ * notification tap. In that case the launching Intent's notification extras
+ * are stale and should not re-fire navigation.
+ */
+const val FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY: Int = 0x00100000
+
+fun isReplayedFromHistory(flags: Int): Boolean =
+    (flags and FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != 0
+
+/**
+ * Outcome of inspecting an Android notification-tap Intent. [Skip] means the
+ * Intent is either a recents/launcher replay or doesn't carry the tap marker;
+ * either way, the caller must not invoke [NotificationService.handleNotificationClicked].
+ * [Process] means the Intent is a fresh, marked tap and the payload should be
+ * forwarded to NotificationService.
+ */
+sealed interface NotificationIntentDecision {
+    data object Skip : NotificationIntentDecision
+    data class Process(val payload: PayloadData) : NotificationIntentDecision
+}
+
+/**
+ * Decides whether a notification-tap Intent should be processed. Pure function —
+ * no Activity, no Intent — so it's reachable from JVM unit tests. The Android
+ * call site reads `intent.flags`, `intent.getBooleanExtra(EXTRA_NOTIFICATION_TAP)`,
+ * and `intent.extras` and routes through this.
+ *
+ * Skip when:
+ *  - `flags` carries [FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY] (Android resumed the
+ *    activity from recents/launcher and handed back the original launching Intent
+ *    — the extras are stale; this is the bug from homebase.log 2026-05-01 08:05:49).
+ *  - The Intent doesn't carry the notification-tap marker (deep links, normal app
+ *    launches, etc.).
+ */
+fun decideNotificationIntent(
+    flags: Int,
+    isMarkedAsTap: Boolean,
+    payload: PayloadData,
+): NotificationIntentDecision = when {
+    isReplayedFromHistory(flags) -> NotificationIntentDecision.Skip
+    !isMarkedAsTap -> NotificationIntentDecision.Skip
+    else -> NotificationIntentDecision.Process(payload)
+}
+
+/**
  * Parses a chat notification's `typeId` (conversation) and `tagId`
  * (message) into Uuids. Returns null if either is missing or malformed
  * — the caller then skips setting the pending tap and the user lands

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/PendingNotificationTap.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/PendingNotificationTap.kt
@@ -47,6 +47,12 @@ class PendingNotificationTap(
      * Tests pass `backgroundScope` from `runTest` so virtual time advances expiries.
      */
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob()),
+    /**
+     * Time source for `createdAt` timestamps and the consume-dedup window. Defaults
+     * to wall clock; tests inject a virtual-time clock so the dedup window advances
+     * with `advanceTimeBy(...)` rather than real elapsed time.
+     */
+    private val now: () -> Instant = { Clock.System.now() },
 ) {
 
     data class Tap(
@@ -63,20 +69,50 @@ class PendingNotificationTap(
     private var expiryJob: Job? = null
 
     /**
+     * Last `(conv, msg, consumedAt)` tuple from a *user-resolved* tap (set then
+     * cleared via [clear] or [clearIfMatches] — NOT a TTL expiry). Within
+     * [DEDUP_WINDOW] of consumedAt, a duplicate `set(conv, msg)` for the same
+     * pair is treated as an Intent replay and dropped.
+     */
+    @Volatile
+    private var lastConsumed: ConsumeRecord? = null
+
+    private data class ConsumeRecord(
+        val conversationId: Uuid,
+        val messageId: Uuid,
+        val consumedAt: Instant,
+    )
+
+    /**
      * Set a fresh pending tap. Any previous tap is overwritten and its TTL timer
      * cancelled — the new tap starts a new countdown. Safe to call from any context;
      * non-suspend by design so action handlers (e.g. `onAction.ConversationClicked`)
      * can call it without a coroutine.
      */
     fun set(conversationId: Uuid, messageId: Uuid) {
+        val recent = lastConsumed
+        if (recent != null &&
+            recent.conversationId == conversationId &&
+            recent.messageId == messageId &&
+            now() - recent.consumedAt <= DEDUP_WINDOW
+        ) {
+            Logger.i(tag = TAG) {
+                "set ignored as duplicate within ${DEDUP_WINDOW.inWholeSeconds}s of consume " +
+                    "(conv=$conversationId msg=$messageId)"
+            }
+            return
+        }
+
         expiryJob?.cancel()
-        val tap = Tap(conversationId, messageId, Clock.System.now())
+        val tap = Tap(conversationId, messageId, now())
         _state.value = tap
         expiryJob = scope.launch {
             delay(ttl)
             // compareAndSet: only clear if THIS exact tap is still the active one.
             // A racing set() that landed between our delay and now would have
             // replaced _state.value already; we must not clobber the newer tap.
+            // TTL expiry intentionally does NOT seed `lastConsumed` — a tap the
+            // user never actually saw resolve shouldn't dedup their next try.
             if (_state.compareAndSet(tap, null)) {
                 Logger.i(tag = TAG) {
                     "expired after ${ttl.inWholeSeconds}s without resolution " +
@@ -93,6 +129,7 @@ class PendingNotificationTap(
             // case is "tap was set then cleared without resolving" — pair this with the
             // `Setting pendingNotificationTap` line at INFO to reconstruct what happened.
             Logger.d(tag = TAG) { "cleared (was conv=${previous.conversationId})" }
+            seedConsumed(previous)
         }
         expiryJob?.cancel()
         _state.value = null
@@ -111,8 +148,14 @@ class PendingNotificationTap(
             expiryJob?.cancel()
             // compareAndSet: another set() may have replaced the tap between our read
             // and now — leaving the newer tap intact is the correct behavior.
-            _state.compareAndSet(current, null)
+            if (_state.compareAndSet(current, null)) {
+                seedConsumed(current)
+            }
         }
+    }
+
+    private fun seedConsumed(tap: Tap) {
+        lastConsumed = ConsumeRecord(tap.conversationId, tap.messageId, now())
     }
 
     companion object {
@@ -124,5 +167,14 @@ class PendingNotificationTap(
          * won't surprise the user after they've moved on.
          */
         val DEFAULT_TTL: Duration = 10.seconds
+
+        /**
+         * After a `(conv, msg)` tap resolves, a duplicate `set(conv, msg)` for the
+         * same pair within this window is treated as a stale Intent replay
+         * (e.g. onCreate + onNewIntent both feeding the same payload) and ignored.
+         * A real new message in the same conv arrives with a different msgId and
+         * is unaffected.
+         */
+        val DEDUP_WINDOW: Duration = 30.seconds
     }
 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/PushNotification.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/PushNotification.kt
@@ -1,5 +1,6 @@
 package id.homebase.core.notifications
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** Push notification payload matching the backend DevicePushNotificationRequest format. */
@@ -8,6 +9,7 @@ data class PushNotification(
     val id: String? = null,
     val senderId: String,
     val unread: Boolean = false,
+    @SerialName("timestamp")
     val created: Long = 0,
     val options: PushNotificationPayloadOptions,
     val appDisplayName: String? = null

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/IsReplayedFromHistoryTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/IsReplayedFromHistoryTest.kt
@@ -1,0 +1,47 @@
+package id.homebase.core.notifications
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Locks down the bit-mask check that detects when MainActivity is being
+ * re-resumed from the recents/history stack with a stale notification
+ * Intent (the symptom in homebase.log around 2026-05-01 08:05:49).
+ *
+ * Mirrors `Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY` (0x00100000).
+ * The `Intent` constant itself is Android-only; the helper takes an Int
+ * so it's unit-testable from JVM without Robolectric.
+ */
+class IsReplayedFromHistoryTest {
+
+    private val FLAG_HISTORY = 0x00100000           // Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY
+    private val FLAG_NEW_TASK = 0x10000000          // Intent.FLAG_ACTIVITY_NEW_TASK
+    private val FLAG_CLEAR_TOP = 0x04000000         // Intent.FLAG_ACTIVITY_CLEAR_TOP
+
+    @Test
+    fun launchedFromHistoryOnly_returnsTrue() {
+        assertTrue(isReplayedFromHistory(FLAG_HISTORY))
+    }
+
+    @Test
+    fun launchedFromHistoryCombinedWithOthers_returnsTrue() {
+        assertTrue(isReplayedFromHistory(FLAG_HISTORY or FLAG_NEW_TASK or FLAG_CLEAR_TOP))
+    }
+
+    @Test
+    fun otherFlagsOnly_returnsFalse() {
+        assertFalse(isReplayedFromHistory(FLAG_NEW_TASK or FLAG_CLEAR_TOP))
+    }
+
+    @Test
+    fun zeroFlags_returnsFalse() {
+        assertFalse(isReplayedFromHistory(0))
+    }
+
+    @Test
+    fun helperConstantMatchesAndroidValue() {
+        // Pin the constant — if someone mistypes it the bit-mask quietly stops working.
+        assertTrue(FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY == 0x00100000)
+    }
+}

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/NotificationIntentDecisionTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/NotificationIntentDecisionTest.kt
@@ -1,0 +1,84 @@
+package id.homebase.core.notifications
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Locks down the decision wiring at MainActivity.handleNotificationIntent — what
+ * the bug-from-the-log actually exercised. The bit-mask helper is already pinned
+ * by [IsReplayedFromHistoryTest]; this test pins the call site that combines
+ * the flag check, the marker-extra check, and the hand-off to NotificationService.
+ *
+ * Replicates 2026-05-01 08:05:49: a launching Intent with the notification
+ * marker still set AND `FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY` because the user
+ * resumed the app from launcher. Decision must be Skip — otherwise the user
+ * gets auto-navigated to a 73-minute-old notification's conversation.
+ */
+class NotificationIntentDecisionTest {
+
+    private val FLAG_NEW_TASK = 0x10000000           // Intent.FLAG_ACTIVITY_NEW_TASK
+    private val FLAG_HISTORY = FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY
+
+    private val examplePayload: Map<String, Any> = mapOf(
+        "data" to """{"senderId":"x","timestamp":1,"options":{"appId":"a","typeId":"b","tagId":"c"}}""",
+        "notification_tap" to true,
+        "notification_conversation_id" to "42af4ac1-cc54-4a81-aa02-2a7854ce0980",
+    )
+
+    @Test
+    fun replayedIntentWithMarker_isSkipped() {
+        val decision = decideNotificationIntent(
+            flags = FLAG_HISTORY or FLAG_NEW_TASK,
+            isMarkedAsTap = true,
+            payload = examplePayload,
+        )
+        assertEquals(NotificationIntentDecision.Skip, decision)
+    }
+
+    @Test
+    fun freshIntentWithMarker_isProcessed() {
+        val decision = decideNotificationIntent(
+            flags = FLAG_NEW_TASK,
+            isMarkedAsTap = true,
+            payload = examplePayload,
+        )
+        assertTrue(decision is NotificationIntentDecision.Process)
+    }
+
+    @Test
+    fun intentWithoutMarker_isSkipped() {
+        // Deep-links and other intents that lack the EXTRA_NOTIFICATION_TAP marker
+        // must not be routed through NotificationService.handleNotificationClicked.
+        val decision = decideNotificationIntent(
+            flags = 0,
+            isMarkedAsTap = false,
+            payload = emptyMap<String, Any>(),
+        )
+        assertEquals(NotificationIntentDecision.Skip, decision)
+    }
+
+    @Test
+    fun replayedIntentWithoutMarker_isSkipped() {
+        // Both conditions are independently sufficient for Skip.
+        val decision = decideNotificationIntent(
+            flags = FLAG_HISTORY,
+            isMarkedAsTap = false,
+            payload = emptyMap<String, Any>(),
+        )
+        assertEquals(NotificationIntentDecision.Skip, decision)
+    }
+
+    @Test
+    fun processBranchPreservesPayload() {
+        val decision = decideNotificationIntent(
+            flags = FLAG_NEW_TASK,
+            isMarkedAsTap = true,
+            payload = examplePayload,
+        )
+        val process = decision as NotificationIntentDecision.Process
+        // Must hand the exact same map through — no copy, no transformation.
+        assertSame(examplePayload, process.payload)
+    }
+}

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/PendingNotificationTapTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/PendingNotificationTapTest.kt
@@ -1,6 +1,7 @@
 package id.homebase.core.notifications
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -8,8 +9,19 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.time.ExperimentalTime
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 import kotlin.uuid.Uuid
+
+/**
+ * Returns a virtual-time clock backed by the [TestScope]'s scheduler so the
+ * dedup window (and any other Instant-based check inside the holder) advances
+ * with `advanceTimeBy(...)` rather than wall-clock time.
+ */
+@OptIn(ExperimentalTime::class, ExperimentalCoroutinesApi::class)
+private fun TestScope.virtualClock(): () -> Instant =
+    { Instant.fromEpochMilliseconds(testScheduler.currentTime) }
 
 /**
  * Locks down the PendingNotificationTap contract consumed by
@@ -168,5 +180,131 @@ class PendingNotificationTapTest {
         advanceTimeBy(1_500)
         advanceUntilIdle()
         assertNull(holder.state.value)
+    }
+
+    // ---------- consume-dedup ----------
+    //
+    // After a real `set → resolve` cycle, a duplicate `set(conv,msg)` call within
+    // DEDUP_WINDOW is a no-op. This catches rapid-fire replays — e.g. onCreate
+    // and onNewIntent both processing the same Intent in the same activity
+    // lifecycle, or any future code path that re-feeds the same payload — without
+    // breaking the legitimate "user receives a new message in the same conv"
+    // case (different msgId → fresh tap) or "user taps a new conv" case
+    // (different convId → fresh tap). The TTL expiry path does NOT seed
+    // dedup, since "tap I never resolved" is not a thing the user already saw.
+
+    @Test
+    fun setAfterRecentConsume_isIgnoredAsDuplicate() = runTest {
+        val holder = PendingNotificationTap(scope = backgroundScope, now = virtualClock())
+        holder.set(convoA, msgA)
+        holder.clearIfMatches(convoA)
+        assertNull(holder.state.value)
+
+        advanceTimeBy(5_000)  // well within DEDUP_WINDOW
+        advanceUntilIdle()
+
+        holder.set(convoA, msgA)
+        assertNull(
+            holder.state.value,
+            "duplicate set within dedup window must be a no-op",
+        )
+    }
+
+    @Test
+    fun setAfterStaleConsume_succeeds() = runTest {
+        val holder = PendingNotificationTap(scope = backgroundScope, now = virtualClock())
+        holder.set(convoA, msgA)
+        holder.clearIfMatches(convoA)
+
+        advanceTimeBy(31_000)  // past DEDUP_WINDOW
+        advanceUntilIdle()
+
+        holder.set(convoA, msgA)
+        val tap = holder.state.value
+        assertNotNull(tap, "set after dedup window expired must produce a fresh tap")
+        assertEquals(convoA, tap.conversationId)
+        assertEquals(msgA, tap.messageId)
+    }
+
+    @Test
+    fun setDifferentConvAfterRecentConsume_succeeds() = runTest {
+        val holder = PendingNotificationTap(scope = backgroundScope, now = virtualClock())
+        holder.set(convoA, msgA)
+        holder.clearIfMatches(convoA)
+
+        advanceTimeBy(5_000)
+        advanceUntilIdle()
+
+        holder.set(convoB, msgB)
+        val tap = holder.state.value
+        assertNotNull(tap, "different conv must not be deduped")
+        assertEquals(convoB, tap.conversationId)
+    }
+
+    @Test
+    fun setSameConvDifferentMsgAfterRecentConsume_succeeds() = runTest {
+        val holder = PendingNotificationTap(scope = backgroundScope, now = virtualClock())
+        holder.set(convoA, msgA)
+        holder.clearIfMatches(convoA)
+
+        advanceTimeBy(5_000)
+        advanceUntilIdle()
+
+        // A new message arriving in the same conversation is a fresh tap —
+        // dedup is per (conv, msg), not per conv.
+        holder.set(convoA, msgB)
+        val tap = holder.state.value
+        assertNotNull(tap, "same conv with different msg must not be deduped")
+        assertEquals(convoA, tap.conversationId)
+        assertEquals(msgB, tap.messageId)
+    }
+
+    @Test
+    fun dedupRecordIsNotSeededByTtlExpiry() = runTest {
+        val holder = PendingNotificationTap(
+            ttl = 10.seconds,
+            scope = backgroundScope,
+            now = virtualClock(),
+        )
+        holder.set(convoA, msgA)
+
+        // No resolve — let the TTL fire.
+        advanceTimeBy(11_000)
+        advanceUntilIdle()
+        assertNull(holder.state.value)
+
+        // Same payload taps next — must be treated as a fresh tap, not a dup.
+        holder.set(convoA, msgA)
+        val tap = holder.state.value
+        assertNotNull(tap, "TTL expiry must not seed dedup")
+        assertEquals(convoA, tap.conversationId)
+    }
+
+    @Test
+    fun clearWithoutMatchingTap_doesNotSeedDedup() = runTest {
+        val holder = PendingNotificationTap(scope = backgroundScope, now = virtualClock())
+        // No prior set — clear() on an empty holder is a no-op.
+        holder.clear()
+
+        holder.set(convoA, msgA)
+        val tap = holder.state.value
+        assertNotNull(tap, "clear() on empty state must not poison a future fresh tap")
+        assertEquals(convoA, tap.conversationId)
+    }
+
+    @Test
+    fun dedupAppliesAfterPlainClearToo() = runTest {
+        val holder = PendingNotificationTap(scope = backgroundScope, now = virtualClock())
+        holder.set(convoA, msgA)
+        holder.clear()  // not clearIfMatches — both clear paths must seed dedup
+
+        advanceTimeBy(5_000)
+        advanceUntilIdle()
+
+        holder.set(convoA, msgA)
+        assertNull(
+            holder.state.value,
+            "plain clear() should also seed dedup so a replayed Intent is no-oped",
+        )
     }
 }

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/PushNotificationTimestampDeserializationTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/PushNotificationTimestampDeserializationTest.kt
@@ -1,0 +1,36 @@
+package id.homebase.core.notifications
+
+import id.homebase.api.serialization.OdinSystemSerializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins the wire-format ⇄ data-class mapping for the inner notification payload.
+ *
+ * The FCM "data" extra arrives as the JSON below — see homebase.log entries like
+ * `{"senderId":"…","timestamp":1777598471888,"options":{…}}`. Without a
+ * @SerialName("timestamp") on PushNotification.created, kotlinx.serialization
+ * silently drops the field and the staleness gate cannot fire.
+ */
+class PushNotificationTimestampDeserializationTest {
+
+    private val sampleJson = """
+        {
+          "senderId": "bjarne.hansen.id.pub",
+          "appDisplayName": "Homebase - Chat",
+          "timestamp": 1777598471888,
+          "options": {
+            "appId": "2d781401-3804-4b57-b4aa-d8e4e2ef39f4",
+            "typeId": "42af4ac1-cc54-4a81-aa02-2a7854ce0980",
+            "tagId": "c4b73e34-9b1e-4f12-98b7-e72149725c59",
+            "silent": false
+          }
+        }
+    """.trimIndent()
+
+    @Test
+    fun wireTimestamp_isDeserializedIntoCreated() {
+        val notification = OdinSystemSerializer.deserialize<PushNotification>(sampleJson)
+        assertEquals(1777598471888L, notification.created)
+    }
+}


### PR DESCRIPTION
Symptom (homebase.log 2026-05-01 08:05:49): user opened the app from launcher, briefly saw the "select a conversation" empty pane, then got auto-navigated to a 73-minute-old notification's conversation.

Root cause: after Android process death, recents/launcher resume re-creates MainActivity with the original launching Intent. The Intent still carries the EXTRA_NOTIFICATION_TAP marker and the old payload, so handleNotification- Intent fires again with stale data. removeExtra() in the old handler only mutated the in-memory Intent of the prior (now-dead) activity instance.

Three layers of defence:

1. MainActivity early-returns when intent.flags carries FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY. This is what catches the actual replay symptom from the log. The decision logic is extracted into a pure commonMain helper (decideNotificationIntent) so it's regression- testable from JVM without Robolectric.

2. PendingNotificationTap now refuses a duplicate set(conv, msg) within 30s of the last consume. Catches rapid-fire replays inside the same activity lifecycle (e.g. onCreate + onNewIntent both feeding the same Intent). TTL expiry intentionally does NOT seed dedup -- a tap the user never saw resolve shouldn't dedup their next try. Time source is now injectable so virtual-time tests work with kotlinx-coroutines-test.

3. ColdStartDetailGuard pops the pane scaffold back to List 800ms after a rememberSaveable-restored Detail destination fails to match any loaded conversation. Single-pane only -- two-pane mode legitimately shows Detail without selection. Keys on a derived Boolean (isRestoredConvLoaded), not the underlying conversation set, so chunked drive-sync arrivals don't reset the timer.

Plus a latent fix discovered while wiring this: PushNotification.created needed @SerialName("timestamp") to actually deserialize the wire field. Previously always 0, so RichNotificationData.timestamp (used for Android setWhen on rich notifications) fell back to System.currentTimeMillis().

Tests:
- PushNotificationTimestampDeserializationTest pins the wire-format mapping
- IsReplayedFromHistoryTest pins the bit-mask + Android constant value
- NotificationIntentDecisionTest pins the decision wiring (incl. the exact replay-with-marker scenario from the log)
- PendingNotificationTapTest gains 7 dedup cases (same-pair-deduped, stale-pair-succeeds, different-conv-succeeds, different-msg-same-conv- succeeds, ttl-doesn't-seed, clear-on-empty-doesn't-poison, plain-clear- also-seeds)
- ColdStartDetailGuardTest covers happy-path pop, cancellation when conv loads, two-pane exemption, and the keying-bug regression where unrelated drive-sync chunks would have reset the 800ms timer

Verified: androidApp:compileDebugKotlin, homebase-chat:jvmTest, homebase-common:jvmTest, homebase-auth:jvmTest, homebase-api:jvmTest all pass with --rerun-tasks.