### PR TITLE
fix(chat): heal-group recovers missing files, not just broken ones

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupFilesDiagnosticBlock.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupFilesDiagnosticBlock.kt
@@ -1,0 +1,178 @@
+package id.homebase.chat.groupsettings
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.unit.dp
+import id.homebase.core.clipboard.clipEntryOf
+import id.homebase.resources.MR
+import id.homebase.resources.chat_group_files_diagnostic_absent
+import id.homebase.resources.chat_group_files_diagnostic_db_admin_label
+import id.homebase.resources.chat_group_files_diagnostic_db_group_label
+import id.homebase.resources.chat_group_files_diagnostic_placeholder
+import id.homebase.resources.chat_group_files_diagnostic_present
+import id.homebase.resources.chat_group_files_diagnostic_server_admin_label
+import id.homebase.resources.chat_group_files_diagnostic_server_group_label
+import id.homebase.resources.chat_group_files_diagnostic_title
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Read-only DB-vs-own-server diagnostic for the user's two group files
+ * (main + admin), rendered at the very bottom of the group-info screen.
+ *
+ * Four rows: DB-group, DB-admin, Server-group, Server-admin. Each row
+ * shows one of three states (Present / Placeholder / Absent for DB rows;
+ * Present / Absent for Server rows — server never stores placeholders).
+ *
+ * Long-press copies a single-line support blob with full UUIDs to the
+ * clipboard. Visible-row UUIDs are 8-hex truncated to fit on a phone.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun GroupFilesDiagnosticBlock(
+    diagnostic: GroupFilesDiagnostic,
+    selfDomain: String?,
+    modifier: Modifier = Modifier,
+) {
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
+    val copyBlob = buildSupportBlob(diagnostic, selfDomain)
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .combinedClickable(
+                onClick = {},
+                onLongClick = {
+                    scope.launch {
+                        clipboard.setClipEntry(clipEntryOf(copyBlob))
+                    }
+                },
+            )
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+    ) {
+        Text(
+            text = stringResource(MR.string.chat_group_files_diagnostic_title),
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Spacer(Modifier.height(8.dp))
+
+        DiagnosticRow(
+            label = stringResource(MR.string.chat_group_files_diagnostic_db_group_label),
+            value = dbValueText(diagnostic.dbGroup, expectedUid = diagnostic.expectedMainUniqueId),
+            isHealthy = diagnostic.dbGroup is DbFileRow.Present,
+        )
+        DiagnosticRow(
+            label = stringResource(MR.string.chat_group_files_diagnostic_db_admin_label),
+            value = dbValueText(diagnostic.dbAdmin, expectedUid = diagnostic.expectedAdminUniqueId),
+            isHealthy = diagnostic.dbAdmin is DbFileRow.Present,
+        )
+        DiagnosticRow(
+            label = stringResource(MR.string.chat_group_files_diagnostic_server_group_label),
+            value = serverValueText(diagnostic.serverGroup, expectedUid = diagnostic.expectedMainUniqueId),
+            isHealthy = diagnostic.serverGroup is ServerFileRow.Present,
+        )
+        DiagnosticRow(
+            label = stringResource(MR.string.chat_group_files_diagnostic_server_admin_label),
+            value = serverValueText(diagnostic.serverAdmin, expectedUid = diagnostic.expectedAdminUniqueId),
+            isHealthy = diagnostic.serverAdmin is ServerFileRow.Present,
+        )
+    }
+}
+
+@Composable
+private fun DiagnosticRow(
+    label: String,
+    value: String,
+    isHealthy: Boolean,
+) {
+    Row(modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp)) {
+        Text(
+            text = label,
+            modifier = Modifier.width(110.dp),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodySmall,
+            color = if (isHealthy) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.error,
+        )
+    }
+}
+
+@Composable
+private fun dbValueText(row: DbFileRow, expectedUid: Uuid): String = when (row) {
+    is DbFileRow.Present -> stringResource(
+        MR.string.chat_group_files_diagnostic_present,
+        shortHex(expectedUid),
+        shortHex(row.versionTag),
+        row.originalAuthor.domainName,
+    )
+    is DbFileRow.Placeholder -> stringResource(
+        MR.string.chat_group_files_diagnostic_placeholder,
+        shortHex(expectedUid),
+    )
+    DbFileRow.Absent -> stringResource(
+        MR.string.chat_group_files_diagnostic_absent,
+        shortHex(expectedUid),
+    )
+}
+
+@Composable
+private fun serverValueText(row: ServerFileRow, expectedUid: Uuid): String = when (row) {
+    is ServerFileRow.Present -> stringResource(
+        MR.string.chat_group_files_diagnostic_present,
+        shortHex(expectedUid),
+        shortHex(row.versionTag),
+        row.originalAuthor.domainName,
+    )
+    ServerFileRow.Absent -> stringResource(
+        MR.string.chat_group_files_diagnostic_absent,
+        shortHex(expectedUid),
+    )
+}
+
+/** First 8 hex chars of the UUID's canonical form. Stable, readable, and fits on a phone row. */
+private fun shortHex(uuid: Uuid): String = uuid.toString().take(8)
+
+/**
+ * Single-line support blob with full UUIDs. Pasted by users into support
+ * messages to give us everything we'd need to grep `homebase.log`.
+ */
+internal fun buildSupportBlob(d: GroupFilesDiagnostic, selfDomain: String?): String = buildString {
+    append("[group-files] convo=").append(d.conversationId)
+    append(" domain=").append(selfDomain ?: "?")
+    append("\n  db-group=").append(describeDb(d.dbGroup))
+    append("\n  db-admin=").append(describeDb(d.dbAdmin))
+    append("\n  server-group=").append(describeServer(d.serverGroup))
+    append("\n  server-admin=").append(describeServer(d.serverAdmin))
+    append("\n  expectedMainUid=").append(d.expectedMainUniqueId)
+    append(" expectedAdminUid=").append(d.expectedAdminUniqueId)
+}
+
+private fun describeDb(row: DbFileRow): String = when (row) {
+    is DbFileRow.Present -> "Present(vt=${row.versionTag}, author=${row.originalAuthor.domainName}, fileId=${row.fileId})"
+    is DbFileRow.Placeholder -> "Placeholder(fileId=${row.fileId})"
+    DbFileRow.Absent -> "Absent"
+}
+
+private fun describeServer(row: ServerFileRow): String = when (row) {
+    is ServerFileRow.Present -> "Present(vt=${row.versionTag}, author=${row.originalAuthor.domainName}, fileId=${row.fileId})"
+    ServerFileRow.Absent -> "Absent"
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupFilesDiagnosticProjection.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupFilesDiagnosticProjection.kt
@@ -1,0 +1,49 @@
+package id.homebase.chat.groupsettings
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.client.drives.HomebaseFile
+
+/**
+ * Projection helpers for the group-info file health diagnostic. Pure
+ * functions over a single [HomebaseFile] (or null for "no row"); all the
+ * branching that decides what each diagnostic row displays lives here so
+ * it can be unit-tested without ViewModel scaffolding.
+ *
+ * Notes on the rules:
+ *
+ * - **DB Placeholder** is the local-only marker written by
+ *   `OptimisticWriter.writeLocalOnlyConversationPlaceholder` /
+ *   `writeLocalOnlyAdminPlaceholder` (versionTag=null). It exists in
+ *   the local DB but never on the server.
+ * - **Server Placeholder** is impossible by construction — the server
+ *   never accepts a versionTag=null write. If the server ever returns one
+ *   we treat it as Absent and log so we notice.
+ * - A DB row with a real versionTag but no author is malformed; surface
+ *   as Placeholder rather than crashing on the unwrap and log.
+ */
+internal fun toDbRow(file: HomebaseFile?): DbFileRow {
+    if (file == null) return DbFileRow.Absent
+    val vt = file.fileMetadata.versionTag
+    if (vt == null) return DbFileRow.Placeholder(fileId = file.fileId)
+    val author = file.fileMetadata.originalAuthor ?: file.fileMetadata.senderOdinId
+    if (author == null) {
+        Logger.w { "toDbRow: file ${file.fileId} has versionTag=$vt but no author — surfacing as Placeholder" }
+        return DbFileRow.Placeholder(fileId = file.fileId)
+    }
+    return DbFileRow.Present(versionTag = vt, originalAuthor = author, fileId = file.fileId)
+}
+
+internal fun toServerRow(file: HomebaseFile?): ServerFileRow {
+    if (file == null) return ServerFileRow.Absent
+    val vt = file.fileMetadata.versionTag
+    if (vt == null) {
+        Logger.w { "toServerRow: server returned a file with versionTag=null (fileId=${file.fileId}) — surfacing as Absent" }
+        return ServerFileRow.Absent
+    }
+    val author = file.fileMetadata.originalAuthor ?: file.fileMetadata.senderOdinId
+    if (author == null) {
+        Logger.w { "toServerRow: server returned a file with no author (fileId=${file.fileId}, vt=$vt) — surfacing as Absent" }
+        return ServerFileRow.Absent
+    }
+    return ServerFileRow.Present(versionTag = vt, originalAuthor = author, fileId = file.fileId)
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsScreen.kt
@@ -438,6 +438,16 @@ fun GroupSettingsUi(
                             }
                         )
                     }
+                    if (uiState.filesDiagnostic != null) {
+                        item {
+                            HorizontalDivider()
+                            GroupFilesDiagnosticBlock(
+                                diagnostic = uiState.filesDiagnostic,
+                                selfDomain = uiState.currentOdinId?.domainName,
+                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp),
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsUiState.kt
@@ -29,6 +29,11 @@ data class GroupSettingsUiState(
     /** True while leaveGroup is awaiting server completion. Drives the full-screen
      *  overlay. Cleared on error; on success the screen pops via the [Back] event. */
     val isLeaving: Boolean = false,
+    /** Local-only DB-vs-own-server diagnostic for this group's two files (main + admin).
+     *  Populated by [GroupSettingsViewModel.loadTransferHistory]; null while loading and
+     *  on non-group / legacy-group conversations (legacy groups inline admins, so a
+     *  separate "DB-admin: absent" row would be a false positive). */
+    val filesDiagnostic: GroupFilesDiagnostic? = null,
     val uiEvent: GroupSettingsUiEvent? = null,
     val uiDialog: GroupSettingsUiDialog? = null,
     val uiSheet: GroupSettingsUiSheet? = null,
@@ -40,6 +45,60 @@ data class GroupSettingsUiState(
 sealed interface RecipientFileStatus {
     data object Ok : RecipientFileStatus
     data class Problem(val rawStatus: TransferStatus, val detailRes: StringResource?) : RecipientFileStatus
+}
+
+/**
+ * Local-DB state of one of the two group files (main conversation file or
+ * admin file). Three states; [Placeholder] is the local-only marker written
+ * by `OptimisticWriter.writeLocalOnlyConversationPlaceholder` /
+ * `writeLocalOnlyAdminPlaceholder` (versionTag=null) — server has no copy
+ * yet, peer push from canonical author will replace it.
+ */
+@Immutable
+sealed interface DbFileRow {
+    data class Present(
+        val versionTag: Uuid,
+        val originalAuthor: OdinId,
+        val fileId: Uuid,
+    ) : DbFileRow
+
+    data class Placeholder(val fileId: Uuid) : DbFileRow
+
+    data object Absent : DbFileRow
+}
+
+/**
+ * Server-side state, derived from [DbFileRow]: post-sync, local DB and own
+ * server agree except for placeholders. From the server's point of view a
+ * [DbFileRow.Placeholder] is indistinguishable from absent.
+ */
+@Immutable
+sealed interface ServerFileRow {
+    data class Present(
+        val versionTag: Uuid,
+        val originalAuthor: OdinId,
+        val fileId: Uuid,
+    ) : ServerFileRow
+
+    data object Absent : ServerFileRow
+}
+
+/** The four cells of the group-info diagnostic block. */
+@Immutable
+data class GroupFilesDiagnostic(
+    val conversationId: Uuid,
+    val expectedMainUniqueId: Uuid,
+    val expectedAdminUniqueId: Uuid,
+    val dbGroup: DbFileRow,
+    val dbAdmin: DbFileRow,
+    val serverGroup: ServerFileRow,
+    val serverAdmin: ServerFileRow,
+) {
+    val allHealthy: Boolean
+        get() = dbGroup is DbFileRow.Present &&
+                dbAdmin is DbFileRow.Present &&
+                serverGroup is ServerFileRow.Present &&
+                serverAdmin is ServerFileRow.Present
 }
 
 sealed interface GroupSettingsUiEvent {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsViewModel.kt
@@ -18,8 +18,12 @@ import id.homebase.chat.groupsettings.GroupSettingsUiEvent.Error
 import id.homebase.chat.groupsettings.GroupSettingsUiEvent.ShowAddMembers
 import id.homebase.chat.groupsettings.GroupSettingsUiEvent.ShowContactInfo
 import id.homebase.chat.groupsettings.GroupSettingsUiEvent.ShowEditGroup
+import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.convo.ConversationService
 import id.homebase.chat.services.convo.ConversationStream
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import id.homebase.chat.services.convo.contact.ContactConnectionState
 import id.homebase.chat.services.convo.contact.ContactService
 import id.homebase.chat.services.toErrorDetailRes
@@ -364,18 +368,81 @@ class GroupSettingsViewModel(
         val mainTransfer = fetchTransferIfAuthor("main", domain, mainFile)
         val adminTransfer = fetchTransferIfAuthor("admin", domain, adminFile)
 
+        // DB-vs-own-server diagnostic. Local rows come from the file reads
+        // above (already in memory). Server rows are fetched directly from
+        // the user's own drive — `getFileHeaderByUid` hits
+        // `/drives/{driveId}/files/by-uid/{uniqueId}/header` and returns
+        // null on 404, so we get the truth regardless of whether drive-sync
+        // is current. The two GETs run in parallel; they're cheap (header
+        // only, no payloads) and only fire when this screen is open.
+        val dbGroup = toDbRow(mainFile)
+        val dbAdmin = toDbRow(adminFile)
+        val expectedMainUniqueId = conversation.id // main file's uniqueId == conversationId by construction
+        val expectedAdminUniqueId = ChatProtocol.getAdminFileUniqueId(conversation.id)
+
+        val (serverMainFile, serverAdminFile) = try {
+            coroutineScope {
+                val main = async {
+                    runCatching {
+                        driveFileProvider.getFileHeaderByUid(chatTargetDrive.alias, expectedMainUniqueId)
+                    }.onFailure {
+                        Logger.w(throwable = it) { "loadTransferHistory: getFileHeaderByUid(main) failed for ${conversation.id}" }
+                    }.getOrNull()
+                }
+                val admin = async {
+                    runCatching {
+                        driveFileProvider.getFileHeaderByUid(chatTargetDrive.alias, expectedAdminUniqueId)
+                    }.onFailure {
+                        Logger.w(throwable = it) { "loadTransferHistory: getFileHeaderByUid(admin) failed for ${conversation.id}" }
+                    }.getOrNull()
+                }
+                listOf(main, admin).awaitAll().let { it[0] to it[1] }
+            }
+        } catch (e: Exception) {
+            Logger.w(throwable = e) { "loadTransferHistory: parallel server header fetch failed for ${conversation.id}" }
+            null to null
+        }
+
+        val diagnostic = GroupFilesDiagnostic(
+            conversationId = conversation.id,
+            expectedMainUniqueId = expectedMainUniqueId,
+            expectedAdminUniqueId = expectedAdminUniqueId,
+            dbGroup = dbGroup,
+            dbAdmin = dbAdmin,
+            serverGroup = toServerRow(serverMainFile),
+            serverAdmin = toServerRow(serverAdminFile),
+        )
+
         Logger.d {
             "loadTransferHistory: ${conversation.id} mainAuthored=${mainTransfer != null} mainEntries=${mainTransfer?.size} " +
                     "adminAuthored=${adminTransfer != null} adminEntries=${adminTransfer?.size} " +
                     "main=${renderTransferMap(mainTransfer)} admin=${renderTransferMap(adminTransfer)}"
+        }
+        Logger.i {
+            "GroupSettings: filesDiagnostic conversationId=${conversation.id} " +
+                "dbGroup=${describeDb(diagnostic.dbGroup)} dbAdmin=${describeDb(diagnostic.dbAdmin)} " +
+                "serverGroup=${describeServer(diagnostic.serverGroup)} serverAdmin=${describeServer(diagnostic.serverAdmin)} " +
+                "expectedMainUid=${diagnostic.expectedMainUniqueId} expectedAdminUid=${diagnostic.expectedAdminUniqueId}"
         }
 
         _uiState.update {
             it.copy(
                 mainFileTransfer = mainTransfer,
                 adminFileTransfer = adminTransfer,
+                filesDiagnostic = diagnostic,
             )
         }
+    }
+
+    private fun describeDb(row: DbFileRow): String = when (row) {
+        is DbFileRow.Present -> "Present(vt=${row.versionTag}, author=${row.originalAuthor.domainName}, fileId=${row.fileId})"
+        is DbFileRow.Placeholder -> "Placeholder(fileId=${row.fileId})"
+        DbFileRow.Absent -> "Absent"
+    }
+
+    private fun describeServer(row: ServerFileRow): String = when (row) {
+        is ServerFileRow.Present -> "Present(vt=${row.versionTag}, author=${row.originalAuthor.domainName}, fileId=${row.fileId})"
+        ServerFileRow.Absent -> "Absent"
     }
 
     private fun renderTransferMap(map: Map<OdinId, RecipientFileStatus>?): String {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/StatusMessageData.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/StatusMessageData.kt
@@ -27,6 +27,11 @@ data class GroupHealInfo(
     val canonicalParticipants: List<OdinId>,
     val canonicalAdminFileUniqueId: Uuid,
     val canonicalAdminVersionTag: Uuid?,
+    // Nullable for backwards-compat: pre-hardening senders never set this. When
+    // present, the receive-side handler can rebuild a fully-formed local admin
+    // placeholder (matching content) instead of just deleting the broken row
+    // and relying on getAdmins()' originalAuthor fallback.
+    val canonicalAdmins: List<OdinId>? = null,
 )
 
 @Serializable

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -1660,6 +1660,64 @@ class ConversationService(
         audit.step(3, "conversationStream.loadConversation()")
         conversationStream.loadConversation(conversationId)
     }
+
+    /**
+     * Counterpart to [writeOrReplaceConversationPlaceholder] for the admin
+     * file. Used by [handleIncomingHealRequest] when the incoming heal
+     * payload carries `canonicalAdmins` and the local admin file is missing
+     * or broken.
+     *
+     * Deletes the existing broken admin row first (if any) to sidestep
+     * DriveMainIndex's modified-timestamp upsert guard, then writes a
+     * local-only admin placeholder via
+     * [OptimisticWriter.writeLocalOnlyAdminPlaceholder] (versionTag=null so
+     * a later genuine peer push from the canonical author replaces it).
+     */
+    private suspend fun writeOrReplaceAdminPlaceholder(
+        conversationId: Uuid,
+        brokenFileIdToDelete: Uuid?,
+        admins: List<OdinId>,
+        audit: MethodAudit,
+    ) {
+        if (brokenFileIdToDelete != null) {
+            audit.step(1, "deleteBy(broken admin row fileId=$brokenFileIdToDelete)")
+            runCatching {
+                dbm.driveMainIndex.deleteBy(
+                    identityId = credentialsManager.requireActiveCredentials().getIdentityId(),
+                    driveId = chatDrive,
+                    fileId = brokenFileIdToDelete,
+                )
+            }.onSuccess { audit.checkPass("deleteBrokenAdminRow") }
+                .onFailure {
+                    audit.threw("deleteBrokenAdminRow", it)
+                    Logger.w(it) {
+                        "writeOrReplaceAdminPlaceholder($conversationId) — failed to delete broken admin row fileId=$brokenFileIdToDelete; placeholder write may be a no-op"
+                    }
+                }
+        } else {
+            audit.info("writeOrReplaceAdminPlaceholder: no broken local admin row to delete (admin file was missing)")
+        }
+
+        audit.step(2, "writeLocalOnlyAdminPlaceholder(admins=${admins.size})")
+        runCatching {
+            optimisticWriter.writeLocalOnlyAdminPlaceholder(
+                driveId = chatDrive,
+                conversationId = conversationId,
+                admins = admins,
+            )
+        }.onSuccess {
+            audit.checkPass("adminPlaceholderWritten")
+            Logger.i {
+                "writeOrReplaceAdminPlaceholder: wrote local admin placeholder conversationId=$conversationId admins(${admins.size})=${admins.map { it.domainName }}"
+            }
+        }.onFailure { e ->
+            audit.threw("adminPlaceholderWritten", e)
+            Logger.w(e) {
+                "writeOrReplaceAdminPlaceholder: FAILED to write local admin placeholder for $conversationId"
+            }
+            throw e
+        }
+    }
     // endregion
 
     suspend fun deleteConversation(conversationId: Uuid) {
@@ -1933,7 +1991,15 @@ class ConversationService(
                 (preMainFile.fileMetadata.originalAuthor ?: preMainFile.fileMetadata.senderOdinId) == domain
         if (callerIsMainAuthor) {
             try {
-                Logger.i { "healGroupDistribution: sending GroupHealRequested status conversationId=$conversationId versionTag=${preMainFile.fileMetadata.versionTag} adminVersionTag=${preAdminFile?.fileMetadata?.versionTag}" }
+                val canonicalAdminsForStatus = conversation.admins.toList()
+                Logger.i {
+                    "healGroupDistribution: sending GroupHealRequested status conversationId=$conversationId " +
+                        "versionTag=${preMainFile.fileMetadata.versionTag} " +
+                        "adminVersionTag=${preAdminFile?.fileMetadata?.versionTag} " +
+                        "title=\"${conversation.name}\" " +
+                        "participants(${conversation.participants.size})=${conversation.participants.map { it.domainName }} " +
+                        "admins(${canonicalAdminsForStatus.size})=${canonicalAdminsForStatus.map { it.domainName }}"
+                }
                 chatMessageSenderService.sendStatusMessage(
                     messageUniqueId = Uuid.random(),
                     conversationId = conversationId,
@@ -1947,6 +2013,7 @@ class ConversationService(
                             canonicalParticipants = conversation.participants,
                             canonicalAdminFileUniqueId = ChatProtocol.getAdminFileUniqueId(conversationId),
                             canonicalAdminVersionTag = preAdminFile?.fileMetadata?.versionTag,
+                            canonicalAdmins = canonicalAdminsForStatus,
                         ),
                     ),
                 )
@@ -2028,21 +2095,43 @@ class ConversationService(
 
     /**
      * Receive-side handler for an incoming [StatusMessage.GroupHealRequested]
-     * status. Compares the local conversation + admin files against the canonical
-     * fields the sender announced; if either is broken (mismatched originalAuthor
-     * or versionTag), hard-deletes the broken file on our own server, deletes
-     * the local row, writes an optimistic placeholder so the next genuine peer
-     * push lands cleanly, and surfaces a local-only [StatusMessage.GroupHealLocalCleanup]
+     * status. Compares the local conversation + admin files against the
+     * canonical fields the sender announced; if either is *broken* (mismatched
+     * originalAuthor or versionTag) or *missing* (no local row at all), hard-
+     * deletes the broken row from our own server (no-op when the file is
+     * merely missing), writes a local-only placeholder seeded from the heal
+     * payload — title/participants for the main file, [GroupHealInfo.canonicalAdmins]
+     * for the admin file when present — so the UI behaves as if nothing was
+     * ever broken, and surfaces a local-only [StatusMessage.GroupHealLocalCleanup]
      * status into the conversation so the user sees the cleanup.
      *
-     * No-op cases (return without side effects):
+     * Two-step protocol:
+     *   1. First heal status: receiver cleans up its broken/missing server
+     *      state and writes a versionTag=null placeholder. The receiver's
+     *      drive on the server is now empty for this conversation.
+     *   2. Subsequent peer push (driven by the canonical author's
+     *      [healGroupDistribution] → [updateConversationInternal] /
+     *      [updateAdminFile]) lands as a fresh create on the receiver's
+     *      drive (no versionTag conflict because the broken row was hard-
+     *      deleted), and DriveMainIndex's modified-timestamp guard passes
+     *      because the placeholder's `updated` is ZeroTime — so the
+     *      placeholder is replaced in-place by the real file.
+     *
+     * Legacy compatibility: pre-hardening senders set
+     * [GroupHealInfo.canonicalAdmins] to null. In that case the admin branch
+     * falls back to the old delete-only behaviour (relying on getAdmins()'
+     * originalAuthor fallback to keep things functional in the gap). The
+     * main-file branch always has enough data to rebuild — title and
+     * participants have always been in the payload.
+     *
+     * No-op cases (return without side effects beyond markHealApplied):
      *   - Sender's domain doesn't match the canonical originalAuthor (forgery
      *     guard).
      *   - The canonical originalAuthor is us (we're seeing our own outgoing
      *     status loop back).
      *   - The local conversation is in Left/Removed/RejoinPending state — we
      *     don't resurrect groups the user has explicitly left.
-     *   - Both local files match the canonical identity.
+     *   - Both local files exist and match the canonical identity.
      */
     suspend fun handleIncomingHealRequest(
         status: StatusMessageData,
@@ -2095,6 +2184,20 @@ class ConversationService(
         val mainFile = getConversationHomebaseFile(info.conversationUniqueId)
         val adminFile = getConversationAdminHomebaseFile(info.conversationUniqueId)
 
+        // Distinguish "missing" from "broken":
+        //   missing → no local row at all (post-wipe, never-synced, hard-
+        //             deleted on a prior heal pass that happened to lose the
+        //             follow-up peer push).
+        //   broken  → row exists but originalAuthor or versionTag diverges
+        //             from the canonical identity (the classic heal target).
+        // The previous implementation collapsed missing into "not broken"
+        // because mainFile==null short-circuited the && isFileBroken check.
+        // That left users whose file had vanished from both their local DB
+        // and their server-side drive permanently stuck — markHealApplied
+        // would tag the status message and every future replay would
+        // short-circuit at the HealAppliedTag gate.
+        val mainMissing = mainFile == null
+        val adminMissing = adminFile == null
         val mainBroken = mainFile != null && isFileBroken(
             file = mainFile,
             canonicalAuthor = info.canonicalOriginalAuthor,
@@ -2105,12 +2208,40 @@ class ConversationService(
             canonicalAuthor = info.canonicalOriginalAuthor,
             canonicalVersionTag = info.canonicalAdminVersionTag,
         )
+        val mainNeedsHeal = mainMissing || mainBroken
+        val adminNeedsHeal = adminMissing || adminBroken
 
-        audit.pre("mainFile: exists=${mainFile != null} broken=$mainBroken localAuthor=${mainFile?.fileMetadata?.originalAuthor?.domainName} localVT=${mainFile?.fileMetadata?.versionTag} canonicalAuthor=${info.canonicalOriginalAuthor.domainName} canonicalVT=${info.canonicalVersionTag}")
-        audit.pre("adminFile: exists=${adminFile != null} broken=$adminBroken localAuthor=${adminFile?.fileMetadata?.originalAuthor?.domainName} localVT=${adminFile?.fileMetadata?.versionTag} canonicalAdminVT=${info.canonicalAdminVersionTag}")
+        audit.pre(
+            "mainFile: exists=${mainFile != null} missing=$mainMissing broken=$mainBroken needsHeal=$mainNeedsHeal " +
+                "fileId=${mainFile?.fileId} localAuthor=${mainFile?.fileMetadata?.originalAuthor?.domainName} " +
+                "localVT=${mainFile?.fileMetadata?.versionTag} " +
+                "canonicalAuthor=${info.canonicalOriginalAuthor.domainName} canonicalVT=${info.canonicalVersionTag}"
+        )
+        audit.pre(
+            "adminFile: exists=${adminFile != null} missing=$adminMissing broken=$adminBroken needsHeal=$adminNeedsHeal " +
+                "fileId=${adminFile?.fileId} localAuthor=${adminFile?.fileMetadata?.originalAuthor?.domainName} " +
+                "localVT=${adminFile?.fileMetadata?.versionTag} canonicalAdminVT=${info.canonicalAdminVersionTag} " +
+                "canonicalAdminsCarried=${info.canonicalAdmins != null} canonicalAdminCount=${info.canonicalAdmins?.size ?: -1}"
+        )
+        Logger.i {
+            "handleIncomingHealRequest: PRE conversationId=${info.conversationUniqueId} sender=${sender.domainName} " +
+                "messageFileId=${messageFile.fileId} " +
+                "main(missing=$mainMissing broken=$mainBroken needsHeal=$mainNeedsHeal) " +
+                "admin(missing=$adminMissing broken=$adminBroken needsHeal=$adminNeedsHeal) " +
+                "canonicalParticipants(${info.canonicalParticipants.size})=${info.canonicalParticipants.map { it.domainName }} " +
+                "canonicalAdmins=${info.canonicalAdmins?.map { it.domainName }}"
+        }
 
-        if (!mainBroken && !adminBroken) {
+        if (!mainNeedsHeal && !adminNeedsHeal) {
+            // !mainNeedsHeal && !adminNeedsHeal ⇒ both files exist (mainMissing
+            // and adminMissing are both false) — smart-cast confirms non-null,
+            // so no safe-call needed for the audit values below.
             audit.info("nothing to clean up — local copies match canonical identity")
+            Logger.i {
+                "handleIncomingHealRequest: NO-OP — local main+admin already match canonical " +
+                    "conversationId=${info.conversationUniqueId} mainVT=${mainFile.fileMetadata.versionTag} " +
+                    "adminVT=${adminFile.fileMetadata.versionTag}"
+            }
             // Still mark applied: if we don't, a future BatchReceived carrying
             // this same heal message could re-evaluate against a now-different
             // local versionTag (canonical author updated the group in the
@@ -2124,64 +2255,127 @@ class ConversationService(
         // this strictly local (no peer fan-out); hardDelete=true removes the row
         // entirely so the next peer push from the canonical author lands as a
         // fresh create rather than a versionTag conflict.
+        //
+        // Note: we delete only the *broken* files, not the *missing* ones.
+        // A missing file has no local fileId to act on and the server already
+        // lacks the row — DeleteLocalFilesByFileIdRequest with no targets is
+        // a pointless outbox job. The placeholder-write step below covers
+        // both missing and broken cases.
         val brokenFileIds = buildList {
             if (mainBroken) add(mainFile.fileId)
             if (adminBroken) add(adminFile.fileId)
         }
-        Logger.i { "handleIncomingHealRequest: hard-deleting ${brokenFileIds.size} broken file(s) for conversation=${info.conversationUniqueId} mainBroken=$mainBroken adminBroken=$adminBroken fileIds=$brokenFileIds" }
-        audit.step(1, "outboxSync.tryEnqueue(DeleteLocalFilesByFileIdRequest hardDelete=true recipients=null fileIds=$brokenFileIds)")
-        runCatching {
-            outboxSync.tryEnqueue(
-                DeleteLocalFilesByFileIdRequest(
-                    driveId = chatDrive,
-                    fileIds = brokenFileIds,
-                    recipients = null,
-                    hardDelete = true,
+        if (brokenFileIds.isNotEmpty()) {
+            Logger.i { "handleIncomingHealRequest: hard-deleting ${brokenFileIds.size} broken file(s) for conversation=${info.conversationUniqueId} mainBroken=$mainBroken adminBroken=$adminBroken fileIds=$brokenFileIds" }
+            audit.step(1, "outboxSync.tryEnqueue(DeleteLocalFilesByFileIdRequest hardDelete=true recipients=null fileIds=$brokenFileIds)")
+            runCatching {
+                outboxSync.tryEnqueue(
+                    DeleteLocalFilesByFileIdRequest(
+                        driveId = chatDrive,
+                        fileIds = brokenFileIds,
+                        recipients = null,
+                        hardDelete = true,
+                    )
                 )
-            )
-        }.onSuccess { enqueued ->
-            audit.info("STEP 1 enqueued=$enqueued")
-            if (enqueued) audit.checkPass("hardDeleteEnqueue") else audit.checkWarn("hardDeleteEnqueue", "tryEnqueue returned false (UNIQUE collision)")
-        }.onFailure { e -> audit.threw("hardDeleteEnqueue", e) }
+            }.onSuccess { enqueued ->
+                audit.info("STEP 1 enqueued=$enqueued")
+                if (enqueued) audit.checkPass("hardDeleteEnqueue") else audit.checkWarn("hardDeleteEnqueue", "tryEnqueue returned false (UNIQUE collision)")
+            }.onFailure { e -> audit.threw("hardDeleteEnqueue", e) }
+        } else {
+            audit.info("STEP 1 SKIPPED — no broken local files to hard-delete (mainMissing=$mainMissing adminMissing=$adminMissing)")
+            Logger.i { "handleIncomingHealRequest: STEP 1 skipped (no broken local files); mainMissing=$mainMissing adminMissing=$adminMissing conversationId=${info.conversationUniqueId}" }
+        }
 
-        // For the conversation file, also write a local placeholder (versionTag=null)
-        // so the UI doesn't go blank in the gap before the next peer push.
-        if (mainBroken) {
+        // STEP 2 — write a local placeholder (versionTag=null) for either the
+        // conversation file, the admin file, or both. The placeholder is
+        // self-sufficient: title + participants for the main file, admins for
+        // the admin file. From the user's perspective the conversation looks
+        // healthy immediately. When the canonical author's peer push lands
+        // (driven by their healGroupDistribution → updateConversationInternal /
+        // updateAdminFile), it replaces the placeholder by uniqueId with the
+        // real file (DriveMainIndex's modified-timestamp guard passes because
+        // the placeholder's `updated` is ZeroTime).
+        if (mainNeedsHeal) {
             val placeholderParticipants = info.canonicalParticipants.distinct()
             val placeholderTitle = info.canonicalTitle
-            audit.step(2, "writeOrReplaceConversationPlaceholder(participants=${placeholderParticipants.size}, title=\"$placeholderTitle\")")
+            val brokenMainId = if (mainBroken) mainFile.fileId else null
+            Logger.i {
+                "handleIncomingHealRequest: STEP 2 main → writeOrReplaceConversationPlaceholder " +
+                    "conversationId=${info.conversationUniqueId} brokenFileIdToDelete=$brokenMainId " +
+                    "participants(${placeholderParticipants.size})=${placeholderParticipants.map { it.domainName }} title=\"$placeholderTitle\""
+            }
+            audit.step(2, "writeOrReplaceConversationPlaceholder(participants=${placeholderParticipants.size}, title=\"$placeholderTitle\", brokenFileIdToDelete=$brokenMainId, missing=$mainMissing)")
             runCatching {
                 writeOrReplaceConversationPlaceholder(
                     conversationId = info.conversationUniqueId,
-                    brokenFileIdToDelete = mainFile.fileId,
+                    brokenFileIdToDelete = brokenMainId,
                     participants = placeholderParticipants,
                     isGroup = true,
                     title = placeholderTitle,
                     audit = audit,
                 )
             }.onFailure { e ->
-                Logger.w(e) { "handleIncomingHealRequest: placeholder write failed for ${info.conversationUniqueId}" }
+                Logger.w(e) { "handleIncomingHealRequest: main placeholder write failed for ${info.conversationUniqueId}" }
             }
-        } else if (adminBroken) {
-            // Admin file is broken but main is fine — just delete the local
-            // admin row so the next peer push can land. getAdmins() falls back
-            // to originalAuthor in the gap.
-            audit.step(2, "deleteBy(local admin row fileId=${adminFile.fileId})")
-            runCatching {
-                dbm.driveMainIndex.deleteBy(
-                    identityId = credentialsManager.requireActiveCredentials().getIdentityId(),
-                    driveId = chatDrive,
-                    fileId = adminFile.fileId,
+        }
+
+        if (adminNeedsHeal) {
+            val canonicalAdmins = info.canonicalAdmins.orEmpty().distinct()
+            val brokenAdminId = if (adminBroken) adminFile.fileId else null
+            if (canonicalAdmins.isNotEmpty()) {
+                Logger.i {
+                    "handleIncomingHealRequest: STEP 2 admin → writeOrReplaceAdminPlaceholder " +
+                        "conversationId=${info.conversationUniqueId} brokenFileIdToDelete=$brokenAdminId " +
+                        "admins(${canonicalAdmins.size})=${canonicalAdmins.map { it.domainName }} adminMissing=$adminMissing adminBroken=$adminBroken"
+                }
+                audit.step(2, "writeOrReplaceAdminPlaceholder(admins=${canonicalAdmins.size}, brokenFileIdToDelete=$brokenAdminId, missing=$adminMissing)")
+                runCatching {
+                    writeOrReplaceAdminPlaceholder(
+                        conversationId = info.conversationUniqueId,
+                        brokenFileIdToDelete = brokenAdminId,
+                        admins = canonicalAdmins,
+                        audit = audit,
+                    )
+                }.onFailure { e ->
+                    Logger.w(e) { "handleIncomingHealRequest: admin placeholder write failed for ${info.conversationUniqueId}" }
+                }
+            } else {
+                // Legacy sender (canonicalAdmins not in payload) — we can't
+                // fully rebuild the admin file. Fall back to the prior
+                // behaviour: if the admin row is broken locally, delete it so
+                // a future peer push lands cleanly; getAdmins() falls back to
+                // originalAuthor in the gap. If the admin file is merely
+                // missing there's nothing to do here — a future heal from a
+                // hardened sender will carry canonicalAdmins.
+                audit.checkWarn(
+                    "legacyAdminPayload",
+                    "incoming heal payload omits canonicalAdmins (legacy sender) — " +
+                        "cannot rebuild admin placeholder; falling back to delete-only path. " +
+                        "adminMissing=$adminMissing adminBroken=$adminBroken brokenAdminId=$brokenAdminId"
                 )
-            }.onSuccess { audit.checkPass("deleteBrokenAdminRow") }
-                .onFailure { e -> audit.threw("deleteBrokenAdminRow", e) }
+                Logger.w {
+                    "handleIncomingHealRequest: legacy heal payload (no canonicalAdmins) for ${info.conversationUniqueId} — " +
+                        "admin placeholder will NOT be rebuilt. adminMissing=$adminMissing adminBroken=$adminBroken brokenAdminId=$brokenAdminId"
+                }
+                if (adminBroken) {
+                    audit.step(2, "deleteBy(local admin row fileId=${adminFile.fileId}) [legacy fallback]")
+                    runCatching {
+                        dbm.driveMainIndex.deleteBy(
+                            identityId = credentialsManager.requireActiveCredentials().getIdentityId(),
+                            driveId = chatDrive,
+                            fileId = adminFile.fileId,
+                        )
+                    }.onSuccess { audit.checkPass("deleteBrokenAdminRow") }
+                        .onFailure { e -> audit.threw("deleteBrokenAdminRow", e) }
+                }
+            }
         }
 
         // Surface the cleanup to the user. Local-only status message — never
         // sent to peers (additionalRecipients stays empty; the conversation
         // recipients list is irrelevant because sendStatusMessage routes the
         // optimistic write through the same path regardless of fan-out).
-        audit.step(3, "sendStatusMessage(GroupHealLocalCleanup)")
+        audit.step(3, "sendStatusMessage(GroupHealLocalCleanup mainNeedsHeal=$mainNeedsHeal adminNeedsHeal=$adminNeedsHeal)")
         runCatching {
             chatMessageSenderService.sendStatusMessage(
                 messageUniqueId = Uuid.random(),
@@ -2189,8 +2383,8 @@ class ConversationService(
                 statusMessage = StatusMessageData(
                     statusMessage = StatusMessage.GroupHealLocalCleanup,
                     groupHealCleanup = GroupHealCleanupInfo(
-                        cleanedUpMain = mainBroken,
-                        cleanedUpAdmin = adminBroken,
+                        cleanedUpMain = mainNeedsHeal,
+                        cleanedUpAdmin = adminNeedsHeal,
                     ),
                 ),
             )
@@ -2205,7 +2399,12 @@ class ConversationService(
         // BatchReceived carrying the same heal message.
         markHealApplied(messageFile, currentTags, audit)
 
-        audit.finish("cleanedUpMain=$mainBroken cleanedUpAdmin=$adminBroken")
+        Logger.i {
+            "handleIncomingHealRequest: DONE conversationId=${info.conversationUniqueId} " +
+                "mainNeedsHeal=$mainNeedsHeal (missing=$mainMissing broken=$mainBroken) " +
+                "adminNeedsHeal=$adminNeedsHeal (missing=$adminMissing broken=$adminBroken)"
+        }
+        audit.finish("mainNeedsHeal=$mainNeedsHeal (missing=$mainMissing broken=$mainBroken) adminNeedsHeal=$adminNeedsHeal (missing=$adminMissing broken=$adminBroken)")
     }
 
     /**
@@ -2257,12 +2456,19 @@ class ConversationService(
         canonicalAuthor: OdinId,
         canonicalVersionTag: Uuid?,
     ): Boolean {
+        // Placeholder check FIRST: versionTag=null marks a local-only
+        // placeholder we (or recoverConversation) wrote in a prior pass —
+        // by design the next peer push from the canonical author will
+        // replace it, so it must be left alone here regardless of what its
+        // synthetic originalAuthor reads (placeholders are stamped with the
+        // local domain, not the canonical author, so an author check fired
+        // before this placeholder gate would re-classify the placeholder as
+        // broken on every replay and produce an infinite cleanup loop).
+        val localVT = file.fileMetadata.versionTag
+        if (localVT == null) return false
+
         val localAuthor = file.fileMetadata.originalAuthor ?: file.fileMetadata.senderOdinId
         if (localAuthor != canonicalAuthor) return true
-        val localVT = file.fileMetadata.versionTag
-        // versionTag=null marks a placeholder we already wrote in a prior heal
-        // pass — leave it alone; the next peer push will overwrite it.
-        if (localVT == null) return false
         return localVT != canonicalVersionTag
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -83,12 +83,18 @@ class ConversationStream(
     /** Hook for explicit (non-sync) conversation recovery.
      *
      *  Wired in AppModule to ConversationService.recoverConversation().
-     *  Currently has no live caller — the previous sync-handler triggers
-     *  were removed because enqueuing a server write from inside a
-     *  drive-sync batch produced spurious conflicts (real file later in
-     *  sync, or transfer-to-self). The plumbing is retained so a future
-     *  explicit-recovery path (e.g. ensure-file-on-send, or a post-sync
-     *  reconciliation pass) can wire in without touching DI. */
+     *  Live callers:
+     *    - [triggerRecoveryForInvalidRows] (post-load reconciliation for
+     *      rows whose state is [ConversationState.Invalid]).
+     *    - the orphan branch in [processMessageBatchIncrementally] (when an
+     *      incoming message references a conversationId with no main file
+     *      in the local DB — closes the gap where requireConversation
+     *      would otherwise throw on every send/react/markRead).
+     *
+     *  recoverConversation is local-only today (writes a versionTag=null
+     *  placeholder, no outbox enqueue, no peer fan-out), so it is safe to
+     *  call from inside a drive-sync batch handler. The historic concerns
+     *  about server-write conflicts no longer apply. */
     var onRecoverConversation: (suspend (conversationId: Uuid, originalAuthor: OdinId?) -> Unit)? = null
 
     /**
@@ -456,26 +462,70 @@ class ConversationStream(
 
                 // region Placeholder: conversation file not yet synced
                 // Insert a UI placeholder so the message is visible now.
-                // Intentionally do NOT enqueue a server-side recovery from
-                // here. A drive-sync handler reads server state; enqueuing
-                // a server write from inside that read produced spurious
+                // We intentionally do NOT enqueue a server-side write from
+                // here — that path historically produced spurious
                 // "File already exists with ClientUniqueId" conflicts
                 // (when the real conversation file is simply later in the
                 // sync order) and "Cannot transfer to yourself" rejections
-                // (when originalAuthor == self for groups we started), for
-                // every login. Recovery is now self-healing:
+                // (when originalAuthor == self for groups we started).
+                //
+                // We DO trigger [onRecoverConversation] (local-only — writes a
+                // versionTag=null placeholder via
+                // OptimisticWriter.writeLocalOnlyConversationPlaceholder, no
+                // outbox enqueue, no peer fan-out). This closes the gap that
+                // used to leave a user with messages arriving for a
+                // conversation whose main file was missing from local DB:
+                // requireConversation would throw on every send/react/markRead
+                // because getConversationHomebaseFile returned null. Wiring
+                // the local-only recovery here gives us a DB row immediately,
+                // so requireConversation succeeds and the heal flow can take
+                // over if the canonical author is online.
+                //
+                // Self-healing for the in-memory UI is unchanged:
                 //   1. If the real conversation file exists on the server
                 //      (the common case), it will arrive in a later sync
                 //      batch and replace this placeholder via
                 //      processConversationBatchIncrementally →
                 //      updateConversation.
-                //   2. If the server truly lacks the file, the placeholder
-                //      stays until the user interacts with the
-                //      conversation. A follow-up will add "ensure
-                //      conversation file on send" to close that gap.
+                //   2. If the server truly lacks the file, the local-only
+                //      placeholder written by recoverConversation persists
+                //      until a peer push from a member who has the file
+                //      restores it.
                 Logger.w("ConversationStream: orphaned conversation ${m.conversationId} from=${m.originalAuthor} isOneToOne=$isOneToOne, creating placeholder")
                 insertNewConversation(emptyConversation)
                 placeholderIds += m.conversationId
+
+                // Fire-and-forget local-only recovery. recoveryAttemptedIds
+                // dedups within a session — exactly one attempt per missing
+                // conversation, matching triggerRecoveryForInvalidRows
+                // (line 841). The recover lambda may be null (DI not wired
+                // for tests / before AppModule binds it).
+                val recover = onRecoverConversation
+                if (recover != null && recoveryAttemptedIds.add(m.conversationId)) {
+                    val convoId = m.conversationId
+                    val originalAuthor = m.originalAuthor
+                    Logger.i(tag = "OrphanRecovery") {
+                        "ConversationStream: triggering recoverConversation from orphan branch " +
+                            "convoId=$convoId originalAuthor=${originalAuthor?.domainName} sender=${m.sender?.domainName} isOneToOne=$isOneToOne"
+                    }
+                    scope.launch {
+                        try {
+                            recover(convoId, originalAuthor)
+                            Logger.i(tag = "OrphanRecovery") {
+                                "ConversationStream: orphan-branch recoverConversation completed convoId=$convoId"
+                            }
+                        } catch (t: Throwable) {
+                            Logger.e(throwable = t, tag = "OrphanRecovery") {
+                                "ConversationStream: orphan-branch recoverConversation FAILED convoId=$convoId — " +
+                                    "in-memory placeholder will keep the message visible but requireConversation may still throw on send"
+                            }
+                        }
+                    }
+                } else if (recover == null) {
+                    Logger.d(tag = "OrphanRecovery") {
+                        "ConversationStream: orphan branch — onRecoverConversation not wired, skipping local-only recovery for ${m.conversationId}"
+                    }
+                }
                 // endregion
             } else {
                 updateConversationFromNewMessage(matchingConversation, m, file.sqlUserDateMs())

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
@@ -247,6 +247,100 @@ class OptimisticWriter(
         }
     }
 
+    /**
+     * Persist a local-only admin-file placeholder for a group whose admin file
+     * is missing or broken. Counterpart to [writeLocalOnlyConversationPlaceholder]
+     * for the group's admin file.
+     *
+     * Used by the receive-side heal handler when the incoming heal message
+     * carries `canonicalAdmins`. Strictly local: no outbox enqueue, no
+     * `isPendingSendTag`. The row exists so [getAdmins] can read the canonical
+     * admin set immediately, instead of falling back to `originalAuthor`.
+     *
+     * The placeholder uses the canonical [adminUniqueId] derived from the
+     * conversation id (`ChatProtocol.getAdminFileUniqueId`) so a future peer
+     * push of the real admin file replaces the placeholder by uniqueId.
+     *
+     * `versionTag = null` and `updated = ZeroTime` for the same reason as
+     * [writeLocalOnlyConversationPlaceholder]: any non-zero `modified` here
+     * would block the real file's upsert via DriveMainIndex.sq:68.
+     */
+    suspend fun writeLocalOnlyAdminPlaceholder(
+        driveId: Uuid,
+        conversationId: Uuid,
+        admins: List<OdinId>,
+    ) {
+        val credentials = credentialsManager.requireActiveCredentials()
+        val domain = credentials.domain
+        val created = UnixTimeUtc.now()
+        val adminUniqueId = ChatProtocol.getAdminFileUniqueId(conversationId)
+        val content = OdinSystemSerializer.serialize(
+            id.homebase.chat.services.convo.ConversationAdminInfo(admins = admins)
+        )
+
+        val file = HomebaseFile(
+            fileId = Uuid.random(),
+            driveId = driveId,
+            serverFileIsEncrypted = true,
+            fileState = FileState.Active,
+            fileSystemType = FileSystemType.Standard,
+            keyHeader = KeyHeader.newRandom16(),
+            fileMetadata = FileMetadata(
+                appData = AppFileMetaData(
+                    uniqueId = adminUniqueId,
+                    tags = null,
+                    fileType = ChatProtocol.ConversationAdminFileType,
+                    dataType = 0,
+                    groupId = conversationId,
+                    userDate = null,
+                    content = content,
+                    previewThumbnail = null,
+                    archivalStatus = null,
+                ),
+                localAppData = LocalAppMetadata(
+                    tags = emptyList(),
+                ),
+                created = created,
+                updated = UnixTimeUtc.ZeroTime,
+                isEncrypted = true,
+                senderOdinId = domain,
+                originalAuthor = domain,
+                versionTag = null,
+                payloads = null,
+            ),
+            serverMetadata = ServerMetadata(
+                accessControlList = AccessControlList(
+                    requiredSecurityGroup = "Owner"
+                ),
+                allowDistribution = true,
+                fileSystemType = FileSystemType.Standard,
+                fileByteCount = 100,
+                originalRecipientCount = admins.size,
+                transferHistory = null,
+            ),
+            priority = 100,
+            fileByteCount = 100,
+        )
+
+        try {
+            fileProcessor.baseUpsertEntryZapZap(
+                identityId = credentials.getIdentityId(),
+                driveId = driveId,
+                fileHeaders = listOf(file),
+                cursor = null,
+            )
+            Logger.i(tag = TAG) {
+                "writeLocalOnlyAdminPlaceholder: persisted adminUniqueId=$adminUniqueId " +
+                        "conversationId=$conversationId driveId=$driveId admins(${admins.size})=${admins.map { it.domainName }} fileId=${file.fileId}"
+            }
+        } catch (e: Exception) {
+            Logger.e(throwable = e, tag = TAG) {
+                "writeLocalOnlyAdminPlaceholder FAILED for adminUniqueId=$adminUniqueId conversationId=$conversationId"
+            }
+            throw e
+        }
+    }
+
     suspend fun writeUpdate(
         driveId: Uuid,
         keyHeader: KeyHeader,

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/groupsettings/GroupFilesDiagnosticProjectionTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/groupsettings/GroupFilesDiagnosticProjectionTest.kt
@@ -1,0 +1,226 @@
+package id.homebase.chat.groupsettings
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.drives.AccessControlList
+import id.homebase.api.client.drives.FileState
+import id.homebase.api.client.drives.FileSystemType
+import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.client.drives.ServerMetadata
+import id.homebase.api.client.drives.files.AppFileMetaData
+import id.homebase.api.client.drives.files.FileMetadata
+import id.homebase.api.client.drives.files.LocalAppMetadata
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.time.UnixTimeUtc
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * Pure-function tests for [toDbRow] / [toServerRow] — the projection
+ * helpers that drive the four-row file-health diagnostic at the bottom of
+ * the group-info screen.
+ *
+ * The projection rules:
+ *
+ *   DB-side:
+ *     null               → Absent
+ *     versionTag = null  → Placeholder (local-only marker)
+ *     versionTag = X, author present → Present(X, author, fileId)
+ *     versionTag = X, author null    → Placeholder (malformed; defensive)
+ *
+ *   Server-side (response from getFileHeaderByUid):
+ *     null               → Absent
+ *     versionTag = null  → Absent (server should never return this; logged)
+ *     author null        → Absent (malformed; logged)
+ *     versionTag = X, author present → Present(X, author, fileId)
+ */
+class GroupFilesDiagnosticProjectionTest {
+
+    private val alice = OdinId("alice.test")
+
+    @Test
+    fun toDbRow_null_returnsAbsent() {
+        assertEquals(DbFileRow.Absent, toDbRow(null))
+    }
+
+    @Test
+    fun toDbRow_versionTagNull_returnsPlaceholderWithFileId() {
+        val fileId = Uuid.random()
+        val file = stubFile(versionTag = null, originalAuthor = alice, fileId = fileId)
+
+        val row = toDbRow(file)
+
+        assertIs<DbFileRow.Placeholder>(row)
+        assertEquals(fileId, row.fileId)
+    }
+
+    @Test
+    fun toDbRow_versionTagPresent_returnsPresentWithAuthorAndVersion() {
+        val fileId = Uuid.random()
+        val vt = Uuid.random()
+        val file = stubFile(versionTag = vt, originalAuthor = alice, fileId = fileId)
+
+        val row = toDbRow(file)
+
+        assertIs<DbFileRow.Present>(row)
+        assertEquals(vt, row.versionTag)
+        assertEquals(alice, row.originalAuthor)
+        assertEquals(fileId, row.fileId)
+    }
+
+    @Test
+    fun toDbRow_originalAuthorNull_fallsBackToSenderOdinId() {
+        // Forwarded / wire-only files can have a null originalAuthor; the
+        // diagnostic should fall back to senderOdinId so we still render an
+        // author column instead of pretending the row is malformed.
+        val sender = OdinId("forwarder.test")
+        val file = stubFile(
+            versionTag = Uuid.random(),
+            originalAuthor = null,
+            senderOdinId = sender,
+        )
+
+        val row = toDbRow(file)
+
+        assertIs<DbFileRow.Present>(row)
+        assertEquals(sender, row.originalAuthor)
+    }
+
+    @Test
+    fun toDbRow_bothAuthorsNullDespiteVersionTag_returnsPlaceholder() {
+        // Defensive: a row with a real versionTag but no author at all is
+        // malformed. Surface as Placeholder so the UI shows the oddity in
+        // red rather than crashing on the unwrap.
+        val file = stubFile(
+            versionTag = Uuid.random(),
+            originalAuthor = null,
+            senderOdinId = null,
+        )
+
+        val row = toDbRow(file)
+
+        assertIs<DbFileRow.Placeholder>(row)
+    }
+
+    @Test
+    fun toServerRow_null_isAbsent() {
+        assertEquals(ServerFileRow.Absent, toServerRow(null))
+    }
+
+    @Test
+    fun toServerRow_serverFileWithVersionTagNull_isAbsent() {
+        // Server never stores placeholders. If the API ever returns a file
+        // with versionTag=null, treat it as Absent — but we log so we'd see
+        // the regression in homebase.log.
+        val file = stubFile(versionTag = null, originalAuthor = alice)
+
+        assertEquals(ServerFileRow.Absent, toServerRow(file))
+    }
+
+    @Test
+    fun toServerRow_serverFileWithNoAuthor_isAbsent() {
+        // Defensive: server file with versionTag but no author at all.
+        val file = stubFile(
+            versionTag = Uuid.random(),
+            originalAuthor = null,
+            senderOdinId = null,
+        )
+
+        assertEquals(ServerFileRow.Absent, toServerRow(file))
+    }
+
+    @Test
+    fun toServerRow_present_carriesVersionTagAuthorAndFileId() {
+        val fileId = Uuid.random()
+        val vt = Uuid.random()
+        val file = stubFile(versionTag = vt, originalAuthor = alice, fileId = fileId)
+
+        val row = toServerRow(file)
+
+        assertIs<ServerFileRow.Present>(row)
+        assertEquals(vt, row.versionTag)
+        assertEquals(alice, row.originalAuthor)
+        assertEquals(fileId, row.fileId)
+    }
+
+    @Test
+    fun supportBlob_includesAllFourRowsAndExpectedUids() {
+        val convoId = Uuid.random()
+        val expectedAdminUid = Uuid.random()
+        val mainVt = Uuid.random()
+        val mainFileId = Uuid.random()
+        val adminPlaceholderFileId = Uuid.random()
+
+        val diagnostic = GroupFilesDiagnostic(
+            conversationId = convoId,
+            expectedMainUniqueId = convoId,
+            expectedAdminUniqueId = expectedAdminUid,
+            dbGroup = DbFileRow.Present(versionTag = mainVt, originalAuthor = alice, fileId = mainFileId),
+            dbAdmin = DbFileRow.Placeholder(fileId = adminPlaceholderFileId),
+            serverGroup = ServerFileRow.Present(versionTag = mainVt, originalAuthor = alice, fileId = mainFileId),
+            serverAdmin = ServerFileRow.Absent,
+        )
+
+        val blob = buildSupportBlob(diagnostic, selfDomain = "owner.test")
+
+        // Sanity: every row label appears, full UUIDs (not 8-char prefix)
+        // are present so support can grep by them.
+        assertTrue(blob.contains("convo=$convoId"), "support blob must include the conversation id")
+        assertTrue(blob.contains("domain=owner.test"), "support blob must include the user's own domain")
+        assertTrue(blob.contains("db-group=Present"), "db-group row missing in: $blob")
+        assertTrue(blob.contains("db-admin=Placeholder"), "db-admin row missing in: $blob")
+        assertTrue(blob.contains("server-group=Present"), "server-group row missing in: $blob")
+        assertTrue(blob.contains("server-admin=Absent"), "server-admin row missing in: $blob")
+        assertTrue(blob.contains("vt=$mainVt"), "support blob must carry the FULL versionTag for grep, got: $blob")
+        assertTrue(blob.contains("expectedAdminUid=$expectedAdminUid"), "must carry expected admin uid")
+    }
+
+    // ---------- helpers ----------
+
+    private fun stubFile(
+        versionTag: Uuid?,
+        originalAuthor: OdinId?,
+        senderOdinId: OdinId? = originalAuthor,
+        fileId: Uuid = Uuid.random(),
+    ): HomebaseFile = HomebaseFile(
+        fileId = fileId,
+        driveId = Uuid.random(),
+        serverFileIsEncrypted = false,
+        fileState = FileState.Active,
+        fileSystemType = FileSystemType.Standard,
+        keyHeader = KeyHeader.newRandom16(),
+        fileMetadata = FileMetadata(
+            appData = AppFileMetaData(
+                uniqueId = Uuid.random(),
+                tags = null,
+                fileType = 8888,
+                dataType = 0,
+                groupId = null,
+                userDate = null,
+                content = null,
+                previewThumbnail = null,
+                archivalStatus = null,
+            ),
+            localAppData = LocalAppMetadata(tags = emptyList()),
+            created = UnixTimeUtc.now(),
+            updated = UnixTimeUtc.ZeroTime,
+            isEncrypted = false,
+            senderOdinId = senderOdinId,
+            originalAuthor = originalAuthor,
+            versionTag = versionTag,
+            payloads = null,
+        ),
+        serverMetadata = ServerMetadata(
+            accessControlList = AccessControlList(requiredSecurityGroup = "Owner"),
+            allowDistribution = false,
+            fileSystemType = FileSystemType.Standard,
+            fileByteCount = 100,
+            originalRecipientCount = 0,
+            transferHistory = null,
+        ),
+        priority = 100,
+        fileByteCount = 100,
+    )
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceHealTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceHealTest.kt
@@ -1,0 +1,489 @@
+package id.homebase.chat.services.convo
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.drives.AccessControlList
+import id.homebase.api.client.drives.FileState
+import id.homebase.api.client.drives.FileSystemType
+import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.client.drives.ServerMetadata
+import id.homebase.api.client.drives.files.AppFileMetaData
+import id.homebase.api.client.drives.files.FileMetadata
+import id.homebase.api.client.drives.files.LocalAppMetadata
+import id.homebase.api.client.drives.files.DeleteLocalFilesByFileIdRequest
+import id.homebase.api.client.drives.files.DriveOutboxUploader
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.time.UnixTimeUtc
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.sync.database.Outbox
+import id.homebase.chat.services.ChatProtocol
+import id.homebase.chat.services.GroupHealInfo
+import id.homebase.chat.services.StatusMessage
+import id.homebase.chat.services.StatusMessageData
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Tier-3 coverage for [ConversationService.handleIncomingHealRequest].
+ *
+ * The handler is the receive-side of the group-heal protocol. It runs when a
+ * [StatusMessage.GroupHealRequested] status message arrives from the canonical
+ * author of a group. The handler must:
+ *
+ *   1. Detect both **broken** (file present but mismatched author/versionTag)
+ *      and **missing** (no local row at all) states. The pre-hardening
+ *      implementation collapsed missing into "no-op" because mainFile==null
+ *      short-circuited the && isFileBroken check, leaving recipients
+ *      permanently stuck after markHealApplied tagged the status message.
+ *   2. Hard-delete *only* the broken local files (a missing file has no
+ *      fileId to act on and the server already lacks the row).
+ *   3. Write a self-sufficient local placeholder (versionTag=null) for both
+ *      the main and admin files so the UI behaves as if nothing was broken
+ *      while the canonical author's peer push is in flight.
+ *   4. Skip the admin placeholder when the heal payload omits
+ *      [GroupHealInfo.canonicalAdmins] (legacy senders) — fall back to the
+ *      delete-only path so getAdmins()' originalAuthor fallback keeps things
+ *      functional.
+ *   5. Stay no-op on a second pass once the placeholder is in place
+ *      (placeholder has versionTag=null, isFileBroken returns false).
+ */
+class ConversationServiceHealTest {
+
+    private val canonicalAuthorDomain = "alice.test"
+
+    @Test
+    fun mainMissing_writesPlaceholderFromCanonicalParticipants_andDoesNotEnqueueHardDelete() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = Uuid.random()
+            val canonicalParticipants = listOf(
+                OdinId(canonicalAuthorDomain),
+                OdinId(fixture.testDomain),
+                OdinId("bob.test"),
+            )
+            val outboxRowsBefore = fixture.outboxRowCount()
+
+            service.handleIncomingHealRequest(
+                status = healStatus(
+                    conversationId = convoId,
+                    canonicalAuthor = canonicalAuthorDomain,
+                    canonicalParticipants = canonicalParticipants,
+                    canonicalAdmins = listOf(OdinId(canonicalAuthorDomain)),
+                ),
+                sender = OdinId(canonicalAuthorDomain),
+                messageFile = stubStatusMessageFile(fixture.chatDriveId),
+            )
+
+            // Missing file ⇒ no DeleteLocalFilesByFileIdRequest enqueued.
+            val drained = fixture.drainOutbox()
+            val deleteRequests = drained.filter { it.isHardDeleteRequest() }
+            assertTrue(
+                deleteRequests.isEmpty(),
+                "missing file ⇒ NO hard-delete should be enqueued; got $deleteRequests",
+            )
+            // We may have enqueued the markHealApplied tag-update — that's fine,
+            // the assertion above scoped to the hard-delete shape only.
+
+            // Main placeholder file should now exist with versionTag=null and
+            // canonical participants in its content.
+            val mainFile = fixture.getConversationFile(convoId)
+            assertNotNull(mainFile, "missing main file must be replaced by a local placeholder")
+            assertNull(mainFile.fileMetadata.versionTag, "placeholder marker (versionTag=null)")
+            val storedRecipients = readPlaceholderRecipients(mainFile)
+            assertEquals(
+                canonicalParticipants.map { it.domainName }.toSet(),
+                storedRecipients.toSet(),
+                "placeholder must list all canonicalParticipants from the heal payload",
+            )
+
+            // The conversation list should have been refreshed via loadConversation.
+            assertTrue(
+                fixture.conversationLoader.loaded.contains(convoId),
+                "loadConversation must be called to refresh the in-memory model after heal",
+            )
+            assertTrue(
+                fixture.outboxRowCount() >= outboxRowsBefore,
+                "outbox row count should not decrease",
+            )
+        }
+    }
+
+    @Test
+    fun mainBroken_hardDeletesLocalFile_andWritesPlaceholderFromCanonicalIdentity() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = Uuid.random()
+            // Seed a "broken" main file: originalAuthor = us, but the canonical
+            // author claims to be alice. isFileBroken returns true (author mismatch).
+            fixture.seedGroup(
+                conversationId = convoId,
+                others = listOf(canonicalAuthorDomain, "bob.test"),
+                adminDomains = listOf(fixture.testDomain),
+                seedAdminFile = false,
+            )
+            val brokenMainFile = fixture.getConversationFile(convoId)
+            assertNotNull(brokenMainFile, "precondition: seeded main file present")
+            val brokenMainFileId = brokenMainFile.fileId
+
+            val canonicalParticipants = listOf(
+                OdinId(canonicalAuthorDomain),
+                OdinId(fixture.testDomain),
+                OdinId("bob.test"),
+            )
+
+            service.handleIncomingHealRequest(
+                status = healStatus(
+                    conversationId = convoId,
+                    canonicalAuthor = canonicalAuthorDomain,
+                    canonicalParticipants = canonicalParticipants,
+                    canonicalAdmins = listOf(OdinId(canonicalAuthorDomain)),
+                ),
+                sender = OdinId(canonicalAuthorDomain),
+                messageFile = stubStatusMessageFile(fixture.chatDriveId),
+            )
+
+            // Hard-delete request enqueued targeting the broken main fileId.
+            val drained = fixture.drainOutbox()
+            val deletes = drained.mapNotNull { it.asHardDeleteRequestOrNull() }
+            assertTrue(
+                deletes.any { req -> req.fileIds.contains(brokenMainFileId) && req.hardDelete },
+                "broken main file ⇒ hardDelete=true request for fileId=$brokenMainFileId; got $deletes",
+            )
+
+            // Placeholder written in place: same uniqueId, versionTag=null, new fileId.
+            val placeholder = fixture.getConversationFile(convoId)
+            assertNotNull(placeholder, "broken row must be replaced with a placeholder, not deleted outright")
+            assertNull(placeholder.fileMetadata.versionTag, "placeholder marker")
+            assertFalse(
+                placeholder.fileId == brokenMainFileId,
+                "placeholder fileId must differ from the broken row's fileId",
+            )
+        }
+    }
+
+    @Test
+    fun adminMissing_withCanonicalAdmins_writesAdminPlaceholder() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = Uuid.random()
+            val canonicalAdmins = listOf(
+                OdinId(canonicalAuthorDomain),
+                OdinId("bob.test"),
+            )
+            // Seed only the main file so isFileBroken on main returns false (versionTag matches null
+            // canonical) — but we want the main path to also be triggered to compare. Simpler: leave
+            // both files missing; both branches fire.
+
+            service.handleIncomingHealRequest(
+                status = healStatus(
+                    conversationId = convoId,
+                    canonicalAuthor = canonicalAuthorDomain,
+                    canonicalParticipants = listOf(
+                        OdinId(canonicalAuthorDomain),
+                        OdinId(fixture.testDomain),
+                    ),
+                    canonicalAdmins = canonicalAdmins,
+                ),
+                sender = OdinId(canonicalAuthorDomain),
+                messageFile = stubStatusMessageFile(fixture.chatDriveId),
+            )
+
+            // Admin placeholder file should now exist at the deterministic admin uniqueId.
+            val adminUniqueId = ChatProtocol.getAdminFileUniqueId(convoId)
+            val adminPlaceholder = fixture.dbm.driveMainIndex
+                .selectHomebaseFileByUnique(fixture.testIdentityId, fixture.chatDriveId, adminUniqueId)
+            assertNotNull(adminPlaceholder, "missing admin file must be replaced with a local admin placeholder")
+            assertNull(adminPlaceholder.fileMetadata.versionTag, "admin placeholder marker (versionTag=null)")
+            assertEquals(
+                ChatProtocol.ConversationAdminFileType,
+                adminPlaceholder.fileMetadata.appData.fileType,
+                "admin placeholder must be tagged as the admin file type so getAdmins() reads it",
+            )
+
+            // Content should contain the canonical admins so getAdmins() returns the
+            // full set instead of falling back to originalAuthor.
+            val storedAdmins = readAdminPlaceholderAdmins(adminPlaceholder)
+            assertEquals(
+                canonicalAdmins.map { it.domainName }.toSet(),
+                storedAdmins.toSet(),
+                "admin placeholder content must list every canonicalAdmin from the heal payload",
+            )
+        }
+    }
+
+    @Test
+    fun adminMissing_legacyPayloadWithoutCanonicalAdmins_doesNotWriteAdminPlaceholder() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = Uuid.random()
+            // Both main and admin missing; legacy payload (canonicalAdmins=null).
+
+            service.handleIncomingHealRequest(
+                status = healStatus(
+                    conversationId = convoId,
+                    canonicalAuthor = canonicalAuthorDomain,
+                    canonicalParticipants = listOf(
+                        OdinId(canonicalAuthorDomain),
+                        OdinId(fixture.testDomain),
+                    ),
+                    canonicalAdmins = null, // legacy sender
+                ),
+                sender = OdinId(canonicalAuthorDomain),
+                messageFile = stubStatusMessageFile(fixture.chatDriveId),
+            )
+
+            // Main placeholder still gets written (we always have title+participants).
+            val mainPlaceholder = fixture.getConversationFile(convoId)
+            assertNotNull(mainPlaceholder, "main placeholder must still be written even on legacy payloads")
+
+            // Admin placeholder must NOT be written — we have no canonicalAdmins to seed it.
+            val adminUniqueId = ChatProtocol.getAdminFileUniqueId(convoId)
+            val adminPlaceholder = fixture.dbm.driveMainIndex
+                .selectHomebaseFileByUnique(fixture.testIdentityId, fixture.chatDriveId, adminUniqueId)
+            assertNull(
+                adminPlaceholder,
+                "legacy heal payload (canonicalAdmins=null) must NOT fabricate an admin placeholder; " +
+                        "fall back to delete-only path with getAdmins() originalAuthor fallback",
+            )
+        }
+    }
+
+    @Test
+    fun secondPass_afterPlaceholderWritten_isNoOp() = runTest {
+        // First pass writes a versionTag=null placeholder. Second pass (a
+        // different status message file id, simulating a re-fired heal from
+        // the canonical author after they updated something else) reads
+        // isFileBroken → false (placeholder versionTag=null is the explicit
+        // "leave me alone" marker) and takes the no-op branch. No additional
+        // hard-deletes or placeholders should be emitted.
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = Uuid.random()
+            val canonicalParticipants = listOf(
+                OdinId(canonicalAuthorDomain),
+                OdinId(fixture.testDomain),
+            )
+
+            // ---- pass 1: missing → placeholder
+            service.handleIncomingHealRequest(
+                status = healStatus(
+                    conversationId = convoId,
+                    canonicalAuthor = canonicalAuthorDomain,
+                    canonicalParticipants = canonicalParticipants,
+                    canonicalAdmins = listOf(OdinId(canonicalAuthorDomain)),
+                ),
+                sender = OdinId(canonicalAuthorDomain),
+                messageFile = stubStatusMessageFile(fixture.chatDriveId),
+            )
+            val placeholderAfterPass1 = fixture.getConversationFile(convoId)
+            assertNotNull(placeholderAfterPass1, "pass 1 must write a placeholder")
+            val placeholderFileIdAfterPass1 = placeholderAfterPass1.fileId
+            // Drain anything pass 1 enqueued so we can isolate pass 2.
+            fixture.drainOutbox()
+            val sendCallsAfterPass1 = fixture.statusMessageSender.calls.size
+
+            // ---- pass 2: same canonical identity, different status message file id
+            service.handleIncomingHealRequest(
+                status = healStatus(
+                    conversationId = convoId,
+                    canonicalAuthor = canonicalAuthorDomain,
+                    canonicalParticipants = canonicalParticipants,
+                    canonicalAdmins = listOf(OdinId(canonicalAuthorDomain)),
+                ),
+                sender = OdinId(canonicalAuthorDomain),
+                messageFile = stubStatusMessageFile(fixture.chatDriveId),
+            )
+
+            // Placeholder still in place, fileId unchanged → no rewrite happened.
+            val placeholderAfterPass2 = fixture.getConversationFile(convoId)
+            assertNotNull(placeholderAfterPass2, "placeholder must still be present after pass 2")
+            assertEquals(
+                placeholderFileIdAfterPass1,
+                placeholderAfterPass2.fileId,
+                "pass 2 must NOT rewrite the placeholder — versionTag=null is the leave-alone marker",
+            )
+
+            // No hard-delete request was enqueued in pass 2.
+            val drainedPass2 = fixture.drainOutbox()
+            val deletesPass2 = drainedPass2.mapNotNull { it.asHardDeleteRequestOrNull() }
+            assertTrue(
+                deletesPass2.isEmpty(),
+                "pass 2 must take the no-op branch and NOT enqueue any hard-delete; got $deletesPass2",
+            )
+
+            // No GroupHealLocalCleanup status was emitted on pass 2 (no-op branch).
+            assertEquals(
+                sendCallsAfterPass1,
+                fixture.statusMessageSender.calls.size,
+                "pass 2 must NOT send a GroupHealLocalCleanup status — that would spam the user every replay",
+            )
+        }
+    }
+
+    @Test
+    fun selfLoopback_skipsHandling() = runTest {
+        // Sender is us — we're seeing our own outgoing heal status loop back.
+        // The handler must short-circuit before any cleanup work.
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = Uuid.random()
+            // Seed a "broken" file so a non-self-loopback heal would have
+            // hard-deleted it. We assert that nothing happens.
+            fixture.seedGroup(
+                conversationId = convoId,
+                others = listOf("bob.test"),
+                adminDomains = listOf(fixture.testDomain),
+                seedAdminFile = false,
+            )
+            val seededFileId = fixture.getConversationFile(convoId)?.fileId
+            assertNotNull(seededFileId)
+
+            service.handleIncomingHealRequest(
+                status = healStatus(
+                    conversationId = convoId,
+                    // Canonical author is us → self-loopback.
+                    canonicalAuthor = fixture.testDomain,
+                    canonicalParticipants = listOf(OdinId(fixture.testDomain), OdinId("bob.test")),
+                    canonicalAdmins = listOf(OdinId(fixture.testDomain)),
+                ),
+                sender = OdinId(fixture.testDomain),
+                messageFile = stubStatusMessageFile(fixture.chatDriveId),
+            )
+
+            // File untouched.
+            assertEquals(seededFileId, fixture.getConversationFile(convoId)?.fileId)
+            // No outbox enqueue.
+            val drained = fixture.drainOutbox()
+            val deletes = drained.mapNotNull { it.asHardDeleteRequestOrNull() }
+            assertTrue(deletes.isEmpty(), "self-loopback must NOT enqueue any hard-delete")
+        }
+    }
+
+    @Test
+    fun forgedSender_skipsHandling() = runTest {
+        // Sender's domain doesn't match the canonical author — forgery guard.
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = Uuid.random()
+
+            service.handleIncomingHealRequest(
+                status = healStatus(
+                    conversationId = convoId,
+                    canonicalAuthor = canonicalAuthorDomain,
+                    canonicalParticipants = listOf(
+                        OdinId(canonicalAuthorDomain),
+                        OdinId(fixture.testDomain),
+                    ),
+                    canonicalAdmins = listOf(OdinId(canonicalAuthorDomain)),
+                ),
+                sender = OdinId("malicious.test"), // ≠ canonicalAuthor
+                messageFile = stubStatusMessageFile(fixture.chatDriveId),
+            )
+
+            // No placeholder was written — handler exited at the forgery guard.
+            assertNull(
+                fixture.getConversationFile(convoId),
+                "forged sender must not produce any local writes",
+            )
+        }
+    }
+
+    // ---------- helpers ----------
+
+    /** Build a [GroupHealRequested] [StatusMessageData] with the canonical fields. */
+    private fun healStatus(
+        conversationId: Uuid,
+        canonicalAuthor: String,
+        canonicalParticipants: List<OdinId>,
+        canonicalAdmins: List<OdinId>?,
+        canonicalVersionTag: Uuid? = null,
+        canonicalAdminVersionTag: Uuid? = null,
+    ): StatusMessageData = StatusMessageData(
+        statusMessage = StatusMessage.GroupHealRequested,
+        groupHeal = GroupHealInfo(
+            conversationUniqueId = conversationId,
+            canonicalOriginalAuthor = OdinId(canonicalAuthor),
+            canonicalVersionTag = canonicalVersionTag,
+            canonicalTitle = "Test Group",
+            canonicalParticipants = canonicalParticipants,
+            canonicalAdminFileUniqueId = Uuid.random(), // not used by the handler
+            canonicalAdminVersionTag = canonicalAdminVersionTag,
+            canonicalAdmins = canonicalAdmins,
+        ),
+    )
+
+    /**
+     * Build an in-memory stub for the [HomebaseFile] passed as `messageFile`
+     * to the heal handler. The file is deliberately *not* inserted into the
+     * test DB — `markHealApplied` short-circuits cleanly when the file is
+     * absent (updateLocalTags returns silently when the row doesn't exist),
+     * so tests can focus on the cleanup behaviour.
+     */
+    private fun stubStatusMessageFile(driveId: Uuid): HomebaseFile = HomebaseFile(
+        fileId = Uuid.random(),
+        driveId = driveId,
+        serverFileIsEncrypted = false,
+        fileState = FileState.Active,
+        fileSystemType = FileSystemType.Standard,
+        keyHeader = KeyHeader.newRandom16(),
+        fileMetadata = FileMetadata(
+            appData = AppFileMetaData(
+                uniqueId = Uuid.random(),
+                tags = null,
+                fileType = ChatProtocol.MessageFileType,
+                dataType = ChatProtocol.ChatStatusMessageDataType,
+                groupId = null,
+                userDate = null,
+                content = null,
+                previewThumbnail = null,
+                archivalStatus = null,
+            ),
+            localAppData = LocalAppMetadata(tags = emptyList()),
+            created = UnixTimeUtc.now(),
+            updated = UnixTimeUtc.ZeroTime,
+            isEncrypted = false,
+            senderOdinId = OdinId(canonicalAuthorDomain),
+            originalAuthor = OdinId(canonicalAuthorDomain),
+            versionTag = Uuid.random(),
+            payloads = null,
+        ),
+        serverMetadata = ServerMetadata(
+            accessControlList = AccessControlList(requiredSecurityGroup = "Owner"),
+            allowDistribution = false,
+            fileSystemType = FileSystemType.Standard,
+            fileByteCount = 100,
+            originalRecipientCount = 0,
+            transferHistory = null,
+        ),
+        priority = 100,
+        fileByteCount = 100,
+    )
+
+    private fun Outbox.isHardDeleteRequest(): Boolean = asHardDeleteRequestOrNull() != null
+
+    private fun Outbox.asHardDeleteRequestOrNull(): DeleteLocalFilesByFileIdRequest? {
+        if (this.uploadType != DriveOutboxUploader.DeleteFile) return null
+        return try {
+            OdinSystemSerializer.deserialize<DeleteLocalFilesByFileIdRequest>(this.json.decodeToString())
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    private fun readPlaceholderRecipients(file: HomebaseFile): List<String> {
+        val raw = file.fileMetadata.appData.content ?: return emptyList()
+        val content = OdinSystemSerializer.deserialize<ConversationAppDataJson>(raw)
+        return content.recipients?.filterNotNull()?.map { it.domainName } ?: emptyList()
+    }
+
+    private fun readAdminPlaceholderAdmins(file: HomebaseFile): List<String> {
+        val raw = file.fileMetadata.appData.content ?: return emptyList()
+        val content = OdinSystemSerializer.deserialize<ConversationAdminInfo>(raw)
+        return content.admins?.map { it.domainName } ?: emptyList()
+    }
+}

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -435,6 +435,22 @@
     <string name="chat_group_heal_completed">Re-distributing group files…</string>
     <string name="chat_group_heal_completed_nothing">Nothing to redistribute (you didn't author the group files).</string>
 
+    <!-- Group-info file health diagnostic (footer at the bottom of group settings).
+         Each row reports the local-DB or own-server state of one of the two group
+         files (main + admin). Long-press the block to copy a support blob with
+         full UUIDs to the clipboard. -->
+    <string name="chat_group_files_diagnostic_title">Group files</string>
+    <string name="chat_group_files_diagnostic_db_group_label">DB-group:</string>
+    <string name="chat_group_files_diagnostic_db_admin_label">DB-admin:</string>
+    <string name="chat_group_files_diagnostic_server_group_label">Server-group:</string>
+    <string name="chat_group_files_diagnostic_server_admin_label">Server-admin:</string>
+    <!-- Args: 1=8-char uniqueId, 2=8-char versionTag, 3=originalAuthor domain -->
+    <string name="chat_group_files_diagnostic_present">exists · uid %1$s · v %2$s · author %3$s</string>
+    <!-- Arg: 1=8-char uniqueId -->
+    <string name="chat_group_files_diagnostic_placeholder">placeholder · uid %1$s</string>
+    <!-- Arg: 1=8-char uniqueId (the value the row would carry if it were present) -->
+    <string name="chat_group_files_diagnostic_absent">absent · uid %1$s expected</string>
+
     <!-- 1:1 connection state banner (shown in place of the message composer) -->
     <string name="chat_not_connected_description">You're not connected.</string>
     <string name="chat_not_connected_outgoing_description">Waiting for them to accept your connection request.</string>


### PR DESCRIPTION
The receive-side handler `handleIncomingHealRequest` previously collapsed "main file missing locally" into the no-op branch because the broken-check was `mainFile != null && isFileBroken(...)`. `markHealApplied` then tagged the status message and every subsequent replay short-circuited at the `HealAppliedTag` gate, leaving the recipient permanently unable to send/react/markRead (every path through `requireConversation` threw "No conversation found"). Observed in the wild for bishwajeetparhi.dev on the "Homies" group after a wipeAndRecreate cleared local state and the owner-drive copy of the conversation file was already gone server-side.

Changes:

- Distinguish *missing* (no local row) from *broken* (mismatched author or versionTag). The handler now treats both as "needs heal," gates the hard-delete on broken-only (a missing file has no fileId to act on), and writes a self-sufficient local placeholder for either case so the UI behaves as if nothing was broken while the canonical author's peer push is in flight.

- Extend `GroupHealInfo` with a nullable `canonicalAdmins` list so the receiver can rebuild a fully-formed admin placeholder, not just the main one. Pre-hardening senders (legacy clients) omit the field; the receiver falls back to the prior delete-only behaviour for the admin file in that case so getAdmins()' originalAuthor fallback keeps things functional.

- New `OptimisticWriter.writeLocalOnlyAdminPlaceholder` and `ConversationService.writeOrReplaceAdminPlaceholder` helpers, mirroring the existing main-file placeholder writers. Both write versionTag=null with `updated=ZeroTime` so the next genuine peer push from the canonical author replaces the placeholder cleanly via DriveMainIndex's modified-timestamp upsert guard.

- Fix `isFileBroken`: the placeholder check (versionTag=null marks a "leave me alone" row) now runs *before* the author check. Previous order made every replay re-classify a placeholder as broken, because the placeholder writers stamp the local domain as originalAuthor (not the canonical author) — producing an infinite cleanup loop on every heal status. Test caught this exact bug.

- Wire the `ConversationStream` orphan branch (incoming message for a conversationId with no main file) to fire `onRecoverConversation` once per session, deduped via the existing `recoveryAttemptedIds` set. recoverConversation is local-only today, so it is safe to call from inside a drive-sync batch handler — the historic concerns about spurious server-write conflicts no longer apply. Closes the gap that let messages keep arriving for a conversation whose file was missing from local DB while every send/react/markRead threw.

- Heavy logging at every decision point (Logger.i + audit lines) with conversationId, missing/broken/needsHeal flags, file ids, version tags, participant/admin counts, and which branch fired. Heal is rare and load-bearing — these traces let us diagnose the next regression from logs alone.

Tests: ConversationServiceHealTest covers main-missing, main-broken, admin-missing-with-canonicalAdmins, legacy payload fallback, second-pass no-op (regression for the isFileBroken placeholder ordering), self- loopback, and forged sender. All passing alongside the existing chat suite (homebase-chat:jvmTest).