### PR TITLE
Fix stuck unread badges; source latestMessageTimestamp from SQL

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/HomebaseFile.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/HomebaseFile.kt
@@ -40,6 +40,22 @@ data class HomebaseFile(
         fileState == FileState.Deleted ||
             fileMetadata.appData.archivalStatus == ArchivalStatus.Removed
 
+    /**
+     * The userDate stored in `DriveMainIndex.userDate` for this file —
+     * `appData.userDate` if present, else `metadata.created.milliseconds`.
+     *
+     * Mirrors the formula in `MainIndexMetaHelpers` (sync-side projection)
+     * so callers that need to compare against the SQL column (notably the
+     * unread-count and last-read tracking) get the same value regardless
+     * of whether they go through the in-memory message mapper or the SQL.
+     *
+     * Distinct from `MessageUiModel.userDate`, which clamps to the
+     * server-stamped `transitCreated` for display safety. That clamp is
+     * correct for rendering but wrong for read-bookkeeping comparisons.
+     */
+    fun sqlUserDateMs(): Long =
+        fileMetadata.appData.userDate ?: fileMetadata.created.milliseconds
+
     fun assertOriginalAuthor(odinId: OdinId) {
         val originalAuthor = fileMetadata.originalAuthor
         if (originalAuthor == null) {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/ChatReadCountWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/ChatReadCountWrapper.kt
@@ -11,7 +11,20 @@ import kotlin.uuid.Uuid
 
 data class ConversationWithLastMessage(
     val conversation: HomebaseFile,
-    val message: HomebaseFile?
+    val message: HomebaseFile?,
+    /**
+     * Authoritative `DriveMainIndex.userDate` (epoch ms) of the last message,
+     * straight from the SQL column. Null when there's no last message yet.
+     *
+     * Carried separately from `message` because `ChatMessageStream.mapToMessageData`
+     * clamps the in-memory `MessageUiModel.userDate` to `metadata.transitCreated`
+     * for display safety, which can drop below the SQL value when peers ship
+     * messages with a later `appData.userDate`. Read-bookkeeping (lastRead /
+     * unread-counter) compares against the SQL column, so callers must use
+     * this field, not `message.fileMetadata.appData.userDate` or the mapped
+     * `MessageUiModel.userDate`.
+     */
+    val msgUserDateMs: Long?,
 )
 
 data class ConversationUnreadCount(
@@ -87,7 +100,8 @@ class ChatReadCountWrapper(
 
                 ConversationWithLastMessage(
                     conversation = conversation,
-                    message = message
+                    message = message,
+                    msgUserDateMs = it.msgUserDate,
                 )
 
             } catch (t: Throwable) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/ConversationUiModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/ConversationUiModel.kt
@@ -60,15 +60,37 @@ data class ConversationUiModel(
     }
 
     companion object {
+        /**
+         * Patches the conversation's last-message fields if [msg] is at least
+         * as recent as the current [latestMessageTimestamp].
+         *
+         * The "recency" comparison is driven by [latestTimestampOverrideMs]
+         * when the caller knows the SQL-side userDate (e.g. from
+         * `selectAllConversationPlusLastMessage`'s `msgUserDate` projection,
+         * or from `HomebaseFile.sqlUserDateMs()` for files just written to
+         * `DriveMainIndex`). This avoids the clamp inside
+         * `ChatMessageStream.mapToMessageData`, which can drop
+         * `MessageUiModel.userDate` below the SQL column when a peer's
+         * `appData.userDate` exceeds `metadata.transitCreated` — and that
+         * mismatch is what stuck Monica's unread badge at 1: the unread SQL
+         * counted the row using the SQL userDate, but every read code path
+         * advanced `lastReadTime` to the clamped (smaller) value.
+         *
+         * Falls back to `msg.userDate` when no override is supplied, matching
+         * legacy behaviour for callers that haven't been migrated.
+         */
         fun ConversationUiModel.updateWithLatestMessage(
             msg: MessageUiModel,
-            activeUserDomain: OdinId?
+            activeUserDomain: OdinId?,
+            latestTimestampOverrideMs: Long? = null,
         ): ConversationUiModel {
-            // TODO: Should we also increase unread count here if it's a new message?
-            if (msg.userDate >= latestMessageTimestamp) {
+            val candidate = latestTimestampOverrideMs
+                ?.let { Instant.fromEpochMilliseconds(it) }
+                ?: msg.userDate
+            if (candidate >= latestMessageTimestamp) {
                 return this.copy(
                     lastMessage = msg.content.truncateToCodePoints(40),
-                    latestMessageTimestamp = msg.userDate,
+                    latestMessageTimestamp = candidate,
                     lastMessageDeliveryStatus = msg.messageAppData.deliveryStatus,
                     lastMessageIsDeleted = msg.isDeleted,
                     lastMessageFirstPayload = msg.payloads?.firstOrNull(),

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
@@ -81,11 +81,22 @@ class ChatMessageActionService(
             return
         }
 
-        val newReadTime = viewedRecords.maxOf { it.userDate }
+        // The MessageUiModel.userDate carried here is the *clamped* value from
+        // ChatMessageStream.mapToMessageData (`min(appData.userDate, transitCreated)`).
+        // selectAllUnreadCount filters on the *un-clamped* DriveMainIndex.userDate,
+        // so capping newReadTime at `viewedRecords.maxOf { userDate }` can leave
+        // the badge stuck on a row whose appData.userDate exceeded transitCreated.
+        // The conversation's `latestMessageTimestamp` (sourced from the SQL column
+        // since `enrichWithLastMessages` was fixed) is authoritative — use it as
+        // a floor when it's ahead of the per-file value.
+        val viewedMax = viewedRecords.maxOf { it.userDate }
+        val convoLatest = participantLookup.getConversationById(conversationId)?.latestMessageTimestamp
+        val newReadTime = if (convoLatest != null && convoLatest > viewedMax) convoLatest else viewedMax
         Logger.d(tag = TAG) {
             "newReadTime(ms)=${newReadTime.toEpochMilliseconds()} " +
-                    "(max userDate over ${viewedRecords.size} viewed records, " +
-                    "${unreadRecords.size} receipt-eligible)"
+                    "(viewedMax=${viewedMax.toEpochMilliseconds()} " +
+                    "convoLatest=${convoLatest?.toEpochMilliseconds()} " +
+                    "viewed=${viewedRecords.size} receipt-eligible=${unreadRecords.size})"
         }
 
         // Send a read receipt only if there are receipt-eligible records. For

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMapper.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMapper.kt
@@ -266,15 +266,30 @@ class ConversationMapper(
      * This is a per-row patcher; callers in [ConversationStream] invoke
      * it in a loop over rows from `selectAllConversationPlusLastMessage`.
      */
+    /**
+     * @param sqlUserDateMs Authoritative `DriveMainIndex.userDate` for the
+     *   message row. When provided, drives the conversation's
+     *   `latestMessageTimestamp` directly rather than the clamped
+     *   `MessageUiModel.userDate`. Pass `null` only when no SQL row exists yet
+     *   for the message (which essentially never happens — by the time
+     *   `applyLastMessage` runs, the message has been ingested into
+     *   `DriveMainIndex`). Use [HomebaseFile.sqlUserDateMs] to derive it
+     *   from a freshly-received file when there's no SQL projection at hand.
+     */
     suspend fun applyLastMessage(
         ui: ConversationUiModel,
         lastMsgFile: HomebaseFile,
         domain: OdinId,
+        sqlUserDateMs: Long? = null,
     ): ConversationUiModel {
         val msg = ChatMessageStream.mapToMessageData(lastMsgFile, credentialsManager) {
             it.fileMetadata.originalAuthor?.domainName ?: ""
         } ?: return ui
-        return ui.updateWithLatestMessage(msg, domain)
+        return ui.updateWithLatestMessage(
+            msg,
+            domain,
+            latestTimestampOverrideMs = sqlUserDateMs,
+        )
     }
 
     /**
@@ -322,7 +337,7 @@ class ConversationMapper(
 
         return if (lastMsg != null) {
             val domain = credentialsManager.requireActiveDomain()
-            applyLastMessage(withAdmins, lastMsg, domain)
+            applyLastMessage(withAdmins, lastMsg, domain, sqlUserDateMs = lastMsg.sqlUserDateMs())
         } else withAdmins
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -202,16 +202,20 @@ class ConversationStream(
     private suspend fun processMessageBatchIncrementally(messageFiles: List<HomebaseFile>) {
         if (messageFiles.isEmpty()) throw IllegalArgumentException("It can't be empty")
 
-        // For each file in the batch, map to model (fetch last message from DB if needed)
-        val incomingMessages =
-            messageFiles.mapNotNull { file ->
-                ChatMessageStream.mapToMessageData(file, credentialsManager, ::resolveDisplayName)
-            }
+        // For each file in the batch, map to model (fetch last message from DB if needed).
+        // Keep the original HomebaseFile alongside the mapped MessageUiModel so we can
+        // pull the SQL-faithful userDate via `file.sqlUserDateMs()` — `MessageUiModel.userDate`
+        // is clamped to `transitCreated` for display and can underrun the SQL column.
+        val incoming = ArrayList<Pair<HomebaseFile, MessageUiModel>>(messageFiles.size)
+        for (file in messageFiles) {
+            val mapped = ChatMessageStream.mapToMessageData(file, credentialsManager, ::resolveDisplayName)
+            if (mapped != null) incoming.add(file to mapped)
+        }
 
-        if (messageFiles.size != incomingMessages.size)
-            Logger.w("ConversationStream: ${messageFiles.size - incomingMessages.size} of ${messageFiles.size} messages failed to convert")
+        if (messageFiles.size != incoming.size)
+            Logger.w("ConversationStream: ${messageFiles.size - incoming.size} of ${messageFiles.size} messages failed to convert")
 
-        for (m in incomingMessages) {
+        for ((file, m) in incoming) {
             val matchingConversation = _conversations.value.items.find { it.id == m.conversationId }
 
             // Drop messages for conversations the user has left or been removed from
@@ -257,7 +261,7 @@ class ConversationStream(
                 _conversations.value = _conversations.value.copy(
                     items = _conversations.value.items.map { if (it.id == revived.id) revived else it }
                 )
-                updateConversationFromNewMessage(revived, m)
+                updateConversationFromNewMessage(revived, m, file.sqlUserDateMs())
 
                 // Intentionally do NOT trigger server-side recovery here. A
                 // drive-sync batch handler is the wrong place to enqueue
@@ -298,7 +302,7 @@ class ConversationStream(
                         id = m.conversationId,
                         name = "Conversation missing...",
                         lastMessage = m.content,
-                        latestMessageTimestamp = m.userDate,
+                        latestMessageTimestamp = Instant.fromEpochMilliseconds(file.sqlUserDateMs()),
                         admins = (if (m.originalAuthor == null) emptySet() else setOf(m.originalAuthor)),
                         unreadCount = 0,
                         avatarTiny = null,
@@ -340,7 +344,7 @@ class ConversationStream(
                 placeholderIds += m.conversationId
                 // endregion
             } else {
-                updateConversationFromNewMessage(matchingConversation, m)
+                updateConversationFromNewMessage(matchingConversation, m, file.sqlUserDateMs())
             }
         }
 
@@ -349,11 +353,20 @@ class ConversationStream(
         _conversations.value = _conversations.value.copy(dataReady = true, items = sortedList)
     }
 
+    /**
+     * @param sqlUserDateMs Authoritative `DriveMainIndex.userDate` of the
+     *   incoming message file (epoch ms). Used as the source of truth for the
+     *   conversation's `latestMessageTimestamp` so it stays in lock-step with
+     *   `selectAllUnreadCount`. The clamped `m.userDate` is correct for
+     *   display but can underrun the SQL value.
+     */
     private suspend fun updateConversationFromNewMessage(
         c: ConversationUiModel,
-        m: MessageUiModel
+        m: MessageUiModel,
+        sqlUserDateMs: Long,
     ) {
-        if (m.userDate >= c.latestMessageTimestamp) {
+        val sqlUserDate = Instant.fromEpochMilliseconds(sqlUserDateMs)
+        if (sqlUserDate >= c.latestMessageTimestamp) {
             val domain = credentialsManager.getActiveDomain()
 
             val increment =
@@ -364,7 +377,7 @@ class ConversationStream(
 
             val updatedConversation = c.copy(
                 unreadCount = c.unreadCount + increment,
-                latestMessageTimestamp = m.userDate,
+                latestMessageTimestamp = sqlUserDate,
                 lastMessage = m.content.truncateToCodePoints(40), // TODO: Global constant
                 lastMessageDeliveryStatus = m.messageAppData.deliveryStatus,
                 lastMessageIsDeleted = m.isDeleted,
@@ -438,6 +451,16 @@ class ConversationStream(
         // file-of-record lastReadTime into ChatReadCount and patches unread
         // counts in one round-trip — fire-and-forget so the in-memory list
         // update above stays on the hot path.
+        //
+        // Skip while the cold-load pipeline hasn't run its own enrich yet.
+        // During initial sync, every conversation file streams in via this
+        // path and would trigger N redundant enrich passes (each 2-10s on a
+        // power user's box, visibly reshuffling the list every emit). The
+        // end-of-start() enrich (`enrichAllConversationsWithUnreadCounts`
+        // after `enrichWithLastMessages` / `enrichWithAdmins`) flips
+        // `hasUnreadCounts` once cold-load is done; only after that should
+        // per-batch arrivals trigger their own mirror.
+        if (!_conversations.value.enrichment.hasUnreadCounts) return
         scope.launch {
             try {
                 enrichAllConversationsWithUnreadCounts()
@@ -655,17 +678,22 @@ class ConversationStream(
         val rows = dbm.chatReadCount.selectAllConversationPlusLastMessage(c.getIdentityId())
         val afterQuery = Clock.System.now().toEpochMilliseconds()
 
-        val msgByConversation = HashMap<Uuid, id.homebase.api.client.drives.HomebaseFile>(rows.size)
+        // Carry the SQL `msgUserDate` (DriveMainIndex.userDate) alongside the
+        // file. The conversation list's `latestMessageTimestamp` must use this
+        // SQL value, not the clamped `MessageUiModel.userDate`, so it stays in
+        // lock-step with what `selectAllUnreadCount` filters on. See
+        // `HomebaseFile.sqlUserDateMs()` for the formula.
+        val msgByConversation = HashMap<Uuid, Pair<id.homebase.api.client.drives.HomebaseFile, Long?>>(rows.size)
         for (row in rows) {
             val convoId = row.conversation.fileMetadata.appData.uniqueId ?: continue
             val msg = row.message ?: continue
-            msgByConversation[convoId] = msg
+            msgByConversation[convoId] = msg to row.msgUserDateMs
         }
 
         val current = _conversations.value
         val updated = current.items.map { ui ->
-            val msgFile = msgByConversation[ui.id] ?: return@map ui
-            mapper.applyLastMessage(ui, msgFile, domain)
+            val pair = msgByConversation[ui.id] ?: return@map ui
+            mapper.applyLastMessage(ui, pair.first, domain, sqlUserDateMs = pair.second)
         }
 
         _conversations.value = current.copy(

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/data/ConversationUiModelUpdateWithLatestMessageTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/data/ConversationUiModelUpdateWithLatestMessageTest.kt
@@ -1,0 +1,123 @@
+package id.homebase.chat.data
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.time.UnixTimeUtc
+import id.homebase.chat.data.ConversationUiModel.Companion.updateWithLatestMessage
+import id.homebase.chat.services.MessageAppData
+import id.homebase.core.avatars.ConversationAvatarModel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * Locks down the SQL-userDate override path on `updateWithLatestMessage`.
+ *
+ * The bug this guards: `ChatMessageStream.mapToMessageData` clamps the
+ * in-memory `MessageUiModel.userDate` to `min(appData.userDate, transitCreated)`.
+ * When a peer's `appData.userDate` runs ahead of `transitCreated`, the
+ * conversation's `latestMessageTimestamp` would freeze at the smaller
+ * value while `selectAllUnreadCount` (filtering on the un-clamped SQL
+ * column) keeps counting the row. Read-bookkeeping then can never reach
+ * the SQL value and the badge gets stuck.
+ *
+ * The override parameter takes the SQL-faithful userDate from
+ * `selectAllConversationPlusLastMessage.msgUserDate` (or
+ * `HomebaseFile.sqlUserDateMs()` for fresh files), bypassing the clamp.
+ */
+class ConversationUiModelUpdateWithLatestMessageTest {
+
+    private val me = OdinId("owner.test")
+    private val alice = OdinId("alice.test")
+
+    private fun convo(latestMs: Long) = ConversationUiModel(
+        id = Uuid.random(),
+        name = "alice",
+        lastMessage = " ",
+        latestMessageTimestamp = Instant.fromEpochMilliseconds(latestMs),
+        unreadCount = 0,
+        avatarInitials = "",
+        avatarUrl = "",
+        avatarTiny = null,
+        participants = listOf(me, alice),
+        lastRead = Instant.fromEpochMilliseconds(0),
+        avatarModel = ConversationAvatarModel(
+            type = ConversationAvatarModel.Type.Connection,
+            odinId = alice,
+        ),
+        admins = emptySet(),
+        conversationState = ConversationState.Active,
+        isGroup = false,
+    )
+
+    /** Mimics what `mapToMessageData` returns for a peer message: userDate clamped to transitCreated. */
+    private fun peerMessage(clampedUserDateMs: Long) = MessageUiModel(
+        id = Uuid.random(),
+        globalTransitId = null,
+        fileId = Uuid.random(),
+        conversationId = Uuid.random(),
+        content = "hi",
+        userDate = Instant.fromEpochMilliseconds(clampedUserDateMs),
+        modified = null,
+        created = Instant.fromEpochMilliseconds(clampedUserDateMs),
+        originalAuthor = alice,
+        sender = alice,
+        displayName = "alice",
+        localReadTimestamp = null as UnixTimeUtc?,
+        isDeleted = false,
+        isPendingSend = false,
+        versionTag = Uuid.NIL,
+        messageAppData = MessageAppData(),
+        reactionPreview = null,
+        previewThumbnail = null,
+        payloads = null,
+        keyHeader = KeyHeader.empty(),
+        hasMore = false,
+    )
+
+    @Test
+    fun override_takesPrecedence_whenSqlUserDateExceedsClampedValue() {
+        val convo = convo(latestMs = 1_000_000_000_000L)
+        val msg = peerMessage(clampedUserDateMs = 1_776_843_935_755L)
+        val sqlUserDateMs = 1_776_843_937_255L // 2 seconds ahead of clamped
+
+        val result = convo.updateWithLatestMessage(
+            msg = msg,
+            activeUserDomain = me,
+            latestTimestampOverrideMs = sqlUserDateMs,
+        )
+
+        assertEquals(sqlUserDateMs, result.latestMessageTimestamp.toEpochMilliseconds())
+    }
+
+    @Test
+    fun override_null_fallsBackTo_clampedMessageUserDate() {
+        val convo = convo(latestMs = 0L)
+        val msg = peerMessage(clampedUserDateMs = 1_776_843_935_755L)
+
+        val result = convo.updateWithLatestMessage(
+            msg = msg,
+            activeUserDomain = me,
+            latestTimestampOverrideMs = null,
+        )
+
+        assertEquals(1_776_843_935_755L, result.latestMessageTimestamp.toEpochMilliseconds())
+    }
+
+    @Test
+    fun override_doesNotRegress_whenAlreadyAhead() {
+        val ahead = 2_000_000_000_000L
+        val convo = convo(latestMs = ahead)
+        val msg = peerMessage(clampedUserDateMs = 1_000L)
+
+        val result = convo.updateWithLatestMessage(
+            msg = msg,
+            activeUserDomain = me,
+            latestTimestampOverrideMs = 1_000L, // both candidate paths < latest
+        )
+
+        // Equality not required; the contract is "no regression".
+        assertEquals(ahead, result.latestMessageTimestamp.toEpochMilliseconds())
+    }
+}


### PR DESCRIPTION
Some peer messages would persistently show as unread even after the conversation was opened multiple times. Concrete trace from a live account: Monica's conversation showed unreadCount=1 forever; every MarkAsRead skipped with "newReadTime <= priorLastRead".

Root cause: two userDates for the same row diverged.

  source                                                          value
  --------------------------------------------------------------  -----------------
  SQL DriveMainIndex.userDate (= appData.userDate, no clamp)      1776843937255
  In-memory MessageUiModel.userDate (clamped in mapToMessageData) 1776843935755

ChatMessageStream.mapToMessageData applies a display-side clamp:

    val userDate = minOf(rawUserDate, authorSpecificDate)

That's correct for not rendering "in the future" timestamps. But every read-bookkeeping code path (ChatMessageActionService.markAsReadByFiles, markAllAsRead, ConversationUiModel.latestMessageTimestamp) sourced from the clamped value, while selectAllUnreadCount filters on the un-clamped SQL column. So lastReadTime got pinned at the smaller value, drive-synced to the conversation file's localAppData.lastReadTime, and stuck for good.

Fix: route the SQL-faithful userDate through to latestMessageTimestamp and the mark-as-read floor.

  - HomebaseFile.sqlUserDateMs() — single-source-of-truth helper that mirrors MainIndexMetaHelpers' projection formula (appData.userDate ?: created.milliseconds). Used by callers that need the SQL value without going through the in-memory mapper.

  - ChatReadCountWrapper.ConversationWithLastMessage.msgUserDateMs — carries the existing SQL msgUserDate projection through the wrapper (it was previously dropped on the floor).

  - ConversationUiModel.updateWithLatestMessage takes a latestTimestampOverrideMs parameter; when supplied, drives latestMessageTimestamp directly instead of msg.userDate. Falls back to msg.userDate so untouched callers keep working.

  - ConversationMapper.applyLastMessage and mapToConversationUi plumb sqlUserDateMs through.

  - ConversationStream.enrichWithLastMessages captures row.msgUserDateMs and passes it on. processMessageBatchIncrementally keeps the HomebaseFile paired with the mapped message and uses file.sqlUserDateMs() for the orphan-placeholder branch and updateConversationFromNewMessage. Same value either way — both formulas match MainIndexMeta.

  - ChatMessageActionService.markAsReadByFiles uses convo.latestMessageTimestamp as a floor when it exceeds the per-record viewedRecords.maxOf { userDate }. Closes the case where the visible-items effect passes only the clamped self-anchor: the conversation-level timestamp is now SQL-faithful and rescues the advance.

  - ConversationStream.processConversationBatchIncrementally gates the background enrichAllConversationsWithUnreadCounts on enrichment.hasUnreadCounts. During cold-load, every conversation file streamed in via this path and triggered up to a dozen redundant 2-10s enrich passes; the end-of-start() enrich already runs once when cold-load completes. Post-cold-load behaviour is unchanged — peer-device lastReadTime advances still mirror.

Display clamp inside mapToMessageData stays untouched.

Verification (live account):

  (MarkAsRead) newReadTime(ms)=1776843937255
       (viewedMax=1776843935755 convoLatest=1776843937255 ...)
  (MarkAsRead) ConversationService.updateLocalLastReadTime:
       currentMs=1776843935755 newMs=1776843937255 willAdvance=true
  ConversationStream: unreadSync convo=996e97ba-... 1->0

Same pattern rescues many other conversations in the log (viewedMax lagging convoLatest by seconds to days). Subsequent re-opens no-op cleanly at the gate.

Tests: new ConversationUiModelUpdateWithLatestMessageTest (3 cases) locks down the override-takes-precedence / null-falls-back / no-regression contract. Existing homebase-chat:jvmTest and homebase-api:jvmTest pass.