### PR TITLE
fix(chat): skip mobile gallery strip on desktop attachment sheet

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -129,6 +129,7 @@ import id.homebase.core.avatars.ConversationAvatar
 import id.homebase.core.util.dismissKeyboardOnTap
 import id.homebase.core.util.initials
 import id.homebase.core.util.isDesktop
+import id.homebase.core.util.isMobile
 import id.homebase.core.util.isWeb
 import id.homebase.core.util.keyboardAsState
 import id.homebase.core.util.programmaticBackspace
@@ -1216,17 +1217,24 @@ fun ConversationContent(
                         .height(keyboardHeight.coerceAtLeast(300.dp)),
                     visible = showAttachmentSheet && !isKeyboardVisible,
                 ) {
-                    AttachmentGallery(
-                        onImageSelected = {
-                            showAttachmentSheet = false
-                            onUiAction(
-                                ConversationListUiAction.AttachGalleryItem(
-                                    conversationId = conversation.conversation.id,
-                                    files = listOf(it)
+                    // The gallery thumb strip reads the OS photo library via GalleryCache,
+                    // which only exists on Android/iOS. On desktop/web the row would be
+                    // empty, so we skip it entirely and let the icon row sit at the top of
+                    // the sheet. The 300 dp height floor on AttachmentOptionsDisplay still
+                    // applies — desktop can host a virtual keyboard, so the floor stays.
+                    if (isMobile()) {
+                        AttachmentGallery(
+                            onImageSelected = {
+                                showAttachmentSheet = false
+                                onUiAction(
+                                    ConversationListUiAction.AttachGalleryItem(
+                                        conversationId = conversation.conversation.id,
+                                        files = listOf(it)
+                                    )
                                 )
-                            )
-                        },
-                    )
+                            },
+                        )
+                    }
                     AttachmentOptions(onGalleryClick = {
                         showAttachmentSheet = false
                         galleryLauncher.launch()


### PR DESCRIPTION
When opening the attachment sheet (+) on Desktop, the icon row was preceded by an empty band where the photo-gallery thumb strip lives on mobile. AttachmentGallery is internally gated on isMobile() and emits nothing off-mobile, but it was still being placed inside the AttachmentOptionsDisplay column, leaving the icon row anchored below empty space inside the 300 dp height floor.

Skip the AttachmentGallery call entirely when !isMobile() so the icon row sits at the top of the sheet on desktop and web. The 300 dp floor on AttachmentOptionsDisplay is preserved — desktop can host a virtual keyboard, and matching keyboardHeight prevents layout jumps when one is shown.

The internal isMobile() guard inside AttachmentGallery is left in place as defense-in-depth; GalleryCache and rememberGalleryPermissionState are not wired for desktop and the function should remain self-contained for any future caller.