### PR TITLE
Stop notification-tap navigation waiting on the message DB read

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
@@ -163,12 +163,21 @@ class DriveSync(
                         val latestModified = searchResults.last().fileMetadata.updated
 
                         pendingDbJob = scope.async {
-                            fileHeaderProcessor.baseUpsertEntryZapZap(
-                                identityId = identityId,
-                                driveId = driveId,
-                                fileHeaders = searchResults,
-                                cursor = batchCursorToSave
-                            )
+                            val (_, upsertElapsed) = measureTimedValue {
+                                fileHeaderProcessor.baseUpsertEntryZapZap(
+                                    identityId = identityId,
+                                    driveId = driveId,
+                                    fileHeaders = searchResults,
+                                    cursor = batchCursorToSave
+                                )
+                            }
+                            // Wall-clock for the batch upsert (queue wait +
+                            // SQLite transaction). Lets us tell whether sync's
+                            // 100+-row catch-up batches are starving concurrent
+                            // UI reads on the shared DB dispatcher.
+                            Logger.i {
+                                "DriveSync: batch upsert drive=$driveId rows=${searchResults.size} took=$upsertElapsed"
+                            }
 
                             eventBus.emit(
                                 BackendEvent.DriveEvent.BatchReceived(

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
@@ -5,7 +5,6 @@ import app.cash.sqldelight.db.SqlCursor
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlPreparedStatement
 import co.touchlab.kermit.Logger
-import kotlin.time.TimeSource
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -168,40 +167,17 @@ class DatabaseManager(
     }
 
     suspend fun withWriteTransaction(block: (OdinDatabase) -> Unit) {
-        val queueStart = TimeSource.Monotonic.markNow()
         withContext(dispatcher) {
-            val wait = queueStart.elapsedNow()
-            val execStart = TimeSource.Monotonic.markNow()
             database.transaction { block(database) }
-            Logger.i(tag = "DbWrite") {
-                "withWriteTransaction wait=$wait exec=${execStart.elapsedNow()}"
-            }
         }
     }
 
     suspend fun withWrite(block: (OdinDatabase) -> Unit) {
-        val queueStart = TimeSource.Monotonic.markNow()
-        withContext(dispatcher) {
-            val wait = queueStart.elapsedNow()
-            val execStart = TimeSource.Monotonic.markNow()
-            block(database)
-            Logger.i(tag = "DbWrite") {
-                "withWrite wait=$wait exec=${execStart.elapsedNow()}"
-            }
-        }
+        withContext(dispatcher) { block(database) }
     }
 
-    suspend fun <R> withWriteValue(block: (OdinDatabase) -> R): R {
-        val queueStart = TimeSource.Monotonic.markNow()
-        return withContext(dispatcher) {
-            val wait = queueStart.elapsedNow()
-            val execStart = TimeSource.Monotonic.markNow()
-            val result = block(database)
-            Logger.i(tag = "DbWrite") {
-                "withWriteValue wait=$wait exec=${execStart.elapsedNow()}"
-            }
-            result
-        }
+    suspend fun <R> withWriteValue(block: (OdinDatabase) -> R): R = withContext(dispatcher) {
+        block(database)
     }
 
     // Nuke every table and rebuild the schema from scratch. Used on logout (via

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
@@ -5,6 +5,7 @@ import app.cash.sqldelight.db.SqlCursor
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlPreparedStatement
 import co.touchlab.kermit.Logger
+import kotlin.time.TimeSource
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -167,17 +168,40 @@ class DatabaseManager(
     }
 
     suspend fun withWriteTransaction(block: (OdinDatabase) -> Unit) {
+        val queueStart = TimeSource.Monotonic.markNow()
         withContext(dispatcher) {
+            val wait = queueStart.elapsedNow()
+            val execStart = TimeSource.Monotonic.markNow()
             database.transaction { block(database) }
+            Logger.i(tag = "DbWrite") {
+                "withWriteTransaction wait=$wait exec=${execStart.elapsedNow()}"
+            }
         }
     }
 
     suspend fun withWrite(block: (OdinDatabase) -> Unit) {
-        withContext(dispatcher) { block(database) }
+        val queueStart = TimeSource.Monotonic.markNow()
+        withContext(dispatcher) {
+            val wait = queueStart.elapsedNow()
+            val execStart = TimeSource.Monotonic.markNow()
+            block(database)
+            Logger.i(tag = "DbWrite") {
+                "withWrite wait=$wait exec=${execStart.elapsedNow()}"
+            }
+        }
     }
 
-    suspend fun <R> withWriteValue(block: (OdinDatabase) -> R): R = withContext(dispatcher) {
-        block(database)
+    suspend fun <R> withWriteValue(block: (OdinDatabase) -> R): R {
+        val queueStart = TimeSource.Monotonic.markNow()
+        return withContext(dispatcher) {
+            val wait = queueStart.elapsedNow()
+            val execStart = TimeSource.Monotonic.markNow()
+            val result = block(database)
+            Logger.i(tag = "DbWrite") {
+                "withWriteValue wait=$wait exec=${execStart.elapsedNow()}"
+            }
+            result
+        }
     }
 
     // Nuke every table and rebuild the schema from scratch. Used on logout (via

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -2408,6 +2408,18 @@ class ConversationListViewModel(
             )
         }
 
+        // Flip the selected id NOW, not after messages arrive. The scaffold's
+        // detail-pane navigation in NotificationNavigationEffects keys off this
+        // value via LaunchedEffect(selectedConversationId); waiting for the first
+        // ChatMessagesData.Messages emission held the navigation hostage to a
+        // potentially slow DB read on cold-start / post-reconnect. The detail pane
+        // already shows isLoadingMessages = true above; messages will fill in via
+        // the collect block below.
+        Logger.i(tag = "ConversationListViewModel") {
+            "selectedConversationId set id=$conversationId (pending messages)"
+        }
+        _uiState.update { it.copy(selectedConversationId = conversationId) }
+
         // When loading message for newly selected conversation, cancel any previous job to
         // avoid observing multiple messageStreams
         currentConversationJob?.cancel()
@@ -2516,12 +2528,17 @@ class ConversationListViewModel(
                                 )
                             }
 
-                            Logger.i(tag = "ConversationListViewModel") {
-                                "selectedConversationId flip id=$conversationId messageCount=${messages.size}"
+                            if (setInitialScroll) {
+                                // Crisp proof that the detail pane is no longer
+                                // gated on messages: this is the gap between the
+                                // synchronous selectedConversationId flip and the
+                                // first messages payload landing in the UI. If
+                                // it's long, navigation already completed (tap →
+                                // detailPane render) without waiting for it.
+                                Logger.i(tag = "ConversationListViewModel") {
+                                    "messages first emission id=$conversationId messageCount=${messages.size} sinceSelected=${loadStart.elapsedNow()}"
+                                }
                             }
-                            _uiState.value = _uiState.value.copy(
-                                selectedConversationId = conversationId,
-                            )
 
                             _messagesUiState.update {
                                 it.copy(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/NotificationNavigationEffects.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/NotificationNavigationEffects.kt
@@ -26,6 +26,13 @@ import kotlin.uuid.Uuid
  * scaffold to `Detail(selectedId)`. If the scaffold is already at `Detail` with a stale
  * `contentKey`, pop first so `navigateTo` is not treated as a no-op.
  *
+ * Contract with [ConversationListViewModel.selectConversation]: the VM MUST update
+ * `selectedConversationId` synchronously when a conversation is selected, *before*
+ * any message-stream collect resumes. If that flip is delayed until the first
+ * `ChatMessagesData.Messages` arrives, this effect won't fire and a slow DB read on
+ * cold-start / post-reconnect will hold notification-tap navigation hostage for
+ * seconds. See `loadMessagesForConversation` for the prelude that enforces this.
+ *
  * The two effects race during a programmatic swap: `navigateBack()` transits the
  * scaffold through the "list-only" state that effect 1 watches for. `isSwappingDetailPane`
  * gates effect 1 during that window so it doesn't null out `selectedConversationId`


### PR DESCRIPTION
After a network outage, tapping a chat notification opened the app but the conversation detail pane sat blank for ~3 seconds before rendering — even when the target message was already in the local DB. The conversation-list pattern of "emit basic snapshot, enrich in background" was working as designed; the list itself populated within ~190 ms. The gate was further downstream:

  ConversationListViewModel.loadMessagesForConversation only flipped
  uiState.selectedConversationId inside the first ChatMessagesData.Messages
  collect callback. Until that callback fired, NotificationNavigationEffects
  (which keys off selectedConversationId via LaunchedEffect) never told the
  scaffold to navigate to the detail pane. So a slow DB read on cold-start /
  post-reconnect held navigation hostage to data the screen didn't actually
  need to render its chrome.

Move the flip into the synchronous prelude of loadMessagesForConversation, right after the isLoadingMessages = true update. The detail pane now navigates as soon as the tap is processed; the message-loading state covers the gap until ChatMessagesData.Messages arrives. Document the contract on NotificationNavigationEffects so the dependency is explicit.

Add a "messages first emission … sinceSelected=Xms" log so we can measure post-fix how long the message read actually took once it stops blocking navigation. Also instrument DatabaseManager's three write entry points with wait/exec timings (DbWrite tag) — pure observability, no behavioural change, intended to support a follow-up reader/writer-parallelism investigation on a separate branch.