### PR TITLE
Defragger: heal legacy null appData.userDate in jsonHeader

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
@@ -242,7 +242,9 @@ class DriveSync(
 
         try {
             pendingDbJob?.await()
-            Logger.d("DriveSync: all DB writes complete for drive $driveId ($totalCount total records)")
+            if (totalCount > 0) {
+                Logger.d("DriveSync: all DB writes complete for drive $driveId ($totalCount total records)")
+            }
             eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, totalCount, BackendEvent.DriveResult.Success))
             Logger.d("Drive $driveId synchronized with $totalCount records read.")
         } catch (e: Exception) {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DriveMainIndexWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DriveMainIndexWrapper.kt
@@ -197,6 +197,19 @@ class DriveMainIndexWrapper(
         }
     }
 
+    /**
+     * Defragmenter: rewrite a row's jsonHeader text after the
+     * LegacyUserDateZero repair has patched `appData.userDate` in the
+     * parsed header. Local-only.
+     */
+    suspend fun repairJsonHeaderByRowId(rowId: Long, jsonHeader: String): Boolean {
+        return databaseManager.withWriteValue { db ->
+            db.driveMainIndexQueries
+                .repairJsonHeaderByRowId(jsonHeader, rowId)
+                .value > 0
+        }
+    }
+
     suspend fun upsertDriveMainIndex(
         identityId: Uuid,
         driveId: Uuid,

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/DriveMainIndex.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/DriveMainIndex.sq
@@ -157,3 +157,10 @@ UPDATE DriveMainIndex SET archivalStatus = ? WHERE rowId = ?;
 -- Used by the repair pass to correct LegacyUserDateZero rows. Local-only.
 repairUserDateByRowId:
 UPDATE DriveMainIndex SET userDate = ? WHERE rowId = ?;
+
+-- Defragmenter: rewrite a row's jsonHeader text after we patch
+-- appData.userDate locally (LegacyUserDateZero repair). Local-only —
+-- if the row ever resyncs from the server the original null returns,
+-- which is fine: the classifier will re-flag and re-repair next pass.
+repairJsonHeaderByRowId:
+UPDATE DriveMainIndex SET jsonHeader = ? WHERE rowId = ?;

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/DefragRowClassifier.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/DefragRowClassifier.kt
@@ -145,9 +145,15 @@ internal suspend fun classifyRow(
     }
 
     // 5. Legacy null-userDate (chat messages only).
+    //
+    // Gates only on `appData.userDate == null` in the parsed JSON header
+    // (the source of truth the consumer reads). Deliberately ignores
+    // `row.userDate` — it may already be non-zero from a prior repair pass
+    // that patched the SQL projection but didn't yet patch the header. We
+    // need to re-flag those so the now-extended repair can rewrite the
+    // jsonHeader column too.
     if (
         fileType == MESSAGE_FILE_TYPE &&
-        row.userDate == 0L &&
         header.fileMetadata.appData.userDate == null &&
         header.fileMetadata.created.milliseconds > 0L
     ) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/DefragSource.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/DefragSource.kt
@@ -92,7 +92,10 @@ sealed interface DefragAnalyzeEvent {
  *  3. isSoftDeleted + archivalStatus drift → [SoftDeleteArchivalMismatch] (msg only)
  *     else                                  → [SoftDeleted] (existing semantic)
  *  4. fileType=7878 + appData.groupId not in known/healthy conversation set → [OrphanChatMessage]
- *  5. fileType=7878 + userDate=0 + appData.userDate=null + created>0 → [LegacyUserDateZero]
+ *  5. fileType=7878 + appData.userDate=null + created>0 → [LegacyUserDateZero]
+ *     (re-flags rows whose SQL `userDate` column was patched in a prior
+ *     repair pass but whose JSON header still has the null — repair now
+ *     rewrites the jsonHeader column too)
  *  6. fileType=7878 + appData.content fails strict deserialise → [CorruptMessageContent]
  *  7. otherwise → [Healthy]
  */
@@ -109,7 +112,7 @@ sealed interface CellState {
         val rowId: Long,
     ) : CellState
 
-    /** Chat message with `appData.userDate = null` projected as 0. UI: amber. */
+    /** Chat message with `appData.userDate = null` in the JSON header. UI: amber. */
     data class LegacyUserDateZero(
         val driveId: Uuid,
         val fileId: Uuid,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/LiveDefragSource.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/LiveDefragSource.kt
@@ -13,6 +13,10 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlin.concurrent.Volatile
 import kotlin.uuid.Uuid
 
@@ -468,18 +472,38 @@ class LiveDefragSource(
                             }
                         }
                         is CellState.LegacyUserDateZero -> {
-                            val ok = runCatching {
+                            // Two writes: SQL `userDate` column projection AND
+                            // the `jsonHeader` text. The consumer (ChatMessageStream)
+                            // reads `appData.userDate` from the parsed header, so
+                            // patching the column alone leaves the cold-boot
+                            // "null userDate" debug log firing every load.
+                            val patchedHeader = patchHeaderUserDate(
+                                rawHeader = row.jsonHeader,
+                                createdMs = state.createdMs,
+                            )
+                            val sqlOk = patchedHeader != null && runCatching {
                                 mainIndex.repairUserDateByRowId(
                                     rowId = row.rowId,
                                     userDate = state.createdMs,
                                 )
                             }.getOrElse {
                                 Logger.w(tag = tag, throwable = it) {
-                                    "repair userDate failed rowId=${row.rowId}"
+                                    "repair userDate (SQL col) failed rowId=${row.rowId}"
                                 }
                                 false
                             }
-                            if (ok) {
+                            val headerOk = sqlOk && runCatching {
+                                mainIndex.repairJsonHeaderByRowId(
+                                    rowId = row.rowId,
+                                    jsonHeader = patchedHeader,
+                                )
+                            }.getOrElse {
+                                Logger.w(tag = tag, throwable = it) {
+                                    "repair userDate (jsonHeader) failed rowId=${row.rowId}"
+                                }
+                                false
+                            }
+                            if (headerOk) {
                                 repaired += 1
                                 repairedLegacy += 1
                                 emit(
@@ -742,4 +766,21 @@ class LiveDefragSource(
     private companion object {
         const val PAGE_SIZE = 500L
     }
+}
+
+/**
+ * Mutate the parsed jsonHeader so `fileMetadata.appData.userDate = createdMs`
+ * and re-serialise. Uses `kotlinx.serialization.json` tree manipulation so we
+ * preserve any header fields the typed `HomebaseFile` model doesn't capture.
+ * Returns null if the header doesn't have the expected nested shape.
+ */
+internal fun patchHeaderUserDate(rawHeader: String, createdMs: Long): String? {
+    val root = runCatching { Json.parseToJsonElement(rawHeader) as? JsonObject }.getOrNull()
+        ?: return null
+    val fileMetadata = root["fileMetadata"] as? JsonObject ?: return null
+    val appData = fileMetadata["appData"] as? JsonObject ?: return null
+    val newAppData = JsonObject(appData + ("userDate" to JsonPrimitive(createdMs)))
+    val newFileMetadata = JsonObject(fileMetadata + ("appData" to newAppData))
+    val newRoot = JsonObject(root + ("fileMetadata" to newFileMetadata))
+    return Json.encodeToString(JsonElement.serializer(), newRoot)
 }

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/defragmenter/service/DefragRowClassifierTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/defragmenter/service/DefragRowClassifierTest.kt
@@ -111,13 +111,42 @@ class DefragRowClassifierTest {
         assertEquals(CellState.Healthy, state)
     }
 
+    @Test
+    fun classify_messageWithNullHeaderUserDate_returnsLegacyUserDateZero() = runTest {
+        // Even when the SQL `userDate` column has been previously repaired
+        // (non-zero), a null in the parsed `appData.userDate` re-flags the
+        // row so the new repair pass can rewrite the jsonHeader column too.
+        val row = chatMessageRow(
+            content = """{"message":"hi","deliveryStatus":50}""",
+            groupId = convoId,
+            headerUserDate = null,
+            rowUserDate = 5000L,
+        )
+        val probe: suspend (HomebaseFile) -> Throwable? = { null }
+
+        val state = classifyRow(
+            driveId = driveId,
+            row = row,
+            mapToBasicProbe = null,
+            healthyConversationIds = healthyConvos,
+            decodeMessageContentProbe = probe,
+        )
+
+        val legacy = state as? CellState.LegacyUserDateZero
+        assertNotNull(legacy, "expected LegacyUserDateZero, got $state")
+        assertEquals(1000L, legacy.createdMs)
+    }
+
     private fun chatMessageRow(
         content: String,
         groupId: Uuid,
         fileId: Uuid = Uuid.random(),
         rowId: Long = 1L,
+        headerUserDate: Long? = 1000L,
+        rowUserDate: Long = 1000L,
     ): PagedScanRow {
         val jsonContent = content.replace("\\", "\\\\").replace("\"", "\\\"")
+        val userDateField = if (headerUserDate == null) "null" else headerUserDate.toString()
         val jsonHeader = """{
             "driveId": "$driveId",
             "fileId": "$fileId",
@@ -143,7 +172,7 @@ class DefragRowClassifierTest {
                     "fileType": 7878,
                     "dataType": 0,
                     "groupId": "$groupId",
-                    "userDate": 1000,
+                    "userDate": $userDateField,
                     "content": "$jsonContent",
                     "previewThumbnail": null,
                     "archivalStatus": 0
@@ -174,7 +203,7 @@ class DefragRowClassifierTest {
         return PagedScanRow(
             rowId = rowId,
             fileId = fileId,
-            userDate = 1000L,
+            userDate = rowUserDate,
             archivalStatus = 0L,
             jsonHeader = jsonHeader,
         )


### PR DESCRIPTION
The previous LegacyUserDateZero repair only patched the SQL projection column (DriveMainIndex.userDate) — the JSON header's appData.userDate stayed null. ChatMessageStream reads from the parsed header, so the "null userDate. using authorSpecificDate" debug log kept firing every cold boot for the same rows even after a "successful" repair pass.

Worse, the classifier gated detection on row.userDate == 0L. After the SQL-only repair set userDate = createdMs, those rows no longer flagged as LegacyUserDateZero on the next analyze — defrag would happily report "all green" while the underlying header was still wrong.

Two changes:

1. Relax the classifier (DefragRowClassifier.kt) to gate solely on appData.userDate == null in the parsed header. Now re-flags rows whose SQL column was patched in a prior pass but whose header still has the null.

2. Extend the LegacyUserDateZero repair branch (LiveDefragSource.kt) to patch the jsonHeader column too — kotlinx.serialization tree edit so we preserve any header fields the typed HomebaseFile model doesn't capture. Adds a new repairJsonHeaderByRowId SQL helper + DriveMainIndexWrapper method. Both writes must succeed for the row to count as repaired.

Local-only repair, same posture as the existing SoftDeleteArchivalMismatch TODO: if a peer ever resyncs the header, the null returns and the row re-flags on next analyze. No new cell state / colour added — reuses the existing amber LegacyUserDateZero state.

Bonus: silence DriveSync's "all DB writes complete" / "Drive synchronized" debug logs when the round wrote zero records (mirrors the recent ConversationStream post-Stopped enrich gate).