### PR TITLE
fix(ci): iOS launch crash — restore Compose resource bundling

### DIFF
--- a/.github/workflows/build-mobile-release-dev.yml
+++ b/.github/workflows/build-mobile-release-dev.yml
@@ -172,20 +172,15 @@ jobs:
 
           // CI optimizations
           COMPILER_INDEX_STORE_ENABLE = NO
-          FRAMEWORK_SEARCH_PATHS = $(inherited) $(SRCROOT)/../homebase-core/build/bin/iosArm64/releaseFramework
           XCEOF
 
       - name: Pre-build KMP framework
-        run: |
-          ./gradlew :homebase-core:linkReleaseFrameworkIosArm64
-          ./gradlew :homebase-core:syncComposeResourcesForIos
+        run: ./gradlew :homebase-core:linkReleaseFrameworkIosArm64
         env:
           JDK_17: ${{ env.JAVA_HOME }}
 
       - name: Build iOS
         uses: yukiarrr/ios-build-action@v1.12.0
-        env:
-          OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED: "YES"
         with:
           project-path: iosApp/iosApp.xcodeproj
           workspace-path: iosApp/iosApp.xcodeproj/project.xcworkspace

--- a/.github/workflows/build-mobile-release-prod.yml
+++ b/.github/workflows/build-mobile-release-prod.yml
@@ -180,20 +180,15 @@ jobs:
 
           // CI optimizations
           COMPILER_INDEX_STORE_ENABLE = NO
-          FRAMEWORK_SEARCH_PATHS = $(inherited) $(SRCROOT)/../homebase-core/build/bin/iosArm64/releaseFramework
           XCEOF
 
       - name: Pre-build KMP framework
-        run: |
-          ./gradlew :homebase-core:linkReleaseFrameworkIosArm64
-          ./gradlew :homebase-core:syncComposeResourcesForIos
+        run: ./gradlew :homebase-core:linkReleaseFrameworkIosArm64
         env:
           JDK_17: ${{ env.JAVA_HOME }}
 
       - name: Build iOS
         uses: yukiarrr/ios-build-action@v1.12.0
-        env:
-          OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED: "YES"
         with:
           project-path: iosApp/iosApp.xcodeproj
           workspace-path: iosApp/iosApp.xcodeproj/project.xcworkspace


### PR DESCRIPTION
## Summary

- **Supersedes PR #465** which added `syncComposeResourcesForIos` but fails because that task requires Xcode env vars (`ARCHS`, `BUILT_PRODUCTS_DIR`)
- Removes `OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED=YES` so `embedAndSignAppleFrameworkForXcode` runs inside xcodebuild again — this handles both resource sync and framework copy/sign
- Removes `FRAMEWORK_SEARCH_PATHS` injection (unnecessary when `embedAndSignAppleFrameworkForXcode` places the framework)
- Keeps `linkReleaseFrameworkIosArm64` pre-build from PR #461 — Gradle's up-to-date check skips recompilation inside xcodebuild, so only fast resource sync + copy/sign run

## Root cause

PR #462 set `OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED=YES` to skip the entire Gradle build phase inside xcodebuild. This skipped `syncComposeResourcesForIos` (part of `embedAndSignAppleFrameworkForXcode`'s 149-task dependency chain), leaving the app bundle without Compose resources. First `stringResource()` call at launch → SIGABRT.

## Test plan

- [ ] Trigger dev workflow manually — verify iOS build completes without `syncComposeResourcesForIos` error
- [ ] Install resulting TestFlight build — confirm app launches without crash
- [ ] Verify string resources render correctly on first screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)