### PR TITLE
perf(ci): pre-build KMP framework to cut iOS build time by ~30min

### DIFF
--- a/.github/workflows/build-mobile-release-dev.yml
+++ b/.github/workflows/build-mobile-release-dev.yml
@@ -82,7 +82,7 @@ jobs:
 
   build-ios:
     runs-on: macos-15
-    timeout-minutes: 75
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@v5
@@ -165,6 +165,17 @@ jobs:
           # Also update Info.plist as a fallback
           /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION_NAME" iosApp/iosApp/Info.plist || /usr/libexec/PlistBuddy -c "Add :CFBundleShortVersionString string $VERSION_NAME" iosApp/iosApp/Info.plist
           /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $VERSION_CODE" iosApp/iosApp/Info.plist || /usr/libexec/PlistBuddy -c "Add :CFBundleVersion string $VERSION_CODE" iosApp/iosApp/Info.plist
+
+      - name: Inject CI build optimizations
+        run: |
+          echo "" >> iosApp/Configuration/Config.xcconfig
+          echo "// CI optimizations" >> iosApp/Configuration/Config.xcconfig
+          echo "COMPILER_INDEX_STORE_ENABLE = NO" >> iosApp/Configuration/Config.xcconfig
+
+      - name: Pre-build KMP framework
+        run: ./gradlew :homebase-core:linkReleaseFrameworkIosArm64
+        env:
+          JDK_17: ${{ env.JAVA_HOME }}
 
       - name: Build iOS
         uses: yukiarrr/ios-build-action@v1.12.0

--- a/.github/workflows/build-mobile-release-prod.yml
+++ b/.github/workflows/build-mobile-release-prod.yml
@@ -90,7 +90,7 @@ jobs:
 
   build-ios:
     runs-on: macos-15
-    timeout-minutes: 75
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@v5
@@ -173,6 +173,17 @@ jobs:
           # Also update Info.plist as a fallback
           /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION_NAME" iosApp/iosApp/Info.plist || /usr/libexec/PlistBuddy -c "Add :CFBundleShortVersionString string $VERSION_NAME" iosApp/iosApp/Info.plist
           /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $VERSION_CODE" iosApp/iosApp/Info.plist || /usr/libexec/PlistBuddy -c "Add :CFBundleVersion string $VERSION_CODE" iosApp/iosApp/Info.plist
+
+      - name: Inject CI build optimizations
+        run: |
+          echo "" >> iosApp/Configuration/Config.xcconfig
+          echo "// CI optimizations" >> iosApp/Configuration/Config.xcconfig
+          echo "COMPILER_INDEX_STORE_ENABLE = NO" >> iosApp/Configuration/Config.xcconfig
+
+      - name: Pre-build KMP framework
+        run: ./gradlew :homebase-core:linkReleaseFrameworkIosArm64
+        env:
+          JDK_17: ${{ env.JAVA_HOME }}
 
       - name: Build iOS
         uses: yukiarrr/ios-build-action@v1.12.0


### PR DESCRIPTION
## Summary

Follow-up to #459. The iOS "Build iOS" step still takes ~61 minutes because the Xcode build phase recompiles all Kotlin/Native code inside `xcodebuild`.

- **Pre-build KMP framework** (`linkReleaseFrameworkIosArm64`) as a separate step before xcodebuild — when `embedAndSignAppleFrameworkForXcode` runs inside Xcode, Gradle sees the framework is already up-to-date and skips recompilation (~30-40 min saved)
- **Disable Xcode index store in CI** (`COMPILER_INDEX_STORE_ENABLE=NO`) — not needed in CI, saves a few minutes
- **Bump timeout** from 75 to 90 minutes — safety net while caches warm up

### How it works
The Xcode project has a "Compile Kotlin Framework" build phase that calls `./gradlew :homebase-core:embedAndSignAppleFrameworkForXcode`. This task depends on `linkReleaseFrameworkIosArm64`. By running `linkReleaseFrameworkIosArm64` beforehand, Gradle's up-to-date checking skips the expensive compilation and only runs the fast embed/sign step (~1-2 min vs ~30-40 min).

**Expected iOS build time: ~35-45 min** (down from ~65 min).

## Test plan

- [ ] Trigger manual dev release build and verify "Pre-build KMP framework" step completes
- [ ] Verify "Build iOS" step is significantly faster (should be ~15-20 min instead of ~60 min)
- [ ] Verify IPA is produced and uploaded to TestFlight successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)