### PR TITLE
fix(ci): remove redundant pre-build step and timeout limit

### DIFF
--- a/.github/workflows/build-mobile-release-dev.yml
+++ b/.github/workflows/build-mobile-release-dev.yml
@@ -82,8 +82,6 @@ jobs:
 
   build-ios:
     runs-on: macos-15
-    timeout-minutes: 90
-
     steps:
       - uses: actions/checkout@v5
 
@@ -173,11 +171,6 @@ jobs:
           // CI optimizations
           COMPILER_INDEX_STORE_ENABLE = NO
           XCEOF
-
-      - name: Pre-build KMP framework
-        run: ./gradlew :homebase-core:linkReleaseFrameworkIosArm64
-        env:
-          JDK_17: ${{ env.JAVA_HOME }}
 
       - name: Build iOS
         uses: yukiarrr/ios-build-action@v1.12.0

--- a/.github/workflows/build-mobile-release-prod.yml
+++ b/.github/workflows/build-mobile-release-prod.yml
@@ -90,8 +90,6 @@ jobs:
 
   build-ios:
     runs-on: macos-15
-    timeout-minutes: 90
-
     steps:
       - uses: actions/checkout@v5
 
@@ -181,11 +179,6 @@ jobs:
           // CI optimizations
           COMPILER_INDEX_STORE_ENABLE = NO
           XCEOF
-
-      - name: Pre-build KMP framework
-        run: ./gradlew :homebase-core:linkReleaseFrameworkIosArm64
-        env:
-          JDK_17: ${{ env.JAVA_HOME }}
 
       - name: Build iOS
         uses: yukiarrr/ios-build-action@v1.12.0


### PR DESCRIPTION
## Summary

The pre-build step (`linkReleaseFrameworkIosArm64`) added in #461 is counterproductive — `embedAndSignAppleFrameworkForXcode` still runs inside xcodebuild and recompiles the framework, doubling the build time (~60 min wasted).

We tried skipping Gradle inside xcodebuild via `OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED` (#462), but that broke Compose resource syncing (#465, #466).

**This PR:**
- Removes the pre-build step — eliminates ~60 min of redundant K/N compilation
- Removes `timeout-minutes: 90` — lets the build complete without artificial cutoff (GitHub default: 360 min)
- Keeps `COMPILER_INDEX_STORE_ENABLE=NO` and all caching optimizations from #459

**Expected: iOS build goes back to ~65 min (single K/N compilation) without timing out.**

## Test plan

- [ ] Trigger manual dev release build
- [ ] Verify no "Pre-build KMP framework" step exists
- [ ] Verify "Build iOS" completes successfully (single K/N + Swift + archive)
- [ ] Verify build does not time out

🤖 Generated with [Claude Code](https://claude.com/claude-code)