### PR TITLE
Fix notification-tap navigation race in compact mode

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/NotificationNavigationEffects.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/NotificationNavigationEffects.kt
@@ -18,9 +18,13 @@ import kotlin.uuid.Uuid
  * Installs the two coupled `LaunchedEffect`s that drive notification-tap navigation
  * between the list and detail panes.
  *
- * Effect 1 (cleanup): in compact single-pane layouts, when the scaffold transitions to
- * list-only while a conversation is still selected, dispatch `ClearSelection`. This is
- * the user-back-to-list path.
+ * Effect 1 (cleanup): in compact single-pane layouts, when the scaffold transitions
+ * back to list-only *after the detail pane has been visible* and a conversation is
+ * still selected, dispatch `ClearSelection`. This is the user-back-to-list path.
+ * The `hadDetailVisible` latch is required because the natural entry state of a
+ * fresh compact scaffold is also "list visible, detail hidden" — without the latch,
+ * Effect 1 fires on initial composition and races Effect 2 when ChatList is brought
+ * forward by `AppNavHost.popBackStack(ChatList)` after a notification tap.
  *
  * Effect 2 (swap): when `selectedConversationId` changes to a new value, navigate the
  * scaffold to `Detail(selectedId)`. If the scaffold is already at `Detail` with a stale
@@ -52,8 +56,10 @@ internal fun NotificationNavigationEffects(
         scaffoldNavigator.scaffoldValue[ListDetailPaneScaffoldRole.Detail] != PaneAdaptedValue.Hidden
 
     var isSwappingDetailPane by remember { mutableStateOf(false) }
+    var hadDetailVisible by remember { mutableStateOf(false) }
     LaunchedEffect(isListPaneHidden, isDetailPaneVisible) {
-        if (!isSwappingDetailPane && scaffoldDirective.maxHorizontalPartitions == 1 && !isListPaneHidden && !isDetailPaneVisible && selectedConversationId != null) {
+        if (isDetailPaneVisible) hadDetailVisible = true
+        if (!isSwappingDetailPane && scaffoldDirective.maxHorizontalPartitions == 1 && !isListPaneHidden && !isDetailPaneVisible && hadDetailVisible && selectedConversationId != null) {
             Logger.i(tag = "ConversationListUi") { "ClearSelection fired (compact back-to-list) selectedId=$selectedConversationId" }
             onClearSelection()
         }
@@ -66,17 +72,27 @@ internal fun NotificationNavigationEffects(
             Logger.i(tag = "ConversationListUi") { "Restore detail pane for $selectedId" }
             lastNavigatedConversationId = selectedId
             val cur = scaffoldNavigator.currentDestination
-            if (cur?.pane == ListDetailPaneScaffoldRole.Detail && cur.contentKey != selectedId) {
-                Logger.i(tag = "ConversationListUi") { "Swapping detail pane ${cur.contentKey}->$selectedId" }
-                isSwappingDetailPane = true
-                try {
-                    scaffoldNavigator.navigateBack()
+            try {
+                if (cur?.pane == ListDetailPaneScaffoldRole.Detail && cur.contentKey != selectedId) {
+                    Logger.i(tag = "ConversationListUi") { "Swapping detail pane ${cur.contentKey}->$selectedId" }
+                    isSwappingDetailPane = true
+                    try {
+                        scaffoldNavigator.navigateBack()
+                        scaffoldNavigator.navigateTo(ListDetailPaneScaffoldRole.Detail, selectedId)
+                    } finally {
+                        isSwappingDetailPane = false
+                    }
+                } else {
                     scaffoldNavigator.navigateTo(ListDetailPaneScaffoldRole.Detail, selectedId)
-                } finally {
-                    isSwappingDetailPane = false
                 }
-            } else {
-                scaffoldNavigator.navigateTo(ListDetailPaneScaffoldRole.Detail, selectedId)
+                Logger.i(tag = "ConversationListUi") { "Restore detail pane completed for $selectedId" }
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                // Effect re-keys when selectedConversationId changes; cancellation here means
+                // navigateTo() was interrupted before settling. Surfacing this is critical for
+                // diagnosing notification-tap navigation regressions: a silent cancel looks
+                // identical to success in the log otherwise.
+                Logger.w(tag = "ConversationListUi") { "Restore detail pane CANCELLED for $selectedId (selectedConversationId changed mid-navigateTo)" }
+                throw e
             }
         } else if (selectedId == null) {
             lastNavigatedConversationId = null

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/conversationlist/NotificationNavigationEffectsTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/conversationlist/NotificationNavigationEffectsTest.kt
@@ -89,13 +89,45 @@ class NotificationNavigationEffectsTest {
     }
 
     @Test
+    fun compact_initial_selection_does_not_fire_clear_selection() = runComposeUiTest {
+        // Regression: notification-tap path lands on ChatList with selectedConversationId
+        // already set. The compact scaffold initialises in {List=Expanded, Detail=Hidden},
+        // which used to trip the cleanup effect on initial composition and wipe the VM
+        // selection before the swap effect could navigate to Detail. The
+        // `hadDetailVisible` latch in NotificationNavigationEffects gates the cleanup
+        // effect until the detail pane has actually been visible at least once.
+        val idA = Uuid.parse("cc0577d2-2c92-4843-b08d-166e05ad4c19")
+        val selected = mutableStateOf<Uuid?>(idA)
+        var clearCount = 0
+
+        setContent {
+            MaterialTheme {
+                TestHost(
+                    selectedId = selected,
+                    directive = compactDirective(),
+                    onClearSelection = { clearCount++ },
+                )
+            }
+        }
+        waitForIdle()
+
+        // Effect 2 should have driven the scaffold to Detail(A); Effect 1 must not have fired.
+        onNodeWithText("detail=$idA").assertExists()
+        assertEquals(
+            0,
+            clearCount,
+            "initial composition with pending selection must not fire ClearSelection — the hadDetailVisible latch should suppress the cleanup effect until Detail has been visible at least once"
+        )
+    }
+
+    @Test
     fun compact_warm_swap_does_not_fire_clear_selection() = runComposeUiTest {
         val idA = Uuid.parse("cc0577d2-2c92-4843-b08d-166e05ad4c19")
         val idB = Uuid.parse("37c7d258-e56c-4446-bf6c-0fcc12862577")
-        // Start with no selection — mirrors the production startup path where selection
-        // arrives as a state transition (user tap or notification) rather than on mount.
-        // Starting non-null would race the cleanup effect on initial composition because
-        // the scaffold's default history is list-only in compact mode.
+        // Start with no selection — selection arrives as a state transition (user tap
+        // or notification). The hadDetailVisible-latched cleanup effect makes the
+        // initial-non-null case safe too (see compact_initial_selection_*), but this
+        // test specifically exercises the swap path.
         val selected = mutableStateOf<Uuid?>(null)
         var clearCount = 0
 


### PR DESCRIPTION
When AppNavHost.popBackStack(ChatList) brings ChatList forward after a notification tap, the compact scaffold initialises in its natural "list visible, detail hidden" state. The cleanup effect in NotificationNavigationEffects (compact back-to-list path) had historically conflated that entry state with a real Detail->List back navigation: on first composition it would dispatch ClearSelection, nulling selectedConversationId before the swap effect's navigateTo(Detail) could settle. The user landed on the list view with no detail pane.

The cleanup effect's intent is to detect a transition Detail->List, not the entry state. Add a hadDetailVisible latch so the effect only fires after the detail pane has been visible at least once during the composition's lifetime. This is strictly tighter than "skip first emission" — it encodes the actual semantic.

Also wrap the swap effect's navigateTo in try/catch(CancellationException) so a silent mid-flight cancel (the failure mode this bug exhibited) shows up in the log as "Restore detail pane CANCELLED for X" rather than looking identical to a successful navigation.

Regression test added: compact_initial_selection_does_not_fire_clear_selection pins the previously-untestable scenario (the prior author had documented that "starting non-null would race the cleanup effect" and worked around it by always starting with null).