### PR TITLE
Redesign reaction emoji UX to match Signal/WhatsApp

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -76,6 +76,7 @@ data class MessageListUiState(
     val isEditingVersionTag: Uuid? = null,
     val ownerSession: OwnerSession? = null,
     val messageReactions: List<ReactionDisplayItem>? = null,
+    val reactionDetailsMessageId: Uuid? = null,
     val isReactionsLoading: Boolean = false,
     val downloadingFiles: Set<String> = emptySet(),
     val recordingData: RecordingData? = null,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -1694,11 +1694,12 @@ class ConversationListViewModel(
             }
 
             is ConversationListUiAction.ShowReactionDetails -> {
+                _messagesUiState.update { it.copy(reactionDetailsMessageId = action.messageId) }
                 loadReactionDetails(action.messageId)
             }
 
             is ConversationListUiAction.HideReactionDetails -> {
-                _messagesUiState.update { it.copy(messageReactions = null, isReactionsLoading = false) }
+                _messagesUiState.update { it.copy(messageReactions = null, isReactionsLoading = false, reactionDetailsMessageId = null) }
             }
 
             is ConversationListUiAction.ShowContactInfo -> {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -460,6 +460,18 @@ fun ConversationContent(
             onContactClick = { odinId ->
                 onUiAction(ConversationListUiAction.ShowContactInfo(odinId))
             },
+            onAddReaction = uiState.reactionDetailsMessageId?.let { messageId ->
+                { emoji: String ->
+                    onUiAction(
+                        ConversationListUiAction.ToggleReaction(
+                            conversationId = conversation.conversation.id,
+                            messageId = messageId,
+                            reaction = emoji,
+                        )
+                    )
+                    onUiAction(ConversationListUiAction.HideReactionDetails)
+                }
+            },
             onDismiss = { onUiAction(ConversationListUiAction.HideReactionDetails) },
         )
     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -291,8 +291,8 @@ fun SentMessageBubble(
                         ReactionList(
                             modifier = Modifier.align(Alignment.BottomStart).padding(start = 4.dp),
                             reactionSummary = reactionSummary,
-                            onClick = { onAddReaction?.invoke(message.id, it) },
-                            onLongClick = { onShowReactions?.invoke() },
+                            onReactionClick = { onShowReactions?.invoke() },
+                            onAddEmoji = onAddReaction?.let { { popupMode = MessagePopupMode.Reaction } },
                         )
                     }
                 }
@@ -329,8 +329,7 @@ fun SentMessageBubbleDisplayOnly(
             ReactionList(
                 modifier = Modifier.align(Alignment.BottomStart).padding(start = 4.dp),
                 reactionSummary = reactionSummary,
-                onClick = { },
-                onLongClick = { },
+                onReactionClick = { },
             )
         }
     }
@@ -473,8 +472,8 @@ fun ReceivedMessageBubble(
                                 modifier = Modifier.align(Alignment.BottomEnd)
                                     .padding(end = 4.dp),
                                 reactionSummary = reactionSummary,
-                                onClick = { onAddReaction?.invoke(message.id, it) },
-                                onLongClick = { onShowReactions?.invoke() },
+                                onReactionClick = { onShowReactions?.invoke() },
+                                onAddEmoji = onAddReaction?.let { { popupMode = MessagePopupMode.Reaction } },
                             )
                         }
                     }
@@ -649,8 +648,7 @@ fun ReceivedMessageBubbleDisplayOnly(
             ReactionList(
                 modifier = Modifier.align(Alignment.BottomStart).padding(start = 4.dp),
                 reactionSummary = reactionSummary,
-                onClick = { },
-                onLongClick = { },
+                onReactionClick = { },
             )
         }
     }

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -555,6 +555,7 @@
     <string name="chat_message_emoji">Emoji</string>
     <string name="chat_reactions_title">Reactions</string>
     <string name="chat_reactions_all">All</string>
+    <string name="chat_reactions_tap_to_remove">Tap to remove</string>
     <string name="chat_message_discard_draft">Discard draft?</string>
 
     <string name="chat_message_forward_to">Forward to</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionList.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionList.kt
@@ -1,18 +1,17 @@
 package id.homebase.core.widget
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddReaction
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -20,6 +19,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -31,6 +31,7 @@ import id.homebase.api.client.drives.files.reactions.ReactionContent
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.resources.MR
 import id.homebase.resources.chat_message_emoji_options
+import id.homebase.resources.chat_message_reaction
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import org.jetbrains.compose.resources.stringResource
@@ -39,23 +40,55 @@ import org.jetbrains.compose.resources.stringResource
 fun ReactionList(
     modifier: Modifier = Modifier,
     reactionSummary: ReactionSummary,
-    onClick: (reaction: String) -> Unit,
-    onLongClick: () -> Unit
+    onReactionClick: () -> Unit,
+    onAddEmoji: (() -> Unit)? = null,
 ) {
-    LazyRow(
-        modifier = modifier
+    val allReactions = remember(reactionSummary) {
+        reactionSummary.reactions.entries.mapNotNull { entry ->
+            extractEmoji(entry.value.reactionContent)?.let { emoji -> emoji to entry.value.count }
+        }
+    }
+    if (allReactions.isEmpty()) return
+
+    val displayEmojis = remember(allReactions) { allReactions.take(3) }
+    val totalCount = remember(allReactions) { allReactions.sumOf { it.second } }
+
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        val reactions = reactionSummary.reactions.entries.toList()
-        items(reactions) { entry ->
-            val emoji = extractEmoji(entry.value.reactionContent)
-            if (emoji != null) {
-                ReactionIcon(
-                    emoji = emoji,
-                    count = entry.value.count,
-                    onClick = { onClick(emoji) },
-                    onLongClick = onLongClick
-                )
+        Surface(
+            modifier = Modifier
+                .clip(RoundedCornerShape(16.dp))
+                .clickable(onClick = onReactionClick),
+            shape = RoundedCornerShape(16.dp),
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ) {
+            Row(
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                displayEmojis.forEach { (emoji, _) ->
+                    Text(
+                        text = emoji,
+                        fontSize = 16.sp,
+                    )
+                }
+                if (totalCount > 1) {
+                    Text(
+                        text = totalCount.toString(),
+                        fontSize = 13.sp,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(start = 2.dp),
+                    )
+                }
             }
+        }
+        if (onAddEmoji != null) {
+            AddReactionChip(onClick = onAddEmoji)
         }
     }
 }
@@ -129,31 +162,17 @@ fun ReactionMenu(
 }
 
 
-/**
- * Displays a Signal-style circular reaction icon with emoji and optional count.
- *
- * Shows the emoji and count (if > 1) in a rounded pill shape with a subtle border.
- * Supports long-press interaction for managing reactions.
- *
- * @param emoji The emoji character to display
- * @param count The number of reactions (count is only shown if > 1)
- * @param onClick Callback invoked on press for managing the reaction
- */
 @Composable
 fun ReactionIcon(
     emoji: String,
     count: Int,
     onClick: () -> Unit,
-    onLongClick: () -> Unit,
 ) {
     Surface(
         modifier = Modifier
             .padding(2.dp)
             .clip(RoundedCornerShape(12.dp))
-            .combinedClickable(
-                onClick = onClick,
-                onLongClick = onLongClick
-            ),
+            .clickable(onClick = onClick),
         shape = RoundedCornerShape(12.dp),
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.8f),
         border = BorderStroke(
@@ -180,5 +199,30 @@ fun ReactionIcon(
                 )
             }
         }
+    }
+}
+
+@Composable
+fun AddReactionChip(
+    onClick: () -> Unit,
+) {
+    Surface(
+        modifier = Modifier
+            .padding(2.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.8f),
+        border = BorderStroke(
+            1.dp,
+            MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
+        )
+    ) {
+        Icon(
+            imageVector = Icons.Default.AddReaction,
+            contentDescription = stringResource(MR.string.chat_message_reaction),
+            modifier = Modifier.padding(horizontal = 6.dp, vertical = 4.dp).size(16.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionsBottomSheet.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionsBottomSheet.kt
@@ -15,12 +15,16 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddReaction
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -32,11 +36,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import id.homebase.api.common.OdinId
@@ -45,7 +51,9 @@ import id.homebase.core.avatars.OwnerAvatar
 import id.homebase.core.avatars.PublicAvatar
 import id.homebase.core.util.initials
 import id.homebase.resources.MR
+import id.homebase.resources.chat_message_reaction
 import id.homebase.resources.chat_reactions_all
+import id.homebase.resources.chat_reactions_tap_to_remove
 import id.homebase.resources.chat_reactions_title
 import id.homebase.resources.you
 import org.jetbrains.compose.resources.stringResource
@@ -64,8 +72,10 @@ fun ReactionsBottomSheet(
     isLoading: Boolean,
     ownerOdinId: String?,
     onContactClick: (odinId: String) -> Unit,
+    onAddReaction: ((String) -> Unit)? = null,
     onDismiss: () -> Unit,
 ) {
+    var showEmojiPicker by remember { mutableStateOf(false) }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
 
     ModalBottomSheet(
@@ -102,9 +112,21 @@ fun ReactionsBottomSheet(
                     reactions = reactions,
                     ownerOdinId = ownerOdinId,
                     onContactClick = onContactClick,
+                    onAddEmoji = onAddReaction?.let { { showEmojiPicker = true } },
+                    onRemoveReaction = onAddReaction,
                 )
             }
         }
+    }
+
+    if (showEmojiPicker) {
+        EmojiSelectorDialog(
+            onDismiss = { showEmojiPicker = false },
+            onEmojiSelected = { emoji ->
+                showEmojiPicker = false
+                onAddReaction?.invoke(emoji)
+            },
+        )
     }
 }
 
@@ -113,23 +135,29 @@ private fun ColumnScope.ReactionsContent(
     reactions: List<ReactionDisplayItem>,
     ownerOdinId: String?,
     onContactClick: (odinId: String) -> Unit,
+    onAddEmoji: (() -> Unit)? = null,
+    onRemoveReaction: ((String) -> Unit)? = null,
 ) {
     val grouped = remember(reactions) {
         reactions.groupBy { it.emoji }
     }
     val emojiKeys = remember(grouped) { grouped.keys.toList() }
     val showAllTab = emojiKeys.size > 1
+    val ownerEmojis = remember(reactions, ownerOdinId) {
+        reactions.filter { it.odinId == ownerOdinId }.map { it.emoji }.toSet()
+    }
 
     var selectedTabIndex by remember { mutableIntStateOf(0) }
 
-    val filteredReactions = remember(selectedTabIndex, reactions, grouped, emojiKeys, showAllTab) {
-        if (!showAllTab || selectedTabIndex == 0) {
+    val filteredReactions = remember(selectedTabIndex, reactions, grouped, emojiKeys, showAllTab, ownerOdinId) {
+        val base = if (!showAllTab || selectedTabIndex == 0) {
             reactions
         } else {
             val emojiIndex = if (showAllTab) selectedTabIndex - 1 else selectedTabIndex
             val emoji = emojiKeys.getOrNull(emojiIndex) ?: return@remember reactions
             grouped[emoji] ?: emptyList()
         }
+        base.sortedByDescending { it.odinId == ownerOdinId }
     }
 
     Row(
@@ -138,6 +166,9 @@ private fun ColumnScope.ReactionsContent(
             .horizontalScroll(rememberScrollState()),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
+        if (onAddEmoji != null) {
+            AddEmojiChip(onClick = onAddEmoji)
+        }
         if (showAllTab) {
             EmojiFilterChip(
                 selected = selectedTabIndex == 0,
@@ -148,8 +179,10 @@ private fun ColumnScope.ReactionsContent(
         emojiKeys.forEachIndexed { index, emoji ->
             val tabIndex = if (showAllTab) index + 1 else index
             val count = grouped[emoji]?.size ?: 0
+            val isOwnReaction = emoji in ownerEmojis
             EmojiFilterChip(
                 selected = selectedTabIndex == tabIndex,
+                isOwnReaction = isOwnReaction,
                 label = "$emoji $count",
                 onClick = { selectedTabIndex = tabIndex },
             )
@@ -168,7 +201,9 @@ private fun ColumnScope.ReactionsContent(
                 item = item,
                 isOwner = isOwner,
                 ownerOdinId = ownerOdinId,
-                onClick = if (!isOwner) {
+                onClick = if (isOwner && onRemoveReaction != null) {
+                    { onRemoveReaction(item.emoji) }
+                } else if (!isOwner) {
                     { onContactClick(item.odinId) }
                 } else null,
             )
@@ -182,19 +217,22 @@ private fun EmojiFilterChip(
     selected: Boolean,
     label: String,
     onClick: () -> Unit,
+    isOwnReaction: Boolean = false,
 ) {
     val backgroundColor by animateColorAsState(
-        targetValue = if (selected)
-            MaterialTheme.colorScheme.primaryContainer
-        else
-            MaterialTheme.colorScheme.surfaceContainerHighest,
+        targetValue = when {
+            isOwnReaction -> Color(0xFF1E88E5).copy(alpha = 0.20f)
+            selected -> MaterialTheme.colorScheme.surfaceContainerHighest
+            else -> MaterialTheme.colorScheme.surfaceContainerHighest
+        },
         animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
     )
     val textColor by animateColorAsState(
-        targetValue = if (selected)
-            MaterialTheme.colorScheme.onPrimaryContainer
-        else
-            MaterialTheme.colorScheme.onSurfaceVariant,
+        targetValue = when {
+            isOwnReaction -> Color(0xFF1565C0)
+            selected -> MaterialTheme.colorScheme.onSurface
+            else -> MaterialTheme.colorScheme.onSurfaceVariant
+        },
         animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
     )
 
@@ -215,6 +253,24 @@ private fun EmojiFilterChip(
 }
 
 @Composable
+private fun AddEmojiChip(onClick: () -> Unit) {
+    Surface(
+        shape = RoundedCornerShape(20.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        modifier = Modifier
+            .clip(RoundedCornerShape(20.dp))
+            .clickable(onClick = onClick),
+    ) {
+        Icon(
+            imageVector = Icons.Default.AddReaction,
+            contentDescription = stringResource(MR.string.chat_message_reaction),
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp).size(20.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
 private fun ReactionRow(
     item: ReactionDisplayItem,
     isOwner: Boolean,
@@ -222,6 +278,7 @@ private fun ReactionRow(
     onClick: (() -> Unit)?,
 ) {
     val youLabel = stringResource(MR.string.you)
+    val tapToRemoveLabel = stringResource(MR.string.chat_reactions_tap_to_remove)
 
     Row(
         modifier = Modifier
@@ -250,12 +307,20 @@ private fun ReactionRow(
 
         Spacer(modifier = Modifier.width(12.dp))
 
-        Text(
-            text = if (isOwner) youLabel else item.displayName,
-            style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.weight(1f),
-        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = if (isOwner) youLabel else item.displayName,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            if (isOwner && onClick != null) {
+                Text(
+                    text = tapToRemoveLabel,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
 
         Text(
             text = item.emoji,

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/ReactionIconTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/ReactionIconTest.kt
@@ -19,7 +19,6 @@ class ReactionIconTest {
                     emoji = "\uD83D\uDC4D",
                     count = 1,
                     onClick = {},
-                    onLongClick = {},
                 )
             }
         }
@@ -34,7 +33,6 @@ class ReactionIconTest {
                     emoji = "\uD83D\uDC4D",
                     count = 1,
                     onClick = {},
-                    onLongClick = {},
                 )
             }
         }
@@ -50,7 +48,6 @@ class ReactionIconTest {
                     emoji = "\uD83D\uDC4D",
                     count = 5,
                     onClick = {},
-                    onLongClick = {},
                 )
             }
         }
@@ -66,7 +63,6 @@ class ReactionIconTest {
                     emoji = "\uD83D\uDC4D",
                     count = 1,
                     onClick = { clicked = true },
-                    onLongClick = {},
                 )
             }
         }


### PR DESCRIPTION
## Summary
- **Tap to open details**: Tapping a reaction badge now opens the reaction details bottom sheet (previously required long-press)
- **Merged reaction pill**: All emojis rendered in a single pill with total count (max 3 emojis visible), matching Signal/WhatsApp style
- **Add reaction chip**: ☺+ button appears next to reactions and in the bottom sheet filter row for quick emoji adding
- **Bottom sheet improvements**: Owner reactions sorted to top, "Tap to remove" subtitle on own reactions, own-reaction emoji chips highlighted with blue tint, full emoji picker accessible via ☺+ chip
- **State tracking**: `reactionDetailsMessageId` tracked in UI state so reactions can be added/removed directly from the bottom sheet

## Test plan
- [ ] Tap a reaction badge → should open the reaction details bottom sheet
- [ ] Verify merged pill shows max 3 emojis + total count
- [ ] Tap ☺+ chip under message → should open quick reaction picker
- [ ] Tap ☺+ chip in bottom sheet → should open full emoji picker
- [ ] Verify own-reaction emoji chip in bottom sheet has blue tint
- [ ] Verify "You" row appears first with "Tap to remove" subtitle
- [ ] Tap "You" row → should remove your reaction
- [ ] Verify desktop hover-based add reaction still works
- [ ] Test light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)