### PR TITLE
fix(chat): UI polish — hit targets, timestamps, unread separator, a11y, i18n

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactinfo/ContactInfoScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactinfo/ContactInfoScreen.kt
@@ -26,6 +26,7 @@ import id.homebase.chat.widget.LoadingListItem
 import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.ContactAvatar
 import id.homebase.resources.MR
+import id.homebase.resources.error_no_contact_loaded
 import id.homebase.resources.menu_back
 import org.jetbrains.compose.resources.stringResource
 
@@ -80,7 +81,7 @@ fun ContactInfoUi(
                 if (uiState.isLoading) {
                     LoadingListItem()
                 } else {
-                    ErrorInfoItem("No contact could be loaded")
+                    ErrorInfoItem(stringResource(MR.string.error_no_contact_loaded))
                 }
             }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -61,6 +61,7 @@ import id.homebase.chat.widget.ExtendPermissionDialog
 import id.homebase.core.connections.ConnectRequestAction
 import id.homebase.core.connections.ConnectRequestBottomSheet
 import id.homebase.core.connections.ConnectRequestViewModel
+import id.homebase.core.localization.TranslationUtil
 import id.homebase.core.ui.theme.HomebaseTheme
 import id.homebase.core.util.getUriHandler
 import id.homebase.core.util.isDesktop
@@ -97,6 +98,9 @@ import id.homebase.resources.chat_leave_and_delete_conversation_title
 import id.homebase.resources.chat_select_a_conversation
 import id.homebase.resources.chat_select_a_conversation_subtitle
 import id.homebase.resources.discard
+import id.homebase.resources.error_unknown
+import id.homebase.resources.file_save_failed
+import id.homebase.resources.file_saved_to
 import kotlinx.coroutines.launch
 import kotlinx.io.files.Path
 import org.jetbrains.compose.resources.stringResource
@@ -204,14 +208,15 @@ fun ConversationListScreen(
                     file = Path(event.filePath),
                     suggestedName = event.suggestedName,
                     onSuccess = { location ->
-                        scope.launch { snackbarHostState.showSnackbar("Saved to $location") }
+                        val msg = TranslationUtil.getString(MR.string.file_saved_to, location)
+                        scope.launch { snackbarHostState.showSnackbar(msg) }
                     },
                     onError = { error ->
-                        scope.launch {
-                            snackbarHostState.showSnackbar(
-                                "Failed to save: ${error.message ?: "Unknown error"}"
-                            )
-                        }
+                        val msg = TranslationUtil.getString(
+                            MR.string.file_save_failed,
+                            error.message ?: TranslationUtil.getString(MR.string.error_unknown)
+                        )
+                        scope.launch { snackbarHostState.showSnackbar(msg) }
                     },
                 )
             }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -160,6 +160,8 @@ sealed class MessageListContentModel(val id: String) {
         val message: MessageUiModel,
         val clusterPosition: MessageClusterPosition = MessageClusterPosition.ALONE,
     ) : MessageListContentModel(message.id.toString() + message.versionTag.toString() + message.hasMore)
+
+    data object UnreadSeparator : MessageListContentModel("unread-separator")
 }
 
 @Immutable

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -2549,6 +2549,23 @@ class ConversationListViewModel(
                                 }
                             })
 
+                            // Insert "New Messages" separator before the first unread message
+                            val convoModel = _uiState.value.activeConversations
+                                .find { it.conversation.id == conversationId }
+                                ?.conversation
+                            val lastRead = convoModel?.lastRead
+                            val currentOdinId = _uiState.value.ownerSession?.odinId
+                            if (lastRead != null && convoModel.unreadCount > 0) {
+                                val firstUnreadIdx = messagesModels.indexOfFirst {
+                                    it is MessageListContentModel.Message &&
+                                        it.message.sender != currentOdinId &&
+                                        it.message.userDate > lastRead
+                                }
+                                if (firstUnreadIdx > 0) {
+                                    messagesModels.add(firstUnreadIdx, MessageListContentModel.UnreadSeparator)
+                                }
+                            }
+
                             // Scroll handling: navigate to a specific message (search results,
                             // cross-conversation jumps, etc.). The user's own just-sent messages
                             // are handled by the LazyColumn auto-follow effect in ConversationContent.kt,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationsettings/ConversationSettingsScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationsettings/ConversationSettingsScreen.kt
@@ -20,6 +20,7 @@ import id.homebase.chat.widget.AvatarNameDisplay
 import id.homebase.chat.widget.ErrorInfoItem
 import id.homebase.chat.widget.LoadingListItem
 import id.homebase.resources.MR
+import id.homebase.resources.error_no_group_loaded
 import id.homebase.resources.menu_back
 import org.jetbrains.compose.resources.stringResource
 
@@ -81,7 +82,7 @@ fun ConversationSettingsUi(
                 if (uiState.isLoading) {
                     LoadingListItem()
                 } else {
-                    ErrorInfoItem("No group could be loaded")
+                    ErrorInfoItem(stringResource(MR.string.error_no_group_loaded))
                 }
             }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/createconversation/CreateConversationScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/createconversation/CreateConversationScreen.kt
@@ -66,6 +66,8 @@ import id.homebase.resources.chat_new_conversation_search_placeholder
 import id.homebase.resources.chat_no_contacts_found
 import id.homebase.resources.chat_note_to_self
 import id.homebase.resources.chat_search_result_empty
+import id.homebase.resources.cd_not_selected
+import id.homebase.resources.cd_selected
 import id.homebase.resources.contacts
 import id.homebase.resources.menu_back
 import kotlinx.coroutines.launch
@@ -342,9 +344,9 @@ fun ContactItem(
         if (selectionMode) {
             val tint = if(isSelectionEnabled) LocalContentColor.current else LocalContentColor.current.copy(alpha = 0.4f)
             if (isSelected) {
-                Icon(Icons.Filled.CheckCircle, contentDescription = null, tint = tint)
+                Icon(Icons.Filled.CheckCircle, contentDescription = stringResource(MR.string.cd_selected), tint = tint)
             } else {
-                Icon(Icons.Outlined.Circle, contentDescription = null, tint = tint)
+                Icon(Icons.Outlined.Circle, contentDescription = stringResource(MR.string.cd_not_selected), tint = tint)
             }
         }
     }
@@ -408,9 +410,9 @@ fun GroupOrConversationItem(
         if (selectionMode) {
             val tint = if(isSelectionEnabled) LocalContentColor.current else LocalContentColor.current.copy(alpha = 0.4f)
             if (isSelected) {
-                Icon(Icons.Filled.CheckCircle, contentDescription = null, tint = tint)
+                Icon(Icons.Filled.CheckCircle, contentDescription = stringResource(MR.string.cd_selected), tint = tint)
             } else {
-                Icon(Icons.Outlined.Circle, contentDescription = null, tint = tint)
+                Icon(Icons.Outlined.Circle, contentDescription = stringResource(MR.string.cd_not_selected), tint = tint)
             }
         }
     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsScreen.kt
@@ -80,6 +80,7 @@ import id.homebase.core.widget.ListItemAction
 import id.homebase.core.widget.ListItemActionNormalIcon
 import id.homebase.resources.MR
 import id.homebase.resources.cancel
+import id.homebase.resources.error_no_group_loaded
 import id.homebase.resources.chat_group_add_members
 import id.homebase.resources.chat_group_admin
 import id.homebase.resources.chat_group_admin_file_delivered
@@ -284,7 +285,7 @@ fun GroupSettingsUi(
                 if (uiState.isLoading) {
                     LoadingListItem()
                 } else {
-                    ErrorInfoItem("No group could be loaded")
+                    ErrorInfoItem(stringResource(MR.string.error_no_group_loaded))
                 }
             }
             uiState.conversation?.let { conversation ->

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/AttachmentOptions.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/AttachmentOptions.kt
@@ -70,6 +70,8 @@ import id.homebase.resources.chat_location_share
 import id.homebase.resources.chat_message_needs_gallery_permission
 import id.homebase.resources.chat_message_needs_gallery_permission_button_text
 import id.homebase.resources.chat_no_gallery_items
+import id.homebase.resources.cd_gallery_thumbnail
+import id.homebase.resources.cd_play_video
 import id.homebase.resources.chat_select_more_photos
 import id.homebase.resources.go_to_settings
 import id.homebase.resources.manage
@@ -153,7 +155,7 @@ fun AttachmentGallery(
                                 AsyncImage(
                                     imageLoader = imageLoader,
                                     model = galleryImage.file.toString(),
-                                    contentDescription = null,
+                                    contentDescription = stringResource(MR.string.cd_gallery_thumbnail),
                                     modifier = Modifier
                                         .size(160.dp)
                                         .clip(RoundedCornerShape(8.dp))
@@ -163,7 +165,7 @@ fun AttachmentGallery(
                                 if (galleryImage.isVideo()) {
                                     Icon(
                                         Icons.Default.PlayCircle,
-                                        contentDescription = null,
+                                        contentDescription = stringResource(MR.string.cd_play_video),
                                         tint = Color.White.copy(alpha = 0.85f)
                                     )
                                     val duration = galleryImage.durationMs

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -4,7 +4,9 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.keyframes
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandHorizontally
 import androidx.compose.animation.expandVertically
@@ -78,6 +80,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -89,6 +92,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.backhandler.BackHandler
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.focus.FocusRequester
@@ -889,7 +893,12 @@ fun ConversationContent(
                                     }
 
                                     is MessageListContentModel.UnreadSeparator -> {
-                                        Box(modifier = Modifier.animateItem()) {
+                                        Box(
+                                            modifier = Modifier.animateItem(
+                                                fadeInSpec = tween(300),
+                                                fadeOutSpec = tween(400),
+                                            ),
+                                        ) {
                                             UnreadMessagesSeparator()
                                         }
                                     }
@@ -1762,8 +1771,28 @@ private fun ScrollToBottomButton(
                 enter = fadeIn() + expandVertically(),
                 exit = fadeOut() + shrinkVertically(),
             ) {
+                val badgeScale = remember { Animatable(1f) }
+                var previousCount by remember { mutableIntStateOf(unreadCount) }
+                LaunchedEffect(unreadCount) {
+                    if (unreadCount > previousCount) {
+                        badgeScale.animateTo(
+                            targetValue = 1f,
+                            animationSpec = keyframes {
+                                durationMillis = 300
+                                1.25f at 100
+                                0.95f at 200
+                                1f at 300
+                            },
+                        )
+                    }
+                    previousCount = unreadCount
+                }
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     Surface(
+                        modifier = Modifier.graphicsLayer {
+                            scaleX = badgeScale.value
+                            scaleY = badgeScale.value
+                        },
                         shape = RoundedCornerShape(50),
                         color = MaterialTheme.colorScheme.primary,
                         contentColor = MaterialTheme.colorScheme.onPrimary,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -182,6 +182,7 @@ import id.homebase.resources.connect
 import id.homebase.resources.contacts
 import id.homebase.resources.groups
 import id.homebase.resources.menu_back
+import id.homebase.resources.cd_connection_succeeded
 import id.homebase.resources.recents
 import id.homebase.resources.search
 import id.homebase.resources.time_today
@@ -884,6 +885,12 @@ fun ConversationContent(
                                     is MessageListContentModel.System -> {
                                         Box(modifier = Modifier.animateItem()) {
                                             MessagesSystemMessage(text = item.text)
+                                        }
+                                    }
+
+                                    is MessageListContentModel.UnreadSeparator -> {
+                                        Box(modifier = Modifier.animateItem()) {
+                                            UnreadMessagesSeparator()
                                         }
                                     }
 
@@ -1598,7 +1605,7 @@ private fun ConnectIdentityRow(
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(
                         imageVector = Icons.Filled.CheckCircle,
-                        contentDescription = null,
+                        contentDescription = stringResource(MR.string.cd_connection_succeeded),
                         tint = SuccessGreen,
                     )
                     Spacer(modifier = Modifier.width(6.dp))

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -986,31 +986,17 @@ fun ConversationContent(
                             }
                         }
 
-                        Column(
+                        ScrollToBottomButton(
+                            visible = showScrollToBottom,
+                            unreadCount = conversation.conversation.unreadCount,
                             modifier = Modifier.align(Alignment.BottomEnd)
                                 .padding(end = 16.dp, bottom = 16.dp),
-                        ) {
-                            AnimatedVisibility(
-                                visible = showScrollToBottom,
-                                enter = fadeIn() + scaleIn(),
-                                exit = fadeOut() + scaleOut(),
-                            ) {
-                                SmallFloatingActionButton(
-                                    onClick = {
-                                        coroutineScope.launch {
-                                            listState.animateScrollToItem(listState.layoutInfo.totalItemsCount - 1)
-                                        }
-                                    },
-                                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                                    contentColor = MaterialTheme.colorScheme.onSurface,
-                                ) {
-                                    Icon(
-                                        imageVector = Icons.Default.KeyboardArrowDown,
-                                        contentDescription = stringResource(MR.string.chat_scroll_to_bottom),
-                                    )
+                            onClick = {
+                                coroutineScope.launch {
+                                    listState.animateScrollToItem(listState.layoutInfo.totalItemsCount - 1)
                                 }
-                            }
-                        }
+                            },
+                        )
 
                     } else {
                         CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
@@ -1746,6 +1732,54 @@ private fun getDateSectionLabel(messageDate: LocalDate): String {
                 day()
             }
             messageDate.format(format)
+        }
+    }
+}
+
+@Composable
+private fun ScrollToBottomButton(
+    visible: Boolean,
+    unreadCount: Int,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    androidx.compose.animation.AnimatedVisibility(
+        visible = visible,
+        modifier = modifier,
+        enter = fadeIn() + scaleIn(),
+        exit = fadeOut() + scaleOut(),
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            androidx.compose.animation.AnimatedVisibility(
+                visible = unreadCount > 0,
+                enter = fadeIn() + expandVertically(),
+                exit = fadeOut() + shrinkVertically(),
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Surface(
+                        shape = RoundedCornerShape(50),
+                        color = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onPrimary,
+                    ) {
+                        Text(
+                            text = if (unreadCount > 999) "999+" else unreadCount.toString(),
+                            style = MaterialTheme.typography.labelSmall,
+                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(2.dp))
+                }
+            }
+            SmallFloatingActionButton(
+                onClick = onClick,
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                contentColor = MaterialTheme.colorScheme.onSurface,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.KeyboardArrowDown,
+                    contentDescription = stringResource(MR.string.chat_scroll_to_bottom),
+                )
+            }
         }
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenAttachmentEditor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenAttachmentEditor.kt
@@ -67,6 +67,13 @@ import id.homebase.chat.widget.video.TrimDurationLabel
 import id.homebase.chat.widget.video.TrimmableVideoPlayerSurface
 import id.homebase.chat.widget.video.VideoTrimScrubber
 import id.homebase.resources.MR
+import id.homebase.resources.cd_file_attachment
+import id.homebase.resources.cd_gallery_thumbnail
+import id.homebase.resources.cd_image_attachment
+import id.homebase.resources.cd_pause_video
+import id.homebase.resources.cd_play_video
+import id.homebase.resources.cd_send_to
+import id.homebase.resources.cd_video_thumbnail
 import id.homebase.resources.chat_message_add_gallery_image
 import id.homebase.resources.chat_message_remove_gallery_image
 import id.homebase.resources.crop
@@ -168,7 +175,7 @@ fun FullScreenAttachmentEditor(
                             verticalArrangement = Arrangement.Center,
                             horizontalAlignment = Alignment.CenterHorizontally
                         ) {
-                            Icon(Icons.Default.UploadFile, contentDescription = null, Modifier.size(96.dp))
+                            Icon(Icons.Default.UploadFile, contentDescription = stringResource(MR.string.cd_file_attachment), Modifier.size(96.dp))
                             Spacer(modifier = Modifier.height(16.dp))
                             Text(attachment.file.name)
                         }
@@ -177,7 +184,7 @@ fun FullScreenAttachmentEditor(
                         AsyncImage(
                             imageLoader = imageLoader,
                             model = attachment.file.toString(),
-                            contentDescription = null,
+                            contentDescription = stringResource(MR.string.cd_image_attachment),
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .clip(RoundedCornerShape(16.dp)),
@@ -226,7 +233,7 @@ fun FullScreenAttachmentEditor(
                                 AsyncImage(
                                     imageLoader = imageLoader,
                                     model = posterModel,
-                                    contentDescription = null,
+                                    contentDescription = stringResource(MR.string.cd_video_thumbnail),
                                     modifier = Modifier.fillMaxWidth(),
                                     contentScale = ContentScale.Fit,
                                 )
@@ -240,7 +247,7 @@ fun FullScreenAttachmentEditor(
                             ) {
                                 Icon(
                                     imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
-                                    contentDescription = null,
+                                    contentDescription = stringResource(if (isPlaying) MR.string.cd_pause_video else MR.string.cd_play_video),
                                     tint = Color.White,
                                 )
                             }
@@ -250,7 +257,7 @@ fun FullScreenAttachmentEditor(
                         AsyncImage(
                             imageLoader = imageLoader,
                             model = attachment.image.thumbnailUri ?: attachment.image.file.toString(),
-                            contentDescription = null,
+                            contentDescription = stringResource(MR.string.cd_gallery_thumbnail),
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .clip(RoundedCornerShape(16.dp)),
@@ -282,7 +289,7 @@ fun FullScreenAttachmentEditor(
                     .padding(horizontal = 16.dp, vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = null)
+                Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = stringResource(MR.string.cd_send_to, data.conversationTitle))
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
                     text = data.conversationTitle,
@@ -385,14 +392,14 @@ fun FullScreenAttachmentEditor(
                                     modifier = Modifier.fillMaxSize(),
                                     contentAlignment = Alignment.Center,
                                 ) {
-                                    Icon(Icons.Default.UploadFile, contentDescription = null)
+                                    Icon(Icons.Default.UploadFile, contentDescription = stringResource(MR.string.cd_file_attachment))
                                 }
                             }
                             is AttachmentPendingFile.FileImage -> {
                                 AsyncImage(
                                     imageLoader = imageLoader,
                                     model = attachment.file.toString(),
-                                    contentDescription = null,
+                                    contentDescription = stringResource(MR.string.cd_image_attachment),
                                     modifier = Modifier.fillMaxSize(),
                                     contentScale = ContentScale.Crop
                                 )
@@ -405,13 +412,13 @@ fun FullScreenAttachmentEditor(
                                     AsyncImage(
                                         imageLoader = imageLoader,
                                         model = attachment.thumbnailBytes ?: attachment.file.toString(),
-                                        contentDescription = null,
+                                        contentDescription = stringResource(MR.string.cd_video_thumbnail),
                                         modifier = Modifier.fillMaxSize(),
                                         contentScale = ContentScale.Crop
                                     )
                                     Icon(
                                         Icons.Default.PlayCircle,
-                                        contentDescription = null,
+                                        contentDescription = stringResource(MR.string.cd_play_video),
                                         tint = Color.White.copy(alpha = 0.85f)
                                     )
                                 }
@@ -420,7 +427,7 @@ fun FullScreenAttachmentEditor(
                                 AsyncImage(
                                     imageLoader = imageLoader,
                                     model = attachment.image.thumbnailUri ?: attachment.image.file.toString(),
-                                    contentDescription = null,
+                                    contentDescription = stringResource(MR.string.cd_gallery_thumbnail),
                                     modifier = Modifier.fillMaxSize(),
                                     contentScale = ContentScale.Crop
                                 )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenMediaViewer.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenMediaViewer.kt
@@ -66,6 +66,7 @@ import id.homebase.core.util.formatTimestamp
 import id.homebase.resources.MR
 import id.homebase.resources.chat_options
 import id.homebase.resources.menu_back
+import id.homebase.resources.share
 import org.jetbrains.compose.resources.stringResource
 import kotlin.io.encoding.Base64
 import kotlin.uuid.Uuid
@@ -341,7 +342,7 @@ fun FullScreenMediaViewer(
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     IconButton(onClick = { onShare(data.messageId, data.selectedPayloadKey) }) {
-                        Icon(Icons.Default.Share, contentDescription = null)
+                        Icon(Icons.Default.Share, contentDescription = stringResource(MR.string.share))
                     }
                 }
             }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LinkPreview.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LinkPreview.kt
@@ -41,6 +41,7 @@ import id.homebase.core.image.ImageSize
 import id.homebase.core.ui.theme.Dimens
 import id.homebase.resources.MR
 import id.homebase.resources.cancel
+import id.homebase.resources.cd_link_preview_image
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.decodeToImageBitmap
 import org.jetbrains.compose.resources.stringResource
@@ -148,7 +149,7 @@ fun LinkPreviewCard(
                 Box(modifier = Modifier.height(80.dp).aspectRatio(1f)) {
                     Image(
                         bitmap = imageBitmap,
-                        contentDescription = null,
+                        contentDescription = stringResource(MR.string.cd_link_preview_image),
                         modifier = Modifier.matchParentSize(),
                         contentScale = ContentScale.Crop
                     )
@@ -184,7 +185,7 @@ fun LinkPreviewCard(
                     if (imageBitmap != null) {
                         Image(
                             bitmap = imageBitmap,
-                            contentDescription = null,
+                            contentDescription = stringResource(MR.string.cd_link_preview_image),
                             modifier = Modifier.fillMaxWidth().heightIn(max = 180.dp).clip(
                                 RoundedCornerShape(
                                     topStart = Dimens.Message.cornerRadius,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LocationPreview.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LocationPreview.kt
@@ -42,6 +42,7 @@ import id.homebase.core.image.ImageSize
 import id.homebase.core.ui.theme.Dimens
 import id.homebase.resources.MR
 import id.homebase.resources.cancel
+import id.homebase.resources.cd_location_pin
 import id.homebase.resources.chat_location_attachment
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.decodeToImageBitmap
@@ -184,7 +185,7 @@ fun LocationPreviewCard(
                     ) {
                         Icon(
                             imageVector = Icons.Default.LocationOn,
-                            contentDescription = null,
+                            contentDescription = stringResource(MR.string.cd_location_pin),
                             tint = MaterialTheme.colorScheme.primary,
                             modifier = Modifier.size(40.dp),
                         )
@@ -274,7 +275,7 @@ fun LocationPreviewCard(
             ) {
                 Icon(
                     imageVector = Icons.Default.LocationOn,
-                    contentDescription = null,
+                    contentDescription = stringResource(MR.string.cd_location_pin),
                     tint = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.size(40.dp),
                 )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaGallery.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaGallery.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -22,6 +23,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.drives.files.PayloadDescriptor
@@ -72,73 +74,84 @@ fun MediaGallery(
 ) {
     if (payloads.isEmpty()) return
 
-    Box(modifier = modifier.width(Dimens.Album.totalWidth).clip(shape)) {
-        when (payloads.size) {
-            1 -> {
-                // Single item - delegate to MediaItem directly
-                MediaItem(
-                    payload = payloads[0],
-                    fileId = fileId,
-                    driveId = driveId,
-                    keyHeader = keyHeader,
-                    previewThumbnail = previewThumbnail
-                        ?: payloads[0].previewThumbnail?.toEmbeddedThumb(),
-                    modifier = Modifier.fillMaxWidth().height(Dimens.MediaBubble.maxHeight),
-                    imageSize = ImageSize.THUMB_LARGE,
-                    onClick = { onMediaClick?.invoke(payloads[0]) },
-                    onLongPress = { offset -> onMediaLongPress?.invoke(payloads[0], offset) },
-                    sharedTransitionScope = sharedTransitionScope,
-                    animatedVisibilityScope = animatedVisibilityScope,
-                    isDownloading = downloadingFiles.contains("${messageId}_${payloads[0].key}"),
-                    messageId = messageId,
-                    isUploading = isUploading,
-                )
+    BoxWithConstraints(modifier = modifier.clip(shape)) {
+        // Signal-style breakpoints: scale album width with available space.
+        val albumWidth = when {
+            maxWidth >= 400.dp -> 300.dp
+            maxWidth >= 360.dp -> 252.dp
+            else -> Dimens.Album.totalWidth
+        }
+
+        Box(modifier = Modifier.width(albumWidth)) {
+            when (payloads.size) {
+                1 -> {
+                    MediaItem(
+                        payload = payloads[0],
+                        fileId = fileId,
+                        driveId = driveId,
+                        keyHeader = keyHeader,
+                        previewThumbnail = previewThumbnail
+                            ?: payloads[0].previewThumbnail?.toEmbeddedThumb(),
+                        modifier = Modifier.fillMaxWidth().height(Dimens.MediaBubble.maxHeight),
+                        imageSize = ImageSize.THUMB_LARGE,
+                        onClick = { onMediaClick?.invoke(payloads[0]) },
+                        onLongPress = { offset -> onMediaLongPress?.invoke(payloads[0], offset) },
+                        sharedTransitionScope = sharedTransitionScope,
+                        animatedVisibilityScope = animatedVisibilityScope,
+                        isDownloading = downloadingFiles.contains("${messageId}_${payloads[0].key}"),
+                        messageId = messageId,
+                        isUploading = isUploading,
+                    )
+                }
+
+                2 ->
+                    TwoImageLayout(
+                        albumWidth = albumWidth,
+                        payloads = payloads,
+                        fileId = fileId,
+                        driveId = driveId,
+                        keyHeader = keyHeader,
+                        onMediaClick = onMediaClick,
+                        onMediaLongPress = onMediaLongPress,
+                        sharedTransitionScope = sharedTransitionScope,
+                        animatedVisibilityScope = animatedVisibilityScope,
+                        messageId = messageId,
+                        downloadingFiles = downloadingFiles,
+                        isUploading = isUploading,
+                    )
+
+                3 ->
+                    ThreeImageLayout(
+                        albumWidth = albumWidth,
+                        payloads = payloads,
+                        fileId = fileId,
+                        driveId = driveId,
+                        keyHeader = keyHeader,
+                        onMediaClick = onMediaClick,
+                        onMediaLongPress = onMediaLongPress,
+                        sharedTransitionScope = sharedTransitionScope,
+                        animatedVisibilityScope = animatedVisibilityScope,
+                        messageId = messageId,
+                        downloadingFiles = downloadingFiles,
+                        isUploading = isUploading,
+                    )
+
+                else ->
+                    FourPlusImageLayout(
+                        albumWidth = albumWidth,
+                        payloads = payloads,
+                        fileId = fileId,
+                        driveId = driveId,
+                        keyHeader = keyHeader,
+                        onMediaClick = onMediaClick,
+                        onMediaLongPress = onMediaLongPress,
+                        sharedTransitionScope = sharedTransitionScope,
+                        animatedVisibilityScope = animatedVisibilityScope,
+                        messageId = messageId,
+                        downloadingFiles = downloadingFiles,
+                        isUploading = isUploading,
+                    )
             }
-
-            2 ->
-                TwoImageLayout(
-                    payloads = payloads,
-                    fileId = fileId,
-                    driveId = driveId,
-                    keyHeader = keyHeader,
-                    onMediaClick = onMediaClick,
-                    onMediaLongPress = onMediaLongPress,
-                    sharedTransitionScope = sharedTransitionScope,
-                    animatedVisibilityScope = animatedVisibilityScope,
-                    messageId = messageId,
-                    downloadingFiles = downloadingFiles,
-                    isUploading = isUploading,
-                )
-
-            3 ->
-                ThreeImageLayout(
-                    payloads = payloads,
-                    fileId = fileId,
-                    driveId = driveId,
-                    keyHeader = keyHeader,
-                    onMediaClick = onMediaClick,
-                    onMediaLongPress = onMediaLongPress,
-                    sharedTransitionScope = sharedTransitionScope,
-                    animatedVisibilityScope = animatedVisibilityScope,
-                    messageId = messageId,
-                    downloadingFiles = downloadingFiles,
-                    isUploading = isUploading,
-                )
-
-            else ->
-                FourPlusImageLayout(
-                    payloads = payloads,
-                    fileId = fileId,
-                    driveId = driveId,
-                    keyHeader = keyHeader,
-                    onMediaClick = onMediaClick,
-                    onMediaLongPress = onMediaLongPress,
-                    sharedTransitionScope = sharedTransitionScope,
-                    animatedVisibilityScope = animatedVisibilityScope,
-                    messageId = messageId,
-                    downloadingFiles = downloadingFiles,
-                    isUploading = isUploading,
-                )
         }
     }
 }
@@ -146,6 +159,7 @@ fun MediaGallery(
 /** Layout for 2 images: side by side with equal width. */
 @Composable
 private fun TwoImageLayout(
+    albumWidth: Dp,
     payloads: List<PayloadDescriptor>,
     fileId: Uuid,
     driveId: Uuid,
@@ -159,7 +173,7 @@ private fun TwoImageLayout(
     isUploading: Boolean,
 ) {
     Row(
-        modifier = Modifier.fillMaxWidth().height(Dimens.Album.twoTotalHeight),
+        modifier = Modifier.fillMaxWidth().height(albumWidth / 2),
         horizontalArrangement = Arrangement.spacedBy(GALLERY_CELL_SPACING),
     ) {
         payloads.take(2).forEach { payload ->
@@ -187,6 +201,7 @@ private fun TwoImageLayout(
 /** Layout for 3 images: 2 on top side-by-side, 1 full width below. */
 @Composable
 private fun ThreeImageLayout(
+    albumWidth: Dp,
     payloads: List<PayloadDescriptor>,
     fileId: Uuid,
     driveId: Uuid,
@@ -199,13 +214,15 @@ private fun ThreeImageLayout(
     downloadingFiles: Set<String>,
     isUploading: Boolean,
 ) {
+    val rowHeight = (albumWidth * 2 / 3 - GALLERY_CELL_SPACING) / 2
+
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(GALLERY_CELL_SPACING),
     ) {
         // Top row: 2 images side by side
         Row(
-            modifier = Modifier.fillMaxWidth().height(Dimens.Album.threeCellSizeSmall),
+            modifier = Modifier.fillMaxWidth().height(rowHeight),
             horizontalArrangement = Arrangement.spacedBy(GALLERY_CELL_SPACING),
         ) {
             payloads.take(2).forEach { payload ->
@@ -236,7 +253,7 @@ private fun ThreeImageLayout(
             driveId = driveId,
             keyHeader = keyHeader,
             previewThumbnail = payloads[2].previewThumbnail?.toEmbeddedThumb(),
-            modifier = Modifier.fillMaxWidth().height(Dimens.Album.threeCellSizeSmall),
+            modifier = Modifier.fillMaxWidth().height(rowHeight),
             imageSize = ImageSize.THUMB_MEDIUM,
             shape = RectangleShape,
             onClick = { onMediaClick?.invoke(payloads[2]) },
@@ -250,9 +267,10 @@ private fun ThreeImageLayout(
     }
 }
 
-/** Layout for 4+ images: 2×2 grid with overlay on 4th showing remaining count. */
+/** Layout for 4+ images: 2x2 grid with overlay on 4th showing remaining count. */
 @Composable
 private fun FourPlusImageLayout(
+    albumWidth: Dp,
     payloads: List<PayloadDescriptor>,
     fileId: Uuid,
     driveId: Uuid,
@@ -266,6 +284,7 @@ private fun FourPlusImageLayout(
     isUploading: Boolean,
 ) {
     val remainingCount = payloads.size - 4
+    val cellHeight = (albumWidth - GALLERY_CELL_SPACING) / 2
 
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -273,7 +292,7 @@ private fun FourPlusImageLayout(
     ) {
         // Top row: 2 images
         Row(
-            modifier = Modifier.fillMaxWidth().height(Dimens.Album.fourCellSize),
+            modifier = Modifier.fillMaxWidth().height(cellHeight),
             horizontalArrangement = Arrangement.spacedBy(GALLERY_CELL_SPACING),
         ) {
             payloads.take(2).forEach { payload ->
@@ -299,7 +318,7 @@ private fun FourPlusImageLayout(
 
         // Bottom row: 2 images, with overlay on 4th if more than 4
         Row(
-            modifier = Modifier.fillMaxWidth().height(Dimens.Album.fourCellSize),
+            modifier = Modifier.fillMaxWidth().height(cellHeight),
             horizontalArrangement = Arrangement.spacedBy(GALLERY_CELL_SPACING),
         ) {
             // Third image

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
@@ -59,6 +59,7 @@ import id.homebase.core.image.ImageSize
 import id.homebase.core.ui.theme.Dimens
 import id.homebase.core.widget.AudioPlayerWidget
 import id.homebase.resources.MR
+import id.homebase.resources.cd_play_video
 import id.homebase.resources.chat_message_image_attachment
 import id.homebase.resources.chat_message_video_thumbnail
 import kotlinx.collections.immutable.ImmutableMap
@@ -372,7 +373,7 @@ fun MediaItem(
                     if (!isUploading) {
                         Icon(
                             imageVector = Icons.Default.PlayCircle,
-                            contentDescription = null,
+                            contentDescription = stringResource(MR.string.cd_play_video),
                             modifier = Modifier
                                 .size(48.dp)
                                 .align(Alignment.Center),

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
@@ -32,6 +32,7 @@ import id.homebase.chat.conversationlist.UploadStatus
 import id.homebase.core.image.ImageSize
 import id.homebase.core.ui.theme.Dimens
 import id.homebase.resources.MR
+import id.homebase.resources.cd_upload_complete
 import id.homebase.resources.upload_compressing
 import id.homebase.resources.upload_done
 import id.homebase.resources.upload_encrypting
@@ -259,7 +260,7 @@ internal fun UploadProgressOverlay(status: UploadStatus, modifier: Modifier = Mo
                 UploadStatus.Completed -> {
                     Icon(
                         imageVector = Icons.Default.CheckCircle,
-                        contentDescription = null,
+                        contentDescription = stringResource(MR.string.cd_upload_complete),
                         tint = Color.White,
                         modifier = Modifier.size(40.dp),
                     )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -67,16 +67,20 @@ import id.homebase.chat.services.ChatDeliveryStatus
 import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.MessageAppData
 import id.homebase.chat.services.ReplyPreview
+import id.homebase.core.avatars.AvatarOptions
+import id.homebase.core.avatars.PublicAvatar
 import id.homebase.core.clipboard.clipEntryOf
 import id.homebase.core.image.HomebaseImage
 import id.homebase.core.image.HomebaseImageData
 import id.homebase.core.image.ImageSize
+import id.homebase.core.ui.theme.Dimens
 import id.homebase.core.ui.assets.HomebaseIcons
 import id.homebase.core.ui.assets.MessageSent
 import id.homebase.core.ui.assets.MessageSentAndDelivered
 import id.homebase.core.ui.assets.MessageSentAndRead
 import id.homebase.core.ui.theme.HomebaseTheme
 import id.homebase.core.util.getOdinIdColor
+import id.homebase.core.util.initials
 import id.homebase.core.util.isDesktop
 import id.homebase.core.util.isEmojiContentOnly
 import id.homebase.core.util.isMobile
@@ -106,6 +110,8 @@ import org.jetbrains.compose.resources.stringResource
 import kotlin.io.encoding.Base64
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
+
+private val GroupMessageAvatarOptions = AvatarOptions(size = Dimens.Conversation.itemAvatarSize)
 
 /**
  * Displays a message bubble for messages sent to other users.
@@ -375,6 +381,7 @@ fun ReceivedMessageBubble(
     userDefaultReactions: ImmutableList<String>,
     decryptedFiles: ImmutableMap<DecryptedFileKey, String>,
     renderAuthorName: Boolean = false,
+    isGroupConversation: Boolean = false,
     clusterPosition: MessageClusterPosition = MessageClusterPosition.ALONE,
     onMessageInfo: (() -> Unit)? = null,
     onReply: (() -> Unit)? = null,
@@ -417,9 +424,31 @@ fun ReceivedMessageBubble(
     val scope = rememberCoroutineScope()
 
     Row(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)
+        modifier = Modifier.fillMaxWidth()
+            .padding(start = if (isGroupConversation) 8.dp else 16.dp, end = 16.dp)
             .padding(top = clusterPosition.topSpacing(), bottom = clusterPosition.bottomSpacing()),
     ) {
+        if (isGroupConversation) {
+            val showAvatar = clusterPosition == MessageClusterPosition.ALONE ||
+                clusterPosition == MessageClusterPosition.END
+            Box(
+                modifier = Modifier
+                    .align(Alignment.Bottom)
+                    .padding(start = 4.dp, end = 8.dp)
+                    .size(Dimens.Conversation.itemAvatarSize),
+            ) {
+                if (showAvatar && message.originalAuthor != null) {
+                    val initials = remember(message.displayName) {
+                        message.displayName.initials()
+                    }
+                    PublicAvatar(
+                        odinId = message.originalAuthor,
+                        initials = initials,
+                        options = GroupMessageAvatarOptions,
+                    )
+                }
+            }
+        }
         Row(
             modifier = Modifier.weight(1f).hoverable(interactionSource),
             horizontalArrangement = Arrangement.Start,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -98,7 +98,11 @@ import id.homebase.resources.chat_message_report
 import id.homebase.resources.chat_message_report_confirm_body
 import id.homebase.resources.chat_message_report_confirm_title
 import id.homebase.resources.media
+import id.homebase.resources.cd_reply_thumbnail
+import id.homebase.resources.message_delivered
+import id.homebase.resources.message_read
 import id.homebase.resources.message_sending
+import id.homebase.resources.message_sent
 import id.homebase.resources.you
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableMap
@@ -456,7 +460,7 @@ fun ReceivedMessageBubble(
         ) {
             Box(
                 modifier = if (isMobile()) {
-                    Modifier.fillMaxWidth().combinedClickable(
+                    Modifier.combinedClickable(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null,
                         onClick = {},
@@ -729,7 +733,7 @@ fun DeliveryStatus(
             ChatDeliveryStatus.Read.value -> {
                 Icon(
                     HomebaseIcons.MessageSentAndRead,
-                    contentDescription = null,
+                    contentDescription = stringResource(MR.string.message_read),
                     modifier = Modifier.height(DELIVERY_ICON_SIZE),
                     tint = contentColor,
                 )
@@ -738,7 +742,7 @@ fun DeliveryStatus(
             ChatDeliveryStatus.Delivered.value -> {
                 Icon(
                     HomebaseIcons.MessageSentAndDelivered,
-                    contentDescription = null,
+                    contentDescription = stringResource(MR.string.message_delivered),
                     modifier = Modifier.height(DELIVERY_ICON_SIZE),
                     tint = contentColor,)
             }
@@ -746,7 +750,7 @@ fun DeliveryStatus(
             ChatDeliveryStatus.Sent.value -> {
                 Icon(
                     HomebaseIcons.MessageSent,
-                    contentDescription = null,
+                    contentDescription = stringResource(MR.string.message_sent),
                     modifier = Modifier.height(DELIVERY_ICON_SIZE),
                     tint = contentColor,
                 )
@@ -916,13 +920,13 @@ fun InlineReplyPreview(
                     .size(40.dp)
                     .clip(RoundedCornerShape(4.dp)),
                 contentScale = ContentScale.Crop,
-                contentDescription = null,
+                contentDescription = stringResource(MR.string.cd_reply_thumbnail),
             )
         } else {
             thumbnailBitmap?.let { bitmap ->
                 Image(
                     bitmap = bitmap,
-                    contentDescription = null,
+                    contentDescription = stringResource(MR.string.cd_reply_thumbnail),
                     modifier = Modifier
                         .padding(end = 4.dp)
                         .size(40.dp)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -631,7 +631,8 @@ fun MessageBubbleRaw(
                                             textPlaceable.height +
                                             (showMorePlaceable.height) +
                                             infoPlaceable.height +
-                                            8.dp.roundToPx()
+                                            8.dp.roundToPx() +
+                                            4.dp.roundToPx()
                             }
                         } else {
                             finalWidth = maxOf(
@@ -645,7 +646,7 @@ fun MessageBubbleRaw(
                                 placeables.sumOf { it.height } + replyHeight + textPlaceable.height
                             infoX = finalWidth - infoPlaceable.width
                             finalHeight =
-                                placeables.sumOf { it.height } + replyHeight + textPlaceable.height + infoPlaceable.height
+                                placeables.sumOf { it.height } + replyHeight + textPlaceable.height + infoPlaceable.height + 4.dp.roundToPx()
                         }
 
                         layout(finalWidth, finalHeight) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageItem.kt
@@ -161,6 +161,7 @@ fun MessageItem(
                 userDefaultReactions = userDefaultReactions,
                 decryptedFiles = decryptedFiles,
                 renderAuthorName = renderAuthorName,
+                isGroupConversation = isGroupConversation,
                 clusterPosition = clusterPosition,
                 onMessageInfo = onMessageInfo,
                 onReply = onReply,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessagesSection.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessagesSection.kt
@@ -1,17 +1,24 @@
 package id.homebase.chat.widget
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import id.homebase.resources.MR
+import id.homebase.resources.chat_new_messages
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun MessagesSection(text: String) {
@@ -36,6 +43,32 @@ fun MessagesSection(text: String) {
                 textAlign = TextAlign.Center,
             )
         }
+    }
+}
+
+@Composable
+fun UnreadMessagesSeparator() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 12.dp, horizontal = 16.dp)
+            .semantics(mergeDescendants = true) { heading() },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        HorizontalDivider(
+            modifier = Modifier.weight(1f),
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Text(
+            text = stringResource(MR.string.chat_new_messages),
+            modifier = Modifier.padding(horizontal = 12.dp),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        HorizontalDivider(
+            modifier = Modifier.weight(1f),
+            color = MaterialTheme.colorScheme.primary,
+        )
     }
 }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ReplyPreviewBar.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ReplyPreviewBar.kt
@@ -34,6 +34,7 @@ import id.homebase.core.image.HomebaseImageData
 import id.homebase.core.image.ImageSize
 import id.homebase.resources.MR
 import id.homebase.resources.cancel_reply
+import id.homebase.resources.cd_reply_thumbnail
 import id.homebase.resources.you
 import org.jetbrains.compose.resources.stringResource
 import kotlin.io.encoding.Base64
@@ -155,7 +156,7 @@ fun ReplyPreviewBar(message: MessageUiModel, onDismiss: () -> Unit, modifier: Mo
                         .size(48.dp)
                         .clip(RoundedCornerShape(8.dp)),
                     contentScale = ContentScale.Crop,
-                    contentDescription = null,
+                    contentDescription = stringResource(MR.string.cd_reply_thumbnail),
                 )
             }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/video/VideoTrimScrubber.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/video/VideoTrimScrubber.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
 import id.homebase.api.video.IndexedFrame
 import id.homebase.resources.MR
+import id.homebase.resources.cd_video_scrubber_frame
 import id.homebase.resources.trim_end_handle
 import id.homebase.resources.trim_position
 import id.homebase.resources.trim_start_handle
@@ -175,7 +176,7 @@ fun VideoTrimScrubber(
                     if (frame != null) {
                         AsyncImage(
                             model = frame.jpegBytes,
-                            contentDescription = null,
+                            contentDescription = stringResource(MR.string.cd_video_scrubber_frame),
                             modifier = Modifier.fillMaxSize(),
                             contentScale = ContentScale.Crop,
                         )

--- a/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.jvm.kt
+++ b/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.jvm.kt
@@ -48,6 +48,7 @@ import id.homebase.api.video.VideoPreloader
 import id.homebase.api.video.resolveVideoContent
 import id.homebase.chat.conversationlist.FullScreenOverlay
 import id.homebase.resources.MR
+import id.homebase.resources.cd_video_frame
 import id.homebase.resources.vlc_required
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -406,7 +407,7 @@ internal fun VlcjPlayer(
         if (frame != null) {
             Image(
                 bitmap = frame,
-                contentDescription = null,
+                contentDescription = stringResource(MR.string.cd_video_frame),
                 modifier = Modifier.fillMaxSize(),
                 contentScale = ContentScale.Fit,
             )

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -458,6 +458,7 @@
     <string name="chat_clear">Clear</string>
     <string name="chat_options">Conversation options</string>
     <string name="chat_no_messages">No messages yet</string>
+    <string name="chat_new_messages">New messages</string>
     <string name="chat_connection_invited">Invited</string>
     <string name="chat_connection_wants_to_connect">Wants to connect</string>
     <string name="chat_connection_invitation_sent">Invitation sent — waiting for them to accept</string>
@@ -616,9 +617,73 @@
 
     <!-- Delivery status -->
     <string name="message_sending">Sending</string>
+    <string name="message_read">Read</string>
+    <string name="message_delivered">Delivered</string>
+    <string name="message_sent">Sent</string>
+
+    <!-- Accessibility: content descriptions -->
+    <string name="cd_play_video">Play video</string>
+    <string name="cd_pause_video">Pause video</string>
+    <string name="cd_file_attachment">File attachment</string>
+    <string name="cd_image_attachment">Image attachment</string>
+    <string name="cd_video_thumbnail">Video thumbnail</string>
+    <string name="cd_video_frame">Video frame</string>
+    <string name="cd_gallery_thumbnail">Gallery thumbnail</string>
+    <string name="cd_send_to">Send to %1$s</string>
+    <string name="cd_upload_complete">Upload complete</string>
+    <string name="cd_location_pin">Location</string>
+    <string name="cd_link_preview_image">Link preview image</string>
+    <string name="cd_reply_thumbnail">Reply thumbnail</string>
+    <string name="cd_selected">Selected</string>
+    <string name="cd_not_selected">Not selected</string>
+    <string name="cd_open_externally">Open externally</string>
+    <string name="cd_navigate_forward">Navigate forward</string>
+    <string name="cd_group_avatar">Group</string>
+    <string name="cd_connection_succeeded">Connection succeeded</string>
+    <string name="cd_video_scrubber_frame">Video scrubber frame</string>
 
     <!-- Settings section headers -->
     <string name="settings_section_general">General</string>
     <string name="settings_section_danger_zone">Danger Zone</string>
+
+    <!-- Audio player -->
+    <string name="audio_pause">Pause</string>
+    <string name="audio_play">Play</string>
+
+    <!-- Bottom navigation -->
+    <string name="nav_chats">Chats</string>
+    <string name="nav_feed">Feed</string>
+    <string name="nav_home">Home</string>
+
+    <!-- Developer menu -->
+    <string name="dev_menu_title">Developer menu</string>
+    <string name="dev_menu_section_misc">Misc info</string>
+    <string name="dev_menu_section_sync">Sync &amp; Connection</string>
+    <string name="dev_menu_section_database">Database &amp; Storage</string>
+    <string name="dev_menu_section_testing">Testing Tools</string>
+    <string name="dev_menu_force_sync">Force Sync All</string>
+    <string name="dev_menu_clear_data">Clear All Data</string>
+    <string name="dev_menu_test_notification">Test Rich Notification</string>
+
+    <!-- Defragmenter issue labels -->
+    <string name="defragmenter_issue_legacy_user_date">Legacy userDate=0</string>
+    <string name="defragmenter_issue_soft_delete_drift">Soft-delete drift</string>
+    <string name="defragmenter_issue_bad_header">Bad header blocks</string>
+    <string name="defragmenter_issue_unmappable_convo">Unmappable conversation</string>
+    <string name="defragmenter_issue_orphan_messages">Orphan messages</string>
+    <string name="defragmenter_issue_bad_message">Bad message blocks</string>
+
+    <!-- Storage warnings -->
+    <string name="storage_orphan_coil_title">Orphan Coil disk cache detected</string>
+    <string name="storage_orphan_coil_body">%1$s in cache/coil3_disk_cache. Coil\'s default disk cache should be off — this directory means something is bypassing the Homebase cache layer. Tap \"Clear caches\" to delete it.</string>
+
+    <!-- Error states -->
+    <string name="error_no_group_loaded">No group could be loaded</string>
+    <string name="error_no_contact_loaded">No contact could be loaded</string>
+
+    <!-- File save snackbar -->
+    <string name="file_saved_to">Saved to %1$s</string>
+    <string name="file_save_failed">Failed to save: %1$s</string>
+    <string name="error_unknown">Unknown error</string>
 
 </resources>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AudioPlayerWidget.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AudioPlayerWidget.kt
@@ -50,6 +50,8 @@ import id.homebase.core.image.HomebaseImageData
 import id.homebase.core.image.ImageSize
 import id.homebase.core.ui.theme.Dimens
 import id.homebase.resources.MR
+import id.homebase.resources.audio_pause
+import id.homebase.resources.audio_play
 import id.homebase.resources.audio_waveform
 import org.jetbrains.compose.resources.stringResource
 import kotlin.io.encoding.Base64
@@ -152,7 +154,7 @@ fun AudioPlayerWidget(
                 } else {
                     Icon(
                         imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
-                        contentDescription = if (isPlaying) "Pause" else "Play",
+                        contentDescription = if (isPlaying) stringResource(MR.string.audio_pause) else stringResource(MR.string.audio_play),
                         modifier = Modifier.size(32.dp),
                         tint = MaterialTheme.colorScheme.onSurface,
                     )

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AvatarImage.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AvatarImage.kt
@@ -33,6 +33,7 @@ import id.homebase.api.image.toImageBitmap
 import id.homebase.core.util.ifTrue
 import id.homebase.resources.MR
 import id.homebase.resources.avatar_person
+import id.homebase.resources.cd_group_avatar
 import org.jetbrains.compose.resources.stringResource
 import kotlin.io.encoding.Base64
 
@@ -94,7 +95,7 @@ fun AvatarImage(
                     // Fallback composable on error and loading
                     if (isGroup) {
                         // Show group icon
-                        Icon(Icons.Default.People, contentDescription = null)
+                        Icon(Icons.Default.People, contentDescription = stringResource(MR.string.cd_group_avatar))
                     } else {
                         Text(
                             text = avatarInitials,
@@ -107,7 +108,7 @@ fun AvatarImage(
             }
         } else if (isGroup) {
             // Show group icon
-            Icon(Icons.Default.People, contentDescription = null)
+            Icon(Icons.Default.People, contentDescription = stringResource(MR.string.cd_group_avatar))
         } else {
             // Show initials when no avatar URL
             Text(

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ConnectionRequestBanner.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ConnectionRequestBanner.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import id.homebase.core.ui.theme.ExtendedColors
 import id.homebase.resources.MR
+import id.homebase.resources.cd_navigate_forward
 import id.homebase.resources.connection_requests_banner
 import org.jetbrains.compose.resources.stringResource
 
@@ -42,7 +43,7 @@ fun ConnectionRequestHeaderBanner(
             color = ExtendedColors.OnRequestBanner
         )
         Spacer(modifier = Modifier.weight(1f))
-        Icon(Icons.Default.ChevronRight, contentDescription = null, tint = ExtendedColors.OnRequestBanner)
+        Icon(Icons.Default.ChevronRight, contentDescription = stringResource(MR.string.cd_navigate_forward), tint = ExtendedColors.OnRequestBanner)
     }
 
 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionList.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionList.kt
@@ -1,6 +1,5 @@
 package id.homebase.core.widget
 
-import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
@@ -36,7 +35,6 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import kotlinx.coroutines.delay
 import id.homebase.api.client.drives.files.ReactionSummary
 import id.homebase.api.client.drives.files.reactions.ReactionContent
 import id.homebase.api.serialization.OdinSystemSerializer
@@ -103,42 +101,19 @@ fun ReactionList(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(2.dp),
             ) {
-                displayEmojis.forEachIndexed { index, (emoji, _) ->
-                    val emojiScale = remember(emoji) { Animatable(0f) }
-                    LaunchedEffect(emoji) {
-                        delay(index * 50L)
-                        emojiScale.animateTo(
-                            targetValue = 1f,
-                            animationSpec = spring(
-                                dampingRatio = Spring.DampingRatioMediumBouncy,
-                                stiffness = Spring.StiffnessMediumLow,
-                            )
-                        )
-                    }
+                displayEmojis.forEach { (emoji, _) ->
                     Text(
                         text = emoji,
                         fontSize = 16.sp,
-                        modifier = Modifier.scale(emojiScale.value),
                     )
                 }
                 if (totalCount > 1) {
-                    val countScale = remember { Animatable(1f) }
-                    LaunchedEffect(totalCount) {
-                        countScale.snapTo(0.6f)
-                        countScale.animateTo(
-                            targetValue = 1f,
-                            animationSpec = spring(
-                                dampingRatio = Spring.DampingRatioMediumBouncy,
-                                stiffness = Spring.StiffnessMedium,
-                            )
-                        )
-                    }
                     Text(
                         text = totalCount.toString(),
                         fontSize = 13.sp,
                         style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(start = 2.dp).scale(countScale.value),
+                        modifier = Modifier.padding(start = 2.dp),
                     )
                 }
             }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/UpdateAvailableBanner.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/UpdateAvailableBanner.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import id.homebase.resources.MR
+import id.homebase.resources.cd_navigate_forward
 import id.homebase.resources.update_available
 import org.jetbrains.compose.resources.stringResource
 
@@ -42,6 +43,6 @@ fun UpdateAvailableBanner(
             color = MaterialTheme.colorScheme.onPrimaryContainer
         )
         Spacer(modifier = Modifier.weight(1f))
-        Icon(Icons.Default.ChevronRight, contentDescription = null, tint = MaterialTheme.colorScheme.onPrimaryContainer)
+        Icon(Icons.Default.ChevronRight, contentDescription = stringResource(MR.string.cd_navigate_forward), tint = MaterialTheme.colorScheme.onPrimaryContainer)
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -91,6 +91,12 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import org.koin.compose.viewmodel.koinViewModel
 import id.homebase.core.ui.screens.help.HelpScreen
+import id.homebase.resources.MR
+import id.homebase.resources.nav_chats
+import id.homebase.resources.nav_feed
+import id.homebase.resources.nav_home
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
 import kotlin.uuid.Uuid
 
 @Composable
@@ -234,8 +240,8 @@ fun AppNavHost(
                 NavigationBar {
                     topLevelRoutes.forEach { topLevelRoute ->
                         NavigationBarItem(
-                            icon = { Icon(topLevelRoute.icon, contentDescription = null) },
-                            label = { Text(topLevelRoute.label) },
+                            icon = { Icon(topLevelRoute.icon, contentDescription = stringResource(topLevelRoute.labelRes)) },
+                            label = { Text(stringResource(topLevelRoute.labelRes)) },
                             selected = currentDestination?.hasRoute(
                                 topLevelRoute.route::class
                             ) == true,
@@ -260,8 +266,8 @@ fun AppNavHost(
                     NavigationRail(header = { Spacer(modifier = Modifier.height(12.dp)) }) {
                         topLevelRoutes.forEach { topLevelRoute ->
                             NavigationRailItem(
-                                icon = { Icon(topLevelRoute.icon, contentDescription = null) },
-                                // label = { Text(topLevelRoute.label) },
+                                icon = { Icon(topLevelRoute.icon, contentDescription = stringResource(topLevelRoute.labelRes)) },
+                                // label = { Text(stringResource(topLevelRoute.labelRes)) },
                                 selected = currentDestination?.hasRoute(topLevelRoute.route::class) == true,
                                 onClick = {
                                     navController.navigate(topLevelRoute.route) {
@@ -750,9 +756,9 @@ private fun AnimatedContentTransitionScope<NavBackStackEntry>.isBetweenTopLevelR
 }
 
 sealed class TopLevelRoute(
-    val route: Route, val label: String, val icon: androidx.compose.ui.graphics.vector.ImageVector
+    val route: Route, val labelRes: StringResource, val icon: androidx.compose.ui.graphics.vector.ImageVector
 ) {
-    data object Chat : TopLevelRoute(Route.ChatList, "Chats", BootstrapChat)
-    data object Feed : TopLevelRoute(Route.Feed, "Feed", Icons.Default.RssFeed)
-    data object Home : TopLevelRoute(Route.Home, "Home", Icons.Default.Home)
+    data object Chat : TopLevelRoute(Route.ChatList, MR.string.nav_chats, BootstrapChat)
+    data object Feed : TopLevelRoute(Route.Feed, MR.string.nav_feed, Icons.Default.RssFeed)
+    data object Home : TopLevelRoute(Route.Home, MR.string.nav_home, Icons.Default.Home)
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/connections/ConnectionsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/connections/ConnectionsScreen.kt
@@ -73,6 +73,7 @@ import id.homebase.resources.connections_refresh
 import id.homebase.resources.connections_sent_timestamp
 import id.homebase.resources.connections_tab_incoming
 import id.homebase.resources.connections_tab_outgoing
+import id.homebase.resources.cd_navigate_forward
 import id.homebase.resources.menu_back
 import id.homebase.resources.settings_connections
 import org.jetbrains.compose.resources.stringResource
@@ -392,7 +393,7 @@ private fun ConnectionRequestRow(
         }
         Icon(
             imageVector = Icons.Default.ChevronRight,
-            contentDescription = null,
+            contentDescription = stringResource(MR.string.cd_navigate_forward),
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.size(20.dp),
         )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/defragmenter/DefragmenterScreen.kt
@@ -42,6 +42,12 @@ import id.homebase.core.ui.screens.defragmenter.ui.Win98ProgressBar
 import id.homebase.core.ui.screens.defragmenter.ui.Win98WindowFrame
 import id.homebase.resources.MR
 import id.homebase.resources.defragmenter_analyze
+import id.homebase.resources.defragmenter_issue_bad_header
+import id.homebase.resources.defragmenter_issue_bad_message
+import id.homebase.resources.defragmenter_issue_legacy_user_date
+import id.homebase.resources.defragmenter_issue_orphan_messages
+import id.homebase.resources.defragmenter_issue_soft_delete_drift
+import id.homebase.resources.defragmenter_issue_unmappable_convo
 import id.homebase.resources.defragmenter_cancel
 import id.homebase.resources.defragmenter_close
 import id.homebase.resources.defragmenter_drive_label_all
@@ -296,32 +302,32 @@ private fun StatsPanel(state: DefragmenterUiState, modifier: Modifier = Modifier
             // in mid-analyze shrink the grid panel above and visibly clip
             // its bottom row of cells.
             IssueTallyRow(
-                label = "Legacy userDate=0",
+                label = stringResource(MR.string.defragmenter_issue_legacy_user_date),
                 count = state.issueCountLegacyUserDateZero,
                 activeColor = Win98Palette.IssueLegacyUserDateZeroFill,
             )
             IssueTallyRow(
-                label = "Soft-delete drift",
+                label = stringResource(MR.string.defragmenter_issue_soft_delete_drift),
                 count = state.issueCountArchivalMismatch,
                 activeColor = Win98Palette.IssueArchivalMismatchFill,
             )
             IssueTallyRow(
-                label = "Bad header blocks",
+                label = stringResource(MR.string.defragmenter_issue_bad_header),
                 count = state.issueCountCorruptJson,
                 activeColor = Win98Palette.IssueCorruptJsonFill,
             )
             IssueTallyRow(
-                label = "Unmappable conversation",
+                label = stringResource(MR.string.defragmenter_issue_unmappable_convo),
                 count = state.issueCountUnmappableConvo,
                 activeColor = Win98Palette.IssueUnmappableConvoFill,
             )
             IssueTallyRow(
-                label = "Orphan messages",
+                label = stringResource(MR.string.defragmenter_issue_orphan_messages),
                 count = state.issueCountOrphanMessage,
                 activeColor = Win98Palette.IssueOrphanMessageFill,
             )
             IssueTallyRow(
-                label = "Bad message blocks",
+                label = stringResource(MR.string.defragmenter_issue_bad_message),
                 count = state.issueCountCorruptMessageContent,
                 activeColor = Win98Palette.IssueCorruptMessageContentFill,
             )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/devmenu/DeveloperMenuScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/devmenu/DeveloperMenuScreen.kt
@@ -34,6 +34,14 @@ import chat_kmp.homebase_common.BuildConfig
 import id.homebase.core.ui.screens.help.HelpClickableRow
 import id.homebase.core.ui.screens.help.HelpSectionHeader
 import id.homebase.resources.MR
+import id.homebase.resources.dev_menu_clear_data
+import id.homebase.resources.dev_menu_force_sync
+import id.homebase.resources.dev_menu_section_database
+import id.homebase.resources.dev_menu_section_misc
+import id.homebase.resources.dev_menu_section_sync
+import id.homebase.resources.dev_menu_section_testing
+import id.homebase.resources.dev_menu_test_notification
+import id.homebase.resources.dev_menu_title
 import id.homebase.resources.menu_back
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
@@ -89,7 +97,7 @@ fun DeveloperMenuUi(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
-                title = { Text("Developer menu") },
+                title = { Text(stringResource(MR.string.dev_menu_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBackClick) {
                         Icon(
@@ -112,7 +120,7 @@ fun DeveloperMenuUi(
         ) {
             Spacer(modifier = Modifier.height(8.dp))
 
-            HelpSectionHeader(title = "Misc info")
+            HelpSectionHeader(title = stringResource(MR.string.dev_menu_section_misc))
             Text(
                 text = BuildConfig.APP_BUILD_TIME,
                 style = MaterialTheme.typography.bodyMedium,
@@ -121,11 +129,11 @@ fun DeveloperMenuUi(
             Spacer(modifier = Modifier.height(8.dp))
 
             // Sync & Connection Section
-            HelpSectionHeader(title = "Sync & Connection")
+            HelpSectionHeader(title = stringResource(MR.string.dev_menu_section_sync))
             Card(modifier = Modifier.fillMaxWidth()) {
                 Column {
                     HelpClickableRow(
-                        label = "Force Sync All",
+                        label = stringResource(MR.string.dev_menu_force_sync),
                         showChevron = false,
                         onClick = { onAction(DeveloperMenuUiAction.ForceSyncAll) }
                     )
@@ -134,11 +142,11 @@ fun DeveloperMenuUi(
             Spacer(modifier = Modifier.height(8.dp))
 
             // Database Section
-            HelpSectionHeader(title = "Database & Storage")
+            HelpSectionHeader(title = stringResource(MR.string.dev_menu_section_database))
             Card(modifier = Modifier.fillMaxWidth()) {
                 Column {
                     HelpClickableRow(
-                        label = "Clear All Data",
+                        label = stringResource(MR.string.dev_menu_clear_data),
                         showChevron = false,
                         onClick = { onAction(DeveloperMenuUiAction.ClearAllData) }
                     )
@@ -147,11 +155,11 @@ fun DeveloperMenuUi(
             Spacer(modifier = Modifier.height(8.dp))
 
             // Testing Section
-            HelpSectionHeader(title = "Testing Tools")
+            HelpSectionHeader(title = stringResource(MR.string.dev_menu_section_testing))
             Card(modifier = Modifier.fillMaxWidth()) {
                 Column {
                     HelpClickableRow(
-                        label = "Test Rich Notification",
+                        label = stringResource(MR.string.dev_menu_test_notification),
                         showChevron = false,
                         onClick = { onAction(DeveloperMenuUiAction.TestRichNotification) }
                     )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/help/HelpScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/help/HelpScreen.kt
@@ -39,6 +39,7 @@ import id.homebase.core.util.getUriHandler
 import id.homebase.core.widget.CheckboxRow
 import id.homebase.resources.MR
 import id.homebase.resources.about_homebase
+import id.homebase.resources.dev_menu_title
 import id.homebase.resources.help_contact_us
 import id.homebase.resources.help_copyright
 import id.homebase.resources.help_debug_log_description
@@ -244,7 +245,7 @@ fun HelpUi(
                     if (uiState.showDeveloperMenu) {
                         HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
                         HelpClickableRow(
-                            label = "Developer menu",
+                            label = stringResource(MR.string.dev_menu_title),
                             onClick = { onAction(HelpUiAction.DeveloperMenu) }
                         )
                     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsScreen.kt
@@ -83,6 +83,7 @@ import id.homebase.resources.settings_notifications_issue
 import id.homebase.resources.settings_open_owner_console
 import id.homebase.resources.settings_profile_info
 import id.homebase.resources.settings_security_setup
+import id.homebase.resources.cd_open_externally
 import id.homebase.resources.settings_section_danger_zone
 import id.homebase.resources.settings_section_general
 import id.homebase.resources.settings_storage
@@ -281,7 +282,7 @@ fun SettingsUi(
                 trailingContent = {
                     Icon(
                         imageVector = Icons.AutoMirrored.Outlined.OpenInNew,
-                        contentDescription = null,
+                        contentDescription = stringResource(MR.string.cd_open_externally),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.size(20.dp)
                     )
@@ -329,7 +330,7 @@ fun SettingsUi(
                 trailingContent = {
                     Icon(
                         imageVector = Icons.AutoMirrored.Outlined.OpenInNew,
-                        contentDescription = null,
+                        contentDescription = stringResource(MR.string.cd_open_externally),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.size(20.dp)
                     )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsScreen.kt
@@ -46,6 +46,8 @@ import id.homebase.api.client.cache.CacheStats
 import id.homebase.resources.MR
 import id.homebase.resources.menu_back
 import id.homebase.resources.settings_storage
+import id.homebase.resources.storage_orphan_coil_body
+import id.homebase.resources.storage_orphan_coil_title
 import id.homebase.resources.storage_cache_coil_memory
 import id.homebase.resources.storage_cache_payloads
 import id.homebase.resources.storage_cache_profile_images
@@ -453,10 +455,8 @@ private fun EmptyRow(text: String) {
 @Composable
 private fun OrphanCoilCacheWarning(bytes: Long) {
     ErrorCard(
-        title = "Orphan Coil disk cache detected",
-        body = "${formatBytes(bytes)} in cache/coil3_disk_cache. Coil's default disk " +
-                "cache should be off — this directory means something is bypassing " +
-                "the Homebase cache layer. Tap \"Clear caches\" to delete it.",
+        title = stringResource(MR.string.storage_orphan_coil_title),
+        body = stringResource(MR.string.storage_orphan_coil_body, formatBytes(bytes)),
     )
 }
 


### PR DESCRIPTION
## Summary

- **Received bubble hit target** — removed fillMaxWidth from clickable Box so only the bubble area is tappable (1.12)
- **Timestamp footer padding** — added 4dp bottom padding when timestamp wraps to own line (1.7)
- **New Messages unread separator** — divider with label before first unread message, using lastRead + unreadCount guard, heading semantics for a11y (T2.10)
- **FAB unread badge bounce** — keyframes animation via graphicsLayer on count increase (T2.9)
- **Unread separator fade** — animateItem fadeInSpec/fadeOutSpec for LazyColumn enter/exit
- **Accessibility** — fixed ~35 contentDescription=null across 20 files (4.3)
- **Internationalization** — replaced 30+ hardcoded strings with stringResource across 11 files (4.2, T2.16)
- **Responsive media gallery** — Signal-style BoxWithConstraints breakpoints (T2.15)
- **Group sender avatars** — 28dp PublicAvatar at END/ALONE cluster positions (T1.4)
- **Reaction scroll jank fix** — removed per-emoji stagger animations

## Test plan

- [ ] Unread messages: verify New messages separator at correct position
- [ ] Receive messages while scrolled up: verify FAB badge bounces
- [ ] Long-press empty space beside received bubble: should NOT trigger menu
- [ ] Timestamp on own line: verify bottom padding present
- [ ] TalkBack/VoiceOver: verify icons announce purpose
- [ ] Dev menu, defragmenter, storage: verify localized text
- [ ] Group conversation: verify sender avatars at cluster end
- [ ] Multi-image message: verify gallery scales with width
- [ ] Scroll with reactions: verify no jank