### PR TITLE
fix

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
@@ -105,6 +105,15 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
     }
 
     private fun initShareFlow() {
+        // Kick the conversation and contact loaders. start() is idempotent — a no-op
+        // when MainActivity has already booted them via AuthConnectionCoordinator's
+        // onPostAuthenticated hook. On a true cold start whose first activity is this
+        // one (process force-killed, then a generic share), MainActivity never runs,
+        // AuthConnectionCoordinator is never instantiated as a Koin singleton, and
+        // the SharePickerScreen would otherwise spin on dataReady=false forever.
+        conversationStream.start()
+        contactService.start()
+
         // Extract shared content
         val tempDir = File(cacheDir, "share_temp")
         val sharedContent = SharedContentExtractor.extract(intent, contentResolver, tempDir)


### PR DESCRIPTION
fix(share): kick streams from ShareReceiverActivity so the picker loads on cold start

When the user shares to the generic Homebase app icon (not a Direct Share
quick link) and the Homebase process has been killed, ShareReceiverActivity
is the first activity to launch. SharePickerScreen subscribes to
ConversationStream.conversations and gates its spinner on
ConversationsData.dataReady, which only flips to true inside
ConversationStream.start() after loadBasicConversations() runs.

start() is normally invoked from AuthConnectionCoordinator's
onPostAuthenticated lambda (AppModule.kt:177). The coordinator is a Koin
singleton instantiated lazily on first get() — but ShareReceiverActivity
never resolves it. On a cold-start share, MainActivity / AppLoadingViewModel
never run, the coordinator is never constructed, the lambda never fires, and
the picker spins forever on dataReady = false. ContactService.start() is
gated through the same hook, so even once conversations loaded, the contact
map fed to ConversationEnricher would be empty and 1:1 conversations would
render with fallback names.

Fix: call conversationStream.start() and contactService.start() at the top
of initShareFlow(), after the auth-state wait. Both methods are guarded by
an idempotent `started` flag, so this is a no-op when MainActivity already
booted them in the warm-process case. Mirrors the pattern in
ConversationListViewModel.kt:322-323 and ArchivedConversationsViewModel.kt.

Direct Share shortcut path is unaffected — it bypasses the picker entirely.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>