### PR TITLE
Replace mayakapps/kache with Coil 3 DiskCache for drive + profile caches

### DIFF
--- a/homebase-api/build.gradle.kts
+++ b/homebase-api/build.gradle.kts
@@ -93,6 +93,7 @@ kotlin {
             implementation(libs.kotlinx.immutableCollections)
             implementation(libs.kache)
             implementation(libs.kache.file)
+            implementation(libs.coil3)
             implementation(libs.okio)
         }
         commonTest.dependencies {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
@@ -1,7 +1,7 @@
 package id.homebase.api.client.drives.cache
 
 import co.touchlab.kermit.Logger
-import com.mayakapps.kache.FileKache
+import coil3.disk.DiskCache
 import id.homebase.api.client.ByteApiResponse
 import id.homebase.api.client.cache.CacheStats
 import id.homebase.api.client.KeyHeader
@@ -23,6 +23,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.sync.withPermit
+import okio.ByteString.Companion.encodeUtf8
 import okio.FileSystem
 import okio.Path.Companion.toPath
 import okio.SYSTEM
@@ -32,12 +33,12 @@ import okio.SYSTEM
  * [DriveFileHttpProvider] so callers get transparent read-through caching
  * for payloads and thumbnails.
  *
- * Two underlying [com.mayakapps.kache.FileKache] instances back the two
+ * Two underlying [coil3.disk.DiskCache] instances back the two
  * Storage-screen rows:
  * - `drive_payloads`   — media payload bytes (attachments). Directory
- *   `homebase-payloads`, cap 200 MB. Fetches are gated by
+ *   `homebase-payloads-v2`, cap 200 MB. Fetches are gated by
  *   [payloadSemaphore] (1 concurrent network request).
- * - `drive_thumbnails` — thumbnail bytes. Directory `homebase-thumbs`,
+ * - `drive_thumbnails` — thumbnail bytes. Directory `homebase-thumbs-v2`,
  *   cap 300 MB. Fetches are gated by [thumbnailSemaphore] (30 concurrent).
  *
  * The payload/thumbnail split follows the same "small-hot vs large-cold"
@@ -60,10 +61,10 @@ import okio.SYSTEM
  * A new version lands under a new key, which gets fetched fresh; the old
  * key ages out through LRU eviction.
  *
- * Both FileKache instances are created lazily through mutex-gated
- * accessors; [clearCaches] deletes the directories recursively and nulls
- * the refs, so concurrent readers cannot end up with a disposed
- * FileKache reference — they re-create it on next access.
+ * Both DiskCache instances are constructed eagerly. Coil's DiskCache
+ * (a Kotlin port of OkHttp's DiskLruCache) is thread-safe by contract,
+ * so concurrent get/put/clear are all safe and no lifecycle mutex is
+ * needed. [clearCaches] calls [coil3.disk.DiskCache.clear] on each.
  */
 class DriveFileProviderCached(
         httpClient: HttpClient,
@@ -79,8 +80,6 @@ class DriveFileProviderCached(
     private val payloadSemaphore = Semaphore(1)
     private val thumbnailSemaphore = Semaphore(30)
 
-    private val thumbnailKacheWriteMutex = Mutex()
-
     // TODO: unbounded growth — keyLocks gains one entry per unique cacheKey
     //  ever touched and never drops any. Over a long session this leaks
     //  memory. Same shape in PublicProfileProviderCached. Fix with a
@@ -95,90 +94,35 @@ class DriveFileProviderCached(
     @Volatile private var notFoundCache: Set<String> = emptySet()
     private val notFoundCacheMutex = Mutex()
 
-    private var _payloadDiskKache: FileKache? = null
-    private var _thumbDiskKache: FileKache? = null
-    @Volatile private var payloadKacheFailure: Throwable? = null
-    @Volatile private var thumbKacheFailure: Throwable? = null
-    private val kacheMutex = Mutex()
+    private val payloadDir = "$directory/homebase-payloads-v2"
+    private val thumbDir = "$directory/homebase-thumbs-v2"
 
-    // Always acquires kacheMutex — the previous lock-free fast path let a
-    // reader hand out a reference to a FileKache instance that clearCaches()
-    // was simultaneously disposing, producing a NPE inside FileKache's
-    // internals when the reader resumed and called .get() on it.
-    //
-    // createDirectories + tombstone on construction failure: observed on one
-    // real device that FileKache(…) itself throws `getClass() on null` from
-    // mayakapps/kache internals when the managed directory is missing.
-    // We pre-create the dir to avoid the library's fragile init path, and
-    // record any construction exception so we don't spam retries for the
-    // rest of the session. clearCaches() resets the tombstone.
-    private suspend fun payloadDiskKache(): FileKache = kacheMutex.withLock {
-        _payloadDiskKache?.let { return@withLock it }
-        payloadKacheFailure?.let { throw it }
+    // Coil's DiskCache (DiskLruCache descendant) is thread-safe; no lifecycle
+    // mutex, no write serialization, no construction tombstones — concurrent
+    // get()/put()/clear() are all safe per the Coil contract.
+    private val payloadDiskCache: DiskCache = DiskCache.Builder()
+            .directory(payloadDir.toPath())
+            .maxSizeBytes(200L * 1024L * 1024L) // 200MB
+            .build()
 
-        val dir = "$directory/homebase-payloads"
-        try {
-            fileSystem.createDirectories(dir.toPath())
-            FileKache(directory = dir, maxSize = 200L * 1024L * 1024L) // 200MB
-                    .also { _payloadDiskKache = it }
-        } catch (e: Throwable) {
-            Logger.e(tag = "DriveFileProviderCached", throwable = e) {
-                "FileKache construction FAILED (payload) — disabling disk cache for this session"
-            }
-            payloadKacheFailure = e
-            throw e
-        }
+    private val thumbDiskCache: DiskCache = DiskCache.Builder()
+            .directory(thumbDir.toPath())
+            .maxSizeBytes(300L * 1024L * 1024L) // 300MB
+            .build()
+
+    init {
+        // Reclaim disk from the pre-migration mayakapps/kache cache directories.
+        // Best-effort — a missing dir is fine, and any failure here is purely
+        // a missed cleanup, not a correctness issue.
+        runCatching { fileSystem.deleteRecursively("$directory/homebase-payloads".toPath()) }
+        runCatching { fileSystem.deleteRecursively("$directory/homebase-thumbs".toPath()) }
     }
 
-    private suspend fun thumbDiskKache(): FileKache = kacheMutex.withLock {
-        _thumbDiskKache?.let { return@withLock it }
-        thumbKacheFailure?.let { throw it }
-
-        val dir = "$directory/homebase-thumbs"
-        try {
-            fileSystem.createDirectories(dir.toPath())
-            FileKache(directory = dir, maxSize = 300L * 1024L * 1024L) // 300MB
-                    .also { _thumbDiskKache = it }
-        } catch (e: Throwable) {
-            Logger.e(tag = "DriveFileProviderCached", throwable = e) {
-                "FileKache construction FAILED (thumb) — disabling disk cache for this session"
-            }
-            thumbKacheFailure = e
-            throw e
-        }
-    }
-
-    // Drop the live FileKache reference under the lifecycle mutex so the next
-    // accessor reconstructs from the on-disk journal. Use this only for
-    // exceptions that look like internal-state corruption (NPE, ISE) — observed
-    // on real Android devices where a single mayakapps/kache failure leaves
-    // the instance with a null internal sink/source and every subsequent
-    // get()/put() fires the same `getClass() on null` NPE for the rest of the
-    // session (90k+ identical errors in one user log). Not for IOException /
-    // disk-full, which are per-operation and recover on their own.
-    private fun isKacheInstanceCorrupt(e: Throwable): Boolean =
-            e is NullPointerException || e is IllegalStateException
-
-    // Internal so jvmTest can drive the recovery path directly. The on-disk
-    // journal survives — a fresh FileKache built over the same dir picks up
-    // existing entries.
-    internal suspend fun discardThumbKache() = kacheMutex.withLock {
-        if (_thumbDiskKache != null) {
-            Logger.w(tag = "DriveFileProviderCached") {
-                "discarding broken thumb FileKache — next access will reconstruct"
-            }
-            _thumbDiskKache = null
-        }
-    }
-
-    internal suspend fun discardPayloadKache() = kacheMutex.withLock {
-        if (_payloadDiskKache != null) {
-            Logger.w(tag = "DriveFileProviderCached") {
-                "discarding broken payload FileKache — next access will reconstruct"
-            }
-            _payloadDiskKache = null
-        }
-    }
+    // Coil's DiskLruCache enforces `[a-z0-9_-]{1,120}` on keys. Our logical
+    // cache keys (`payload:driveId:fileId:…`) contain colons and overflow that
+    // length, so hash to a fixed-width hex digest. SHA-256 → 64 hex chars,
+    // collision-resistant.
+    private fun String.toDiskKey(): String = encodeUtf8().sha256().hex()
 
     // ================================================================
     // -------------------- CACHED PAYLOAD METHODS --------------------
@@ -223,16 +167,7 @@ class DriveFileProviderCached(
                     check(result.status in 200..299) {
                         "Unexpected non-2xx status ${result.status} reached disk cache write — not caching"
                     }
-                    try {
-                        payloadDiskKache().put(cacheKey) { filePath ->
-                            writeBytesResponse(filePath, result)
-                        }
-                    } catch (e: Exception) {
-                        // A write failure should not prevent the caller from getting the fetched bytes.
-                        // Surface it loudly so we can spot corrupted journals or full disks.
-                        Logger.e(tag = "PayloadIO", throwable = e) { "payload cache-write FAILED key=$cacheKey" }
-                        if (isKacheInstanceCorrupt(e)) discardPayloadKache()
-                    }
+                    writeToDiskCache(payloadDiskCache, cacheKey, "PayloadIO", result)
                     result
                 } catch (e: NotFoundException) {
                     // 404 thrown by network layer — cache it so future calls skip the network
@@ -301,30 +236,32 @@ class DriveFileProviderCached(
             fileOps: FileOperationsProvider
     ): Boolean {
         val cacheKey = buildPayloadCacheKey(driveId, fileId, key, null, null)
-        val cachedFilePath = payloadDiskKache().get(cacheKey)
+        val snapshot = payloadDiskCache.openSnapshot(cacheKey.toDiskKey())
                 ?: return delegate.streamPayloadDecryptedToPath(driveId, fileId, key, keyHeader, outputPath, fileOps)
 
-        val encryptedFlow = channelFlow<ByteArray> {
-            val channel = this
-            fileSystem.read(cachedFilePath.toPath()) {
-                readInt() // skip status
-                val ctLen = readInt()
-                readUtf8(ctLen.toLong()) // skip contentType
-                readByte() // skip payloadEncrypted flag
-                val chunkSize = 65_536L
-                while (true) {
-                    if (!request(chunkSize)) {
-                        if (!exhausted()) channel.send(readByteArray())
-                        break
+        return snapshot.use { snap ->
+            val encryptedFlow = channelFlow<ByteArray> {
+                val channel = this
+                fileSystem.read(snap.data) {
+                    readInt() // skip status
+                    val ctLen = readInt()
+                    readUtf8(ctLen.toLong()) // skip contentType
+                    readByte() // skip payloadEncrypted flag
+                    val chunkSize = 65_536L
+                    while (true) {
+                        if (!request(chunkSize)) {
+                            if (!exhausted()) channel.send(readByteArray())
+                            break
+                        }
+                        channel.send(readByteArray(chunkSize))
                     }
-                    channel.send(readByteArray(chunkSize))
                 }
             }
-        }
 
-        val decryptedFlow = AesCbc.streamDecryptWithCbc(encryptedFlow, keyHeader.aesKey, keyHeader.iv)
-        fileOps.writeStream(outputPath, decryptedFlow)
-        return true
+            val decryptedFlow = AesCbc.streamDecryptWithCbc(encryptedFlow, keyHeader.aesKey, keyHeader.iv)
+            fileOps.writeStream(outputPath, decryptedFlow)
+            true
+        }
     }
 
     // ==============================================================
@@ -373,22 +310,10 @@ class DriveFileProviderCached(
                             )
 
                     // 3️⃣ Store to disk (only 200/206 can reach here — throwForFailure throws for everything else).
-                    // Serialise writes to avoid corrupting FileKache's journal file.
                     check(result.status in 200..299) {
                         "Unexpected non-2xx status ${result.status} reached disk cache write — not caching"
                     }
-                    try {
-                        thumbnailKacheWriteMutex.withLock {
-                            thumbDiskKache().put(cacheKey) { filePath ->
-                                writeBytesResponse(filePath, result)
-                            }
-                        }
-                    } catch (e: Exception) {
-                        // A write failure should not prevent the caller from getting the fetched bytes.
-                        // Surface it loudly so we can spot corrupted journals or full disks.
-                        Logger.e(tag = "ThumbIO", throwable = e) { "thumb cache-write FAILED key=$cacheKey" }
-                        if (isKacheInstanceCorrupt(e)) discardThumbKache()
-                    }
+                    writeToDiskCache(thumbDiskCache, cacheKey, "ThumbIO", result)
                     result
                 } catch (e: NotFoundException) {
                     // 404 thrown by network layer — cache it so future calls skip the network
@@ -405,34 +330,32 @@ class DriveFileProviderCached(
 
     /**
      * Read a thumb from the disk cache. Returns null on cache miss OR when the
-     * cached file cannot be parsed (corrupted entry, truncated write, etc.) OR
-     * when the underlying FileKache throws (e.g. a concurrent clearCaches()
-     * on another thread). All exceptions are logged as errors so the caller
-     * can fall through to the network cleanly.
+     * cached file cannot be parsed (corrupted entry, truncated write, etc.).
+     * All exceptions are logged as errors so the caller can fall through to
+     * the network cleanly.
      */
-    private suspend fun readCachedThumbOrLog(cacheKey: String): ByteApiResponse? {
+    private fun readCachedThumbOrLog(cacheKey: String): ByteApiResponse? {
         return try {
-            val filePath = thumbDiskKache().get(cacheKey) ?: return null
-            readBytesResponse(filePath)
+            thumbDiskCache.openSnapshot(cacheKey.toDiskKey())?.use { snap ->
+                readBytesResponse(snap.data.toString())
+            }
         } catch (e: Exception) {
             Logger.e(tag = "ThumbIO", throwable = e) { "thumb cache-read FAILED key=$cacheKey" }
-            if (isKacheInstanceCorrupt(e)) discardThumbKache()
             null
         }
     }
 
     /**
      * Payload-cache analog of [readCachedThumbOrLog]. Defense-in-depth against
-     * FileKache internal errors and parse failures.
+     * parse failures.
      */
-    private suspend fun readCachedPayloadOrLog(cacheKey: String): ByteApiResponse? {
+    private fun readCachedPayloadOrLog(cacheKey: String): ByteApiResponse? {
         return try {
-            val filePath = payloadDiskKache().get(cacheKey) ?: return null
-            val result = readBytesResponse(filePath)
-            result
+            payloadDiskCache.openSnapshot(cacheKey.toDiskKey())?.use { snap ->
+                readBytesResponse(snap.data.toString())
+            }
         } catch (e: Exception) {
             Logger.e(tag = "PayloadIO", throwable = e) { "payload cache-read FAILED key=$cacheKey" }
-            if (isKacheInstanceCorrupt(e)) discardPayloadKache()
             null
         }
     }
@@ -480,6 +403,28 @@ class DriveFileProviderCached(
     // =================================================
     // -------------------- FILE IO --------------------
     // =================================================
+
+    /**
+     * Write a ByteApiResponse to a Coil DiskCache entry. Surface failures
+     * loudly (corrupt journal, full disk) but never propagate them to the
+     * caller — a cache-write failure must not poison the fresh bytes the
+     * caller already paid the network round-trip for.
+     */
+    private fun writeToDiskCache(
+            cache: DiskCache,
+            cacheKey: String,
+            logTag: String,
+            value: ByteApiResponse
+    ) {
+        val editor = cache.openEditor(cacheKey.toDiskKey()) ?: return
+        try {
+            writeBytesResponse(editor.data.toString(), value)
+            editor.commit()
+        } catch (e: Exception) {
+            try { editor.abort() } catch (_: Exception) {}
+            Logger.e(tag = logTag, throwable = e) { "cache-write FAILED key=$cacheKey" }
+        }
+    }
 
     private fun writeBytesResponse(filePath: String, value: ByteApiResponse): Boolean {
         val path = filePath.toPath()
@@ -548,43 +493,19 @@ class DriveFileProviderCached(
                     .joinToString(":")
 
     suspend fun clearCaches() {
-        val payloadDir = "$directory/homebase-payloads".toPath()
-        val thumbDir = "$directory/homebase-thumbs".toPath()
         val preloadDir = "$directory/hbvid_preload".toPath()
 
-        // Serialised with the accessor functions: any in-flight payload/thumb
-        // reader either completed before we took the mutex (so its reference
-        // is no longer reachable from us) or is still waiting for it (so it
-        // will observe the post-teardown null and construct a fresh kache).
-        //
-        // We intentionally do NOT call FileKache.clear() — on at least one
-        // Android device that call raced with concurrent .get() calls and
-        // nulled internal FileKache state under a reader's feet, producing
-        // the `getClass() on null` NPE that fired 335× after logout.
-        // Deleting the directory directly achieves the same outcome and the
-        // next accessor reconstructs a clean FileKache on top of an empty dir.
-        kacheMutex.withLock {
-            _payloadDiskKache = null
-            _thumbDiskKache = null
-            // Reset the ctor tombstones. This is the recovery path for a
-            // FileKache-ctor NPE (observed on real devices with a populated
-            // homebase-thumbs dir from a prior install): the Storage-screen
-            // "Clear caches" button deletes the directory and clears the
-            // tombstone so the next access builds a fresh FileKache on top
-            // of an empty dir.
-            payloadKacheFailure = null
-            thumbKacheFailure = null
-
-            try {
-                fileSystem.deleteRecursively(payloadDir)
-            } catch (e: Exception) {
-                Logger.w(tag = "DriveFileProviderCached", throwable = e) { "payload cache dir delete failed" }
-            }
-            try {
-                fileSystem.deleteRecursively(thumbDir)
-            } catch (e: Exception) {
-                Logger.w(tag = "DriveFileProviderCached", throwable = e) { "thumb cache dir delete failed" }
-            }
+        // Coil's DiskCache.clear() is documented as thread-safe; it serialises
+        // internally against in-flight readers/writers.
+        try {
+            payloadDiskCache.clear()
+        } catch (e: Exception) {
+            Logger.w(tag = "DriveFileProviderCached", throwable = e) { "payload cache clear failed" }
+        }
+        try {
+            thumbDiskCache.clear()
+        } catch (e: Exception) {
+            Logger.w(tag = "DriveFileProviderCached", throwable = e) { "thumb cache clear failed" }
         }
 
         try {
@@ -596,26 +517,20 @@ class DriveFileProviderCached(
         notFoundCache = emptySet()
     }
 
-    // Per-cache try/catch: one broken FileKache (e.g. ctor tombstoned after a
-    // mayakapps/kache NPE on this device's pre-existing cache state) must not
-    // hide the other row. A thrown `payloadDiskKache()` used to propagate up
-    // through the ViewModel's outer runCatching and wipe *both* drive rows
-    // from the Storage screen, leaving the user with no indication that a
-    // cache was unhealthy. Return sentinel `sizeBytes = CacheStats.UNAVAILABLE`
-    // (-1L) so the UI can render a visible "Unavailable" row and point the
-    // user at the Clear caches button — which resets the tombstone.
+    // Per-cache try/catch as defense-in-depth: a thrown size read on one cache
+    // must not hide the other row. Returns sentinel `sizeBytes = CacheStats.UNAVAILABLE`
+    // (-1L) so the UI can render a visible "Unavailable" row when one cache is
+    // unhealthy.
     suspend fun getCacheStats(): List<CacheStats> {
         val out = ArrayList<CacheStats>(2)
         try {
-            val payload = payloadDiskKache()
-            out.add(CacheStats(id = "drive_payloads", sizeBytes = payload.size, maxBytes = payload.maxSize))
+            out.add(CacheStats(id = "drive_payloads", sizeBytes = payloadDiskCache.size, maxBytes = payloadDiskCache.maxSize))
         } catch (e: Throwable) {
             Logger.w(tag = "DriveFileProviderCached", throwable = e) { "drive_payloads stats unavailable" }
             out.add(CacheStats(id = "drive_payloads", sizeBytes = CacheStats.UNAVAILABLE, maxBytes = 0L))
         }
         try {
-            val thumb = thumbDiskKache()
-            out.add(CacheStats(id = "drive_thumbnails", sizeBytes = thumb.size, maxBytes = thumb.maxSize))
+            out.add(CacheStats(id = "drive_thumbnails", sizeBytes = thumbDiskCache.size, maxBytes = thumbDiskCache.maxSize))
         } catch (e: Throwable) {
             Logger.w(tag = "DriveFileProviderCached", throwable = e) { "drive_thumbnails stats unavailable" }
             out.add(CacheStats(id = "drive_thumbnails", sizeBytes = CacheStats.UNAVAILABLE, maxBytes = 0L))

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
@@ -13,7 +13,11 @@ import id.homebase.api.client.drives.files.DriveFileHttpProvider
 import id.homebase.api.client.drives.files.PayloadOperationOptions
 import id.homebase.api.crypto.AesCbc
 import id.homebase.api.file.FileOperationsProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.launch
 import io.ktor.client.HttpClient
 import io.ktor.http.Headers
 import kotlin.collections.mutableMapOf
@@ -111,11 +115,15 @@ class DriveFileProviderCached(
             .build()
 
     init {
-        // Reclaim disk from the pre-migration mayakapps/kache cache directories.
-        // Best-effort — a missing dir is fine, and any failure here is purely
-        // a missed cleanup, not a correctness issue.
-        runCatching { fileSystem.deleteRecursively("$directory/homebase-payloads".toPath()) }
-        runCatching { fileSystem.deleteRecursively("$directory/homebase-thumbs".toPath()) }
+        // Fire-and-forget reclaim of the pre-migration mayakapps/kache cache
+        // directories. Best-effort — a missing dir is fine, and any failure
+        // here is purely a missed cleanup, not a correctness issue. Done off
+        // the construction thread so an upgrade-day delete of a populated
+        // 500 MB dir cannot block whatever path instantiates this class.
+        CoroutineScope(SupervisorJob() + Dispatchers.Default).launch {
+            runCatching { fileSystem.deleteRecursively("$directory/homebase-payloads".toPath()) }
+            runCatching { fileSystem.deleteRecursively("$directory/homebase-thumbs".toPath()) }
+        }
     }
 
     // Coil's DiskLruCache enforces `[a-z0-9_-]{1,120}` on keys. Our logical

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
@@ -13,6 +13,10 @@ import io.ktor.client.statement.bodyAsBytes
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import kotlin.concurrent.Volatile
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import okio.ByteString.Companion.encodeUtf8
@@ -94,9 +98,12 @@ class PublicProfileProviderCached(
         .build()
 
     init {
-        // Reclaim disk from the pre-migration mayakapps/kache cache directories.
-        runCatching { fileSystem.deleteRecursively("$directory/homebase-public-profiles".toPath()) }
-        runCatching { fileSystem.deleteRecursively("$directory/homebase-public-images".toPath()) }
+        // Fire-and-forget reclaim of the pre-migration mayakapps/kache cache
+        // directories — see DriveFileProviderCached.init for rationale.
+        CoroutineScope(SupervisorJob() + Dispatchers.Default).launch {
+            runCatching { fileSystem.deleteRecursively("$directory/homebase-public-profiles".toPath()) }
+            runCatching { fileSystem.deleteRecursively("$directory/homebase-public-images".toPath()) }
+        }
     }
 
     // Coil's DiskLruCache enforces `[a-z0-9_-]{1,120}` on keys; SHA-256 hex

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
@@ -1,7 +1,7 @@
 package id.homebase.api.client.profile
 
 import co.touchlab.kermit.Logger
-import com.mayakapps.kache.FileKache
+import coil3.disk.DiskCache
 import id.homebase.api.client.cache.CacheStats
 import id.homebase.api.common.OdinId
 import id.homebase.api.serialization.OdinSystemSerializer
@@ -15,7 +15,9 @@ import io.ktor.http.HttpHeaders
 import kotlin.concurrent.Volatile
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import okio.ByteString.Companion.encodeUtf8
 import okio.FileSystem
+import okio.Path
 import okio.Path.Companion.toPath
 import okio.SYSTEM
 import kotlin.time.Clock
@@ -26,19 +28,19 @@ import kotlin.time.Clock
  * and `https://{odinId}/pub/image`. Both endpoints are public HTTPS, so their
  * responses are stored on disk unencrypted.
  *
- * Two underlying [com.mayakapps.kache.FileKache] instances back the two
+ * Two underlying [coil3.disk.DiskCache] instances back the two
  * Storage-screen rows:
  * - `public_profiles` — serialized [ProfileCard] JSON (display name, bio,
  *   links, email list, avatar URL, etc.). Directory
- *   `homebase-public-profiles`, cap 10 MB.
+ *   `homebase-public-profiles-v2`, cap 10 MB.
  * - `public_images`   — raw avatar image bytes. Directory
- *   `homebase-public-images`, cap 200 MB.
+ *   `homebase-public-images-v2`, cap 200 MB.
  *
  * The split is deliberate, not incidental. Profile JSON is small (~1–10 KB)
  * and used as a sparse fallback for identities without a local contact-drive
  * record — push senders, forward-sheet targets, unmet-peer [id.homebase.core.widget.ContactName]
  * renders. Avatar bytes are an order of magnitude larger. A single merged
- * FileKache would let a burst of avatar loads evict profile JSON entries
+ * DiskCache would let a burst of avatar loads evict profile JSON entries
  * under shared-pool LRU pressure; separate caps (10 MB profiles, 200 MB
  * images) protect the small tier from the large one regardless of relative
  * request rates. It also lets the two caps be tuned independently and
@@ -48,11 +50,11 @@ import kotlin.time.Clock
  * lookups of missing identities skip the network. Transient failures
  * (5xx, network errors) are never cached.
  *
- * Both FileKache instances are created lazily through mutex-gated accessors
- * so that [clearCaches] cannot race with a reader: clears delete the
- * directory recursively and null the refs, and readers re-create the
- * FileKache on next access. See also [id.homebase.api.client.drives.cache.DriveFileProviderCached]
- * which follows the same lifecycle pattern.
+ * Both DiskCache instances are constructed eagerly. Coil's DiskCache
+ * (a Kotlin port of OkHttp's DiskLruCache) is thread-safe by contract,
+ * so concurrent get/put/clear are all safe and no lifecycle mutex is
+ * needed. See also [id.homebase.api.client.drives.cache.DriveFileProviderCached]
+ * which follows the same shape.
  */
 class PublicProfileProviderCached(
     private val httpClient: HttpClient,
@@ -78,57 +80,28 @@ class PublicProfileProviderCached(
     @Volatile private var notFoundCache: Set<String> = emptySet()
     private val notFoundCacheMutex = Mutex()
 
-    private var _profileDiskKache: FileKache? = null
-    private var _imageDiskKache: FileKache? = null
-    @Volatile private var profileKacheFailure: Throwable? = null
-    @Volatile private var imageKacheFailure: Throwable? = null
-    private val kacheMutex = Mutex()
+    private val profileDir = "$directory/homebase-public-profiles-v2"
+    private val imageDir = "$directory/homebase-public-images-v2"
 
-    // Always acquires kacheMutex — the previous `by lazy { runBlocking { ... } }`
-    // handed out a permanent FileKache reference that a concurrent clearCaches()
-    // could poison with .clear(). Mirrors DriveFileProviderCached post-fix.
-    //
-    // createDirectories + tombstone on construction failure: observed on one
-    // Android device that FileKache(…) throws `getClass() on null` from
-    // mayakapps/kache internals when the managed directory is missing.
-    // Pre-create the dir and tombstone the first construction exception so we
-    // don't spam retries for the rest of the session. clearCaches() resets
-    // the tombstone.
-    private suspend fun profileDiskKache(): FileKache = kacheMutex.withLock {
-        _profileDiskKache?.let { return@withLock it }
-        profileKacheFailure?.let { throw it }
+    private val profileDiskCache: DiskCache = DiskCache.Builder()
+        .directory(profileDir.toPath())
+        .maxSizeBytes(10L * 1024L * 1024L)
+        .build()
 
-        val dir = "$directory/homebase-public-profiles"
-        try {
-            fileSystem.createDirectories(dir.toPath())
-            FileKache(directory = dir, maxSize = 10L * 1024L * 1024L)
-                .also { _profileDiskKache = it }
-        } catch (e: Throwable) {
-            Logger.e(tag = "PublicProfileIO", throwable = e) {
-                "FileKache construction FAILED (profile) — disabling disk cache for this session"
-            }
-            profileKacheFailure = e
-            throw e
-        }
+    private val imageDiskCache: DiskCache = DiskCache.Builder()
+        .directory(imageDir.toPath())
+        .maxSizeBytes(200L * 1024L * 1024L)
+        .build()
+
+    init {
+        // Reclaim disk from the pre-migration mayakapps/kache cache directories.
+        runCatching { fileSystem.deleteRecursively("$directory/homebase-public-profiles".toPath()) }
+        runCatching { fileSystem.deleteRecursively("$directory/homebase-public-images".toPath()) }
     }
 
-    private suspend fun imageDiskKache(): FileKache = kacheMutex.withLock {
-        _imageDiskKache?.let { return@withLock it }
-        imageKacheFailure?.let { throw it }
-
-        val dir = "$directory/homebase-public-images"
-        try {
-            fileSystem.createDirectories(dir.toPath())
-            FileKache(directory = dir, maxSize = 200L * 1024L * 1024L)
-                .also { _imageDiskKache = it }
-        } catch (e: Throwable) {
-            Logger.e(tag = "PublicProfileIO", throwable = e) {
-                "FileKache construction FAILED (image) — disabling disk cache for this session"
-            }
-            imageKacheFailure = e
-            throw e
-        }
-    }
+    // Coil's DiskLruCache enforces `[a-z0-9_-]{1,120}` on keys; SHA-256 hex
+    // gives a 64-char compliant digest with no collision risk in practice.
+    private fun String.toDiskKey(): String = encodeUtf8().sha256().hex()
 
     // =========================================================
     // PUBLIC API
@@ -137,20 +110,20 @@ class PublicProfileProviderCached(
     suspend fun getPublicProfile(odinId: OdinId): ProfileCard? =
         getCached(
             cacheKey = "profile:$odinId",
-            disk = { profileDiskKache() },
+            disk = profileDiskCache,
             fetch = { httpClient.get("https://${odinId}/pub/profile") },
             transform = { response ->
                 serializer.deserialize<ProfileCard>(response.bodyAsText())
             },
             readFromDisk = { path ->
-                fileSystem.read(path.toPath()) {
+                fileSystem.read(path) {
                     val expiry = readLong()
                     val json = readUtf8()
                     CachedEntry(expiry, serializer.deserialize<ProfileCard>(json))
                 }
             },
             writeToDisk = { path, expiry, value ->
-                fileSystem.write(path.toPath()) {
+                fileSystem.write(path) {
                     writeLong(expiry)
                     writeUtf8(serializer.serialize(value))
                 }
@@ -160,13 +133,13 @@ class PublicProfileProviderCached(
     suspend fun getPublicImage(odinId: OdinId): ByteArray? =
         getCached(
             cacheKey = "image:$odinId",
-            disk = { imageDiskKache() },
+            disk = imageDiskCache,
             fetch = { httpClient.get("https://${odinId}/pub/image") },
             transform = { response ->
                 response.bodyAsBytes()
             },
             readFromDisk = { path ->
-                fileSystem.read(path.toPath()) {
+                fileSystem.read(path) {
                     val expiry = readLong()
                     val size = readInt()
                     val bytes = readByteArray(size.toLong())
@@ -174,7 +147,7 @@ class PublicProfileProviderCached(
                 }
             },
             writeToDisk = { path, expiry, value ->
-                fileSystem.write(path.toPath()) {
+                fileSystem.write(path) {
                     writeLong(expiry)
                     writeInt(value.size)
                     write(value)
@@ -183,34 +156,15 @@ class PublicProfileProviderCached(
         )
 
     suspend fun clearCaches() {
-        val profileDir = "$directory/homebase-public-profiles".toPath()
-        val imageDir = "$directory/homebase-public-images".toPath()
-
-        // Serialised with the accessor functions: any in-flight reader either
-        // completed before we took the mutex or is still waiting for it (and
-        // will observe the post-teardown null and construct a fresh kache).
-        //
-        // We intentionally do NOT call FileKache.clear() — see the same-shape
-        // fix in DriveFileProviderCached.clearCaches for the reason.
-        kacheMutex.withLock {
-            _profileDiskKache = null
-            _imageDiskKache = null
-            // Reset the ctor tombstones — see DriveFileProviderCached.clearCaches
-            // for the full rationale. This is the Clear-caches-button recovery
-            // path for a tombstoned FileKache ctor failure.
-            profileKacheFailure = null
-            imageKacheFailure = null
-
-            try {
-                fileSystem.deleteRecursively(profileDir)
-            } catch (e: Exception) {
-                Logger.w(tag = "PublicProfileIO", throwable = e) { "profile cache dir delete failed" }
-            }
-            try {
-                fileSystem.deleteRecursively(imageDir)
-            } catch (e: Exception) {
-                Logger.w(tag = "PublicProfileIO", throwable = e) { "image cache dir delete failed" }
-            }
+        try {
+            profileDiskCache.clear()
+        } catch (e: Exception) {
+            Logger.w(tag = "PublicProfileIO", throwable = e) { "profile cache clear failed" }
+        }
+        try {
+            imageDiskCache.clear()
+        } catch (e: Exception) {
+            Logger.w(tag = "PublicProfileIO", throwable = e) { "image cache clear failed" }
         }
 
         notFoundCache = emptySet()
@@ -221,15 +175,13 @@ class PublicProfileProviderCached(
     suspend fun getCacheStats(): List<CacheStats> {
         val out = ArrayList<CacheStats>(2)
         try {
-            val profile = profileDiskKache()
-            out.add(CacheStats(id = "public_profiles", sizeBytes = profile.size, maxBytes = profile.maxSize))
+            out.add(CacheStats(id = "public_profiles", sizeBytes = profileDiskCache.size, maxBytes = profileDiskCache.maxSize))
         } catch (e: Throwable) {
             Logger.w(tag = "PublicProfileIO", throwable = e) { "public_profiles stats unavailable" }
             out.add(CacheStats(id = "public_profiles", sizeBytes = CacheStats.UNAVAILABLE, maxBytes = 0L))
         }
         try {
-            val image = imageDiskKache()
-            out.add(CacheStats(id = "public_images", sizeBytes = image.size, maxBytes = image.maxSize))
+            out.add(CacheStats(id = "public_images", sizeBytes = imageDiskCache.size, maxBytes = imageDiskCache.maxSize))
         } catch (e: Throwable) {
             Logger.w(tag = "PublicProfileIO", throwable = e) { "public_images stats unavailable" }
             out.add(CacheStats(id = "public_images", sizeBytes = CacheStats.UNAVAILABLE, maxBytes = 0L))
@@ -243,11 +195,11 @@ class PublicProfileProviderCached(
 
     private suspend fun <T> getCached(
         cacheKey: String,
-        disk: suspend () -> FileKache,
+        disk: DiskCache,
         fetch: suspend () -> HttpResponse,
         transform: suspend (HttpResponse) -> T,
-        readFromDisk: (String) -> CachedEntry<T>,
-        writeToDisk: (String, Long, T) -> Unit
+        readFromDisk: (Path) -> CachedEntry<T>,
+        writeToDisk: (Path, Long, T) -> Unit
     ): T? {
 
         if (cacheKey in notFoundCache) return null
@@ -255,7 +207,7 @@ class PublicProfileProviderCached(
         // Pre-mutex peek: pure read, no remove. A hit returns immediately;
         // a miss or expired entry falls through to the mutex where the
         // refresh (and any remove) is serialised.
-        readCachedOrLog(disk(), cacheKey, readFromDisk)?.let { cached ->
+        readCachedOrLog(disk, cacheKey, readFromDisk)?.let { cached ->
             if (!cached.isExpired(clock)) return cached.value
         }
 
@@ -265,12 +217,12 @@ class PublicProfileProviderCached(
 
             if (cacheKey in notFoundCache) return@withLock null
 
-            readCachedOrLog(disk(), cacheKey, readFromDisk)?.let { cached ->
+            readCachedOrLog(disk, cacheKey, readFromDisk)?.let { cached ->
                 if (!cached.isExpired(clock)) {
                     return@withLock cached.value
                 } else {
                     try {
-                        disk().remove(cacheKey)
+                        disk.remove(cacheKey.toDiskKey())
                     } catch (e: Exception) {
                         Logger.w(tag = "PublicProfileIO", throwable = e) { "remove expired entry failed key=$cacheKey" }
                     }
@@ -289,13 +241,15 @@ class PublicProfileProviderCached(
                     val value = transform(response)
 
                     if (shouldStore(cacheControl)) {
-                        try {
-                            disk().put(cacheKey) { path ->
-                                writeToDisk(path, expiry, value)
-                                true
+                        val editor = disk.openEditor(cacheKey.toDiskKey())
+                        if (editor != null) {
+                            try {
+                                writeToDisk(editor.data, expiry, value)
+                                editor.commit()
+                            } catch (e: Exception) {
+                                try { editor.abort() } catch (_: Exception) {}
+                                Logger.w(tag = "PublicProfileIO", throwable = e) { "cache-write failed key=$cacheKey" }
                             }
-                        } catch (e: Exception) {
-                            Logger.w(tag = "PublicProfileIO", throwable = e) { "cache-write failed key=$cacheKey" }
                         }
                     }
 
@@ -318,19 +272,17 @@ class PublicProfileProviderCached(
     }
 
     /**
-     * Read a cached entry from [disk]. Returns null on cache miss OR when the
-     * FileKache layer throws (e.g. concurrent clearCaches() on another thread)
-     * OR when [readFromDisk] fails (corrupted/truncated entry). Any failure is
-     * logged so the caller can fall through to the network cleanly.
+     * Read a cached entry from [disk]. Returns null on cache miss OR when
+     * [readFromDisk] fails (corrupted/truncated entry). Any failure is logged
+     * so the caller can fall through to the network cleanly.
      */
-    private suspend fun <T> readCachedOrLog(
-        disk: FileKache,
+    private fun <T> readCachedOrLog(
+        disk: DiskCache,
         cacheKey: String,
-        readFromDisk: (String) -> CachedEntry<T>
+        readFromDisk: (Path) -> CachedEntry<T>
     ): CachedEntry<T>? {
         return try {
-            val path = disk.get(cacheKey) ?: return null
-            readFromDisk(path)
+            disk.openSnapshot(cacheKey.toDiskKey())?.use { snap -> readFromDisk(snap.data) }
         } catch (e: Exception) {
             Logger.e(tag = "PublicProfileIO", throwable = e) { "cache-read FAILED key=$cacheKey" }
             null

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
@@ -168,7 +168,7 @@ class DriveFileProviderCachedTest {
         // but pre-fix code paths could have produced them — so a user upgrading
         // past the fix might still carry one on disk. This test documents the
         // failure mode and pins the diagnostic log to the right context.
-        val thumbDir = Path.of(tempDir, "homebase-thumbs")
+        val thumbDir = Path.of(tempDir, "homebase-thumbs-v2")
         val filesBefore = snapshotFiles(thumbDir)
 
         provider.getThumbBytesRaw(driveId, fileId, key, 100, 100)
@@ -218,7 +218,7 @@ class DriveFileProviderCachedTest {
 
         // Truncate every file under the thumb cache dir to simulate a corrupted
         // on-disk entry (short read in readBytesResponse => EOFException / NPE).
-        val thumbDir = Path.of(tempDir, "homebase-thumbs")
+        val thumbDir = Path.of(tempDir, "homebase-thumbs-v2")
         Files.walk(thumbDir).use { stream ->
             stream.filter { Files.isRegularFile(it) }.forEach { Files.write(it, ByteArray(0)) }
         }
@@ -310,7 +310,7 @@ class DriveFileProviderCachedTest {
     fun `getCacheStats returns sentinel for broken cache without hiding the healthy one`() = runTest {
         // Pre-fail the thumb cache: create homebase-thumbs as a FILE, which
         // makes the subsequent FileKache ctor blow up on createDirectories.
-        Files.write(Path.of(tempDir, "homebase-thumbs"), ByteArray(0))
+        Files.write(Path.of(tempDir, "homebase-thumbs-v2"), ByteArray(0))
 
         val stats = provider.getCacheStats()
 
@@ -326,41 +326,6 @@ class DriveFileProviderCachedTest {
         assertEquals(
             CacheStats.UNAVAILABLE, thumb.sizeBytes,
             "broken thumb cache must be marked unavailable via the sentinel"
-        )
-    }
-
-    /**
-     * Regression for an Android log where a single internal mayakapps/kache
-     * NPE poisoned the live FileKache instance and every subsequent
-     * `get()`/`put()` fired the same `getClass() on null` NPE for the rest of
-     * the session — 90k+ identical errors in one user log. The self-healing
-     * path nulls the bad reference under the lifecycle mutex so the next
-     * accessor reconstructs over the existing on-disk journal, recovering
-     * already-cached entries instead of needing a full re-download.
-     */
-    @Test
-    fun `discardThumbKache rebuilds cache and previously-cached bytes survive`() = runTest {
-        // Populate the cache so there's a live instance + on-disk journal.
-        provider.getThumbBytesRaw(driveId, fileId, key, 100, 100)
-        val countAfterPopulate = requestCount
-
-        // Same key reads from cache — no network — proving the live instance works.
-        provider.getThumbBytesRaw(driveId, fileId, key, 100, 100)
-        assertEquals(
-            countAfterPopulate, requestCount,
-            "warm read should hit the live cache (no extra network call)"
-        )
-
-        // Simulate the recovery path the new catch blocks invoke.
-        provider.discardThumbKache()
-
-        // Next call must succeed — a fresh FileKache reconstructs over the
-        // same directory and finds the existing entry. Network count must NOT
-        // change: the on-disk journal survives, so this is a cache hit.
-        provider.getThumbBytesRaw(driveId, fileId, key, 100, 100)
-        assertEquals(
-            countAfterPopulate, requestCount,
-            "after discard + reconstruct, the previously-cached entry must still serve from disk"
         )
     }
 
@@ -384,7 +349,7 @@ class DriveFileProviderCachedTest {
     }
 }
 
-/** Snapshot every regular file under [dir] (recursively), skipping FileKache's journal. */
+/** Snapshot every regular file under [dir] (recursively), skipping the disk-cache journal. */
 private fun snapshotFiles(dir: Path): Set<Path> {
     if (!Files.exists(dir)) return emptySet()
     return Files.walk(dir).use { stream ->

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/profile/PublicProfileProviderCachedTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/profile/PublicProfileProviderCachedTest.kt
@@ -116,7 +116,7 @@ class PublicProfileProviderCachedTest {
 
         // Truncate every file under the image cache dir to simulate a corrupted
         // on-disk entry. readFromDisk will throw (EOF) when it tries to parse it.
-        val imageDir = Path.of(tempDir, "homebase-public-images")
+        val imageDir = Path.of(tempDir, "homebase-public-images-v2")
         Files.walk(imageDir).use { stream ->
             stream.filter { Files.isRegularFile(it) }.forEach { Files.write(it, ByteArray(0)) }
         }
@@ -244,7 +244,7 @@ class PublicProfileProviderCachedTest {
      */
     @Test
     fun `getCacheStats returns sentinel for broken cache without hiding the healthy one`() = runTest {
-        Files.write(Path.of(tempDir, "homebase-public-profiles"), ByteArray(0))
+        Files.write(Path.of(tempDir, "homebase-public-profiles-v2"), ByteArray(0))
 
         val stats = provider.getCacheStats()
 

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
@@ -525,14 +525,19 @@ class ChatMessageActionServiceTestFixture(
  * Cheap FileOperationsProvider used only so DriveFileProviderCached's ctor can run.
  * Every method throws — if markAsReadByFiles (or any test path we expect NOT to hit
  * file I/O) actually reaches file ops, the test fails loudly instead of silently.
+ *
+ * Each instance gets its own unique cache subdirectory so multiple test classes'
+ * Coil DiskCache instances don't contend on the same on-disk journal.
  */
 private class NoopFileOperationsProvider : FileOperationsProvider {
+    private val uniqueCacheDir: String =
+        java.nio.file.Files.createTempDirectory("hb-chat-test-cache").toString()
     private fun nope(): Nothing =
         error("NoopFileOperationsProvider: no file IO expected in markAsReadByFiles tests")
     override fun openFileInput(path: String) = nope()
     override suspend fun readFileBytes(path: String) = nope()
     override fun deleteTempFile(path: String) = nope()
-    override fun getCacheDirectory(): String = System.getProperty("java.io.tmpdir") ?: "/tmp"
+    override fun getCacheDirectory(): String = uniqueCacheDir
     override fun getFileSize(path: String) = nope()
     override suspend fun writeBytesToTempFile(bytes: ByteArray, prefix: String, suffix: String) = nope()
     override suspend fun writeStream(path: String, data: Flow<ByteArray>) = nope()

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceTestFixture.kt
@@ -256,13 +256,17 @@ class SeedableConversationLookup(private val testDomain: String) : ConversationP
 }
 
 private class SenderNoopFileOperationsProvider : FileOperationsProvider {
+    // Per-instance unique dir so multiple test classes' Coil DiskCache instances
+    // don't contend on the same on-disk journal.
+    private val uniqueCacheDir: String =
+        java.nio.file.Files.createTempDirectory("hb-chat-sender-test-cache").toString()
     private fun nope(): Nothing =
         error("SenderNoopFileOperationsProvider: no file IO expected in chain-shape tests")
 
     override fun openFileInput(path: String) = nope()
     override suspend fun readFileBytes(path: String) = nope()
     override fun deleteTempFile(path: String) = nope()
-    override fun getCacheDirectory(): String = System.getProperty("java.io.tmpdir") ?: "/tmp"
+    override fun getCacheDirectory(): String = uniqueCacheDir
     override fun getFileSize(path: String) = nope()
     override suspend fun writeBytesToTempFile(bytes: ByteArray, prefix: String, suffix: String) = nope()
     override suspend fun writeStream(path: String, data: Flow<ByteArray>) = nope()


### PR DESCRIPTION
A user log captured 658 consecutive `getClass() on null` NPEs deep inside mayakapps/kache 2.1.1 (FileKache.get/put), all on the same thumb cache. Once the in-memory FileKache instance loses an internal sink/source field to a concurrent eviction race, every subsequent op throws the same NPE for the rest of the session — until the user hits "Clear caches" and deletes the directory by hand.

Three layers of defensive scaffolding had been built up around FileKache: a kacheMutex gating lifecycle, a thumbnailKacheWriteMutex serialising writes, ctor tombstones to suppress repeated init failures, and an isKacheInstanceCorrupt-discardThumbKache self-heal path. None of it prevents the journal-level corruption that triggers the NPE storm.

Coil 3's DiskCache is a Kotlin port of OkHttp's DiskLruCache (~14 years of production pedigree) and is thread-safe by contract. Coil 3.4.0 is already a transitive dep via homebase-common, so no new library added — just an extra `implementation(libs.coil3)` on homebase-api so the disk cache types resolve there.

Migration shape:

  - Two `FileKache` fields per class become two `DiskCache` fields.
  - All defensive scaffolding (kacheMutex, write mutex, tombstones, discard helpers, isKacheInstanceCorrupt) deleted — Coil handles concurrent get/put/clear safely.
  - `kache.get(key)` becomes `cache.openSnapshot(key)?.use { ... }`.
  - `kache.put(key) { fp -> write(fp) }` becomes the `openEditor` / `commit` / `abort` dance, factored into a `writeToDiskCache` helper.
  - `clearCaches()` calls `cache.clear()` directly instead of the null-the-ref-and-rmrf workaround that existed because FileKache.clear() wasn't safe to call concurrently.
  - `streamPayloadDecryptedToPath` now holds a Snapshot via .use {} for the duration of the stream — fixes a latent eviction race where the underlying file could be deleted mid-stream (Coil holds the entry until the snapshot closes; FileKache had no equivalent guarantee).

Coil's DiskLruCache enforces `[a-z0-9_-]{1,120}` on keys. Our logical keys (`payload:driveId:fileId:…`) contain colons and overflow that length, so a `String.toDiskKey()` SHA-256-hex helper maps them to a 64-char compliant digest.

On-disk layout differs between the two libraries, so directories get a `-v2` suffix (`homebase-thumbs-v2`, `homebase-payloads-v2`, `homebase-public-profiles-v2`, `homebase-public-images-v2`). Each class's `init {}` does a best-effort `deleteRecursively` of the old (kache-format) directory so users reclaim disk on first launch after upgrade.

Tests: directory names updated; the `discardThumbKache rebuilds cache and previously-cached bytes survive` test deleted (the recovery path it exercised is gone). The 300-iteration concurrent-clearCaches stress test passes on Coil — direct evidence that the new code preserves the thread-safety properties the old code went to such lengths to maintain.

Net diff: -167 lines. All 465 unit tests pass; Android + iOS targets compile clean.