### PR TITLE
refactor(chat): hoist composer previews into a staged-attachments list

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
@@ -2,8 +2,8 @@ package id.homebase.chat.conversationlist
 
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.drives.files.PayloadDescriptor
-import id.homebase.api.client.link.LinkPreview
 import id.homebase.api.common.OdinId
+import id.homebase.chat.services.staged.StagedAttachment
 import id.homebase.chat.data.ConversationUiModel
 import id.homebase.chat.data.MessageUiModel
 import id.homebase.core.gallery.GalleryImage
@@ -61,8 +61,10 @@ sealed interface ConversationListUiAction {
     data class OpenConnectionRequestInOwnerConsole(val odinId: OdinId) : ConversationListUiAction
     data class OpenSendConnectionRequestDialog(val odinId: OdinId) : ConversationListUiAction
     data object DismissSheet : ConversationListUiAction
-    data class SendMessage(val conversationId: Uuid, val linkPreview: LinkPreview? = null) :
-        ConversationListUiAction
+    data class SendMessage(
+        val conversationId: Uuid,
+        val stagedAttachments: List<StagedAttachment> = emptyList(),
+    ) : ConversationListUiAction
 
     data class SendFile(
         val conversationId: Uuid,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -20,7 +20,8 @@ import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
-import id.homebase.api.client.link.LinkPreview
+import id.homebase.chat.services.staged.StagedAttachment
+import id.homebase.chat.services.staged.toCombinedPayloadBundle
 import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.image.ImageHeaderParser
@@ -55,7 +56,6 @@ import id.homebase.chat.services.LocalAttachmentContext
 import id.homebase.chat.services.LocalAttachmentContextStore
 import id.homebase.chat.services.ReplyPreview
 import id.homebase.chat.services.builder.AttachmentInput
-import id.homebase.chat.services.builder.LinkPreviewPayloadBuilder
 import id.homebase.chat.services.builder.MessageAttachmentBuilder
 import id.homebase.chat.services.convo.ConversationEnricher
 import id.homebase.chat.services.convo.ConversationService
@@ -749,7 +749,13 @@ class ConversationListViewModel(
 
             is ConversationListUiAction.SendMessage -> {
                 val hasMessage = !messageInputTextState.annotatedString.isBlank()
-                if (hasMessage) {
+                // User-initiated attachments (location, contact, etc.) enable send even with no
+                // text. Link previews don't — they're auto-detected from typed URLs and only
+                // ride along when there's a text message to send.
+                val hasUserInitiatedAttachment = action.stagedAttachments.any {
+                    it !is id.homebase.chat.services.staged.StagedLinkPreview
+                }
+                if (hasMessage || hasUserInitiatedAttachment) {
                     _messagesUiState.update { it.copy(isSendingMessage = true) }
                     val content = messageInputTextState.toMarkdown().trimEnd()
                     val replyTo = _messagesUiState.value.replyToMessage
@@ -758,13 +764,13 @@ class ConversationListViewModel(
                             conversationId = action.conversationId,
                             replyTo = replyTo,
                             content = content,
-                            linkPreview = action.linkPreview
+                            stagedAttachments = action.stagedAttachments,
                         )
                     } else {
                         addMessage(
                             conversationId = action.conversationId,
                             content = content,
-                            linkPreview = action.linkPreview
+                            stagedAttachments = action.stagedAttachments,
                         )
                     }
                     // Input is cleared inside addMessage/replyToMessage after
@@ -2813,13 +2819,11 @@ class ConversationListViewModel(
     private fun addMessage(
         conversationId: Uuid,
         content: String,
-        linkPreview: LinkPreview? = null
+        stagedAttachments: List<StagedAttachment> = emptyList(),
     ) {
         viewModelScope.launch {
             try {
-                val payloadBundle = linkPreview?.let {
-                    LinkPreviewPayloadBuilder.build(it, fileOperationsProvider)
-                }
+                val payloadBundle = stagedAttachments.toCombinedPayloadBundle(fileOperationsProvider)
 
                 val newMessageId = Uuid.random()
                 pendingMessageId = newMessageId
@@ -2850,13 +2854,11 @@ class ConversationListViewModel(
         conversationId: Uuid,
         replyTo: MessageUiModel,
         content: String,
-        linkPreview: LinkPreview? = null
+        stagedAttachments: List<StagedAttachment> = emptyList(),
     ) {
         viewModelScope.launch {
             try {
-                val payloadBundle = linkPreview?.let {
-                    LinkPreviewPayloadBuilder.build(it, fileOperationsProvider)
-                }
+                val payloadBundle = stagedAttachments.toCombinedPayloadBundle(fileOperationsProvider)
 
                 val replyPreview = ReplyPreview(
                     replyUniqueId = replyTo.id,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/staged/StagedAttachment.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/staged/StagedAttachment.kt
@@ -1,0 +1,30 @@
+package id.homebase.chat.services.staged
+
+import androidx.compose.runtime.Immutable
+import id.homebase.api.client.link.LinkPreview
+
+/**
+ * A piece of content the user has staged in the chat composer to be sent with the next message.
+ *
+ * Each kind has a stable [id] used by the cancel-X button and by the URL-detector logic to
+ * deduplicate (the detector replaces an existing same-id link preview when the URL changes).
+ *
+ * Adding a new attachment kind:
+ *   1. add a `data class StagedXxx(val ...) : StagedAttachment` here,
+ *   2. add a `when` branch in `StagedAttachmentRow` (UI dispatch),
+ *   3. add a `when` branch in `List<StagedAttachment>.toCombinedPayloadBundle` (wire-format dispatch).
+ *
+ * No new params on [MessageInputBar] / [MessageTextFieldExpanded] / [MessageTextFieldCompact],
+ * no new branches in `ConversationListViewModel`. Compare to the pre-staged-attachments shape
+ * where each new preview kind grew the parameter list of three composables and added a manual
+ * combine-bundles helper in the ViewModel.
+ */
+@Immutable
+sealed interface StagedAttachment {
+    val id: String
+}
+
+@Immutable
+data class StagedLinkPreview(val preview: LinkPreview) : StagedAttachment {
+    override val id: String get() = "link:${preview.url}"
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/staged/StagedAttachmentBundle.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/staged/StagedAttachmentBundle.kt
@@ -1,0 +1,36 @@
+package id.homebase.chat.services.staged
+
+import id.homebase.api.file.FileOperationsProvider
+import id.homebase.chat.services.PayloadBundle
+import id.homebase.chat.services.builder.LinkPreviewPayloadBuilder
+
+/**
+ * Convert a list of staged attachments to a single combined [PayloadBundle] suitable for the
+ * chat send pipeline. Returns `null` when the list is empty (the send pipeline treats `null`
+ * as "no payloads").
+ *
+ * This is the single dispatch point between staged-content kinds and their on-wire builder.
+ * `ConversationListViewModel.addMessage` and `replyToMessage` call this once instead of
+ * managing a manual `link/location/contact?` combination — adding a new kind is a one-line
+ * `when` branch addition here, not a new conditional in every send path.
+ */
+suspend fun List<StagedAttachment>.toCombinedPayloadBundle(
+    fileOps: FileOperationsProvider,
+): PayloadBundle? {
+    if (isEmpty()) return null
+    val bundles = map { it.toPayloadBundle(fileOps) }
+    return when (bundles.size) {
+        1 -> bundles.single()
+        else -> PayloadBundle(
+            payloads = bundles.flatMap { it.payloads },
+            thumbnails = bundles.flatMap { it.thumbnails },
+            previewThumbs = bundles.flatMap { it.previewThumbs },
+        )
+    }
+}
+
+private suspend fun StagedAttachment.toPayloadBundle(
+    fileOps: FileOperationsProvider,
+): PayloadBundle = when (this) {
+    is StagedLinkPreview -> LinkPreviewPayloadBuilder.build(preview, fileOps)
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -98,6 +98,7 @@ import id.homebase.api.client.profile.PublicProfileProvider
 import id.homebase.api.common.OdinId
 import id.homebase.chat.conversationlist.AutoConnectRowState
 import id.homebase.chat.conversationlist.ConversationListUiAction
+import id.homebase.chat.services.staged.StagedAttachment
 import id.homebase.chat.conversationlist.MessageListContentModel
 import id.homebase.chat.conversationlist.MessageListUiSheet
 import id.homebase.chat.conversationlist.MessageListUiState
@@ -211,6 +212,12 @@ fun ConversationContent(
     var wasKeyboardVisible by remember { mutableStateOf(isKeyboardVisible) }
     val coroutineScope = rememberCoroutineScope()
     var showScrollToBottom by remember { mutableStateOf(false) }
+
+    // Hoisted composer staging slot. Owned at this level so user-initiated attachments
+    // (location, contact, etc.) can be appended from outside the input bar (e.g. from the
+    // attachment sheet). Auto-detected attachments (link previews from typed URLs) write here
+    // too, via `MessageInputBar`'s onStagedAttachmentsChange callback.
+    var stagedAttachments by remember { mutableStateOf<List<StagedAttachment>>(emptyList()) }
 
     LaunchedEffect(uiState.isSearchActive) {
         if (uiState.isSearchActive) {
@@ -1020,8 +1027,12 @@ fun ConversationContent(
                                 editExistingMode = uiState.isEditingMessageId != null,
                                 showingEmojiSheet = showEmojiSheet,
                                 isSendingMessage = uiState.isSendingMessage,
-                                onSendMessage = { text, linkPreview ->
-                                    if (text.isNotBlank()) {
+                                stagedAttachments = stagedAttachments,
+                                onStagedAttachmentsChange = { stagedAttachments = it },
+                                onSendMessage = { text, attachments ->
+                                    val hasContent = text.isNotBlank() ||
+                                        attachments.any { it !is id.homebase.chat.services.staged.StagedLinkPreview }
+                                    if (hasContent) {
                                         if (uiState.isEditingMessageId != null) {
                                             onUiAction(
                                                 ConversationListUiAction.EditMessageSave
@@ -1030,9 +1041,12 @@ fun ConversationContent(
                                             onUiAction(
                                                 ConversationListUiAction.SendMessage(
                                                     conversationId = conversation.conversation.id,
-                                                    linkPreview = linkPreview,
+                                                    stagedAttachments = attachments,
                                                 )
                                             )
+                                            // Clear the staged slot so the next message doesn't
+                                            // inherit the just-sent attachments.
+                                            stagedAttachments = emptyList()
                                         }
                                     }
                                 },

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
@@ -101,9 +101,10 @@ import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
 import com.mohamedrejeb.richeditor.model.RichTextState
 import com.mohamedrejeb.richeditor.ui.material3.RichTextEditor
 import com.mohamedrejeb.richeditor.ui.material3.RichTextEditorDefaults
-import id.homebase.api.client.link.LinkPreview
 import id.homebase.api.client.link.LinkPreviewProvider
 import id.homebase.chat.conversationlist.RecordingData
+import id.homebase.chat.services.staged.StagedAttachment
+import id.homebase.chat.services.staged.StagedLinkPreview
 import id.homebase.core.audio.rememberRecordAudioPermissionState
 import id.homebase.core.clipboard.clipboardImageReceiverModifier
 import id.homebase.core.clipboard.getImageFromClipboard
@@ -156,7 +157,9 @@ fun MessageInputBar(
     onRecordingStopped: () -> Unit,
     onRecordingCancelled: () -> Unit,
     onRecordingHelp: () -> Unit,
-    onSendMessage: (String, LinkPreview?) -> Unit,
+    stagedAttachments: List<StagedAttachment>,
+    onStagedAttachmentsChange: (List<StagedAttachment>) -> Unit,
+    onSendMessage: (String, List<StagedAttachment>) -> Unit,
     onPasteImage: ((ByteArray) -> Unit)? = null,
     onCancelEdit: () -> Unit,
 ) {
@@ -164,8 +167,11 @@ fun MessageInputBar(
     val isHovered by interactionSource.collectIsHoveredAsState()
     var showExpanded by remember { mutableStateOf(false) }
 
+    // URL-detector private state. Lives here (not in the parent) because it's an
+    // implementation detail of how StagedLinkPreview gets produced from typed text:
+    //  - cancelledUrls: URLs the user explicitly dismissed; don't auto-refetch.
+    //  - lastFetchedUrl: debounce memory; don't spam refetch on every keystroke.
     val linkPreviewProvider: LinkPreviewProvider = koinInject()
-    var linkPreviewData by remember { mutableStateOf<LinkPreview?>(null) }
     var cancelledUrls by remember { mutableStateOf<Set<String>>(emptySet()) }
     var lastFetchedUrl by remember { mutableStateOf<String?>(null) }
 
@@ -178,8 +184,9 @@ fun MessageInputBar(
 
             // If the user modifies the URL, immediately hide the old preview while we
             // wait to fetch the new one.
-            if (linkPreviewData != null && linkPreviewData?.url != url) {
-                linkPreviewData = null
+            val existingLink = stagedAttachments.firstOrNull { it is StagedLinkPreview } as? StagedLinkPreview
+            if (existingLink != null && existingLink.preview.url != url) {
+                onStagedAttachmentsChange(stagedAttachments.filterNot { it is StagedLinkPreview })
             }
 
             if (url !in cancelledUrls && url != lastFetchedUrl) {
@@ -187,27 +194,49 @@ fun MessageInputBar(
                 lastFetchedUrl = url
                 try {
                     val preview = linkPreviewProvider.getLinkPreview(url)
-                    // Ensure the URL wasn't cancelled during the network
-                    // request delay
+                    // Ensure the URL wasn't cancelled during the network request delay.
                     if (preview != null && url !in cancelledUrls) {
-                        linkPreviewData = preview
+                        onStagedAttachmentsChange(
+                            stagedAttachments.filterNot { it is StagedLinkPreview } +
+                                StagedLinkPreview(preview)
+                        )
                     }
                 } catch (_: Exception) {
                     // Ignore API errors, but because it's in lastFetchedUrl, we
-                    // won't spam retry it on every keystroke
+                    // won't spam retry it on every keystroke.
                 }
             }
         } else {
-            // URL was completely removed, so clean up preview and state
-            linkPreviewData = null
+            // URL was completely removed, so clean up preview and reset memory.
+            if (stagedAttachments.any { it is StagedLinkPreview }) {
+                onStagedAttachmentsChange(stagedAttachments.filterNot { it is StagedLinkPreview })
+            }
             cancelledUrls = emptySet()
             lastFetchedUrl = null
         }
     }
 
+    /**
+     * Cancel-X button on a staged attachment card. For link previews, also remembers the URL so
+     * the URL-detector won't re-stage it on the next keystroke (preserves the original behaviour
+     * of `cancelledUrls`).
+     */
+    fun cancelStaged(id: String) {
+        val att = stagedAttachments.firstOrNull { it.id == id } ?: return
+        if (att is StagedLinkPreview) {
+            cancelledUrls = cancelledUrls + att.preview.url
+        }
+        onStagedAttachmentsChange(stagedAttachments.filterNot { it.id == id })
+    }
+
     fun sendMessage() {
-        if (!isSendingMessage && textFieldState.annotatedString.isNotBlank()) {
-            onSendMessage(textFieldState.toMarkdown(), linkPreviewData)
+        val hasText = textFieldState.annotatedString.isNotBlank()
+        // Link previews alone shouldn't enable send (a bare URL with no text was never sendable
+        // in the original shape). User-initiated kinds (location, contact, etc.) WILL enable
+        // send because they're not StagedLinkPreview.
+        val hasUserInitiatedAttachment = stagedAttachments.any { it !is StagedLinkPreview }
+        if (!isSendingMessage && (hasText || hasUserInitiatedAttachment)) {
+            onSendMessage(textFieldState.toMarkdown(), stagedAttachments)
             // Don't clear here — the ViewModel clears after the send is queued,
             // so the text stays in the edit box if the send fails.
         }
@@ -243,13 +272,8 @@ fun MessageInputBar(
                     .padding(bottom = 16.dp),
                 focusRequester = focusRequester,
                 state = textFieldState,
-                linkPreviewData = linkPreviewData,
-                onCancelLinkPreview = {
-                    linkPreviewData?.let { preview ->
-                        cancelledUrls = cancelledUrls + preview.url
-                    }
-                    linkPreviewData = null
-                },
+                stagedAttachments = stagedAttachments,
+                onCancelAttachment = ::cancelStaged,
                 editExistingMode = editExistingMode,
                 onFocused = onFocused,
                 onEmojiClick = onEmojiClick,
@@ -268,14 +292,9 @@ fun MessageInputBar(
                 focusRequester = focusRequester,
                 state = textFieldState,
                 editExistingMode = editExistingMode,
-                linkPreviewData = linkPreviewData,
+                stagedAttachments = stagedAttachments,
                 recordingData = recordingData,
-                onCancelLinkPreview = {
-                    linkPreviewData?.let { preview ->
-                        cancelledUrls = cancelledUrls + preview.url
-                    }
-                    linkPreviewData = null
-                },
+                onCancelAttachment = ::cancelStaged,
                 showingEmojiSheet = showingEmojiSheet,
                 onFocused = onFocused,
                 onEmojiClick = onEmojiClick,
@@ -303,8 +322,8 @@ fun MessageTextFieldExpanded(
     focusRequester: FocusRequester,
     state: RichTextState,
     editExistingMode: Boolean,
-    linkPreviewData: LinkPreview?,
-    onCancelLinkPreview: () -> Unit,
+    stagedAttachments: List<StagedAttachment>,
+    onCancelAttachment: (id: String) -> Unit,
     onEmojiClick: () -> Unit,
     onAddAttachmentClick: () -> Unit,
     onPasteImage: ((ByteArray) -> Unit)? = null,
@@ -326,12 +345,10 @@ fun MessageTextFieldExpanded(
                 onKeyboardClick = {}
             )
         }
-        if (linkPreviewData != null) {
-            LinkPreviewCard(
-                linkPreview = linkPreviewData,
-                modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
-                isCompact = true,
-                onCancel = onCancelLinkPreview
+        stagedAttachments.forEach { att ->
+            StagedAttachmentRow(
+                attachment = att,
+                onCancel = { onCancelAttachment(att.id) },
             )
         }
         val pasteModifier = if (onPasteImage != null) {
@@ -453,9 +470,9 @@ fun MessageTextFieldCompact(
     modifier: Modifier = Modifier,
     focusRequester: FocusRequester,
     state: RichTextState,
-    linkPreviewData: LinkPreview?,
+    stagedAttachments: List<StagedAttachment>,
     recordingData: RecordingData?,
-    onCancelLinkPreview: () -> Unit,
+    onCancelAttachment: (id: String) -> Unit,
     editExistingMode: Boolean,
     showingEmojiSheet: Boolean,
     onEmojiClick: () -> Unit,
@@ -473,7 +490,10 @@ fun MessageTextFieldCompact(
     onSendMessage: () -> Unit,
     onCancelEdit: () -> Unit,
 ) {
-    val showSendButton = state.annotatedString.isNotBlank()
+    // Send button is shown when there's text OR a user-initiated attachment (not link previews,
+    // which are auto-detected from typed URLs and don't on their own indicate intent to send).
+    val showSendButton = state.annotatedString.isNotBlank() ||
+        stagedAttachments.any { it !is StagedLinkPreview }
     val showRecordingButton by remember(
         editExistingMode,
         showSendButton
@@ -552,12 +572,10 @@ fun MessageTextFieldCompact(
 //            if (!isKeyboardFocused) {
 //                Spacer(modifier = Modifier.height(48.dp))
 //            }
-            if (linkPreviewData != null) {
-                LinkPreviewCard(
-                    linkPreview = linkPreviewData,
-                    modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
-                    isCompact = true,
-                    onCancel = onCancelLinkPreview
+            stagedAttachments.forEach { att ->
+                StagedAttachmentRow(
+                    attachment = att,
+                    onCancel = { onCancelAttachment(att.id) },
                 )
             }
         } else {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/StagedAttachmentRow.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/StagedAttachmentRow.kt
@@ -1,0 +1,33 @@
+package id.homebase.chat.widget
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import id.homebase.chat.services.staged.StagedAttachment
+import id.homebase.chat.services.staged.StagedLinkPreview
+
+/**
+ * UI dispatcher for a single staged attachment shown above the chat input bar.
+ *
+ * One `when` branch per [StagedAttachment] subtype — the only place the composer needs to know
+ * how each kind looks. Adding a new kind: add a branch here that delegates to its existing
+ * `XyzPreviewCard(isCompact = true, onCancel = ...)`.
+ */
+@Composable
+fun StagedAttachmentRow(
+    attachment: StagedAttachment,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val rowModifier = modifier.fillMaxWidth().padding(bottom = 8.dp)
+    when (attachment) {
+        is StagedLinkPreview -> LinkPreviewCard(
+            linkPreview = attachment.preview,
+            modifier = rowModifier,
+            isCompact = true,
+            onCancel = onCancel,
+        )
+    }
+}


### PR DESCRIPTION
The chat composer carried link previews via dedicated `linkPreviewData` / `onCancelLinkPreview` parameters threaded through `MessageInputBar`, `MessageTextFieldExpanded`, `MessageTextFieldCompact`, and a `linkPreview: LinkPreview?` field on `ConversationListUiAction.SendMessage`
+ `addMessage`/`replyToMessage`. Adding a second preview kind would have meant repeating that plumbing on every layer.

Replace it with a hoisted `List<StagedAttachment>` slot:

- New `StagedAttachment` sealed interface in `services/staged/`, with a single concrete case today (`StagedLinkPreview`). Stable `id` lets the cancel-X button and the URL-detector deduplicate by identity.
- New `List<StagedAttachment>.toCombinedPayloadBundle(fileOps)` extension — one `when` dispatch maps each kind to its existing `XyzPayloadBuilder`. Replaces the per-kind `?.let { … }` paths in the ViewModel.
- New `StagedAttachmentRow` Compose dispatcher — one `when` branch per kind, delegates to the existing `LinkPreviewCard(isCompact = true, …)`.
- `MessageInputBar` no longer owns `linkPreviewData`. The URL-detector `LaunchedEffect` now produces a `StagedLinkPreview` into the parent-owned list via `onStagedAttachmentsChange`. `cancelledUrls` / `lastFetchedUrl` / 250 ms debounce semantics preserved verbatim.
- `MessageTextFieldExpanded` / `MessageTextFieldCompact` lose their two preview params and gain `stagedAttachments` + `onCancelAttachment(id)`. Render block is a single `forEach { StagedAttachmentRow(…) }`.
- `showSendButton` predicate gains `|| stagedAttachments.any { it !is StagedLinkPreview }` so future user-initiated kinds (location, contact, …) enable send without text. Link-preview-only behaviour is unchanged.
- `ConversationContent` owns `stagedAttachments` at the top level so user-initiated flows (e.g. an attachment-sheet location picker) can append from outside the input bar. Cleared on send.
- `ConversationListUiAction.SendMessage` swaps `linkPreview` for `stagedAttachments: List<StagedAttachment>`. `addMessage` and `replyToMessage` lose their `linkPreview` param and call `toCombinedPayloadBundle` once.

Adding the next attachment kind is now a 3-line change: a sealed-interface case, a `when` branch in the row dispatcher, a `when` branch in the bundle combiner. No new composer params, no new ViewModel branches, no new UiAction fields.

Wire format unchanged. Receiver render unchanged. Behaviour preserved (text-only send, URL-detected link preview, cancel-then-no-refetch, URL replacement, edit-message flow). Builds clean on JVM, Android, and iOS; JVM tests pass.