### PR TITLE
chore: add 'no symptom patching' rule + fix timezone-fragile test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,35 @@ If I push back and you still think you're right, hold the position and
 explain why. Don't cave just because I disagreed. If I've actually
 changed your mind with a real argument, say what specifically changed it.
 
+## Debugging & root cause
+
+When you hit a freeze, ANR, crash, or unexplained behaviour, do not ship
+a workaround that hides the symptom without identifying the cause first.
+Capture concrete evidence — a stack trace, an ANR dump, a profiler
+sample, a reproducible test — and prove what's broken before fixing it.
+If you can't capture evidence, the fix is to install the instrumentation
+that will (a watchdog, a logger, a tombstone reader, an `adb logcat`
+capture) — not to patch around the symptom and move on.
+
+Symptom patches to avoid:
+
+- Wrapping a state read in `remember { }` because "without it the screen
+  freezes" — the underlying read is doing something expensive or
+  reactive on every recomposition; fix that, don't snapshot it.
+- Adding `try { … } catch (_: Exception) { }` around code that's
+  actually misbehaving, so the exception stops surfacing.
+- Adding a `delay()`, an extra `LaunchedEffect`, or a manual redraw
+  trigger to make a UI glitch "go away" without explaining why it
+  helped.
+- Reverting or hiding the feature that exposed the bug, when the bug
+  itself is still there.
+
+Each of these makes the bug invisible at the cost of leaving the cause
+in place to resurface elsewhere later. If you find yourself reaching for
+one of these patterns, stop and write down what you actually observed,
+what you suspect, and what evidence you'd need to confirm — then go get
+that evidence.
+
 ## Project Overview
 
 Homebase Chat — a Kotlin Multiplatform (KMP) chat application targeting Android, iOS, Desktop (

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/MessageProcessingPipelineTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/MessageProcessingPipelineTest.kt
@@ -30,7 +30,11 @@ class MessageProcessingPipelineTest {
     private val alice = OdinId("alice.test")
     private val bob = OdinId("bob.test")
     private val conversationId = Uuid.random()
-    private val baseTime = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+    // 2023-11-14T12:00:00Z — pinned to noon UTC so timezone-shifted offsets in tests
+    // (up to ±12h) stay on the same calendar date. The previous value (22:13:20Z) made
+    // `messagesOnSameDay_shareOneSection` fail in any TZ east of UTC+0:47 because
+    // baseTime+60min crossed local midnight.
+    private val baseTime = Instant.fromEpochMilliseconds(1_699_963_200_000L)
 
     private fun msg(
         sender: OdinId = alice,


### PR DESCRIPTION
Two unrelated cleanups bundled because they're both tiny.

CLAUDE.md — new "Debugging & root cause" section codifying a recurring anti-pattern we saw in PR #460 ("fix forward sheet freeze") and PR #455 ("wrap reads in remember to prevent layout crash"): observe a freeze / ANR / unexplained behaviour, ship a workaround that hides the symptom, move on. The rule: capture concrete evidence (stack trace, ANR dump, profiler sample, repro test) before fixing, and if you can't capture evidence, install the instrumentation that will. Lists four named anti-patterns drawn from real cases so it's clear what's prohibited.

MessageProcessingPipelineTest.kt — fix `messagesOnSameDay_shareOneSection` which fails locally in CPH and any TZ east of UTC+0:47. Root cause: `baseTime = 1_700_000_000_000L` decodes to `2023-11-14T22:13:20Z`. The test creates messages at offsets 0/30/60 minutes; in UTC+1 the +60min message lands at 00:13 the next day, producing 2 sections instead of 1. Pinned baseTime to noon UTC (1_699_963_200_000L) so offsets up to ±12h stay on the same calendar date. Other tests in the file deliberately cross day boundaries (24h, 25h offsets) and still do. CI runners default to UTC so this never surfaced there.