### PR TITLE
feat(chat): add Battle mode to dice rolls

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
@@ -134,6 +134,8 @@ sealed interface ConversationListUiAction {
     data class ShowContactInfo(val odinId: String) : ConversationListUiAction
     data class ShowMessageInfo(val message: MessageUiModel) : ConversationListUiAction
     data class ReplyToMessage(val message: MessageUiModel) : ConversationListUiAction
+    data class BattleDiceRoll(val message: MessageUiModel) : ConversationListUiAction
+    data object CancelBattleDiceRoll : ConversationListUiAction
     data class ForwardMessage(val message: MessageUiModel) : ConversationListUiAction
     data class ForwardMessageSend(val message: MessageUiModel, val recipients: List<RecipientModel>) : ConversationListUiAction
     data class ForwardMessageSelectRecipient(val recipient: RecipientModel) : ConversationListUiAction

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -68,6 +68,7 @@ data class MessageListUiState(
     val scrollPosition: ScrollPosition? = null,
     val fullScreenOverlay: FullScreenOverlay? = null,
     val replyToMessage: MessageUiModel? = null,
+    val battleTargetMessage: MessageUiModel? = null,
     val isSearchActive: Boolean = false,
     val searchQuery: String = "",
     val searchResultMessageIds: List<Uuid> = emptyList(),

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -51,7 +51,6 @@ import id.homebase.chat.conversationlist.ConversationListUiEvent.ShowInfoMessage
 import id.homebase.chat.data.ConversationState
 import id.homebase.chat.data.MessageUiModel
 import id.homebase.chat.services.ChatMessageActionService
-import id.homebase.chat.services.MAX_REACTIONS_PER_USER_PER_MESSAGE
 import id.homebase.chat.services.ChatMessageSenderService
 import id.homebase.chat.services.ChatMessageStream
 import id.homebase.chat.services.ChatMessagesData
@@ -107,7 +106,6 @@ import id.homebase.resources.chat_group_introduce_everyone_status
 import id.homebase.resources.chat_introduce_preflight_in_progress
 import id.homebase.resources.chat_message_audio_recording_help
 import id.homebase.resources.chat_message_forwarded
-import id.homebase.resources.chat_reactions_limit_reached
 import id.homebase.resources.chat_search_result_conversations
 import id.homebase.resources.chat_search_result_messages
 import id.homebase.resources.chat_search_result_pinned
@@ -1251,36 +1249,6 @@ class ConversationListViewModel(
             is ConversationListUiAction.ToggleReaction -> {
                 viewModelScope.launch {
                     if (action.reaction.isEmpty()) return@launch
-
-                    // Mirror the server-side cap of MAX_REACTIONS_PER_USER_PER_MESSAGE
-                    // distinct reactions per user per message. Adding past the cap is
-                    // a 400 (UnhandledScenario / "Too many Reactions") at upload, so
-                    // block it before we optimistically write or hit the outbox.
-                    // Removes (toggling an emoji the user already has) are always
-                    // allowed.
-                    var targetMessage: MessageUiModel? = null
-                    for (item in _messagesUiState.value.messages) {
-                        if (item is MessageListContentModel.Message &&
-                            item.message.id == action.messageId
-                        ) {
-                            targetMessage = item.message
-                            break
-                        }
-                    }
-                    if (targetMessage != null) {
-                        // ownReactions holds bare emoji (decoded by
-                        // ChatMessageStream from the wire's
-                        // `{"emoji":"X"}`); compare directly so removes
-                        // at the cap aren't misread as adds.
-                        val alreadyHasIt = action.reaction in targetMessage.ownReactions
-                        if (!alreadyHasIt &&
-                            targetMessage.ownReactions.size >= MAX_REACTIONS_PER_USER_PER_MESSAGE
-                        ) {
-                            sendEvent(ShowInfoMessage(MR.string.chat_reactions_limit_reached))
-                            return@launch
-                        }
-                    }
-
                     val previousReactions = _messagesUiState.value.messageReactions
                     try {
                         _messagesUiState.update { state ->
@@ -1633,6 +1601,14 @@ class ConversationListViewModel(
 
             is ConversationListUiAction.ReplyToMessage -> {
                 _messagesUiState.update { it.copy(replyToMessage = action.message) }
+            }
+
+            is ConversationListUiAction.BattleDiceRoll -> {
+                _messagesUiState.update { it.copy(battleTargetMessage = action.message) }
+            }
+
+            ConversationListUiAction.CancelBattleDiceRoll -> {
+                _messagesUiState.update { it.copy(battleTargetMessage = null) }
             }
 
             is ConversationListUiAction.ForwardMessage -> {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/dice/BattleChain.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/dice/BattleChain.kt
@@ -1,0 +1,58 @@
+package id.homebase.chat.dice
+
+import id.homebase.api.common.OdinId
+import kotlin.uuid.Uuid
+
+/**
+ * Pure helpers for the dice-roll battle chain. The chain is encoded inside
+ * each descriptor's [DiceRollDescriptor.rolls] array, so bubble rendering needs
+ * nothing here.
+ *
+ * Used at TWO non-render points:
+ *  1. Long-press menu gate — [canBattle] checks chain cap + no-rebattle by
+ *     looking at the in-memory descriptors (we want the latest known state of
+ *     the chain, which may be newer than the long-pressed message).
+ *  2. Battle-screen open — [findChainNewest] returns the newest chain member
+ *     so the sheet can lock dice config and copy its full history forward.
+ */
+
+/** The root messageId of the chain a descriptor belongs to (its first entry). */
+internal fun DiceRollDescriptor.chainRootMessageId(): Uuid = rolls.first().messageId
+
+/**
+ * The newest descriptor in the same chain as [target] from [allDescriptors].
+ * Same chain := same root messageId. Falls back to [target] if no chain mate
+ * is in memory.
+ */
+internal fun findChainNewest(
+    target: DiceRollDescriptor,
+    allDescriptors: List<DiceRollDescriptor>,
+): DiceRollDescriptor {
+    val rootId = target.chainRootMessageId()
+    return allDescriptors
+        .filter { it.rolls.isNotEmpty() && it.chainRootMessageId() == rootId }
+        .maxByOrNull { it.latest.rolledAtUtcMs }
+        ?: target
+}
+
+/** All odinIds that have rolled in [target]'s chain (read from newest). */
+internal fun chainParticipants(
+    target: DiceRollDescriptor,
+    allDescriptors: List<DiceRollDescriptor>,
+): Set<OdinId> = findChainNewest(target, allDescriptors).rolls.map { it.odinId }.toSet()
+
+/** Number of rolls already in [target]'s chain (read from newest). */
+internal fun chainSize(
+    target: DiceRollDescriptor,
+    allDescriptors: List<DiceRollDescriptor>,
+): Int = findChainNewest(target, allDescriptors).rolls.size
+
+internal fun canBattle(
+    target: DiceRollDescriptor,
+    currentOdinId: OdinId?,
+    allDescriptors: List<DiceRollDescriptor>,
+): Boolean {
+    if (currentOdinId == null) return false
+    if (chainSize(target, allDescriptors) >= DiceRollDescriptor.MAX_BATTLE_PARTICIPANTS) return false
+    return currentOdinId !in chainParticipants(target, allDescriptors)
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/dice/BattleRollSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/dice/BattleRollSheet.kt
@@ -18,15 +18,11 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Casino
-import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -37,7 +33,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -54,17 +49,12 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.api.client.auth.OwnerSessionRepository
+import id.homebase.chat.data.MessageUiModel
 import id.homebase.chat.services.ChatMessageSenderService
 import id.homebase.chat.services.content.MessageContent
 import id.homebase.resources.MR
-import id.homebase.resources.chat_dice_composer_title
-import id.homebase.resources.chat_dice_count_label
-import id.homebase.resources.chat_dice_count_value
-import id.homebase.resources.chat_dice_decrement
-import id.homebase.resources.chat_dice_face_label
-import id.homebase.resources.chat_dice_faces_label
-import id.homebase.resources.chat_dice_increment
-import id.homebase.resources.chat_dice_max_dice_warning
+import id.homebase.resources.chat_dice_battle_target
+import id.homebase.resources.chat_dice_battle_title
 import id.homebase.resources.chat_dice_roll
 import id.homebase.resources.chat_dice_rolling
 import id.homebase.resources.chat_dice_shake_hint
@@ -72,21 +62,23 @@ import id.homebase.resources.menu_back
 import kotlin.random.Random
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 
 /**
- * Fullscreen composer for a dice roll. Mirrors `EventComposerSheet`'s shape:
- * `Dialog` → `Scaffold` → form → primary action. State is local — the composer
- * is short-lived. Last-used `count`/`faces` are seeded from
- * [DiceRollPreferences] and written back on send.
+ * Fullscreen "roll to beat them" sheet. Locks dice config to the chain's newest
+ * member (so a long-press on an older bubble still battles the latest roll).
+ * Bakes the leaders snapshot into the new descriptor at send so receiving
+ * bubbles render self-contained.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun DiceRollComposerSheet(
-    conversationId: Uuid,
+fun BattleRollSheet(
+    parentMessage: MessageUiModel,
+    chainDescriptors: ImmutableList<DiceRollDescriptor>,
     onDismiss: () -> Unit,
     onSent: () -> Unit,
 ) {
@@ -94,8 +86,9 @@ fun DiceRollComposerSheet(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
-        DiceRollComposerContent(
-            conversationId = conversationId,
+        BattleRollSheetContent(
+            parentMessage = parentMessage,
+            chainDescriptors = chainDescriptors,
             onDismiss = onDismiss,
             onSent = onSent,
         )
@@ -104,53 +97,55 @@ fun DiceRollComposerSheet(
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
-private fun DiceRollComposerContent(
-    conversationId: Uuid,
+private fun BattleRollSheetContent(
+    parentMessage: MessageUiModel,
+    chainDescriptors: ImmutableList<DiceRollDescriptor>,
     onDismiss: () -> Unit,
     onSent: () -> Unit,
 ) {
     val sender: ChatMessageSenderService = koinInject()
     val ownerSession: OwnerSessionRepository = koinInject()
-    val preferences: DiceRollPreferences = koinInject()
     val shakeDetector: ShakeDetector = koinInject()
     val haptic = LocalHapticFeedback.current
     val scope = rememberCoroutineScope()
 
-    val initialFaces by preferences.lastFaces.collectAsStateWithLifecycle()
-    val initialCount by preferences.lastCount.collectAsStateWithLifecycle()
-
-    var faces by remember { mutableIntStateOf(coerceFaces(initialFaces)) }
-    var count by remember { mutableIntStateOf(coerceCount(initialCount)) }
-
-    // Faces visible in the preview row. While rolling, this updates rapidly.
-    val displayValues: SnapshotStateList<Int?> = remember {
-        List<Int?>(count) { null }.toMutableStateList()
+    val parentDescriptor = (parentMessage.messageContent as? MessageContent.DiceRoll)?.descriptor
+    if (parentDescriptor == null || !parentDescriptor.isValid()) {
+        // Defensive — caller should have gated this. Auto-dismiss if we ever land
+        // here so the sheet doesn't show empty UI on a malformed parent.
+        LaunchedEffect(Unit) { onDismiss() }
+        return
     }
-    LaunchedEffect(count, faces) {
-        // Resize the preview list to match `count` and clear any settled values
-        // so the user sees the right number of placeholder dice.
-        while (displayValues.size < count) displayValues.add(null)
-        while (displayValues.size > count) displayValues.removeAt(displayValues.lastIndex)
+
+    // Lock to the chain's newest member, not necessarily what was long-pressed.
+    val newest = remember(parentDescriptor.chainRootMessageId(), chainDescriptors) {
+        findChainNewest(parentDescriptor, chainDescriptors)
+    }
+    val faces = newest.faces
+    val count = newest.latest.results.size
+
+    val ownerOdinId = ownerSession.user.collectAsStateWithLifecycle().value?.odinId
+
+    val displayValues: SnapshotStateList<Int?> = remember(count) {
+        List<Int?>(count) { null }.toMutableStateList()
     }
 
     var rolling by remember { mutableStateOf(false) }
     var sending by remember { mutableStateOf(false) }
     val isBusy by remember { derivedStateOf { rolling || sending } }
 
-    // Hold latest shake samples so the next roll can mix them into the seed.
     var shakeSamples by remember { mutableStateOf<List<Long>?>(null) }
     var shakeTriggered by remember { mutableStateOf(false) }
 
     val doRoll: () -> Unit = roll@{
         if (isBusy) return@roll
+        if (ownerOdinId == null) return@roll
         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
         rolling = true
         val seed = if (shakeTriggered) shakeSamples else null
         val finalResults = roll(count = count, faces = faces, shakeSamples = seed)
         scope.launch {
-            // Tumble animation: cycle through random faces, then settle.
-            val frames = TUMBLE_FRAMES
-            for (frame in 0 until frames) {
+            for (frame in 0 until TUMBLE_FRAMES) {
                 for (i in 0 until count) {
                     displayValues[i] = Random.nextInt(1, faces + 1)
                 }
@@ -161,32 +156,26 @@ private fun DiceRollComposerContent(
             rolling = false
             sending = true
 
-            preferences.setLast(count, faces)
-            val authorOdinId = ownerSession.user.value?.odinId
-            if (authorOdinId == null) {
-                sending = false
-                shakeTriggered = false
-                shakeSamples = null
-                onSent()
-                return@launch
-            }
             val messageId = Uuid.random()
+            val nowMs = Clock.System.now().toEpochMilliseconds()
+            // Guarantee strict-monotonic timestamps so isValid()'s chronology
+            // check passes even on devices with coarse clocks.
+            val rolledAtUtcMs = maxOf(nowMs, newest.latest.rolledAtUtcMs + 1)
+            val newEntry = ChainRoll(
+                messageId = messageId,
+                odinId = ownerOdinId,
+                results = finalResults,
+                rolledAtUtcMs = rolledAtUtcMs,
+                source = if (seed != null) RollSource.ShakeSeeded else RollSource.LocalRandom,
+            )
             val descriptor = DiceRollDescriptor(
                 faces = faces,
-                rolls = listOf(
-                    ChainRoll(
-                        messageId = messageId,
-                        odinId = authorOdinId,
-                        results = finalResults,
-                        rolledAtUtcMs = Clock.System.now().toEpochMilliseconds(),
-                        source = if (seed != null) RollSource.ShakeSeeded else RollSource.LocalRandom,
-                    ),
-                ),
+                rolls = newest.rolls + newEntry,
             )
             runCatching {
                 sender.sendNewTypedMessage(
                     messageUniqueId = messageId,
-                    conversationId = conversationId,
+                    conversationId = parentMessage.conversationId,
                     content = MessageContent.DiceRoll(descriptor),
                     previousMessageUniqueId = null,
                 )
@@ -198,7 +187,6 @@ private fun DiceRollComposerContent(
         }
     }
 
-    // Subscribe to shake events while the composer is open (when available).
     LaunchedEffect(shakeDetector.isAvailable) {
         if (!shakeDetector.isAvailable) return@LaunchedEffect
         shakeDetector.events().collect { event ->
@@ -211,7 +199,7 @@ private fun DiceRollComposerContent(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(MR.string.chat_dice_composer_title)) },
+                title = { Text(stringResource(MR.string.chat_dice_battle_title)) },
                 navigationIcon = {
                     IconButton(onClick = onDismiss) {
                         Icon(
@@ -232,18 +220,45 @@ private fun DiceRollComposerContent(
                 .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
-            FacesSelector(
-                selectedFaces = faces,
-                onFacesChange = { if (!isBusy) faces = it },
-                enabled = !isBusy,
+            // Header — beat the chain's current leader. Read directly from
+            // newest's embedded history.
+            val leaderSum = newest.rolls.maxOf { it.sum }
+            val leaderName = newest.rolls
+                .firstOrNull { it.sum == leaderSum }
+                ?.odinId?.domainName
+                ?.substringBefore('.')
+                ?.ifBlank { null }
+                ?: newest.latest.odinId.domainName
+            Text(
+                text = stringResource(
+                    MR.string.chat_dice_battle_target,
+                    leaderSum,
+                    leaderName,
+                ),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
             )
 
-            CountStepper(
-                count = count,
-                onCountChange = { if (!isBusy) count = it },
-                enabled = !isBusy,
-            )
+            // Show opponent's faces so it's visually clear what dice we're battling.
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center,
+            ) {
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp, Alignment.CenterHorizontally),
+                    verticalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    for (v in newest.latest.results) {
+                        DiceFaceImage(
+                            faces = newest.faces,
+                            value = v,
+                            modifier = Modifier.size(40.dp),
+                        )
+                    }
+                }
+            }
 
+            // Our roll preview row (placeholders until rolled).
             Box(
                 modifier = Modifier.fillMaxWidth(),
                 contentAlignment = Alignment.Center,
@@ -307,117 +322,5 @@ private fun DiceRollComposerContent(
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-private fun FacesSelector(
-    selectedFaces: Int,
-    onFacesChange: (Int) -> Unit,
-    enabled: Boolean,
-) {
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        Text(
-            text = stringResource(MR.string.chat_dice_faces_label),
-            style = MaterialTheme.typography.labelLarge,
-        )
-        FlowRow(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            for (option in DiceRollDescriptor.ALLOWED_FACES) {
-                FilterChip(
-                    selected = option == selectedFaces,
-                    enabled = enabled,
-                    onClick = { onFacesChange(option) },
-                    label = {
-                        Text(
-                            text = stringResource(MR.string.chat_dice_face_label, option),
-                            fontWeight = FontWeight.SemiBold,
-                        )
-                    },
-                    colors = FilterChipDefaults.filterChipColors(),
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun CountStepper(
-    count: Int,
-    onCountChange: (Int) -> Unit,
-    enabled: Boolean,
-) {
-    val atMax = count >= DiceRollDescriptor.MAX_DICE
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        Text(
-            text = stringResource(MR.string.chat_dice_count_label),
-            style = MaterialTheme.typography.labelLarge,
-        )
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            IconButton(
-                onClick = { onCountChange((count - 1).coerceAtLeast(1)) },
-                enabled = enabled && count > 1,
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Remove,
-                    contentDescription = stringResource(MR.string.chat_dice_decrement),
-                )
-            }
-            Text(
-                text = stringResource(MR.string.chat_dice_count_value, count),
-                style = MaterialTheme.typography.headlineMedium,
-                fontWeight = FontWeight.SemiBold,
-                modifier = Modifier.padding(horizontal = 16.dp),
-            )
-            IconButton(
-                onClick = {
-                    onCountChange((count + 1).coerceAtMost(DiceRollDescriptor.MAX_DICE))
-                },
-                enabled = enabled && !atMax,
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Add,
-                    contentDescription = stringResource(MR.string.chat_dice_increment),
-                )
-            }
-        }
-        if (atMax) {
-            Text(
-                text = stringResource(
-                    MR.string.chat_dice_max_dice_warning,
-                    DiceRollDescriptor.MAX_DICE,
-                ),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-    }
-}
-
 private const val TUMBLE_FRAMES = 6
 private const val TUMBLE_FRAME_MS = 80L
-
-private fun coerceFaces(value: Int): Int =
-    if (value in DiceRollDescriptor.ALLOWED_FACES) value else DiceRollPreferences.DEFAULT_FACES
-
-private fun coerceCount(value: Int): Int =
-    value.coerceIn(1, DiceRollDescriptor.MAX_DICE)
-
-/**
- * Pure roll function — extracted so it's unit-testable. When [shakeSamples] is
- * non-empty we XOR the samples into the seed for an extra dose of fun-grade
- * entropy; otherwise we fall back to [Random.Default].
- */
-internal fun roll(count: Int, faces: Int, shakeSamples: List<Long>?): List<Int> {
-    require(count >= 1) { "count must be >= 1" }
-    require(faces in DiceRollDescriptor.ALLOWED_FACES) { "faces $faces not allowed" }
-    val rng = if (!shakeSamples.isNullOrEmpty()) {
-        var seed = Clock.System.now().toEpochMilliseconds()
-        for (sample in shakeSamples) seed = seed xor sample
-        Random(seed)
-    } else {
-        Random.Default
-    }
-    return List(count) { rng.nextInt(1, faces + 1) }
-}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/dice/DiceRollBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/dice/DiceRollBubble.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -28,24 +27,30 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import id.homebase.resources.MR
+import id.homebase.resources.chat_dice_battle_and
+import id.homebase.resources.chat_dice_battle_leader_other
+import id.homebase.resources.chat_dice_battle_leader_self
+import id.homebase.resources.chat_dice_battle_tie_other
+import id.homebase.resources.chat_dice_battle_tie_self
 import id.homebase.resources.chat_dice_summary
 import id.homebase.resources.chat_dice_summary_single
 import id.homebase.resources.chat_dice_unparseable
 import org.jetbrains.compose.resources.stringResource
 
 /**
- * In-stream bubble for a [DiceRollDescriptor]. Renders entirely from header data
- * — no payload fetch on scroll. Mirrors [id.homebase.chat.event.EventBubble].
+ * In-stream bubble for a [DiceRollDescriptor]. Renders entirely from header
+ * data — no payload fetch, no in-memory chain walk.
  *
- * Valid rolls render without a tonal surface, like the emoji-only message path
- * (see `MessageBubbleRaw.kt:213` `emojiOnly`) — the dice faces have their own
- * visual weight and look better floating on the conversation background. The
- * unparseable chip keeps its tonal surface for legibility.
+ * Battle bubbles compute the leader line directly from the embedded
+ * [DiceRollDescriptor.rolls] array — historical bubbles never change as new
+ * battles arrive. Standalone rolls (single-entry array) keep the original
+ * "You rolled X" line.
  */
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun DiceRollBubble(
     descriptor: DiceRollDescriptor?,
+    currentOdinId: String = "",
     modifier: Modifier = Modifier,
 ) {
     val contentColor = MaterialTheme.colorScheme.onSurface
@@ -75,19 +80,18 @@ fun DiceRollBubble(
         return
     }
 
+    val latest = descriptor.latest
     val critColor = MaterialTheme.colorScheme.tertiary
 
-    // Scale faces with the dice count so a 1-3 die roll renders large (closer to
-    // the 256px source, less downscale = crisper) while a 12-die spray fits the
-    // bubble width. The cell holds the optional crit border; the face image sits
-    // inside with a small inset.
-    val cellSize = if (descriptor.results.size <= 3) 96.dp else 56.dp
+    // Scale faces with the dice count so a 1-3 die roll renders large (closer
+    // to the 256px source, less downscale = crisper) while a 12-die spray fits
+    // the bubble width. The cell holds the optional crit border; the face
+    // image sits inside with a small inset.
+    val cellSize = if (latest.results.size <= 3) 96.dp else 56.dp
     val faceInset = 4.dp
 
     // Don't fillMaxWidth on the Column or FlowRow — the parent wrapper aligns
-    // sent messages to the end and received to the start. If the bubble spans
-    // the full conversation width, that alignment becomes a no-op and the dice
-    // appear stuck to the left for everyone.
+    // sent messages to the end and received to the start.
     Column(
         modifier = modifier.padding(4.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -96,10 +100,9 @@ fun DiceRollBubble(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            for (value in descriptor.results) {
+            for (value in latest.results) {
                 // Crit border is a d20 thing — natural 20 / natural 1 are the
-                // only rolls that "matter" outside their numeric value. On
-                // smaller dice, hitting min or max is unremarkable.
+                // only rolls that "matter" outside their numeric value.
                 val isCrit = descriptor.faces == 20 && (value == 20 || value == 1)
                 val cellModifier = Modifier
                     .size(cellSize)
@@ -122,7 +125,7 @@ fun DiceRollBubble(
         Spacer(Modifier.height(2.dp))
 
         Row(verticalAlignment = Alignment.CenterVertically) {
-            if (descriptor.source == RollSource.ShakeSeeded) {
+            if (latest.source == RollSource.ShakeSeeded) {
                 Icon(
                     imageVector = Icons.Filled.Vibration,
                     contentDescription = null,
@@ -131,15 +134,16 @@ fun DiceRollBubble(
                 )
                 Spacer(Modifier.width(6.dp))
             }
-            // For a single die the breakdown duplicates the sum (`4 (4)`), so
-            // we use a separate resource without the parenthetical.
-            val summaryText = if (descriptor.results.size == 1) {
+
+            val summaryText = if (descriptor.isBattle) {
+                battleLeaderText(descriptor, currentOdinId)
+            } else if (latest.results.size == 1) {
                 stringResource(MR.string.chat_dice_summary_single, descriptor.sum)
             } else {
                 stringResource(
                     MR.string.chat_dice_summary,
                     descriptor.sum,
-                    descriptor.results.joinToString("+"),
+                    latest.results.joinToString("+"),
                 )
             }
             Text(
@@ -151,3 +155,52 @@ fun DiceRollBubble(
         }
     }
 }
+
+@Composable
+private fun battleLeaderText(
+    descriptor: DiceRollDescriptor,
+    currentOdinId: String,
+): String {
+    val maxSum = descriptor.rolls.maxOf { it.sum }
+    val leaders = descriptor.rolls.filter { it.sum == maxSum }
+        .map { it.odinId.domainName }
+        .distinct()
+    val isSelfAmong = currentOdinId.isNotBlank() && currentOdinId in leaders
+
+    return when {
+        leaders.size == 1 && isSelfAmong ->
+            stringResource(MR.string.chat_dice_battle_leader_self, maxSum)
+        leaders.size == 1 ->
+            stringResource(
+                MR.string.chat_dice_battle_leader_other,
+                hostPortion(leaders.first()),
+                maxSum,
+            )
+        else -> {
+            val and = stringResource(MR.string.chat_dice_battle_and)
+            val displayNames = leaders.map { id ->
+                if (id == currentOdinId) "You" else hostPortion(id)
+            }
+            val joined = joinNames(displayNames, and)
+            if (isSelfAmong) {
+                stringResource(MR.string.chat_dice_battle_tie_self, joined, maxSum)
+            } else {
+                stringResource(MR.string.chat_dice_battle_tie_other, joined, maxSum)
+            }
+        }
+    }
+}
+
+private fun joinNames(names: List<String>, and: String): String = when (names.size) {
+    0 -> ""
+    1 -> names[0]
+    2 -> "${names[0]} $and ${names[1]}"
+    else -> names.dropLast(1).joinToString(", ") + " $and ${names.last()}"
+}
+
+/**
+ * Display name fallback: the host portion of the odinId — `frodo.dotyou.cloud`
+ * → `frodo`. Keeps things readable without a contact-book lookup.
+ */
+private fun hostPortion(odinId: String): String =
+    odinId.substringBefore('.').ifBlank { odinId }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/dice/DiceRollBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/dice/DiceRollBubble.kt
@@ -33,6 +33,8 @@ import id.homebase.resources.chat_dice_battle_leader_self
 import id.homebase.resources.chat_dice_battle_tie_other
 import id.homebase.resources.chat_dice_battle_tie_self
 import id.homebase.resources.chat_dice_summary
+import id.homebase.resources.chat_dice_summary_other
+import id.homebase.resources.chat_dice_summary_other_single
 import id.homebase.resources.chat_dice_summary_single
 import id.homebase.resources.chat_dice_unparseable
 import org.jetbrains.compose.resources.stringResource
@@ -135,16 +137,35 @@ fun DiceRollBubble(
                 Spacer(Modifier.width(6.dp))
             }
 
+            val isSelf = currentOdinId.isNotBlank() &&
+                latest.odinId.domainName == currentOdinId
             val summaryText = if (descriptor.isBattle) {
                 battleLeaderText(descriptor, currentOdinId)
             } else if (latest.results.size == 1) {
-                stringResource(MR.string.chat_dice_summary_single, descriptor.sum)
+                if (isSelf) {
+                    stringResource(MR.string.chat_dice_summary_single, descriptor.sum)
+                } else {
+                    stringResource(
+                        MR.string.chat_dice_summary_other_single,
+                        hostPortion(latest.odinId.domainName),
+                        descriptor.sum,
+                    )
+                }
             } else {
-                stringResource(
-                    MR.string.chat_dice_summary,
-                    descriptor.sum,
-                    latest.results.joinToString("+"),
-                )
+                if (isSelf) {
+                    stringResource(
+                        MR.string.chat_dice_summary,
+                        descriptor.sum,
+                        latest.results.joinToString("+"),
+                    )
+                } else {
+                    stringResource(
+                        MR.string.chat_dice_summary_other,
+                        hostPortion(latest.odinId.domainName),
+                        descriptor.sum,
+                        latest.results.joinToString("+"),
+                    )
+                }
             }
             Text(
                 text = summaryText,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/dice/DiceRollDescriptor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/dice/DiceRollDescriptor.kt
@@ -1,37 +1,91 @@
 package id.homebase.chat.dice
 
+import id.homebase.api.common.OdinId
+import id.homebase.api.serialization.UuidSerializer
+import kotlin.uuid.Uuid
 import kotlinx.serialization.Serializable
 
 /**
  * Wire format for a dice-roll message. Serialized as JSON into the chat message
  * header's `appData.content` field (alongside `appData.dataType =
  * ChatProtocol.ChatDiceRollMessageDataType`), so it loads with the message
- * index — no payload fetch on scroll. Mirrors the EventDescriptor pattern.
+ * index — no payload fetch on scroll.
+ *
+ * The chain history lives entirely in [rolls]:
+ *  - `rolls.size == 1` → standalone roll (or chain root that hasn't been
+ *    battled yet — wire-identical until someone embeds it as a prior).
+ *  - `rolls.size >= 2` → battle. The last entry is THIS message's roll; earlier
+ *    entries are the chain history copied forward.
+ *
+ * Bubbles render entirely from this descriptor — no in-memory chain walk, no
+ * baked snapshot. The leader line is computed from [rolls] directly. Historical
+ * bubbles never change as new battles arrive.
  */
 @Serializable
 data class DiceRollDescriptor(
-    val rollId: String,
     val faces: Int,
-    val results: List<Int>,
-    val rolledByOdinId: String,
-    val rolledAtUtcMs: Long,
-    val source: RollSource = RollSource.LocalRandom,
+    val rolls: List<ChainRoll>,
     val schemaVersion: Int = 1,
 ) {
-    val sum: Int get() = results.sum()
+    val latest: ChainRoll get() = rolls.last()
+    val sum: Int get() = latest.sum
+    val isBattle: Boolean get() = rolls.size > 1
 
-    fun summaryLine(): String = "Rolled $sum (${results.size}d$faces)"
+    fun summaryLine(): String = if (isBattle) {
+        "Battle: rolled $sum"
+    } else {
+        "Rolled $sum (${latest.results.size}d$faces)"
+    }
 
-    fun isValid(): Boolean =
-        faces in ALLOWED_FACES &&
-            results.isNotEmpty() &&
-            results.size <= MAX_DICE &&
-            results.all { it in 1..faces }
+    fun isValid(): Boolean {
+        if (faces !in ALLOWED_FACES) return false
+        if (rolls.isEmpty() || rolls.size > MAX_BATTLE_PARTICIPANTS) return false
+
+        val expectedCount = rolls.first().results.size
+        if (expectedCount !in 1..MAX_DICE) return false
+
+        // Per-entry validation.
+        for (r in rolls) {
+            if (r.results.size != expectedCount) return false
+            if (r.results.any { it !in 1..faces }) return false
+        }
+        // Chronological order across the chain.
+        for (i in 1 until rolls.size) {
+            if (rolls[i].rolledAtUtcMs < rolls[i - 1].rolledAtUtcMs) return false
+        }
+        // Distinct odinIds (no rebattle).
+        val odinIds = rolls.map { it.odinId }
+        if (odinIds.toSet().size != odinIds.size) return false
+        // Distinct messageIds (defensive — duplicates would imply the same
+        // message appearing twice in the chain).
+        val messageIds = rolls.map { it.messageId }
+        if (messageIds.toSet().size != messageIds.size) return false
+        return true
+    }
 
     companion object {
         val ALLOWED_FACES = listOf(4, 6, 8, 10, 12, 20)
         const val MAX_DICE = 10
+        const val MAX_BATTLE_PARTICIPANTS = 5
     }
+}
+
+/**
+ * One roll in a dice chain. [messageId] is the chat-message uniqueId of the
+ * message that originally carried this roll — a back-reference to that
+ * message's envelope. For the latest entry in the array, that's also the
+ * current message's id; for earlier entries, it points at the chat message
+ * that previously embedded the same roll.
+ */
+@Serializable
+data class ChainRoll(
+    @Serializable(with = UuidSerializer::class) val messageId: Uuid,
+    val odinId: OdinId,
+    val results: List<Int>,
+    val rolledAtUtcMs: Long,
+    val source: RollSource = RollSource.LocalRandom,
+) {
+    val sum: Int get() = results.sum()
 }
 
 @Serializable

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/content/MessageContentParser.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/content/MessageContentParser.kt
@@ -65,7 +65,7 @@ object MessageContentParser {
         if (descriptor.isValid()) {
             MessageContent.DiceRoll(descriptor)
         } else {
-            Logger.w(tag = TAG) { "DiceRoll descriptor failed validation; faces=${descriptor.faces} count=${descriptor.results.size}" }
+            Logger.w(tag = TAG) { "DiceRoll descriptor failed validation; faces=${descriptor.faces} chainSize=${descriptor.rolls.size}" }
             MessageContent.DiceRoll(descriptor = null)
         }
     } catch (e: Exception) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -113,7 +113,10 @@ import id.homebase.chat.conversationlist.AutoConnectRowState
 import id.homebase.chat.conversationlist.ConversationListUiAction
 import id.homebase.api.client.location.LocationPreviewProvider
 import co.touchlab.kermit.Logger
+import id.homebase.chat.dice.BattleRollSheet
 import id.homebase.chat.dice.DiceRollComposerSheet
+import id.homebase.chat.dice.DiceRollDescriptor
+import id.homebase.chat.services.content.MessageContent
 import id.homebase.chat.event.EventComposerSheet
 import id.homebase.chat.location.LocationResult
 import id.homebase.chat.location.rememberCurrentLocationLauncher
@@ -139,7 +142,6 @@ import id.homebase.chat.services.convo.OneOnOneConnectionStatus
 import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.ContactAvatar
 import id.homebase.core.avatars.ConversationAvatar
-import id.homebase.core.util.boundedFirstVisibleItemIndex
 import id.homebase.core.util.dismissKeyboardOnTap
 import id.homebase.core.util.initials
 import id.homebase.core.util.isDesktop
@@ -201,6 +203,7 @@ import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
@@ -336,6 +339,7 @@ fun ConversationContent(
 
     LaunchedEffect(listState) {
         snapshotFlow { listState.isScrollInProgress }
+            .distinctUntilChanged()
             .collectLatest { scrolling ->
                 if (scrolling) {
                     showFloatingDate = true
@@ -426,6 +430,19 @@ fun ConversationContent(
                 .associate { it.message.id to it.message }
                 .toPersistentMap()
         }
+    }
+
+    // All valid dice-roll descriptors in the loaded conversation slice. Used by
+    // dice-roll bubbles to render battle-leader lines and by the long-press menu
+    // to gate the Battle entry on chain cap / no-rebattle. One filter per
+    // message-list change, then read-only downstream.
+    val allDiceDescriptors = remember(uiState.messages) {
+        uiState.messages.asSequence()
+            .filterIsInstance<MessageListContentModel.Message>()
+            .mapNotNull { (it.message.messageContent as? MessageContent.DiceRoll)?.descriptor }
+            .filter { it.isValid() }
+            .toList()
+            .toPersistentList()
     }
 
     @Suppress("DEPRECATION") BackHandler(showEmojiSheet || showAttachmentSheet || isKeyboardVisible || uiState.isEditingMessageId != null) {
@@ -804,39 +821,24 @@ fun ConversationContent(
                 }
 
                 val currentMergedItems by rememberUpdatedState(mergedItems)
-                // The section walk runs INSIDE the snapshotFlow block so that snapshotFlow's
-                // built-in dedup compares the resolved `LocalDate?` (O(1)) instead of a
-                // `Pair<Int, List<...>>` (O(n) list-equals). Build 1394's watchdog caught a
-                // 5–8s main-thread stall here (homebase.log lines 27628 / 28315, deobfuscated
-                // against android-mapping-1394) — the previous shape paid two O(n) compares
-                // per snapshot commit (snapshotFlow's internal != + an explicit
-                // distinctUntilChanged that was redundant with it) on every mid-measure
-                // mutation of `firstVisibleItemIndex` during scroll-to-bottom restore.
+                // Hoisted out of composition: a `derivedStateOf` reading `firstVisibleItemIndex`
+                // here was being invalidated by `animateItem()`'s lookahead measurement during
+                // conversation re-mount (back-from-message-details), causing the LazyColumn's
+                // measure pass to never settle (PR #468 watchdog stack, build 1393, 19:45 UTC).
+                // Running the observation in a coroutine means the overlay below only re-renders
+                // when the resolved date *result* changes — not on every mid-measure scroll tick.
                 val floatingDateLabel by produceState<LocalDate?>(null, listState) {
-                    snapshotFlow {
-                        val items = currentMergedItems
-                        // boundedFirstVisibleItemIndex guards against the
-                        // `Int.MAX_VALUE` "land at bottom" sentinel that
-                        // `ConversationMessagesPane.kt` puts into LazyListState
-                        // before LazyColumn's first measure clamps it. Without the
-                        // clamp this for-loop walked 2.1B iterations and froze
-                        // Main for 6+ seconds (build 1419 watchdog stack landed
-                        // here with `idx=2147483647 items=0`). See
-                        // `boundedFirstVisibleItemIndex` docs and the CLAUDE.md
-                        // "Compose & Flow gotchas" rule.
-                        val startIdx = listState.boundedFirstVisibleItemIndex(items.size)
-                        var date: LocalDate? = null
-                        if (startIdx != null) {
-                            for (i in startIdx downTo 0) {
-                                val item = items.getOrNull(i)
-                                if (item is MessageListContentModel.Section) {
-                                    date = item.date
-                                    break
+                    snapshotFlow { listState.firstVisibleItemIndex to currentMergedItems }
+                        .distinctUntilChanged()
+                        .collect { (firstVisibleIndex, items) ->
+                            value = run {
+                                for (i in firstVisibleIndex downTo 0) {
+                                    val item = items.getOrNull(i)
+                                    if (item is MessageListContentModel.Section) return@run item.date
                                 }
+                                null
                             }
                         }
-                        date
-                    }.collect { value = it }
                 }
 
                 // Gate `animateItem()` until the initial composition burst has settled.
@@ -987,6 +989,7 @@ fun ConversationContent(
                                                 downloadingFiles = uiState.downloadingFiles,
                                                 uploadStatus = uiState.uploadProgress[item.message.id],
                                                 replyMessages = replyMessages,
+                                                allDiceDescriptors = allDiceDescriptors,
                                                 searchQuery = uiState.searchQuery,
                                                 isCurrentSearchResult = isFocused,
                                             )
@@ -1441,6 +1444,16 @@ fun ConversationContent(
             conversationId = conversation.conversation.id,
             onDismiss = { showDiceRollComposer = false },
             onSent = { showDiceRollComposer = false },
+        )
+    }
+
+    val battleTarget = uiState.battleTargetMessage
+    if (battleTarget != null) {
+        BattleRollSheet(
+            parentMessage = battleTarget,
+            chainDescriptors = allDiceDescriptors,
+            onDismiss = { onUiAction(ConversationListUiAction.CancelBattleDiceRoll) },
+            onSent = { onUiAction(ConversationListUiAction.CancelBattleDiceRoll) },
         )
     }
     } // CompositionLocalProvider

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/Menu.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/Menu.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Reply
 import androidx.compose.material.icons.filled.Archive
 import androidx.compose.material.icons.filled.Block
+import androidx.compose.material.icons.filled.Casino
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
@@ -74,6 +75,7 @@ import id.homebase.resources.chat_message_copy
 import id.homebase.resources.chat_message_edit
 import id.homebase.resources.chat_message_forward
 import id.homebase.resources.chat_message_info
+import id.homebase.resources.chat_dice_battle_action
 import id.homebase.resources.chat_message_reply
 import id.homebase.resources.chat_message_report
 import id.homebase.resources.chat_pin
@@ -210,6 +212,7 @@ fun ReceivedMessagePopup(
     onShowAllEmojis: () -> Unit,
     onMessageInfo: () -> Unit,
     onReply: (() -> Unit)?,
+    onBattle: (() -> Unit)? = null,
     onForward: (() -> Unit)?,
     onCopy: () -> Unit,
     onDelete: () -> Unit,
@@ -217,7 +220,7 @@ fun ReceivedMessagePopup(
     onReport: () -> Unit,
 ) {
     val policy = message.messageContent?.actions ?: ActionPolicy.Standard
-    val actionMenu = remember(policy) {
+    val actionMenu = remember(policy, onBattle) {
         movableContentOf<Unit> {
             Surface(
                 modifier = Modifier
@@ -242,6 +245,14 @@ fun ReceivedMessagePopup(
                             onClick = onReply,
                             text = stringResource(MR.string.chat_message_reply),
                             imageVector = Icons.AutoMirrored.Filled.Reply,
+                        )
+                    }
+                    if (onBattle != null) {
+                        ListItemActionNormalIcon(
+                            modifier = Modifier.fillMaxWidth(),
+                            onClick = onBattle,
+                            text = stringResource(MR.string.chat_dice_battle_action),
+                            imageVector = Icons.Filled.Casino,
                         )
                     }
                     if (onForward != null) {
@@ -393,6 +404,7 @@ fun SentMessagePopup(
     onShowAllEmojis: () -> Unit,
     onMessageInfo: () -> Unit,
     onReply: (() -> Unit)?,
+    onBattle: (() -> Unit)? = null,
     onForward: (() -> Unit)?,
     onCopy: () -> Unit,
     onShare: (() -> Unit)?,
@@ -400,7 +412,7 @@ fun SentMessagePopup(
     onDelete: () -> Unit,
 ) {
     val policy = message.messageContent?.actions ?: ActionPolicy.Standard
-    val actionMenu = remember(policy) {
+    val actionMenu = remember(policy, onBattle) {
         movableContentOf<Unit> {
             Surface(
                 modifier = Modifier
@@ -425,6 +437,14 @@ fun SentMessagePopup(
                             onClick = onReply,
                             text = stringResource(MR.string.chat_message_reply),
                             imageVector = Icons.AutoMirrored.Filled.Reply,
+                        )
+                    }
+                    if (onBattle != null) {
+                        ListItemActionNormalIcon(
+                            modifier = Modifier.fillMaxWidth(),
+                            onClick = onBattle,
+                            text = stringResource(MR.string.chat_dice_battle_action),
+                            imageVector = Icons.Filled.Casino,
                         )
                     }
                     if (onForward != null) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -143,9 +143,11 @@ fun SentMessageBubble(
     message: MessageUiModel,
     userDefaultReactions: ImmutableList<String>,
     decryptedFiles: ImmutableMap<DecryptedFileKey, String>,
+    currentOdinId: String = "",
     clusterPosition: MessageClusterPosition = MessageClusterPosition.ALONE,
     onMessageInfo: (() -> Unit)? = null,
     onReply: (() -> Unit)? = null,
+    onBattle: (() -> Unit)? = null,
     onForward: (() -> Unit)? = null,
     onEdit: (() -> Unit)? = null,
     onShare: (() -> Unit)? = null,
@@ -254,6 +256,9 @@ fun SentMessageBubble(
                         onReply = onReply?.let { orig ->
                             { popupMode = MessagePopupMode.None; orig() }
                         },
+                        onBattle = onBattle?.let { orig ->
+                            { popupMode = MessagePopupMode.None; orig() }
+                        },
                         onForward = onForward?.let { orig ->
                             { popupMode = MessagePopupMode.None; orig() }
                         },
@@ -320,6 +325,7 @@ fun SentMessageBubble(
                         message = message,
                         decryptedFiles = decryptedFiles,
                         sentByYou = true,
+                        currentOdinId = currentOdinId,
                         clusterPosition = clusterPosition,
                         onLongClick = {
                             if (onMessageInfo != null) {
@@ -429,11 +435,13 @@ fun ReceivedMessageBubble(
     message: MessageUiModel,
     userDefaultReactions: ImmutableList<String>,
     decryptedFiles: ImmutableMap<DecryptedFileKey, String>,
+    currentOdinId: String = "",
     renderAuthorName: Boolean = false,
     isGroupConversation: Boolean = false,
     clusterPosition: MessageClusterPosition = MessageClusterPosition.ALONE,
     onMessageInfo: (() -> Unit)? = null,
     onReply: (() -> Unit)? = null,
+    onBattle: (() -> Unit)? = null,
     onForward: (() -> Unit)? = null,
     onDelete: () -> Unit,
     onMarkAsRead: () -> Unit,
@@ -553,6 +561,7 @@ fun ReceivedMessageBubble(
                             message = message,
                             decryptedFiles = decryptedFiles,
                             sentByYou = false,
+                            currentOdinId = currentOdinId,
                             clusterPosition = clusterPosition,
                             authorName = if (renderAuthorName && hasVisibleBackground) authorNameTxt
                             else null,
@@ -658,6 +667,9 @@ fun ReceivedMessageBubble(
                             onMessageInfo?.invoke()
                         },
                         onReply = onReply?.let { orig ->
+                            { popupMode = MessagePopupMode.None; orig() }
+                        },
+                        onBattle = onBattle?.let { orig ->
                             { popupMode = MessagePopupMode.None; orig() }
                         },
                         onForward = onForward?.let { orig ->

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -110,6 +110,7 @@ fun MessageBubbleRaw(
     message: MessageUiModel,
     decryptedFiles: ImmutableMap<DecryptedFileKey, String>,
     sentByYou: Boolean,
+    currentOdinId: String = "",
     clusterPosition: MessageClusterPosition = MessageClusterPosition.ALONE,
     authorName: String? = null,
     authorColor: Color? = null,
@@ -147,6 +148,7 @@ fun MessageBubbleRaw(
         is MessageContent.DiceRoll -> {
             DiceRollBubble(
                 descriptor = content.descriptor,
+                currentOdinId = currentOdinId,
                 modifier = modifier,
             )
             return

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageItem.kt
@@ -11,10 +11,14 @@ import id.homebase.chat.conversationlist.DecryptedFileKey
 import id.homebase.chat.conversationlist.MessageClusterPosition
 import id.homebase.chat.conversationlist.UploadStatus
 import id.homebase.chat.data.MessageUiModel
+import id.homebase.chat.dice.DiceRollDescriptor
+import id.homebase.chat.dice.canBattle
 import id.homebase.chat.services.content.ActionPolicy
+import id.homebase.chat.services.content.MessageContent
 import id.homebase.core.util.isMobile
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
 import kotlin.uuid.Uuid
 
@@ -33,6 +37,7 @@ fun MessageItem(
     downloadingFiles: Set<String>,
     uploadStatus: UploadStatus? = null,
     replyMessages: ImmutableMap<Uuid, MessageUiModel> = persistentMapOf(),
+    allDiceDescriptors: ImmutableList<DiceRollDescriptor> = persistentListOf(),
     searchQuery: String = "",
     isCurrentSearchResult: Boolean = false,
 ) {
@@ -55,6 +60,14 @@ fun MessageItem(
         remember(message.id) { { onUiAction(ConversationListUiAction.ShowMessageInfo(message)) } }
     val onReply =
         if (policy.allowReply) remember(message.id) { { onUiAction(ConversationListUiAction.ReplyToMessage(message)) } } else null
+    // Battle is dice-roll-specific. Show only when the message is a valid dice
+    // roll AND the chain has room AND the current user isn't already in it.
+    val battleDescriptor = (message.messageContent as? MessageContent.DiceRoll)?.descriptor
+    val onBattle = if (battleDescriptor != null && battleDescriptor.isValid() &&
+        canBattle(battleDescriptor, odinId, allDiceDescriptors)
+    ) {
+        remember(message.id) { { onUiAction(ConversationListUiAction.BattleDiceRoll(message)) } }
+    } else null
     val onForward =
         if (policy.allowForward) remember(message.id) { { onUiAction(ConversationListUiAction.ForwardMessage(message)) } } else null
     val onShare =
@@ -126,9 +139,11 @@ fun MessageItem(
                 message = message,
                 userDefaultReactions = userDefaultReactions,
                 decryptedFiles = decryptedFiles,
+                currentOdinId = currentOdinId,
                 clusterPosition = clusterPosition,
                 onMessageInfo = onMessageInfo,
                 onReply = onReply,
+                onBattle = onBattle,
                 onForward = onForward,
                 onEdit = onEdit,
                 onShare = onShare,
@@ -160,11 +175,13 @@ fun MessageItem(
                 message = message,
                 userDefaultReactions = userDefaultReactions,
                 decryptedFiles = decryptedFiles,
+                currentOdinId = currentOdinId,
                 renderAuthorName = renderAuthorName,
                 isGroupConversation = isGroupConversation,
                 clusterPosition = clusterPosition,
                 onMessageInfo = onMessageInfo,
                 onReply = onReply,
+                onBattle = onBattle,
                 onForward = onForward,
                 onDelete = onDelete,
                 onMarkAsRead = onMarkAsRead,

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/dice/BattleChainTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/dice/BattleChainTest.kt
@@ -1,0 +1,165 @@
+package id.homebase.chat.dice
+
+import id.homebase.api.common.OdinId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+class BattleChainTest {
+
+    private val aliceId = Uuid.random()
+    private val bobId = Uuid.random()
+    private val carolId = Uuid.random()
+    private val danId = Uuid.random()
+    private val newcomerId = Uuid.random()
+
+    private val alice = OdinId("alice.test")
+    private val bob = OdinId("bob.test")
+    private val carol = OdinId("carol.test")
+    private val dan = OdinId("dan.test")
+    private val newcomer = OdinId("newcomer.test")
+
+    @Test
+    fun chainRootMessageId_is_first_entry_for_battle() {
+        val battle = battle(
+            entry(aliceId, alice, 10),
+            entry(bobId, bob, 15),
+        )
+        assertEquals(aliceId, battle.chainRootMessageId())
+    }
+
+    @Test
+    fun chainRootMessageId_is_self_for_standalone() {
+        val standalone = standalone(aliceId, alice, 10)
+        assertEquals(aliceId, standalone.chainRootMessageId())
+    }
+
+    @Test
+    fun findChainNewest_returns_target_when_no_chainmate_in_memory() {
+        val target = standalone(aliceId, alice, 10)
+        val newest = findChainNewest(target, listOf(target))
+        assertEquals(target, newest)
+    }
+
+    @Test
+    fun findChainNewest_returns_latest_battle_in_chain() {
+        val root = standalone(aliceId, alice, 10)
+        val bobBattle = battle(
+            entry(aliceId, alice, 10),
+            entry(bobId, bob, 15),
+        )
+        val carolBattle = battle(
+            entry(aliceId, alice, 10),
+            entry(bobId, bob, 15),
+            entry(carolId, carol, 20),
+        )
+        // Long-press the original root — newest in memory is carol's.
+        val newest = findChainNewest(root, listOf(root, bobBattle, carolBattle))
+        assertEquals(carolBattle, newest)
+    }
+
+    @Test
+    fun findChainNewest_ignores_other_chains() {
+        val chainA = standalone(aliceId, alice, 10)
+        val chainBRoot = Uuid.random()
+        val chainBSecond = Uuid.random()
+        val chainB = battle(
+            entry(chainBRoot, carol, 5),
+            entry(chainBSecond, dan, 8),
+        )
+        val newest = findChainNewest(chainA, listOf(chainA, chainB))
+        assertEquals(chainA, newest)
+    }
+
+    @Test
+    fun canBattle_blocks_null_caller() {
+        val target = standalone(aliceId, alice, 10)
+        assertFalse(canBattle(target, currentOdinId = null, listOf(target)))
+    }
+
+    @Test
+    fun canBattle_blocks_self() {
+        val target = standalone(aliceId, alice, 10)
+        // Alice can't battle her own standalone roll.
+        assertFalse(canBattle(target, currentOdinId = alice, listOf(target)))
+    }
+
+    @Test
+    fun canBattle_blocks_already_in_chain() {
+        val carolBattle = battle(
+            entry(aliceId, alice, 10),
+            entry(bobId, bob, 15),
+            entry(carolId, carol, 20),
+        )
+        // Bob already battled — can't go again.
+        assertFalse(canBattle(carolBattle, currentOdinId = bob, listOf(carolBattle)))
+    }
+
+    @Test
+    fun canBattle_blocks_when_chain_full() {
+        val full = battle(
+            entry(Uuid.random(), OdinId("p1.test"), 1),
+            entry(Uuid.random(), OdinId("p2.test"), 2),
+            entry(Uuid.random(), OdinId("p3.test"), 3),
+            entry(Uuid.random(), OdinId("p4.test"), 4),
+            entry(Uuid.random(), OdinId("p5.test"), 5),
+        )
+        assertEquals(DiceRollDescriptor.MAX_BATTLE_PARTICIPANTS, full.rolls.size)
+        assertFalse(canBattle(full, currentOdinId = newcomer, listOf(full)))
+    }
+
+    @Test
+    fun canBattle_allows_fresh_caller_in_open_chain() {
+        val bobBattle = battle(
+            entry(aliceId, alice, 10),
+            entry(bobId, bob, 15),
+        )
+        assertTrue(canBattle(bobBattle, currentOdinId = carol, listOf(bobBattle)))
+    }
+
+    @Test
+    fun canBattle_uses_newest_chain_state_not_long_pressed_message() {
+        // Long-press the original root, but a newer battle in memory has carol
+        // already in the chain. canBattle should reflect that.
+        val root = standalone(aliceId, alice, 10)
+        val bobBattle = battle(
+            entry(aliceId, alice, 10),
+            entry(bobId, bob, 15),
+        )
+        val carolBattle = battle(
+            entry(aliceId, alice, 10),
+            entry(bobId, bob, 15),
+            entry(carolId, carol, 20),
+        )
+        val all = listOf(root, bobBattle, carolBattle)
+        // Carol pressing on the root — already in chain, should be blocked.
+        assertFalse(canBattle(root, currentOdinId = carol, all))
+        // Dan fresh — allowed.
+        assertTrue(canBattle(root, currentOdinId = dan, all))
+    }
+
+    // ---- helpers ----
+
+    private fun entry(messageId: Uuid, odinId: OdinId, sum: Int): ChainRoll = ChainRoll(
+        messageId = messageId,
+        odinId = odinId,
+        results = listOf(sum.coerceIn(1, 20)),
+        rolledAtUtcMs = 1_700_000_000_000L,
+    )
+
+    private fun standalone(messageId: Uuid, odinId: OdinId, sum: Int): DiceRollDescriptor =
+        DiceRollDescriptor(
+            faces = 20,
+            rolls = listOf(entry(messageId, odinId, sum)),
+        )
+
+    /** Builds a battle with chronologically-ordered entries (1ms apart). */
+    private fun battle(vararg entries: ChainRoll): DiceRollDescriptor {
+        val withTimestamps = entries.mapIndexed { idx, e ->
+            e.copy(rolledAtUtcMs = 1_700_000_000_000L + idx)
+        }
+        return DiceRollDescriptor(faces = 20, rolls = withTimestamps)
+    }
+}

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/dice/DiceRollDescriptorTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/dice/DiceRollDescriptorTest.kt
@@ -1,5 +1,6 @@
 package id.homebase.chat.dice
 
+import id.homebase.api.common.OdinId
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.content.MessageContent
@@ -9,7 +10,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.uuid.Uuid
 
 class DiceRollDescriptorTest {
 
@@ -31,46 +34,116 @@ class DiceRollDescriptorTest {
     }
 
     @Test
-    fun summary_line_formats_NdF() {
+    fun summary_line_formats_NdF_for_standalone() {
         val descriptor = DiceRollDescriptor(
-            rollId = "abc", faces = 6,
-            results = listOf(3, 5, 1, 4),
-            rolledByOdinId = "alice.odin", rolledAtUtcMs = 0L,
+            faces = 6,
+            rolls = listOf(chainRoll(messageId = Uuid.random(), odinId = "alice.test", results = listOf(3, 5, 1, 4))),
         )
         assertEquals(13, descriptor.sum)
         assertEquals("Rolled 13 (4d6)", descriptor.summaryLine())
+        assertFalse(descriptor.isBattle)
+    }
+
+    @Test
+    fun summary_line_says_Battle_when_chain_has_two_or_more() {
+        val descriptor = battleDescriptor(
+            faces = 20,
+            entries = listOf(
+                "alice.test" to listOf(4, 17, 8),
+                "bob.test" to listOf(12, 18, 11),
+            ),
+        )
+        assertTrue(descriptor.isBattle)
+        assertEquals(41, descriptor.sum)  // bob's 12+18+11
+        assertEquals("Battle: rolled 41", descriptor.summaryLine())
     }
 
     @Test
     fun isValid_rejects_disallowed_face_count() {
-        val descriptor = baseDescriptor().copy(faces = 7, results = listOf(1, 2, 3))
-        assertTrue(!descriptor.isValid())
+        val descriptor = standaloneDescriptor(faces = 7, results = listOf(1, 2, 3))
+        assertFalse(descriptor.isValid())
     }
 
     @Test
-    fun isValid_rejects_empty_results() {
-        val descriptor = baseDescriptor().copy(results = emptyList())
-        assertTrue(!descriptor.isValid())
+    fun isValid_rejects_empty_rolls() {
+        val descriptor = DiceRollDescriptor(faces = 6, rolls = emptyList())
+        assertFalse(descriptor.isValid())
     }
 
     @Test
     fun isValid_rejects_out_of_range_value() {
-        val descriptor = baseDescriptor().copy(faces = 6, results = listOf(7))
-        assertTrue(!descriptor.isValid())
+        val descriptor = standaloneDescriptor(faces = 6, results = listOf(7))
+        assertFalse(descriptor.isValid())
     }
 
     @Test
     fun isValid_rejects_too_many_dice() {
-        val descriptor = baseDescriptor().copy(
+        val descriptor = standaloneDescriptor(
             faces = 6,
             results = List(DiceRollDescriptor.MAX_DICE + 1) { 3 },
         )
-        assertTrue(!descriptor.isValid())
+        assertFalse(descriptor.isValid())
+    }
+
+    @Test
+    fun isValid_rejects_chain_exceeding_max_participants() {
+        val entries = (1..DiceRollDescriptor.MAX_BATTLE_PARTICIPANTS + 1).map {
+            "p$it.test" to listOf(it.coerceAtMost(20))
+        }
+        val descriptor = battleDescriptor(faces = 20, entries = entries)
+        assertFalse(descriptor.isValid())
+    }
+
+    @Test
+    fun isValid_rejects_duplicate_odinIds_in_chain() {
+        val descriptor = battleDescriptor(
+            faces = 20,
+            entries = listOf(
+                "alice.test" to listOf(10),
+                "bob.test" to listOf(15),
+                "alice.test" to listOf(20),  // alice rebattled — not allowed
+            ),
+        )
+        assertFalse(descriptor.isValid())
+    }
+
+    @Test
+    fun isValid_rejects_chain_with_inconsistent_dice_count() {
+        // First entry has 2 dice, second has 3 — chain should lock the dice config.
+        val descriptor = DiceRollDescriptor(
+            faces = 20,
+            rolls = listOf(
+                chainRoll(messageId = Uuid.random(), odinId = "alice.test", results = listOf(10, 5), rolledAtUtcMs = 1L),
+                chainRoll(messageId = Uuid.random(), odinId = "bob.test", results = listOf(8, 12, 3), rolledAtUtcMs = 2L),
+            ),
+        )
+        assertFalse(descriptor.isValid())
+    }
+
+    @Test
+    fun isValid_rejects_non_chronological_chain() {
+        val descriptor = DiceRollDescriptor(
+            faces = 20,
+            rolls = listOf(
+                chainRoll(messageId = Uuid.random(), odinId = "alice.test", results = listOf(10), rolledAtUtcMs = 1000L),
+                chainRoll(messageId = Uuid.random(), odinId = "bob.test", results = listOf(15), rolledAtUtcMs = 500L),
+            ),
+        )
+        assertFalse(descriptor.isValid())
+    }
+
+    @Test
+    fun isValid_accepts_max_participants_chain() {
+        val entries = (1..DiceRollDescriptor.MAX_BATTLE_PARTICIPANTS).map {
+            "p$it.test" to listOf(it.coerceAtMost(20))
+        }
+        val descriptor = battleDescriptor(faces = 20, entries = entries)
+        assertTrue(descriptor.isValid(), "chain at exactly MAX should be valid")
     }
 
     @Test
     fun parser_round_trips_descriptor_through_messagecontent() {
-        val original = baseDescriptor().copy(faces = 20, results = listOf(20, 1, 10, 7))
+        val original = standaloneDescriptor(faces = 20, results = listOf(20, 1, 10, 7))
         val serialized = MessageContentParser.serialize(MessageContent.DiceRoll(original))
         val parsed = MessageContentParser.parse(
             ChatProtocol.ChatDiceRollMessageDataType,
@@ -84,15 +157,36 @@ class DiceRollDescriptorTest {
     }
 
     @Test
+    fun parser_round_trips_battle_descriptor() {
+        val original = battleDescriptor(
+            faces = 20,
+            entries = listOf(
+                "alice.test" to listOf(4, 17, 8),
+                "bob.test" to listOf(12, 18, 11),
+                "carol.test" to listOf(20, 15, 14),
+            ),
+        )
+        val serialized = MessageContentParser.serialize(MessageContent.DiceRoll(original))
+        val parsed = MessageContentParser.parse(
+            ChatProtocol.ChatDiceRollMessageDataType,
+            serialized,
+        )
+        val diceRoll = assertIs<MessageContent.DiceRoll>(parsed)
+        val descriptor = assertNotNull(diceRoll.descriptor)
+        assertEquals(original, descriptor)
+        assertEquals(3, descriptor.rolls.size)
+        assertTrue(descriptor.isBattle)
+    }
+
+    @Test
     fun parser_returns_dice_with_null_descriptor_for_invalid_payload() {
         // Hand-crafted JSON with disallowed `faces` value — parser must reject
         // it as a valid descriptor but still surface the message as a DiceRoll
         // kind (with a null descriptor) so MessageBubbleRaw renders the
         // unsupported-format chip rather than dropping the message into the
-        // text-fallback path, where the descriptor JSON would fail to
-        // deserialize as MessageAppData and the message would vanish.
+        // text-fallback path.
         val bogus = OdinSystemSerializer.serialize(
-            baseDescriptor().copy(faces = 7, results = listOf(1, 2, 3)),
+            standaloneDescriptor(faces = 7, results = listOf(1, 2, 3)),
         )
         val parsed = MessageContentParser.parse(
             ChatProtocol.ChatDiceRollMessageDataType,
@@ -105,23 +199,52 @@ class DiceRollDescriptorTest {
 
     @Test
     fun parser_dataTypeFor_returns_dice_constant() {
-        val descriptor = baseDescriptor()
+        val descriptor = standaloneDescriptor()
         val dt = MessageContentParser.dataTypeFor(MessageContent.DiceRoll(descriptor))
         assertEquals(ChatProtocol.ChatDiceRollMessageDataType, dt)
     }
 
     @Test
     fun parser_displayLabel_uses_summary_line() {
-        val descriptor = baseDescriptor().copy(faces = 12, results = listOf(11, 12, 6))
+        val descriptor = standaloneDescriptor(faces = 12, results = listOf(11, 12, 6))
         val content = MessageContent.DiceRoll(descriptor)
         assertEquals("Rolled 29 (3d12)", content.displayLabel)
     }
 
-    private fun baseDescriptor(): DiceRollDescriptor = DiceRollDescriptor(
-        rollId = "abc",
-        faces = 6,
-        results = listOf(1, 2, 3),
-        rolledByOdinId = "alice.odin",
-        rolledAtUtcMs = 1_700_000_000_000L,
+    // ---- helpers ----
+
+    private fun chainRoll(
+        messageId: Uuid,
+        odinId: String,
+        results: List<Int>,
+        rolledAtUtcMs: Long = 1_700_000_000_000L,
+    ): ChainRoll = ChainRoll(
+        messageId = messageId,
+        odinId = OdinId(odinId),
+        results = results,
+        rolledAtUtcMs = rolledAtUtcMs,
     )
+
+    private fun standaloneDescriptor(
+        faces: Int = 6,
+        results: List<Int> = listOf(1, 2, 3),
+    ): DiceRollDescriptor = DiceRollDescriptor(
+        faces = faces,
+        rolls = listOf(chainRoll(messageId = Uuid.random(), odinId = "alice.test", results = results)),
+    )
+
+    private fun battleDescriptor(
+        faces: Int,
+        entries: List<Pair<String, List<Int>>>,
+    ): DiceRollDescriptor {
+        val rolls = entries.mapIndexed { idx, (odinId, results) ->
+            chainRoll(
+                messageId = Uuid.random(),
+                odinId = odinId,
+                results = results,
+                rolledAtUtcMs = 1_700_000_000_000L + idx,
+            )
+        }
+        return DiceRollDescriptor(faces = faces, rolls = rolls)
+    }
 }

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -428,6 +428,35 @@
     <string name="chat_message_file">Fil</string>
     <string name="chat_message_multiple_media">Medier</string>
 
+    <!-- Dice attachment -->
+    <string name="chat_dice_share">Terninger</string>
+    <string name="chat_dice_composer_title">Slå terninger</string>
+    <string name="chat_dice_count_label">Antal terninger</string>
+    <string name="chat_dice_faces_label">Sider pr. terning</string>
+    <string name="chat_dice_face_label">d%1$d</string>
+    <string name="chat_dice_count_value">%1$dd</string>
+    <string name="chat_dice_decrement">Færre terninger</string>
+    <string name="chat_dice_increment">Flere terninger</string>
+    <string name="chat_dice_roll">Slå</string>
+    <string name="chat_dice_rolling">Slår…</string>
+    <string name="chat_dice_max_dice_warning">Op til %1$d terninger pr. slag.</string>
+    <string name="chat_dice_shake_hint">Eller ryst din telefon.</string>
+    <string name="chat_dice_face_content_description">d%1$d viser %2$d</string>
+    <string name="chat_dice_face_placeholder_content_description">d%1$d terning</string>
+    <string name="chat_dice_summary">Du slog %1$d (%2$s)</string>
+    <string name="chat_dice_summary_single">Du slog %1$d</string>
+    <string name="chat_dice_summary_other">%1$s slog %2$d (%3$s)</string>
+    <string name="chat_dice_summary_other_single">%1$s slog %2$d</string>
+    <string name="chat_dice_unparseable">Gammelt slag</string>
+    <string name="chat_dice_battle_action">Kamp</string>
+    <string name="chat_dice_battle_title">Kamp</string>
+    <string name="chat_dice_battle_target">Slå højere end %1$d for at slå %2$s</string>
+    <string name="chat_dice_battle_leader_self">Du fører med %1$d</string>
+    <string name="chat_dice_battle_leader_other">%1$s fører med %2$d</string>
+    <string name="chat_dice_battle_tie_self">%1$s er uafgjort med %2$d</string>
+    <string name="chat_dice_battle_tie_other">%1$s er uafgjort med %2$d</string>
+    <string name="chat_dice_battle_and">og</string>
+
     <string name="chat_message_attachment_gallery">Galleri</string>
     <string name="chat_message_attachment_file">Fil</string>
     <string name="chat_message_attachment_contact">Kontakt</string>

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -447,10 +447,10 @@
     <string name="chat_dice_summary_single">Du slog %1$d</string>
     <string name="chat_dice_summary_other">%1$s slog %2$d (%3$s)</string>
     <string name="chat_dice_summary_other_single">%1$s slog %2$d</string>
-    <string name="chat_dice_unparseable">Gammelt slag</string>
-    <string name="chat_dice_battle_action">Kamp</string>
-    <string name="chat_dice_battle_title">Kamp</string>
-    <string name="chat_dice_battle_target">Slå højere end %1$d for at slå %2$s</string>
+    <string name="chat_dice_unparseable">Forhistorisk slag</string>
+    <string name="chat_dice_battle_action">Duel</string>
+    <string name="chat_dice_battle_title">Duel</string>
+    <string name="chat_dice_battle_target">Slå højere end %1$d for at vinde over %2$s</string>
     <string name="chat_dice_battle_leader_self">Du fører med %1$d</string>
     <string name="chat_dice_battle_leader_other">%1$s fører med %2$d</string>
     <string name="chat_dice_battle_tie_self">%1$s er uafgjort med %2$d</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -554,6 +554,8 @@
     <string name="chat_dice_face_placeholder_content_description">d%1$d die</string>
     <string name="chat_dice_summary">You rolled %1$d (%2$s)</string>
     <string name="chat_dice_summary_single">You rolled %1$d</string>
+    <string name="chat_dice_summary_other">%1$s rolled %2$d (%3$s)</string>
+    <string name="chat_dice_summary_other_single">%1$s rolled %2$d</string>
     <string name="chat_dice_unparseable">Ancient roll</string>
     <string name="chat_dice_battle_action">Battle</string>
     <string name="chat_dice_battle_title">Battle</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -554,7 +554,15 @@
     <string name="chat_dice_face_placeholder_content_description">d%1$d die</string>
     <string name="chat_dice_summary">You rolled %1$d (%2$s)</string>
     <string name="chat_dice_summary_single">You rolled %1$d</string>
-    <string name="chat_dice_unparseable">Unable to display this dice roll. Please update the app.</string>
+    <string name="chat_dice_unparseable">Ancient roll</string>
+    <string name="chat_dice_battle_action">Battle</string>
+    <string name="chat_dice_battle_title">Battle</string>
+    <string name="chat_dice_battle_target">Roll higher than %1$d to beat %2$s</string>
+    <string name="chat_dice_battle_leader_self">You lead with %1$d</string>
+    <string name="chat_dice_battle_leader_other">%1$s leads with %2$d</string>
+    <string name="chat_dice_battle_tie_self">%1$s tie with %2$d</string>
+    <string name="chat_dice_battle_tie_other">%1$s tie with %2$d</string>
+    <string name="chat_dice_battle_and">and</string>
     <string name="chat_unknown_message_type">Unknown message type — please update the app.</string>
     <string name="chat_unknown_message_type_diagnostic">(type %1$d)</string>
 
@@ -578,7 +586,6 @@
     <string name="chat_reactions_title">Reactions</string>
     <string name="chat_reactions_all">All</string>
     <string name="chat_reactions_tap_to_remove">Tap to remove</string>
-    <string name="chat_reactions_limit_reached">You cannot add more emojis, remove one first before adding another.</string>
     <string name="chat_message_discard_draft">Discard draft?</string>
 
     <string name="chat_message_forward_to">Forward to</string>


### PR DESCRIPTION
Long-press a dice-roll bubble → "Battle" menu entry → fullscreen sheet with the same dice config locked, only Roll (or shake) and back. Sends a new dice-roll message that joins a chain. Each subsequent person in the chat can battle the latest roll. Bubble copy: "alice leads with 28" / "You and bob tie with 18".

Wire format change on DiceRollDescriptor: replaces the per-message {rollId, results, rolledByOdinId, rolledAtUtcMs, source} fields with a single `rolls: List<ChainRoll>` array. `rolls.size == 1` means standalone roll (or chain root before anyone battles); `rolls.size >= 2` means battle. The latest entry is "this message's roll"; earlier entries are the chain history copied forward. Each ChainRoll uses strong types (`messageId: Uuid`, `odinId: OdinId`) and `messageId` is the chat message's own uniqueId — not a separately-generated GUID. Bubbles render self-contained from the embedded array; historical bubbles never change as new battles arrive.

Constraints (enforced in DiceRollDescriptor.isValid + BattleChain.canBattle):
- max 5 participants per chain
- each odinId may roll at most once per chain (no rebattle)
- chain must have consistent dice config (faces + count) and chronological timestamps

Eligibility gate runs in MessageItem from the in-memory list of dice descriptors; the long-press menu hides Battle when chain is full or the current user is already in it. Battle screen finds the chain's newest member from memory (so long-pressing the original after others battled still locks to the latest config).

Older dice-roll messages on the wire (pre-chain shape) fail isValid and render as the "Ancient roll" chip — renamed from the previous "Unable to display this dice roll" copy.

Files:
- DiceRollDescriptor / ChainRoll: new wire shape + validation
- BattleChain: pure helpers (chainRootMessageId, findChainNewest, chainParticipants, chainSize, canBattle)
- BattleRollSheet: fullscreen Dialog mirroring DiceRollComposerSheet
- DiceRollBubble: leader-line for battles, computed from descriptor.rolls
- DiceRollComposerSheet: now ties messageId = ChainRoll.messageId
- MessageItem / MessageBubble / MessageBubbleRaw / Menu: onBattle callback + menu entry under Reply (Casino icon)
- ConversationContent: derives allDiceDescriptors once, threads to MessageItem, renders BattleRollSheet on battleTargetMessage
- ConversationListUiAction / UiState / ViewModel: BattleDiceRoll + CancelBattleDiceRoll
- strings.xml: chat_dice_battle_* family + retitled chat_dice_unparseable to "Ancient roll"
- Tests: DiceRollDescriptorTest reworked for new shape; BattleChainTest new (root resolution, newest-wins, no-rebattle, cap, fresh caller)