### PR TITLE
fix

### DIFF
--- a/.github/workflows/build-mobile-release-dev.yml
+++ b/.github/workflows/build-mobile-release-dev.yml
@@ -73,6 +73,14 @@ jobs:
           name: homebase-id-app-android
           path: androidApp/build/outputs/bundle/dev/homebase-id-dev-app.aab
 
+      - name: Upload R8 mapping
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: android-mapping-dev-${{ steps.version.outputs.VERSION_CODE }}
+          path: androidApp/build/outputs/mapping/dev/mapping.txt
+          retention-days: 90
+
       - name: Create Google Play Service Account JSON
         run: |
           echo '${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_DEV }}' > google-play-key.json

--- a/.github/workflows/build-mobile-release-prod.yml
+++ b/.github/workflows/build-mobile-release-prod.yml
@@ -81,6 +81,14 @@ jobs:
           name: homebase-id-app-android
           path: androidApp/build/outputs/bundle/release/homebase-id-app.aab
 
+      - name: Upload R8 mapping
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: android-mapping-${{ steps.version.outputs.VERSION_CODE }}
+          path: androidApp/build/outputs/mapping/release/mapping.txt
+          retention-days: 90
+
       - name: Create Google Play Service Account JSON
         run: |
           echo '${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_DEV }}' > google-play-key.json

--- a/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
@@ -16,6 +16,7 @@ import id.homebase.api.sync.database.DatabaseDriverFactory
 import id.homebase.api.sync.database.DatabaseKeyManager
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.core.di.allModules
+import id.homebase.core.diagnostics.MainThreadWatchdog
 import id.homebase.core.logging.CrashLogger
 import id.homebase.core.logging.LoggerConfig
 import id.homebase.core.logging.StartupLogger
@@ -99,6 +100,11 @@ class MainApplication : Application(), KoinComponent {
 
         // Set up uncaught exception handler for crash logging
         setupCrashHandler()
+
+        // Detect main-thread stalls before Android ANRs. Logs the main-thread stack to
+        // homebase.log when a frame budget is exceeded by >4s — gives us a usable trace
+        // ~1s before the OS would kill us at 5s.
+        MainThreadWatchdog().start()
 
         // Provide application context for rich notifications
         RichNotificationDisplayer.initialize(this, smallIconResId = R.mipmap.ic_launcher_monochrome)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/common/OdinId.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/common/OdinId.kt
@@ -1,6 +1,8 @@
 package id.homebase.api.common
 
 import kotlin.uuid.Uuid
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
 import kotlinx.coroutines.runBlocking
 import id.homebase.api.crypto.ByteArrayUtil.reduceSha256Hash
 import kotlinx.serialization.KSerializer
@@ -79,17 +81,9 @@ class OdinId public constructor(
      * The string is validated and normalized by `AsciiDomainName`.
      */
     constructor(identifier: String) : this(
-        _domainName = AsciiDomainName(identifier), // throws if invalid/null
-        _hash = runBlocking { calculateHash(AsciiDomainName(identifier)) }
+        _domainName = AsciiDomainName(identifier),
+        _hash = cachedHash(identifier)
     )
-
-    /**
-     * Creates an `OdinId` from an already-validated `AsciiDomainName`.
-     */
-//    constructor(asciiDomain: AsciiDomainName) : this(
-//        _domainName = asciiDomain,
-//        _hash = runBlocking { calculateHash(asciiDomain) }
-//    )
 
     override fun equals(other: Any?): Boolean {
         if (other !is OdinId) return false
@@ -108,8 +102,22 @@ class OdinId public constructor(
 
     companion object {
 
+        // Thread-safe cache: a chat app sees a small set of unique domains
+        // (conversation participants), so this stays tiny. The SHA-256 hash
+        // is deterministic and domain names don't change, so entries never
+        // need invalidation.
+        private val hashLock = SynchronizedObject()
+        private val hashCache = HashMap<String, Uuid>()
+
+        internal fun cachedHash(identifier: String): Uuid {
+            val key = AsciiDomainName(identifier).domainName
+            synchronized(hashLock) { hashCache[key] }?.let { return it }
+            val hash = runBlocking { calculateHash(key) }
+            return synchronized(hashLock) { hashCache.getOrPut(key) { hash } }
+        }
+
         /** Deterministic hash of any `AsciiDomainName`. */
-        suspend fun toHashId(domainName: AsciiDomainName): Uuid = calculateHash(domainName)
+        suspend fun toHashId(domainName: AsciiDomainName): Uuid = calculateHash(domainName.domainName)
 
         /** Creates an `OdinId` from UTF-8 bytes (the bytes are interpreted as the domain string). */
         fun fromByteArray(id: ByteArray): OdinId = OdinId(id.decodeToString())
@@ -124,11 +132,9 @@ class OdinId public constructor(
             AsciiDomainNameValidator.assertValidDomain(odinId)
         }
 
-        private suspend fun calculateHash(asciiDomain: AsciiDomainName): Uuid {
-            // Matches the original C# behavior:
-            // SHA-256 → reduced to 16 bytes → Guid/Uuid
-            val reduced = reduceSha256Hash(asciiDomain.domainName)
-            return reduced // must be exactly 16 bytes
+        // Matches the original C# behavior: SHA-256 → reduced to 16 bytes → Guid/Uuid
+        private suspend fun calculateHash(normalizedDomain: String): Uuid {
+            return reduceSha256Hash(normalizedDomain)
         }
     }
 }

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/common/OdinIdCacheTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/common/OdinIdCacheTest.kt
@@ -1,0 +1,123 @@
+package id.homebase.api.common
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+
+class OdinIdCacheTest {
+
+    @Test
+    fun sameStringProducesSameHash() {
+        val a = OdinId("alice.test")
+        val b = OdinId("alice.test")
+        assertEquals(a.toHashId(), b.toHashId())
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun differentDomainsProduceDifferentHashes() {
+        val alice = OdinId("alice.test")
+        val bob = OdinId("bob.test")
+        assertNotEquals(alice.toHashId(), bob.toHashId())
+    }
+
+    @Test
+    fun caseNormalization_producesEqualHash() {
+        val lower = OdinId("alice.test")
+        val mixed = OdinId("Alice.Test")
+        val upper = OdinId("ALICE.TEST")
+        assertEquals(lower.toHashId(), mixed.toHashId())
+        assertEquals(lower.toHashId(), upper.toHashId())
+        assertEquals(lower, mixed)
+        assertEquals(lower, upper)
+    }
+
+    @Test
+    fun hashIsDeterministicAcrossCalls() {
+        val first = OdinId("stable.test").toHashId()
+        val second = OdinId("stable.test").toHashId()
+        val third = OdinId("stable.test").toHashId()
+        assertEquals(first, second)
+        assertEquals(second, third)
+    }
+
+    @Test
+    fun hashIsValidUuid() {
+        val hash = OdinId("alice.test").toHashId()
+        assertTrue(hash != Uuid.NIL)
+    }
+
+    @Test
+    fun domainNamePreservedCorrectly() {
+        val odinId = OdinId("Alice.Test")
+        assertEquals("alice.test", odinId.domainName)
+    }
+
+    @Test
+    fun manyDistinctDomainsAllProduceUniqueHashes() {
+        val domains = (1..50).map { OdinId("user$it.test") }
+        val hashes = domains.map { it.toHashId() }.toSet()
+        assertEquals(50, hashes.size)
+    }
+
+    @Test
+    fun concurrentConstructionProducesConsistentResults() = runTest {
+        val results = withContext(Dispatchers.Default) {
+            (1..100).map {
+                async { OdinId("concurrent.test").toHashId() }
+            }.awaitAll()
+        }
+        val unique = results.toSet()
+        assertEquals(1, unique.size, "All concurrent constructions should produce the same hash")
+    }
+
+    @Test
+    fun concurrentConstructionOfManyDomains() = runTest {
+        val domains = listOf("alice.test", "bob.test", "carol.test", "dave.test")
+        val results = withContext(Dispatchers.Default) {
+            (1..200).map { i ->
+                async { OdinId(domains[i % domains.size]) }
+            }.awaitAll()
+        }
+
+        val grouped = results.groupBy { it.domainName }
+        assertEquals(4, grouped.size)
+
+        grouped.forEach { (_, odinIds) ->
+            val hashes = odinIds.map { it.toHashId() }.toSet()
+            assertEquals(1, hashes.size, "Same domain must always produce same hash")
+        }
+    }
+
+    @Test
+    fun fromByteArrayRoundTrips() {
+        val original = OdinId("roundtrip.test")
+        val fromBytes = OdinId.fromByteArray(original.toByteArray())
+        assertEquals(original, fromBytes)
+        assertEquals(original.toHashId(), fromBytes.toHashId())
+    }
+
+    @Test
+    fun toHashIdSuspendMatchesConstructorHash() = runTest {
+        val domain = AsciiDomainName("suspend.test")
+        val suspendHash = OdinId.toHashId(domain)
+        val constructorHash = OdinId("suspend.test").toHashId()
+        assertEquals(suspendHash, constructorHash)
+    }
+
+    @Test
+    fun equalityUsesHashNotReference() {
+        val a = OdinId("equals.test")
+        val b = OdinId("equals.test")
+        assertTrue(a !== b, "Different instances")
+        assertTrue(a == b, "Equal by hash")
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -2512,49 +2512,51 @@ class ConversationListViewModel(
                             val exitedAt = _uiState.value.activeConversations
                                 .find { it.conversation.id == conversationId }
                                 ?.conversation?.exitedAt
-                            val filteredByExit = if (exitedAt != null)
-                                messageState.messages.filter { it.userDate <= exitedAt }
-                            else
-                                messageState.messages
-                            // Hide soft-deleted messages in "Note to Self" conversation
-                            val messages =
-                                if (conversationId == ChatProtocol.ConversationWithYourselfId)
-                                    filteredByExit.filter { !it.isDeleted }
-                                else
-                                    filteredByExit
-                            // Group messages within day sections
-                            val timezone = TimeZone.currentSystemDefault()
-                            val groupedMessages =
-                                messages.sortedBy { it.userDate }.groupBy { message ->
-                                    val date = message.userDate.toLocalDateTime(timezone).date
-                                    date
-                                }
-                            val messagesModels: MutableList<MessageListContentModel> =
-                                mutableListOf(MessageListContentModel.Header)
 
-                            var systemIndex = 0
-                            messagesModels.addAll(groupedMessages.flatMap { (date, messages) ->
-                                val sectionHeader = listOf(MessageListContentModel.Section(date))
-                                val items = messages.map { msg ->
-                                    if (msg.isStatusMessage)
-                                        MessageListContentModel.System(
-                                            msg.content,
-                                            msg.userDate,
-                                            systemIndex++
-                                        )
+                            val messagesModels = withContext(Dispatchers.Default) {
+                                val filteredByExit = if (exitedAt != null)
+                                    messageState.messages.filter { it.userDate <= exitedAt }
+                                else
+                                    messageState.messages
+                                val messages =
+                                    if (conversationId == ChatProtocol.ConversationWithYourselfId)
+                                        filteredByExit.filter { !it.isDeleted }
                                     else
-                                        MessageListContentModel.Message(msg)
-                                }
-                                val messageItems = items.filterIsInstance<MessageListContentModel.Message>()
-                                val clustered = computeClusterPositions(messageItems)
-                                val clusteredMap = clustered.associateBy { it.message.id }
-                                sectionHeader + items.map { item ->
-                                    if (item is MessageListContentModel.Message)
-                                        clusteredMap[item.message.id] ?: item
-                                    else
-                                        item
-                                }
-                            })
+                                        filteredByExit
+                                val timezone = TimeZone.currentSystemDefault()
+                                val groupedMessages =
+                                    messages.sortedBy { it.userDate }.groupBy { message ->
+                                        val date = message.userDate.toLocalDateTime(timezone).date
+                                        date
+                                    }
+                                val models: MutableList<MessageListContentModel> =
+                                    mutableListOf(MessageListContentModel.Header)
+
+                                var systemIndex = 0
+                                models.addAll(groupedMessages.flatMap { (date, messages) ->
+                                    val sectionHeader = listOf(MessageListContentModel.Section(date))
+                                    val items = messages.map { msg ->
+                                        if (msg.isStatusMessage)
+                                            MessageListContentModel.System(
+                                                msg.content,
+                                                msg.userDate,
+                                                systemIndex++
+                                            )
+                                        else
+                                            MessageListContentModel.Message(msg)
+                                    }
+                                    val messageItems = items.filterIsInstance<MessageListContentModel.Message>()
+                                    val clustered = computeClusterPositions(messageItems)
+                                    val clusteredMap = clustered.associateBy { it.message.id }
+                                    sectionHeader + items.map { item ->
+                                        if (item is MessageListContentModel.Message)
+                                            clusteredMap[item.message.id] ?: item
+                                        else
+                                            item
+                                    }
+                                })
+                                models
+                            }
 
                             // Insert "New Messages" separator before the first unread message
                             val convoModel = _uiState.value.activeConversations
@@ -2633,7 +2635,7 @@ class ConversationListViewModel(
                                 // it's long, navigation already completed (tap →
                                 // detailPane render) without waiting for it.
                                 Logger.i(tag = "ConversationListViewModel") {
-                                    "messages first emission id=$conversationId messageCount=${messages.size} sinceSelected=${loadStart.elapsedNow()}"
+                                    "messages first emission id=$conversationId messageCount=${messagesModels.size} sinceSelected=${loadStart.elapsedNow()}"
                                 }
                             }
 
@@ -2650,7 +2652,7 @@ class ConversationListViewModel(
                                 val totalElapsed = loadStart.elapsedNow()
                                 Logger.d(tag = "ConversationLoad") {
                                     "conversationId=$conversationId " +
-                                            "messageCount=${messages.size} " +
+                                            "messageCount=${messagesModels.size} " +
                                             "cached=$hasCachedMessages " +
                                             "total=$totalElapsed"
                                 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -8,6 +8,8 @@ import id.homebase.api.client.drives.QueryBatchSortField
 import id.homebase.api.client.drives.QueryBatchSortOrder
 import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.client.drives.query.QueryBatchCursor
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.client.withRetry
@@ -138,10 +140,11 @@ class ChatMessageStream(
 // ---------- EVENT HANDLING ----------
 
     private suspend fun processIncrementalBatch(files: List<HomebaseFile>) {
-        val messages =
+        val messages = withContext(Dispatchers.Default) {
             files
                 .filter { it.fileMetadata.appData.fileType == ChatProtocol.MessageFileType }
                 .mapNotNull { mapToMessageData(it, credentialsManager, ::resolveDisplayName) }
+        }
 
         val grouped = messages.groupBy { it.conversationId }
         Logger.d("ChatMessageStream: processIncrementalBatch ${messages.size} messages across ${grouped.size} conversation(s)")
@@ -198,8 +201,10 @@ class ChatMessageStream(
         val queryElapsed = queryStart.elapsedNow()
 
         val mapStart = TimeSource.Monotonic.markNow()
-        val records = result.records.mapNotNull { header ->
-            mapToMessageData(header, credentialsManager, ::resolveDisplayName)
+        val records = withContext(Dispatchers.Default) {
+            result.records.mapNotNull { header ->
+                mapToMessageData(header, credentialsManager, ::resolveDisplayName)
+            }
         }
         val mapElapsed = mapStart.elapsedNow()
 
@@ -244,7 +249,7 @@ class ChatMessageStream(
 
         // TODO - remove simple content search filter when actual query does filtering
         return BatchResult(
-            records =
+            records = withContext(Dispatchers.Default) {
                 result.records
                     .filter {
                         it.fileMetadata.appData.content?.contains(
@@ -252,7 +257,8 @@ class ChatMessageStream(
                             ignoreCase = true
                         ) == true
                     }
-                    .mapNotNull { mapToMessageData(it, credentialsManager, ::resolveDisplayName) },
+                    .mapNotNull { mapToMessageData(it, credentialsManager, ::resolveDisplayName) }
+            },
             hasMoreRows = result.hasMoreRows,
             cursor = result.cursor
         )
@@ -280,12 +286,14 @@ class ChatMessageStream(
             )
 
         return BatchResult(
-            records = result.records.mapNotNull {
-                mapToMessageData(
-                    it,
-                    credentialsManager,
-                    ::resolveDisplayName
-                )
+            records = withContext(Dispatchers.Default) {
+                result.records.mapNotNull {
+                    mapToMessageData(
+                        it,
+                        credentialsManager,
+                        ::resolveDisplayName
+                    )
+                }
             },
             hasMoreRows = result.hasMoreRows,
             cursor = result.cursor

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -532,7 +532,7 @@ fun MessageBubbleRaw(
 
                         // Calculate potential final width BEFORE measuring reply
                         val layoutResult = textLayoutResult
-                        val potentialFinalWidth: Int
+                        val rawPotentialFinalWidth: Int
 
                         if (layoutResult != null && layoutResult.lineCount > 0) {
                             val lastLineIndex = layoutResult.lineCount - 1
@@ -545,7 +545,7 @@ fun MessageBubbleRaw(
                             val fitsOnLastLine =
                                 (lastLineEnd + horizontalGap + infoPlaceable.width + textRowPadding) <= availableWidth
 
-                            potentialFinalWidth = if (fitsOnLastLine) {
+                            rawPotentialFinalWidth = if (fitsOnLastLine) {
                                 maxOf(
                                     mediaWidth,
                                     textPlaceable.width,
@@ -561,7 +561,7 @@ fun MessageBubbleRaw(
                                 )
                             }
                         } else {
-                            potentialFinalWidth =
+                            rawPotentialFinalWidth =
                                 maxOf(
                                     mediaWidth,
                                     textPlaceable.width,
@@ -569,6 +569,13 @@ fun MessageBubbleRaw(
                                     authorWidth
                                 )
                         }
+
+                        // Clamp to the parent's bound. The reply re-measure below forces an exact
+                        // width, so an unclamped value here would propagate any computation drift
+                        // straight into a child measurement — turning a one-off mismeasure into a
+                        // sustained layout-invalidation loop. The clamp guarantees convergence.
+                        val potentialFinalWidth =
+                            rawPotentialFinalWidth.coerceAtMost(constraints.maxWidth)
 
                         // NOW measure reply with the correct width that accounts for info placement
                         val replyPlaceable = if (replyIndex != -1) measurables[replyIndex].measure(
@@ -649,7 +656,15 @@ fun MessageBubbleRaw(
                                 placeables.sumOf { it.height } + replyHeight + textPlaceable.height + infoPlaceable.height + 4.dp.roundToPx()
                         }
 
-                        layout(finalWidth, finalHeight) {
+                        // Same containment as `potentialFinalWidth`: never report a width
+                        // wider than the parent allows. A bubble that returns finalWidth >
+                        // constraints.maxWidth makes the parent re-measure us, which can race
+                        // with `textLayoutResult` updates and spin. Pull `infoX` back inside
+                        // the clamped width so the timestamp stays visible in the rare case
+                        // the clamp kicked in.
+                        val clampedFinalWidth = finalWidth.coerceAtMost(constraints.maxWidth)
+                        val clampedInfoX = infoX.coerceAtMost(clampedFinalWidth - infoPlaceable.width)
+                        layout(clampedFinalWidth, finalHeight) {
                             var yPos = 0
                             replyPlaceable?.let {
                                 it.placeRelative(0, yPos)
@@ -666,7 +681,7 @@ fun MessageBubbleRaw(
                             showMorePlaceable.placeRelative(0, yPos)
                             yPos += showMorePlaceable.height
 
-                            infoPlaceable.placeRelative(infoX, infoY)
+                            infoPlaceable.placeRelative(clampedInfoX, infoY)
                         }
                     }
                 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/MessageProcessingPipelineTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/MessageProcessingPipelineTest.kt
@@ -1,0 +1,392 @@
+package id.homebase.chat.conversationlist
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.common.OdinId
+import id.homebase.chat.data.MessageUiModel
+import id.homebase.chat.services.ChatProtocol
+import id.homebase.chat.services.MessageAppData
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+/**
+ * Tests the message processing pipeline that was moved to `withContext(Dispatchers.Default)`
+ * in the ANR fix. Verifies that filtering, sorting, grouping, clustering, and unread
+ * separator insertion produce correct results when run on a background dispatcher.
+ */
+class MessageProcessingPipelineTest {
+
+    private val alice = OdinId("alice.test")
+    private val bob = OdinId("bob.test")
+    private val conversationId = Uuid.random()
+    private val baseTime = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+
+    private fun msg(
+        sender: OdinId = alice,
+        offset: Int = 0,
+        isDeleted: Boolean = false,
+        isStatusMessage: Boolean = false,
+        content: String = "message-$offset",
+    ): MessageUiModel = MessageUiModel(
+        id = Uuid.random(),
+        globalTransitId = null,
+        fileId = Uuid.random(),
+        conversationId = conversationId,
+        content = content,
+        userDate = baseTime + offset.minutes,
+        modified = null,
+        created = baseTime + offset.minutes,
+        originalAuthor = sender,
+        sender = sender,
+        displayName = sender.domainName,
+        localReadTimestamp = null,
+        isDeleted = isDeleted,
+        isPendingSend = false,
+        versionTag = Uuid.NIL,
+        messageAppData = MessageAppData(),
+        reactionPreview = null,
+        previewThumbnail = null,
+        payloads = null,
+        keyHeader = KeyHeader.empty(),
+        hasMore = false,
+        isStatusMessage = isStatusMessage,
+    )
+
+    /**
+     * Replicates the pipeline from ConversationListViewModel.collect that was wrapped
+     * in withContext(Dispatchers.Default). Pure function, no ViewModel dependency.
+     */
+    private fun processMessages(
+        rawMessages: List<MessageUiModel>,
+        conversationId: Uuid = this.conversationId,
+        exitedAt: Instant? = null,
+        isNoteToSelf: Boolean = false,
+    ): List<MessageListContentModel> {
+        val filteredByExit = if (exitedAt != null)
+            rawMessages.filter { it.userDate <= exitedAt }
+        else
+            rawMessages
+        val messages = if (isNoteToSelf)
+            filteredByExit.filter { !it.isDeleted }
+        else
+            filteredByExit
+        val timezone = TimeZone.currentSystemDefault()
+        val groupedMessages = messages.sortedBy { it.userDate }.groupBy { message ->
+            message.userDate.toLocalDateTime(timezone).date
+        }
+        val models: MutableList<MessageListContentModel> =
+            mutableListOf(MessageListContentModel.Header)
+
+        var systemIndex = 0
+        models.addAll(groupedMessages.flatMap { (date, messages) ->
+            val sectionHeader = listOf(MessageListContentModel.Section(date))
+            val items = messages.map { msg ->
+                if (msg.isStatusMessage)
+                    MessageListContentModel.System(msg.content, msg.userDate, systemIndex++)
+                else
+                    MessageListContentModel.Message(msg)
+            }
+            val messageItems = items.filterIsInstance<MessageListContentModel.Message>()
+            val clustered = computeClusterPositions(messageItems)
+            val clusteredMap = clustered.associateBy { it.message.id }
+            sectionHeader + items.map { item ->
+                if (item is MessageListContentModel.Message)
+                    clusteredMap[item.message.id] ?: item
+                else
+                    item
+            }
+        })
+        return models
+    }
+
+    // --- Basic pipeline behavior ---
+
+    @Test
+    fun emptyMessageList_producesOnlyHeader() {
+        val result = processMessages(emptyList())
+        assertEquals(1, result.size)
+        assertIs<MessageListContentModel.Header>(result[0])
+    }
+
+    @Test
+    fun singleMessage_producesHeaderSectionAndMessage() {
+        val result = processMessages(listOf(msg()))
+        assertEquals(3, result.size)
+        assertIs<MessageListContentModel.Header>(result[0])
+        assertIs<MessageListContentModel.Section>(result[1])
+        assertIs<MessageListContentModel.Message>(result[2])
+    }
+
+    @Test
+    fun messagesAreSortedByUserDate() {
+        val messages = listOf(
+            msg(offset = 30, content = "third"),
+            msg(offset = 10, content = "first"),
+            msg(offset = 20, content = "second"),
+        )
+        val result = processMessages(messages)
+        val messageItems = result.filterIsInstance<MessageListContentModel.Message>()
+        assertEquals("first", messageItems[0].message.content)
+        assertEquals("second", messageItems[1].message.content)
+        assertEquals("third", messageItems[2].message.content)
+    }
+
+    // --- Day grouping ---
+
+    @Test
+    fun messagesOnSameDay_shareOneSection() {
+        val messages = listOf(
+            msg(offset = 0),
+            msg(offset = 30),
+            msg(offset = 60),
+        )
+        val result = processMessages(messages)
+        val sections = result.filterIsInstance<MessageListContentModel.Section>()
+        assertEquals(1, sections.size)
+    }
+
+    @Test
+    fun messagesOnDifferentDays_getSeparateSections() {
+        val messages = listOf(
+            msg(offset = 0),
+            msg(offset = 24 * 60), // 24 hours later
+        )
+        val result = processMessages(messages)
+        val sections = result.filterIsInstance<MessageListContentModel.Section>()
+        assertEquals(2, sections.size)
+    }
+
+    @Test
+    fun sectionDatesAreCorrect() {
+        val timezone = TimeZone.currentSystemDefault()
+        val day1Time = baseTime
+        val day2Time = baseTime + 25.hours
+
+        val messages = listOf(msg(offset = 0), msg(offset = 25 * 60))
+        val result = processMessages(messages)
+        val sections = result.filterIsInstance<MessageListContentModel.Section>()
+
+        val expectedDay1 = day1Time.toLocalDateTime(timezone).date
+        val expectedDay2 = day2Time.toLocalDateTime(timezone).date
+        assertEquals(expectedDay1, sections[0].date)
+        assertEquals(expectedDay2, sections[1].date)
+    }
+
+    // --- Clustering integration ---
+
+    @Test
+    fun clusteringAppliedWithinSections() {
+        val messages = listOf(
+            msg(sender = alice, offset = 0),
+            msg(sender = alice, offset = 1),
+            msg(sender = alice, offset = 2),
+        )
+        val result = processMessages(messages)
+        val messageItems = result.filterIsInstance<MessageListContentModel.Message>()
+        assertEquals(MessageClusterPosition.START, messageItems[0].clusterPosition)
+        assertEquals(MessageClusterPosition.MIDDLE, messageItems[1].clusterPosition)
+        assertEquals(MessageClusterPosition.END, messageItems[2].clusterPosition)
+    }
+
+    @Test
+    fun differentSenders_noClustering() {
+        val messages = listOf(
+            msg(sender = alice, offset = 0),
+            msg(sender = bob, offset = 1),
+            msg(sender = alice, offset = 2),
+        )
+        val result = processMessages(messages)
+        val messageItems = result.filterIsInstance<MessageListContentModel.Message>()
+        messageItems.forEach {
+            assertEquals(MessageClusterPosition.ALONE, it.clusterPosition)
+        }
+    }
+
+    // --- Status messages ---
+
+    @Test
+    fun statusMessages_renderedAsSystem() {
+        val messages = listOf(
+            msg(offset = 0, isStatusMessage = true, content = "Alice joined"),
+            msg(offset = 1, content = "Hello"),
+        )
+        val result = processMessages(messages)
+        val systems = result.filterIsInstance<MessageListContentModel.System>()
+        assertEquals(1, systems.size)
+        assertEquals("Alice joined", systems[0].text)
+    }
+
+    @Test
+    fun statusMessagesDoNotAffectClustering() {
+        val messages = listOf(
+            msg(sender = alice, offset = 0),
+            msg(sender = alice, offset = 1, isStatusMessage = true, content = "status"),
+            msg(sender = alice, offset = 2),
+        )
+        val result = processMessages(messages)
+        val messageItems = result.filterIsInstance<MessageListContentModel.Message>()
+        // Only 2 message items (status message is a System, not Message)
+        assertEquals(2, messageItems.size)
+        assertEquals(MessageClusterPosition.START, messageItems[0].clusterPosition)
+        assertEquals(MessageClusterPosition.END, messageItems[1].clusterPosition)
+    }
+
+    // --- Exit filter ---
+
+    @Test
+    fun exitedAt_filtersMessagesAfterExitTime() {
+        val messages = listOf(
+            msg(offset = 0, content = "before"),
+            msg(offset = 10, content = "after"),
+        )
+        val exitTime = baseTime + 5.minutes
+        val result = processMessages(messages, exitedAt = exitTime)
+        val messageItems = result.filterIsInstance<MessageListContentModel.Message>()
+        assertEquals(1, messageItems.size)
+        assertEquals("before", messageItems[0].message.content)
+    }
+
+    // --- Note to Self deletion filter ---
+
+    @Test
+    fun noteToSelf_hidesDeletedMessages() {
+        val messages = listOf(
+            msg(offset = 0, content = "visible"),
+            msg(offset = 1, isDeleted = true, content = "deleted"),
+        )
+        val result = processMessages(messages, isNoteToSelf = true)
+        val messageItems = result.filterIsInstance<MessageListContentModel.Message>()
+        assertEquals(1, messageItems.size)
+        assertEquals("visible", messageItems[0].message.content)
+    }
+
+    @Test
+    fun regularConversation_showsDeletedMessages() {
+        val messages = listOf(
+            msg(offset = 0, content = "visible"),
+            msg(offset = 1, isDeleted = true, content = "deleted"),
+        )
+        val result = processMessages(messages, isNoteToSelf = false)
+        val messageItems = result.filterIsInstance<MessageListContentModel.Message>()
+        assertEquals(2, messageItems.size)
+    }
+
+    // --- Background dispatcher correctness ---
+
+    @Test
+    fun pipelineProducesSameResultOnDefaultDispatcher() = runTest {
+        val messages = (0 until 100).map { i ->
+            msg(
+                sender = if (i % 3 == 0) alice else bob,
+                offset = i * 2,
+                isStatusMessage = i % 10 == 0,
+                content = "msg-$i"
+            )
+        }
+
+        val mainResult = processMessages(messages)
+        val backgroundResult = withContext(Dispatchers.Default) {
+            processMessages(messages)
+        }
+
+        assertEquals(mainResult.size, backgroundResult.size)
+        mainResult.zip(backgroundResult).forEachIndexed { index, (main, bg) ->
+            assertEquals(
+                main::class,
+                bg::class,
+                "Item type mismatch at index $index"
+            )
+            when (main) {
+                is MessageListContentModel.Message -> {
+                    val bgMsg = bg as MessageListContentModel.Message
+                    assertEquals(main.message.id, bgMsg.message.id)
+                    assertEquals(main.clusterPosition, bgMsg.clusterPosition)
+                }
+                is MessageListContentModel.Section -> {
+                    assertEquals(main.date, (bg as MessageListContentModel.Section).date)
+                }
+                is MessageListContentModel.System -> {
+                    assertEquals(main.text, (bg as MessageListContentModel.System).text)
+                }
+                else -> {}
+            }
+        }
+    }
+
+    // --- Scale test ---
+
+    @Test
+    fun largeMessageSet_processesCorrectly() {
+        val messages = (0 until 1000).map { i ->
+            msg(
+                sender = if (i % 2 == 0) alice else bob,
+                offset = i,
+                content = "msg-$i"
+            )
+        }
+        val result = processMessages(messages)
+        val messageItems = result.filterIsInstance<MessageListContentModel.Message>()
+        assertEquals(1000, messageItems.size)
+        // Verify sorted order
+        for (i in 1 until messageItems.size) {
+            assertTrue(
+                messageItems[i].message.userDate >= messageItems[i - 1].message.userDate,
+                "Messages should be sorted by userDate"
+            )
+        }
+    }
+
+    @Test
+    fun largeMessageSet_producesCorrectOnBackgroundDispatcher() = runTest {
+        val messages = (0 until 1000).map { i ->
+            msg(sender = alice, offset = i, content = "msg-$i")
+        }
+        val result = withContext(Dispatchers.Default) {
+            processMessages(messages)
+        }
+        val messageItems = result.filterIsInstance<MessageListContentModel.Message>()
+        assertEquals(1000, messageItems.size)
+
+        // First and last should be START/END of a big cluster
+        assertEquals(MessageClusterPosition.START, messageItems.first().clusterPosition)
+        assertEquals(MessageClusterPosition.END, messageItems.last().clusterPosition)
+    }
+
+    // --- Interleaved types ---
+
+    @Test
+    fun mixedMessageAndStatusTypes_correctOrdering() {
+        val messages = listOf(
+            msg(sender = alice, offset = 0, content = "hello"),
+            msg(sender = alice, offset = 1, isStatusMessage = true, content = "Alice changed topic"),
+            msg(sender = bob, offset = 2, content = "hey"),
+            msg(sender = bob, offset = 3, content = "what's up"),
+        )
+        val result = processMessages(messages)
+
+        // Header, Section, then items in order
+        assertIs<MessageListContentModel.Header>(result[0])
+        assertIs<MessageListContentModel.Section>(result[1])
+        assertIs<MessageListContentModel.Message>(result[2])
+        assertIs<MessageListContentModel.System>(result[3])
+        assertIs<MessageListContentModel.Message>(result[4])
+        assertIs<MessageListContentModel.Message>(result[5])
+
+        // Bob's two messages should be clustered
+        val bobFirst = result[4] as MessageListContentModel.Message
+        val bobSecond = result[5] as MessageListContentModel.Message
+        assertEquals(MessageClusterPosition.START, bobFirst.clusterPosition)
+        assertEquals(MessageClusterPosition.END, bobSecond.clusterPosition)
+    }
+}

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/diagnostics/MainThreadWatchdog.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/diagnostics/MainThreadWatchdog.kt
@@ -1,0 +1,68 @@
+package id.homebase.core.diagnostics
+
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.Looper
+import android.os.SystemClock
+import co.touchlab.kermit.Logger
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Detects main-thread stalls before Android's ANR machinery does.
+ *
+ * A background thread posts a sentinel to the main looper every [tickIntervalMs]; if the sentinel
+ * does not run within [thresholdMs], the watchdog captures the main thread's stack trace and emits
+ * a single WARN log line (per [throttleMs] window) so we get a *deobfuscated-on-mapping* snapshot
+ * of where the main thread is spinning, before the OS kills the process at ~5s.
+ *
+ * Why this exists: build 1.3.1388 ANR'd in a Compose recomposition loop where the system-server's
+ * crash dump landed only after the kill, with R8 frames at the input-dispatcher level — useless
+ * for diagnosing the actual loop site. This watchdog logs the main-thread stack 1s before the ANR
+ * cutoff, into the same `homebase.log` file we already collect.
+ */
+class MainThreadWatchdog(
+    private val thresholdMs: Long = 4_000,
+    private val tickIntervalMs: Long = 1_000,
+    private val throttleMs: Long = 30_000,
+) {
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val watchdogThread = HandlerThread("MainThreadWatchdog").apply { start() }
+    private val watchdogHandler = Handler(watchdogThread.looper)
+    private var lastReportElapsedMs = 0L
+
+    fun start() {
+        watchdogHandler.post(tickRunnable)
+    }
+
+    private val tickRunnable = object : Runnable {
+        override fun run() {
+            val acked = AtomicBoolean(false)
+            mainHandler.post { acked.set(true) }
+
+            val deadline = SystemClock.uptimeMillis() + thresholdMs
+            while (!acked.get() && SystemClock.uptimeMillis() < deadline) {
+                try {
+                    Thread.sleep(50)
+                } catch (_: InterruptedException) {
+                    return
+                }
+            }
+
+            if (!acked.get()) {
+                val now = SystemClock.uptimeMillis()
+                if (now - lastReportElapsedMs >= throttleMs) {
+                    lastReportElapsedMs = now
+                    val stack = Looper.getMainLooper().thread.stackTrace
+                    val rendered = buildString {
+                        appendLine("Main thread stalled >${thresholdMs}ms — likely Compose recomposition loop or blocking I/O.")
+                        appendLine("Stack at sample (top 60 frames):")
+                        stack.take(60).forEach { appendLine("    at $it") }
+                    }
+                    Logger.w(throwable = null, tag = "MainThreadWatchdog") { rendered }
+                }
+            }
+
+            watchdogHandler.postDelayed(this, tickIntervalMs)
+        }
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionList.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionList.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -92,33 +91,18 @@ fun ReactionList(
         prevCount.intValue = totalCount
     }
 
-    BoxWithConstraints(modifier = modifier) {
-        // Show up to 7 emojis in the merged pill, scaling down to fit the available
-        // width when the bubble is narrow. Per-emoji slot is ~24dp (16sp emoji +
-        // 4dp horiz padding + 2dp arrangement spacing). Outer Surface eats ~12dp
-        // of horizontal padding; the count digit uses ~28dp when shown. The "+"
-        // chip from `onAddEmoji` (24dp + 4dp arrangement) is reserved separately
-        // when present so the merged pill never visually crowds it out.
-        val perEmojiDp = 24f
-        val pillPadDp = 12f
-        val countDp = if (totalCount > 1) 32f else 0f
-        // 36dp absorbs both the AddReactionChip's actual rendered width (~28dp
-        // surface + 4dp arrangement spacing) and a bit of extra slack so narrow
-        // bubbles don't render one-too-many emojis. This conservative reservation
-        // shrinks the budget from the start instead of subtracting from the
-        // final count, which would have capped wide bubbles at 6.
-        val addChipDp = if (onAddEmoji != null) 36f else 0f
-        val maxAvailDp = if (maxWidth.value.isFinite()) maxWidth.value else Float.POSITIVE_INFINITY
-        val budgetDp = (maxAvailDp - pillPadDp - countDp - addChipDp).coerceAtLeast(perEmojiDp)
-        val fitCount = (budgetDp / perEmojiDp).toInt()
-            .coerceIn(1, 7)
-            .coerceAtMost(allReactions.size)
-        val displayEmojis = remember(allReactions, fitCount) { allReactions.take(fitCount) }
+    // Cap at 7 emojis with a fixed `take`. Earlier revisions read `BoxWithConstraints.maxWidth`
+    // during composition to compute a dynamic `fitCount` keyed into a `remember(...)` slice — that
+    // pattern produced an ANR on 1.3.1388 when measure-time width feedback caused a layout
+    // invalidation loop. A static cap removes the parent-width feedback edge entirely; on
+    // bubbles too narrow for the full pill, the Surface clips visually, which is acceptable.
+    val displayEmojis = remember(allReactions) { allReactions.take(7) }
 
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
         Surface(
             modifier = Modifier
                 .scale(scaleValue)
@@ -162,9 +146,8 @@ fun ReactionList(
                 }
             }
         }
-            if (onAddEmoji != null) {
-                AddReactionChip(onClick = onAddEmoji)
-            }
+        if (onAddEmoji != null) {
+            AddReactionChip(onClick = onAddEmoji)
         }
     }
 }

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/ReactionListLoopTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/ReactionListLoopTest.kt
@@ -1,0 +1,115 @@
+package id.homebase.core.widget
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import id.homebase.api.client.drives.files.ReactionEntry
+import id.homebase.api.client.drives.files.ReactionSummary
+import kotlin.test.Test
+
+/**
+ * Quiescence tests for [ReactionList].
+ *
+ * Build 1.3.1388 used a `BoxWithConstraints` + measure-time `fitCount` pattern that produced an
+ * Android ANR via a Compose layout-invalidation loop. These tests render the post-fix
+ * implementation under conditions that previously caused the loop — narrow containers, churning
+ * reaction counts — and the test runner's timeout is the implicit assertion: if measure doesn't
+ * settle, the test hangs and CI fails. They also lock in the static `take(7)` cap so a future
+ * regression that re-introduces dynamic slicing would change the visible emoji count.
+ */
+@OptIn(ExperimentalTestApi::class)
+class ReactionListLoopTest {
+
+    @Test
+    fun rendersNothing_whenEmpty() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                ReactionList(
+                    reactionSummary = summaryOf(),
+                    onReactionClick = {},
+                )
+            }
+        }
+        onAllNodesWithText("👍").assertCountEquals(0)
+    }
+
+    @Test
+    fun renders_allEmojis_belowCap() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                ReactionList(
+                    reactionSummary = summaryOf("❤️", "👍", "👎"),
+                    onReactionClick = {},
+                )
+            }
+        }
+        onAllNodesWithText("❤️").assertCountEquals(1)
+        onAllNodesWithText("👍").assertCountEquals(1)
+        onAllNodesWithText("👎").assertCountEquals(1)
+    }
+
+    @Test
+    fun caps_at_seven_emojis_when_overflowing() = runComposeUiTest {
+        // 10 distinct reactions; only the first 7 should appear in the merged pill.
+        setContent {
+            MaterialTheme {
+                ReactionList(
+                    reactionSummary = summaryOf(
+                        "😀", "😁", "😂", "🤣", "😃", "😄", "😅", "😆", "😉", "😊"
+                    ),
+                    onReactionClick = {},
+                )
+            }
+        }
+        // First 7 visible.
+        onAllNodesWithText("😀").assertCountEquals(1)
+        onAllNodesWithText("😁").assertCountEquals(1)
+        onAllNodesWithText("😂").assertCountEquals(1)
+        onAllNodesWithText("🤣").assertCountEquals(1)
+        onAllNodesWithText("😃").assertCountEquals(1)
+        onAllNodesWithText("😄").assertCountEquals(1)
+        onAllNodesWithText("😅").assertCountEquals(1)
+        // 8th onward dropped.
+        onAllNodesWithText("😆").assertCountEquals(0)
+        onAllNodesWithText("😉").assertCountEquals(0)
+        onAllNodesWithText("😊").assertCountEquals(0)
+    }
+
+    @Test
+    fun rendersInNarrowContainer_doesNotLoop() = runComposeUiTest {
+        // 60dp is narrower than a single 40dp emoji slot would naturally need with padding.
+        // The previous implementation would compute fitCount=1 here based on measured maxWidth.
+        // The post-fix implementation simply takes 7 and lets the Surface clip — no measure-time
+        // read, no feedback edge. This test passes if composition completes (i.e. if measure
+        // converges within the test runner's timeout).
+        setContent {
+            MaterialTheme {
+                Box(modifier = Modifier.width(60.dp)) {
+                    ReactionList(
+                        reactionSummary = summaryOf("❤️", "👍", "👎", "😂", "😮"),
+                        onReactionClick = {},
+                    )
+                }
+            }
+        }
+        // Reaching this assertion at all means measure converged.
+        onAllNodesWithText("❤️").assertCountEquals(1)
+    }
+
+    private fun summaryOf(vararg emojis: String): ReactionSummary {
+        val entries = emojis.mapIndexed { idx, emoji ->
+            "k$idx" to ReactionEntry(
+                key = "k$idx",
+                count = 1,
+                reactionContent = "{\"emoji\":\"$emoji\"}",
+            )
+        }.toMap()
+        return ReactionSummary(reactions = entries)
+    }
+}


### PR DESCRIPTION
fix(chat): harden conversation render path against Compose recomp loops

Build 1.3.1388 ANR'd on Android (release) when re-entering a conversation
right after pressing back: 13.5s of main-thread CPU (105%) inside a deep
LayoutNode.measure → SnapshotState.getValue chain, killed by the OS at
the 5s ANR cutoff. This change cuts two known feedback edges in the
Compose render path that was on screen, plus adds instrumentation to
diagnose the next one before the kill.

ReactionList — drop measure-time fitCount (the strong suspect)

The recent "show up to 7 reactions, fewer if they don't fit" feature
wrapped the row in BoxWithConstraints, computed fitCount from
maxWidth.value during composition, and keyed it into
remember(allReactions, fitCount) { allReactions.take(fitCount) }. Two of
three callsites (SentMessageBubble, ReceivedMessageBubbleDisplayOnly)
have no width clamp, so parent width feeds back into emoji count → the
slice changes → layout invalidates → repeat. Replaced with a static
take(7) and let narrow bubbles clip the Surface visually. The "fit
comfortably" UX intent is sacrificed for convergence; most messages have
<7 reactions so the user-visible behavior is essentially unchanged.

MessageBubbleRaw — clamp the bubble's reported width

The custom Layout reads textLayoutResult set by an onTextLayout callback
during composition, then re-measures the reply child with
potentialFinalWidth derived from that result. If any of those
calculations exceed constraints.maxWidth (the parent's bound), the
parent re-measures us, which can race with onTextLayout updates and
spin. Two coerceAtMost() calls (potentialFinalWidth and finalWidth) cap
us at the parent's bound; infoX is pulled inside the clamped width so
the timestamp stays visible if the clamp kicked in. No behavior change
on the happy path — defensive containment, not a Layout rewrite.

MainThreadWatchdog — log main-thread stack 1s before ANR

A HandlerThread posts a sentinel to Looper.getMainLooper() every 1s; if
the sentinel doesn't run within 4s, captures the main thread's stack
trace via getStackTrace() and emits a single WARN line through Kermit
(throttled to once per 30s). The 17:22 incident's logs landed in
homebase.log via run-as; with this watchdog we get the loop site
deobfuscatable on R8 mapping, before the OS kills the process. Wired
into MainApplication.onCreate after the existing crash handler.

Tests

ReactionListLoopTest covers: empty input, sub-cap, the take(7) cap, and
the previously-loop-prone narrow-container case (60dp). The test runner
timeout is the implicit assertion — measure not converging hangs the
test. No new MessageBubbleRaw test: that composable's fixture (drives,
payloads, RichText state, MessageUiModel) is too heavy for a single
quiescence assertion; the containment is conservative enough to be
trivially correct on inspection, and existing tests cover the
surrounding paths.

CI — preserve R8 mappings going forward

build-mobile-release-prod.yml and -dev.yml now upload mapping.txt as
android-mapping-<versionCode> with 90d retention. Build 1388's mapping
was lost because the workflow only uploaded the AAB; this prevents a
repeat of the deobfuscation gap we hit today.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>