### PR TITLE
fix(chat): restore five fixes silently dropped by dice-battle merge

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -51,6 +51,7 @@ import id.homebase.chat.conversationlist.ConversationListUiEvent.ShowInfoMessage
 import id.homebase.chat.data.ConversationState
 import id.homebase.chat.data.MessageUiModel
 import id.homebase.chat.services.ChatMessageActionService
+import id.homebase.chat.services.MAX_REACTIONS_PER_USER_PER_MESSAGE
 import id.homebase.chat.services.ChatMessageSenderService
 import id.homebase.chat.services.ChatMessageStream
 import id.homebase.chat.services.ChatMessagesData
@@ -106,6 +107,7 @@ import id.homebase.resources.chat_group_introduce_everyone_status
 import id.homebase.resources.chat_introduce_preflight_in_progress
 import id.homebase.resources.chat_message_audio_recording_help
 import id.homebase.resources.chat_message_forwarded
+import id.homebase.resources.chat_reactions_limit_reached
 import id.homebase.resources.chat_search_result_conversations
 import id.homebase.resources.chat_search_result_messages
 import id.homebase.resources.chat_search_result_pinned
@@ -1249,6 +1251,36 @@ class ConversationListViewModel(
             is ConversationListUiAction.ToggleReaction -> {
                 viewModelScope.launch {
                     if (action.reaction.isEmpty()) return@launch
+
+                    // Mirror the server-side cap of MAX_REACTIONS_PER_USER_PER_MESSAGE
+                    // distinct reactions per user per message. Adding past the cap is
+                    // a 400 (UnhandledScenario / "Too many Reactions") at upload, so
+                    // block it before we optimistically write or hit the outbox.
+                    // Removes (toggling an emoji the user already has) are always
+                    // allowed.
+                    var targetMessage: MessageUiModel? = null
+                    for (item in _messagesUiState.value.messages) {
+                        if (item is MessageListContentModel.Message &&
+                            item.message.id == action.messageId
+                        ) {
+                            targetMessage = item.message
+                            break
+                        }
+                    }
+                    if (targetMessage != null) {
+                        // ownReactions holds bare emoji (decoded by
+                        // ChatMessageStream from the wire's
+                        // `{"emoji":"X"}`); compare directly so removes
+                        // at the cap aren't misread as adds.
+                        val alreadyHasIt = action.reaction in targetMessage.ownReactions
+                        if (!alreadyHasIt &&
+                            targetMessage.ownReactions.size >= MAX_REACTIONS_PER_USER_PER_MESSAGE
+                        ) {
+                            sendEvent(ShowInfoMessage(MR.string.chat_reactions_limit_reached))
+                            return@launch
+                        }
+                    }
+
                     val previousReactions = _messagesUiState.value.messageReactions
                     try {
                         _messagesUiState.update { state ->

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -142,6 +142,7 @@ import id.homebase.chat.services.convo.OneOnOneConnectionStatus
 import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.ContactAvatar
 import id.homebase.core.avatars.ConversationAvatar
+import id.homebase.core.util.boundedFirstVisibleItemIndex
 import id.homebase.core.util.dismissKeyboardOnTap
 import id.homebase.core.util.initials
 import id.homebase.core.util.isDesktop
@@ -203,7 +204,6 @@ import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
@@ -339,7 +339,6 @@ fun ConversationContent(
 
     LaunchedEffect(listState) {
         snapshotFlow { listState.isScrollInProgress }
-            .distinctUntilChanged()
             .collectLatest { scrolling ->
                 if (scrolling) {
                     showFloatingDate = true
@@ -821,24 +820,37 @@ fun ConversationContent(
                 }
 
                 val currentMergedItems by rememberUpdatedState(mergedItems)
-                // Hoisted out of composition: a `derivedStateOf` reading `firstVisibleItemIndex`
-                // here was being invalidated by `animateItem()`'s lookahead measurement during
-                // conversation re-mount (back-from-message-details), causing the LazyColumn's
-                // measure pass to never settle (PR #468 watchdog stack, build 1393, 19:45 UTC).
-                // Running the observation in a coroutine means the overlay below only re-renders
-                // when the resolved date *result* changes — not on every mid-measure scroll tick.
+                // The section walk runs INSIDE the snapshotFlow block so that snapshotFlow's
+                // built-in dedup compares the resolved `LocalDate?` (O(1)) instead of a
+                // `Pair<Int, List<...>>` (O(n) list-equals). See CLAUDE.md "Compose & Flow
+                // gotchas" — pairing index+list and adding `.distinctUntilChanged()` here
+                // stalled Main for 5–8 s (build 1394 watchdog, restored by PR #472, regressed
+                // by `6adcc6b1` dice-battle merge).
                 val floatingDateLabel by produceState<LocalDate?>(null, listState) {
-                    snapshotFlow { listState.firstVisibleItemIndex to currentMergedItems }
-                        .distinctUntilChanged()
-                        .collect { (firstVisibleIndex, items) ->
-                            value = run {
-                                for (i in firstVisibleIndex downTo 0) {
-                                    val item = items.getOrNull(i)
-                                    if (item is MessageListContentModel.Section) return@run item.date
+                    snapshotFlow {
+                        val items = currentMergedItems
+                        // boundedFirstVisibleItemIndex guards against the
+                        // `Int.MAX_VALUE` "land at bottom" sentinel that
+                        // ConversationMessagesPane puts into LazyListState before
+                        // LazyColumn's first measure clamps it. Without the clamp
+                        // this for-loop walked 2.1B iterations and froze Main for
+                        // 6+ s (build 1419 watchdog, restored by PR #473, regressed
+                        // by `6adcc6b1` dice-battle merge). See
+                        // `boundedFirstVisibleItemIndex` docs and the CLAUDE.md
+                        // "Compose & Flow gotchas" rule.
+                        val startIdx = listState.boundedFirstVisibleItemIndex(items.size)
+                        var date: LocalDate? = null
+                        if (startIdx != null) {
+                            for (i in startIdx downTo 0) {
+                                val item = items.getOrNull(i)
+                                if (item is MessageListContentModel.Section) {
+                                    date = item.date
+                                    break
                                 }
-                                null
                             }
                         }
+                        date
+                    }.collect { value = it }
                 }
 
                 // Gate `animateItem()` until the initial composition burst has settled.

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -604,6 +604,7 @@
     <string name="chat_reactions_title">Reactions</string>
     <string name="chat_reactions_all">All</string>
     <string name="chat_reactions_tap_to_remove">Tap to remove</string>
+    <string name="chat_reactions_limit_reached">You cannot add more emojis, remove one first before adding another.</string>
     <string name="chat_message_discard_draft">Discard draft?</string>
 
     <string name="chat_message_forward_to">Forward to</string>


### PR DESCRIPTION
The dice-battle commit `6adcc6b1` (PR #478) was authored on top of `947ea9f4`, which already contained PRs #472, #473, #474, and the `c0f0cb23` follow-up. Its diff against that base included five unrelated reverts of recently-merged code in `ConversationContent.kt`, `ConversationListViewModel.kt`, and `values/strings.xml`. 

User-visible symptom: opening a *cached* conversation on Android took ~7+ seconds, with `MainThreadWatchdog` firing on the `floatingDateLabel` snapshotFlow stack. Cold loads were fine (~400 ms). The `cached >> cold` inversion is the giveaway: when the message list is already populated, `LazyColumn` renders 545 items immediately while `LazyListState` still holds the `firstVisibleItemIndex = Int.MAX_VALUE` "land at bottom" sentinel; the snapshotFlow body fires before the first measure clamps it. Without the `boundedFirstVisibleItemIndex` guard, the for-loop walks ~2.1 B iterations on Main.

Restored, verbatim from the prior fix commits:

R1 — `ConversationContent.kt:841` re-import + use of
     `boundedFirstVisibleItemIndex` for the section walk.
     Source of truth: `04a861b4` (PR #473).

R2 — `ConversationContent.kt:830` move the section walk back INSIDE
     the snapshotFlow block so the dedup compares the resolved
     `LocalDate?` (O(1)) instead of `Pair<Int, List<...>>` (O(n)
     `List.equals` on every snapshot tick during scroll-to-bottom
     restore). Drop the redundant `.distinctUntilChanged()`.
     Source of truth: `1cecba95` (PR #472).

R3 — `ConversationContent.kt:343` drop the cosmetic
     `.distinctUntilChanged()` on `snapshotFlow { isScrollInProgress }`.
     `Boolean` comparison is O(1) so this isn't a perf hit, but it
     violates the same CLAUDE.md "snapshotFlow already dedups
     internally" rule and the import is no longer needed elsewhere
     in the file once R2 lands.

R4 — `ConversationListViewModel.kt:1253` re-add the 30-line
     `MAX_REACTIONS_PER_USER_PER_MESSAGE` preflight in the
     `ToggleReaction` arm. Without it, the 6th add per user goes to
     the outbox and gets a server 400 (`UnhandledScenario / Too many
     Reactions`) instead of an immediate snackbar.
     Source of truth: `6a614b41` (PR #474) + `c0f0cb23` follow-up.

R5 — `homebase-common/.../values/strings.xml` re-add
     `chat_reactions_limit_reached` (the snackbar copy R4 references).
     The dice merge silently deleted this line. JVM tests don't run
     Compose-resource codegen so the reference would have failed the
     Android build.

Verified:
- `./gradlew homebase-chat:jvmTest --rerun-tasks` — green.
- `./gradlew :homebase-chat:compileDebugKotlinAndroid` — green (exercises the resource codegen R5 needed).
- Audit of all 18 files the dice merge touched against `7afe4c79` (the tip of main pre-#478): no other unrelated changes — only legitimate dice work and the five regressions above.

Refs: `6adcc6b1` (regressing), `04a861b4` (PR #473),
      `1cecba95` (PR #472), `6a614b41` (PR #474),
      `c0f0cb23` (PR #474 follow-up).