### PR TITLE
Defer drive sync kick when mountDrive() runs before start()

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
@@ -165,6 +165,13 @@ class DriveSyncManager(
             }
         }
         isRunning = true
+        // Note: drives registered via mountDrive() while isRunning was false
+        // (bootstrap pre-mounts, or add-on activations during a paused window)
+        // sit in driveSyncs with their initial sync deferred. The caller is
+        // expected to follow start() with syncAll(), which iterates the full
+        // map and kicks each — same path that handles the mandatory drives
+        // we just added above. Both production callers (AuthConnectionCoordinator
+        // and BackgroundSyncOrchestrator) already do this.
     }
 
     suspend fun syncAll() {
@@ -216,15 +223,25 @@ class DriveSyncManager(
 
     /**
      * Dynamically mounts a drive into the sync engine (e.g. when an add-on is activated
-     * mid-session). Starts an HTTP-polling sync immediately; real-time WebSocket push
-     * notifications will arrive only after the next reconnect.
+     * mid-session, or during cold-boot bootstrap before [start] has flipped
+     * [isRunning] true).
+     *
+     * Splits cleanly into "register" (in-memory bookkeeping — always runs once
+     * credentials exist) and "kick a sync" (network I/O — only runs while the
+     * manager is in the running state). A drive registered while paused/not-yet-
+     * started is picked up by the next [start]'s catch-up loop.
      */
     suspend fun mountDrive(driveId: Uuid, label: String) {
-        if (!isRunning) { Logger.w { "mountDrive() skipped — not running" }; return }
         val alreadyExists = driveSyncsMutex.withLock { driveSyncs.containsKey(driveId) }
         if (alreadyExists) return
 
-        val identityId = credentialsManager.requireActiveCredentials().getIdentityId()
+        // getActiveCredentials() instead of requireActiveCredentials() — a logout
+        // race during add-on activation should be a deferred mount, not a crash.
+        val identityId = credentialsManager.getActiveCredentials()?.getIdentityId() ?: run {
+            Logger.w { "mountDrive($driveId) skipped — no active credentials" }
+            return
+        }
+
         val sync = try {
             DriveSync(identityId, driveId, driveQueryProvider, databaseManager, eventBus, scope)
         } catch (e: CancellationException) {
@@ -236,7 +253,10 @@ class DriveSyncManager(
         }
         driveSyncsMutex.withLock { driveSyncs = driveSyncs + (driveId to sync) }
         _driveStatuses.update { it + (driveId to DriveStatus(driveId, label, DriveState.Initialized)) }
-        sync.sync()
+
+        // Defer the network kick if the manager isn't running yet — start()'s
+        // catch-up loop will pick it up when isRunning flips true.
+        if (isRunning) sync.sync()
     }
 
     /**

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncManagerTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncManagerTest.kt
@@ -376,6 +376,96 @@ class DriveSyncManagerTest {
     }
 
     @Test
+    fun mountDriveBeforeStartRegistersAndIsKickedBySyncAll() {
+        // Bootstrap path: AuthConnectionCoordinator mounts add-on drives from the
+        // registry BEFORE the WS handshake fires DriveSyncManager.start(). The mount
+        // must register the drive in-memory, defer the sync kick, and the subsequent
+        // syncAll() (the canonical "kick everything" call after start()) must include
+        // the pre-registered drive.
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val manager = buildManager(db, buildCredentials(), EventBus(), backgroundScope, emptyMap())
+
+            val driveId = Uuid.random()
+            manager.mountDrive(driveId, "Pre-registered")
+            runCurrent()
+
+            // Registered but no sync kicked yet.
+            assertTrue(manager.driveStatuses.value.containsKey(driveId))
+            assertEquals(DriveState.Initialized, manager.driveStatuses.value[driveId]?.state)
+
+            manager.start()
+            runCurrent()
+            // After start() alone, the pre-registered drive is still Initialized — the
+            // kick is deferred until the caller's syncAll().
+            assertEquals(DriveState.Initialized, manager.driveStatuses.value[driveId]?.state)
+
+            // launch is required because syncAll() suspends on joinAll() against the
+            // (hung) MockEngine and would block the test forever if invoked directly.
+            backgroundScope.launch { manager.syncAll() }
+            runCurrent()
+
+            // performSync emits Started → state transitions to Synchronizing.
+            assertIs<DriveState.Synchronizing>(manager.driveStatuses.value[driveId]?.state)
+        }
+        db.close()
+    }
+
+    @Test
+    fun mountDriveWhilePausedRegistersAndIsKickedByNextSyncAll() {
+        // Mid-session add-on install while the WS is paused (network blip / pre-reconnect):
+        // the activation flow's mountDrive() must register, defer the kick, and let the
+        // next reconnect's start() + syncAll() pick it up.
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val mandatoryDrive = Uuid.random()
+            val manager = buildManager(
+                db, buildCredentials(), EventBus(), backgroundScope,
+                mapOf(mandatoryDrive to "Chat"),
+            )
+            manager.start()
+            runCurrent()
+            manager.pause()
+            runCurrent()
+
+            val addonDrive = Uuid.random()
+            manager.mountDrive(addonDrive, "Mid-session add-on")
+            runCurrent()
+
+            // Registered while paused — no sync kicked yet.
+            assertTrue(manager.driveStatuses.value.containsKey(addonDrive))
+            assertEquals(DriveState.Initialized, manager.driveStatuses.value[addonDrive]?.state)
+
+            manager.start()
+            runCurrent()
+            backgroundScope.launch { manager.syncAll() }
+            runCurrent()
+
+            assertIs<DriveState.Synchronizing>(manager.driveStatuses.value[addonDrive]?.state)
+        }
+        db.close()
+    }
+
+    @Test
+    fun mountDriveWithoutCredentialsLogsAndSkips() {
+        // Logout race during add-on activation: getActiveCredentials() returns null,
+        // mountDrive must warn and bail without registering — no DriveSync object,
+        // no entry in driveStatuses.
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val emptyCredentials = CredentialsManager() // never call setActiveCredentials
+            val manager = buildManager(db, emptyCredentials, EventBus(), backgroundScope, emptyMap())
+
+            val driveId = Uuid.random()
+            manager.mountDrive(driveId, "No-creds drive")
+            runCurrent()
+
+            assertTrue(manager.driveStatuses.value.isEmpty())
+        }
+        db.close()
+    }
+
+    @Test
     fun unmountDriveRemovesDriveAndClearsStatus() {
         val db = DatabaseManager({ createInMemoryDatabase() })
         runTest {


### PR DESCRIPTION
Today DriveSyncManager.mountDrive() bails with a "skipped — not running" warning whenever it is called before DriveSyncManager.start() flips isRunning true, or while the manager is paused. The bail is silent for the caller — the drive never enters driveSyncs, never gets a DriveSync object, and never syncs in this session.

This affects two real paths:

1. Cold-boot bootstrap. AuthConnectionCoordinator.onAuthStateChanged() loops over driveRegistry.bootstrap() calling mountDrive() *before* it calls connect(). start() runs much later, inside connect()'s onConnected callback after the WS handshake — so every add-on drive from the registry hits the guard and is dropped. WebSocket push notifications still route correctly (extraDrives is plumbed straight into OdinWebSocketClient), but the post-reconnect catch-up sync via syncAll() is a no-op for those drives because they're not in the map. Visible symptom: missed updates on add-on drives after a network blip until the next cold boot.

2. Mid-session add-on activation while the WS is paused. Same shape — mountDrive() is dropped, the drive recovers only on next cold boot.

Fix splits mountDrive() into two operations:

  - Register (in-memory bookkeeping: build the DriveSync, add to the map, mark Initialized) — runs whenever credentials exist.
  - Kick a sync (DriveSync.sync() — network I/O) — only when running.

A drive registered while not-yet-started or paused sits as Initialized in driveSyncs. The next syncAll() iterates the full map and kicks it, which is the canonical "kick everything" path that both production callers — AuthConnectionCoordinator.connect.onConnected and BackgroundSyncOrchestrator.syncIfAuthenticated — already invoke right after start(). No changes needed in either caller.

Also swaps requireActiveCredentials() for getActiveCredentials() with a null-safe warn: a logout race during add-on activation should defer the mount, not crash the caller's scope.

Tests: three new cases in DriveSyncManagerTest cover the pre-start register + syncAll() kick, the paused-window register + reconnect syncAll() kick, and the no-credentials skip path. The existing mountDriveAddsNewDrive test (start then mount) still passes — the post-start path is unchanged.