### PR TITLE
Fix Direct Share: publish all shortcuts and route share-shortcut taps correctly

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -120,6 +120,12 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
+
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+    }
 }
 
 dependencies {
@@ -154,4 +160,10 @@ dependencies {
     implementation(libs.firebase.crashlytics)
 
     debugImplementation(libs.androidx.ui.tooling)
+
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.junit)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.test.core)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
@@ -21,10 +21,12 @@ import id.homebase.api.ActivityProvider
 import id.homebase.api.youauth.YouAuthFlowManager
 import id.homebase.core.App
 import id.homebase.core.notifications.NotificationIntentDecision
+import id.homebase.core.notifications.NotificationNavigationEvent
 import id.homebase.core.notifications.NotificationService
 import id.homebase.core.notifications.RichNotificationDisplayer
 import id.homebase.core.notifications.decideNotificationIntent
 import id.homebase.core.notifications.isReplayedFromHistory
+import id.homebase.feed.share.ShareShortcutPublisher
 import id.homebase.core.settings.ThemeState
 import id.homebase.core.settings.UserPreferences
 import io.github.vinceglb.filekit.FileKit
@@ -119,8 +121,18 @@ class MainActivity : AppCompatActivity() {
             // Deep link: homebase-fchat://conversation/{conversationId}
             if (data.host == "conversation" && data.pathSegments.isNotEmpty()) {
                 val conversationId = data.pathSegments.first()
-                Logger.i(tag = "MainActivity") { "Deep link: navigating to conversation $conversationId" }
-                notificationService.navigateToConversation(conversationId)
+                val fromShareShortcut = intent.getBooleanExtra(
+                    ShareShortcutPublisher.EXTRA_FROM_SHARE_SHORTCUT, false
+                )
+                val source = if (fromShareShortcut) {
+                    NotificationNavigationEvent.OpenConversation.Source.ShareIntent
+                } else {
+                    NotificationNavigationEvent.OpenConversation.Source.NotificationTap
+                }
+                Logger.i(tag = "MainActivity") {
+                    "Deep link: navigating to conversation $conversationId source=$source"
+                }
+                notificationService.navigateToConversation(conversationId, source = source)
                 // Clear the deep link so it's not re-processed on config changes
                 intent.data = null
                 return

--- a/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
@@ -24,6 +24,8 @@ import chat_kmp.homebase_common.BuildConfig
 import id.homebase.core.notifications.NotificationService
 import id.homebase.core.notifications.RichNotificationDisplayer
 import id.homebase.core.settings.UserPreferences
+import id.homebase.chat.services.convo.ConversationStream
+import id.homebase.feed.share.ShareShortcutAvatarLoader
 import id.homebase.feed.share.ShareShortcutPublisher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -130,7 +132,13 @@ class MainApplication : Application(), KoinComponent {
     private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     private fun initShareShortcuts() {
-        val publisher = ShareShortcutPublisher(this, get(), get())
+        val conversationStream = get<ConversationStream>()
+        val avatarLoader = ShareShortcutAvatarLoader(conversationStream, get())
+        val publisher = ShareShortcutPublisher(
+            context = this,
+            shareableConversations = conversationStream.shareableConversations,
+            loadAvatarIcon = avatarLoader::loadIcon,
+        )
         publisher.start(appScope)
     }
 

--- a/androidApp/src/main/kotlin/id/homebase/feed/share/ShareShortcutAvatarLoader.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/ShareShortcutAvatarLoader.kt
@@ -1,0 +1,147 @@
+package id.homebase.feed.share
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffXfermode
+import android.graphics.Rect
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.drawable.IconCompat
+import co.touchlab.kermit.Logger
+import id.homebase.chat.services.convo.ConversationStream
+import id.homebase.core.avatars.ConversationAvatarModel
+import id.homebase.core.image.HomebaseImageLoader
+import id.homebase.core.image.ImageSize
+import id.homebase.core.share.ShareableConversation
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.URL
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Resolves the icon for a [ShareableConversation] for use as a Direct Share shortcut.
+ *
+ * Resolution order:
+ * 1. Encrypted group avatar via [HomebaseImageLoader] (if conversation has one)
+ * 2. Public 1:1 avatar URL (if conversation has one)
+ * 3. Initials bitmap fallback
+ */
+@OptIn(ExperimentalUuidApi::class)
+class ShareShortcutAvatarLoader(
+    private val conversationStream: ConversationStream,
+    private val imageLoader: HomebaseImageLoader,
+) {
+
+    companion object {
+        private const val TAG = "ShareShortcutAvatarLoader"
+        private const val AVATAR_SIZE = 108 // px — adaptive icon inner size
+    }
+
+    suspend fun loadIcon(conversation: ShareableConversation): IconCompat {
+        // Try loading encrypted group avatar via HomebaseImageLoader
+        val convoModel = conversationStream.getConversationById(Uuid.parse(conversation.id))
+        if (convoModel != null && convoModel.avatarModel.type == ConversationAvatarModel.Type.ConversationImage) {
+            val imageData = convoModel.avatarModel.imageData
+            if (imageData != null) {
+                try {
+                    val cachedImage = imageLoader.loadThumbnail(
+                        data = imageData,
+                        targetSize = ImageSize.THUMB_SMALL,
+                    )
+                    if (cachedImage != null) {
+                        val bitmap = BitmapFactory.decodeByteArray(
+                            cachedImage.bytes,
+                            0,
+                            cachedImage.bytes.size
+                        )
+                        if (bitmap != null) {
+                            return IconCompat.createWithAdaptiveBitmap(createCircularBitmap(bitmap))
+                        }
+                    }
+                } catch (e: Exception) {
+                    Logger.d(tag = TAG) { "Failed to load encrypted avatar for ${conversation.displayName}: ${e.message}" }
+                }
+            }
+        }
+
+        // Try loading public avatar URL (1:1 contacts)
+        val avatarUrl = conversation.avatarUrl
+        if (avatarUrl != null) {
+            try {
+                val bitmap = withContext(Dispatchers.IO) {
+                    val connection = URL(avatarUrl).openConnection()
+                    connection.connectTimeout = 3000
+                    connection.readTimeout = 3000
+                    connection.getInputStream().use { stream ->
+                        BitmapFactory.decodeStream(stream)
+                    }
+                }
+                if (bitmap != null) {
+                    return IconCompat.createWithAdaptiveBitmap(createCircularBitmap(bitmap))
+                }
+            } catch (e: Exception) {
+                Logger.d(tag = TAG) { "Failed to load avatar for ${conversation.displayName}: ${e.message}" }
+            }
+        }
+
+        // Fallback: create initials bitmap
+        return IconCompat.createWithAdaptiveBitmap(createInitialsBitmap(conversation.avatarInitials))
+    }
+
+    private fun createCircularBitmap(source: Bitmap): Bitmap {
+        val size = AVATAR_SIZE
+        val output = createBitmap(size, size)
+        val canvas = Canvas(output)
+
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG)
+        val radius = size / 2f
+
+        // Draw circular clip
+        canvas.drawCircle(radius, radius, radius, paint)
+        paint.setXfermode(PorterDuffXfermode(PorterDuff.Mode.SRC_IN))
+
+        // Scale and center-crop the source
+        val srcSize = minOf(source.width, source.height)
+        val srcX = (source.width - srcSize) / 2
+        val srcY = (source.height - srcSize) / 2
+        canvas.drawBitmap(
+            source,
+            Rect(srcX, srcY, srcX + srcSize, srcY + srcSize),
+            Rect(0, 0, size, size),
+            paint
+        )
+
+        return output
+    }
+
+    private fun createInitialsBitmap(initials: String): Bitmap {
+        val size = AVATAR_SIZE
+        val bitmap = createBitmap(size, size)
+        val canvas = Canvas(bitmap)
+
+        // Background circle
+        val bgPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = 0xFF6366F1.toInt() // Indigo accent
+            style = Paint.Style.FILL
+        }
+        canvas.drawCircle(size / 2f, size / 2f, size / 2f, bgPaint)
+
+        // Initials text
+        val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = 0xFFFFFFFF.toInt()
+            textSize = size * 0.38f
+            textAlign = Paint.Align.CENTER
+            typeface = android.graphics.Typeface.DEFAULT_BOLD
+        }
+        val textBounds = Rect()
+        val displayInitials = initials.take(2).uppercase()
+        textPaint.getTextBounds(displayInitials, 0, displayInitials.length, textBounds)
+        val y = size / 2f + textBounds.height() / 2f
+        canvas.drawText(displayInitials, size / 2f, y, textPaint)
+
+        return bitmap
+    }
+}

--- a/androidApp/src/main/kotlin/id/homebase/feed/share/ShareShortcutPublisher.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/ShareShortcutPublisher.kt
@@ -3,61 +3,43 @@ package id.homebase.feed.share
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
-import android.graphics.Canvas
-import android.graphics.Paint
-import android.graphics.PorterDuff
-import android.graphics.PorterDuffXfermode
-import android.graphics.Rect
 import androidx.core.app.Person
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
 import co.touchlab.kermit.Logger
-import id.homebase.chat.services.convo.ConversationStream
-import id.homebase.core.avatars.ConversationAvatarModel
-import id.homebase.core.image.HomebaseImageLoader
-import id.homebase.core.image.ImageSize
 import id.homebase.core.share.ShareableConversation
 import id.homebase.feed.MainActivity
-import id.homebase.feed.share.ShareReceiverActivity
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import java.net.URL
 import java.util.Collections
-import kotlin.uuid.ExperimentalUuidApi
-import kotlin.uuid.Uuid
 import androidx.core.net.toUri
-import androidx.core.graphics.createBitmap
 
 /**
  * Publishes dynamic shortcuts for recent conversations so they appear
  * as direct share targets in the Android share sheet's top row.
  *
- * Self-contained: subscribes to [ConversationStream.shareableConversations]
- * which already has resolved contact names and avatar URLs.
- * Uses [HomebaseImageLoader] to fetch encrypted group conversation avatars.
+ * Avatar loading is delegated via the [loadAvatarIcon] function so the publisher
+ * can be exercised in unit tests without spinning up the full ConversationStream
+ * + HomebaseImageLoader graph.
  */
-@OptIn(ExperimentalUuidApi::class)
 class ShareShortcutPublisher(
     private val context: Context,
-    private val conversationStream: ConversationStream,
-    private val imageLoader: HomebaseImageLoader,
+    private val shareableConversations: Flow<List<ShareableConversation>>,
+    private val loadAvatarIcon: suspend (ShareableConversation) -> IconCompat,
 ) {
 
     companion object {
+        const val EXTRA_FROM_SHARE_SHORTCUT = "id.homebase.feed.share.FROM_SHARE_SHORTCUT"
         private const val TAG = "ShareShortcutPublisher"
         private const val MAX_SHORTCUTS = 8
         private const val SHARE_CATEGORY = "id.homebase.feed.category.SHARE_TARGET"
-        private const val AVATAR_SIZE = 108 // px — adaptive icon inner size
     }
 
     fun start(scope: CoroutineScope) {
         scope.launch {
-            conversationStream.shareableConversations.collect { conversations ->
+            shareableConversations.collect { conversations ->
                 if (conversations.isNotEmpty()) {
                     updateShortcuts(conversations)
                 }
@@ -65,7 +47,7 @@ class ShareShortcutPublisher(
         }
     }
 
-    private suspend fun updateShortcuts(conversations: List<ShareableConversation>) {
+    internal suspend fun updateShortcuts(conversations: List<ShareableConversation>) {
         try {
             val shortcuts = conversations
                 .sortedByDescending { it.lastMessageTimestamp }
@@ -98,16 +80,28 @@ class ShareShortcutPublisher(
             type = "*/*"
         }
 
-        // Main intent: open the conversation directly when tapped from launcher long-press
+        // Main intent: open the conversation directly when tapped from launcher long-press,
+        // and also runs underneath the shareIntent on Direct Share so the user lands on the
+        // conversation after sending. The EXTRA lets MainActivity tag the resulting
+        // OpenConversation event as Source.ShareIntent so AppNavHost routes via
+        // selectConversationOnChatList instead of the PendingNotificationTap path.
         val mainIntent = Intent(Intent.ACTION_VIEW).apply {
             component = ComponentName(context, MainActivity::class.java)
             data = "homebase-fchat://conversation/${conversation.id}".toUri()
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra(EXTRA_FROM_SHARE_SHORTCUT, true)
         }
 
+        // displayName can be blank for unresolved 1:1 contacts; setShortLabel/setLongLabel
+        // throw IllegalArgumentException on empty strings, and setDynamicShortcuts is atomic
+        // — one bad row drops the entire batch and Direct Share goes dark for the whole app.
+        val label = conversation.displayName
+            .ifBlank { conversation.avatarInitials }
+            .ifBlank { "Conversation" }
+
         return ShortcutInfoCompat.Builder(context, "share_${conversation.id}")
-            .setShortLabel(conversation.displayName)
-            .setLongLabel(conversation.displayName)
+            .setShortLabel(label)
+            .setLongLabel(label)
             .setIcon(icon)
             .setIntents(arrayOf(mainIntent, shareIntent))
             .setLongLived(true)
@@ -116,110 +110,5 @@ class ShareShortcutPublisher(
             .setCategories(Collections.singleton(SHARE_CATEGORY))
             .setPerson(person)
             .build()
-    }
-
-    private suspend fun loadAvatarIcon(conversation: ShareableConversation): IconCompat {
-        // Try loading encrypted group avatar via HomebaseImageLoader
-        val convoModel = conversationStream.getConversationById(Uuid.parse(conversation.id))
-        if (convoModel != null && convoModel.avatarModel.type == ConversationAvatarModel.Type.ConversationImage) {
-            val imageData = convoModel.avatarModel.imageData
-            if (imageData != null) {
-                try {
-                    val cachedImage = imageLoader.loadThumbnail(
-                        data = imageData,
-                        targetSize = ImageSize.THUMB_SMALL,
-                    )
-                    if (cachedImage != null) {
-                        val bitmap = BitmapFactory.decodeByteArray(
-                            cachedImage.bytes,
-                            0,
-                            cachedImage.bytes.size
-                        )
-                        if (bitmap != null) {
-                            return IconCompat.createWithAdaptiveBitmap(createCircularBitmap(bitmap))
-                        }
-                    }
-                } catch (e: Exception) {
-                    Logger.d(tag = TAG) { "Failed to load encrypted avatar for ${conversation.displayName}: ${e.message}" }
-                }
-            }
-        }
-
-        // Try loading public avatar URL (1:1 contacts)
-        val avatarUrl = conversation.avatarUrl
-        if (avatarUrl != null) {
-            try {
-                val bitmap = withContext(Dispatchers.IO) {
-                    val connection = URL(avatarUrl).openConnection()
-                    connection.connectTimeout = 3000
-                    connection.readTimeout = 3000
-                    connection.getInputStream().use { stream ->
-                        BitmapFactory.decodeStream(stream)
-                    }
-                }
-                if (bitmap != null) {
-                    return IconCompat.createWithAdaptiveBitmap(createCircularBitmap(bitmap))
-                }
-            } catch (e: Exception) {
-                Logger.d(tag = TAG) { "Failed to load avatar for ${conversation.displayName}: ${e.message}" }
-            }
-        }
-
-        // Fallback: create initials bitmap
-        return IconCompat.createWithAdaptiveBitmap(createInitialsBitmap(conversation.avatarInitials))
-    }
-
-    private fun createCircularBitmap(source: Bitmap): Bitmap {
-        val size = AVATAR_SIZE
-        val output = createBitmap(size, size)
-        val canvas = Canvas(output)
-
-        val paint = Paint(Paint.ANTI_ALIAS_FLAG)
-        val radius = size / 2f
-
-        // Draw circular clip
-        canvas.drawCircle(radius, radius, radius, paint)
-        paint.setXfermode(PorterDuffXfermode(PorterDuff.Mode.SRC_IN))
-
-        // Scale and center-crop the source
-        val srcSize = minOf(source.width, source.height)
-        val srcX = (source.width - srcSize) / 2
-        val srcY = (source.height - srcSize) / 2
-        canvas.drawBitmap(
-            source,
-            Rect(srcX, srcY, srcX + srcSize, srcY + srcSize),
-            Rect(0, 0, size, size),
-            paint
-        )
-
-        return output
-    }
-
-    private fun createInitialsBitmap(initials: String): Bitmap {
-        val size = AVATAR_SIZE
-        val bitmap = createBitmap(size, size)
-        val canvas = Canvas(bitmap)
-
-        // Background circle
-        val bgPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            color = 0xFF6366F1.toInt() // Indigo accent
-            style = Paint.Style.FILL
-        }
-        canvas.drawCircle(size / 2f, size / 2f, size / 2f, bgPaint)
-
-        // Initials text
-        val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            color = 0xFFFFFFFF.toInt()
-            textSize = size * 0.38f
-            textAlign = Paint.Align.CENTER
-            typeface = android.graphics.Typeface.DEFAULT_BOLD
-        }
-        val textBounds = Rect()
-        val displayInitials = initials.take(2).uppercase()
-        textPaint.getTextBounds(displayInitials, 0, displayInitials.length, textBounds)
-        val y = size / 2f + textBounds.height() / 2f
-        canvas.drawText(displayInitials, size / 2f, y, textPaint)
-
-        return bitmap
     }
 }

--- a/androidApp/src/test/kotlin/id/homebase/feed/share/ShareShortcutPublisherTest.kt
+++ b/androidApp/src/test/kotlin/id/homebase/feed/share/ShareShortcutPublisherTest.kt
@@ -1,0 +1,132 @@
+package id.homebase.feed.share
+
+import android.app.Application
+import android.content.Intent
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.drawable.IconCompat
+import androidx.test.core.app.ApplicationProvider
+import id.homebase.core.share.ShareableConversation
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Reproduces a bug observed in production where Shelly's Direct Share row
+ * never showed Homebase contacts. Root cause: [ShareShortcutPublisher.updateShortcuts]
+ * passes a list of [androidx.core.content.pm.ShortcutInfoCompat] to
+ * [ShortcutManagerCompat.setDynamicShortcuts], which throws
+ * `IllegalArgumentException: Shortcut must have a non-empty label` if ANY one of
+ * the shortcuts has an empty label. The publisher's catch block swallows the
+ * exception with a Logger.w — the entire batch silently drops, and zero share
+ * shortcuts get registered for the Homebase app.
+ *
+ * Test asserts the buggy behavior: with one valid + one blank-label conversation,
+ * the count of registered shortcuts is 0. After the fix (filter blank labels OR
+ * fall back to avatarInitials), this test should fail and be updated to assert 1.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class ShareShortcutPublisherTest {
+
+    private val context get() = ApplicationProvider.getApplicationContext<Application>()
+
+    private val noopAvatarLoader: suspend (ShareableConversation) -> IconCompat = {
+        IconCompat.createWithAdaptiveBitmap(createBitmap(108, 108))
+    }
+
+    private fun newPublisher() = ShareShortcutPublisher(
+        context = context,
+        shareableConversations = MutableStateFlow(emptyList()),
+        loadAvatarIcon = noopAvatarLoader,
+    )
+
+    private fun convo(
+        id: String,
+        displayName: String,
+        timestamp: Long = 1L,
+    ) = ShareableConversation(
+        id = id,
+        displayName = displayName,
+        avatarInitials = "AB",
+        isGroup = false,
+        participantCount = 1,
+        lastMessageTimestamp = timestamp,
+        avatarUrl = null,
+    )
+
+    @Test
+    fun `one blank displayName must not drop the entire batch`() = runTest {
+        val publisher = newPublisher()
+        ShortcutManagerCompat.removeAllDynamicShortcuts(context)
+
+        publisher.updateShortcuts(
+            listOf(
+                convo(id = "11111111-1111-1111-1111-111111111111", displayName = "Alice", timestamp = 2L),
+                convo(id = "22222222-2222-2222-2222-222222222222", displayName = "", timestamp = 1L),
+            )
+        )
+
+        val published = ShortcutManagerCompat.getDynamicShortcuts(context)
+        assertEquals(
+            2,
+            published.size,
+            "Direct Share targets vanish for the entire app when one conversation has a " +
+                "blank displayName: setDynamicShortcuts is atomic and rejects the whole " +
+                "batch with `Shortcut must have a non-empty label`. Publisher must " +
+                "fallback-label blank conversations so all shortcuts still publish.",
+        )
+
+        val blankConvoShortcut = published.single {
+            it.id == "share_22222222-2222-2222-2222-222222222222"
+        }
+        assertEquals(
+            "AB",
+            blankConvoShortcut.shortLabel.toString(),
+            "Blank displayName must fall back to avatarInitials so setShortLabel " +
+                "doesn't throw and the entry stays consistent with the avatar bitmap.",
+        )
+    }
+
+    @Test
+    fun `mainIntent is tagged with EXTRA_FROM_SHARE_SHORTCUT so MainActivity can route as ShareIntent`() = runTest {
+        val publisher = newPublisher()
+        ShortcutManagerCompat.removeAllDynamicShortcuts(context)
+
+        publisher.updateShortcuts(
+            listOf(convo(id = "11111111-1111-1111-1111-111111111111", displayName = "Alice"))
+        )
+
+        val shortcut = ShortcutManagerCompat.getDynamicShortcuts(context).single()
+        val mainIntent = shortcut.intents.first { it.action == Intent.ACTION_VIEW }
+        assertTrue(
+            mainIntent.getBooleanExtra(ShareShortcutPublisher.EXTRA_FROM_SHARE_SHORTCUT, false),
+            "mainIntent must carry EXTRA_FROM_SHARE_SHORTCUT so MainActivity can tag the " +
+                "resulting OpenConversation event as Source.ShareIntent. Without it, " +
+                "AppNavHost falls into the NotificationTap branch (which expects a " +
+                "PendingNotificationTap singleton) and navigation dead-ends — " +
+                "see homebase.log: popBackStack(ChatList)=false at 13:04:34.",
+        )
+    }
+
+    @Test
+    fun `all valid displayNames publish all shortcuts (sanity)`() = runTest {
+        val publisher = newPublisher()
+        ShortcutManagerCompat.removeAllDynamicShortcuts(context)
+
+        publisher.updateShortcuts(
+            listOf(
+                convo(id = "11111111-1111-1111-1111-111111111111", displayName = "Alice", timestamp = 2L),
+                convo(id = "22222222-2222-2222-2222-222222222222", displayName = "Bob", timestamp = 1L),
+            )
+        )
+
+        val published = ShortcutManagerCompat.getDynamicShortcuts(context)
+        assertEquals(2, published.size)
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
@@ -477,8 +477,14 @@ class NotificationService(
     }
 
     /** Navigate to a specific conversation (used for deep links and share shortcuts). */
-    fun navigateToConversation(conversationId: String) {
-        _navigationEvents.trySend(NotificationNavigationEvent.OpenConversation(conversationId))
+    fun navigateToConversation(
+        conversationId: String,
+        source: NotificationNavigationEvent.OpenConversation.Source =
+            NotificationNavigationEvent.OpenConversation.Source.NotificationTap,
+    ) {
+        _navigationEvents.trySend(
+            NotificationNavigationEvent.OpenConversation(conversationId, source)
+        )
     }
 
     /** Displays a rich notification using platform-specific APIs. */


### PR DESCRIPTION
Two bugs broke sharing a picture into a Homebase Chat conversation via the Android system share sheet:

1) ShareShortcutPublisher.updateShortcuts called ShortcutManagerCompat
   .setDynamicShortcuts atomically. If any one of the top-8 conversations had a
   blank displayName (e.g. an unresolved 1:1 NotConnected contact), the whole
   batch threw IllegalArgumentException: "Shortcut must have a non-empty label"
   and the catch swallowed it. Result: zero Homebase Direct Share targets ever
   published, so the share sheet's people-row stayed empty for Homebase.

   Fix: fall back to avatarInitials, then to a literal "Conversation", before
   calling setShortLabel/setLongLabel. Every shortcut now publishes regardless
   of displayName resolution state.

2) The shortcut's mainIntent is a homebase-fchat://conversation/{id} ACTION_VIEW
   that runs underneath the shareIntent so the user lands on the conversation
   after the file is sent. MainActivity could not tell that intent apart from a
   regular notification deep link, so it dispatched OpenConversation with the
   default Source.NotificationTap. AppNavHost's NotificationTap branch expects
   PendingNotificationTap to be seeded with (conversationId, messageId), which
   share intents never do — popBackStack(ChatList) returned false and
   navigation dead-ended. Same pattern as the iOS share-extension regression
   guarded by NotificationTapColdStartTest, but the Android side was missed.

   Fix: ShareShortcutPublisher stamps EXTRA_FROM_SHARE_SHORTCUT on the
   mainIntent. MainActivity reads the extra and passes Source.ShareIntent to
   NotificationService.navigateToConversation (which now takes an optional
   source param defaulting to NotificationTap to keep existing callers
   bug-compatible). AppNavHost then writes pendingConversationId via
   selectConversationOnChatList, and the ChatList LaunchedEffect navigates to
   the target conversation.

Refactor + tests:
- Extracted avatar loading into ShareShortcutAvatarLoader so the publisher's constructor takes (context, Flow, suspend fn) instead of full ConversationStream
  + HomebaseImageLoader. Makes the publisher testable in isolation.
- Added Robolectric test scaffolding to androidApp (no test source set existed).
- New ShareShortcutPublisherTest covers: blank-label fallback, mainIntent carries EXTRA_FROM_SHARE_SHORTCUT, and a sanity check.