### PR TITLE
fix(chat): clamp firstVisibleItemIndex sentinel before walking section list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,20 @@ writing or modifying any screen/composable, verify:
   comparing only one field of a heavy value), shape the snapshotFlow block to *return*
   that key — don't bolt distinctUntilChanged on top.
 
+- **Don't use `LazyListState.firstVisibleItemIndex` as an array index without
+  clamping.** Compose's idiom for "land at the bottom on first frame, no flash" is
+  `LazyListState(firstVisibleItemIndex = Int.MAX_VALUE)` — LazyColumn clamps the
+  sentinel during its first measure pass, but anything reading the field *before*
+  that measure runs (a `snapshotFlow {}` body, a `derivedStateOf`, a save-scroll
+  effect on the same frame the state was created) gets `Int.MAX_VALUE` back. Using
+  that as `for (i in firstVisibleIndex downTo 0)` walks ~2.1B iterations and
+  freezes the UI dispatcher for seconds (build 1419 watchdog landed exactly here
+  in `ConversationContent.kt`'s floatingDateLabel snapshotFlow with
+  `idx=2147483647 items=0`). Use the
+  `LazyListState.boundedFirstVisibleItemIndex(itemsSize: Int)` extension in
+  `id.homebase.core.util.ScrollPosition.kt` — it returns `null` for an empty list
+  and a clamped index otherwise.
+
 ## Strings & Unicode
 
 User-entered text (messages, descriptions, names, link previews) can contain emoji and other

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -139,6 +139,7 @@ import id.homebase.chat.services.convo.OneOnOneConnectionStatus
 import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.ContactAvatar
 import id.homebase.core.avatars.ConversationAvatar
+import id.homebase.core.util.boundedFirstVisibleItemIndex
 import id.homebase.core.util.dismissKeyboardOnTap
 import id.homebase.core.util.initials
 import id.homebase.core.util.isDesktop
@@ -813,14 +814,25 @@ fun ConversationContent(
                 // mutation of `firstVisibleItemIndex` during scroll-to-bottom restore.
                 val floatingDateLabel by produceState<LocalDate?>(null, listState) {
                     snapshotFlow {
-                        val firstVisibleIndex = listState.firstVisibleItemIndex
                         val items = currentMergedItems
+                        // boundedFirstVisibleItemIndex guards against the
+                        // `Int.MAX_VALUE` "land at bottom" sentinel that
+                        // `ConversationMessagesPane.kt` puts into LazyListState
+                        // before LazyColumn's first measure clamps it. Without the
+                        // clamp this for-loop walked 2.1B iterations and froze
+                        // Main for 6+ seconds (build 1419 watchdog stack landed
+                        // here with `idx=2147483647 items=0`). See
+                        // `boundedFirstVisibleItemIndex` docs and the CLAUDE.md
+                        // "Compose & Flow gotchas" rule.
+                        val startIdx = listState.boundedFirstVisibleItemIndex(items.size)
                         var date: LocalDate? = null
-                        for (i in firstVisibleIndex downTo 0) {
-                            val item = items.getOrNull(i)
-                            if (item is MessageListContentModel.Section) {
-                                date = item.date
-                                break
+                        if (startIdx != null) {
+                            for (i in startIdx downTo 0) {
+                                val item = items.getOrNull(i)
+                                if (item is MessageListContentModel.Section) {
+                                    date = item.date
+                                    break
+                                }
                             }
                         }
                         date

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
@@ -34,6 +34,7 @@ import id.homebase.chat.conversationlist.MessageListContentModel
 import id.homebase.chat.conversationlist.MessageListUiState
 import id.homebase.chat.services.convo.EnrichedConversationUiModel
 import id.homebase.core.HomebaseConstants
+import id.homebase.core.util.boundedFirstVisibleItemIndex
 import id.homebase.core.util.rememberCameraManager
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher
@@ -111,13 +112,21 @@ fun ConversationMessagesPane(
     // Save scroll position when it changes
     LaunchedEffect(listState) {
         val conversationId = conversation.conversation.id
-        snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }.debounce(
-            300
-        ) // Only save after 300ms of no scrolling
+        // boundedFirstVisibleItemIndex against `layoutInfo.totalItemsCount` (what
+        // LazyColumn actually rendered) drops Int.MAX_VALUE sentinel emissions
+        // that snapshotFlow can see before LazyColumn's first measure clamps the
+        // LazyListState. Without this guard, a Main-busy window > 300 ms could
+        // persist MAX_VALUE to user prefs; the next session would then
+        // reconstruct LazyListState from prefs with MAX_VALUE again, re-arming
+        // the same race we just closed in ConversationContent.kt.
+        snapshotFlow {
+            listState.boundedFirstVisibleItemIndex(listState.layoutInfo.totalItemsCount) to
+                listState.firstVisibleItemScrollOffset
+        }.debounce(300) // Only save after 300ms of no scrolling
             .collect { (index, offset) ->
                 // Only save if we're still viewing the same conversation, messages are loaded,
                 // and not restoring
-                if (!uiState.isLoadingMessages) {
+                if (index != null && !uiState.isLoadingMessages) {
                     Logger.i("Scroll changed: id=${conversationId} -> $index:$offset")
                     onUiAction(
                         SaveScrollPosition(

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/util/ScrollPosition.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/util/ScrollPosition.kt
@@ -1,5 +1,6 @@
 package id.homebase.core.util
 
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Immutable
 
 @Immutable
@@ -8,3 +9,22 @@ data class ScrollPosition(
     val firstVisibleItemScrollOffset: Int = 0,
     val triggerScroll: Boolean = false,
 )
+
+/**
+ * Returns `firstVisibleItemIndex` clamped to a real index in `[0, itemsSize - 1]`,
+ * or `null` if the list is empty.
+ *
+ * Compose's idiom for "land at the bottom on first frame, no flash" is
+ * `LazyListState(firstVisibleItemIndex = Int.MAX_VALUE)` — LazyColumn clamps that
+ * sentinel during its first measure pass. Anything reading `firstVisibleItemIndex`
+ * BEFORE that measure runs (a `snapshotFlow {}` body, a `derivedStateOf`, a
+ * save-scroll effect on the same frame the state was created) gets the raw
+ * sentinel back. Using that as an array index walks ~2.1B iterations and freezes
+ * the UI dispatcher for seconds (build 1419 watchdog landed at
+ * `ConversationContent.kt`'s floatingDateLabel snapshotFlow with
+ * `idx=2147483647 items=0`).
+ */
+fun LazyListState.boundedFirstVisibleItemIndex(itemsSize: Int): Int? {
+    if (itemsSize <= 0) return null
+    return firstVisibleItemIndex.coerceIn(0, itemsSize - 1)
+}


### PR DESCRIPTION
Build 1419 (post PR #472) caught a 6.27-second main-thread stall in the floatingDateLabel snapshotFlow (homebase.log 06:25:59 / 06:26:05, deobfuscated against android-mapping-1419, watchdog stack lands at ConversationContent.kt's snapshotFlow body). Single sample of the block, `thisSample=6.268s items=0 idx=2147483647`. Originates from bug in PR #460.

Root cause:
ConversationMessagesPane.kt:107 constructs LazyListState with `firstVisibleItemIndex = Int.MAX_VALUE` as a "land at the bottom" sentinel — LazyColumn clamps it to size-1 on first measure. If snapshotFlow's first sample fires before that clamp AND before _messagesUiState.update has populated mergedItems (the Android navigation pane swap can race ahead of the message arrival in a way the desktop pane swap doesn't), the for-loop walks `Int.MAX_VALUE downTo 0` ≈ 2.1B iterations of getOrNull(i) returning null. ~3ns per iteration on phone × 2.1B = ~6 seconds, all on AndroidUiDispatcher (= Main). The resume of withContext(Default) queues behind it; the freshly-arrived messages can't be applied to the UI; the user perceives a multi-second freeze.

Fix is consumer-side because the source can't be: LazyListState belongs to androidx.compose.foundation and the MAX_VALUE sentinel is intentional contract for LazyColumn's first measure. Wrapping LazyListState would require delegating its full surface and would still not be substitutable for LazyColumn's parameter.

Three small surgical edits + a CLAUDE.md rule:

1. New extension in homebase-common (next to ScrollPosition): `LazyListState.boundedFirstVisibleItemIndex(itemsSize): Int?` returns null for an empty list, a clamped index in [0, size-1] otherwise. Doc-comment ties back to the build-1419 watchdog so the next reader can find the incident in 30 seconds.

2. ConversationContent.kt's floatingDateLabel snapshotFlow uses the helper; if it returns null the for-loop is skipped entirely.

3. ConversationMessagesPane.kt's save-scroll-position snapshotFlow uses the helper against `layoutInfo.totalItemsCount` (what LazyColumn actually rendered) and skips emissions where index is null. Without this, a Main-busy window > 300 ms would persist MAX_VALUE to user prefs and re-arm the same race on next session.

4. CLAUDE.md "Compose & Flow gotchas" gets one more rule pointing to the helper as the canonical way to read firstVisibleItemIndex as an array index.

No new tests. Reproducing the race needs a Compose fixture with a deferred state update plus a sentinel-state LazyListState — heavier than the bug. The MainThreadWatchdog from PR #468 is the production safety net and caught this one cleanly.

Verified live on v1420 DEV: 21 conversation entries, 0 watchdog stalls, all `floatingDateLabel sample#1 thisSample` in microseconds even when `items=0 rawIdx=2147483647` (the race is still reachable, the fix short-circuits it).