### PR TITLE
test(jvm): de-flake outbox + WS-burst tests; fix List<OdinId?> warnings

### DIFF
--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveWebSocketUpsertWorkerTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveWebSocketUpsertWorkerTest.kt
@@ -9,6 +9,7 @@ import id.homebase.api.sync.database.createInMemoryDatabase
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
@@ -16,6 +17,9 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -100,41 +104,61 @@ class DriveWebSocketUpsertWorkerTest {
         collector.cancel()
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun submit_burst_batchesIntoSingleDrain() = runBlocking {
+    fun submit_burst_batchesIntoSingleDrain() = runTest {
+        // Why not the class-level `runBlocking` + `Dispatchers.Default` setup
+        // the other tests use: this test asserts a coalescing invariant that
+        // is timing-sensitive. On a fast box submits 1..5 all add to the queue
+        // before the launched drain coroutine starts, and we get 1 batch. On a
+        // contended Linux CI runner the worker thread can start the drain
+        // (snapshotting [file_1] alone) before the test thread has issued
+        // submits 2..5 — splitting into 2 batches and failing the assertion.
+        //
+        // Switching to a single-threaded `StandardTestDispatcher` removes the
+        // race entirely: `submit()` doesn't suspend in the no-contention case,
+        // so all 5 submits complete synchronously on the test thread before
+        // the dispatcher gets a chance to run drain_1. drain_1's snapshot is
+        // therefore [file_1..file_5], one batch. Killroy may still be set
+        // (submits 2..5 saw the outer mutex held), so a follow-up drain_2 is
+        // launched — it finds an empty queue and returns without emitting.
+        //
+        // We bridge `withWriteTransaction`'s real-dispatcher hop by waiting on
+        // a `CompletableDeferred` the collector completes, not by relying on
+        // `advanceUntilIdle()` alone (the test scheduler appears idle while
+        // the DB write is in flight on its own dispatcher).
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val testWorkerScope = CoroutineScope(SupervisorJob() + dispatcher)
+
         val identityId = Uuid.random()
         val driveId = Uuid.random()
         val eventBus = EventBus()
 
         val collected = mutableListOf<BackendEvent.DriveEvent.BatchReceived>()
-        val collector = launch {
+        val firstBatch = CompletableDeferred<Unit>()
+        val collector = launch(dispatcher) {
             eventBus.events.collect { event ->
-                if (event is BackendEvent.DriveEvent.BatchReceived) collected.add(event)
+                if (event is BackendEvent.DriveEvent.BatchReceived) {
+                    collected.add(event)
+                    if (collected.size == 1) firstBatch.complete(Unit)
+                }
             }
         }
-        // Give the collector a tick to subscribe.
-        delay(20)
+        advanceUntilIdle() // collector subscribed
 
         val worker = DriveWebSocketUpsertWorker(
             identityId = identityId,
             driveId = driveId,
             databaseManager = db,
             eventBus = eventBus,
-            scope = workerScope,
+            scope = testWorkerScope,
         )
 
         val files = (1..5).map { makeFile(fileId = Uuid.random(), driveId = driveId) }
-        // Submit all 5 inside a single coroutine. The first submit's
-        // run() launches the drain; submits 2..5 see mutex held and
-        // set killroy. By the time the drain runs, all 5 are in the
-        // queue → ONE BatchReceived with 5 files.
-        for (f in files) worker.submit(f)
+        for (f in files) worker.submit(f) // synchronous on a confined dispatcher
 
-        // Wait for at least one batch, then a brief settle period.
-        withTimeoutOrNull(5.seconds) {
-            while (collected.isEmpty()) delay(20)
-        }
-        delay(100)
+        firstBatch.await()   // bridges the DB-dispatcher hop
+        advanceUntilIdle()   // let killroy-triggered drain_2 run (and find an empty queue)
 
         assertEquals(
             1, collected.size,
@@ -150,6 +174,7 @@ class DriveWebSocketUpsertWorkerTest {
         }
 
         collector.cancel()
+        testWorkerScope.cancel()
     }
 
     @Test

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTest.kt
@@ -314,7 +314,7 @@ class ChatMessageActionServiceTest {
     @Test
     fun deleteMessage_deleteForEveryone_drainsOutboxToHttpRequestWithRecipientsOnTheWire() = runTest {
         ChatMessageActionServiceTestFixture(captureHttp = true).use { fixture ->
-            val service = fixture.build(scope = this, outboxScope = backgroundScope)
+            val service = fixture.build(scope = this)
             val peer = "frodo.test"
             val convoId = fixture.seedOneOnOneConversation(other = peer)
             val fileId = Uuid.random()
@@ -354,7 +354,7 @@ class ChatMessageActionServiceTest {
     @Test
     fun deleteMessage_deleteForMe_drainsOutboxToHttpRequestWithoutRecipientsOnTheWire() = runTest {
         ChatMessageActionServiceTestFixture(captureHttp = true).use { fixture ->
-            val service = fixture.build(scope = this, outboxScope = backgroundScope)
+            val service = fixture.build(scope = this)
             val peer = "frodo.test"
             val convoId = fixture.seedOneOnOneConversation(other = peer)
             val fileId = Uuid.random()

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
@@ -47,11 +47,15 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlin.time.Clock
@@ -116,10 +120,19 @@ class ChatMessageActionServiceTestFixture(
     lateinit var participantLookup: FakeConversationParticipantLookup
         private set
 
+    // Owned outbox scope. The uploader's post-`Completed` bookkeeping hops to
+    // `Dispatchers.IO`; if we attached it to `runTest`'s `backgroundScope` the
+    // hop survives `runTest` cancellation and can land DB writes after the
+    // in-memory DB is closed (loaded Linux CI: SQLException → flake). By
+    // owning the scope here we can `cancelAndJoin` it in [close] before
+    // tearing down the DB — no late writers, no race.
+    private val outboxJob = SupervisorJob()
+    private val ownedOutboxScope = CoroutineScope(outboxJob + Dispatchers.IO)
+
     suspend fun build(
         scope: CoroutineScope = TestScope(),
-        outboxScope: CoroutineScope = scope,
     ): ChatMessageActionService {
+        val outboxScope: CoroutineScope = ownedOutboxScope
         dbm = createInMemoryDbm()
         credentialsManager = createCredentialsManager(testDomain)
         eventBus = EventBus()
@@ -486,19 +499,13 @@ class ChatMessageActionServiceTestFixture(
 
     override fun close() {
         if (!::dbm.isInitialized) return
-        // Swallow teardown-time SQL races: `runTest` cancels `backgroundScope`
-        // (where the outbox uploader runs) when the test body returns, but
-        // the uploader's post-`Completed` bookkeeping writes can hop to
-        // `Dispatchers.IO` and outlive `advanceUntilIdle`. On a loaded CI
-        // box those writes can land *after* this `close()` runs, throwing
-        // `SQLException("database has been closed")` and turning a passing
-        // test into a flake. Per-test in-memory DBs make leaks harmless.
-        try {
-            dbm.close()
-        } catch (e: java.sql.SQLException) {
-            // Already torn down or in the middle of a race — nothing to
-            // recover, and propagating would mask the real assertions.
-        }
+        // Drain the outbox scope before destroying the DB. The uploader's
+        // post-`Completed` bookkeeping hops to `Dispatchers.IO`; without this
+        // join those writes can land after `dbm.close()` and throw
+        // `SQLException("database has been closed")` from an IO thread,
+        // which `runTest` reports as a test failure on loaded Linux CI.
+        runBlocking { outboxJob.cancelAndJoin() }
+        dbm.close()
     }
 
     private fun createInMemoryDbm(): DatabaseManager = DatabaseManager({

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceHealTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceHealTest.kt
@@ -478,7 +478,7 @@ class ConversationServiceHealTest {
     private fun readPlaceholderRecipients(file: HomebaseFile): List<String> {
         val raw = file.fileMetadata.appData.content ?: return emptyList()
         val content = OdinSystemSerializer.deserialize<ConversationAppDataJson>(raw)
-        return content.recipients?.filterNotNull()?.map { it.domainName } ?: emptyList()
+        return content.recipients.filterNotNull().map { it.domainName }
     }
 
     private fun readAdminPlaceholderAdmins(file: HomebaseFile): List<String> {

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceRecoveryTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceRecoveryTest.kt
@@ -162,7 +162,7 @@ class ConversationServiceRecoveryTest {
             val contentJson = file.fileMetadata.appData.content
             assertNotNull(contentJson, "placeholder content should be written")
             val content = OdinSystemSerializer.deserialize<ConversationAppDataJson>(contentJson)
-            val recipients = content.recipients?.filterNotNull()?.map { it.domainName } ?: emptyList()
+            val recipients = content.recipients.filterNotNull().map { it.domainName }
             assertTrue(
                 recipients.contains(alice),
                 "1:1 placeholder must list the sender (alice) as participant; got $recipients",


### PR DESCRIPTION
Two intermittent CI failures (Linux GHA only, never reproduced on Windows locally) shared a single root pattern: a background coroutine launched on a real dispatcher (Dispatchers.IO / Dispatchers.Default) outraced the test body's idea of "we're done" on a slower runner.

Flake 1 — ChatMessageActionServiceTest.deleteMessage_deleteForEveryone_…:
  The fixture passed outboxScope = backgroundScope. When the test body
  returned, runTest cancelled backgroundScope, but OutboxSync's post-
  Completed bookkeeping hops to Dispatchers.IO for DB writes — those can
  land *after* dbm.close(), throwing SQLException("database has been
  closed") from an IO thread, which runTest reports as a test failure.
  The existing try { dbm.close() } catch (SQLException) only caught the
  close call itself, not the racing background write.

  Fix: fixture now owns its outbox scope (SupervisorJob + Dispatchers.IO)
  and close() does runBlocking { outboxJob.cancelAndJoin() } *before*
  dbm.close(), so no late writers can survive teardown. Removed the
  SQLException swallow (a real one is now a real bug). Dropped the
  outboxScope parameter from build() and the two outboxScope =
  backgroundScope overrides at the call sites.

Flake 2 — DriveWebSocketUpsertWorkerTest.submit_burst_batchesIntoSingleDrain:
  The test ran on runBlocking + Dispatchers.Default. Its assertion
  (5 submits → 1 batch) only holds if the test thread issues all 5
  submits before the launched drain coroutine starts on a worker thread.
  On a contended Linux runner the worker thread can start drain_1
  (snapshot=[file_1]) before submits 2..5 land, splitting into 2 batches.

  Fix: the burst test now uses runTest + StandardTestDispatcher (single-
  threaded, virtual time). On a confined dispatcher, submit() never
  suspends (no pendingMutex contention), so all 5 calls complete
  synchronously on the test thread before drain_1 ever runs — coalescing
  becomes a property of the dispatcher, not of CI luck. The
  withWriteTransaction's real-dispatcher hop is bridged with a
  CompletableDeferred the collector completes on first batch (the test
  scheduler appears idle while the DB write is in-flight on its own
  dispatcher, so advanceUntilIdle alone wouldn't bridge it). Other tests
  in the class are unchanged; they use deferred-await waits or assert
  invariants robust to drain count.

Warnings — ConversationAppDataJson.recipients is List<OdinId?> (non-null list, nullable elements). Dropped the redundant outer ?. and ?: emptyList() in ConversationServiceHealTest:481 and ConversationServiceRecoveryTest:165. No production callers rely on the field being null.