### PR TITLE
perf(ci): speed up iOS CI builds with caching and parallel compilation

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -30,12 +30,12 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'gradle/libs.versions.toml') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
 
       - name: Run JVM unit tests
-        run: ./gradlew homebase-chat:jvmTest homebase-auth:jvmTest homebase-common:jvmTest homebase-api:jvmTest homebase-core:jvmTest --rerun-tasks
+        run: ./gradlew homebase-chat:jvmTest homebase-auth:jvmTest homebase-common:jvmTest homebase-api:jvmTest homebase-core:jvmTest
         env:
           JDK_21: ${{ env.JAVA_HOME }}
           CI: true
@@ -83,9 +83,18 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'gradle/libs.versions.toml') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+
+      - name: Cache Kotlin/Native
+        if: matrix.os == 'macos-latest'
+        uses: actions/cache@v5
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml', '**/gradle.properties') }}
+          restore-keys: |
+            konan-${{ runner.os }}-
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew

--- a/.github/workflows/build-mobile-release-dev.yml
+++ b/.github/workflows/build-mobile-release-dev.yml
@@ -102,7 +102,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'gradle/libs.versions.toml') }}
           restore-keys: |
             gradle-${{ runner.os }}-
 
@@ -110,7 +110,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.konan
-          key: konan-${{ runner.os }}-${{ hashFiles('**/gradle.properties') }}
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml', '**/gradle.properties') }}
+          restore-keys: |
+            konan-${{ runner.os }}-
 
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -126,6 +128,14 @@ jobs:
           key: pods-${{ runner.os }}-${{ hashFiles('**/Podfile.lock') }}
           restore-keys: |
             pods-${{ runner.os }}-
+
+      - name: Cache Xcode Derived Data
+        uses: actions/cache@v5
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: xcode-derived-${{ runner.os }}-${{ hashFiles('iosApp/iosApp.xcodeproj/project.pbxproj', 'gradle/libs.versions.toml') }}
+          restore-keys: |
+            xcode-derived-${{ runner.os }}-
 
       - name: Set iOS version
         run: |

--- a/.github/workflows/build-mobile-release-prod.yml
+++ b/.github/workflows/build-mobile-release-prod.yml
@@ -110,7 +110,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'gradle/libs.versions.toml') }}
           restore-keys: |
             gradle-${{ runner.os }}-
 
@@ -118,7 +118,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.konan
-          key: konan-${{ runner.os }}-${{ hashFiles('**/gradle.properties') }}
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml', '**/gradle.properties') }}
+          restore-keys: |
+            konan-${{ runner.os }}-
 
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -134,6 +136,14 @@ jobs:
           key: pods-${{ runner.os }}-${{ hashFiles('**/Podfile.lock') }}
           restore-keys: |
             pods-${{ runner.os }}-
+
+      - name: Cache Xcode Derived Data
+        uses: actions/cache@v5
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: xcode-derived-${{ runner.os }}-${{ hashFiles('iosApp/iosApp.xcodeproj/project.pbxproj', 'gradle/libs.versions.toml') }}
+          restore-keys: |
+            xcode-derived-${{ runner.os }}-
 
       - name: Set iOS version
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,13 +17,13 @@ jobs:
             # Run Android Unit Tests and Desktop Tests
             test-command: |
               set -o pipefail
-              ./gradlew testDebugUnitTest --rerun-tasks --info | tee test-output.log
-              ./gradlew homebase-common:jvmTest homebase-chat:jvmTest --rerun-tasks
-              ./gradlew desktopTest --rerun-tasks
+              ./gradlew testDebugUnitTest --info | tee test-output.log
+              ./gradlew homebase-common:jvmTest homebase-chat:jvmTest
+              ./gradlew desktopTest
           - os: macos-latest
             name: iOS
             # Run iOS Simulator Tests
-            test-command: ./gradlew iosSimulatorArm64Test --rerun-tasks
+            test-command: ./gradlew iosSimulatorArm64Test
       fail-fast: false
     name: ${{ matrix.name }} Tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -43,9 +43,18 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'gradle/libs.versions.toml') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+
+      - name: Cache Kotlin/Native
+        if: matrix.os == 'macos-latest'
+        uses: actions/cache@v5
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml', '**/gradle.properties') }}
+          restore-keys: |
+            konan-${{ runner.os }}-
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,20 +1,17 @@
 #Kotlin
 kotlin.code.style=official
-kotlin.daemon.jvmargs=-Xmx4g
-
+kotlin.daemon.jvmargs=-Xmx8g
+#kotlin.daemon.jvmargs=-Xmx4g
 #Gradle
 # Default JVM args for Gradle Daemon
 org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=1g -XX:+UseParallelGC -Dfile.encoding=UTF-8
 org.gradle.configuration-cache=true
 org.gradle.caching=true
-
-
+org.gradle.parallel=true
 #Android
 android.nonTransitiveRClass=true
 android.useAndroidX=true
-
 #Robolectric
 # Use Robolectric's binary resource mode for faster tests
 robolectric.enabledSdks=33
-
 kotlin.mpp.enableCInteropCommonization=true


### PR DESCRIPTION
## Summary

- **Remove `--rerun-tasks`** from all test/build commands — was forcing full recompilation on every CI run, defeating all Gradle caching
- **Add Kotlin/Native cache** to `build-check.yml` and `test.yml` — these workflows were completely missing K/N caching, causing cold K/N toolchain downloads every run
- **Add Xcode derived data cache** to both iOS release workflows — caches compiled Xcode artifacts between runs
- **Include `libs.versions.toml` in all cache keys** — prevents stale cache hits when dependency versions change
- **Add `restore-keys` fallback** to Kotlin/Native cache — enables partial cache restore on key miss instead of cold start
- **Enable `org.gradle.parallel=true`** — allows independent KMP modules to compile simultaneously
- **Bump Kotlin daemon memory** from 4g to 8g — reduces GC pressure during Kotlin/Native framework compilation

**Estimated savings: 20-35 minutes per iOS CI run** (from ~90 min target to ~55-70 min).

## Test plan

- [ ] Verify `build-check.yml` iOS build passes on PR (K/N cache now active)
- [ ] Verify `test.yml` iOS tests pass without `--rerun-tasks`
- [ ] Trigger manual dev release build and confirm iOS job completes faster
- [ ] Check GitHub Actions cache tab shows new `konan-*` and `xcode-derived-*` entries after first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)