### PR TITLE
perf(chat): gate unread-count enrich on dirty bit, drop per-batch fan-out

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
@@ -275,7 +275,10 @@ class ChatMessageActionService(
     ) {
         val msg = messageLookup.getMessage(messageId) ?: return
         val conversation = conversationService.getConversation(msg.conversationId) ?: return
-        val fileId = requireFileId(messageId)
+        // msg.fileId is already populated by messageLookup.getMessage above —
+        // an extra requireFileId(messageId) here would issue a second
+        // selectHomebaseFileByUnique for the exact same row.
+        val fileId = msg.fileId
 
         // Soft-delete only for now — propagates to other clients via sync.
         // Hard-delete will be added as a second phase (user invokes delete again on soft-deleted msg).
@@ -327,6 +330,13 @@ class ChatMessageActionService(
     }
 
     suspend fun requireFileId(messageId: Uuid): Uuid {
+        // In-memory tier first: if the message's conversation is currently
+        // open and loaded, the MessageUiModel already carries fileId — no
+        // DB round-trip needed. Hit rate is effectively 100% for the
+        // remaining caller (getReactions on a visible message).
+        messageLookup.findCachedFileId(messageId)?.let { return it }
+
+        // Cache miss → indexed primary-key lookup.
         val credentials = credentialsManager.requireActiveCredentials()
         val file = dbm.driveMainIndex.selectHomebaseFileByUnique(
             credentials.getIdentityId(), chatDrive, messageId

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -176,6 +176,28 @@ class ChatMessageStream(
         )
     }
 
+    /** Walk the open conversations' in-memory message lists for a model whose
+     *  `id == messageId` and return its `fileId`. The hit rate is effectively
+     *  100% for messageId-keyed actions invoked from a visible message
+     *  (toggleReaction's optimistic path is fileId-keyed and bypasses this
+     *  entirely; the remaining call sites — getReactions, deleteMessage's
+     *  fall-through — operate on a message the user just interacted with).
+     *
+     *  The scan is over distinct *open* conversations only, which is one for
+     *  the active conversation in steady state. Returns `null` (caller must
+     *  fall through to DB) if the message isn't loaded — including the case
+     *  where it exists on disk but its conversation hasn't been opened.
+     */
+    override fun findCachedFileId(messageId: Uuid): Uuid? {
+        val open = conversationState.messages.value
+        for ((_, list) in open) {
+            for (m in list) {
+                if (m.id == messageId) return m.fileId
+            }
+        }
+        return null
+    }
+
     suspend fun fetchMessages(
         conversationId: Uuid,
         limit: Int = 1000,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/MessageLookup.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/MessageLookup.kt
@@ -20,4 +20,11 @@ interface MessageLookup {
     /** For messages whose content was offloaded to a payload (over the
      *  in-header size budget), read the full text back. */
     suspend fun loadFullMessage(conversationId: Uuid, messageId: Uuid): String?
+
+    /** Cache-only lookup. Returns the drive `fileId` for [messageId] if the
+     *  message is currently in the in-memory state (i.e. its conversation is
+     *  open and loaded), otherwise `null`. Cheap, synchronous-equivalent —
+     *  callers fall through to a DB lookup on `null` rather than treating it
+     *  as "not found". */
+    fun findCachedFileId(messageId: Uuid): Uuid?
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -136,6 +136,34 @@ class ConversationStream(
     var onUnarchiveConversation: (suspend (conversationId: Uuid) -> Unit)? = null
     // endregion
 
+    // region Unread-count dirty bits
+    // Conversation IDs whose unread count is suspected stale relative to the
+    // DB. Set when a conversation file arrives and its lastRead advanced
+    // (peer-device mark-as-read) or when a brand-new conversation appears
+    // in memory without an unread baseline. The Stopped handler (drive-sync)
+    // and the WebSocket-batch handler each check this set at their respective
+    // checkpoints; if non-empty, run [enrichAllConversationsWithUnreadCounts],
+    // which clears the set at the top.
+    //
+    // Only mutated from inside the sequential `eventBus.events.collect { ... }`
+    // loop in init and from inside enrichAllConversationsWithUnreadCounts,
+    // so no synchronization is needed.
+    //
+    // All access goes through [markUnreadDirty] / [hasDirtyUnread] /
+    // [clearDirtyUnread] so callers don't reach into the set directly.
+    private val dirtyUnreadIds = mutableSetOf<Uuid>()
+
+    private fun markUnreadDirty(conversationId: Uuid) {
+        dirtyUnreadIds += conversationId
+    }
+
+    private fun hasDirtyUnread(): Boolean = dirtyUnreadIds.isNotEmpty()
+
+    private fun clearDirtyUnread() {
+        dirtyUnreadIds.clear()
+    }
+    // endregion
+
 
     // The full conversation list is loaded once from the local DB on authentication
     // (via start(), called from onPostAuthenticated in AppModule).
@@ -144,10 +172,10 @@ class ConversationStream(
     // file notification — arrive as BatchReceived events and are applied incrementally.
     // We intentionally do NOT re-read the full list on DriveEvent.Stopped; the
     // incremental BatchReceived path is sufficient and avoids an expensive full reload
-    // on every incoming message. We DO, however, re-enrich unread counts on Stopped —
-    // that's a small ChatReadCount scan and catches reads written by batches that
-    // landed during the sync round (and message-only batches, which the per-batch
-    // enrich path further down doesn't cover).
+    // on every incoming message. Unread counts are re-enriched at end-of-sync only
+    // when [hasDirtyUnread] is true (see the dirty-bit region) — i.e. when a
+    // conversation file's lastRead actually advanced during the round, which is
+    // the only case `enrichAllConversationsWithUnreadCounts` materially changes.
     init {
         scope.launch {
             eventBus.events.collect { event ->
@@ -178,17 +206,19 @@ class ConversationStream(
                                     }
                                 }
                             }
-                            // Re-enrich unread counts after the chat-drive sync
-                            // completes — but only if the sync actually received
-                            // records. totalCount=0 means no batches, no writes to
-                            // ChatReadCount, so nothing to re-enrich. Replaces the
-                            // old BackendEvent.ConnectionOnline trigger so the second
-                            // cold-boot enrich (when there is one) now lands AFTER
-                            // sync writes (deterministic order), not concurrent with them.
-                            if (event.totalCount > 0) {
+                            // Re-enrich unread counts at end of round, but only
+                            // if a conversation file's lastRead actually advanced
+                            // during the round (peer-device mark-as-read echo).
+                            // [markUnreadDirty] is called from
+                            // [processConversationBatchIncrementally] when that
+                            // happens. Anything else the round brought —
+                            // metadata-only conversation updates, message-only
+                            // batches, admin files — leaves the dirty set empty
+                            // and skips the ~500ms full-DB recount.
+                            if (hasDirtyUnread()) {
                                 scope.launch {
                                     try {
-                                        enrichAllConversationsWithUnreadCounts()
+                                        enrichAllConversationsWithUnreadCounts(trigger = "Stopped")
                                     } catch (e: Exception) {
                                         Logger.e(e) {
                                             "ConversationStream: post-Stopped enrich failed: ${e.message}"
@@ -223,7 +253,7 @@ class ConversationStream(
                         )
 
                         if (conversationFiles.isNotEmpty())
-                            processConversationBatchIncrementally(conversationFiles)
+                            processConversationBatchIncrementally(conversationFiles, event.source)
 
                         if (messageFiles.isNotEmpty())
                             processMessageBatchIncrementally(messageFiles)
@@ -489,7 +519,8 @@ class ConversationStream(
     }
 
     private suspend fun processConversationBatchIncrementally(
-        conversationFiles: List<HomebaseFile>
+        conversationFiles: List<HomebaseFile>,
+        source: BackendEvent.SyncSource,
     ) {
         // For each file in the batch, map to model (fetch last message from DB if needed)
         val incomingConversations =
@@ -500,8 +531,19 @@ class ConversationStream(
         for (c in incomingConversations) {
             val matchingConversation = _conversations.value.items.find { it.id == c.id }
             if (matchingConversation == null) {
+                // Brand-new in-memory conversation — we have no unread baseline
+                // yet, so mark dirty so the next checkpoint recounts.
                 insertNewConversation(c)
+                markUnreadDirty(c.id)
             } else {
+                // lastRead advanced ⇒ peer-device mark-as-read echo. Anything
+                // else the file carries (name, participants, lastMessage)
+                // does not affect unread count. Compare BEFORE updateConversation
+                // runs — that helper merges lastRead with `max(existing, incoming)`
+                // and would erase the delta we're testing for.
+                if (c.lastRead > matchingConversation.lastRead) {
+                    markUnreadDirty(c.id)
+                }
                 updateConversation(matchingConversation, c)
             }
             // A real file has now arrived for this id; it no longer needs
@@ -513,27 +555,30 @@ class ConversationStream(
         val sortedList = _conversations.value.items.sortedByDescending { it.latestMessageTimestamp }
         _conversations.value = _conversations.value.copy(items = sortedList)
 
-        // Drive-sync of a conversation file (peer-device echo) writes only
-        // DriveMainIndex; ChatReadCount lags. The merged enrich pass mirrors
-        // file-of-record lastReadTime into ChatReadCount and patches unread
-        // counts in one round-trip — fire-and-forget so the in-memory list
-        // update above stays on the hot path.
-        //
         // Skip while the cold-load pipeline hasn't run its own enrich yet.
         // During initial sync, every conversation file streams in via this
-        // path and would trigger N redundant enrich passes (each 2-10s on a
-        // power user's box, visibly reshuffling the list every emit). The
-        // end-of-start() enrich (`enrichAllConversationsWithUnreadCounts`
-        // after `enrichWithLastMessages` / `enrichWithAdmins`) flips
-        // `hasUnreadCounts` once cold-load is done; only after that should
-        // per-batch arrivals trigger their own mirror.
+        // path; the end-of-start() enrich
+        // (`enrichAllConversationsWithUnreadCounts(trigger = "ColdLoad")`)
+        // flips `hasUnreadCounts` once cold-load is done. Only after that
+        // should per-batch arrivals drive enrichment.
         if (!_conversations.value.enrichment.hasUnreadCounts) return
-        scope.launch {
-            try {
-                enrichAllConversationsWithUnreadCounts()
-            } catch (e: Exception) {
-                Logger.e(e) {
-                    "ConversationStream: background enrich after conversation batch failed: ${e.message}"
+
+        // Source-aware checkpoint:
+        //
+        // - DriveSync: nothing to do here. The matching DriveEvent.Stopped
+        //   handler will inspect [hasDirtyUnread] at end of the sync round
+        //   and run a single enrichAll for the whole round.
+        // - WebSocket: there is no Started/Stopped envelope — this batch IS
+        //   the whole event. If anything in it dirtied an unread count, run
+        //   enrichAll right here.
+        if (source == BackendEvent.SyncSource.WebSocket && hasDirtyUnread()) {
+            scope.launch {
+                try {
+                    enrichAllConversationsWithUnreadCounts(trigger = "WebSocketBatch")
+                } catch (e: Exception) {
+                    Logger.e(e) {
+                        "ConversationStream: WebSocket-batch enrich failed: ${e.message}"
+                    }
                 }
             }
         }
@@ -881,15 +926,27 @@ class ConversationStream(
      * so the unread counts reflect the just-mirrored values before they're
      * patched onto the model.
      *
-     * Also invoked from message-read actions (see [ChatMessageActionService])
-     * and after every chat-drive `BackendEvent.DriveEvent.Stopped` that
-     * received at least one record. Flips `enrichment.hasUnreadCounts`
-     * (first call only; subsequent calls just patch counts).
+     * Invoked from cold-load ([start]), the [BackendEvent.DriveEvent.Stopped]
+     * handler when [hasDirtyUnread] is true, and the WebSocket-batch
+     * handler when [hasDirtyUnread] is true at end of batch. Flips
+     * `enrichment.hasUnreadCounts` (first call only; subsequent calls just
+     * patch counts).
+     *
+     * Clears the dirty set at the top — anything dirtied while this call
+     * is in flight remains for the next checkpoint.
+     *
+     * @param trigger short label naming the call site (e.g. "ColdLoad",
+     *   "Stopped", "WebSocketBatch"). Surfaces in the `ConvListPerf` log so
+     *   we can attribute frequency without a stack walk.
      *
      * Safe to defer, safe to skip, safe to retry.
      */
-    suspend fun enrichAllConversationsWithUnreadCounts() {
+    suspend fun enrichAllConversationsWithUnreadCounts(trigger: String) {
         val startedAt = Clock.System.now().toEpochMilliseconds()
+        // Take ownership of the current dirty set as we begin work. New
+        // bits set during this call's lifetime persist for the next
+        // checkpoint — preferred over a lost-wakeup race.
+        clearDirtyUnread()
         val c = credentialsManager.requireActiveCredentials()
         var unread = dbm.chatReadCount.selectAllUnreadCount(c.getIdentityId(), c.domain)
 
@@ -938,7 +995,7 @@ class ConversationStream(
 
         Logger.i(tag = "ConvListPerf") {
             "enrichAllConversationsWithUnreadCounts=${Clock.System.now().toEpochMilliseconds() - startedAt}ms " +
-                    "mirrored=$mirroredCount changedRows=$changed totalRows=${current.items.size}"
+                    "trigger=$trigger mirrored=$mirroredCount changedRows=$changed totalRows=${current.items.size}"
         }
     }
 
@@ -1002,7 +1059,7 @@ class ConversationStream(
             // then admins (group-settings only), then unread counts.
             enrichWithLastMessages()
             enrichWithAdmins()
-            enrichAllConversationsWithUnreadCounts()
+            enrichAllConversationsWithUnreadCounts(trigger = "ColdLoad")
         }
 
         // Reactively update share cache when conversations or contacts change,

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
@@ -566,6 +566,15 @@ class FakeMessageLookup : MessageLookup {
 
     override suspend fun loadFullMessage(conversationId: Uuid, messageId: Uuid): String? =
         error("FakeMessageLookup.loadFullMessage not exercised by tests using this fixture")
+
+    /** Mirrors the real implementation's contract: returns the cached fileId
+     *  if the message has been seeded into [records], otherwise null so the
+     *  caller falls through to its DB lookup. Existing requireFileId tests
+     *  seed only the DriveMainIndex row (not [records]), so they exercise
+     *  the DB fall-through; tests that want to assert the cache-hit path
+     *  add the message to [records] explicitly. */
+    override fun findCachedFileId(messageId: Uuid): Uuid? =
+        records.firstOrNull { it.id == messageId }?.fileId
 }
 
 class FakeLocalLastReadUpdater : LocalLastReadUpdater {


### PR DESCRIPTION
The reaction PR's `(ConvListPerf)` instrumentation surfaced a steady 12+ calls of `enrichAllConversationsWithUnreadCounts=~500ms mirrored=0 changedRows=0` per chat session — wasted background work that contended with the UI dispatcher and made reactions feel janky.

Cause: `processConversationBatchIncrementally` fired the full enrich on every conversation-file batch (`ConversationStream.kt:530-539`), including drive-sync rounds that deliver many batches back-to-back and conversation files whose only change was metadata (name, participants, lastMessage timestamp). The actual job of that enrich is to mirror peer-device mark-as-read echoes — `localAppData.lastReadTime` into `ChatReadCount.lastReadTime` — which only matters when a conversation file's `lastRead` actually advanced.

Fix: a per-stream `dirtyUnreadIds: Set<Uuid>` accessed via three helpers (`markUnreadDirty`, `hasDirtyUnread`, `clearDirtyUnread`). A conversation is marked dirty exactly when a conversation file arrives and its `lastRead` is later than the prior in-memory entry, or when a brand-new conversation appears with no unread baseline.

Two checkpoints inspect the set:
- `DriveEvent.Stopped` (end of a sync round): gate flipped from `event.totalCount > 0` to `hasDirtyUnread()`. Mid-sync batches no longer fire enrichAll at all — the round's one Stopped picks up everything dirtied in flight.
- `BatchReceived(source = WebSocket)` (no Started/Stopped envelope — this batch is the whole event): runs enrichAll in-place if the batch dirtied anything.

`enrichAllConversationsWithUnreadCounts` now takes a `trigger: String` ("ColdLoad", "Stopped", "WebSocketBatch") that surfaces in the ConvListPerf log so we can attribute frequency without a stack walk. It clears the dirty set at the top — anything dirtied while it's in flight persists for the next checkpoint, preferring a small redundancy to a lost-wakeup race.

Trade-off this commit consciously accepts: today's `Stopped(totalCount > 0)` doubled as periodic reconciliation of the in-memory `++ unreadCount` at `:439-442` against the SQL formula in `ChatReadCount.sq`. After this PR, message-only sync rounds don't trigger enrichAll, so the in-memory increment is the source of truth between peer-mark-as-read events. Cold-load enrich still re-derives every count on next app start. If drift becomes observable in logs, the simple recovery is to OR the Stopped gate with `messageFilesInRound > 0` (separate counter, ~5 lines).

Future work this scaffold cleanly enables (none of it in this PR): debouncing rapid checkpoint hits, swapping in
`selectUnreadCountForConversation` when only one id is dirty, and marking dirty on suspect message arrivals if reconciliation needs to return.

Existing `homebase-chat:jvmTest` suite passes. No new tests this round (no existing ConversationStream test fixture; full integration fixture is ~400 lines of stubs for ContactService / DriveContactService / ConnectionService / image / share-cache deps — deferred). Manual verification path documented at the top of the diff: cold-boot for one ColdLoad line, idle for absence of mid-sync bursts, peer mark-as-read for a single Stopped or WebSocketBatch line.