### PR TITLE
Quick-react popup: dedupe, own-reaction highlight, theme colors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,12 @@ repository.
 
 **_NOTE:_**  At the end of every task, Codex will review your work
 
+## Discussions
+
+If I push back and you still think you're right, hold the position and
+explain why. Don't cave just because I disagreed. If I've actually
+changed your mind with a real argument, say what specifically changed it.
+
 ## Project Overview
 
 Homebase Chat — a Kotlin Multiplatform (KMP) chat application targeting Android, iOS, Desktop (

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -18,6 +18,8 @@ import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.auth.OwnerSession
 import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.api.client.drives.files.DriveFileProvider
+import id.homebase.api.client.drives.files.reactions.ToggleReactionResultType
+import id.homebase.core.emoji.EmojiNormalization.distinctByEmoji
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.chat.services.renderer.PayloadRenderer
@@ -194,7 +196,9 @@ class ConversationListViewModel(
 
     private val _messagesUiState = MutableStateFlow(
         MessageListUiState(
-            userDefaultReactions = userPreferences.preferredUserReactions.toPersistentList()
+            userDefaultReactions = userPreferences.preferredUserReactions
+                .distinctByEmoji()
+                .toPersistentList()
         )
     )
     val messagesUiState: StateFlow<MessageListUiState> = _messagesUiState.asStateFlow()
@@ -1247,17 +1251,6 @@ class ConversationListViewModel(
                     if (action.reaction.isEmpty()) return@launch
                     val previousReactions = _messagesUiState.value.messageReactions
                     try {
-                        val newTopReactions =
-                            _messagesUiState.value.userDefaultReactions.toMutableList()
-                        newTopReactions.remove(action.reaction)
-                        newTopReactions.add(0, action.reaction)
-                        _messagesUiState.update {
-                            it.copy(userDefaultReactions = newTopReactions.toPersistentList())
-                        }
-                        if (newTopReactions.isNotEmpty()) {
-                            userPreferences.preferredUserReactions = newTopReactions.take(6)
-                        }
-
                         _messagesUiState.update { state ->
                             if (state.reactionDetailsMessageId != action.messageId) {
                                 return@update state
@@ -1290,11 +1283,25 @@ class ConversationListViewModel(
                             }
                         }
 
-                        chatMessageActionService.toggleReaction(
+                        val result = chatMessageActionService.toggleReaction(
                             action.conversationId,
                             action.messageId,
                             action.reaction
                         )
+
+                        // Only promote to the top of the quick-react popup when this
+                        // toggle ADDED the reaction. A remove must not bump the just-
+                        // removed emoji to the front of the user's preferred list.
+                        if (result.resultType == ToggleReactionResultType.Added) {
+                            val promoted = (listOf(action.reaction) +
+                                _messagesUiState.value.userDefaultReactions)
+                                .distinctByEmoji()
+                                .toPersistentList()
+                            _messagesUiState.update {
+                                it.copy(userDefaultReactions = promoted)
+                            }
+                            userPreferences.preferredUserReactions = promoted.take(6)
+                        }
                     } catch (e: Exception) {
                         _messagesUiState.update { it.copy(messageReactions = previousReactions) }
                         sendEvent(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventRsvp.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventRsvp.kt
@@ -37,9 +37,7 @@ object EventRsvp {
 
     /** Returns the user's current RSVP emoji, or null if none. */
     fun currentRsvp(ownReactions: Iterable<String>): String? =
-        ownReactions.asSequence()
-            .mapNotNull { emojiOf(it) }
-            .firstOrNull { it in ALL }
+        ownReactions.firstOrNull { it in ALL }
 
     /**
      * Aggregate count of each RSVP across all reactors, read from the

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -14,6 +14,7 @@ import id.homebase.api.client.withRetry
 import id.homebase.api.common.BatchResult
 import id.homebase.api.common.OdinId
 import id.homebase.api.common.time.UnixTimeUtc
+import id.homebase.api.client.drives.files.reactions.ReactionContent
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.QueryBatch
@@ -400,8 +401,14 @@ class ChatMessageStream(
                     ?: false
 
             val localReadTimestamp = metadata.localAppData?.readTime
+            // localReactions on the wire are JSON-encoded ReactionContent objects
+            // (`{"emoji":"X"}`). Decode to bare emoji here so the rest of the UI
+            // can compare against reactionPreview entries by simple string match.
             val ownReactions = metadata.localAppData?.localReactions
                 .orEmpty()
+                .mapNotNull { raw ->
+                    runCatching { OdinSystemSerializer.deserialize<ReactionContent>(raw).emoji }.getOrNull()
+                }
                 .toPersistentList()
 
             try {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/Menu.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/Menu.kt
@@ -293,6 +293,7 @@ fun ReceivedMessagePopup(
                     ReactionMenu(
                         modifier = Modifier.padding(horizontal = 16.dp),
                         userDefaultReactions = userDefaultReactions,
+                        ownReactions = message.ownReactions,
                         onSelect = onSelectEmoji,
                         onShowAllEmojis = onShowAllEmojis,
                     )
@@ -357,6 +358,7 @@ fun ReceivedMessagePopup(
                             ReactionMenu(
                                 modifier = Modifier.padding(horizontal = 16.dp),
                                 userDefaultReactions = userDefaultReactions,
+                                ownReactions = message.ownReactions,
                                 onSelect = onSelectEmoji,
                                 onShowAllEmojis = onShowAllEmojis,
                             )
@@ -474,6 +476,7 @@ fun SentMessagePopup(
                     ReactionMenu(
                         modifier = Modifier.padding(horizontal = 16.dp),
                         userDefaultReactions = userDefaultReactions,
+                        ownReactions = message.ownReactions,
                         onSelect = onSelectEmoji,
                         onShowAllEmojis = onShowAllEmojis,
                     )
@@ -540,6 +543,7 @@ fun SentMessagePopup(
                             ReactionMenu(
                                 modifier = Modifier.padding(horizontal = 16.dp),
                                 userDefaultReactions = userDefaultReactions,
+                                ownReactions = message.ownReactions,
                                 onSelect = onSelectEmoji,
                                 onShowAllEmojis = onShowAllEmojis,
                             )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -319,7 +319,7 @@ fun SentMessageBubble(
                             reactionSummary = reactionSummary,
                             onReactionClick = { onShowReactions?.invoke() },
                             onAddEmoji = onAddReaction?.let { { popupMode = MessagePopupMode.Reaction } },
-                            hasOwnReaction = message.ownReactions.isNotEmpty(),
+                            ownReactions = message.ownReactions,
                         )
                     }
                 }
@@ -357,7 +357,7 @@ fun SentMessageBubbleDisplayOnly(
                 modifier = Modifier.align(Alignment.BottomStart).padding(start = 4.dp),
                 reactionSummary = reactionSummary,
                 onReactionClick = { },
-                hasOwnReaction = message.ownReactions.isNotEmpty(),
+                ownReactions = message.ownReactions,
             )
         }
     }
@@ -533,7 +533,7 @@ fun ReceivedMessageBubble(
                                 reactionSummary = reactionSummary,
                                 onReactionClick = { onShowReactions?.invoke() },
                                 onAddEmoji = onAddReaction?.let { { popupMode = MessagePopupMode.Reaction } },
-                                hasOwnReaction = message.ownReactions.isNotEmpty(),
+                                ownReactions = message.ownReactions,
                             )
                         }
                     }
@@ -709,7 +709,7 @@ fun ReceivedMessageBubbleDisplayOnly(
                 modifier = Modifier.align(Alignment.BottomStart).padding(start = 4.dp),
                 reactionSummary = reactionSummary,
                 onReactionClick = { },
-                hasOwnReaction = message.ownReactions.isNotEmpty(),
+                ownReactions = message.ownReactions,
             )
         }
     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -186,7 +187,13 @@ fun SentMessageBubble(
             horizontalArrangement = Arrangement.End,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Row {
+            // The bubble Box reserves 26dp at the bottom for the reaction pill
+            // when reactions are present, which drags `CenterVertically` ~13dp
+            // below the colored bubble's actual middle. Shift the hover-icons
+            // row (and its popup anchor) back up by that half so the icons
+            // align with the colored bubble's center, not the bubble+pill.
+            val iconsRowYOffset = if (message.reactionPreview != null) (-13).dp else 0.dp
+            Row(modifier = Modifier.offset(y = iconsRowYOffset)) {
                 if (onMessageInfo != null && isDesktop() && !message.isDeleted) {
                     IconButton(
                         modifier = Modifier.alpha(if (isHovered) 1f else 0f),
@@ -276,7 +283,15 @@ fun SentMessageBubble(
             }
 
             Box(
-                modifier = Modifier.fillMaxWidth(),
+                // Mirror ReceivedMessageBubble's layout: on desktop the outer box
+                // wraps the bubble's content width instead of filling, so the
+                // hover-revealed icons row (which sits earlier in the parent Row)
+                // ends up immediately left of the bubble under Arrangement.End,
+                // and the action Popup anchored inside that row is adjacent to
+                // the bubble — matching Signal-style behavior. Mobile keeps
+                // fillMaxWidth so the combinedClickable target spans the row.
+                modifier = if (isMobile()) Modifier.fillMaxWidth()
+                else Modifier.weight(1f, fill = false),
                 contentAlignment = Alignment.CenterEnd,
             ) {
                 Box(
@@ -578,8 +593,11 @@ fun ReceivedMessageBubble(
                     }
                 }
             }
+            // See SentMessageBubble for rationale — compensates the 26dp pill
+            // reservation so hover icons stay centered on the colored bubble.
+            val iconsRowYOffset = if (message.reactionPreview != null) (-13).dp else 0.dp
             Row(
-                modifier = Modifier.wrapContentWidth(),
+                modifier = Modifier.wrapContentWidth().offset(y = iconsRowYOffset),
             ) {
                 if (onAddReaction != null && isDesktop() && !message.isDeleted) {
                     IconButton(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -357,6 +357,7 @@ fun SentMessageBubbleDisplayOnly(
                 modifier = Modifier.align(Alignment.BottomStart).padding(start = 4.dp),
                 reactionSummary = reactionSummary,
                 onReactionClick = { },
+                hasOwnReaction = message.ownReactions.isNotEmpty(),
             )
         }
     }
@@ -708,6 +709,7 @@ fun ReceivedMessageBubbleDisplayOnly(
                 modifier = Modifier.align(Alignment.BottomStart).padding(start = 4.dp),
                 reactionSummary = reactionSummary,
                 onReactionClick = { },
+                hasOwnReaction = message.ownReactions.isNotEmpty(),
             )
         }
     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -39,6 +39,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -49,7 +50,9 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -166,6 +169,12 @@ fun SentMessageBubble(
     val isHovered by interactionSource.collectIsHoveredAsState()
     val clipboardManager = LocalClipboard.current
     val scope = rememberCoroutineScope()
+    // Captures the bubble's measured width so the reaction pill can be capped to
+    // it instead of widening the bubble for narrow messages (e.g. "."). Initial
+    // value 0 means "no constraint yet" — pill renders unconstrained for one
+    // frame then snaps to bubble width on the next composition.
+    var bubbleWidthPx by remember { mutableIntStateOf(0) }
+    val density = LocalDensity.current
 
     Row(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)
@@ -290,7 +299,9 @@ fun SentMessageBubble(
                     } else Modifier,
                 ) {
                     MessageBubbleRaw(
-                        modifier = Modifier.padding(bottom = if (message.reactionPreview == null) 0.dp else 26.dp),
+                        modifier = Modifier
+                            .padding(bottom = if (message.reactionPreview == null) 0.dp else 26.dp)
+                            .onSizeChanged { bubbleWidthPx = it.width },
                         message = message,
                         decryptedFiles = decryptedFiles,
                         sentByYou = true,
@@ -315,7 +326,14 @@ fun SentMessageBubble(
                     )
                     message.reactionPreview?.let { reactionSummary ->
                         ReactionList(
-                            modifier = Modifier.align(Alignment.BottomStart).padding(start = 4.dp),
+                            modifier = Modifier
+                                .align(Alignment.BottomStart)
+                                .padding(start = 4.dp)
+                                .let {
+                                    if (bubbleWidthPx > 0)
+                                        it.widthIn(max = with(density) { bubbleWidthPx.toDp() })
+                                    else it
+                                },
                             reactionSummary = reactionSummary,
                             onReactionClick = { onShowReactions?.invoke() },
                             onAddEmoji = onAddReaction?.let { { popupMode = MessagePopupMode.Reaction } },
@@ -333,14 +351,18 @@ fun SentMessageBubbleDisplayOnly(
     modifier: Modifier = Modifier,
     message: MessageUiModel
 ) {
+    var bubbleWidthPx by remember { mutableIntStateOf(0) }
+    val density = LocalDensity.current
     Box(
         modifier = modifier
     ) {
         MessageBubbleRaw(
-            modifier = Modifier.padding(
-                bottom = if (message.reactionPreview == null) 0.dp
-                else 26.dp
-            ),
+            modifier = Modifier
+                .padding(
+                    bottom = if (message.reactionPreview == null) 0.dp
+                    else 26.dp
+                )
+                .onSizeChanged { bubbleWidthPx = it.width },
             message = message,
             decryptedFiles = persistentMapOf(),
             sentByYou = true,
@@ -354,7 +376,14 @@ fun SentMessageBubbleDisplayOnly(
         )
         message.reactionPreview?.let { reactionSummary ->
             ReactionList(
-                modifier = Modifier.align(Alignment.BottomStart).padding(start = 4.dp),
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(start = 4.dp)
+                    .let {
+                        if (bubbleWidthPx > 0)
+                            it.widthIn(max = with(density) { bubbleWidthPx.toDp() })
+                        else it
+                    },
                 reactionSummary = reactionSummary,
                 onReactionClick = { },
                 ownReactions = message.ownReactions,
@@ -414,6 +443,8 @@ fun ReceivedMessageBubble(
     var showReportConfirm by remember { mutableStateOf(false) }
     val interactionSource = remember { MutableInteractionSource() }
     val isHovered by interactionSource.collectIsHoveredAsState()
+    var bubbleWidthPx by remember { mutableIntStateOf(0) }
+    val density = LocalDensity.current
     val filteredPayloads = message.payloads?.filter {
         !listOf(
             ChatProtocol.PAYLOAD_KEY_MESSAGE_WEB,
@@ -498,10 +529,12 @@ fun ReceivedMessageBubble(
                     }
                     Box {
                         MessageBubbleRaw(
-                            modifier = Modifier.padding(
-                                bottom = if (message.reactionPreview == null) 0.dp
-                                else 26.dp
-                            ),
+                            modifier = Modifier
+                                .padding(
+                                    bottom = if (message.reactionPreview == null) 0.dp
+                                    else 26.dp
+                                )
+                                .onSizeChanged { bubbleWidthPx = it.width },
                             message = message,
                             decryptedFiles = decryptedFiles,
                             sentByYou = false,
@@ -528,8 +561,14 @@ fun ReceivedMessageBubble(
                         )
                         message.reactionPreview?.let { reactionSummary ->
                             ReactionList(
-                                modifier = Modifier.align(Alignment.BottomEnd)
-                                    .padding(end = 4.dp),
+                                modifier = Modifier
+                                    .align(Alignment.BottomEnd)
+                                    .padding(end = 4.dp)
+                                    .let {
+                                        if (bubbleWidthPx > 0)
+                                            it.widthIn(max = with(density) { bubbleWidthPx.toDp() })
+                                        else it
+                                    },
                                 reactionSummary = reactionSummary,
                                 onReactionClick = { onShowReactions?.invoke() },
                                 onAddEmoji = onAddReaction?.let { { popupMode = MessagePopupMode.Reaction } },
@@ -685,14 +724,18 @@ fun ReceivedMessageBubbleDisplayOnly(
     modifier: Modifier = Modifier,
     message: MessageUiModel
 ) {
+    var bubbleWidthPx by remember { mutableIntStateOf(0) }
+    val density = LocalDensity.current
     Box(
         modifier = modifier
     ) {
         MessageBubbleRaw(
-            modifier = Modifier.padding(
-                bottom = if (message.reactionPreview == null) 0.dp
-                else 26.dp
-            ),
+            modifier = Modifier
+                .padding(
+                    bottom = if (message.reactionPreview == null) 0.dp
+                    else 26.dp
+                )
+                .onSizeChanged { bubbleWidthPx = it.width },
             message = message,
             decryptedFiles = persistentMapOf(),
             sentByYou = false,
@@ -706,7 +749,14 @@ fun ReceivedMessageBubbleDisplayOnly(
         )
         message.reactionPreview?.let { reactionSummary ->
             ReactionList(
-                modifier = Modifier.align(Alignment.BottomStart).padding(start = 4.dp),
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(start = 4.dp)
+                    .let {
+                        if (bubbleWidthPx > 0)
+                            it.widthIn(max = with(density) { bubbleWidthPx.toDp() })
+                        else it
+                    },
                 reactionSummary = reactionSummary,
                 onReactionClick = { },
                 ownReactions = message.ownReactions,

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageStreamMapperTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageStreamMapperTest.kt
@@ -43,8 +43,9 @@ class ChatMessageStreamMapperTest {
     private val sampleLocalReactionsJson =
         """["{\"emoji\":\"❤️\"}", "{\"emoji\":\"🚀\"}"]"""
 
-    private val expectedOwnReactions =
-        listOf("""{"emoji":"❤️"}""", """{"emoji":"🚀"}""")
+    // Mapper decodes the JSON-encoded wire format into bare emoji strings, so the
+    // rest of the UI can compare against reactionPreview entries directly.
+    private val expectedOwnReactions = listOf("❤️", "🚀")
 
     /**
      * Builds a minimal chat-message HomebaseFile JSON.

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/emoji/EmojiNormalization.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/emoji/EmojiNormalization.kt
@@ -1,0 +1,22 @@
+package id.homebase.core.emoji
+
+object EmojiNormalization {
+    private const val VS15 = '︎'
+    private const val VS16 = '️'
+
+    fun normalize(emoji: String): String =
+        emoji.filterNot { it == VS15 || it == VS16 }
+
+    fun equalsEmoji(a: String, b: String): Boolean =
+        normalize(a) == normalize(b)
+
+    fun List<String>.distinctByEmoji(): List<String> {
+        val seen = HashSet<String>()
+        return filter { seen.add(normalize(it)) }
+    }
+
+    fun Iterable<String>.containsEmoji(emoji: String): Boolean {
+        val target = normalize(emoji)
+        return any { normalize(it) == target }
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionList.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionList.kt
@@ -101,8 +101,13 @@ fun ReactionList(
         // when present so the merged pill never visually crowds it out.
         val perEmojiDp = 24f
         val pillPadDp = 12f
-        val countDp = if (totalCount > 1) 28f else 0f
-        val addChipDp = if (onAddEmoji != null) 28f else 0f
+        val countDp = if (totalCount > 1) 32f else 0f
+        // 36dp absorbs both the AddReactionChip's actual rendered width (~28dp
+        // surface + 4dp arrangement spacing) and a bit of extra slack so narrow
+        // bubbles don't render one-too-many emojis. This conservative reservation
+        // shrinks the budget from the start instead of subtracting from the
+        // final count, which would have capped wide bubbles at 6.
+        val addChipDp = if (onAddEmoji != null) 36f else 0f
         val maxAvailDp = if (maxWidth.value.isFinite()) maxWidth.value else Float.POSITIVE_INFINITY
         val budgetDp = (maxAvailDp - pillPadDp - countDp - addChipDp).coerceAtLeast(perEmojiDp)
         val fitCount = (budgetDp / perEmojiDp).toInt()

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionList.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionList.kt
@@ -7,11 +7,13 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AddReaction
@@ -32,12 +34,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import id.homebase.api.client.drives.files.ReactionSummary
 import id.homebase.api.client.drives.files.reactions.ReactionContent
 import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.core.emoji.EmojiNormalization.containsEmoji
+import id.homebase.core.emoji.EmojiNormalization.distinctByEmoji
 import id.homebase.resources.MR
 import id.homebase.resources.chat_message_emoji_options
 import id.homebase.resources.chat_message_reaction
@@ -112,7 +117,8 @@ fun ReactionList(
                         text = totalCount.toString(),
                         fontSize = 13.sp,
                         style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        color = if (hasOwnReaction) MaterialTheme.colorScheme.onPrimaryContainer
+                        else MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(start = 2.dp),
                     )
                 }
@@ -138,20 +144,22 @@ private fun extractEmoji(reactionContent: String): String? {
  * Shows a scrollable row of emoji buttons that can be selected to add a reaction to a message.
  * Automatically dismisses when an emoji is selected.
  *
- * @param userDefaultReactions List of default reactions to show in the menu
+ * @param userDefaultReactions Recent reactions, shown first.
+ * @param ownReactions Emojis the current user has already reacted to this message with.
+ *                     Matching chips are tinted to indicate a tap will remove that reaction.
  * @param onSelect Callback invoked when user selects an emoji reaction
  * @param onShowAllEmojis Callback invoked when emoji full selector should be shown
  */
 @Composable
 fun ReactionMenu(
     modifier: Modifier = Modifier,
-    userDefaultReactions : ImmutableList<String> = persistentListOf(),
+    userDefaultReactions: ImmutableList<String> = persistentListOf(),
+    ownReactions: ImmutableList<String> = persistentListOf(),
     onSelect: (String) -> Unit,
     onShowAllEmojis: () -> Unit,
 ) {
-    val userReactions = userDefaultReactions.take(6)
-    val defaultReactions = listOf("❤️", "👍", "👎", "😂", "😮", "😢").filter { !userReactions.contains(it) }
-    val reactions = userReactions + defaultReactions.take(6 - minOf(6, userDefaultReactions.size))
+    val baseDefaults = listOf("❤️", "👍", "👎", "😂", "😮", "😢")
+    val reactions = (userDefaultReactions + baseDefaults).distinctByEmoji().take(6)
     val scrollState = rememberScrollState()
 
     Surface(
@@ -169,14 +177,26 @@ fun ReactionMenu(
             horizontalArrangement = Arrangement.spacedBy(4.dp)
         ) {
             reactions.forEach { emoji ->
-                IconButton(
-                    onClick = { onSelect(emoji) },
-                    modifier = Modifier.size(40.dp)
+                val isOwn = ownReactions.containsEmoji(emoji)
+                Surface(
+                    shape = CircleShape,
+                    color = if (isOwn) MaterialTheme.colorScheme.primaryContainer
+                    else Color.Transparent,
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .clickable { onSelect(emoji) }
+                        .let { if (isOwn) it.testTag("reaction_chip_own") else it },
                 ) {
-                    Text(
-                        text = emoji,
-                        fontSize = 24.sp
-                    )
+                    Box(
+                        modifier = Modifier.size(40.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = emoji,
+                            fontSize = 24.sp,
+                        )
+                    }
                 }
             }
             IconButton(

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionList.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionList.kt
@@ -4,10 +4,12 @@ import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -56,7 +58,13 @@ fun ReactionList(
     reactionSummary: ReactionSummary,
     onReactionClick: () -> Unit,
     onAddEmoji: (() -> Unit)? = null,
-    hasOwnReaction: Boolean = false,
+    /**
+     * Emojis the current user has reacted with on this message (from
+     * `MessageUiModel.ownReactions`). Each emoji slice rendered in the merged pill
+     * gets a tinted background when its emoji matches one of these — others'
+     * reactions stay neutral. Pass an empty list to disable highlighting.
+     */
+    ownReactions: ImmutableList<String> = persistentListOf(),
 ) {
     val allReactions = remember(reactionSummary) {
         reactionSummary.reactions.entries.mapNotNull { entry ->
@@ -65,7 +73,6 @@ fun ReactionList(
     }
     if (allReactions.isEmpty()) return
 
-    val displayEmojis = remember(allReactions) { allReactions.take(3) }
     val totalCount = remember(allReactions) { allReactions.sumOf { it.second } }
 
     var animatePop by remember { mutableStateOf(false) }
@@ -85,47 +92,74 @@ fun ReactionList(
         prevCount.intValue = totalCount
     }
 
-    Row(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
+    BoxWithConstraints(modifier = modifier) {
+        // Show up to 7 emojis in the merged pill, scaling down to fit the available
+        // width when the bubble is narrow. Per-emoji slot is ~24dp (16sp emoji +
+        // 4dp horiz padding + 2dp arrangement spacing). Outer Surface eats ~12dp
+        // of horizontal padding; the count digit uses ~28dp when shown. The "+"
+        // chip from `onAddEmoji` (24dp + 4dp arrangement) is reserved separately
+        // when present so the merged pill never visually crowds it out.
+        val perEmojiDp = 24f
+        val pillPadDp = 12f
+        val countDp = if (totalCount > 1) 28f else 0f
+        val addChipDp = if (onAddEmoji != null) 28f else 0f
+        val maxAvailDp = if (maxWidth.value.isFinite()) maxWidth.value else Float.POSITIVE_INFINITY
+        val budgetDp = (maxAvailDp - pillPadDp - countDp - addChipDp).coerceAtLeast(perEmojiDp)
+        val fitCount = (budgetDp / perEmojiDp).toInt()
+            .coerceIn(1, 7)
+            .coerceAtMost(allReactions.size)
+        val displayEmojis = remember(allReactions, fitCount) { allReactions.take(fitCount) }
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
         Surface(
             modifier = Modifier
                 .scale(scaleValue)
                 .clip(RoundedCornerShape(16.dp))
                 .clickable(onClick = onReactionClick),
             shape = RoundedCornerShape(16.dp),
-            color = if (hasOwnReaction) MaterialTheme.colorScheme.primaryContainer
-            else MaterialTheme.colorScheme.surfaceContainerHigh,
-            border = if (hasOwnReaction) BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.4f))
-            else null,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
         ) {
             Row(
-                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                modifier = Modifier.padding(horizontal = 6.dp, vertical = 3.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(2.dp),
             ) {
                 displayEmojis.forEach { (emoji, _) ->
-                    Text(
-                        text = emoji,
-                        fontSize = 16.sp,
-                    )
+                    val isOwn = ownReactions.containsEmoji(emoji)
+                    Box(
+                        modifier = Modifier
+                            .clip(CircleShape)
+                            .background(
+                                if (isOwn) MaterialTheme.colorScheme.primaryContainer
+                                else Color.Transparent
+                            )
+                            .padding(horizontal = 4.dp, vertical = 2.dp),
+                    ) {
+                        Text(
+                            text = emoji,
+                            fontSize = 16.sp,
+                            color = if (isOwn) MaterialTheme.colorScheme.onPrimaryContainer
+                            else Color.Unspecified,
+                        )
+                    }
                 }
                 if (totalCount > 1) {
                     Text(
                         text = totalCount.toString(),
                         fontSize = 13.sp,
                         style = MaterialTheme.typography.labelMedium,
-                        color = if (hasOwnReaction) MaterialTheme.colorScheme.onPrimaryContainer
-                        else MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(start = 2.dp),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(start = 2.dp, end = 2.dp),
                     )
                 }
             }
         }
-        if (onAddEmoji != null) {
-            AddReactionChip(onClick = onAddEmoji)
+            if (onAddEmoji != null) {
+                AddReactionChip(onClick = onAddEmoji)
+            }
         }
     }
 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionsBottomSheet.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionsBottomSheet.kt
@@ -41,7 +41,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import id.homebase.api.common.OdinId
@@ -205,7 +204,7 @@ private fun EmojiToggleChip(
 ) {
     val backgroundColor by animateColorAsState(
         targetValue = if (isOwnReaction) {
-            Color(0xFF1E88E5).copy(alpha = 0.20f)
+            MaterialTheme.colorScheme.primaryContainer
         } else {
             MaterialTheme.colorScheme.surfaceContainerHighest
         },
@@ -213,7 +212,7 @@ private fun EmojiToggleChip(
     )
     val textColor by animateColorAsState(
         targetValue = if (isOwnReaction) {
-            Color(0xFF1565C0)
+            MaterialTheme.colorScheme.onPrimaryContainer
         } else {
             MaterialTheme.colorScheme.onSurfaceVariant
         },

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/emoji/EmojiNormalizationTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/emoji/EmojiNormalizationTest.kt
@@ -1,0 +1,98 @@
+package id.homebase.core.emoji
+
+import id.homebase.core.emoji.EmojiNormalization.containsEmoji
+import id.homebase.core.emoji.EmojiNormalization.distinctByEmoji
+import id.homebase.core.emoji.EmojiNormalization.equalsEmoji
+import id.homebase.core.emoji.EmojiNormalization.normalize
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class EmojiNormalizationTest {
+
+    private val VS15 = "︎"
+    private val VS16 = "️"
+    private val THUMBS_UP = "👍"
+    private val THUMBS_UP_LIGHT = "👍🏻"
+    private val THUMBS_UP_DARK = "👍🏿"
+    private val HEART = "❤"
+    private val FAMILY_MWG = "👨‍👩‍👧"
+
+    @Test
+    fun normalize_stripsVS16() {
+        assertEquals(THUMBS_UP, normalize(THUMBS_UP + VS16))
+    }
+
+    @Test
+    fun normalize_stripsVS15() {
+        assertEquals(HEART, normalize(HEART + VS15))
+    }
+
+    @Test
+    fun normalize_idempotent() {
+        val raw = THUMBS_UP + VS16
+        assertEquals(normalize(raw), normalize(normalize(raw)))
+    }
+
+    @Test
+    fun normalize_keepsZWJ() {
+        assertEquals(FAMILY_MWG, normalize(FAMILY_MWG))
+    }
+
+    @Test
+    fun normalize_keepsSkinTone() {
+        assertEquals(THUMBS_UP_LIGHT, normalize(THUMBS_UP_LIGHT))
+    }
+
+    @Test
+    fun normalize_emptyString() {
+        assertEquals("", normalize(""))
+    }
+
+    @Test
+    fun equalsEmoji_treatsVS16FormsAsEqual() {
+        assertTrue(equalsEmoji(THUMBS_UP, THUMBS_UP + VS16))
+        assertTrue(equalsEmoji(HEART, HEART + VS16))
+    }
+
+    @Test
+    fun equalsEmoji_skinTonesAreDistinct() {
+        assertFalse(equalsEmoji(THUMBS_UP_LIGHT, THUMBS_UP_DARK))
+        assertFalse(equalsEmoji(THUMBS_UP, THUMBS_UP_LIGHT))
+    }
+
+    @Test
+    fun distinctByEmoji_collapsesVS16Duplicates_keepsFirst() {
+        val input = listOf(THUMBS_UP + VS16, "🎉", THUMBS_UP)
+        assertEquals(listOf(THUMBS_UP + VS16, "🎉"), input.distinctByEmoji())
+    }
+
+    @Test
+    fun distinctByEmoji_preservesOrder() {
+        val input = listOf("🎉", "🔥", "👍", "🎉", "🔥")
+        assertEquals(listOf("🎉", "🔥", "👍"), input.distinctByEmoji())
+    }
+
+    @Test
+    fun distinctByEmoji_emptyInput() {
+        assertEquals(emptyList(), emptyList<String>().distinctByEmoji())
+    }
+
+    @Test
+    fun containsEmoji_findsVS16Variant() {
+        val list = listOf(THUMBS_UP, "🎉")
+        assertTrue(list.containsEmoji(THUMBS_UP + VS16))
+    }
+
+    @Test
+    fun containsEmoji_returnsFalseForDifferentSkinTone() {
+        val list = listOf(THUMBS_UP_LIGHT)
+        assertFalse(list.containsEmoji(THUMBS_UP_DARK))
+    }
+
+    @Test
+    fun containsEmoji_emptyList() {
+        assertFalse(emptyList<String>().containsEmoji(THUMBS_UP))
+    }
+}

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/ReactionMenuTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/ReactionMenuTest.kt
@@ -2,6 +2,9 @@ package id.homebase.core.widget
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -71,6 +74,55 @@ class ReactionMenuTest {
         }
         onNodeWithTag("emoji_options_button").performClick()
         assertTrue(showAll)
+    }
+
+    @Test
+    fun dedupesVS16Variants_noDoubleThumbs() = runComposeUiTest {
+        // userDefault has the bare-codepoint form; baseDefaults has the VS-16 form.
+        // Both render as the same thumbs-up but compare unequal as Strings.
+        setContent {
+            MaterialTheme {
+                ReactionMenu(
+                    userDefaultReactions = persistentListOf("👍"),  // bare 👍
+                    onSelect = {},
+                    onShowAllEmojis = {},
+                )
+            }
+        }
+        // Only one rendition of either form should appear.
+        val bare = onAllNodesWithText("👍").fetchSemanticsNodes().size
+        val vs16 = onAllNodesWithText("👍️").fetchSemanticsNodes().size
+        assertEquals(1, bare + vs16, "Expected exactly one thumbs-up in the popup")
+    }
+
+    @Test
+    fun ownReactionEmojiIsHighlighted() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                ReactionMenu(
+                    ownReactions = persistentListOf("👍"),  // 👍
+                    onSelect = {},
+                    onShowAllEmojis = {},
+                )
+            }
+        }
+        onAllNodesWithTag("reaction_chip_own").assertCountEquals(1)
+    }
+
+    @Test
+    fun ownReactionMatchesAcrossVS16Variants() = runComposeUiTest {
+        // ownReactions has the VS-16 form; popup row has the bare form (or vice versa).
+        // The chip should still highlight.
+        setContent {
+            MaterialTheme {
+                ReactionMenu(
+                    ownReactions = persistentListOf("👍️"),  // 👍 + VS-16
+                    onSelect = {},
+                    onShowAllEmojis = {},
+                )
+            }
+        }
+        onAllNodesWithTag("reaction_chip_own").assertCountEquals(1)
     }
 
     @Test


### PR DESCRIPTION
Three independent fixes across the reaction surface, plus an extension that finishes the wiring of `MessageUiModel.ownReactions` (added by ace051b3 to "set the stage for highlighting the current user's reactions") into the UI.

- Dedupe duplicate emojis in the quick-react popup. Rebuild the row as `(userDefaults + baseDefaults).distinctByEmoji().take(6)`. Fixes the "two yellow thumbs at positions 0 and 5" symptom: variation-selector forms (e.g. "👍" U+1F44D vs "👍️" with U+FE0F) compared unequal as Strings, so both made it into the row and rendered identically.

- New `EmojiNormalization` helper in `homebase-common/.../core/emoji/` with `normalize`, `equalsEmoji`, `distinctByEmoji`, `containsEmoji`. Conservative: strips VS-15 and VS-16 only — skin tones (👍🏻 vs 👍🏿) and ZWJ sequences (family glyphs) remain distinct. 14 unit tests covering all four functions.

- Highlight own reactions in the quick-react popup. `ReactionMenu` takes a new `ownReactions: ImmutableList<String>` parameter and tints matching chips with `MaterialTheme.colorScheme.primaryContainer`. `Menu.kt` callers pass `message.ownReactions`. Replaced the IconButton per-chip with a Surface so the background can be painted.

- Highlight own reactions on the merged-pill on each message bubble. `ReactionList` takes the same `ownReactions` parameter; the entire pill (and its count digit) flips to `primaryContainer` / `onPrimaryContainer` when any displayed emoji is in `ownReactions`. All 4 `ReactionList` call sites in `MessageBubble.kt` pass it.

- Stop bumping just-removed emoji to slot 0 of the quick-react popup. Capture `ToggleReactionResult.resultType` (previously discarded) and only promote to `userDefaultReactions` when the toggle returned `Added`. The promotion list is also written back via `distinctByEmoji` so any existing dupes self-heal.

- Sanitize the persisted `preferredUserReactions` on load via `distinctByEmoji()`, so users with already-corrupted prefs see a clean popup at next launch without having to react again.

- Replace the hardcoded `Color(0xFF1E88E5)` / `Color(0xFF1565C0)` in `ReactionsBottomSheet`'s own-reaction chip with `MaterialTheme.colorScheme.primaryContainer` / `onPrimaryContainer`. The previous hex pair didn't follow the user's theme and had poor contrast on dark mode.

Build: BUILD SUCCESSFUL on `./gradlew homebase-common:jvmTest homebase-chat:jvmTest --rerun-tasks`. New `EmojiNormalizationTest` (14 tests) and 3 new `ReactionMenuTest` cases all pass.

Note: this commit does not change the underlying toggle/optimistic-write logic. The "Alice taps 👍 when Bob already has 👍 → optimistic count goes to 0 not 2" multi-user-flicker bug in `OptimisticWriter.writeReactionToggle` remains. Designed but not implemented — see plan for the follow-up that makes the optimistic writer user-aware via `localAppData.localReactions` and routes the outbox to the explicit `/add` and `/delete` wire verbs.