### PR TITLE
fix: propagate peer-synced lastRead in updateConversation

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -601,6 +601,12 @@ class ConversationStream(
             conversationState = resolvedState,
             exitedAt = resolvedExitedAt,
             fileUpdated = incoming.fileUpdated,
+            // Carries the conversation file's localAppData.lastReadTime forward —
+            // a peer device's mark-as-read advances it, syncs it, and we'd otherwise
+            // drop it here, which leaves enrichAllConversationsWithUnreadCounts
+            // mirroring modelMs=0 and skipping the ChatReadCount upsert. Max
+            // keeps it monotonic against a stale drive-sync echo.
+            lastRead = if (incoming.lastRead > existing.lastRead) incoming.lastRead else existing.lastRead,
             // Message preview — only overwrite if the file carries a newer last-message snapshot
             latestMessageTimestamp = if (incoming.latestMessageTimestamp >= existing.latestMessageTimestamp) incoming.latestMessageTimestamp else existing.latestMessageTimestamp,
             lastMessage = if (incoming.latestMessageTimestamp >= existing.latestMessageTimestamp) incoming.lastMessage else existing.lastMessage,


### PR DESCRIPTION
When a conversation file arrives via BatchReceived for a conversation already in memory (returning user, or placeholder being replaced), ConversationStream.updateConversation copied every incoming field EXCEPT lastRead. The in-memory ConversationUiModel.lastRead therefore stayed pinned at whatever the existing row had — typically epoch 0 for a placeholder or a stale local-DB row.

The cold-load mirror in enrichAllConversationsWithUnreadCounts reads that same in-memory lastRead to decide whether to upsert into ChatReadCount. With modelMs=0 and storedMs=0 (fresh ChatReadCount), the guard `modelMs > storedMs` fails, the upsert is skipped, and the next selectAllUnreadCount returns every peer message as unread.

Net effect: opening Desktop with a populated local DB but a fresh ChatReadCount made every conversation come back showing thousands of unread messages, even when the peer device had marked them read and synced localAppData.lastReadTime through to this device's server.

Fix: copy incoming.lastRead into the merged model, taking max so the field stays monotonic if a stale drive-sync echo arrives after a newer local mark-as-read advance.

The insertNewConversation path was already correct (the freshly-mapped ConversationUiModel from mapToBasic carries localAppData.lastReadTime), and local mark-as-read goes through applyLocalAdvance, which patches in-memory lastRead directly — neither path needed changes.