### PR TITLE
perf(ci): skip Gradle in xcodebuild, use pre-built static framework

### DIFF
--- a/.github/workflows/build-mobile-release-dev.yml
+++ b/.github/workflows/build-mobile-release-dev.yml
@@ -168,9 +168,12 @@ jobs:
 
       - name: Inject CI build optimizations
         run: |
-          echo "" >> iosApp/Configuration/Config.xcconfig
-          echo "// CI optimizations" >> iosApp/Configuration/Config.xcconfig
-          echo "COMPILER_INDEX_STORE_ENABLE = NO" >> iosApp/Configuration/Config.xcconfig
+          cat >> iosApp/Configuration/Config.xcconfig << 'XCEOF'
+
+          // CI optimizations
+          COMPILER_INDEX_STORE_ENABLE = NO
+          FRAMEWORK_SEARCH_PATHS = $(inherited) $(SRCROOT)/../homebase-core/build/bin/iosArm64/releaseFramework
+          XCEOF
 
       - name: Pre-build KMP framework
         run: ./gradlew :homebase-core:linkReleaseFrameworkIosArm64
@@ -179,6 +182,8 @@ jobs:
 
       - name: Build iOS
         uses: yukiarrr/ios-build-action@v1.12.0
+        env:
+          OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED: "YES"
         with:
           project-path: iosApp/iosApp.xcodeproj
           workspace-path: iosApp/iosApp.xcodeproj/project.xcworkspace

--- a/.github/workflows/build-mobile-release-prod.yml
+++ b/.github/workflows/build-mobile-release-prod.yml
@@ -176,9 +176,12 @@ jobs:
 
       - name: Inject CI build optimizations
         run: |
-          echo "" >> iosApp/Configuration/Config.xcconfig
-          echo "// CI optimizations" >> iosApp/Configuration/Config.xcconfig
-          echo "COMPILER_INDEX_STORE_ENABLE = NO" >> iosApp/Configuration/Config.xcconfig
+          cat >> iosApp/Configuration/Config.xcconfig << 'XCEOF'
+
+          // CI optimizations
+          COMPILER_INDEX_STORE_ENABLE = NO
+          FRAMEWORK_SEARCH_PATHS = $(inherited) $(SRCROOT)/../homebase-core/build/bin/iosArm64/releaseFramework
+          XCEOF
 
       - name: Pre-build KMP framework
         run: ./gradlew :homebase-core:linkReleaseFrameworkIosArm64
@@ -187,6 +190,8 @@ jobs:
 
       - name: Build iOS
         uses: yukiarrr/ios-build-action@v1.12.0
+        env:
+          OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED: "YES"
         with:
           project-path: iosApp/iosApp.xcodeproj
           workspace-path: iosApp/iosApp.xcodeproj/project.xcworkspace


### PR DESCRIPTION
## Summary

Follow-up to #461. The pre-build approach in #461 compiled K/N framework separately (58 min) but xcodebuild still invoked Gradle via `embedAndSignAppleFrameworkForXcode`, adding 31 min of overhead — totaling 89 min, which is **worse** than before.

**Root cause:** Gradle was being called twice — once to pre-build, and again inside xcodebuild's build phase script. Even though `linkReleaseFrameworkIosArm64` was up-to-date, the Gradle daemon startup + configuration + copy still took ~30 min.

**Fix:** Since ComposeApp is a **static framework** (`isStatic = true`), Xcode only needs `FRAMEWORK_SEARCH_PATHS` to find it at link time — no embedding step needed. So we:
- Set `OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED=YES` to skip the Gradle build phase script inside xcodebuild entirely
- Add `FRAMEWORK_SEARCH_PATHS` pointing to the Gradle build output directory
- xcodebuild now only does Swift compilation + archive (~7-10 min instead of ~31 min)

**Expected total: ~60-65 min** (58 min K/N pre-build + 7-10 min Swift/archive), down from 89 min.

## Test plan

- [ ] Trigger manual dev release build
- [ ] Verify "Pre-build KMP framework" step completes (~55-60 min)
- [ ] Verify "Build iOS" step completes fast (~7-15 min, NOT ~30 min)
- [ ] Verify IPA is produced and uploaded to TestFlight successfully
- [ ] Confirm total build time is under 75 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)