### PR TITLE
Wire orphaned-conversation recovery into the basic-load path

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -103,6 +103,18 @@ class ConversationStream(
     private val placeholderIds = mutableSetOf<Uuid>()
     // endregion
 
+    // region Orphan-recovery: read-path dedup of recover attempts
+    // [loadBasicConversations] triggers [onRecoverConversation] for any row
+    // that mapped to [ConversationState.Invalid] (the mapper's catch-all for
+    // unmappable conversation files — e.g. a 1:1 whose other participant is
+    // gone, leaving recipients=[self], which crashes the
+    // `participants.first { it != domain }` deref). Recovery is local-only and
+    // idempotent; the set is session-scoped so a fresh app launch retries.
+    // Within a session the set prevents a recovery → reload → recovery loop
+    // if the placeholder write somehow fails silently.
+    private val recoveryAttemptedIds = mutableSetOf<Uuid>()
+    // endregion
+
     // region Auto-unarchive: incoming message for archived conversation
     /** Called when a message arrives for an archived conversation.
      *  Wired in AppModule to ConversationService.unarchiveConversation(). */
@@ -632,7 +644,7 @@ class ConversationStream(
         val files = dbm.chatReadCount.selectAllConversations(c.getIdentityId())
         val afterQuery = Clock.System.now().toEpochMilliseconds()
 
-        val basic = files
+        val basicWithSource = files
             // Locally-deleted conversations stay on disk (soft-deleted) until the
             // outbox processes the server-side delete; without this filter the
             // mapper would resurrect a "deleted conversation" placeholder for them
@@ -640,10 +652,13 @@ class ConversationStream(
             .filterNot { it.fileMetadata.appData.uniqueId in deletedIds }
             .map { file ->
                 val ui = mapper.mapToBasic(file)
-                if (ui.id in leftIds && ui.conversationState != ConversationState.Left) {
+                val finalUi = if (ui.id in leftIds && ui.conversationState != ConversationState.Left) {
                     ui.copy(conversationState = ConversationState.Left)
                 } else ui
+                finalUi to file
             }
+
+        val basic = basicWithSource.map { it.first }
 
         _conversations.value = ConversationsData(
             dataReady = true,
@@ -655,6 +670,42 @@ class ConversationStream(
             "loadBasicConversations end-to-end=${Clock.System.now().toEpochMilliseconds() - startedAt}ms " +
                     "(query=${afterQuery - startedAt}ms map=${Clock.System.now().toEpochMilliseconds() - afterQuery}ms) " +
                     "items=${basic.size}"
+        }
+
+        // Trigger orphan recovery for any row that landed in the Invalid
+        // placeholder. Fire-and-forget on the existing scope: do NOT block
+        // the basic emit, do NOT await — recoverConversation writes a local
+        // placeholder file and re-syncs the row, which arrives back via the
+        // normal drive-sync → reload path.
+        triggerRecoveryForInvalidRows(basicWithSource)
+    }
+
+    private fun triggerRecoveryForInvalidRows(
+        basicWithSource: List<Pair<ConversationUiModel, id.homebase.api.client.drives.HomebaseFile>>,
+    ) {
+        val recover = onRecoverConversation ?: return
+        val toRecover = mutableListOf<Pair<Uuid, OdinId?>>()
+        for ((ui, file) in basicWithSource) {
+            if (ui.conversationState != ConversationState.Invalid) continue
+            val convoId = file.fileMetadata.appData.uniqueId ?: continue
+            if (!recoveryAttemptedIds.add(convoId)) continue
+            toRecover.add(convoId to file.fileMetadata.originalAuthor)
+        }
+        for ((convoId, originalAuthor) in toRecover) {
+            scope.launch {
+                try {
+                    Logger.w(tag = "OrphanRecovery") {
+                        "loadBasicConversations: triggering recoverConversation for Invalid row " +
+                                "convoId=$convoId originalAuthor=${originalAuthor?.domainName}"
+                    }
+                    recover(convoId, originalAuthor)
+                } catch (t: Throwable) {
+                    Logger.e(throwable = t, tag = "OrphanRecovery") {
+                        "loadBasicConversations: recoverConversation failed for convoId=$convoId — " +
+                                "placeholder will keep showing until next session retry"
+                    }
+                }
+            }
         }
     }
 

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceRecoveryTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceRecoveryTest.kt
@@ -174,6 +174,61 @@ class ConversationServiceRecoveryTest {
         }
     }
 
+    /**
+     * Regression: an orphaned 1:1 with `recipients=[self]` crashes the
+     * mapper at line 151 (`participants.first { it != domain }`). The
+     * recovery path (ConversationService.kt:1583–1597) is explicitly designed
+     * to handle this — it forces the placeholder to the group branch so the
+     * mapper takes the safe path instead of crashing. Without an active caller
+     * invoking `recoverConversation` this row stays broken on every list load,
+     * which is what `ConversationStream.loadBasicConversations` now wires up.
+     *
+     * Pins the local-only recovery contract: after recovery the placeholder
+     * file carries the group tag (so the mapper's group branch fires) and
+     * no outbox work was enqueued.
+     */
+    @Test
+    fun recoverConversation_oneOnOne_existingInvalidSelfOnly_revivesAsGroupPlaceholder() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            // The orphan shape: recipients=[testDomain only]. The conversationId
+            // doesn't matter for the crash — what matters is that the stored
+            // recipients list contains only the current user.
+            val convoId = fixture.seedOrphanedOneOnOneSelfOnly()
+            val rowsBefore = fixture.outboxRowCount()
+
+            service.recoverConversation(
+                conversationId = convoId,
+                originalAuthor = OdinId(fixture.testDomain),
+            )
+
+            assertEquals(
+                rowsBefore,
+                fixture.outboxRowCount(),
+                "recovery is local-only ⇒ no outbox enqueue",
+            )
+
+            val file = fixture.getConversationFile(convoId)
+            assertNotNull(file, "post-recovery placeholder file must exist")
+            assertNull(file.fileMetadata.versionTag, "placeholder marker (versionTag=null)")
+
+            // The placeholder MUST carry the group tag so the mapper takes the
+            // group branch — the whole point of the forced-group recovery is to
+            // avoid the `participants.first { it != domain }` deref.
+            val tags = file.fileMetadata.appData.tags ?: emptyList()
+            assertTrue(
+                tags.contains(ChatProtocol.ConversationGroupTag),
+                "self-only 1:1 must be revived with the group tag so the mapper " +
+                        "takes the safe (group) branch; got tags=$tags",
+            )
+
+            assertTrue(
+                fixture.conversationLoader.loaded.contains(convoId),
+                "recoverConversation should refresh the in-memory model via loadConversation",
+            )
+        }
+    }
+
     @Test
     fun recoverConversation_group_noFile_writesLocalPlaceholder() = runTest {
         ConversationServiceTestFixture().use { fixture ->

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceTestFixture.kt
@@ -171,6 +171,27 @@ class ConversationServiceTestFixture : AutoCloseable {
         return conversationId
     }
 
+    /**
+     * Seed an orphaned 1:1 conversation file: recipients contains ONLY the
+     * test domain (the other party is gone — e.g. participant removed,
+     * corrupt/migrated content). Reproduces the
+     * `participants.first { it != domain }` crash in `ConversationMapper.mapToBasic`
+     * line 151 that motivated the read-path orphan-recovery wiring.
+     */
+    suspend fun seedOrphanedOneOnOneSelfOnly(
+        conversationId: Uuid = Uuid.random(),
+    ): Uuid {
+        insertConversationFile(
+            fileId = Uuid.random(),
+            uniqueId = conversationId,
+            participants = listOf(testDomain),
+            originalAuthor = testDomain,
+            isGroup = false,
+            title = "",
+        )
+        return conversationId
+    }
+
     /** A legacy (pre-tag) group — >2 participants but no ConversationGroupTag. */
     suspend fun seedLegacyGroup(
         others: List<String>,


### PR DESCRIPTION
ConversationService.recoverConversation has long had explicit support for ConversationState.Invalid -- the placeholder the mapper produces when mapToBasic throws (e.g. a 1:1 whose recipients deserialise to [self] only, which crashes participants.first { it != domain } at line 151). Its design comment even names the exact crash site. But the ConversationStream.onRecoverConversation hook had no live caller, so a broken row sat in local DB and surfaced as "Failure loading conversation" on every list reload.

The previous wiring lived inside drive-sync handlers and was removed because enqueuing server writes from inside a sync batch caused spurious conflicts ("File already exists with ClientUniqueId", "Cannot transfer to yourself"). recoverConversation is now strictly local-only -- no outbox, no transit -- so triggering it from the read path is safe.

Wire it from ConversationStream.loadBasicConversations: after the basic emit, fire-and-forget recoverConversation for every row that mapped to Invalid. Recovery writes a local placeholder file, the next sync->reload maps it cleanly through the safer group branch.

Changes:
- ConversationStream: keep file<->ui pairing in loadBasicConversations so the source HomebaseFile stays available, then iterate Invalid rows and call onRecoverConversation(convoId, originalAuthor) on the existing scope. Add a session-scoped recoveryAttemptedIds set to prevent recovery -> reload -> recovery loops within a session; app-restart retries are fine since recovery is idempotent.
- New OrphanRecovery log tag (warn/error) so a future grep distinguishes read-path orphans from the write-path placeholder logic that already uses "ConversationStream: orphaned conversation ...".
- ConversationServiceTestFixture: new seedOrphanedOneOnOneSelfOnly() helper that produces the exact failing shape (recipients=[testDomain], no group tag).
- ConversationServiceRecoveryTest: regression recoverConversation_oneOnOne_existingInvalidSelfOnly_revivesAsGroupPlaceholder pinning that the post-recovery placeholder carries the group tag (so the mapper takes the safe branch) and that no outbox row was enqueued.

All 180 homebase-chat:jvmTest tests pass, including 13 in ConversationServiceRecoveryTest (12 existing + 1 new).