### PR TITLE
fix(chat): gate group-heal status with HealAppliedTag

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPreloader.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPreloader.kt
@@ -56,7 +56,7 @@ class VideoPreloader(
             mutexMap.getOrPut(key) { Mutex() } to progressMap.getOrPut(key) { MutableStateFlow(0f) }
         }
         val emit: (Float) -> Unit = { v ->
-            Logger.d(tag = "VideoIO") { "preload emit: ${data.fileId}/${data.payloadKey} v=$v" }
+            // Logger.d(tag = "VideoIO") { "preload emit: ${data.fileId}/${data.payloadKey} v=$v" } // floods log — fires per ~4KB HTTP chunk
             progressSink.value = v
             onProgress?.invoke(v)
         }

--- a/homebase-chat/src/androidMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.android.kt
+++ b/homebase-chat/src/androidMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.android.kt
@@ -99,7 +99,7 @@ actual fun VideoPlayerSurface(
                         val progressJob = scope.launch {
                             var highWater = 0f
                             videoPreloader.progressFlow(data.fileId, data.payloadKey).collect { p ->
-                                Logger.d(tag = "VideoIO") { "hls surface progress: fileId=${data.fileId} p=$p" }
+                                // Logger.d(tag = "VideoIO") { "hls surface progress: fileId=${data.fileId} p=$p" } // floods log — fires per ~4KB HTTP chunk
                                 if (p > highWater) highWater = p
                                 if (highWater < 1f) onProgress(highWater)
                             }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatProtocol.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatProtocol.kt
@@ -43,6 +43,15 @@ object ChatProtocol {
     /** Local metadata tag: conversation has been pinned by the user */
     val ConversationPinnedTag = Uuid.parse("3f7e4c1d-5a2b-4f89-b3e7-9c1d2e3f4a5b")
 
+    /** Local metadata tag: this GroupHealRequested status message has already been
+     *  applied on this recipient's drive. Idempotency gate for
+     *  `ConversationService.handleIncomingHealRequest` — without it, a heal status
+     *  message that is reprocessed (cursor reset, full re-sync, sibling device)
+     *  could re-classify a now-canonical local file as broken and hard-delete it
+     *  against a stale canonical-versionTag snapshot. The marker rides on the
+     *  message file's localAppData and syncs across the recipient's devices. */
+    val HealAppliedTag = Uuid.parse("c5b2e1d4-8a7f-4d6e-a3c2-1b9e8f7d6c5a")
+
     /** Server-side appData tag: conversation was originally created as a group (never removed) */
     val ConversationGroupTag = Uuid.parse("b4e3c2d1-7f6a-4e8b-9c5d-1a2b3c4d5e6f")
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -2044,10 +2044,27 @@ class ConversationService(
      *     don't resurrect groups the user has explicitly left.
      *   - Both local files match the canonical identity.
      */
-    suspend fun handleIncomingHealRequest(status: StatusMessageData, sender: OdinId) {
+    suspend fun handleIncomingHealRequest(
+        status: StatusMessageData,
+        sender: OdinId,
+        messageFile: HomebaseFile,
+    ) {
         val info = status.groupHeal ?: return
         val audit = MethodAudit("handleIncomingHealRequest")
-        audit.start("conversationId=${info.conversationUniqueId} sender=${sender.domainName} canonicalAuthor=${info.canonicalOriginalAuthor.domainName}")
+        audit.start("conversationId=${info.conversationUniqueId} sender=${sender.domainName} canonicalAuthor=${info.canonicalOriginalAuthor.domainName} messageFileId=${messageFile.fileId}")
+
+        // Per-message idempotency gate. The marker rides on this status message
+        // file's localAppData and syncs across the recipient's devices, so a
+        // re-fired BatchReceived (cursor reset, full re-sync, sibling device)
+        // can't replay the destructive cleanup against state that has since
+        // moved on (e.g. canonical author bumped the group's versionTag —
+        // isFileBroken would otherwise misread that as a divergence).
+        val currentTags = messageFile.fileMetadata.localAppData?.tags?.toSet().orEmpty()
+        if (ChatProtocol.HealAppliedTag in currentTags) {
+            audit.info("HealAppliedTag already present on status message ${messageFile.fileId} — skipping")
+            audit.finish("already-applied")
+            return
+        }
 
         // Forgery guard: only the canonical author can announce themselves.
         if (sender != info.canonicalOriginalAuthor) {
@@ -2094,6 +2111,11 @@ class ConversationService(
 
         if (!mainBroken && !adminBroken) {
             audit.info("nothing to clean up — local copies match canonical identity")
+            // Still mark applied: if we don't, a future BatchReceived carrying
+            // this same heal message could re-evaluate against a now-different
+            // local versionTag (canonical author updated the group in the
+            // interim) and misclassify the file as broken.
+            markHealApplied(messageFile, currentTags, audit)
             audit.finish("no-op")
             return
         }
@@ -2178,7 +2200,56 @@ class ConversationService(
             Logger.w(e) { "handleIncomingHealRequest: failed to write GroupHealLocalCleanup status for ${info.conversationUniqueId}" }
         }
 
+        // Mark the status message file as applied so this device — and, once
+        // the upload lands, sibling devices — short-circuit on any future
+        // BatchReceived carrying the same heal message.
+        markHealApplied(messageFile, currentTags, audit)
+
         audit.finish("cleanedUpMain=$mainBroken cleanedUpAdmin=$adminBroken")
+    }
+
+    /**
+     * Writes [ChatProtocol.HealAppliedTag] into the status message file's
+     * `localAppData.tags` (optimistic) and enqueues the server upload so the
+     * marker syncs across the recipient's devices. Failure is logged but not
+     * propagated — the heal action itself has already succeeded.
+     */
+    private suspend fun markHealApplied(
+        messageFile: HomebaseFile,
+        currentTags: Set<Uuid>,
+        audit: MethodAudit,
+    ) {
+        val messageUniqueId = messageFile.fileMetadata.appData.uniqueId
+        if (messageUniqueId == null) {
+            audit.checkWarn("markHealApplied", "status message has no uniqueId — cannot tag, idempotency falls back to isFileBroken")
+            return
+        }
+        val newTags = (currentTags + ChatProtocol.HealAppliedTag).toList()
+        audit.step(4, "updateLocalTags(+HealAppliedTag) on status message ${messageFile.fileId}")
+        runCatching {
+            optimisticWriter.updateLocalTags(
+                driveId = chatDrive,
+                uniqueId = messageUniqueId,
+                newTags = newTags,
+            )
+            outboxSync.tryEnqueue(
+                request = UpdateLocalMetadataTagsOutboxRequest(
+                    file = FileIdFileIdentifier(
+                        fileId = messageFile.fileId.toString(),
+                        targetDrive = chatTargetDrive,
+                    ),
+                    versionTag = messageFile.fileMetadata.localAppData?.versionTag?.toString(),
+                    tags = newTags.map { it.toString() },
+                ),
+                driveId = chatDrive,
+                uniqueId = Uuid.random(),
+                dependencyUniqueId = null,
+            )
+        }.onSuccess { audit.checkPass("healAppliedTagWritten") }
+            .onFailure { e ->
+                audit.threw("healAppliedTagWritten", e)
+                Logger.w(e) { "handleIncomingHealRequest: failed to write HealAppliedTag for status message ${messageFile.fileId}" }
+            }
     }
 
     private fun isFileBroken(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -96,8 +96,12 @@ class ConversationStream(
      * [StatusMessage.GroupHealRequested] status. Wired in AppModule to
      * [ConversationService.handleIncomingHealRequest]. Side effect only —
      * does not affect message-list dispatch.
+     *
+     * The status-message [HomebaseFile] is passed through so the handler can
+     * read/write its `localAppData.tags` and short-circuit on
+     * [ChatProtocol.HealAppliedTag] (per-message idempotency gate).
      */
-    var onIncomingHealRequest: (suspend (status: StatusMessageData, sender: OdinId) -> Unit)? = null
+    var onIncomingHealRequest: (suspend (status: StatusMessageData, sender: OdinId, messageFile: HomebaseFile) -> Unit)? = null
     // endregion
 
     // region Placeholder reconciliation
@@ -250,7 +254,7 @@ class ConversationStream(
             }.getOrNull() ?: continue
             if (status.statusMessage != StatusMessage.GroupHealRequested) continue
             try {
-                handler(status, sender)
+                handler(status, sender, file)
             } catch (e: Exception) {
                 Logger.e(e) { "ConversationStream: heal-request handler threw for sender=${sender.domainName}: ${e.message}" }
             }

--- a/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.jvm.kt
+++ b/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.jvm.kt
@@ -115,7 +115,7 @@ actual fun VideoPlayerSurface(
                         val progressJob = scope.launch {
                             var highWater = 0f
                             videoPreloader.progressFlow(data.fileId, data.payloadKey).collect { p ->
-                                Logger.d(tag = "VideoIO") { "hls surface progress: fileId=${data.fileId} p=$p" }
+                                // Logger.d(tag = "VideoIO") { "hls surface progress: fileId=${data.fileId} p=$p" } // floods log — fires per ~4KB HTTP chunk
                                 if (p > highWater) highWater = p
                                 if (highWater < 1f) onProgress(highWater)
                             }

--- a/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.native.kt
+++ b/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.native.kt
@@ -146,7 +146,7 @@ actual fun VideoPlayerSurface(
                         val progressJob = scope.launch {
                             var highWater = 0f
                             videoPreloader.progressFlow(data.fileId, data.payloadKey).collect { p ->
-                                Logger.d(tag = "VideoIO") { "hls surface progress: fileId=${data.fileId} p=$p" }
+                                // Logger.d(tag = "VideoIO") { "hls surface progress: fileId=${data.fileId} p=$p" } // floods log — fires per ~4KB HTTP chunk
                                 if (p > highWater) highWater = p
                                 if (highWater < 1f) onProgress(highWater)
                             }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -191,8 +191,8 @@ val appModule = module {
                 // endregion
 
                 // region Heal group: incoming GroupHealRequested status
-                conversationStream.onIncomingHealRequest = { status, sender ->
-                    conversationService.handleIncomingHealRequest(status, sender)
+                conversationStream.onIncomingHealRequest = { status, sender, messageFile ->
+                    conversationService.handleIncomingHealRequest(status, sender, messageFile)
                 }
                 // endregion
 


### PR DESCRIPTION
Group-heal status messages drive a destructive cleanup (`ConversationService.handleIncomingHealRequest` hard-deletes the recipient's local conversation/admin file when it diverges from the canonical author's snapshot). The previous gating was structural (only fires from `BackendEvent.DriveEvent.BatchReceived`) plus a `versionTag == null` placeholder check inside `isFileBroken`. That is not enough: the canonical versionTag inside the heal status message is a *snapshot at send time*, so if the canonical author later bumps the group's versionTag (title change, admin change, etc.) and the same heal status message is reprocessed (cursor reset, new device, full re-sync, sibling device), `isFileBroken` reads the now-stale snapshot and re-classifies a perfectly fine local file as broken — deleting it.

Fix: a per-status-message idempotency tag, riding on the message file's own `localAppData.tags` and uploaded via the existing `UpdateLocalMetadataTagsOutboxRequest` path. The marker syncs to the recipient's server and across their devices using the same plumbing as `LeftTag`/`ArchivedTag`/`PinnedTag`.

Changes:
  - Add `ChatProtocol.HealAppliedTag`.
  - `ConversationStream.onIncomingHealRequest` now also passes the status-message `HomebaseFile` through to the handler.
  - `ConversationService.handleIncomingHealRequest` short-circuits if the tag is already present, and writes it after both the cleanup-applied path and the no-op match path (the no-op case matters too — without marking it, a later canonical update would let a re-fire of this message misclassify and delete). `markHealApplied` does an optimistic local upsert via `OptimisticWriter.updateLocalTags` and enqueues the server-side upload.
  - `AppModule` DI lambda updated for the new arg.
  - The legacy `versionTag == null` check in `isFileBroken` is kept as defence-in-depth for the narrow window between cleanup and the marker write landing locally.

Drive-by: comment out the per-progress-emit `Logger.d` lines on the HLS video preload path that fire on every ~4 KB HTTP chunk and were flooding the log:
  - `VideoPreloader.preload` emit lambda
  - `VideoPlayerSurface.{jvm,android,native}` HLS progress collectors

Tests: `./gradlew homebase-chat:jvmTest homebase-auth:jvmTest homebase-common:jvmTest homebase-api:jvmTest --rerun-tasks` → BUILD SUCCESSFUL.