### PR TITLE
Bug. Chat edit: don't double-stamp isPendingSendTag on optimistic update

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
@@ -249,9 +249,13 @@ class OptimisticWriter(
         val lastModified = existingFile.fileMetadata.updated.addMilliseconds(1)
 
         val existing = existingFile.fileMetadata.localAppData
+        val existingTags = existing?.tags.orEmpty()
 
+        // Skip re-adding when present: a stuck pending row would otherwise produce
+        // a duplicate that violates DriveLocalTagIndex's UNIQUE constraint.
         val newLocalAppData = existing?.copy(
-            tags = existing.tags.orEmpty() + ChatProtocol.isPendingSendTag
+            tags = if (ChatProtocol.isPendingSendTag in existingTags) existingTags
+                   else existingTags + ChatProtocol.isPendingSendTag
         ) ?: LocalAppMetadata(
             tags = listOf(ChatProtocol.isPendingSendTag)
         )

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceTestFixture.kt
@@ -76,6 +76,8 @@ class ChatMessageSenderServiceTestFixture : AutoCloseable {
         private set
     lateinit var payloadEncryptor: FakePayloadBundleEncryptor
         private set
+    lateinit var optimisticWriter: OptimisticWriter
+        private set
 
     suspend fun build(scope: CoroutineScope = TestScope()): ChatMessageSenderService {
         dbm = createInMemoryDbm()
@@ -92,7 +94,7 @@ class ChatMessageSenderServiceTestFixture : AutoCloseable {
         conversationLookup = SeedableConversationLookup(testDomain)
         payloadEncryptor = FakePayloadBundleEncryptor()
 
-        val optimisticWriter = OptimisticWriter(
+        optimisticWriter = OptimisticWriter(
             credentialsManager = credentialsManager,
             dbm = dbm,
             eventBus = eventBus,

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/outbox/OptimisticWriterPendingSendTagTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/outbox/OptimisticWriterPendingSendTagTest.kt
@@ -1,0 +1,107 @@
+package id.homebase.chat.services.outbox
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.drives.upload.UploadAppFileMetaData
+import id.homebase.api.client.drives.upload.UploadFileMetadata
+import id.homebase.api.crypto.ByteArrayUtil
+import id.homebase.chat.services.ChatMessageSenderServiceTestFixture
+import id.homebase.chat.services.ChatProtocol
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Regression test for the SQLiteConstraintException seen in field logs when a
+ * user tried to edit a chat message whose previous send had not yet confirmed.
+ *
+ * Scenario reproduced:
+ *   1. Send a new message (offline outbox: it never confirms). The optimistic
+ *      writer stamps `localAppData.tags = [isPendingSendTag]` on the new row.
+ *   2. Without waiting for confirmation, edit the same message. Pre-fix,
+ *      [OptimisticWriter.writeUpdate] appended `isPendingSendTag` again,
+ *      producing a duplicate in the input list. `performBaseUpsert`'s
+ *      `deleteByFile` then `insertLocalTag` loop blew up on the duplicate
+ *      because `DriveLocalTagIndex` has `UNIQUE(identityId,driveId,fileId,tagId)`
+ *      and `insertLocalTag` is a plain INSERT — the whole optimistic write
+ *      transaction rolled back, leaving the row stuck for every subsequent
+ *      edit attempt.
+ */
+class OptimisticWriterPendingSendTagTest {
+
+    @Test
+    fun editingPendingMessage_doesNotDuplicatePendingSendTag() = runTest {
+        ChatMessageSenderServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val conversationId = fixture.seedConversation(others = listOf("alice.test"))
+
+            val messageId = Uuid.random()
+            service.sendNewMessage(
+                messageUniqueId = messageId,
+                conversationId = conversationId,
+                messageText = "first version",
+                previousMessageUniqueId = null,
+                payloadBundle = null,
+            )
+
+            // Sanity: send path stamped exactly one isPendingSendTag.
+            val seedRow = fixture.dbm.driveMainIndex.selectHomebaseFileByUnique(
+                identityId = fixture.testIdentityId,
+                driveId = fixture.chatDriveId,
+                uniqueId = messageId,
+            ) ?: error("expected optimistic row for $messageId after sendNewMessage")
+            val tagsAfterSend = fixture.dbm.driveLocalTagIndex.selectByFile(
+                identityId = fixture.testIdentityId,
+                driveId = fixture.chatDriveId,
+                fileId = seedRow.fileId,
+            ).map { it.tagId }
+            assertEquals(
+                listOf(ChatProtocol.isPendingSendTag),
+                tagsAfterSend,
+                "send path should stamp exactly one isPendingSendTag",
+            )
+
+            // Edit the still-pending message. The interesting bit: the row already
+            // carries isPendingSendTag, and writeUpdate must not re-add it.
+            val newKeyHeader = KeyHeader(
+                iv = ByteArrayUtil.getRndByteArray(16),
+                aesKey = seedRow.keyHeader.aesKey,
+            )
+            val editMetadata = UploadFileMetadata(
+                allowDistribution = true,
+                isEncrypted = true,
+                appData = UploadAppFileMetaData(
+                    uniqueId = messageId,
+                    groupId = conversationId,
+                    fileType = ChatProtocol.MessageFileType,
+                    dataType = 0,
+                    userDate = 0L,
+                    content = "edited version",
+                ),
+            )
+
+            // Pre-fix: this throws SQLiteConstraintException.
+            fixture.optimisticWriter.writeUpdate(
+                driveId = fixture.chatDriveId,
+                keyHeader = newKeyHeader,
+                unecryptedMetadata = editMetadata,
+            )
+
+            val editedRow = fixture.dbm.driveMainIndex.selectHomebaseFileByUnique(
+                identityId = fixture.testIdentityId,
+                driveId = fixture.chatDriveId,
+                uniqueId = messageId,
+            ) ?: error("expected row for $messageId after writeUpdate")
+            val tagsAfterEdit = fixture.dbm.driveLocalTagIndex.selectByFile(
+                identityId = fixture.testIdentityId,
+                driveId = fixture.chatDriveId,
+                fileId = editedRow.fileId,
+            ).map { it.tagId }
+            assertEquals(
+                listOf(ChatProtocol.isPendingSendTag),
+                tagsAfterEdit,
+                "edit must leave exactly one isPendingSendTag, not duplicate it",
+            )
+        }
+    }
+}


### PR DESCRIPTION
Editing a chat message whose previous send had not yet confirmed could crash the entire optimistic write transaction with:

  SQLiteConstraintException: UNIQUE constraint failed:
    DriveLocalTagIndex.identityId, driveId, fileId, tagId
      at DriveLocalTagIndexQueries.insertLocalTag
      at MainIndexMetaHelpers$HomebaseFileProcessor.performBaseUpsert

Root cause: OptimisticWriter.writeUpdate appended ChatProtocol .isPendingSendTag to the existing localAppData.tags list without checking whether it was already present. For a row that had been stamped pending by an earlier writeNewFile (or a previous writeUpdate) and never cleared - typical of a message whose original send is still queued, or a message that turned into a server-side orphan because the original send never landed - the resulting list contained the tag twice. performBaseUpsert clears existing tag rows then re-inserts the input list one row at a time via a plain INSERT against DriveLocalTagIndex, which has UNIQUE(identityId,driveId,fileId,tagId). The duplicate caused the second INSERT to fail, the whole transaction rolled back, and the local row stayed stuck with the pending tag for every subsequent edit attempt - making one specific message permanently uneditable until app reinstall.

Fix: check membership before adding. If isPendingSendTag is already in the existing tag list, leave the list untouched; otherwise append. The fix is at the source (the input list), not in performBaseUpsert, because the dedup-via-distinct() option in performBaseUpsert would mask similar mistakes elsewhere - better to keep the upsert strict and have callers produce a clean tag list.

Test: new OptimisticWriterPendingSendTagTest reproduces the field scenario end-to-end against the real in-memory SQLite DB used by ChatMessageSenderServiceTestFixture - sends a message offline (so the pending tag stays), then calls writeUpdate and asserts the local-tag row count is exactly one. Without the fix the test fails with the same SQLiteException seen in the field log; with the fix it passes. Fixture grew one line: optimisticWriter is now exposed so the test can call writeUpdate directly without going through ChatMessageSenderService.updateMessage (which requires a ChatMessageStream the fixture doesn't fully wire).

Out of scope - the secondary "400 UnhandledScenario: Could not find file with uniqueId" the same edit also produced. That one is the server-orphan side: the message never made it to the server, so the PATCH-by-uniqueId has nothing to update. The orphan-recovery work on the defragmenter-orphan-recovery branch addresses that side; this commit only fixes the local-DB error so a stuck row stops being unconditionally fatal.