### PR TITLE
Dedupe cold-boot conversation/connection loads

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMapper.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMapper.kt
@@ -118,7 +118,7 @@ class ConversationMapper(
                     val nullCount = rawRecipients.count { it == null }
                     val rawSize = rawRecipients.size
                     val droppedDistinct = rawRecipients.filterNotNull().size - participants.size
-                    Logger.i(tag = "ParticipantsAudit") {
+                    Logger.d(tag = "ParticipantsAudit") {
                         "ConversationMapper.mapToBasic READ for $conversationId: " +
                             "rawRecipients.size=$rawSize nullCount=$nullCount distinctDropped=$droppedDistinct " +
                             "final.size=${participants.size} domains=[${participants.joinToString(",") { it.domainName }}] " +

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -56,19 +56,6 @@ class ConversationStream(
     private var started = false
     private var shareCacheJob: Job? = null
 
-    // Coalesces concurrent enrich requests via an in-flight guard. Triggered
-    // from start()'s cold-boot pipeline AND from the chat-drive DriveStopped
-    // handler in init (the post-sync re-enrich, which always fires AFTER the
-    // sync round's batches have landed in ChatReadCount). Per-batch enrich
-    // after a conversation-file batch (further down) stays outside this guard
-    // — it has its own hasUnreadCounts gate.
-    private var enrichUnreadJob: Job? = null
-
-    private fun launchEnrichUnread() {
-        if (enrichUnreadJob?.isActive == true) return
-        enrichUnreadJob = scope.launch { enrichAllConversationsWithUnreadCounts() }
-    }
-
     /**
      * Conversation ids the user deleted in this app session. The file is still
      * on disk (soft-deleted via archivalStatus=Removed) until the outbox processes
@@ -183,7 +170,17 @@ class ConversationStream(
                             // old BackendEvent.ConnectionOnline trigger so the second
                             // cold-boot enrich (when there is one) now lands AFTER
                             // sync writes (deterministic order), not concurrent with them.
-                            if (event.totalCount > 0) launchEnrichUnread()
+                            if (event.totalCount > 0) {
+                                scope.launch {
+                                    try {
+                                        enrichAllConversationsWithUnreadCounts()
+                                    } catch (e: Exception) {
+                                        Logger.e(e) {
+                                            "ConversationStream: post-Stopped enrich failed: ${e.message}"
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
 
@@ -960,9 +957,7 @@ class ConversationStream(
             // then admins (group-settings only), then unread counts.
             enrichWithLastMessages()
             enrichWithAdmins()
-            // launchEnrichUnread (not direct call) so the WS-online handler
-            // in init can see this enrich is in-flight and skip its own.
-            launchEnrichUnread()
+            enrichAllConversationsWithUnreadCounts()
         }
 
         // Reactively update share cache when conversations or contacts change,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -53,8 +53,21 @@ class ConversationStream(
     private val chatDrive = chatTargetDrive.alias
     private val _conversations = MutableStateFlow(ConversationsData(dataReady = false))
     private val _shareableConversations = MutableStateFlow<List<ShareableConversation>>(emptyList())
-    private var loadJob: Job? = null
+    private var started = false
     private var shareCacheJob: Job? = null
+
+    // Coalesces concurrent enrich requests via an in-flight guard. Triggered
+    // from start()'s cold-boot pipeline AND from the chat-drive DriveStopped
+    // handler in init (the post-sync re-enrich, which always fires AFTER the
+    // sync round's batches have landed in ChatReadCount). Per-batch enrich
+    // after a conversation-file batch (further down) stays outside this guard
+    // — it has its own hasUnreadCounts gate.
+    private var enrichUnreadJob: Job? = null
+
+    private fun launchEnrichUnread() {
+        if (enrichUnreadJob?.isActive == true) return
+        enrichUnreadJob = scope.launch { enrichAllConversationsWithUnreadCounts() }
+    }
 
     /**
      * Conversation ids the user deleted in this app session. The file is still
@@ -129,15 +142,13 @@ class ConversationStream(
     // file notification — arrive as BatchReceived events and are applied incrementally.
     // We intentionally do NOT re-read the full list on DriveEvent.Stopped; the
     // incremental BatchReceived path is sufficient and avoids an expensive full reload
-    // on every incoming message.
+    // on every incoming message. We DO, however, re-enrich unread counts on Stopped —
+    // that's a small ChatReadCount scan and catches reads written by batches that
+    // landed during the sync round (and message-only batches, which the per-batch
+    // enrich path further down doesn't cover).
     init {
         scope.launch {
             eventBus.events.collect { event ->
-
-                if (event is BackendEvent.ConnectionOnline) {
-                    enrichAllConversationsWithUnreadCounts()
-                    return@collect
-                }
 
                 if (event !is BackendEvent.DriveEvent || event.driveId != chatDrive) return@collect
 
@@ -146,25 +157,33 @@ class ConversationStream(
 
                     is BackendEvent.DriveEvent.Stopped -> {
                         Logger.d("ConversationStream: Stopped(totalCount=${event.totalCount})")
-                        // If placeholders remain after sync completion, the real
-                        // conversation files genuinely didn't arrive — persist
-                        // the placeholders to local DB so they survive restart.
-                        // Only on success: on failure we'd prefer to retry on the
-                        // next sync rather than commit a speculative placeholder.
-                        if (event.result is BackendEvent.DriveResult.Success &&
-                            placeholderIds.isNotEmpty()
-                        ) {
-                            val toReconcile = placeholderIds.toSet()
-                            placeholderIds.clear()
-                            scope.launch {
-                                try {
-                                    reconcileUnresolvedPlaceholders(toReconcile)
-                                } catch (e: Exception) {
-                                    Logger.e(e) {
-                                        "ConversationStream: placeholder reconciliation FAILED: ${e.message}"
+                        if (event.result is BackendEvent.DriveResult.Success) {
+                            // If placeholders remain after sync completion, the real
+                            // conversation files genuinely didn't arrive — persist
+                            // the placeholders to local DB so they survive restart.
+                            // Only on success: on failure we'd prefer to retry on the
+                            // next sync rather than commit a speculative placeholder.
+                            if (placeholderIds.isNotEmpty()) {
+                                val toReconcile = placeholderIds.toSet()
+                                placeholderIds.clear()
+                                scope.launch {
+                                    try {
+                                        reconcileUnresolvedPlaceholders(toReconcile)
+                                    } catch (e: Exception) {
+                                        Logger.e(e) {
+                                            "ConversationStream: placeholder reconciliation FAILED: ${e.message}"
+                                        }
                                     }
                                 }
                             }
+                            // Re-enrich unread counts after the chat-drive sync
+                            // completes — but only if the sync actually received
+                            // records. totalCount=0 means no batches, no writes to
+                            // ChatReadCount, so nothing to re-enrich. Replaces the
+                            // old BackendEvent.ConnectionOnline trigger so the second
+                            // cold-boot enrich (when there is one) now lands AFTER
+                            // sync writes (deterministic order), not concurrent with them.
+                            if (event.totalCount > 0) launchEnrichUnread()
                         }
                     }
 
@@ -821,9 +840,9 @@ class ConversationStream(
      * patched onto the model.
      *
      * Also invoked from message-read actions (see [ChatMessageActionService])
-     * and on `BackendEvent.ConnectionOnline`. Flips
-     * `enrichment.hasUnreadCounts` (first call only; subsequent calls just
-     * patch counts).
+     * and after every chat-drive `BackendEvent.DriveEvent.Stopped` that
+     * received at least one record. Flips `enrichment.hasUnreadCounts`
+     * (first call only; subsequent calls just patch counts).
      *
      * Safe to defer, safe to skip, safe to retry.
      */
@@ -915,7 +934,11 @@ class ConversationStream(
 
     // endregion
 
-    // Full conversation list load from local DB.  Idempotent (skips if already running).
+    // Full conversation list load from local DB.  One-shot — subsequent calls
+    // return immediately.  This is what allows the AppModule preload at
+    // onPostAuthenticated (the ~800ms cold-boot win) to coexist with
+    // unconditional start() calls from the various ViewModels' init blocks
+    // without re-running the whole load + enrichment pipeline.
     // Intended call sites — all user-initiated or startup:
     //   - AppModule onPostAuthenticated  (auth startup, preloads while UI composes)
     //   - ConversationListViewModel init (user navigates to list)
@@ -923,9 +946,10 @@ class ConversationStream(
     //   - GroupSettingsViewModel init     (user opens group settings)
     // Do NOT call from DriveEvent.Stopped or other sync events — see init block above.
     fun start() {
-        if (loadJob?.isActive == true) return
+        if (started) return
+        started = true
         Logger.d("ConversationStream: start() — loading full conversation list from DB")
-        loadJob = scope.launch {
+        scope.launch {
             // MANDATORY — flips dataReady=true for the UI.
             loadBasicConversations()
 
@@ -936,7 +960,9 @@ class ConversationStream(
             // then admins (group-settings only), then unread counts.
             enrichWithLastMessages()
             enrichWithAdmins()
-            enrichAllConversationsWithUnreadCounts()
+            // launchEnrichUnread (not direct call) so the WS-online handler
+            // in init can see this enrich is in-flight and skip its own.
+            launchEnrichUnread()
         }
 
         // Reactively update share cache when conversations or contacts change,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ConnectionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ConnectionService.kt
@@ -35,7 +35,22 @@ class ConnectionService(
     val connections: StateFlow<ConnectionState> =
         _connections.asStateFlow()
 
-    private var startJob: Job? = null
+    // One-shot — prevents the AppModule preload and the ConversationListViewModel
+    // init from each running hydrate+refresh on cold boot. WS-reconnect refreshes
+    // go through the BackendEvent.ConnectionOnline handler in init (calls
+    // launchRefresh() below), not through start() — this flag does not block them.
+    private var started = false
+
+    // Coalesces the two automatic refresh triggers (start()'s post-hydrate path
+    // and BackendEvent.ConnectionOnline). On cold boot they fire ~500ms apart
+    // and would otherwise both hit the network. Direct refresh() calls (user
+    // actions, CircleNetworkEvents) bypass this guard so they always re-fetch.
+    private var refreshJob: Job? = null
+
+    private fun launchRefresh() {
+        if (refreshJob?.isActive == true) return
+        refreshJob = scope.launch { refresh() }
+    }
 
     init {
         // Keep the connected-identity map in sync with websocket events so downstream UI
@@ -62,7 +77,7 @@ class ConnectionService(
                     }
                     // When the websocket comes back after an offline window, reconcile
                     // against the server — covers the airplane-mode-off case.
-                    is BackendEvent.ConnectionOnline -> scope.launch { refresh() }
+                    is BackendEvent.ConnectionOnline -> launchRefresh()
                     else -> {}
                 }
             }
@@ -70,10 +85,11 @@ class ConnectionService(
     }
 
     fun start() {
-        if (startJob?.isActive == true) return
-        startJob = scope.launch {
+        if (started) return
+        started = true
+        scope.launch {
             hydrateFromCache()
-            refresh()
+            launchRefresh()
         }
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/requests/ConnectionRequestService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/requests/ConnectionRequestService.kt
@@ -17,6 +17,7 @@ import id.homebase.chat.services.convo.contact.ConnectionCacheRepository
 import id.homebase.chat.services.convo.contact.ConnectionService
 import id.homebase.chat.services.convo.contact.DriveContactService
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -49,10 +50,30 @@ class ConnectionRequestService(
      *  flag to decide whether to show "Unknown" vs. "Not connected" in the UI. */
     val isLoaded: StateFlow<Boolean> = _isLoaded.asStateFlow()
 
+    // One-shot — prevents the AppModule preload and the ConversationListViewModel
+    // init from each running hydrate+refresh on cold boot. WS-reconnect refreshes
+    // go through the BackendEvent.ConnectionOnline handler in init (calls
+    // launchRefresh() below), not through start() — this flag does not block them.
+    private var started = false
+
+    // Coalesces the two automatic refresh triggers (start()'s post-hydrate path
+    // and BackendEvent.ConnectionOnline). On cold boot they fire ~ms apart and
+    // would otherwise both launch the same incoming + outgoing HTTP fetches.
+    // Direct refresh() calls (user actions, CircleNetworkEvents) bypass this
+    // guard so they always re-fetch.
+    private var refreshJob: Job? = null
+
+    private fun launchRefresh() {
+        if (refreshJob?.isActive == true) return
+        refreshJob = scope.launch { refresh() }
+    }
+
     fun start() {
+        if (started) return
+        started = true
         scope.launch {
             hydrateFromCache()
-            refresh()
+            launchRefresh()
         }
     }
 
@@ -84,7 +105,7 @@ class ConnectionRequestService(
                             refresh()
                         }
                     }
-                    is BackendEvent.ConnectionOnline -> scope.launch { refresh() }
+                    is BackendEvent.ConnectionOnline -> launchRefresh()
                     else -> {}
                 }
             }


### PR DESCRIPTION
The cold-boot path on the desktop app fires the same load + refresh pipelines twice within ~1 second: once from AppModule.onPostAuthenticated (the documented "preload while Compose composes" optimisation) and again from ConversationListViewModel.init when the list screen mounts ~700ms later. The duplicate cost ~400ms of redundant DB enrichment, ~6-8 wasted server round-trips, and 116 noisy ParticipantsAudit lines per cold boot.

Three layered fixes:

1. One-shot start() guards. ConversationStream, ConnectionService, and ConnectionRequestService each gain a `started: Boolean` flag (mirroring the existing ContactService.started pattern). Prior in-flight-only guards (`if (loadJob?.isActive == true)`) missed the cold-boot race because the AppModule preload completed before the VM's start() call landed. The new guard makes start() truly idempotent across job completion.

2. Refresh coalescing for the WS-online race. ConnectionService and ConnectionRequestService now route both their start()-driven and BackendEvent.ConnectionOnline-driven refreshes through a shared launchRefresh() helper with an in-flight Job guard. Prevents the two paths (which fire ~500ms apart on cold boot) from each issuing the same HTTP fetch. CircleNetworkEvent and direct user-action refresh() calls bypass the guard so they always re-fetch canonical state after explicit triggers.

3. Move ChatReadCount re-enrich from WS-online to chat-drive Stopped. ConversationStream's second enrich previously fired on BackendEvent.ConnectionOnline, which races with DriveSync batches landing in the same window. Replaced with a chat-drive DriveEvent.Stopped trigger gated by `event.totalCount > 0` and `event.result is Success`. Deterministic ordering: 1st enrich captures pre-sync local DB state, 2nd (only when records arrived) captures post-sync state. Quiet-server cold boots now show exactly one enrich.

Plus a minor cleanup: ConversationMapper.mapToBasic's per-row ParticipantsAudit log demoted from Logger.i to Logger.d so it no longer floods cold-boot logs at info severity (fired N×conversations per list load — 116 lines on a 58-conversation account).

Verified by inspecting the desktop homebase.log across rebuilds: the cold-boot section dropped from ~180 lines to ~120, with each key pipeline log line appearing exactly once where it previously fired twice.