### PR TITLE
Comment out client-side processInbox pokes

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
@@ -445,13 +445,14 @@ class OdinWebSocketClient(
                 notification.data
             )
 
-        notify(
-            command = "processInbox",
-            payload = ProcessInboxPayload(
-                targetDrive = n.targetDrive,
-                batchSize = 100
-            )
-        )
+        // processInbox no longer needed — server auto-processes on QueryBatch.
+        // notify(
+        //     command = "processInbox",
+        //     payload = ProcessInboxPayload(
+        //         targetDrive = n.targetDrive,
+        //         batchSize = 100
+        //     )
+        // )
     }
 
     private suspend fun handleReactionEvent(
@@ -669,15 +670,16 @@ class OdinWebSocketClient(
      * Call this right after a successful handshake / reconnect.
      */
     suspend fun processAllInboxes() {
-        for (drive in drives) {
-            notify(
-                command = "processInbox",
-                payload = ProcessInboxPayload(
-                    targetDrive = drive,
-                    batchSize = 100
-                )
-            )
-        }
+        // processInbox no longer needed — server auto-processes on QueryBatch.
+        // for (drive in drives) {
+        //     notify(
+        //         command = "processInbox",
+        //         payload = ProcessInboxPayload(
+        //             targetDrive = drive,
+        //             batchSize = 100
+        //         )
+        //     )
+        // }
     }
 
     /**

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -185,12 +185,8 @@ class AuthConnectionCoordinator(
                             // would silently skip if isRunning is still false.
                             driveSyncManager.start()
 
-                            // Flush the server inbox before syncing.  While connected the
-                            // server pushes inboxItemReceived notifications in real-time,
-                            // but those notifications are NOT replayed after a reconnect.
-                            // Without this call, items that arrived while we were offline
-                            // stay in the inbox and QueryBatch returns 0 records.
-                            wsClient?.processAllInboxes()
+                            // processInbox no longer needed — server auto-processes on QueryBatch.
+                            // wsClient?.processAllInboxes()
 
                             driveSyncManager.syncAll()
                         } catch (e: Exception) {

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/BackgroundSyncOrchestrator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/BackgroundSyncOrchestrator.kt
@@ -33,13 +33,8 @@ class BackgroundSyncOrchestrator(
         return runCatching {
             driveSyncManager.start()
 
-            // TODO TODD: Poke the inbox via HTTP here
-            // The server holds incoming transfers in the inbox until a processInbox
-            // command is sent.  Over WebSocket this happens automatically via
-            // inboxItemReceived notifications, but when WS is offline we need an
-            // HTTP equivalent (e.g. POST /api/v2/transit/inbox/process) so that
-            // QueryBatch can find the new records.
-            processInboxViaHttp()
+            // processInbox no longer needed — server auto-processes on QueryBatch.
+            // processInboxViaHttp()
 
             driveSyncManager.syncAll()
         }.fold(
@@ -69,8 +64,8 @@ class BackgroundSyncOrchestrator(
      * counterpart of the WS "processInbox" command.
      */
     private suspend fun processInboxViaHttp() {
-        // no-op until the server exposes an HTTP endpoint for inbox processing
-        driveFileHttpProvider.processInbox(chatTargetDrive.alias)
+        // processInbox no longer needed — server auto-processes on QueryBatch.
+        // driveFileHttpProvider.processInbox(chatTargetDrive.alias)
     }
 
     companion object {


### PR DESCRIPTION
The server now auto-processes the inbox whenever query-batch / get / etc. are called, so the client no longer needs to explicitly poke the inbox before syncing. Comment out (rather than delete) the three callsites so they can be revived quickly if any turn out to still be required:

1. BackgroundSyncOrchestrator.processInboxViaHttp — HTTP poke before syncAll() in the iOS background-fetch path. Redundant: syncAll() issues QueryBatch, which now auto-processes server-side.

2. AuthConnectionCoordinator → OdinWebSocketClient.processAllInboxes — WS processInbox for every subscribed drive after handshake/reconnect. Redundant: driveSyncManager.syncAll() runs immediately after.

3. OdinWebSocketClient.handleProcessInbox — outbound WS processInbox ack in response to an inboxItemReceived notification. The notification is still received and dispatched; only the ack is suppressed. The existing fileAdded/fileModified handlers are expected to drive real-time sync via driveSyncManager.syncDrive(...).

What's kept:
- DriveFileHttpProvider.processInbox HTTP method definition
- inboxItemReceived dispatch routing in OdinWebSocketClient
- handleFileEvent flow for fileAdded/fileModified/fileDeleted
- All driveSyncManager.start/syncAll/syncDrive sync paths
- Outbox send paths
- ProcessInboxPayload / InboxItemReceivedNotification / InboxStatus types

Verify with real-time WS message arrival, reconnect-while-offline, and iOS background-fetch smoke tests. If any fails, uncomment the matching block in order #3 → #2 → #1.