### PR TITLE
fix loop de loop

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -82,6 +82,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
@@ -804,17 +805,39 @@ fun ConversationContent(
                 }
 
                 val currentMergedItems by rememberUpdatedState(mergedItems)
-                val floatingDateLabel by remember {
-                    derivedStateOf {
-                        val firstVisibleIndex = listState.firstVisibleItemIndex
-                        for (i in firstVisibleIndex downTo 0) {
-                            val item = currentMergedItems.getOrNull(i)
-                            if (item is MessageListContentModel.Section) {
-                                return@derivedStateOf item.date
+                // Hoisted out of composition: a `derivedStateOf` reading `firstVisibleItemIndex`
+                // here was being invalidated by `animateItem()`'s lookahead measurement during
+                // conversation re-mount (back-from-message-details), causing the LazyColumn's
+                // measure pass to never settle (PR #468 watchdog stack, build 1393, 19:45 UTC).
+                // Running the observation in a coroutine means the overlay below only re-renders
+                // when the resolved date *result* changes — not on every mid-measure scroll tick.
+                val floatingDateLabel by produceState<LocalDate?>(null, listState) {
+                    snapshotFlow { listState.firstVisibleItemIndex to currentMergedItems }
+                        .distinctUntilChanged()
+                        .collect { (firstVisibleIndex, items) ->
+                            value = run {
+                                for (i in firstVisibleIndex downTo 0) {
+                                    val item = items.getOrNull(i)
+                                    if (item is MessageListContentModel.Section) return@run item.date
+                                }
+                                null
                             }
                         }
-                        null
-                    }
+                }
+
+                // Gate `animateItem()` until the initial composition burst has settled.
+                // animateItem activates `EnterExitTransitionModifierNode` + lookahead
+                // measurement, which interleaves badly with `Pre-initializing scroll
+                // position at bottom` mutating LazyListState during re-mount. One frame
+                // is enough for the initial layout to settle; afterwards animations run
+                // normally for live add/remove/move. Keyed on conversation id so switching
+                // chats also gets a clean first frame.
+                var animationsEnabled by remember(conversation.conversation.id) {
+                    mutableStateOf(false)
+                }
+                LaunchedEffect(conversation.conversation.id) {
+                    withFrameNanos { }
+                    animationsEnabled = true
                 }
 
                 Box(
@@ -841,7 +864,9 @@ fun ConversationContent(
                             ) { item ->
                                 when (item) {
                                     is MessageListContentModel.Header -> {
-                                        Column(modifier = Modifier.animateItem()) {
+                                        Column(
+                                            modifier = if (animationsEnabled) Modifier.animateItem() else Modifier
+                                        ) {
                                             AvatarNameDisplay(
                                                 modifier = Modifier.fillMaxWidth()
                                                     .padding(horizontal = 16.dp)
@@ -881,23 +906,31 @@ fun ConversationContent(
                                     }
 
                                     is MessageListContentModel.Section -> {
-                                        Box(modifier = Modifier.animateItem()) {
+                                        Box(
+                                            modifier = if (animationsEnabled) Modifier.animateItem() else Modifier
+                                        ) {
                                             MessagesSection(text = getDateSectionLabel(item.date))
                                         }
                                     }
 
                                     is MessageListContentModel.System -> {
-                                        Box(modifier = Modifier.animateItem()) {
+                                        Box(
+                                            modifier = if (animationsEnabled) Modifier.animateItem() else Modifier
+                                        ) {
                                             MessagesSystemMessage(text = item.text)
                                         }
                                     }
 
                                     is MessageListContentModel.UnreadSeparator -> {
                                         Box(
-                                            modifier = Modifier.animateItem(
-                                                fadeInSpec = tween(300),
-                                                fadeOutSpec = tween(400),
-                                            ),
+                                            modifier = if (animationsEnabled) {
+                                                Modifier.animateItem(
+                                                    fadeInSpec = tween(300),
+                                                    fadeOutSpec = tween(400),
+                                                )
+                                            } else {
+                                                Modifier
+                                            },
                                         ) {
                                             UnreadMessagesSeparator()
                                         }
@@ -922,7 +955,7 @@ fun ConversationContent(
                                             onUiAction(ConversationListUiAction.ClearHighlightedMessage)
                                         }
                                         Box(
-                                            modifier = Modifier.animateItem()
+                                            modifier = (if (animationsEnabled) Modifier.animateItem() else Modifier)
                                                 .background(MaterialTheme.colorScheme.primary.copy(alpha = highlightAlpha))
                                         ) {
                                             MessageItem(
@@ -947,7 +980,9 @@ fun ConversationContent(
                                     }
 
                                     is PendingOutgoingMessage -> {
-                                        Box(modifier = Modifier.animateItem()) {
+                                        Box(
+                                            modifier = if (animationsEnabled) Modifier.animateItem() else Modifier
+                                        ) {
                                             PendingMessageBubble(
                                                 message = item,
                                                 uploadStatus = uiState.uploadProgress[item.id],


### PR DESCRIPTION
fix(chat): break conversation-list recomp loop on back-from-message-details

Build 1.3.1393 caught a 19-second main-thread stall via the watchdog from
PR #468, with stack
  ParcelableSnapshotMutableState.getValue
  → DerivedSnapshotState.compute
  → CompositionImpl.recompose
  → ConversationContentKt$$ExternalSyntheticLambda18
  → ... LookaheadPassDelegate
  → AnimatedContentMeasurePolicy / EnterExitTransitionModifierNode

Repro: from inside a conversation, open Message Details, press back. The
conversation detail re-mounts and emits `Pre-initializing scroll position
at bottom`, mutating LazyListState.firstVisibleItemIndex.
ConversationContent.kt's `floatingDateLabel` derivedStateOf reads that
field during composition and walks the merged-items list O(n) for a
section header. Combined with `Modifier.animateItem()` on every LazyColumn
item driving lookahead measurement and EnterExitTransitionModifierNode,
the measure pass kept observing state that the animation pass kept
mutating. Lookahead never settled — Android killed the process at the 5s
ANR cutoff.

Two fixes, both in ConversationContent.kt:

1. Hoist floatingDateLabel out of composition. snapshotFlow inside a
   produceState observes firstVisibleItemIndex from a coroutine and writes
   the resolved date into a plain State<LocalDate?>. The overlay that
   renders the floating date now invalidates only when the *result*
   changes — not on every mid-measure scroll tick. The feedback edge
   from animation→measure→listState→derivedState→recompose is cut.

2. Gate Modifier.animateItem() until the initial composition burst
   settles. A `var animationsEnabled` flag flips after one withFrameNanos
   tick, keyed on conversation.conversation.id so each chat re-entry gets
   a clean first frame. animateItem still runs for live insert/remove/move
   afterwards; only the re-mount burst is suppressed. Pattern precedent at
   VideoPlayerSurface.jvm.kt:262-277.

PR #468's hardening targeted MessageBubbleRaw and ReactionList — the
bubble interior. This loop was list-level, so neither clamp helped. The
watchdog from #468 is what made it diagnosable: production stack landed
in homebase.log 1s before the OS kill, and CI now archives the R8
mapping for 90 days, so the deobfuscation took minutes instead of being
impossible.

No new tests. ConversationContent's fixture (drives, payloads, a populated
SharedTransitionScope, RichText state, MessageUiModel × N) is too heavy
for a quiescence test that would actually catch this. The watchdog is the
real safety net — if this fix is wrong, the next stall lands another
stack via the same channel.

A pre-existing test failure
`MessageProcessingPipelineTest.messagesOnSameDay_shareOneSection`
reproduces on clean main; it's unrelated to this change (came in with
#469's clustering pipeline) and is not addressed here.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>