### PR TITLE
perf(ws): pure-push WS drive file events; retire per-event syncDrive

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
@@ -3,7 +3,6 @@ package id.homebase.api.client.websockets
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.SharedSecretEncryptedPayload
 import id.homebase.api.client.auth.CredentialsManager
-import id.homebase.api.client.drives.SystemDriveConstants
 import id.homebase.api.client.drives.TargetDrive
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
@@ -11,8 +10,8 @@ import id.homebase.api.common.SecureByteArray
 import id.homebase.api.crypto.AesCbc
 import id.homebase.api.crypto.ByteArrayUtil
 import id.homebase.api.serialization.OdinSystemSerializer
-import id.homebase.api.sync.ChatDriveWebSocketUpsertWorker
 import id.homebase.api.sync.DriveSyncManager
+import id.homebase.api.sync.DriveWebSocketUpsertWorker
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.MainIndexMetaHelpers
 import id.homebase.api.toBase64
@@ -66,11 +65,18 @@ class OdinWebSocketClient(
 
     private var fileHeaderProcessor = MainIndexMetaHelpers.HomebaseFileProcessor(databaseManager)
 
-    // Lazily initialised on the first [connectOnce] call once we have
-    // credentials. Receives WS-pushed file headers for the chat drive
-    // and writes them straight to DriveMainIndex without a Drive.sync()
-    // round-trip. Other drives stay on [driveSyncManager.syncDrive].
-    private var chatWsUpsertWorker: ChatDriveWebSocketUpsertWorker? = null
+    // Per-drive WS upsert workers. Lazily created on the first file
+    // event for a drive (see [getOrCreateWorker]). Each worker
+    // batches incoming files into one DB transaction and emits a
+    // single [BackendEvent.DriveEvent.BatchReceived] per drain;
+    // shape mirrors [DriveSync].
+    //
+    // Cleared in [disconnect]. Mount/unmount of drives is handled
+    // automatically because [AuthConnectionCoordinator.reconnectWebSocket]
+    // destroys the old [OdinWebSocketClient] and creates a fresh one
+    // with an empty map.
+    private val wsUpsertWorkers = mutableMapOf<Uuid, DriveWebSocketUpsertWorker>()
+    private val wsUpsertWorkersMutex = Mutex()
 
     private lateinit var sharedSecret: ByteArray
 
@@ -202,18 +208,9 @@ class OdinWebSocketClient(
         val identity = creds.domain
         sharedSecret = creds.sharedSecret.unsafeBytes
 
-        // Lazily build the chat-drive WS upsert worker once we know the
-        // identity. Idempotent across reconnects — the same worker drains
-        // future bursts. Cancelled in [disconnect].
-        if (chatWsUpsertWorker == null) {
-            chatWsUpsertWorker = ChatDriveWebSocketUpsertWorker(
-                identityId = creds.getIdentityId(),
-                driveId = SystemDriveConstants.chatDrive.alias,
-                databaseManager = databaseManager,
-                eventBus = eventBus,
-                scope = scope,
-            )
-        }
+        // Per-drive WS upsert workers materialise lazily in
+        // [getOrCreateWorker] when a file event for that drive
+        // arrives — no need to predeclare which drives we expect.
 
         _connectionState.value = WebSocketState.Connecting
 
@@ -477,74 +474,75 @@ class OdinWebSocketClient(
     }
 
     /**
-     * Reaction add/remove notification.
+     * Reaction add/remove notification — no-op for every drive.
      *
-     * For the chat drive: no work is needed here. A `statisticsChanged`
-     * notification fires alongside this one carrying the updated file
-     * header (with the new `reactionPreview`), and that notification
-     * lands in [handleFileEvent] → the chat-drive pure-push path,
-     * which writes the new header to DriveMainIndex via the worker.
-     * Calling `syncDrive` here would refetch the same data via HTTP
-     * — pure redundant work. The per-user reaction details (who reacted
-     * with which emoji, used by the reaction-detail view) are fetched
-     * on-demand via `getReactions()` and don't ride on the WS at all.
-     *
-     * Other drives (e.g. feed) still need the syncDrive fallback —
-     * they don't have a per-event WS upsert worker yet.
+     * The server fires a parallel `statisticsChanged` notification
+     * carrying the updated file header (with the new
+     * `reactionPreview`); that notification lands in
+     * [handleFileEvent] → the per-drive pure-push worker, which
+     * writes the new header to DriveMainIndex. Calling syncDrive
+     * here would refetch the same data via HTTP. The per-user
+     * reaction details (who reacted with which emoji, used by the
+     * reaction-detail view) are fetched on-demand via
+     * `getReactions()` and don't ride on this WS event at all.
      */
-    private suspend fun handleReactionEvent(
+    @Suppress("UNUSED_PARAMETER")
+    private fun handleReactionEvent(
         notification: ClientNotificationPayload,
-        isDeleted: Boolean
+        isDeleted: Boolean,
     ) {
-        val eventData = OdinSystemSerializer
-            .deserialize<ClientReactionNotification>(notification.data)
-        val driveId = eventData.fileId.driveId
-
-        if (driveId == SystemDriveConstants.chatDrive.alias) {
-            return
-        }
-
-        Logger.i {
-            "WSFileEvent: syncDrive($driveId) for reaction event " +
-                "(isDeleted=$isDeleted, fileId=${eventData.fileId.fileId})"
-        }
-        driveSyncManager.syncDrive(driveId)
+        // intentional no-op — see KDoc
     }
 
-    /** All-reactions-cleared notification. Same chat-drive shortcut as
-     *  [handleReactionEvent] — `statisticsChanged` for the file already
-     *  rewrites `reactionPreview` to empty via the pure-push worker. */
-    private suspend fun handleAllReactionsDeletedEvent(notification: ClientNotificationPayload) {
-        val file =
-            OdinSystemSerializer.deserialize<InternalDriveFileId>(notification.data)
+    /**
+     * All-reactions-cleared notification — no-op for every drive,
+     * same rationale as [handleReactionEvent]: the parallel
+     * `statisticsChanged` for the file rewrites `reactionPreview` to
+     * empty via the pure-push worker.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    private fun handleAllReactionsDeletedEvent(notification: ClientNotificationPayload) {
+        // intentional no-op — see KDoc
+    }
 
-        if (file.driveId == SystemDriveConstants.chatDrive.alias) {
-            return
-        }
-
-        try {
-            Logger.i { "WSFileEvent: syncDrive(${file.driveId}) for allReactionsByFileDeleted (fileId=${file.fileId})" }
-            driveSyncManager.syncDrive(file.driveId)
-        } catch (e: Exception) {
-            Logger.e("handleAllReactionsDeletedEvent() probably used invalid driveId ${file.driveId} Exception:$e")
+    /**
+     * Get-or-create the WS upsert worker for [driveId]. Returns null
+     * when the client is closed or has no active credentials —
+     * caller falls through to [DriveSyncManager.syncDrive].
+     */
+    private suspend fun getOrCreateWorker(driveId: Uuid): DriveWebSocketUpsertWorker? {
+        if (closed) return null
+        val identityId = credentialsManager.getActiveCredentials()?.getIdentityId() ?: return null
+        return wsUpsertWorkersMutex.withLock {
+            wsUpsertWorkers[driveId] ?: DriveWebSocketUpsertWorker(
+                identityId = identityId,
+                driveId = driveId,
+                databaseManager = databaseManager,
+                eventBus = eventBus,
+                scope = scope,
+            ).also { wsUpsertWorkers[driveId] = it }
         }
     }
 
     /**
      * Dispatcher for `fileAdded` / `fileDeleted` / `fileModified` /
-     * `statisticsChanged` notifications.
+     * `statisticsChanged` notifications, for any drive.
      *
-     * Chat drive: if the WS payload carries a header, decrypt it and
-     * submit to the [chatWsUpsertWorker] — no HTTP round-trip. The
-     * worker batches bursts of incoming files into one DB transaction
-     * and emits a single `BatchReceived(source = WebSocket)` event.
+     * If the WS payload carries a header, decrypt it and submit to
+     * the per-drive [DriveWebSocketUpsertWorker] — no HTTP
+     * round-trip. The worker batches bursts of incoming files into
+     * one DB transaction and emits a single
+     * `BatchReceived(source = WebSocket)` event.
      *
-     * Everything else (other drives, or chat-drive notifications with
-     * a null header, or any failure in the pure-push path) falls back
-     * to [DriveSyncManager.syncDrive]. The fallback is logged at INFO
-     * so we can monitor the rate in production — a steady stream for
-     * chat-drive notifications would mean the WS payload is missing
-     * headers somewhere we didn't expect.
+     * Falls back to [DriveSyncManager.syncDrive] when:
+     *  - the notification has no header (e.g. some
+     *    `statisticsChanged` variants),
+     *  - decrypt or upsert throws,
+     *  - we can't get/create a worker (closed, no credentials).
+     *
+     * Every fallback is logged at INFO so the rate is observable in
+     * production — a steady stream for any drive means the WS
+     * payload is missing headers somewhere we didn't expect.
      */
     private suspend fun handleFileEvent(notification: ClientNotificationPayload) {
         val fileNotification =
@@ -552,8 +550,8 @@ class OdinWebSocketClient(
         val driveId = fileNotification.targetDrive!!.alias
         val header = fileNotification.header
 
-        if (driveId == SystemDriveConstants.chatDrive.alias && header != null) {
-            val worker = chatWsUpsertWorker
+        if (header != null) {
+            val worker = getOrCreateWorker(driveId)
             if (worker != null) {
                 try {
                     val file = header.asHomebaseFile(SecureByteArray(sharedSecret))
@@ -561,7 +559,7 @@ class OdinWebSocketClient(
                     return
                 } catch (e: Exception) {
                     Logger.w(e) {
-                        "WSFileEvent: pure-push path failed for chat drive " +
+                        "WSPush: pure-push path failed for drive=$driveId " +
                             "(notificationType=${notification.notificationType}); " +
                             "falling back to syncDrive: ${e.message}"
                     }
@@ -573,8 +571,7 @@ class OdinWebSocketClient(
         Logger.i {
             "WSFileEvent: syncDrive($driveId) — " +
                 "notificationType=${notification.notificationType} " +
-                "headerPresent=${header != null} " +
-                "isChatDrive=${driveId == SystemDriveConstants.chatDrive.alias}"
+                "headerPresent=${header != null}"
         }
         try {
             driveSyncManager.syncDrive(driveId)
@@ -622,19 +619,12 @@ class OdinWebSocketClient(
         onConnected()
         eventBus.emit(BackendEvent.ConnectionOnline)
 
-        // Catch-up backstop for the chat drive. Now that per-event
-        // file notifications take the pure-push path (no syncDrive),
-        // we still need to recover anything the server queued while
-        // the WS was disconnected. One targeted sync per (re)connect
-        // is enough — the dirty-bit gate downstream keeps it cheap
-        // when the round brings nothing relevant.
-        try {
-            driveSyncManager.syncDrive(SystemDriveConstants.chatDrive.alias)
-        } catch (e: Exception) {
-            Logger.w(e) {
-                "onHandshakeSuccess: chat-drive catch-up syncDrive failed: ${e.message}"
-            }
-        }
+        // Catch-up after a (re)connect is handled by
+        // [AuthConnectionCoordinator]'s `onConnected` callback, which
+        // fires `driveSyncManager.syncAll()` on every handshake — see
+        // `AuthConnectionCoordinator.kt:179-202`. That covers all
+        // mounted drives, which is what we need now that per-event
+        // file notifications take the pure-push path for every drive.
     }
 
     /**
@@ -647,8 +637,15 @@ class OdinWebSocketClient(
         session = null
         connectionJob?.cancel()
         connectionJob = null
-        chatWsUpsertWorker?.cancel()
-        chatWsUpsertWorker = null
+        // Snapshot-then-clear is safe without acquiring [wsUpsertWorkersMutex]:
+        // [getOrCreateWorker] checks `closed` before allocating, so any
+        // concurrent call after `closed = true` returns null and never
+        // re-populates the map. Worst case is a worker created right
+        // before `closed = true` flipped — that one ends up in the
+        // snapshot and gets cancelled.
+        val workersSnapshot = wsUpsertWorkers.values.toList()
+        wsUpsertWorkers.clear()
+        workersSnapshot.forEach { it.cancel() }
         _connectionState.value = WebSocketState.Disconnected
         Logger.i { "WebSocket disconnected" }
     }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
@@ -3,6 +3,7 @@ package id.homebase.api.client.websockets
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.SharedSecretEncryptedPayload
 import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.SystemDriveConstants
 import id.homebase.api.client.drives.TargetDrive
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
@@ -10,6 +11,7 @@ import id.homebase.api.common.SecureByteArray
 import id.homebase.api.crypto.AesCbc
 import id.homebase.api.crypto.ByteArrayUtil
 import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.sync.ChatDriveWebSocketUpsertWorker
 import id.homebase.api.sync.DriveSyncManager
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.MainIndexMetaHelpers
@@ -63,6 +65,12 @@ class OdinWebSocketClient(
     }
 
     private var fileHeaderProcessor = MainIndexMetaHelpers.HomebaseFileProcessor(databaseManager)
+
+    // Lazily initialised on the first [connectOnce] call once we have
+    // credentials. Receives WS-pushed file headers for the chat drive
+    // and writes them straight to DriveMainIndex without a Drive.sync()
+    // round-trip. Other drives stay on [driveSyncManager.syncDrive].
+    private var chatWsUpsertWorker: ChatDriveWebSocketUpsertWorker? = null
 
     private lateinit var sharedSecret: ByteArray
 
@@ -194,6 +202,19 @@ class OdinWebSocketClient(
         val identity = creds.domain
         sharedSecret = creds.sharedSecret.unsafeBytes
 
+        // Lazily build the chat-drive WS upsert worker once we know the
+        // identity. Idempotent across reconnects — the same worker drains
+        // future bursts. Cancelled in [disconnect].
+        if (chatWsUpsertWorker == null) {
+            chatWsUpsertWorker = ChatDriveWebSocketUpsertWorker(
+                identityId = creds.getIdentityId(),
+                driveId = SystemDriveConstants.chatDrive.alias,
+                databaseManager = databaseManager,
+                eventBus = eventBus,
+                scope = scope,
+            )
+        }
+
         _connectionState.value = WebSocketState.Connecting
 
         val wsUrl = "wss://${identity}/api/apps/v1/notify/ws"
@@ -271,6 +292,15 @@ class OdinWebSocketClient(
     }
 
     private suspend fun handleNotification(notification: ClientNotificationPayload) {
+        // TODO: remove before merge — Step 0 diagnostic for the
+        // websocket-pure-push-chat-drive PR. Captures the notification
+        // type for every WS message so we can confirm which types fire
+        // when (especially: does a reaction toggle also produce a
+        // fileModified, or only reactionContentAdded?).
+        Logger.d(tag = "WSDiag") {
+            "WS notification: type=${notification.notificationType}"
+        }
+
         notificationBufferMutex.withLock {
             notificationBuffer += notification
         }
@@ -462,8 +492,11 @@ class OdinWebSocketClient(
         val eventData = OdinSystemSerializer
             .deserialize<ClientReactionNotification>(notification.data)
         val driveId = eventData.fileId.driveId
+        Logger.i {
+            "WSFileEvent: syncDrive($driveId) for reaction event " +
+                "(isDeleted=$isDeleted, fileId=${eventData.fileId.fileId})"
+        }
         driveSyncManager.syncDrive(driveId)
-
     }
 
     private suspend fun handleAllReactionsDeletedEvent(notification: ClientNotificationPayload) {
@@ -471,62 +504,63 @@ class OdinWebSocketClient(
             OdinSystemSerializer.deserialize<InternalDriveFileId>(notification.data)
 
         try {
+            Logger.i { "WSFileEvent: syncDrive(${file.driveId}) for allReactionsByFileDeleted (fileId=${file.fileId})" }
             driveSyncManager.syncDrive(file.driveId)
         } catch (e: Exception) {
             Logger.e("handleAllReactionsDeletedEvent() probably used invalid driveId ${file.driveId} Exception:$e")
         }
     }
 
-
+    /**
+     * Dispatcher for `fileAdded` / `fileDeleted` / `fileModified` /
+     * `statisticsChanged` notifications.
+     *
+     * Chat drive: if the WS payload carries a header, decrypt it and
+     * submit to the [chatWsUpsertWorker] — no HTTP round-trip. The
+     * worker batches bursts of incoming files into one DB transaction
+     * and emits a single `BatchReceived(source = WebSocket)` event.
+     *
+     * Everything else (other drives, or chat-drive notifications with
+     * a null header, or any failure in the pure-push path) falls back
+     * to [DriveSyncManager.syncDrive]. The fallback is logged at INFO
+     * so we can monitor the rate in production — a steady stream for
+     * chat-drive notifications would mean the WS payload is missing
+     * headers somewhere we didn't expect.
+     */
     private suspend fun handleFileEvent(notification: ClientNotificationPayload) {
         val fileNotification =
             OdinSystemSerializer.deserialize<ClientDriveNotification>(notification.data)
         val driveId = fileNotification.targetDrive!!.alias
+        val header = fileNotification.header
 
+        if (driveId == SystemDriveConstants.chatDrive.alias && header != null) {
+            val worker = chatWsUpsertWorker
+            if (worker != null) {
+                try {
+                    val file = header.asHomebaseFile(SecureByteArray(sharedSecret))
+                    worker.submit(file)
+                    return
+                } catch (e: Exception) {
+                    Logger.w(e) {
+                        "WSFileEvent: pure-push path failed for chat drive " +
+                            "(notificationType=${notification.notificationType}); " +
+                            "falling back to syncDrive: ${e.message}"
+                    }
+                    // fall through
+                }
+            }
+        }
+
+        Logger.i {
+            "WSFileEvent: syncDrive($driveId) — " +
+                "notificationType=${notification.notificationType} " +
+                "headerPresent=${header != null} " +
+                "isChatDrive=${driveId == SystemDriveConstants.chatDrive.alias}"
+        }
         try {
             driveSyncManager.syncDrive(driveId)
         } catch (e: Exception) {
             Logger.e("handleFileEvent() probably used invalid driveId $driveId Exception:$e")
-        }
-    }
-
-
-    private suspend fun handleFileEvent_manual(notification: ClientNotificationPayload) {
-        val fileNotification =
-            OdinSystemSerializer.deserialize<ClientDriveNotification>(notification.data)
-
-        val header = fileNotification.header!!
-        val driveId = fileNotification.targetDrive!!.alias
-        val identityId = credentialsManager.getActiveCredentials()!!.getIdentityId()
-
-        val file = header.asHomebaseFile(SecureByteArray(sharedSecret))
-        val lastModified = file.fileMetadata.updated
-
-        val batch = listOf(file)
-        try {
-            fileHeaderProcessor.baseUpsertEntryZapZap(
-                identityId = identityId,
-                driveId = driveId,
-                fileHeaders = batch,
-                cursor = null
-            )
-        } catch (e: Exception) {
-            Logger.e("DB upsert failed for burst: ${e.message}")
-        }
-
-        eventBus.emit(
-            BackendEvent.DriveEvent.BatchReceived(
-                driveId = driveId,
-                totalCount = batch.size,
-                batchCount = batch.size,
-                latestModified = lastModified,
-                batchData = batch,
-                source = BackendEvent.SyncSource.WebSocket
-            )
-        )
-
-        Logger.i {
-            "Flushed ${batch.size} file events for drive $driveId"
         }
     }
 
@@ -568,6 +602,20 @@ class OdinWebSocketClient(
         pingSupervisor.start()
         onConnected()
         eventBus.emit(BackendEvent.ConnectionOnline)
+
+        // Catch-up backstop for the chat drive. Now that per-event
+        // file notifications take the pure-push path (no syncDrive),
+        // we still need to recover anything the server queued while
+        // the WS was disconnected. One targeted sync per (re)connect
+        // is enough — the dirty-bit gate downstream keeps it cheap
+        // when the round brings nothing relevant.
+        try {
+            driveSyncManager.syncDrive(SystemDriveConstants.chatDrive.alias)
+        } catch (e: Exception) {
+            Logger.w(e) {
+                "onHandshakeSuccess: chat-drive catch-up syncDrive failed: ${e.message}"
+            }
+        }
     }
 
     /**
@@ -580,6 +628,8 @@ class OdinWebSocketClient(
         session = null
         connectionJob?.cancel()
         connectionJob = null
+        chatWsUpsertWorker?.cancel()
+        chatWsUpsertWorker = null
         _connectionState.value = WebSocketState.Disconnected
         Logger.i { "WebSocket disconnected" }
     }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
@@ -292,15 +292,6 @@ class OdinWebSocketClient(
     }
 
     private suspend fun handleNotification(notification: ClientNotificationPayload) {
-        // TODO: remove before merge — Step 0 diagnostic for the
-        // websocket-pure-push-chat-drive PR. Captures the notification
-        // type for every WS message so we can confirm which types fire
-        // when (especially: does a reaction toggle also produce a
-        // fileModified, or only reactionContentAdded?).
-        Logger.d(tag = "WSDiag") {
-            "WS notification: type=${notification.notificationType}"
-        }
-
         notificationBufferMutex.withLock {
             notificationBuffer += notification
         }
@@ -485,6 +476,22 @@ class OdinWebSocketClient(
         // )
     }
 
+    /**
+     * Reaction add/remove notification.
+     *
+     * For the chat drive: no work is needed here. A `statisticsChanged`
+     * notification fires alongside this one carrying the updated file
+     * header (with the new `reactionPreview`), and that notification
+     * lands in [handleFileEvent] → the chat-drive pure-push path,
+     * which writes the new header to DriveMainIndex via the worker.
+     * Calling `syncDrive` here would refetch the same data via HTTP
+     * — pure redundant work. The per-user reaction details (who reacted
+     * with which emoji, used by the reaction-detail view) are fetched
+     * on-demand via `getReactions()` and don't ride on the WS at all.
+     *
+     * Other drives (e.g. feed) still need the syncDrive fallback —
+     * they don't have a per-event WS upsert worker yet.
+     */
     private suspend fun handleReactionEvent(
         notification: ClientNotificationPayload,
         isDeleted: Boolean
@@ -492,6 +499,11 @@ class OdinWebSocketClient(
         val eventData = OdinSystemSerializer
             .deserialize<ClientReactionNotification>(notification.data)
         val driveId = eventData.fileId.driveId
+
+        if (driveId == SystemDriveConstants.chatDrive.alias) {
+            return
+        }
+
         Logger.i {
             "WSFileEvent: syncDrive($driveId) for reaction event " +
                 "(isDeleted=$isDeleted, fileId=${eventData.fileId.fileId})"
@@ -499,9 +511,16 @@ class OdinWebSocketClient(
         driveSyncManager.syncDrive(driveId)
     }
 
+    /** All-reactions-cleared notification. Same chat-drive shortcut as
+     *  [handleReactionEvent] — `statisticsChanged` for the file already
+     *  rewrites `reactionPreview` to empty via the pure-push worker. */
     private suspend fun handleAllReactionsDeletedEvent(notification: ClientNotificationPayload) {
         val file =
             OdinSystemSerializer.deserialize<InternalDriveFileId>(notification.data)
+
+        if (file.driveId == SystemDriveConstants.chatDrive.alias) {
+            return
+        }
 
         try {
             Logger.i { "WSFileEvent: syncDrive(${file.driveId}) for allReactionsByFileDeleted (fileId=${file.fileId})" }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/ChatDriveWebSocketUpsertWorker.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/ChatDriveWebSocketUpsertWorker.kt
@@ -1,0 +1,151 @@
+package id.homebase.api.sync
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.client.eventbus.BackendEvent
+import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.sync.database.MainIndexMetaHelpers
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.time.measureTimedValue
+import kotlin.uuid.Uuid
+
+/**
+ * Receives decrypted [HomebaseFile] headers shipped on the WebSocket
+ * push channel and writes them straight to [DriveMainIndex] without
+ * going through HTTP `Drive.sync()`.
+ *
+ * Mirrors [DriveSync]'s job-serialization pattern (kept deliberately
+ * close so the two paths are easy to reason about side by side):
+ *  - [Mutex.tryLock] gives single-flight semantics — only one drain
+ *    runs at a time per worker.
+ *  - An atomic killroy bit captures "another file came in while we
+ *    were busy"; the `finally` block re-launches a drain if it's set,
+ *    exactly like [DriveSync.sync].
+ *  - Pending files accumulate in a small queue while a drain runs;
+ *    the next drain picks them up as one batch.
+ *
+ * Why batch: a peer sending several messages back-to-back produces
+ * several WS notifications in tight succession. Funnelling them into
+ * one [MainIndexMetaHelpers.HomebaseFileProcessor.baseUpsertEntryZapZap]
+ * call collapses N transactions into one — much faster, and matches
+ * the shape that DriveSync produces for its own batches.
+ *
+ * Scoped to one drive — currently only the chat drive uses this path.
+ * Other drives stay on [DriveSyncManager.syncDrive] for now; see
+ * `OdinWebSocketClient.handleFileEvent`.
+ *
+ * The WS path does NOT advance a sync cursor — that's [DriveSync]'s
+ * job. The per-reconnect `syncDrive(chatDrive)` in
+ * `OdinWebSocketClient.onHandshakeSuccess` is the catch-up backstop
+ * for anything missed during a transient disconnect.
+ */
+class ChatDriveWebSocketUpsertWorker(
+    private val identityId: Uuid,
+    private val driveId: Uuid,
+    databaseManager: DatabaseManager,
+    private val eventBus: EventBus,
+    scope: CoroutineScope? = null,
+) {
+    // Network/DB-bound work. Same dispatcher choice as DriveSync.
+    private val scope = scope ?: CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    private val mutex = Mutex()
+    private var job: Job? = null
+    private val killroy = atomic(false)
+
+    // Files awaiting drain. Producer ([submit]) adds; consumer
+    // ([drainOnce]) snapshots & clears under [pendingMutex].
+    private val pendingMutex = Mutex()
+    private val pendingFiles = ArrayList<HomebaseFile>()
+
+    private val fileHeaderProcessor =
+        MainIndexMetaHelpers.HomebaseFileProcessor(databaseManager)
+
+    /** Enqueue a decrypted file from a WS push and trigger a drain. */
+    suspend fun submit(file: HomebaseFile) {
+        pendingMutex.withLock { pendingFiles.add(file) }
+        run()
+    }
+
+    /**
+     * Single-flight launcher — mirrors [DriveSync.sync].
+     * Returns the in-flight [Job], or null if another drain was already
+     * running (in which case [killroy] flags it to recurse on finish).
+     */
+    private fun run(): Job? {
+        if (!mutex.tryLock()) {
+            killroy.value = true
+            return null
+        }
+        job = scope.launch {
+            try {
+                drainOnce()
+            } finally {
+                job = null
+                mutex.unlock()
+            }
+            if (killroy.value) {
+                Logger.i { "ChatDriveWS: killroy triggered recursive drain for drive $driveId" }
+                run()
+            }
+        }
+        return job
+    }
+
+    private suspend fun drainOnce() {
+        val batch: List<HomebaseFile> = pendingMutex.withLock {
+            killroy.value = false
+            if (pendingFiles.isEmpty()) return
+            val snapshot = pendingFiles.toList()
+            pendingFiles.clear()
+            snapshot
+        }
+
+        try {
+            val (_, upsertElapsed) = measureTimedValue {
+                fileHeaderProcessor.baseUpsertEntryZapZap(
+                    identityId = identityId,
+                    driveId = driveId,
+                    fileHeaders = batch,
+                    cursor = null,
+                )
+            }
+            Logger.i {
+                "ChatDriveWS: batch upsert drive=$driveId rows=${batch.size} took=$upsertElapsed"
+            }
+
+            eventBus.emit(
+                BackendEvent.DriveEvent.BatchReceived(
+                    driveId = driveId,
+                    totalCount = batch.size,
+                    batchCount = batch.size,
+                    latestModified = batch.last().fileMetadata.updated,
+                    batchData = batch,
+                    source = BackendEvent.SyncSource.WebSocket,
+                )
+            )
+        } catch (e: Exception) {
+            // The batch is dropped from the queue, but the next drive-sync
+            // round (cold-boot or the per-reconnect catch-up) will pick
+            // these files back up from the server cursor.
+            Logger.e(e) {
+                "ChatDriveWS: batch upsert FAILED for drive=$driveId rows=${batch.size}: ${e.message}"
+            }
+        }
+    }
+
+    /** Cancel the in-flight drain. Clears killroy so we don't relaunch
+     *  after cancellation. */
+    fun cancel() {
+        killroy.value = false
+        job?.cancel()
+    }
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveWebSocketUpsertWorker.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveWebSocketUpsertWorker.kt
@@ -22,6 +22,10 @@ import kotlin.uuid.Uuid
  * push channel and writes them straight to [DriveMainIndex] without
  * going through HTTP `Drive.sync()`.
  *
+ * One worker instance per drive. [OdinWebSocketClient] keeps a map
+ * of these and lazily creates entries on the first file event for
+ * each drive.
+ *
  * Mirrors [DriveSync]'s job-serialization pattern (kept deliberately
  * close so the two paths are easy to reason about side by side):
  *  - [Mutex.tryLock] gives single-flight semantics — only one drain
@@ -32,22 +36,18 @@ import kotlin.uuid.Uuid
  *  - Pending files accumulate in a small queue while a drain runs;
  *    the next drain picks them up as one batch.
  *
- * Why batch: a peer sending several messages back-to-back produces
+ * Why batch: a peer sending several files back-to-back produces
  * several WS notifications in tight succession. Funnelling them into
  * one [MainIndexMetaHelpers.HomebaseFileProcessor.baseUpsertEntryZapZap]
  * call collapses N transactions into one — much faster, and matches
  * the shape that DriveSync produces for its own batches.
  *
- * Scoped to one drive — currently only the chat drive uses this path.
- * Other drives stay on [DriveSyncManager.syncDrive] for now; see
- * `OdinWebSocketClient.handleFileEvent`.
- *
  * The WS path does NOT advance a sync cursor — that's [DriveSync]'s
- * job. The per-reconnect `syncDrive(chatDrive)` in
- * `OdinWebSocketClient.onHandshakeSuccess` is the catch-up backstop
- * for anything missed during a transient disconnect.
+ * job. The per-reconnect catch-up via
+ * `AuthConnectionCoordinator.onConnected → driveSyncManager.syncAll()`
+ * is the backstop for anything missed during a transient disconnect.
  */
-class ChatDriveWebSocketUpsertWorker(
+class DriveWebSocketUpsertWorker(
     private val identityId: Uuid,
     private val driveId: Uuid,
     databaseManager: DatabaseManager,
@@ -93,7 +93,7 @@ class ChatDriveWebSocketUpsertWorker(
                 mutex.unlock()
             }
             if (killroy.value) {
-                Logger.i { "ChatDriveWS: killroy triggered recursive drain for drive $driveId" }
+                Logger.i { "WSPush: killroy triggered recursive drain for drive $driveId" }
                 run()
             }
         }
@@ -109,6 +109,30 @@ class ChatDriveWebSocketUpsertWorker(
             snapshot
         }
 
+        // ╔════════════════════════════════════════════════════════════════╗
+        // ║  HACK detection — REMOVE ONCE THE SERVER STOPS FAN-OUT-PER-   ║
+        // ║  WRITE                                                         ║
+        // ║                                                                ║
+        // ║  TODO(server): the chat-drive WS currently emits N             ║
+        // ║  notifications (typically 3) per logical file write — same     ║
+        // ║  fileId, same versionTag, same content, just delivered         ║
+        // ║  multiple times. The DB upsert is idempotent so correctness    ║
+        // ║  isn't affected, but we redundantly decrypt + upsert. This     ║
+        // ║  warning is the canary so we don't forget to fix it on the    ║
+        // ║  backend.                                                      ║
+        // ║                                                                ║
+        // ║  When the server-side fix lands: delete this block.            ║
+        // ╚════════════════════════════════════════════════════════════════╝
+        val uniqueFileIds = batch.mapTo(HashSet()) { it.fileId }
+        if (uniqueFileIds.size != batch.size) {
+            Logger.w {
+                "WSPush: HACK detected ${batch.size - uniqueFileIds.size} duplicate file(s) " +
+                    "in batch drive=$driveId rows=${batch.size} unique=${uniqueFileIds.size} " +
+                    "(server fan-out workaround — same fileId delivered multiple times). " +
+                    "TODO(server): stop fan-out-per-write."
+            }
+        }
+
         try {
             val (_, upsertElapsed) = measureTimedValue {
                 fileHeaderProcessor.baseUpsertEntryZapZap(
@@ -119,7 +143,7 @@ class ChatDriveWebSocketUpsertWorker(
                 )
             }
             Logger.i {
-                "ChatDriveWS: batch upsert drive=$driveId rows=${batch.size} took=$upsertElapsed"
+                "WSPush: batch upsert drive=$driveId rows=${batch.size} took=$upsertElapsed"
             }
 
             eventBus.emit(
@@ -134,10 +158,10 @@ class ChatDriveWebSocketUpsertWorker(
             )
         } catch (e: Exception) {
             // The batch is dropped from the queue, but the next drive-sync
-            // round (cold-boot or the per-reconnect catch-up) will pick
-            // these files back up from the server cursor.
+            // round (cold-boot or the per-reconnect syncAll catch-up) will
+            // pick these files back up from the server cursor.
             Logger.e(e) {
-                "ChatDriveWS: batch upsert FAILED for drive=$driveId rows=${batch.size}: ${e.message}"
+                "WSPush: batch upsert FAILED for drive=$driveId rows=${batch.size}: ${e.message}"
             }
         }
     }

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveWebSocketUpsertWorkerTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveWebSocketUpsertWorkerTest.kt
@@ -1,0 +1,390 @@
+package id.homebase.api.sync
+
+import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.client.eventbus.BackendEvent
+import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.sync.database.createInMemoryDatabase
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
+import kotlin.uuid.Uuid
+
+/**
+ * Locks down [DriveWebSocketUpsertWorker]'s contract:
+ *  - one batch upsert per drain (queue + single-flight Mutex),
+ *  - a [BackendEvent.DriveEvent.BatchReceived] with
+ *    `source = SyncSource.WebSocket` per drain,
+ *  - works for any drive id (not just chat),
+ *  - cancel() prevents pending work.
+ *
+ * Uses [runBlocking] with real dispatchers (the worker's
+ * [SupervisorJob] + [Dispatchers.Default] default) — this exercises
+ * the actual concurrency the worker is built for. Tests poll for
+ * expected events with bounded timeouts so they're deterministic.
+ */
+class DriveWebSocketUpsertWorkerTest {
+
+    private lateinit var db: DatabaseManager
+    private lateinit var workerScope: CoroutineScope
+
+    @BeforeTest
+    fun setUp() {
+        db = DatabaseManager({ createInMemoryDatabase() })
+        workerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        workerScope.cancel()
+        db.close()
+    }
+
+    @Test
+    fun submit_singleFile_persistsRowAndEmitsBatchReceived() = runBlocking {
+        val identityId = Uuid.random()
+        val driveId = Uuid.random()
+        val eventBus = EventBus()
+
+        val firstBatch = CompletableDeferred<BackendEvent.DriveEvent.BatchReceived>()
+        val collector = launch {
+            eventBus.events.collect { event ->
+                if (event is BackendEvent.DriveEvent.BatchReceived) {
+                    firstBatch.complete(event)
+                }
+            }
+        }
+
+        val worker = DriveWebSocketUpsertWorker(
+            identityId = identityId,
+            driveId = driveId,
+            databaseManager = db,
+            eventBus = eventBus,
+            scope = workerScope,
+        )
+
+        val fileId = Uuid.random()
+        val file = makeFile(fileId = fileId, driveId = driveId)
+
+        worker.submit(file)
+
+        val batch = withTimeoutOrNull(5.seconds) { firstBatch.await() }
+        assertNotNull(batch, "no BatchReceived event observed within timeout")
+
+        val stored = db.driveMainIndex.selectByIdentityAndDriveAndFile(
+            identityId = identityId, driveId = driveId, fileId = fileId
+        )
+        assertNotNull(stored, "expected DriveMainIndex row to be present")
+
+        assertEquals(driveId, batch.driveId)
+        assertEquals(1, batch.batchData.size)
+        assertEquals(fileId, batch.batchData.first().fileId)
+
+        collector.cancel()
+    }
+
+    @Test
+    fun submit_burst_batchesIntoSingleDrain() = runBlocking {
+        val identityId = Uuid.random()
+        val driveId = Uuid.random()
+        val eventBus = EventBus()
+
+        val collected = mutableListOf<BackendEvent.DriveEvent.BatchReceived>()
+        val collector = launch {
+            eventBus.events.collect { event ->
+                if (event is BackendEvent.DriveEvent.BatchReceived) collected.add(event)
+            }
+        }
+        // Give the collector a tick to subscribe.
+        delay(20)
+
+        val worker = DriveWebSocketUpsertWorker(
+            identityId = identityId,
+            driveId = driveId,
+            databaseManager = db,
+            eventBus = eventBus,
+            scope = workerScope,
+        )
+
+        val files = (1..5).map { makeFile(fileId = Uuid.random(), driveId = driveId) }
+        // Submit all 5 inside a single coroutine. The first submit's
+        // run() launches the drain; submits 2..5 see mutex held and
+        // set killroy. By the time the drain runs, all 5 are in the
+        // queue → ONE BatchReceived with 5 files.
+        for (f in files) worker.submit(f)
+
+        // Wait for at least one batch, then a brief settle period.
+        withTimeoutOrNull(5.seconds) {
+            while (collected.isEmpty()) delay(20)
+        }
+        delay(100)
+
+        assertEquals(
+            1, collected.size,
+            "burst of 5 submits should drain into ONE batch (got ${collected.size})"
+        )
+        assertEquals(5, collected.first().batchData.size)
+
+        for (f in files) {
+            val row = db.driveMainIndex.selectByIdentityAndDriveAndFile(
+                identityId = identityId, driveId = driveId, fileId = f.fileId
+            )
+            assertNotNull(row, "missing row for fileId=${f.fileId}")
+        }
+
+        collector.cancel()
+    }
+
+    @Test
+    fun emit_carriesWebSocketSource() = runBlocking {
+        val identityId = Uuid.random()
+        val driveId = Uuid.random()
+        val eventBus = EventBus()
+
+        val firstBatch = CompletableDeferred<BackendEvent.DriveEvent.BatchReceived>()
+        val collector = launch {
+            eventBus.events.collect { event ->
+                if (event is BackendEvent.DriveEvent.BatchReceived) firstBatch.complete(event)
+            }
+        }
+
+        val worker = DriveWebSocketUpsertWorker(
+            identityId = identityId,
+            driveId = driveId,
+            databaseManager = db,
+            eventBus = eventBus,
+            scope = workerScope,
+        )
+
+        worker.submit(makeFile(fileId = Uuid.random(), driveId = driveId))
+
+        val batch = withTimeoutOrNull(5.seconds) { firstBatch.await() }
+        assertNotNull(batch)
+        assertEquals(
+            BackendEvent.SyncSource.WebSocket, batch.source,
+            "downstream consumers (dirty-bit gating) branch on this field; " +
+                "WebSocket source must be set"
+        )
+
+        collector.cancel()
+    }
+
+    @Test
+    fun submit_isDriveAgnostic() = runBlocking {
+        val identityId = Uuid.random()
+        val driveAlpha = Uuid.random()
+        val driveBeta = Uuid.random()
+        val eventBus = EventBus()
+
+        val collected = mutableListOf<BackendEvent.DriveEvent.BatchReceived>()
+        val collector = launch {
+            eventBus.events.collect { event ->
+                if (event is BackendEvent.DriveEvent.BatchReceived) collected.add(event)
+            }
+        }
+        delay(20)
+
+        val workerA = DriveWebSocketUpsertWorker(
+            identityId = identityId,
+            driveId = driveAlpha,
+            databaseManager = db,
+            eventBus = eventBus,
+            scope = workerScope,
+        )
+        val workerB = DriveWebSocketUpsertWorker(
+            identityId = identityId,
+            driveId = driveBeta,
+            databaseManager = db,
+            eventBus = eventBus,
+            scope = workerScope,
+        )
+
+        val fileA = makeFile(fileId = Uuid.random(), driveId = driveAlpha)
+        val fileB = makeFile(fileId = Uuid.random(), driveId = driveBeta)
+
+        workerA.submit(fileA)
+        workerB.submit(fileB)
+
+        withTimeoutOrNull(5.seconds) {
+            while (collected.size < 2) delay(20)
+        }
+        delay(100)
+
+        assertNotNull(
+            db.driveMainIndex.selectByIdentityAndDriveAndFile(identityId, driveAlpha, fileA.fileId)
+        )
+        assertNotNull(
+            db.driveMainIndex.selectByIdentityAndDriveAndFile(identityId, driveBeta, fileB.fileId)
+        )
+
+        val byDrive = collected.groupBy { it.driveId }
+        assertEquals(setOf(driveAlpha, driveBeta), byDrive.keys)
+        assertEquals(1, byDrive[driveAlpha]?.size)
+        assertEquals(1, byDrive[driveBeta]?.size)
+        assertEquals(fileA.fileId, byDrive[driveAlpha]?.first()?.batchData?.first()?.fileId)
+        assertEquals(fileB.fileId, byDrive[driveBeta]?.first()?.batchData?.first()?.fileId)
+
+        collector.cancel()
+    }
+
+    @Test
+    fun submit_sequential_emitsTwoBatches() = runBlocking {
+        // Sanity check: back-to-back submit+settle cycles drain
+        // independently. Distinct from the batched-burst case because
+        // the mutex is fully released between them.
+        val identityId = Uuid.random()
+        val driveId = Uuid.random()
+        val eventBus = EventBus()
+
+        val collected = mutableListOf<BackendEvent.DriveEvent.BatchReceived>()
+        val collector = launch {
+            eventBus.events.collect { event ->
+                if (event is BackendEvent.DriveEvent.BatchReceived) collected.add(event)
+            }
+        }
+        delay(20)
+
+        val worker = DriveWebSocketUpsertWorker(
+            identityId = identityId,
+            driveId = driveId,
+            databaseManager = db,
+            eventBus = eventBus,
+            scope = workerScope,
+        )
+
+        worker.submit(makeFile(fileId = Uuid.random(), driveId = driveId))
+        withTimeoutOrNull(5.seconds) {
+            while (collected.isEmpty()) delay(20)
+        }
+
+        worker.submit(makeFile(fileId = Uuid.random(), driveId = driveId))
+        withTimeoutOrNull(5.seconds) {
+            while (collected.size < 2) delay(20)
+        }
+        delay(100)
+
+        assertEquals(2, collected.size)
+        assertEquals(1, collected[0].batchData.size)
+        assertEquals(1, collected[1].batchData.size)
+
+        collector.cancel()
+    }
+
+    @Test
+    fun cancel_doesNotProduceMoreThanOneBatch() = runBlocking {
+        val identityId = Uuid.random()
+        val driveId = Uuid.random()
+        val eventBus = EventBus()
+
+        val collected = mutableListOf<BackendEvent.DriveEvent.BatchReceived>()
+        val collector = launch {
+            eventBus.events.collect { event ->
+                if (event is BackendEvent.DriveEvent.BatchReceived) collected.add(event)
+            }
+        }
+        delay(20)
+
+        val worker = DriveWebSocketUpsertWorker(
+            identityId = identityId,
+            driveId = driveId,
+            databaseManager = db,
+            eventBus = eventBus,
+            scope = workerScope,
+        )
+
+        worker.submit(makeFile(fileId = Uuid.random(), driveId = driveId))
+        worker.cancel()
+        delay(200) // give any in-flight drain a chance to either complete or abort
+
+        assertTrue(
+            collected.size <= 1,
+            "cancel must not produce more than one BatchReceived (got ${collected.size})"
+        )
+
+        collector.cancel()
+    }
+
+    /**
+     * Build a minimal [HomebaseFile] from a JSON template that satisfies
+     * `baseUpsertEntryZapZap`'s SQL constraints. Same shape as
+     * [id.homebase.api.sync.database.MainIndexMetaTest]'s fixture.
+     */
+    private fun makeFile(
+        fileId: Uuid,
+        driveId: Uuid,
+        uniqueId: Uuid = Uuid.random(),
+    ): HomebaseFile {
+        val now = Clock.System.now().epochSeconds
+        val json = """{
+            "fileId": "$fileId",
+            "driveId": "$driveId",
+            "fileState": "active",
+            "fileSystemType": "standard",
+            "serverFileIsEncrypted": "true",
+            "keyHeader": {
+                "iv": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+                "aesKey": {"bytes": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}
+            },
+            "fileMetadata": {
+                "globalTransitId": "${Uuid.random()}",
+                "created": ${now}000,
+                "updated": ${now}000,
+                "transitCreated": 0,
+                "transitUpdated": 0,
+                "serverFileIsEncrypted": true,
+                "senderOdinId": "test.sender",
+                "originalAuthor": "test.sender",
+                "appData": {
+                    "uniqueId": "$uniqueId",
+                    "tags": null,
+                    "fileType": 1,
+                    "dataType": 1,
+                    "groupId": null,
+                    "userDate": ${now}000,
+                    "content": "x",
+                    "previewThumbnail": null,
+                    "archivalStatus": 0
+                },
+                "localAppData": null,
+                "referencedFile": null,
+                "reactionPreview": null,
+                "versionTag": "${Uuid.random()}",
+                "payloads": [],
+                "dataSource": null
+            },
+            "serverMetadata": {
+                "accessControlList": {
+                    "requiredSecurityGroup": "owner",
+                    "circleIdList": null,
+                    "odinIdList": null
+                },
+                "doNotIndex": false,
+                "allowDistribution": false,
+                "fileSystemType": "standard",
+                "fileByteCount": 100,
+                "originalRecipientCount": 0,
+                "transferHistory": null
+            },
+            "priority": 100,
+            "fileByteCount": 100
+        }"""
+        return OdinSystemSerializer.deserialize<HomebaseFile>(json)
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMessageBump.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMessageBump.kt
@@ -12,16 +12,26 @@ import kotlin.uuid.Uuid
  * in-memory conversation list.
  *
  * Returns `null` when the message doesn't require a UI change (the
- * targeted conversation isn't in the list, or the message is older
- * than the current `latestMessageTimestamp`). Returns the new list
- * otherwise.
+ * targeted conversation isn't in the list, or the message's
+ * `userDate` is not strictly newer than the conversation's current
+ * `latestMessageTimestamp`). Returns the new list otherwise.
  *
- * Why this is its own function: the equivalent logic used to delegate
- * to [ConversationStream.updateConversation], which silently drops
- * `unreadCount` because it's designed for whole-file refreshes (those
- * always carry `incoming.unreadCount = 0` from the mapper). Going
- * through that helper masked the unread bump and the bug only
- * surfaced once the dirty-bit gating tightened the
+ * The strict `>` (rather than `>=`) check is the guard against
+ * reaction-driven re-emits. When someone reacts to a message, the
+ * server pushes the modified message file (with the new
+ * `reactionPreview` baked into the header) over the WS. That
+ * re-emit has the SAME `userDate` as the original message
+ * (`userDate` is the message's authored time — reactions don't
+ * change it), so a `>=` check would incorrectly bump unread every
+ * time anyone reacts. Strict `>` rejects re-emits and only accepts
+ * messages with a newer `userDate` than the conversation has seen.
+ *
+ * Why this is its own function: the equivalent logic used to
+ * delegate to [ConversationStream.updateConversation], which
+ * silently drops `unreadCount` because it's designed for whole-file
+ * refreshes (those always carry `incoming.unreadCount = 0` from the
+ * mapper). Going through that helper masked the unread bump and
+ * the bug only surfaced once the dirty-bit gating tightened the
  * `enrichAllConversationsWithUnreadCounts` cadence so the in-memory
  * `++` stopped being constantly overwritten by a fresh DB recount.
  *
@@ -62,7 +72,9 @@ internal fun applyIncomingMessageBump(
     var didChange = false
     val updated = items.map { existing ->
         if (existing.id != targetConversationId) return@map existing
-        if (sqlUserDate < existing.latestMessageTimestamp) return@map existing
+        // Strict > so reaction-driven re-emits (which carry the same
+        // userDate as the original message) don't bump unread.
+        if (sqlUserDate <= existing.latestMessageTimestamp) return@map existing
         didChange = true
         existing.copy(
             unreadCount = existing.unreadCount + increment,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMessageBump.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMessageBump.kt
@@ -1,0 +1,79 @@
+package id.homebase.chat.services.convo
+
+import id.homebase.api.common.OdinId
+import id.homebase.api.util.truncateToCodePoints
+import id.homebase.chat.data.ConversationUiModel
+import id.homebase.chat.data.MessageUiModel
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * Pure function that applies one incoming chat-message arrival to the
+ * in-memory conversation list.
+ *
+ * Returns `null` when the message doesn't require a UI change (the
+ * targeted conversation isn't in the list, or the message is older
+ * than the current `latestMessageTimestamp`). Returns the new list
+ * otherwise.
+ *
+ * Why this is its own function: the equivalent logic used to delegate
+ * to [ConversationStream.updateConversation], which silently drops
+ * `unreadCount` because it's designed for whole-file refreshes (those
+ * always carry `incoming.unreadCount = 0` from the mapper). Going
+ * through that helper masked the unread bump and the bug only
+ * surfaced once the dirty-bit gating tightened the
+ * `enrichAllConversationsWithUnreadCounts` cadence so the in-memory
+ * `++` stopped being constantly overwritten by a fresh DB recount.
+ *
+ * Extracting the bump as a pure function makes the unread-count
+ * accumulation testable in isolation (no DB, no Koin, no
+ * coroutines). See `ConversationMessageBumpTest`.
+ *
+ * The map callback reads `existing` (live state) instead of any
+ * captured-from-caller snapshot so consecutive bumps for the same
+ * conversation in one batch are additive — the caller's loop applies
+ * messages one at a time, and each call sees the previous call's
+ * write through the returned list.
+ *
+ * @param items                  the current in-memory list.
+ * @param targetConversationId   the conversation [m] belongs to.
+ * @param m                      the incoming message (already mapped).
+ * @param sqlUserDate            authoritative `DriveMainIndex.userDate`
+ *                               for the message file. Used as the
+ *                               source of truth for the conversation's
+ *                               `latestMessageTimestamp` so it stays in
+ *                               lock-step with `selectAllUnreadCount`.
+ * @param activeDomain           the local identity, for the
+ *                               not-authored-by-self test that gates
+ *                               the unread bump.
+ * @return                       the new list, or null if the message
+ *                               doesn't trigger a change.
+ */
+internal fun applyIncomingMessageBump(
+    items: List<ConversationUiModel>,
+    targetConversationId: Uuid,
+    m: MessageUiModel,
+    sqlUserDate: Instant,
+    activeDomain: OdinId?,
+): List<ConversationUiModel>? {
+    val increment =
+        if (!m.isEdited && !m.isAuthoredBy(activeDomain) && !m.isStatusMessage) 1 else 0
+
+    var didChange = false
+    val updated = items.map { existing ->
+        if (existing.id != targetConversationId) return@map existing
+        if (sqlUserDate < existing.latestMessageTimestamp) return@map existing
+        didChange = true
+        existing.copy(
+            unreadCount = existing.unreadCount + increment,
+            latestMessageTimestamp = sqlUserDate,
+            lastMessage = m.content.truncateToCodePoints(40),
+            lastMessageDeliveryStatus = m.messageAppData.deliveryStatus,
+            lastMessageIsDeleted = m.isDeleted,
+            lastMessageFirstPayload = m.payloads?.firstOrNull(),
+            lastMessageHasMultiplePayloads = (m.payloads?.size ?: 0) > 1,
+            lastMessageIsFromActiveUser = m.isAuthoredBy(activeDomain),
+        )
+    }
+    return if (didChange) updated else null
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -312,7 +312,44 @@ class ConversationStream(
         if (messageFiles.size != incoming.size)
             Logger.w("ConversationStream: ${messageFiles.size - incoming.size} of ${messageFiles.size} messages failed to convert")
 
-        for ((file, m) in incoming) {
+        // ╔══════════════════════════════════════════════════════════════╗
+        // ║  HACK ── REMOVE ONCE THE SERVER STOPS FAN-OUT-PER-WRITE      ║
+        // ║                                                              ║
+        // ║  TODO(server): the chat-drive WS currently emits N           ║
+        // ║  notifications (typically 3) per logical file write — same   ║
+        // ║  uniqueId, same versionTag, same content, just delivered     ║
+        // ║  multiple times. Suspected cause: multi-stage server-side    ║
+        // ║  processing or duplicated subscription registration.         ║
+        // ║                                                              ║
+        // ║  Downstream caches dedupe naturally:                         ║
+        // ║    • [DriveMainIndex] upsert is idempotent on uniqueId.      ║
+        // ║    • [ActiveConversationState.upsertMessages] collapses by   ║
+        // ║      `m.id`.                                                 ║
+        // ║                                                              ║
+        // ║  But the per-message side effects in this loop (unread bump  ║
+        // ║  via [applyIncomingMessageBump], orphan placeholder, deleted-║
+        // ║  conversation revive, auto-unarchive) would otherwise fire   ║
+        // ║  N times per logical message — N-x over-counting unread      ║
+        // ║  observable in homebase.log as repeated `unread++` lines all ║
+        // ║  carrying the same convo id within a millisecond.            ║
+        // ║                                                              ║
+        // ║  Until the server is fixed, we collapse the batch by         ║
+        // ║  message id here. `associateBy` keeps the LAST occurrence on ║
+        // ║  key collision, which gives us the latest wire state.        ║
+        // ║                                                              ║
+        // ║  When the server-side fix lands: delete this block and the   ║
+        // ║  loop should iterate `incoming` directly.                    ║
+        // ╚══════════════════════════════════════════════════════════════╝
+        val deduped = incoming.associateBy { (_, m) -> m.id }.values.toList()
+        if (deduped.size != incoming.size) {
+            Logger.w(
+                "ConversationStream: HACK dedupe — dropped ${incoming.size - deduped.size} " +
+                    "duplicate message file(s) from batch (server fan-out workaround; " +
+                    "kept ${deduped.size} unique by id)"
+            )
+        }
+
+        for ((file, m) in deduped) {
             val matchingConversation = _conversations.value.items.find { it.id == m.conversationId }
 
             // Drop messages for conversations the user has left or been removed from
@@ -456,6 +493,21 @@ class ConversationStream(
      *   conversation's `latestMessageTimestamp` so it stays in lock-step with
      *   `selectAllUnreadCount`. The clamped `m.userDate` is correct for
      *   display but can underrun the SQL value.
+     *
+     * Writes the message-preview fields and the bumped [unreadCount]
+     * directly to [_conversations]. Does NOT route through
+     * [updateConversation] — that helper is designed for whole-file
+     * refreshes and explicitly preserves `existing.unreadCount` (because
+     * incoming-from-file always maps with `unreadCount=0`). Routing this
+     * path through it silently drops the bump; the bug was masked while
+     * `Stopped` always re-ran [enrichAllConversationsWithUnreadCounts]
+     * but is no longer masked now that the dirty-bit gates the post-sync
+     * recount.
+     *
+     * The map callback reads `existing` (live state) instead of the
+     * captured `c` parameter so consecutive bumps for the same
+     * conversation in one batch are additive — each iteration of the
+     * caller's loop sees the previous iteration's write.
      */
     private suspend fun updateConversationFromNewMessage(
         c: ConversationUiModel,
@@ -463,27 +515,27 @@ class ConversationStream(
         sqlUserDateMs: Long,
     ) {
         val sqlUserDate = Instant.fromEpochMilliseconds(sqlUserDateMs)
-        if (sqlUserDate >= c.latestMessageTimestamp) {
-            val domain = credentialsManager.getActiveDomain()
+        val domain = credentialsManager.getActiveDomain()
 
-            val increment =
-                if (!m.isEdited && !m.isAuthoredBy(domain) && !m.isStatusMessage) 1 else 0
-            if (increment > 0) {
-                Logger.d("ConversationStream: unread++ convo=${c.id} count=${c.unreadCount + increment}")
-            }
+        val current = _conversations.value
+        val updated = applyIncomingMessageBump(
+            items = current.items,
+            targetConversationId = c.id,
+            m = m,
+            sqlUserDate = sqlUserDate,
+            activeDomain = domain,
+        ) ?: return
 
-            val updatedConversation = c.copy(
-                unreadCount = c.unreadCount + increment,
-                latestMessageTimestamp = sqlUserDate,
-                lastMessage = m.content.truncateToCodePoints(40), // TODO: Global constant
-                lastMessageDeliveryStatus = m.messageAppData.deliveryStatus,
-                lastMessageIsDeleted = m.isDeleted,
-                lastMessageFirstPayload = m.payloads?.firstOrNull(),
-                lastMessageHasMultiplePayloads = (m.payloads?.size ?: 0) > 1,
-                lastMessageIsFromActiveUser = m.isAuthoredBy(credentialsManager.getActiveDomain()),
-            )
-            updateConversation(c, updatedConversation)
+        // Log the unread bump for the touched conversation, if any. We
+        // diff before-vs-after rather than recomputing the increment
+        // here so the log never disagrees with the persisted state.
+        val before = current.items.firstOrNull { it.id == c.id }
+        val after = updated.firstOrNull { it.id == c.id }
+        if (before != null && after != null && after.unreadCount > before.unreadCount) {
+            Logger.d("ConversationStream: unread++ convo=${c.id} count=${after.unreadCount}")
         }
+
+        _conversations.value = current.copy(items = updated)
     }
 
     override suspend fun loadConversation(conversationId: Uuid) {

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationMessageBumpTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationMessageBumpTest.kt
@@ -217,6 +217,80 @@ class ConversationMessageBumpTest {
         assertNull(updated)
     }
 
+    /**
+     * Regression guard for the reaction-echo bug observed in homebase.log
+     * around 18:15:21 (commit b7aa8809 build): when someone reacts to a
+     * message, the server pushes the modified message file (with updated
+     * `reactionPreview`) over the WS. That re-emit has the SAME
+     * `userDate` as the original message (userDate is the authored
+     * time — reactions don't change it). Pre-fix: the `<` guard let
+     * the re-emit through and bumped unread on every reaction. Post-fix:
+     * the `<=` guard rejects re-emits.
+     */
+    @Test
+    fun reactionEcho_sameUserDate_returnsNull_noUnreadBump() {
+        // Convo's latestMessageTimestamp was set to T by the original
+        // peer message arrival. The reaction echo carries the same T.
+        val originalUserDateMs = 1_777_000_000_000L
+        val items = listOf(convo(latestMs = originalUserDateMs, unread = 1))
+        val msg = message(author = alice, userDateMs = originalUserDateMs)
+
+        val updated = applyIncomingMessageBump(
+            items = items,
+            targetConversationId = convoId,
+            m = msg,
+            sqlUserDate = Instant.fromEpochMilliseconds(originalUserDateMs),
+            activeDomain = me,
+        )
+
+        assertNull(
+            updated,
+            "reaction-driven re-emit (same userDate as conversation's latestMessageTimestamp) " +
+                "must not bump unread",
+        )
+    }
+
+    /**
+     * Full reaction-echo lifecycle: a peer message arrives (bump 0→1),
+     * then several reaction echoes arrive carrying the same userDate
+     * (because reactions don't advance userDate). Unread count must
+     * stay at 1, not climb to 2/3/4.
+     */
+    @Test
+    fun peerMessageThenReactionEchoes_doesNotMultiplyUnread() {
+        var items: List<ConversationUiModel> = listOf(convo(unread = 0))
+        val originalUserDateMs = 1_777_000_000_000L
+
+        // Initial peer message arrival.
+        val originalMsg = message(author = alice, userDateMs = originalUserDateMs)
+        val afterArrival = applyIncomingMessageBump(
+            items = items,
+            targetConversationId = convoId,
+            m = originalMsg,
+            sqlUserDate = Instant.fromEpochMilliseconds(originalUserDateMs),
+            activeDomain = me,
+        )
+        assertNotNull(afterArrival)
+        items = afterArrival
+        assertEquals(1, items.first().unreadCount)
+
+        // Three reaction-driven re-emits (server fan-out for one reaction).
+        // Each carries the same userDate. None should bump.
+        for (i in 1..3) {
+            val echo = message(author = alice, userDateMs = originalUserDateMs)
+            val result = applyIncomingMessageBump(
+                items = items,
+                targetConversationId = convoId,
+                m = echo,
+                sqlUserDate = Instant.fromEpochMilliseconds(originalUserDateMs),
+                activeDomain = me,
+            )
+            assertNull(result, "echo #$i must not produce a list change")
+        }
+
+        assertEquals(1, items.first().unreadCount, "unread must stay at 1 after reaction echoes")
+    }
+
     @Test
     fun messageForUnknownConversation_returnsNull() {
         val items = listOf(convo())

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationMessageBumpTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationMessageBumpTest.kt
@@ -1,0 +1,259 @@
+package id.homebase.chat.services.convo
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.time.UnixTimeUtc
+import id.homebase.chat.data.ConversationState
+import id.homebase.chat.data.ConversationUiModel
+import id.homebase.chat.data.MessageUiModel
+import id.homebase.chat.services.MessageAppData
+import id.homebase.core.avatars.ConversationAvatarModel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * Locks down the unread-count bump path that lives in
+ * [applyIncomingMessageBump].
+ *
+ * The regression this exists to guard against:
+ * [ConversationStream.updateConversationFromNewMessage] used to delegate
+ * to [ConversationStream.updateConversation] for the bump, but that
+ * helper is shaped for whole-file refreshes and explicitly preserves
+ * `existing.unreadCount` (because incoming-from-file always maps with
+ * `unreadCount = 0`). The bug was masked while
+ * `enrichAllConversationsWithUnreadCounts` ran on every `Stopped`, but
+ * surfaced once the dirty-bit gating tightened that cadence — peer
+ * messages would log `unread++ count=N` per arrival but the count
+ * never actually persisted, freezing at whatever value the last
+ * recount-from-DB landed.
+ *
+ * The most important test in this file is
+ * [sequentialPeerMessages_accumulateUnread] — three pure
+ * `applyIncomingMessageBump` calls in a row must yield unreadCount=3,
+ * not 1.
+ */
+class ConversationMessageBumpTest {
+
+    private val me = OdinId("owner.test")
+    private val alice = OdinId("alice.test")
+    private val convoId = Uuid.parse("11111111-1111-1111-1111-111111111111")
+    private val otherConvoId = Uuid.parse("22222222-2222-2222-2222-222222222222")
+
+    private fun convo(
+        id: Uuid = convoId,
+        latestMs: Long = 0L,
+        unread: Int = 0,
+    ) = ConversationUiModel(
+        id = id,
+        name = "alice",
+        lastMessage = "",
+        latestMessageTimestamp = Instant.fromEpochMilliseconds(latestMs),
+        unreadCount = unread,
+        avatarInitials = "",
+        avatarUrl = "",
+        avatarTiny = null,
+        participants = listOf(me, alice),
+        lastRead = Instant.fromEpochMilliseconds(0),
+        avatarModel = ConversationAvatarModel(
+            type = ConversationAvatarModel.Type.Connection,
+            odinId = alice,
+        ),
+        admins = emptySet(),
+        conversationState = ConversationState.Active,
+        isGroup = false,
+    )
+
+    private fun message(
+        author: OdinId,
+        userDateMs: Long,
+        content: String = "hi",
+        isEdited: Boolean = false,
+        isStatusMessage: Boolean = false,
+    ) = MessageUiModel(
+        id = Uuid.random(),
+        globalTransitId = null,
+        fileId = Uuid.random(),
+        conversationId = convoId,
+        content = content,
+        userDate = Instant.fromEpochMilliseconds(userDateMs),
+        modified = null,
+        created = Instant.fromEpochMilliseconds(userDateMs),
+        originalAuthor = author,
+        sender = author,
+        displayName = author.domainName,
+        localReadTimestamp = null as UnixTimeUtc?,
+        isEdited = isEdited,
+        isDeleted = false,
+        isPendingSend = false,
+        isStatusMessage = isStatusMessage,
+        versionTag = Uuid.NIL,
+        messageAppData = MessageAppData(),
+        reactionPreview = null,
+        previewThumbnail = null,
+        payloads = null,
+        keyHeader = KeyHeader.empty(),
+        hasMore = false,
+    )
+
+    @Test
+    fun peerMessage_bumpsUnreadAndUpdatesPreview() {
+        val items = listOf(convo(unread = 0))
+        val msg = message(author = alice, userDateMs = 1_000L, content = "hello")
+
+        val updated = applyIncomingMessageBump(
+            items = items,
+            targetConversationId = convoId,
+            m = msg,
+            sqlUserDate = Instant.fromEpochMilliseconds(1_000L),
+            activeDomain = me,
+        )
+
+        assertNotNull(updated)
+        val convo = updated.first()
+        assertEquals(1, convo.unreadCount)
+        assertEquals("hello", convo.lastMessage)
+        assertEquals(1_000L, convo.latestMessageTimestamp.toEpochMilliseconds())
+        assertEquals(false, convo.lastMessageIsFromActiveUser)
+    }
+
+    /**
+     * THE regression guard for the bug we just fixed. Three peer messages
+     * in sequence (one [applyIncomingMessageBump] call per message,
+     * threading the returned list into the next call) must accumulate
+     * unread count to 3. The pre-fix code went 0 → 1 → 1 → 1 because
+     * `updateConversation` silently dropped each freshly-computed
+     * `unreadCount`.
+     */
+    @Test
+    fun sequentialPeerMessages_accumulateUnread() {
+        var items: List<ConversationUiModel> = listOf(convo(unread = 0))
+        for (i in 1..3) {
+            val msg = message(author = alice, userDateMs = i * 1_000L, content = "msg-$i")
+            val next = applyIncomingMessageBump(
+                items = items,
+                targetConversationId = convoId,
+                m = msg,
+                sqlUserDate = Instant.fromEpochMilliseconds(i * 1_000L),
+                activeDomain = me,
+            )
+            assertNotNull(next, "iteration $i should produce a list change")
+            items = next
+        }
+        assertEquals(3, items.first().unreadCount)
+    }
+
+    @Test
+    fun selfMessage_doesNotBumpUnread_butStillUpdatesPreview() {
+        val items = listOf(convo(unread = 0))
+        val msg = message(author = me, userDateMs = 1_000L, content = "my own message")
+
+        val updated = applyIncomingMessageBump(
+            items = items,
+            targetConversationId = convoId,
+            m = msg,
+            sqlUserDate = Instant.fromEpochMilliseconds(1_000L),
+            activeDomain = me,
+        )
+
+        assertNotNull(updated)
+        val convo = updated.first()
+        assertEquals(0, convo.unreadCount)
+        assertEquals("my own message", convo.lastMessage)
+        assertEquals(true, convo.lastMessageIsFromActiveUser)
+    }
+
+    @Test
+    fun editedPeerMessage_doesNotBumpUnread() {
+        val items = listOf(convo(unread = 5))
+        val msg = message(author = alice, userDateMs = 1_000L, isEdited = true)
+
+        val updated = applyIncomingMessageBump(
+            items = items,
+            targetConversationId = convoId,
+            m = msg,
+            sqlUserDate = Instant.fromEpochMilliseconds(1_000L),
+            activeDomain = me,
+        )
+
+        assertNotNull(updated)
+        assertEquals(5, updated.first().unreadCount)
+    }
+
+    @Test
+    fun statusMessage_doesNotBumpUnread() {
+        val items = listOf(convo(unread = 5))
+        val msg = message(author = alice, userDateMs = 1_000L, isStatusMessage = true)
+
+        val updated = applyIncomingMessageBump(
+            items = items,
+            targetConversationId = convoId,
+            m = msg,
+            sqlUserDate = Instant.fromEpochMilliseconds(1_000L),
+            activeDomain = me,
+        )
+
+        assertNotNull(updated)
+        assertEquals(5, updated.first().unreadCount)
+    }
+
+    @Test
+    fun olderMessage_returnsNull_noChange() {
+        val items = listOf(convo(latestMs = 5_000L, unread = 2))
+        val msg = message(author = alice, userDateMs = 1_000L)
+
+        val updated = applyIncomingMessageBump(
+            items = items,
+            targetConversationId = convoId,
+            m = msg,
+            sqlUserDate = Instant.fromEpochMilliseconds(1_000L),
+            activeDomain = me,
+        )
+
+        assertNull(updated)
+    }
+
+    @Test
+    fun messageForUnknownConversation_returnsNull() {
+        val items = listOf(convo())
+        val msg = message(author = alice, userDateMs = 1_000L)
+        val unknownConvoId = Uuid.parse("99999999-9999-9999-9999-999999999999")
+
+        val updated = applyIncomingMessageBump(
+            items = items,
+            targetConversationId = unknownConvoId,
+            m = msg,
+            sqlUserDate = Instant.fromEpochMilliseconds(1_000L),
+            activeDomain = me,
+        )
+
+        assertNull(updated)
+    }
+
+    @Test
+    fun bump_doesNotTouchOtherConversations() {
+        val target = convo(id = convoId, unread = 0)
+        val other = convo(id = otherConvoId, unread = 7)
+        val items = listOf(target, other)
+        val msg = message(author = alice, userDateMs = 1_000L)
+
+        val updated = applyIncomingMessageBump(
+            items = items,
+            targetConversationId = convoId,
+            m = msg,
+            sqlUserDate = Instant.fromEpochMilliseconds(1_000L),
+            activeDomain = me,
+        )
+
+        assertNotNull(updated)
+        // The other conversation must be the same instance back — no
+        // unnecessary copies, no field changes.
+        assertSame(other, updated.first { it.id == otherConvoId })
+        assertEquals(7, updated.first { it.id == otherConvoId }.unreadCount)
+        assertEquals(1, updated.first { it.id == convoId }.unreadCount)
+    }
+}


### PR DESCRIPTION
Today every WebSocket file notification triggers
OdinWebSocketClient.handleFileEvent → driveSyncManager.syncDrive(driveId)
which fires an HTTP QueryBatch round-trip just to fetch a file the server already shipped on the WS payload (the encrypted header rides along on ClientDriveNotification.header). In a typical 2-minute chat session that's ~10 chat-drive sync rounds, each ~100-500ms.

The dirty-bit-unread-enrichment PR made each Stopped cheap, so the user-visible perf urgency is gone. What's left is bandwidth and architectural cleanliness. The dead handleFileEvent_manual showed the shape: decrypt header, upsert, emit BatchReceived(source=WebSocket). This commit wires that shape up properly — for the chat drive only — with batching and serialization mirroring DriveSync.

Scope: chat drive only. Other drives keep syncDrive (their cadences aren't part of this PR).

NEW: ChatDriveWebSocketUpsertWorker
  Mirrors DriveSync's job-serialization pattern as closely as
  possible (per user's explicit request). Single-flight Mutex.tryLock,
  atomic killroy bit, job var, finally-unlock-then-recurse-if-killroy.
  Adds a pendingFiles queue so bursts of WS notifications coalesce
  into one baseUpsertEntryZapZap call (one SQLite transaction
  instead of N) and one BatchReceived event.

  No sync cursor — the WS path doesn't manage one. The reconnect
  catch-up below is the recovery mechanism.

MODIFIED: OdinWebSocketClient
  - handleFileEvent now branches: chat drive + non-null header → decrypt + chatWsUpsertWorker.submit(file). Anything else (other drives, null header on chat drive, decrypt failures) falls through to syncDrive(driveId), logged at INFO so we can monitor the rate. A steady stream of chat-drive fallback logs would mean the WS payload is missing headers somewhere we didn't expect.
  - handleReactionEvent and handleAllReactionsDeletedEvent gain INFO logs at their syncDrive call sites too (per user request: visible accounting of every WS-triggered syncDrive).
  - onHandshakeSuccess adds a fire-and-forget syncDrive(SystemDriveConstants.chatDrive.alias) right after the ConnectionOnline emit. One sync per (re)connect — replaces the per-event syncDrive spam with a targeted catch-up backstop. The dirty-bit gating downstream keeps it cheap when the round brings nothing relevant.
  - disconnect() cancels the worker.
  - Dead handleFileEvent_manual removed (its work moved into the worker).

DIAGNOSTIC (Step 0 of the plan, REMOVED before merge):
  A temporary Logger.d at the top of handleNotification prints
  notification.notificationType for every WS message. Lets the user
  observe — on Desktop, in homebase.log — which notification types
  fire for which actions. Critical question this answers: does a
  reaction toggle also produce a fileModified (carrying the updated
  reactionPreview-baked header), or only a reactionContentAdded? If
  both, the reaction handlers' syncDrive calls become redundant for
  the chat drive (a follow-up to drop them). If only the latter,
  reactions remain a separate follow-up PR.

  Tagged "WSDiag" so it's easy to grep, and marked TODO: remove
  before merge.

Existing chat:jvmTest and api:jvmTest suites pass (54 tasks executed, BUILD SUCCESSFUL). No new tests this round; OdinWebSocketClient has no existing test fixture and the manual Desktop log is the proving ground (mirroring how dirty-bit-unread-enrichment shipped).

Manual verification path is in the plan; the headline checks are:
  1. Send/receive a chat message → see "ChatDriveWS: batch upsert rows=N took=Xms" in homebase.log instead of "Synchronizing drive 9ff813af-...".
  2. Reconnect after a forced WS drop → exactly one "Synchronizing drive 9ff813af-..." (the new catch-up) right after handshake.
  3. Watch for "WSFileEvent: syncDrive(...)" — chat-drive entries here are the fallback signal we want to know about.