### PR TITLE
feat(desktop): implement audio message playback

### DIFF
--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/audio/JvmAudioPlayer.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/audio/JvmAudioPlayer.kt
@@ -1,31 +1,248 @@
 package id.homebase.core.audio
 
-class JvmAudioPlayer: AudioPlayer {
+import co.touchlab.kermit.Logger
+import id.homebase.api.video.FFmpegBinaryManager
+import java.io.File
+import java.io.InputStream
+import java.util.concurrent.TimeUnit
+import javax.sound.sampled.AudioFormat
+import javax.sound.sampled.AudioSystem
+import javax.sound.sampled.SourceDataLine
+
+open class JvmAudioPlayer : AudioPlayer {
+    private var process: Process? = null
+    private var sourceLine: SourceDataLine? = null
+    private var playbackThread: Thread? = null
+    private var progressThread: Thread? = null
+    private var observer: AudioPlaybackObserver? = null
+
+    private var currentFilePath: String? = null
+
+    @Volatile
+    internal var totalDurationSeconds: Int = 0
+        private set
+
+    @Volatile
+    internal var seekOffsetSeconds: Int = 0
+        private set
+
+    @Volatile
+    private var isPaused = false
+
+    @Volatile
+    private var isStopped = true
+
     override fun play(filePath: String) {
-        //TODO("Not yet implemented")
-    }
-
-    override fun jump(seconds: Int) {
-        //TODO("Not yet implemented")
-    }
-
-    override fun resume() {
-        //TODO("Not yet implemented")
+        stopPlayback()
+        currentFilePath = filePath
+        seekOffsetSeconds = 0
+        isStopped = false
+        isPaused = false
+        totalDurationSeconds = probeDurationSeconds(filePath)
+        startPlayback(filePath, seekSeconds = 0)
     }
 
     override fun pause() {
-        //TODO("Not yet implemented")
+        isPaused = true
+        sourceLine?.stop()
+    }
+
+    override fun resume() {
+        sourceLine?.start()
+        isPaused = false
+    }
+
+    override fun jump(seconds: Int) {
+        val path = currentFilePath ?: return
+        val clamped = seconds.coerceIn(0, totalDurationSeconds)
+        stopPlayback()
+        seekOffsetSeconds = clamped
+        isStopped = false
+        isPaused = false
+        startPlayback(path, seekSeconds = clamped)
     }
 
     override fun stop() {
-        //TODO("Not yet implemented")
+        isStopped = true
+        stopPlayback()
+        seekOffsetSeconds = 0
     }
 
     override fun release() {
-        //TODO("Not yet implemented")
+        stop()
+        observer = null
+        currentFilePath = null
     }
 
     override fun setPlaybackObserver(observer: AudioPlaybackObserver) {
-        //TODO("Not yet implemented")
+        this.observer = observer
+    }
+
+    internal fun buildFfmpegCommand(filePath: String, seekSeconds: Int): List<String> = buildList {
+        add(FFmpegBinaryManager.ffmpegPath())
+        add("-v"); add("error")
+        if (seekSeconds > 0) {
+            add("-ss"); add(seekSeconds.toString())
+        }
+        add("-i"); add(filePath)
+        add("-f"); add("s16le")
+        add("-acodec"); add("pcm_s16le")
+        add("-ar"); add(SAMPLE_RATE.toString())
+        add("-ac"); add(CHANNELS.toString())
+        add("pipe:1")
+    }
+
+    protected open fun startDecoder(filePath: String, seekSeconds: Int): InputStream? {
+        if (!FFmpegBinaryManager.isAvailable()) {
+            Logger.e(tag = TAG) { "FFmpeg binaries not available — cannot decode audio" }
+            return null
+        }
+        val command = buildFfmpegCommand(filePath, seekSeconds)
+        process = ProcessBuilder(command)
+            .redirectError(ProcessBuilder.Redirect.PIPE)
+            .start()
+        drainStderr(process!!)
+        return process?.inputStream
+    }
+
+    protected open fun openAudioLine(format: AudioFormat): SourceDataLine {
+        val line = AudioSystem.getSourceDataLine(format)
+        line.open(format, BUFFER_SIZE)
+        line.start()
+        return line
+    }
+
+    private fun startPlayback(filePath: String, seekSeconds: Int) {
+        val pcmFormat = AudioFormat(
+            SAMPLE_RATE.toFloat(), SAMPLE_SIZE_BITS, CHANNELS, true, false
+        )
+
+        try {
+            val input = startDecoder(filePath, seekSeconds) ?: return
+
+            val line = openAudioLine(pcmFormat)
+            sourceLine = line
+
+            playbackThread = Thread({
+                val buffer = ByteArray(BUFFER_SIZE)
+                try {
+                    while (!isStopped) {
+                        if (isPaused) {
+                            Thread.sleep(50)
+                            continue
+                        }
+                        val bytesRead = input.read(buffer)
+                        if (bytesRead == -1) break
+                        line.write(buffer, 0, bytesRead)
+                    }
+                    if (!isStopped) {
+                        line.drain()
+                        observer?.onComplete()
+                    }
+                } catch (_: InterruptedException) {
+                } catch (e: Exception) {
+                    Logger.e(e, tag = TAG) { "Playback error" }
+                }
+            }, "JvmAudioPlayback").apply {
+                isDaemon = true
+                start()
+            }
+
+            progressThread = Thread({
+                try {
+                    while (!isStopped && playbackThread?.isAlive == true) {
+                        if (!isPaused) {
+                            val linePositionSeconds =
+                                (line.microsecondPosition / 1_000_000).toInt()
+                            val currentSeconds = seekOffsetSeconds + linePositionSeconds
+                            observer?.onProgressUpdate(
+                                currentSeconds.coerceAtMost(totalDurationSeconds),
+                                totalDurationSeconds
+                            )
+                        }
+                        Thread.sleep(PROGRESS_INTERVAL_MS)
+                    }
+                } catch (_: InterruptedException) {
+                }
+            }, "JvmAudioProgress").apply {
+                isDaemon = true
+                start()
+            }
+        } catch (e: Exception) {
+            Logger.e(e, tag = TAG) { "Failed to start audio playback" }
+            stopPlayback()
+        }
+    }
+
+    private fun stopPlayback() {
+        isStopped = true
+        process?.destroy()
+        process = null
+        playbackThread?.interrupt()
+        playbackThread = null
+        progressThread?.interrupt()
+        progressThread = null
+        try {
+            sourceLine?.stop()
+            sourceLine?.close()
+        } catch (_: Exception) {
+        }
+        sourceLine = null
+    }
+
+    private fun drainStderr(proc: Process) {
+        Thread({
+            try {
+                proc.errorStream.bufferedReader().forEachLine { line ->
+                    Logger.w(tag = TAG) { "ffmpeg: $line" }
+                }
+            } catch (_: Exception) {
+            }
+        }, "JvmAudioStderr").apply {
+            isDaemon = true
+            start()
+        }
+    }
+
+    protected open fun probeDurationSeconds(filePath: String): Int {
+        if (!FFmpegBinaryManager.isAvailable()) {
+            Logger.w(tag = TAG) { "FFmpeg not available, falling back to file-size estimate" }
+            return estimateDurationFromFileSize(filePath)
+        }
+        return try {
+            val proc = ProcessBuilder(
+                FFmpegBinaryManager.ffprobePath(),
+                "-v", "error",
+                "-show_entries", "format=duration",
+                "-of", "default=noprint_wrappers=1:nokey=1",
+                filePath
+            ).redirectErrorStream(true).start()
+
+            val output = proc.inputStream.bufferedReader().readText().trim()
+            val completed = proc.waitFor(10, TimeUnit.SECONDS)
+            if (!completed) {
+                proc.destroy()
+                Logger.w(tag = TAG) { "ffprobe timed out" }
+            }
+            output.toDoubleOrNull()?.toInt() ?: 0
+        } catch (e: Exception) {
+            Logger.e(e, tag = TAG) { "ffprobe failed" }
+            0
+        }
+    }
+
+    companion object {
+        private const val TAG = "JvmAudioPlayer"
+        internal const val SAMPLE_RATE = 44100
+        internal const val SAMPLE_SIZE_BITS = 16
+        internal const val CHANNELS = 2
+        internal const val BUFFER_SIZE = 8192
+        internal const val PROGRESS_INTERVAL_MS = 500L
+
+        internal fun estimateDurationFromFileSize(filePath: String): Int {
+            val sizeBytes = File(filePath).length()
+            val bytesPerSecond = SAMPLE_RATE * CHANNELS * (SAMPLE_SIZE_BITS / 8)
+            return (sizeBytes / bytesPerSecond).toInt().coerceAtLeast(1)
+        }
     }
 }

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/audio/JvmAudioPlayerTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/audio/JvmAudioPlayerTest.kt
@@ -1,0 +1,324 @@
+package id.homebase.core.audio
+
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.InputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import javax.sound.sampled.AudioFormat
+import javax.sound.sampled.SourceDataLine
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Fake SourceDataLine that discards audio and tracks position via bytes written.
+ */
+private class FakeSourceDataLine(
+    private val format: AudioFormat,
+    private val simulateRealtime: Boolean = false,
+) : StubSourceDataLine() {
+    @Volatile var totalBytesWritten = 0L
+    @Volatile var started = false
+    @Volatile var stopped = false
+    @Volatile var closed = false
+    @Volatile var drained = false
+
+    override fun open(format: AudioFormat, bufferSize: Int) {}
+    override fun start() { started = true; stopped = false }
+    override fun stop() { stopped = true; started = false }
+    override fun close() { closed = true }
+    override fun drain() { drained = true }
+    override fun write(b: ByteArray, off: Int, len: Int): Int {
+        totalBytesWritten += len
+        if (simulateRealtime) Thread.sleep(10)
+        return len
+    }
+    override fun getMicrosecondPosition(): Long {
+        val bytesPerSecond = format.sampleRate * format.channels * (format.sampleSizeInBits / 8)
+        return (totalBytesWritten * 1_000_000L / bytesPerSecond.toLong())
+    }
+    override fun getFormat(): AudioFormat = format
+}
+
+/**
+ * Test subclass that bypasses FFmpeg and audio hardware.
+ */
+private class TestableAudioPlayer(
+    private val fakeDuration: Int = 30,
+    private val fakeAudioBytes: ByteArray = ByteArray(44100 * 2 * 2), // 1 second of stereo 16-bit
+) : JvmAudioPlayer() {
+
+    var lastSeekSeconds: Int? = null
+    var decoderStartCount = 0
+    var fakeLine: FakeSourceDataLine? = null
+    var simulateRealtime = false
+
+    override fun startDecoder(filePath: String, seekSeconds: Int): InputStream {
+        lastSeekSeconds = seekSeconds
+        decoderStartCount++
+        return ByteArrayInputStream(fakeAudioBytes)
+    }
+
+    override fun openAudioLine(format: AudioFormat): SourceDataLine {
+        val line = FakeSourceDataLine(format, simulateRealtime)
+        fakeLine = line
+        return line
+    }
+
+    override fun probeDurationSeconds(filePath: String): Int = fakeDuration
+}
+
+class JvmAudioPlayerTest {
+
+    @Test
+    fun playSetsDurationAndStartsDecoder() {
+        val player = TestableAudioPlayer(fakeDuration = 45)
+        player.play("/fake/audio.m4a")
+        Thread.sleep(100) // let threads start
+
+        assertEquals(45, player.totalDurationSeconds)
+        assertEquals(0, player.seekOffsetSeconds)
+        assertEquals(1, player.decoderStartCount)
+        assertEquals(0, player.lastSeekSeconds)
+
+        player.release()
+    }
+
+    @Test
+    fun stopResetsSeekOffset() {
+        val player = TestableAudioPlayer(fakeDuration = 60)
+        player.play("/fake/audio.wav")
+        Thread.sleep(50)
+
+        player.jump(20)
+        Thread.sleep(50)
+        assertEquals(20, player.seekOffsetSeconds)
+
+        player.stop()
+        assertEquals(0, player.seekOffsetSeconds)
+
+        player.release()
+    }
+
+    @Test
+    fun jumpClampsToTotalDuration() {
+        val player = TestableAudioPlayer(fakeDuration = 30)
+        player.play("/fake/audio.wav")
+        Thread.sleep(50)
+
+        player.jump(100)
+        Thread.sleep(50)
+        assertEquals(30, player.seekOffsetSeconds)
+
+        player.jump(-5)
+        Thread.sleep(50)
+        assertEquals(0, player.seekOffsetSeconds)
+
+        player.release()
+    }
+
+    @Test
+    fun jumpRestartsDecoder() {
+        val player = TestableAudioPlayer(fakeDuration = 60)
+        player.play("/fake/audio.wav")
+        Thread.sleep(50)
+        assertEquals(1, player.decoderStartCount)
+
+        player.jump(15)
+        Thread.sleep(50)
+        assertEquals(2, player.decoderStartCount)
+        assertEquals(15, player.lastSeekSeconds)
+
+        player.release()
+    }
+
+    @Test
+    fun jumpDoesNothingWithoutPriorPlay() {
+        val player = TestableAudioPlayer()
+        player.jump(10)
+        assertEquals(0, player.decoderStartCount)
+        assertNull(player.lastSeekSeconds)
+    }
+
+    @Test
+    fun releaseResetsState() {
+        val player = TestableAudioPlayer()
+        val observer = object : AudioPlaybackObserver {
+            override fun onComplete() {}
+            override fun onProgressUpdate(progressSeconds: Int, totalSeconds: Int) {}
+        }
+        player.setPlaybackObserver(observer)
+        player.play("/fake/audio.wav")
+        Thread.sleep(50)
+
+        player.release()
+        assertEquals(0, player.seekOffsetSeconds)
+    }
+
+    @Test
+    fun observerReceivesOnComplete() {
+        val shortAudio = ByteArray(1764) // ~10ms of stereo 16-bit at 44100
+        val completed = CountDownLatch(1)
+        val player = TestableAudioPlayer(fakeDuration = 1, fakeAudioBytes = shortAudio)
+
+        player.setPlaybackObserver(object : AudioPlaybackObserver {
+            override fun onComplete() { completed.countDown() }
+            override fun onProgressUpdate(progressSeconds: Int, totalSeconds: Int) {}
+        })
+
+        player.play("/fake/short.wav")
+        assertTrue(completed.await(3, TimeUnit.SECONDS), "onComplete should fire after stream ends")
+        player.release()
+    }
+
+    @Test
+    fun observerReceivesProgressUpdates() {
+        val audio = ByteArray(44100 * 2 * 2 * 2) // ~2 seconds
+        val progressLatch = CountDownLatch(1)
+        val lastTotal = AtomicInteger(0)
+
+        val player = TestableAudioPlayer(fakeDuration = 2, fakeAudioBytes = audio)
+        player.simulateRealtime = true
+        player.setPlaybackObserver(object : AudioPlaybackObserver {
+            override fun onComplete() {}
+            override fun onProgressUpdate(progressSeconds: Int, totalSeconds: Int) {
+                lastTotal.set(totalSeconds)
+                progressLatch.countDown()
+            }
+        })
+
+        player.play("/fake/audio.wav")
+        assertTrue(progressLatch.await(3, TimeUnit.SECONDS), "Observer should receive progress updates")
+        assertEquals(2, lastTotal.get())
+        player.release()
+    }
+
+    @Test
+    fun progressClampsToTotalDuration() {
+        val audio = ByteArray(44100 * 2 * 2 * 3) // ~3 seconds
+        val maxProgress = AtomicInteger(0)
+        val progressLatch = CountDownLatch(2)
+        val player = TestableAudioPlayer(fakeDuration = 1, fakeAudioBytes = audio)
+        player.simulateRealtime = true
+        player.setPlaybackObserver(object : AudioPlaybackObserver {
+            override fun onComplete() {}
+            override fun onProgressUpdate(progressSeconds: Int, totalSeconds: Int) {
+                if (progressSeconds > maxProgress.get()) maxProgress.set(progressSeconds)
+                progressLatch.countDown()
+            }
+        })
+
+        player.play("/fake/audio.wav")
+        progressLatch.await(3, TimeUnit.SECONDS)
+
+        assertTrue(maxProgress.get() <= 1, "Progress should not exceed total duration")
+        player.release()
+    }
+
+    @Test
+    fun multiplePlayCallsRestartCleanly() {
+        val player = TestableAudioPlayer(fakeDuration = 30)
+
+        player.play("/fake/first.wav")
+        Thread.sleep(50)
+        assertEquals(1, player.decoderStartCount)
+
+        player.play("/fake/second.wav")
+        Thread.sleep(50)
+        assertEquals(2, player.decoderStartCount)
+        assertEquals(0, player.lastSeekSeconds)
+
+        player.release()
+    }
+
+    @Test
+    fun pauseStopsAudioLine() {
+        val player = TestableAudioPlayer()
+        player.play("/fake/audio.wav")
+        Thread.sleep(50)
+
+        player.pause()
+        Thread.sleep(50)
+        val line = player.fakeLine
+        assertTrue(line?.stopped == true, "Audio line should be stopped after pause")
+
+        player.release()
+    }
+
+    @Test
+    fun resumeRestartsAudioLine() {
+        val player = TestableAudioPlayer()
+        player.play("/fake/audio.wav")
+        Thread.sleep(50)
+
+        player.pause()
+        Thread.sleep(50)
+        player.resume()
+        Thread.sleep(50)
+        val line = player.fakeLine
+        assertTrue(line?.started == true, "Audio line should be started after resume")
+
+        player.release()
+    }
+
+    @Test
+    fun estimateDurationFromFileSizeReturnsAtLeastOne() {
+        val temp = File.createTempFile("test_audio", ".raw")
+        try {
+            temp.writeBytes(ByteArray(100))
+            val duration = JvmAudioPlayer.estimateDurationFromFileSize(temp.absolutePath)
+            assertEquals(1, duration, "Very small files should return at least 1 second")
+        } finally {
+            temp.delete()
+        }
+    }
+
+    @Test
+    fun estimateDurationFromFileSizeCalculatesCorrectly() {
+        val temp = File.createTempFile("test_audio", ".raw")
+        try {
+            // 5 seconds of 44100 Hz, stereo, 16-bit = 44100 * 2 * 2 * 5 = 882000 bytes
+            temp.writeBytes(ByteArray(882000))
+            val duration = JvmAudioPlayer.estimateDurationFromFileSize(temp.absolutePath)
+            assertEquals(5, duration)
+        } finally {
+            temp.delete()
+        }
+    }
+}
+
+/**
+ * Minimal stub implementing SourceDataLine with no-ops.
+ * Only methods used by tests are overridden in FakeSourceDataLine.
+ */
+private abstract class StubSourceDataLine : SourceDataLine {
+    override fun open(format: AudioFormat, bufferSize: Int) {}
+    override fun open(format: AudioFormat) {}
+    override fun open() {}
+    override fun write(b: ByteArray, off: Int, len: Int): Int = len
+    override fun drain() {}
+    override fun flush() {}
+    override fun start() {}
+    override fun stop() {}
+    override fun isRunning(): Boolean = false
+    override fun isActive(): Boolean = false
+    override fun getFormat(): AudioFormat = AudioFormat(44100f, 16, 2, true, false)
+    override fun getBufferSize(): Int = 8192
+    override fun available(): Int = 0
+    override fun getFramePosition(): Int = 0
+    override fun getLongFramePosition(): Long = 0
+    override fun getMicrosecondPosition(): Long = 0
+    override fun getLevel(): Float = 0f
+    override fun getLineInfo(): javax.sound.sampled.Line.Info = javax.sound.sampled.DataLine.Info(SourceDataLine::class.java, AudioFormat(44100f, 16, 2, true, false))
+    override fun close() {}
+    override fun isOpen(): Boolean = true
+    override fun getControls(): Array<javax.sound.sampled.Control> = emptyArray()
+    override fun isControlSupported(control: javax.sound.sampled.Control.Type): Boolean = false
+    override fun getControl(control: javax.sound.sampled.Control.Type): javax.sound.sampled.Control = throw IllegalArgumentException()
+    override fun addLineListener(listener: javax.sound.sampled.LineListener) {}
+    override fun removeLineListener(listener: javax.sound.sampled.LineListener) {}
+}


### PR DESCRIPTION
## Summary
- Replace the stub `JvmAudioPlayer` (all 8 methods were `//TODO`) with a real streaming implementation
- Uses the **bundled FFmpeg** to decode any audio format (WAV, M4A/AAC, MP3, OGG, etc.) to raw PCM, piped directly to `javax.sound.sampled.SourceDataLine` — no temp files, no conversion step
- Duration probed via `ffprobe` upfront; progress polled every 500ms (matching Android/iOS pattern)
- Seek restarts the FFmpeg process with `-ss`; pause/resume controls the `SourceDataLine`
- Adds **14 unit tests** covering play/stop/pause/resume/jump lifecycle, observer callbacks, seek clamping, progress reporting, and file-size duration estimation

## What was broken
Desktop users could **record** voice messages (JvmAudioRecorder works) but could **not play them back** — pressing play did nothing because every method in JvmAudioPlayer was an empty stub.

## Design decisions
- **FFmpeg streaming over VLC-J**: VLC-J requires users to install VLC separately — most Mac/Windows users won't have it. The bundled FFmpeg binaries (already shipped for video processing) require zero user action
- **`SourceDataLine` over `Clip`**: Streaming avoids loading the entire audio into memory and starts playback immediately
- **Stereo 44.1kHz PCM**: Standard CD-quality output; FFmpeg resamples any input to this format
- **`destroy()` over `destroyForcibly()`**: SIGTERM lets FFmpeg clean up gracefully
- **Stderr drain thread**: FFmpeg decode errors are logged via Kermit instead of silently discarded

## Test plan
- [x] 14 unit tests pass (`./gradlew homebase-common:jvmTest --tests "*.JvmAudioPlayerTest"`)
- [x] Full JVM test suite passes (`./gradlew homebase-common:jvmTest homebase-api:jvmTest`)
- [ ] Manual: play a WAV voice message on desktop
- [ ] Manual: play an M4A voice message (sent from Android/iOS) on desktop
- [ ] Manual: pause/resume/seek during playback
- [ ] Manual: verify progress bar updates and completion resets play button

🤖 Generated with [Claude Code](https://claude.com/claude-code)