### PR TITLE
Drop "Mismatching version tag" + missing-local-file from outbox

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveOutboxUploader.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveOutboxUploader.kt
@@ -2,6 +2,7 @@ package id.homebase.api.client.drives.files
 
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.ClientException
+import id.homebase.api.client.NotFoundException
 import id.homebase.api.client.OdinClientErrorCode
 import id.homebase.api.client.drives.upload.DriveUploadProvider
 import id.homebase.api.client.drives.upload.FileUpdateInstructionSet
@@ -59,24 +60,27 @@ class DriveOutboxUploader(
                     )
                     return
                 }
-                when (e.errorCode) {
-                    OdinClientErrorCode.VersionTagMismatch -> {
-                        Logger.w(
-                            "Discarding outbox item ${outboxRecord.uniqueId} " +
-                                    "uploadType=${outboxRecord.uploadType} — VersionTagMismatch: ${e.message}"
-                        )
-                        return
-                    }
-
-                    else -> {
-                        Logger.e(
-                            "$TAG upload: 400 for outbox item ${outboxRecord.uniqueId} " +
-                                    "uploadType=${outboxRecord.uploadType} errorCode=${e.errorCode} " +
-                                    "— will retry (server message: ${e.message})"
-                        )
-                        throw e
-                    }
+                // Title-match in addition to the structured errorCode because the server
+                // sometimes collapses VersionTagMismatch into errorCode=UnhandledScenario
+                // while preserving the title text "Mismatching version tag …". Without
+                // this fallback the outbox burns 20 attempts (~48h) on a stale tag.
+                val isVersionTagMismatch =
+                    e.errorCode == OdinClientErrorCode.VersionTagMismatch ||
+                            e.message?.contains("Mismatching version tag", ignoreCase = true) == true
+                if (isVersionTagMismatch) {
+                    Logger.w(
+                        "$TAG upload: dropping outbox item ${outboxRecord.uniqueId} " +
+                                "uploadType=${outboxRecord.uploadType} driveId=${outboxRecord.driveId} " +
+                                "— VersionTagMismatch (errorCode=${e.errorCode}): ${e.message}"
+                    )
+                    return
                 }
+                Logger.e(
+                    "$TAG upload: 400 for outbox item ${outboxRecord.uniqueId} " +
+                            "uploadType=${outboxRecord.uploadType} errorCode=${e.errorCode} " +
+                            "— will retry (server message: ${e.message})"
+                )
+                throw e
             }
             Logger.e(
                 "$TAG upload: failing outbox item ${outboxRecord.uniqueId} " +
@@ -251,9 +255,22 @@ class DriveOutboxUploader(
 
     private suspend fun updateLocalMetadataTags(outboxRecord: Outbox) {
         val request = OdinSystemSerializer.deserialize<UpdateLocalMetadataTagsOutboxRequest>(outboxRecord.json.decodeToString())
+        Logger.d(tag = "MarkAsRead") {
+            "DriveOutboxUploader.updateLocalMetadataTags: outboxRow=${outboxRecord.uniqueId} drive=${request.file.targetDrive.alias} fileId=${request.file.fileId} hasRequestVersionTag=${request.versionTag != null}"
+        }
+        // Falling back to versionTag=null when both the request and the local header
+        // are missing causes the server to reject with VersionTagMismatch and the
+        // outbox to retry for ~48h. Treat the missing local file as a permanent
+        // failure (NotFoundException is dropped by OutboxSync.isPermanentFailure).
         val versionTag = request.versionTag
             ?: fileProvider.getFileHeader(request.file.targetDrive.alias, Uuid.parse(request.file.fileId))
                 ?.fileMetadata?.localAppData?.versionTag?.toString()
+            ?: run {
+                Logger.w(tag = "MarkAsRead") {
+                    "DriveOutboxUploader.updateLocalMetadataTags: dropping outboxRow=${outboxRecord.uniqueId} drive=${request.file.targetDrive.alias} fileId=${request.file.fileId} — no version tag in request and local file gone"
+                }
+                throw NotFoundException()
+            }
         driveUploadProvider.uploadLocalMetadataTags(
             file = request.file,
             localAppData = LocalAppData(versionTag = versionTag, tags = request.tags)
@@ -266,7 +283,12 @@ class DriveOutboxUploader(
             "DriveOutboxUploader.updateLocalMetadataContent: outboxRow=${outboxRecord.uniqueId} drive=${request.driveId} fileId=${request.fileId} hasIv=${request.iv != null}"
         }
         val file = fileProvider.getFileHeader(request.driveId, request.fileId)
-            ?: error("File not found for local metadata content update: ${request.fileId}")
+            ?: run {
+                Logger.w(tag = "MarkAsRead") {
+                    "DriveOutboxUploader.updateLocalMetadataContent: dropping outboxRow=${outboxRecord.uniqueId} drive=${request.driveId} fileId=${request.fileId} — local file no longer present"
+                }
+                throw NotFoundException()
+            }
         val versionTag = request.versionTag
             ?: file.fileMetadata.localAppData?.versionTag?.toString()
         try {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
@@ -80,17 +80,19 @@ class OutboxSync(
             when (e.errorCode) {
                 OdinClientErrorCode.FileNotFound,
                 OdinClientErrorCode.MissingVersionTag,
+                OdinClientErrorCode.VersionTagMismatch,
                 OdinClientErrorCode.CannotOverwriteNonExistentFile,
                 OdinClientErrorCode.UnknownId -> return true
                 else -> Unit
             }
             // The server sometimes returns 400 with the structured errorCode
             // collapsed to UnhandledScenario but the message text intact.
-            // Catch the two recurring local-only-placeholder failures we've
-            // seen so they don't loop in the outbox.
+            // Catch the recurring local-only-placeholder failures we've seen
+            // so they don't loop in the outbox. The version-tag check matches
+            // both "Missing version tag" and "Mismatching version tag".
             val msg = e.message ?: return false
             if (msg.contains("Could not find file", ignoreCase = true)) return true
-            if (msg.contains("Missing version tag", ignoreCase = true)) return true
+            if (msg.contains(Regex("Mis(sing|matching) version tag", RegexOption.IGNORE_CASE))) return true
         }
         return false
     }

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSyncTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSyncTest.kt
@@ -22,9 +22,14 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 import kotlin.uuid.Uuid
+import id.homebase.api.client.ClientException
+import id.homebase.api.client.NotFoundException
+import id.homebase.api.client.OdinClientErrorCode
+import id.homebase.api.client.ProblemDetails
 
 class TestUploader : OutboxUploader {
     var shouldFail = false
+    var failureException: Throwable? = null
     val uploaded = mutableListOf<Outbox>()
 
     // For concurrency testing
@@ -43,6 +48,11 @@ class TestUploader : OutboxUploader {
             )
         )
 
+        failureException?.let {
+            currentActive.decrementAndGet()
+            throw it
+        }
+
         if (shouldFail) {
             currentActive.decrementAndGet()
             throw Exception("Test failure")
@@ -55,6 +65,18 @@ class TestUploader : OutboxUploader {
         currentActive.decrementAndGet()
     }
 }
+
+private fun clientException(
+    status: Int = 400,
+    errorCode: OdinClientErrorCode = OdinClientErrorCode.UnhandledScenario,
+    message: String,
+): ClientException = ClientException(
+    status = status,
+    errorCode = errorCode,
+    message = message,
+    correlationId = null,
+    problem = ProblemDetails(status = status, title = message),
+)
 
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -469,6 +491,160 @@ class OutboxSyncTest {
             val row = db.outbox.checkout()
             assertNotNull(row)
             assertEquals("fresh", row.json.decodeToString(), "new payload must win over the stale one")
+        }
+        db.close()
+    }
+
+    /**
+     * Regression: a `NotFoundException` from the uploader (e.g. local file no longer
+     * present when DriveOutboxUploader.updateLocalMetadataContent goes to look it up)
+     * is a permanent failure — must drop on the first attempt instead of burning
+     * 20 retries (~48h).
+     */
+    @Test
+    fun testPermanentFailure_NotFoundExceptionDroppedOnFirstAttempt() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+
+        runTest {
+            val eventBus = EventBus()
+            val uploader = TestUploader()
+            uploader.failureException = NotFoundException()
+
+            val sync = OutboxSync(
+                databaseManager = db, uploader = uploader, eventBus = eventBus, scope = backgroundScope
+            )
+            sync.setOnline(true)
+
+            val droppedDeferred = async {
+                eventBus.events.filterIsInstance<BackendEvent.OutboxEvent.OutboxItemDropped>().first()
+            }
+            testScheduler.runCurrent()
+
+            val driveId = Uuid.random()
+            val uniqueId = Uuid.random()
+            db.outbox.insert(
+                driveId = driveId,
+                uniqueId = uniqueId,
+                dependencyUniqueId = null,
+                priority = 0,
+                uploadType = 0,
+                json = byteArrayOf(),
+                filePaths = null,
+            )
+
+            try { sync.send() } catch (_: Exception) {}
+            advanceUntilIdle()
+
+            val dropped = droppedDeferred.await()
+
+            assertEquals(0L, db.outbox.count(), "row must be dropped on first attempt")
+            assertEquals(uniqueId, dropped.uniqueId)
+            assertEquals(driveId, dropped.driveId)
+            assertEquals(1, dropped.attempts, "drop must happen on attempt 1, not after MAX_RETRIES")
+        }
+        db.close()
+    }
+
+    /**
+     * Regression: a `ClientException` carrying `errorCode = VersionTagMismatch`
+     * (the structured server response) is permanent — drop on first attempt.
+     * This locks in the existing enum-based branch in `isPermanentFailure`.
+     */
+    @Test
+    fun testPermanentFailure_VersionTagMismatchByCodeDroppedOnFirstAttempt() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+
+        runTest {
+            val eventBus = EventBus()
+            val uploader = TestUploader()
+            uploader.failureException = clientException(
+                errorCode = OdinClientErrorCode.VersionTagMismatch,
+                message = "Mismatching version tag 7373d519-d042-d100-4aad-a8e5d48dd851",
+            )
+
+            val sync = OutboxSync(
+                databaseManager = db, uploader = uploader, eventBus = eventBus, scope = backgroundScope
+            )
+            sync.setOnline(true)
+
+            val droppedDeferred = async {
+                eventBus.events.filterIsInstance<BackendEvent.OutboxEvent.OutboxItemDropped>().first()
+            }
+            testScheduler.runCurrent()
+
+            val driveId = Uuid.random()
+            val uniqueId = Uuid.random()
+            db.outbox.insert(
+                driveId = driveId,
+                uniqueId = uniqueId,
+                dependencyUniqueId = null,
+                priority = 0,
+                uploadType = 0,
+                json = byteArrayOf(),
+                filePaths = null,
+            )
+
+            try { sync.send() } catch (_: Exception) {}
+            advanceUntilIdle()
+
+            val dropped = droppedDeferred.await()
+
+            assertEquals(0L, db.outbox.count())
+            assertEquals(uniqueId, dropped.uniqueId)
+            assertEquals(1, dropped.attempts)
+        }
+        db.close()
+    }
+
+    /**
+     * Regression for the actual user-reported scenario (homebase.log 2026-05-04):
+     * the server collapsed `errorCode` to `UnhandledScenario` while preserving the
+     * title `Mismatching version tag …`. Without a title-match fallback this loops
+     * for 20 retries / ~48h. The fallback in `isPermanentFailure` (and the
+     * symmetrical fallback in `DriveOutboxUploader.upload`) must drop on attempt 1.
+     */
+    @Test
+    fun testPermanentFailure_MismatchingVersionTagByTitleDroppedOnFirstAttempt() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+
+        runTest {
+            val eventBus = EventBus()
+            val uploader = TestUploader()
+            uploader.failureException = clientException(
+                errorCode = OdinClientErrorCode.UnhandledScenario,
+                message = "Mismatching version tag 7373d519-d042-d100-4aad-a8e5d48dd851",
+            )
+
+            val sync = OutboxSync(
+                databaseManager = db, uploader = uploader, eventBus = eventBus, scope = backgroundScope
+            )
+            sync.setOnline(true)
+
+            val droppedDeferred = async {
+                eventBus.events.filterIsInstance<BackendEvent.OutboxEvent.OutboxItemDropped>().first()
+            }
+            testScheduler.runCurrent()
+
+            val driveId = Uuid.random()
+            val uniqueId = Uuid.random()
+            db.outbox.insert(
+                driveId = driveId,
+                uniqueId = uniqueId,
+                dependencyUniqueId = null,
+                priority = 0,
+                uploadType = 0,
+                json = byteArrayOf(),
+                filePaths = null,
+            )
+
+            try { sync.send() } catch (_: Exception) {}
+            advanceUntilIdle()
+
+            val dropped = droppedDeferred.await()
+
+            assertEquals(0L, db.outbox.count())
+            assertEquals(uniqueId, dropped.uniqueId)
+            assertEquals(1, dropped.attempts)
         }
         db.close()
     }


### PR DESCRIPTION
Two failure modes were retrying every 30s for ~48h despite never being fixable:

1. Server "Mismatching version tag" on UpdateLocalMetadataTags: the structured errorCode VersionTagMismatch is sometimes collapsed to UnhandledScenario, with the title text intact. The existing DriveOutboxUploader branch only matched on errorCode, and the OutboxSync title fallback matched "Missing version tag" not "Mismatching version tag" (Mis vs Miss).

2. Local "File not found for local metadata content update" thrown via error(...) as IllegalStateException -- wasn't caught by the NotFoundException branch in OutboxSync.isPermanentFailure.

Changes:
- OutboxSync.isPermanentFailure: add OdinClientErrorCode.VersionTagMismatch to the enum check; widen the title regex to Mis(sing|matching) so both "Missing" and "Mismatching" match.
- DriveOutboxUploader.upload: title-match "Mismatching version tag" next to the existing VersionTagMismatch enum branch; collapse the when into one boolean; structured warn-level drop log with uniqueId/uploadType/ driveId/errorCode/message.
- DriveOutboxUploader.updateLocalMetadataTags: log entry-tag debug line; if both request.versionTag and the local header are missing, throw NotFoundException with a warn log instead of silently sending versionTag=null (which is what triggered the server-side mismatch in the first place).
- DriveOutboxUploader.updateLocalMetadataContent: replace error(...) with a warn log + throw NotFoundException so OutboxSync drops on the first attempt.
- OutboxSyncTest: extend TestUploader with a failureException field; three regression tests covering NotFoundException, VersionTagMismatch by errorCode, and "Mismatching version tag" by title with errorCode=UnhandledScenario (the exact user-log scenario).