### PR TITLE
fix(ci): iOS launch crash — missing Compose resources

### DIFF
--- a/.github/workflows/build-mobile-release-dev.yml
+++ b/.github/workflows/build-mobile-release-dev.yml
@@ -176,7 +176,9 @@ jobs:
           XCEOF
 
       - name: Pre-build KMP framework
-        run: ./gradlew :homebase-core:linkReleaseFrameworkIosArm64
+        run: |
+          ./gradlew :homebase-core:linkReleaseFrameworkIosArm64
+          ./gradlew :homebase-core:syncComposeResourcesForIos
         env:
           JDK_17: ${{ env.JAVA_HOME }}
 

--- a/.github/workflows/build-mobile-release-prod.yml
+++ b/.github/workflows/build-mobile-release-prod.yml
@@ -184,7 +184,9 @@ jobs:
           XCEOF
 
       - name: Pre-build KMP framework
-        run: ./gradlew :homebase-core:linkReleaseFrameworkIosArm64
+        run: |
+          ./gradlew :homebase-core:linkReleaseFrameworkIosArm64
+          ./gradlew :homebase-core:syncComposeResourcesForIos
         env:
           JDK_17: ${{ env.JAVA_HOME }}
 


### PR DESCRIPTION
## Summary

- **iOS app crashes on launch with SIGABRT** on all CI-built releases since PR #462
- Root cause: `linkReleaseFrameworkIosArm64` only builds the static framework binary but does **not** run `syncComposeResourcesForIos`, which bundles string/drawable resources into the app
- When `OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED=YES` skips `embedAndSignAppleFrameworkForXcode`, the 149-task dependency chain (including resource sync) is entirely skipped
- Fix: explicitly run `syncComposeResourcesForIos` after the framework link step in both dev and prod workflows

## Root cause

```
embedAndSignAppleFrameworkForXcode (149 tasks)
  └── syncComposeResourcesForIos    ← bundles Compose resources
  └── linkReleaseFrameworkIosArm64  ← builds binary only

PR #462 replaced the full task with just linkRelease, losing the resource sync.
```

## Test plan

- [ ] Trigger dev workflow manually and verify iOS build completes
- [ ] Install the resulting TestFlight build and confirm app launches without crash
- [ ] Verify Compose string resources render correctly on first screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)