### PR TITLE
fix snapshot flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,18 @@ writing or modifying any screen/composable, verify:
 - UiState should be a flat `data class` with `_uiState.update { }` pattern
 - One-time events (navigation, snackbar) should use separate `SharedFlow`, not stored in UiState
 
+## Compose & Flow gotchas
+
+- **Don't write `snapshotFlow { ... }.distinctUntilChanged()`** — `snapshotFlow` already
+  dedups internally with structural equality (`!=`) before emitting, so the trailing
+  `.distinctUntilChanged()` runs the *same* comparison a second time. For scalar samples
+  it's just waste; for samples like `Pair<Int, List<...>>` the doubled O(n) `List.equals`
+  on every snapshot commit can stall the Compose UI dispatcher (Main) for seconds during
+  bursty mutations like `LazyListState.scrollToItem` (build 1394 watchdog stack landed
+  here at `ConversationContent.kt:817`). If you genuinely need a different equality (e.g.
+  comparing only one field of a heavy value), shape the snapshotFlow block to *return*
+  that key — don't bolt distinctUntilChanged on top.
+
 ## Strings & Unicode
 
 User-entered text (messages, descriptions, names, link previews) can contain emoji and other

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -200,7 +200,6 @@ import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
@@ -336,7 +335,6 @@ fun ConversationContent(
 
     LaunchedEffect(listState) {
         snapshotFlow { listState.isScrollInProgress }
-            .distinctUntilChanged()
             .collectLatest { scrolling ->
                 if (scrolling) {
                     showFloatingDate = true
@@ -805,24 +803,28 @@ fun ConversationContent(
                 }
 
                 val currentMergedItems by rememberUpdatedState(mergedItems)
-                // Hoisted out of composition: a `derivedStateOf` reading `firstVisibleItemIndex`
-                // here was being invalidated by `animateItem()`'s lookahead measurement during
-                // conversation re-mount (back-from-message-details), causing the LazyColumn's
-                // measure pass to never settle (PR #468 watchdog stack, build 1393, 19:45 UTC).
-                // Running the observation in a coroutine means the overlay below only re-renders
-                // when the resolved date *result* changes — not on every mid-measure scroll tick.
+                // The section walk runs INSIDE the snapshotFlow block so that snapshotFlow's
+                // built-in dedup compares the resolved `LocalDate?` (O(1)) instead of a
+                // `Pair<Int, List<...>>` (O(n) list-equals). Build 1394's watchdog caught a
+                // 5–8s main-thread stall here (homebase.log lines 27628 / 28315, deobfuscated
+                // against android-mapping-1394) — the previous shape paid two O(n) compares
+                // per snapshot commit (snapshotFlow's internal != + an explicit
+                // distinctUntilChanged that was redundant with it) on every mid-measure
+                // mutation of `firstVisibleItemIndex` during scroll-to-bottom restore.
                 val floatingDateLabel by produceState<LocalDate?>(null, listState) {
-                    snapshotFlow { listState.firstVisibleItemIndex to currentMergedItems }
-                        .distinctUntilChanged()
-                        .collect { (firstVisibleIndex, items) ->
-                            value = run {
-                                for (i in firstVisibleIndex downTo 0) {
-                                    val item = items.getOrNull(i)
-                                    if (item is MessageListContentModel.Section) return@run item.date
-                                }
-                                null
+                    snapshotFlow {
+                        val firstVisibleIndex = listState.firstVisibleItemIndex
+                        val items = currentMergedItems
+                        var date: LocalDate? = null
+                        for (i in firstVisibleIndex downTo 0) {
+                            val item = items.getOrNull(i)
+                            if (item is MessageListContentModel.Section) {
+                                date = item.date
+                                break
                             }
                         }
+                        date
+                    }.collect { value = it }
                 }
 
                 // Gate `animateItem()` until the initial composition burst has settled.

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
@@ -40,7 +40,6 @@ import io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlin.uuid.Uuid
@@ -115,7 +114,7 @@ fun ConversationMessagesPane(
         snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }.debounce(
             300
         ) // Only save after 300ms of no scrolling
-            .distinctUntilChanged().collect { (index, offset) ->
+            .collect { (index, offset) ->
                 // Only save if we're still viewing the same conversation, messages are loaded,
                 // and not restoring
                 if (!uiState.isLoadingMessages) {


### PR DESCRIPTION
fix(chat): cut Pair<Int,List> comparison cost in floatingDateLabel snapshotFlow

Build 1.3.1394 (post PR #470) shipped with the layout-loop ANR fixed but
the watchdog from PR #468 caught two new main-thread stalls of 5–8 seconds
on conversation entry (homebase.log lines 27628 and 28315, 2026-05-09 UTC).
Deobfuscated against android-mapping-1394, the stack lands at
ConversationContent.kt:817 — the very lines PR #470 added — running on
the AndroidUiDispatcher (Compose's frame-aligned dispatcher = Main).

Stack chain (deobfuscated):

  ConversationContent$floatingDateLabel collect lambda
  → DistinctFlowImpl.collect          ← .distinctUntilChanged()
  → SafeCollector
  → SnapshotStateKt$snapshotFlowImpl$1
  → ConversationContent$floatingDateLabel produceState body (line 817)
  → SnapshotStateKt$produceState$1$1
  → DispatchedTask.run
  → AndroidUiDispatcher  → Looper.loop

Root cause: PR #470's snapshotFlow sampled Pair<Int, List<...>>. Each
snapshot commit during scroll-to-bottom restore caused snapshotFlow's
*internal* != check to walk the message list (O(n)), and the explicit
.distinctUntilChanged() then walked it again. Two O(n) list-equals per
commit, plus the O(n) for-loop in the collect block, all on Main during
the LazyColumn's measure burst. For a 1000-msg conversation it adds up
to seconds of synchronous work.

Fix: move the section walk *inside* the snapshotFlow block, so
snapshotFlow's own dedup compares LocalDate? (O(1)) instead of
Pair<Int, List<...>> (O(n)). Drop the explicit .distinctUntilChanged()
that was redundant with snapshotFlow's internal dedup. Same observable
behavior, comparison cost per commit drops from 2*O(n) to O(1).

Also strip the same redundant `.distinctUntilChanged()` from the two
other snapshotFlow callsites in ConversationContent.kt (Boolean) and
ConversationMessagesPane.kt (Pair<Int,Int>). Both were benign — neither
caused a stall — but they shared the antipattern, and removing them
keeps the codebase consistent with the new CLAUDE.md guidance.

Add a "Compose & Flow gotchas" section to CLAUDE.md documenting why
`snapshotFlow { ... }.distinctUntilChanged()` is always wrong, with a
pointer back to this incident so future contributors don't reach for
the same defensive pattern.

No new tests. The fixture is too heavy for a quiescence assertion that
would catch this; the watchdog from PR #468 is the production safety
net and CI's 90-day mapping retention made deobfuscation a one-shot.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>