### PR TITLE
defragger: catch corrupt content, prune in-memory, freeze layout

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -543,7 +543,11 @@ class ChatMessageStream(
             } catch (t: Throwable) {
 
                 Logger.e(t) {
-                    "failed while mapping a message with uniqueId ${appData.uniqueId} and fileId ${header.fileId} appData=[${appData}]. Message: ${t.message}"
+                    "failed while mapping a message with uniqueId ${appData.uniqueId} and fileId ${header.fileId} " +
+                            "created=${metadata.created} updated=${metadata.updated} transitCreated=${metadata.transitCreated} " +
+                            "originalAuthor=${metadata.originalAuthor?.domainName} senderOdinId=${metadata.senderOdinId?.domainName} " +
+                            "versionTag=${metadata.versionTag} globalTransitId=${metadata.globalTransitId} " +
+                            "appData=[${appData}]. Message: ${t.message}"
                 }
 
                 try {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterScreen.kt
@@ -209,13 +209,14 @@ private fun DefragmenterContent(
 
         val reviewTotal =
             state.corruptHeaderCandidates.size + state.corruptMessageCandidates.size
-        if (reviewTotal > 0) {
-            Win98Button(
-                text = stringResource(MR.string.defragmenter_review_button, reviewTotal),
-                enabled = true,
-                onClick = { onAction(DefragmenterUiAction.OpenReview) },
-            )
-        }
+        // Render unconditionally so the grid panel above retains the same
+        // height across phases — without this, the button appearing/disappearing
+        // mid-analyze visibly resizes every block.
+        Win98Button(
+            text = stringResource(MR.string.defragmenter_review_button, reviewTotal),
+            enabled = reviewTotal > 0,
+            onClick = { onAction(DefragmenterUiAction.OpenReview) },
+        )
     }
 
     if (state.showReviewDialog) {
@@ -290,44 +291,40 @@ private fun StatsPanel(state: DefragmenterUiState, modifier: Modifier = Modifier
                 stringResource(MR.string.defragmenter_stat_eta, formatDuration(state.estRemainingMs))
             )
             // Per-issue tallies + colour swatches so the user can map block
-            // colour → meaning at a glance. Hidden when the count is zero so
-            // the panel doesn't grow until issues actually exist.
-            if (state.issueCountLegacyUserDateZero > 0) {
-                Win98Label(
-                    text = "Legacy userDate=0: ${state.issueCountLegacyUserDateZero}",
-                    color = Win98Palette.IssueLegacyUserDateZeroFill,
-                )
-            }
-            if (state.issueCountArchivalMismatch > 0) {
-                Win98Label(
-                    text = "Soft-delete drift: ${state.issueCountArchivalMismatch}",
-                    color = Win98Palette.IssueArchivalMismatchFill,
-                )
-            }
-            if (state.issueCountCorruptJson > 0) {
-                Win98Label(
-                    text = "Bad header blocks: ${state.issueCountCorruptJson}",
-                    color = Win98Palette.IssueCorruptJsonFill,
-                )
-            }
-            if (state.issueCountUnmappableConvo > 0) {
-                Win98Label(
-                    text = "Unmappable conversation: ${state.issueCountUnmappableConvo}",
-                    color = Win98Palette.IssueUnmappableConvoFill,
-                )
-            }
-            if (state.issueCountOrphanMessage > 0) {
-                Win98Label(
-                    text = "Orphan messages: ${state.issueCountOrphanMessage}",
-                    color = Win98Palette.IssueOrphanMessageFill,
-                )
-            }
-            if (state.issueCountCorruptMessageContent > 0) {
-                Win98Label(
-                    text = "Bad message blocks: ${state.issueCountCorruptMessageContent}",
-                    color = Win98Palette.IssueCorruptMessageContentFill,
-                )
-            }
+            // colour → meaning at a glance. Always rendered so the panel
+            // height is constant across phases — without this, rows popping
+            // in mid-analyze shrink the grid panel above and visibly clip
+            // its bottom row of cells.
+            IssueTallyRow(
+                label = "Legacy userDate=0",
+                count = state.issueCountLegacyUserDateZero,
+                activeColor = Win98Palette.IssueLegacyUserDateZeroFill,
+            )
+            IssueTallyRow(
+                label = "Soft-delete drift",
+                count = state.issueCountArchivalMismatch,
+                activeColor = Win98Palette.IssueArchivalMismatchFill,
+            )
+            IssueTallyRow(
+                label = "Bad header blocks",
+                count = state.issueCountCorruptJson,
+                activeColor = Win98Palette.IssueCorruptJsonFill,
+            )
+            IssueTallyRow(
+                label = "Unmappable conversation",
+                count = state.issueCountUnmappableConvo,
+                activeColor = Win98Palette.IssueUnmappableConvoFill,
+            )
+            IssueTallyRow(
+                label = "Orphan messages",
+                count = state.issueCountOrphanMessage,
+                activeColor = Win98Palette.IssueOrphanMessageFill,
+            )
+            IssueTallyRow(
+                label = "Bad message blocks",
+                count = state.issueCountCorruptMessageContent,
+                activeColor = Win98Palette.IssueCorruptMessageContentFill,
+            )
         }
     }
 }
@@ -384,6 +381,18 @@ private fun ActionButtons(state: DefragmenterUiState, onAction: (DefragmenterUiA
             )
         }
     }
+}
+
+/**
+ * One legend row in the StatsPanel issue tallies. Always rendered (even when
+ * count is zero) so the panel keeps a constant height across phases. Coloured
+ * with the issue's swatch when active; muted grey when zero so the legend
+ * reads as "this bucket is empty so far" rather than as a coloured signal.
+ */
+@Composable
+private fun IssueTallyRow(label: String, count: Int, activeColor: Color) {
+    val color = if (count > 0) activeColor else Win98Palette.Black.copy(alpha = 0.45f)
+    Win98Label(text = "$label: $count", color = color)
 }
 
 @Composable

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterViewModel.kt
@@ -16,6 +16,8 @@ import id.homebase.core.ui.screens.defragmenter.service.DefragAnalyzeEvent
 import id.homebase.core.ui.screens.defragmenter.service.DefragRepairEvent
 import id.homebase.core.ui.screens.defragmenter.service.DefragSource
 import id.homebase.core.ui.screens.defragmenter.service.DeletedFileRef
+import id.homebase.core.ui.screens.defragmenter.service.MessageContentQuarantineCandidate
+import id.homebase.core.ui.screens.defragmenter.service.QuarantineCandidate
 import kotlin.uuid.Uuid
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -755,20 +757,44 @@ class DefragmenterViewModel(
                 break
             }
         }
-        _uiState.update {
-            val tally = if (isMessageContent) {
-                it.copy(
-                    issueCountCorruptMessageContent =
-                        (it.issueCountCorruptMessageContent - 1).coerceAtLeast(0),
-                )
+        // Atomically prune the deleted entry from the in-memory candidate list,
+        // adjust counts, and re-derive reviewIndex / showReviewDialog. Done in
+        // a single _uiState.update so Compose snapshots the new lists and
+        // index together — the dialog never sees a stale entry vs an advanced
+        // index. After removing the entry at reviewIndex, that index already
+        // points at the *next* candidate, so we don't bump it.
+        _uiState.update { current ->
+            val newHeader: List<QuarantineCandidate>
+            val newMessage: List<MessageContentQuarantineCandidate>
+            if (isMessageContent) {
+                val msgIdx = current.reviewIndex - current.corruptHeaderCandidates.size
+                newHeader = current.corruptHeaderCandidates
+                newMessage = current.corruptMessageCandidates.toMutableList()
+                    .apply { if (msgIdx in indices) removeAt(msgIdx) }
             } else {
-                it.copy(
-                    issueCountCorruptJson = (it.issueCountCorruptJson - 1).coerceAtLeast(0),
-                )
+                val hdrIdx = current.reviewIndex
+                newHeader = current.corruptHeaderCandidates.toMutableList()
+                    .apply { if (hdrIdx in indices) removeAt(hdrIdx) }
+                newMessage = current.corruptMessageCandidates
             }
-            tally.copy(gridVersion = it.gridVersion + 1)
+            val newTotal = newHeader.size + newMessage.size
+            val newIndex =
+                if (newTotal == 0) 0 else current.reviewIndex.coerceAtMost(newTotal - 1)
+            val showDialog = current.showReviewDialog && newTotal > 0
+            current.copy(
+                corruptHeaderCandidates = newHeader,
+                corruptMessageCandidates = newMessage,
+                reviewIndex = newIndex,
+                showReviewDialog = showDialog,
+                issueCountCorruptMessageContent = if (isMessageContent)
+                    (current.issueCountCorruptMessageContent - 1).coerceAtLeast(0)
+                else current.issueCountCorruptMessageContent,
+                issueCountCorruptJson = if (!isMessageContent)
+                    (current.issueCountCorruptJson - 1).coerceAtLeast(0)
+                else current.issueCountCorruptJson,
+                gridVersion = current.gridVersion + 1,
+            )
         }
-        advanceReviewIndex()
     }
 
     private fun advanceReviewIndex() {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/DefragRowClassifier.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/service/DefragRowClassifier.kt
@@ -144,7 +144,36 @@ internal suspend fun classifyRow(
         }
     }
 
-    // 5. Legacy null-userDate (chat messages only).
+    // 5. Chat message (7878) whose appData.content fails strict deserialise.
+    //    Placed AFTER the OrphanChatMessage branch so an orphan that *also*
+    //    has corrupt content stays classified as orphan — recovering the
+    //    parent may resolve both at once. Placed BEFORE LegacyUserDateZero
+    //    because a corrupt-content row often *also* has a null userDate
+    //    (older corrupt rows commonly never had userDate stamped); without
+    //    this ordering the row would be classified Legacy and "repaired"
+    //    by stamping a userDate, which leaves the unreadable content in
+    //    place and the consumer keeps throwing on every cold-load.
+    //    Probe is null in tests / when the caller doesn't want runtime-typed
+    //    decode (e.g. probe-disabled).
+    if (fileType == MESSAGE_FILE_TYPE && decodeMessageContentProbe != null) {
+        val err = decodeMessageContentProbe(header)
+        if (err != null) {
+            val content = header.fileMetadata.appData.content
+            return CellState.CorruptMessageContent(
+                driveId = driveId,
+                fileId = row.fileId,
+                rowId = row.rowId,
+                conversationId = header.fileMetadata.appData.groupId,
+                originalAuthor = header.fileMetadata.originalAuthor,
+                sender = header.fileMetadata.senderOdinId,
+                createdMs = header.fileMetadata.created.milliseconds,
+                decodeError = err.message?.take(200),
+                rawContentPrefix = content?.take(4000) ?: "",
+            )
+        }
+    }
+
+    // 6. Legacy null-userDate (chat messages only).
     //
     // Gates only on `appData.userDate == null` in the parsed JSON header
     // (the source of truth the consumer reads). Deliberately ignores
@@ -163,29 +192,6 @@ internal suspend fun classifyRow(
             rowId = row.rowId,
             createdMs = header.fileMetadata.created.milliseconds,
         )
-    }
-
-    // 6. Chat message (7878) whose appData.content fails strict deserialise.
-    //    Placed AFTER the OrphanChatMessage branch so an orphan that *also*
-    //    has corrupt content stays classified as orphan — recovering the
-    //    parent may resolve both at once. Probe is null in tests / when
-    //    the caller doesn't want runtime-typed decode (e.g. probe-disabled).
-    if (fileType == MESSAGE_FILE_TYPE && decodeMessageContentProbe != null) {
-        val err = decodeMessageContentProbe(header)
-        if (err != null) {
-            val content = header.fileMetadata.appData.content
-            return CellState.CorruptMessageContent(
-                driveId = driveId,
-                fileId = row.fileId,
-                rowId = row.rowId,
-                conversationId = header.fileMetadata.appData.groupId,
-                originalAuthor = header.fileMetadata.originalAuthor,
-                sender = header.fileMetadata.senderOdinId,
-                createdMs = header.fileMetadata.created.milliseconds,
-                decodeError = err.message?.take(200),
-                rawContentPrefix = content?.take(4000) ?: "",
-            )
-        }
     }
 
     // 7. Default.

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/defragmenter/service/DefragRowClassifierTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/defragmenter/service/DefragRowClassifierTest.kt
@@ -112,6 +112,37 @@ class DefragRowClassifierTest {
     }
 
     @Test
+    fun classify_messageWithNullUserDateAndCorruptContent_corruptWinsOverLegacy() = runTest {
+        // Older corrupt rows commonly carry both a null appData.userDate and an
+        // unparseable content blob. If LegacyUserDateZero takes priority, the
+        // repair pass stamps a userDate and leaves the unreadable content in
+        // place — the consumer keeps throwing on every cold-load. CorruptMessageContent
+        // must take priority so the row surfaces in the user-review queue.
+        val row = chatMessageRow(
+            content = "?garbage{",
+            groupId = convoId,
+            headerUserDate = null,
+            rowUserDate = 0L,
+        )
+        val probe: suspend (HomebaseFile) -> Throwable? = {
+            IllegalStateException("expected '{' but got '?'")
+        }
+
+        val state = classifyRow(
+            driveId = driveId,
+            row = row,
+            mapToBasicProbe = null,
+            healthyConversationIds = healthyConvos,
+            decodeMessageContentProbe = probe,
+        )
+
+        assertTrue(
+            state is CellState.CorruptMessageContent,
+            "expected CorruptMessageContent to win over LegacyUserDateZero, got $state",
+        )
+    }
+
+    @Test
     fun classify_messageWithNullHeaderUserDate_returnsLegacyUserDateZero() = runTest {
         // Even when the SQL `userDate` column has been previously repaired
         // (non-zero), a null in the parsed `appData.userDate` re-flags the


### PR DESCRIPTION
Five related fixes after diagnosing a stale corrupt chat-message row that the Defragmenter was failing to surface:

1. ChatMessageStream.mapToMessageData catch block now logs the row's created/updated/transitCreated timestamps and originalAuthor / senderOdinId / versionTag / globalTransitId. Without these, a corrupt-content failure printed only the raw appData blob, leaving no way to tell whether the row was an ancient artifact or a fresh regression.

2. DefragRowClassifier reorders steps 5 and 6 so CorruptMessageContent takes priority over LegacyUserDateZero. Older corrupt rows commonly carry both `appData.userDate == null` and an unparseable content blob; the previous order classified them as Legacy, "repaired" them by stamping a userDate, and left the unreadable content in place — so the consumer kept throwing on every cold-load. Added a regression test that pins the new precedence.

3. DefragmenterScreen renders the "Review N bad blocks" button unconditionally (disabled when N == 0). The conditional render was making the grid panel above (.weight(1f)) shrink the moment the first corrupt cell was found, snapping every block to a new pixel size mid-analyze.

4. DefragmenterScreen.StatsPanel renders all six per-issue tally rows unconditionally — muted grey when 0, issue colour when > 0. Without this the panel grew row-by-row as new issue types were discovered, shifting the page up and clipping the bottom row of the grid.

5. DefragmenterViewModel.reviewDelete now prunes the deleted candidate from corruptHeaderCandidates / corruptMessageCandidates inside the same _uiState.update that adjusts counts and re-derives reviewIndex / showReviewDialog. The dialog never sees a half-updated state because Compose snapshots the new lists and the new index together. Previously the Review button kept the original count and reopening the dialog walked past the now-deleted entries.