### PR TITLE
fix(chat): cap reactions at 5 per user, mirror server limit client-side

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/QueryBatch.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/QueryBatch.kt
@@ -1,6 +1,7 @@
 package id.homebase.api.sync.database
 
 import app.cash.sqldelight.db.QueryResult
+import co.touchlab.kermit.Logger
 import id.homebase.api.common.IntRange
 import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.api.common.time.UnixTimeUtcRange
@@ -160,6 +161,21 @@ class QueryBatch(
 
         if (fileSystemType == null) {
             throw IllegalArgumentException("fileSystemType required in Query Batch")
+        }
+
+        // Smoke alarm for "single-uniqueId" misuse: queryBatchAsync sorts and
+        // scans the whole drive index; for a single uniqueId, callers should
+        // use DriveMainIndexWrapper.selectHomebaseFileByUnique instead. We've
+        // had this cost ~500ms latency on the chat reaction/delete/get paths.
+        // Stack trace surfaces the offender directly in shipped logs.
+        if (uniqueIdAnyOf?.size == 1) {
+            Logger.w(tag = "QueryBatch") {
+                val callsite = Throwable().stackTraceToString()
+                    .lineSequence().drop(1).take(6).joinToString("\n")
+                "queryBatchAsync called with a single uniqueId — prefer " +
+                        "DriveMainIndexWrapper.selectHomebaseFileByUnique. " +
+                        "callsite:\n$callsite"
+            }
         }
 
         if (noOfItems < 1) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -51,6 +51,7 @@ import id.homebase.chat.conversationlist.ConversationListUiEvent.ShowInfoMessage
 import id.homebase.chat.data.ConversationState
 import id.homebase.chat.data.MessageUiModel
 import id.homebase.chat.services.ChatMessageActionService
+import id.homebase.chat.services.MAX_REACTIONS_PER_USER_PER_MESSAGE
 import id.homebase.chat.services.ChatMessageSenderService
 import id.homebase.chat.services.ChatMessageStream
 import id.homebase.chat.services.ChatMessagesData
@@ -106,6 +107,7 @@ import id.homebase.resources.chat_group_introduce_everyone_status
 import id.homebase.resources.chat_introduce_preflight_in_progress
 import id.homebase.resources.chat_message_audio_recording_help
 import id.homebase.resources.chat_message_forwarded
+import id.homebase.resources.chat_reactions_limit_reached
 import id.homebase.resources.chat_search_result_conversations
 import id.homebase.resources.chat_search_result_messages
 import id.homebase.resources.chat_search_result_pinned
@@ -1249,6 +1251,32 @@ class ConversationListViewModel(
             is ConversationListUiAction.ToggleReaction -> {
                 viewModelScope.launch {
                     if (action.reaction.isEmpty()) return@launch
+
+                    // Mirror the server-side cap of MAX_REACTIONS_PER_USER_PER_MESSAGE
+                    // distinct reactions per user per message. Adding past the cap is
+                    // a 400 (UnhandledScenario / "Too many Reactions") at upload, so
+                    // block it before we optimistically write or hit the outbox.
+                    // Removes (toggling an emoji the user already has) are always
+                    // allowed.
+                    val targetMessage = _messagesUiState.value.messages
+                        .asSequence()
+                        .filterIsInstance<MessageListContentModel.Message>()
+                        .firstOrNull { it.message.id == action.messageId }
+                        ?.message
+                    if (targetMessage != null) {
+                        // ownReactions holds bare emoji (decoded by
+                        // ChatMessageStream from the wire's
+                        // `{"emoji":"X"}`); compare directly so removes
+                        // at the cap aren't misread as adds.
+                        val alreadyHasIt = action.reaction in targetMessage.ownReactions
+                        if (!alreadyHasIt &&
+                            targetMessage.ownReactions.size >= MAX_REACTIONS_PER_USER_PER_MESSAGE
+                        ) {
+                            sendEvent(ShowInfoMessage(MR.string.chat_reactions_limit_reached))
+                            return@launch
+                        }
+                    }
+
                     val previousReactions = _messagesUiState.value.messageReactions
                     try {
                         _messagesUiState.update { state ->

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -1258,11 +1258,15 @@ class ConversationListViewModel(
                     // block it before we optimistically write or hit the outbox.
                     // Removes (toggling an emoji the user already has) are always
                     // allowed.
-                    val targetMessage = _messagesUiState.value.messages
-                        .asSequence()
-                        .filterIsInstance<MessageListContentModel.Message>()
-                        .firstOrNull { it.message.id == action.messageId }
-                        ?.message
+                    var targetMessage: MessageUiModel? = null
+                    for (item in _messagesUiState.value.messages) {
+                        if (item is MessageListContentModel.Message &&
+                            item.message.id == action.messageId
+                        ) {
+                            targetMessage = item.message
+                            break
+                        }
+                    }
                     if (targetMessage != null) {
                         // ownReactions holds bare emoji (decoded by
                         // ChatMessageStream from the wire's

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/MessageUiModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/MessageUiModel.kt
@@ -42,8 +42,11 @@ data class MessageUiModel(
     /** The timestamp when this file was marked as read for current user's identity */
     val localReadTimestamp: UnixTimeUtc? = null,
 
-    /** Raw JSON-encoded reactions the current identity has applied to this
-     *  message (mirrors server `localAppData.localReactions`). */
+    /** Bare emoji strings the current identity has applied to this
+     *  message. The wire format under `localAppData.localReactions` is
+     *  JSON `{"emoji":"X"}` per entry; `ChatMessageStream` decodes those
+     *  to plain emoji so the UI can compare against `reactionPreview`
+     *  entries by simple string match. */
     val ownReactions: ImmutableList<String> = persistentListOf(),
 
     val isEdited: Boolean = false,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
@@ -3,9 +3,6 @@ package id.homebase.chat.services
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.auth.CredentialsManager
-import id.homebase.api.client.drives.HomebaseFile
-import id.homebase.api.client.drives.QueryBatchSortField
-import id.homebase.api.client.drives.QueryBatchSortOrder
 import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.client.drives.files.DeleteLocalFilesByFileIdRequest
 import id.homebase.api.client.drives.files.SendReadReceiptByFileIdsOutboxRequest
@@ -18,7 +15,6 @@ import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.OutboxSync
-import id.homebase.api.sync.database.QueryBatch
 import id.homebase.chat.services.outbox.OptimisticWriter
 import id.homebase.api.client.drives.files.reactions.ReactionContent
 import id.homebase.chat.services.convo.ConversationParticipantLookup
@@ -232,33 +228,39 @@ class ChatMessageActionService(
         )
 
         val reactionJson = OdinSystemSerializer.serialize(ReactionContent(emoji = emoji))
-        val fileId = requireFileId(messageId)
 
+        // Run the optimistic write first so the bubble updates immediately.
+        // Previously a `requireFileId(messageId)` call ran ahead of this and
+        // did a QueryBatch(1000, NewestFirst) over the whole chat drive just
+        // to look up the fileId for the outbox payload — easily ~500 ms on a
+        // busy drive, all of it spent gating the optimistic update behind
+        // outbox bookkeeping. The optimistic writer already does its own
+        // selectHomebaseFileByUnique and hands the original file (which
+        // carries fileId) back to us; reuse that for the outbox row.
         val (resultType, original) = optimisticWriter.writeReactionToggle(
             chatDrive,
             messageId,
             reactionJson
         )
+        if (original == null) return ToggleReactionResult(resultType = resultType)
 
         try {
             val enqueued = outboxSync.tryEnqueue(
                 request = ToggleReactionOutboxRequest(
                     driveId = chatDrive,
-                    fileId = fileId,
+                    fileId = original.fileId,
                     reaction = reactionJson,
                     recipients = getRecipients(conversationId),
                 )
             )
-            if (!enqueued && original != null) {
+            if (!enqueued) {
                 optimisticWriter.rollbackWrite(chatDrive, original)
             }
         } catch (t: Throwable) {
             Logger.e("toggleReaction failed to enqueue", t)
-            if (original != null) {
-                try {
-                    optimisticWriter.rollbackWrite(chatDrive, original)
-                } catch (_: Exception) {
-                }
+            try {
+                optimisticWriter.rollbackWrite(chatDrive, original)
+            } catch (_: Exception) {
             }
         }
 
@@ -325,28 +327,11 @@ class ChatMessageActionService(
     }
 
     suspend fun requireFileId(messageId: Uuid): Uuid {
-        val d =
-            fetchFileByUid(listOf(messageId)).firstOrNull() ?: throw Exception("invalid message id")
-        return d.fileId
-    }
-
-    suspend fun fetchFileByUid(uidList: List<Uuid>): List<HomebaseFile> {
-
-        val c = credentialsManager.requireActiveCredentials()
-        val queryBatch = QueryBatch(c.getIdentityId())
-
-        val result = queryBatch.queryBatchAsync(
-            dbm = dbm,
-            driveId = chatDrive,
-            noOfItems = 1000,
-            cursor = null,
-            sortOrder = QueryBatchSortOrder.NewestFirst,
-            sortField = QueryBatchSortField.CreatedDate,
-            fileSystemType = 0,
-            uniqueIdAnyOf = uidList
-        )
-
-        return result.records
+        val credentials = credentialsManager.requireActiveCredentials()
+        val file = dbm.driveMainIndex.selectHomebaseFileByUnique(
+            credentials.getIdentityId(), chatDrive, messageId
+        ) ?: throw Exception("invalid message id $messageId")
+        return file.fileId
     }
 
     private fun isValidEmoji(input: String?): Boolean = !input.isNullOrBlank() && input.length <= 8

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
@@ -29,6 +29,11 @@ import id.homebase.core.config.chatTargetDrive
 import id.homebase.core.widget.EmojiReaction
 import kotlin.uuid.Uuid
 
+/** Server-enforced cap on reactions per user per message. The client mirrors
+ *  the rule so we don't enqueue a request the server will reject with
+ *  UnhandledScenario / "Too many Reactions". */
+const val MAX_REACTIONS_PER_USER_PER_MESSAGE = 5
+
 class ChatMessageActionService(
     private val conversationService: ConversationService,
     private val participantLookup: ConversationParticipantLookup,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
@@ -32,6 +32,8 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 import id.homebase.chat.services.convo.ConversationAppDataJson
 import id.homebase.chat.services.convo.ConversationLocalAppDataJson
 import kotlin.uuid.Uuid
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 class OptimisticWriter(
     private val credentialsManager: CredentialsManager,
@@ -44,6 +46,19 @@ class OptimisticWriter(
 
     private val fileProcessor: MainIndexMetaHelpers.HomebaseFileProcessor =
         MainIndexMetaHelpers.HomebaseFileProcessor(dbm)
+
+    // Per-message lock guarding the read-modify-write inside writeReactionToggle.
+    // Without this, rapid taps on the bottom sheet have all five coroutines
+    // read the same starting state, each compute "remove my one", and last-
+    // writer-wins clobbers most of the removes. Per-(driveId, uniqueId) so
+    // toggles on different messages don't queue against each other.
+    private val reactionToggleLocks = mutableMapOf<Pair<Uuid, Uuid>, Mutex>()
+    private val reactionToggleLocksGuard = Mutex()
+
+    private suspend fun reactionLockFor(driveId: Uuid, uniqueId: Uuid): Mutex =
+        reactionToggleLocksGuard.withLock {
+            reactionToggleLocks.getOrPut(driveId to uniqueId) { Mutex() }
+        }
 
     suspend fun writeNewFile(
         driveId: Uuid,
@@ -436,12 +451,12 @@ class OptimisticWriter(
         driveId: Uuid,
         uniqueId: Uuid,
         reactionJson: String,
-    ): Pair<ToggleReactionResultType, HomebaseFile?> {
+    ): Pair<ToggleReactionResultType, HomebaseFile?> = reactionLockFor(driveId, uniqueId).withLock {
         val credentials = credentialsManager.requireActiveCredentials()
 
         val existingFile = dbm.driveMainIndex.selectHomebaseFileByUnique(
             credentials.getIdentityId(), driveId, uniqueId
-        ) ?: return Pair(ToggleReactionResultType.None, null)
+        ) ?: return@withLock Pair(ToggleReactionResultType.None, null)
 
         val lastModified = existingFile.fileMetadata.updated.addMilliseconds(1)
 
@@ -522,14 +537,14 @@ class OptimisticWriter(
             )
         } catch (e: Exception) {
             Logger.e(throwable = e, tag = TAG) { "Optimistic reaction toggle failed for uniqueId=$uniqueId" }
-            return Pair(ToggleReactionResultType.None, null)
+            return@withLock Pair(ToggleReactionResultType.None, null)
         }
 
         val resultType = if (isAdding)
             ToggleReactionResultType.Added
         else
             ToggleReactionResultType.Deleted
-        return Pair(resultType, existingFile)
+        Pair(resultType, existingFile)
     }
 
     suspend fun stampConversationExitedAt(driveId: Uuid, conversationId: Uuid): UpdateLocalAppdataContentOutboxRequest? =

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
@@ -429,8 +429,9 @@ class OptimisticWriter(
         }
     }
 
-    /** Optimistically updates the reactionPreview on a message and emits BatchReceived.
-     *  Returns the original file for rollback, and the optimistic result type. */
+    /** Optimistically updates the reactionPreview AND localAppData.localReactions
+     *  on a message and emits BatchReceived. Returns the original file for
+     *  rollback, and the optimistic result type. */
     suspend fun writeReactionToggle(
         driveId: Uuid,
         uniqueId: Uuid,
@@ -443,27 +444,46 @@ class OptimisticWriter(
         ) ?: return Pair(ToggleReactionResultType.None, null)
 
         val lastModified = existingFile.fileMetadata.updated.addMilliseconds(1)
+
+        // isAdding is per-user, not per-aggregate: in groups, another user
+        // having reacted with the same emoji must not flip our toggle into a
+        // remove. localReactions is the per-user mirror; ChatMessageStream
+        // decodes it into MessageUiModel.ownReactions on every BatchReceived,
+        // so updating it here also closes the rapid-tap race against the cap.
+        val currentLocalReactions =
+            existingFile.fileMetadata.localAppData?.localReactions.orEmpty()
+        val isAdding = reactionJson !in currentLocalReactions
+        val updatedLocalReactions = if (isAdding) {
+            currentLocalReactions + reactionJson
+        } else {
+            currentLocalReactions.filterNot { it == reactionJson }
+        }
+
         val currentReactions =
             existingFile.fileMetadata.reactionPreview?.reactions.orEmpty().toMutableMap()
-
         // The map key is server-assigned and may differ from reactionJson, so find by value.
         val existingKey = currentReactions.entries
             .firstOrNull { it.value.reactionContent == reactionJson }
             ?.key
         val existing = existingKey?.let { currentReactions[it] }
-        val isAdding = existing == null || existing.count == 0
 
         val updatedReactions = if (isAdding) {
-            currentReactions[reactionJson] = ReactionEntry(
-                key = reactionJson,
-                count = 1,
-                reactionContent = reactionJson
-            )
+            if (existing == null) {
+                currentReactions[reactionJson] = ReactionEntry(
+                    key = reactionJson,
+                    count = 1,
+                    reactionContent = reactionJson
+                )
+            } else {
+                currentReactions[existingKey] = existing.copy(count = existing.count + 1)
+            }
             currentReactions
         } else {
-            val newCount = existing.count - 1
-            if (newCount <= 0) currentReactions.remove(existingKey)
-            else currentReactions[existingKey] = existing.copy(count = newCount)
+            if (existing != null) {
+                val newCount = existing.count - 1
+                if (newCount <= 0) currentReactions.remove(existingKey)
+                else currentReactions[existingKey] = existing.copy(count = newCount)
+            }
             currentReactions
         }
 
@@ -473,7 +493,11 @@ class OptimisticWriter(
                 reactionPreview = (existingFile.fileMetadata.reactionPreview
                     ?: ReactionSummary()).copy(
                     reactions = updatedReactions
-                )
+                ),
+                localAppData = (existingFile.fileMetadata.localAppData
+                    ?: LocalAppMetadata()).copy(
+                    localReactions = updatedLocalReactions
+                ),
             )
         )
 

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTest.kt
@@ -475,4 +475,42 @@ class ChatMessageActionServiceTest {
             assertTrue(fixture.drainOutbox().isEmpty())
         }
     }
+
+    // -------------------------------------------------------------------
+    // requireFileId — single-row primary-key lookup, no QueryBatch.
+    // Was previously paying ~500ms latency on busy drives because it
+    // ran QueryBatch(noOfItems = 1000, NewestFirst) over the whole chat
+    // drive just to recover one fileId. The rewrite uses
+    // dbm.driveMainIndex.selectHomebaseFileByUnique, the same single-
+    // row lookup OptimisticWriter uses. These tests pin both branches.
+    // -------------------------------------------------------------------
+
+    @Test
+    fun requireFileId_returnsFileIdForSeededMessage() = runTest {
+        ChatMessageActionServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = Uuid.random()
+            val fileId = Uuid.random()
+            val messageId = fixture.seedDeletableMessage(
+                conversationId = convoId,
+                fileId = fileId,
+            )
+
+            assertEquals(fileId, service.requireFileId(messageId))
+        }
+    }
+
+    @Test
+    fun requireFileId_throws_whenMessageNotInDb() = runTest {
+        ChatMessageActionServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+
+            val ex = kotlin.runCatching { service.requireFileId(Uuid.random()) }
+            assertTrue(ex.isFailure)
+            assertTrue(
+                ex.exceptionOrNull()?.message?.startsWith("invalid message id") == true,
+                "expected 'invalid message id ...' but was '${ex.exceptionOrNull()?.message}'",
+            )
+        }
+    }
 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/outbox/OptimisticWriterReactionToggleTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/outbox/OptimisticWriterReactionToggleTest.kt
@@ -1,0 +1,362 @@
+package id.homebase.chat.services.outbox
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import id.homebase.api.client.auth.ApiCredentials
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.client.drives.files.ReactionEntry
+import id.homebase.api.client.drives.files.reactions.ToggleReactionResultType
+import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.SecureByteArray
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.sync.database.MainIndexMetaHelpers
+import id.homebase.api.sync.database.OdinDatabase
+import id.homebase.chat.services.ChatProtocol
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Tests OptimisticWriter.writeReactionToggle.
+ *
+ * The optimistic writer must keep three pieces of state in sync on every toggle:
+ *   - localAppData.localReactions  (per-user mirror; what ChatMessageStream
+ *     decodes into MessageUiModel.ownReactions)
+ *   - reactionPreview.reactions    (aggregate count, all participants)
+ *   - The returned ToggleReactionResultType
+ *
+ * These tests pin all three. The most subtle case is the group scenario:
+ * if another participant has already reacted with emoji X (preview count==1)
+ * and the current user toggles X for the first time, the toggle MUST be
+ * treated as an add — i.e. preview goes 1 -> 2, not 1 -> 0. The pre-fix code
+ * read isAdding from preview count and got this wrong, briefly hiding the
+ * other user's reaction in the optimistic UI until the server response
+ * corrected it.
+ */
+class OptimisticWriterReactionToggleTest {
+
+    private val testIdentityId: Uuid = Uuid.parse("7b1be23b-48bb-4304-bc7b-db5910c09a92")
+    private val chatDriveId: Uuid = Uuid.parse("9ff813af-f2d6-1e2f-9b9d-b189e72d1a11")
+    private val testDomain: String = "owner.test"
+
+    private lateinit var dbm: DatabaseManager
+    private lateinit var credentialsManager: CredentialsManager
+    private lateinit var eventBus: EventBus
+    private lateinit var writer: OptimisticWriter
+
+    @AfterTest
+    fun tearDown() {
+        if (::dbm.isInitialized) {
+            try { dbm.close() } catch (_: java.sql.SQLException) { }
+        }
+    }
+
+    private suspend fun setUp() {
+        dbm = DatabaseManager({
+            val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+            OdinDatabase.Schema.create(driver)
+            driver
+        })
+        credentialsManager = CredentialsManager().also {
+            it.setActiveCredentials(
+                ApiCredentials.create(
+                    domain = OdinId(testDomain),
+                    clientAccessToken = "test-token",
+                    sharedSecret = SecureByteArray(ByteArray(16)),
+                )
+            )
+        }
+        eventBus = EventBus()
+        writer = OptimisticWriter(
+            credentialsManager = credentialsManager,
+            dbm = dbm,
+            eventBus = eventBus,
+        )
+    }
+
+    /**
+     * Build the JSON for a single ReactionEntry block keyed by the JSON-form
+     * reaction (matching what OptimisticWriter writes). Caller passes count.
+     */
+    private fun previewJson(reactions: Map<String, Int>): String {
+        if (reactions.isEmpty()) return "null"
+        val entries = reactions.entries.joinToString(",") { (json, count) ->
+            // The map key is the JSON form, e.g. {"emoji":"😀"}.
+            // We need to embed it as a JSON string key — escape its quotes.
+            val keyEscaped = json.replace("\\", "\\\\").replace("\"", "\\\"")
+            val contentEscaped = keyEscaped
+            """"$keyEscaped":{"key":"$keyEscaped","count":$count,"reactionContent":"$contentEscaped"}"""
+        }
+        return """{"reactions":{$entries},"comments":[],"totalCommentCount":0}"""
+    }
+
+    private fun localReactionsJson(localReactions: List<String>?): String {
+        if (localReactions == null) return "null"
+        val items = localReactions.joinToString(",") {
+            val escaped = it.replace("\\", "\\\\").replace("\"", "\\\"")
+            "\"$escaped\""
+        }
+        return """{"localReactions":[$items]}"""
+    }
+
+    /**
+     * Seed a chat-message file in DriveMainIndex with optional pre-existing
+     * localReactions and reactionPreview. Returns the message uniqueId.
+     */
+    private suspend fun seedMessage(
+        initialLocalReactions: List<String>? = null,
+        initialReactionPreview: Map<String, Int>? = null,
+        id: Uuid = Uuid.random(),
+        fileId: Uuid = Uuid.random(),
+        senderDomain: String = testDomain,
+    ): Uuid {
+        val now = Clock.System.now().epochSeconds
+        val previewJson = previewJson(initialReactionPreview.orEmpty())
+        val localAppDataJson = localReactionsJson(initialLocalReactions)
+
+        val jsonHeader = """{
+          "fileId": "$fileId",
+          "driveId": "$chatDriveId",
+          "fileState": "active",
+          "fileSystemType": "standard",
+          "serverFileIsEncrypted": "false",
+          "keyHeader": {
+            "iv": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+            "aesKey": {"bytes": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}
+          },
+          "fileMetadata": {
+            "globalTransitId": "${Uuid.random()}",
+            "created": ${now}000,
+            "updated": ${now}000,
+            "transitCreated": ${now}000,
+            "transitUpdated": 0,
+            "isEncrypted": false,
+            "senderOdinId": "$senderDomain",
+            "originalAuthor": "$senderDomain",
+            "appData": {
+              "uniqueId": "$id",
+              "tags": null,
+              "fileType": ${ChatProtocol.MessageFileType},
+              "dataType": 0,
+              "groupId": "${Uuid.random()}",
+              "userDate": ${now}000,
+              "content": "",
+              "previewThumbnail": null,
+              "archivalStatus": 0
+            },
+            "localAppData": $localAppDataJson,
+            "referencedFile": null,
+            "reactionPreview": $previewJson,
+            "versionTag": "${Uuid.random()}",
+            "payloads": [],
+            "dataSource": null
+          },
+          "serverMetadata": {
+            "accessControlList": {
+              "requiredSecurityGroup": "owner",
+              "circleIdList": null,
+              "odinIdList": null
+            },
+            "doNotIndex": false,
+            "allowDistribution": true,
+            "fileSystemType": "standard",
+            "fileByteCount": 50,
+            "originalRecipientCount": 1,
+            "transferHistory": null
+          },
+          "priority": 300,
+          "fileByteCount": 50
+        }"""
+
+        val header = OdinSystemSerializer.deserialize<HomebaseFile>(jsonHeader)
+        val processor = MainIndexMetaHelpers.HomebaseFileProcessor(dbm)
+        val record = processor.convertFileHeaderToDriveMainIndexRecord(
+            testIdentityId, chatDriveId, header
+        )
+        MainIndexMetaHelpers.upsertDriveMainIndex(dbm, record)
+        return id
+    }
+
+    private suspend fun readBack(uniqueId: Uuid): HomebaseFile = assertNotNull(
+        dbm.driveMainIndex.selectHomebaseFileByUnique(testIdentityId, chatDriveId, uniqueId),
+        "expected row for $uniqueId",
+    )
+
+    private fun emojiJson(emoji: String): String =
+        """{"emoji":"$emoji"}"""
+
+    // ---------- Tests ----------
+
+    @Test
+    fun add_writesLocalReactionsAndIncrementsPreview() = runTest {
+        setUp()
+        val messageId = seedMessage()
+        val reaction = emojiJson("👍")
+
+        val (resultType, original) = writer.writeReactionToggle(
+            chatDriveId, messageId, reaction
+        )
+
+        assertEquals(ToggleReactionResultType.Added, resultType)
+        assertNotNull(original, "original should be returned for rollback")
+
+        val updated = readBack(messageId)
+        assertEquals(
+            listOf(reaction),
+            updated.fileMetadata.localAppData?.localReactions,
+            "localReactions should contain the new reaction JSON",
+        )
+        val previewMap = updated.fileMetadata.reactionPreview?.reactions.orEmpty()
+        assertEquals(1, previewMap.size)
+        assertEquals(1, previewMap.values.first().count)
+        assertEquals(reaction, previewMap.values.first().reactionContent)
+    }
+
+    @Test
+    fun remove_clearsLocalReactionsAndDecrementsPreview() = runTest {
+        setUp()
+        val reaction = emojiJson("🎉")
+        val messageId = seedMessage(
+            initialLocalReactions = listOf(reaction),
+            initialReactionPreview = mapOf(reaction to 1),
+        )
+
+        val (resultType, _) = writer.writeReactionToggle(
+            chatDriveId, messageId, reaction
+        )
+
+        assertEquals(ToggleReactionResultType.Deleted, resultType)
+        val updated = readBack(messageId)
+        assertEquals(
+            emptyList(),
+            updated.fileMetadata.localAppData?.localReactions,
+            "localReactions should no longer contain the toggled emoji",
+        )
+        assertTrue(
+            updated.fileMetadata.reactionPreview?.reactions.orEmpty().isEmpty(),
+            "preview should drop the entry once count reaches 0",
+        )
+    }
+
+    /**
+     * Group case: another participant has already reacted with emoji X (preview
+     * count==1), but the current user has NOT (their localReactions is empty).
+     * Toggling X must be treated as an add: preview goes 1 -> 2, not 1 -> 0.
+     * Pre-fix code read isAdding from the aggregate count and decremented;
+     * this is the regression guard.
+     */
+    @Test
+    fun add_inGroupWherePreviewAlreadyHasOtherUsersReaction_bumpsCountNotZeroes() = runTest {
+        setUp()
+        val reaction = emojiJson("❤️")
+        val messageId = seedMessage(
+            initialLocalReactions = null, // current user has nothing
+            initialReactionPreview = mapOf(reaction to 1), // someone else's reaction
+        )
+
+        val (resultType, _) = writer.writeReactionToggle(
+            chatDriveId, messageId, reaction
+        )
+
+        assertEquals(
+            ToggleReactionResultType.Added, resultType,
+            "current user toggling a reaction they don't own must be an add, " +
+                    "regardless of others having it"
+        )
+
+        val updated = readBack(messageId)
+        assertEquals(
+            listOf(reaction),
+            updated.fileMetadata.localAppData?.localReactions,
+        )
+        val previewMap = updated.fileMetadata.reactionPreview?.reactions.orEmpty()
+        assertEquals(1, previewMap.size, "preview still has one entry")
+        assertEquals(
+            2, previewMap.values.first().count,
+            "preview count should be the other user's 1 + the current user's 1 = 2"
+        )
+    }
+
+    @Test
+    fun addThenRemove_returnsToOriginalState() = runTest {
+        setUp()
+        val reaction = emojiJson("🚀")
+        val messageId = seedMessage()
+
+        val (firstType, _) = writer.writeReactionToggle(
+            chatDriveId, messageId, reaction
+        )
+        val (secondType, _) = writer.writeReactionToggle(
+            chatDriveId, messageId, reaction
+        )
+
+        assertEquals(ToggleReactionResultType.Added, firstType)
+        assertEquals(ToggleReactionResultType.Deleted, secondType)
+
+        val updated = readBack(messageId)
+        assertEquals(
+            emptyList(),
+            updated.fileMetadata.localAppData?.localReactions,
+        )
+        assertTrue(
+            updated.fileMetadata.reactionPreview?.reactions.orEmpty().isEmpty(),
+        )
+    }
+
+    @Test
+    fun toggle_whenFileMissing_returnsNoneAndDoesNotInsert() = runTest {
+        setUp()
+        val nonExistent = Uuid.random()
+
+        val (resultType, original) = writer.writeReactionToggle(
+            chatDriveId, nonExistent, emojiJson("😀")
+        )
+
+        assertEquals(ToggleReactionResultType.None, resultType)
+        assertNull(original)
+        assertNull(
+            dbm.driveMainIndex.selectHomebaseFileByUnique(
+                testIdentityId, chatDriveId, nonExistent
+            ),
+            "no row should have been created",
+        )
+    }
+
+    /**
+     * Add a second distinct emoji while the first is still present. localReactions
+     * should grow to two entries; preview should have two distinct keys each at
+     * count==1.
+     */
+    @Test
+    fun add_secondDistinctEmoji_appendsAlongsideExisting() = runTest {
+        setUp()
+        val first = emojiJson("👍")
+        val second = emojiJson("🎉")
+        val messageId = seedMessage(
+            initialLocalReactions = listOf(first),
+            initialReactionPreview = mapOf(first to 1),
+        )
+
+        val (resultType, _) = writer.writeReactionToggle(
+            chatDriveId, messageId, second
+        )
+
+        assertEquals(ToggleReactionResultType.Added, resultType)
+        val updated = readBack(messageId)
+        assertEquals(
+            listOf(first, second),
+            updated.fileMetadata.localAppData?.localReactions,
+        )
+        val previewMap = updated.fileMetadata.reactionPreview?.reactions.orEmpty()
+        assertEquals(2, previewMap.size)
+        assertTrue(previewMap.values.all { it.count == 1 })
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/outbox/OptimisticWriterReactionToggleTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/outbox/OptimisticWriterReactionToggleTest.kt
@@ -22,6 +22,8 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 
 /**
@@ -358,5 +360,61 @@ class OptimisticWriterReactionToggleTest {
         val previewMap = updated.fileMetadata.reactionPreview?.reactions.orEmpty()
         assertEquals(2, previewMap.size)
         assertTrue(previewMap.values.all { it.count == 1 })
+    }
+
+    /**
+     * Diagnostic probe — does NOT directly correspond to a known bug yet.
+     *
+     * Reproduces the user-reported scenario in isolation: five concurrent
+     * removes of the five own-reactions on a single message, going only
+     * through OptimisticWriter (no outbox / server / sync in the loop).
+     * Reads back the DB state to decide between two hypotheses for why
+     * the chat bubble peels reactions off slowly:
+     *
+     *   - Hypothesis A: read-modify-write race in writeReactionToggle.
+     *     If true, this test fails: the residue list is non-empty because
+     *     last-writer-wins clobbered most of the removes.
+     *
+     *   - Hypothesis B: writer is race-safe under runTest's cooperative
+     *     scheduling; the symptom is upstream (e.g. sync overwriting the
+     *     correct optimistic state with stale server data).
+     *     If true, this test passes; the residue is empty.
+     *
+     * runTest's StandardTestDispatcher yields at every suspension point
+     * inside writeReactionToggle (DB read, DB write, eventBus.emit), so a
+     * read-modify-write race would still surface here.
+     *
+     * The println surfaces the actual residue so we can read off the
+     * hypothesis result either way.
+     */
+    @Test
+    fun parallelRemoves_diagnostic_finalDbStateMustBeEmpty() = runTest {
+        setUp()
+        val emojis = listOf("👍", "🎉", "❤️", "🚀", "😀").map { emojiJson(it) }
+        val messageId = seedMessage(
+            initialLocalReactions = emojis,
+            initialReactionPreview = emojis.associateWith { 1 },
+        )
+
+        coroutineScope {
+            for (e in emojis) {
+                launch { writer.writeReactionToggle(chatDriveId, messageId, e) }
+            }
+        }
+
+        val updated = readBack(messageId)
+        val residue = updated.fileMetadata.localAppData?.localReactions.orEmpty()
+        val previewResidue = updated.fileMetadata.reactionPreview?.reactions.orEmpty()
+        println("DIAG localReactionsResidue=$residue previewResidue=$previewResidue")
+        assertEquals(
+            emptyList(),
+            residue,
+            "If the optimistic writer is race-free, all five removes must land. " +
+                    "Non-empty residue ⇒ Hypothesis A (race in writeReactionToggle).",
+        )
+        assertTrue(
+            previewResidue.isEmpty(),
+            "preview should also be empty after all five removes",
+        )
     }
 }

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -578,7 +578,7 @@
     <string name="chat_reactions_title">Reactions</string>
     <string name="chat_reactions_all">All</string>
     <string name="chat_reactions_tap_to_remove">Tap to remove</string>
-    <string name="chat_reactions_limit_reached">You can add up to 5 reactions per message — remove one first.</string>
+    <string name="chat_reactions_limit_reached">You cannot add more emojis, remove one first before adding another.</string>
     <string name="chat_message_discard_draft">Discard draft?</string>
 
     <string name="chat_message_forward_to">Forward to</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -578,6 +578,7 @@
     <string name="chat_reactions_title">Reactions</string>
     <string name="chat_reactions_all">All</string>
     <string name="chat_reactions_tap_to_remove">Tap to remove</string>
+    <string name="chat_reactions_limit_reached">You can add up to 5 reactions per message — remove one first.</string>
     <string name="chat_message_discard_draft">Discard draft?</string>
 
     <string name="chat_message_forward_to">Forward to</string>


### PR DESCRIPTION
The server enforces max 5 reactions per user per message and rejects the upload of any 6th with a 400 / UnhandledScenario / "Too many Reactions count N in ReactionSummary max 5". The client had no matching guard, so it would optimistically write the 6th, enqueue it to the outbox, then surface a generic upload error while local state diverged from server state until the next sync.

Mirror the rule in ConversationListViewModel's ToggleReaction handler: before any optimistic write or service call, if the candidate emoji is not already in the message's ownReactions and ownReactions.size is at the cap, emit a localized info snackbar
(chat_reactions_limit_reached) and return. Removes are never blocked
- they can only reduce the count.

ownReactions on MessageUiModel is decoded by ChatMessageStream into bare emoji strings (the wire form is JSON {"emoji":"X"}); the guard compares action.reaction directly against that list so removes via the ReactionsBottomSheet "slider panel" don't get misread as adds and hit the same snackbar. The KDoc on the field claimed "Raw JSON-encoded reactions" - corrected to match what ChatMessageStream actually produces.

The single source of truth for the cap is a top-level MAX_REACTIONS_PER_USER_PER_MESSAGE = 5 next to
ChatMessageActionService.toggleReaction; no service-layer change since the VM is the only caller. Stale-mirror drift needs no extra defense - the existing rollback path on outbox-enqueue failure plus sync re-alignment is sufficient.