### PR TITLE
refactor(chat): trim EventDescriptor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,3 +290,16 @@ nullable-descriptor parse-failure contract, choosing an `ActionPolicy`, parser/b
 composer/attachment-sheet wiring, the strings the bubble needs, and the `Unknown` chip
 that gives older receivers a visible "please update the app" fallback. Existing kinds:
 Event (`dataType = 210`) and DiceRoll (`dataType = 212`).
+
+**Don't duplicate envelope fields in the descriptor.** The HomebaseFile envelope already
+carries the message identity, sender, and timestamp — your descriptor JSON must NOT
+repeat them:
+
+- No `xxxId` — the HomebaseFile uniqueId already identifies the message.
+- No `createdByOdinId` / authorId — read `HomebaseFile.fileMetadata.originalAuthor`.
+- No `createdAtUtcMs` — read the message's `userDate` (or `fileMetadata.created`).
+
+Duplicating these wastes the 7 KB `MaxHeaderContentBytes` budget, lets the two copies
+drift, and forces every consumer to decide which one to trust. Also keep user-text caps
+tight (e.g. title ≤80 codepoints, description ≤280 codepoints) so the descriptor stays
+comfortably under 7 KB at the maximum slot/option count.

--- a/homebase-chat/src/androidMain/kotlin/id/homebase/chat/event/CalendarLauncher.android.kt
+++ b/homebase-chat/src/androidMain/kotlin/id/homebase/chat/event/CalendarLauncher.android.kt
@@ -7,6 +7,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import co.touchlab.kermit.Logger
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 private const val TAG = "CalendarLauncher"
 
@@ -16,8 +18,9 @@ actual fun rememberCalendarLauncher(): CalendarLauncher {
     return remember(context) { AndroidCalendarLauncher(context.applicationContext) }
 }
 
+@OptIn(ExperimentalUuidApi::class)
 private class AndroidCalendarLauncher(private val appContext: Context) : CalendarLauncher {
-    override fun addToCalendar(event: EventDescriptor) {
+    override fun addToCalendar(event: EventDescriptor, messageId: Uuid) {
         val intent = Intent(Intent.ACTION_INSERT).apply {
             data = CalendarContract.Events.CONTENT_URI
             putExtra(CalendarContract.Events.TITLE, event.title)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/CalendarLauncher.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/CalendarLauncher.kt
@@ -1,6 +1,8 @@
 package id.homebase.chat.event
 
 import androidx.compose.runtime.Composable
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 import kotlinx.datetime.toLocalDateTime
 
 /**
@@ -21,7 +23,8 @@ import kotlinx.datetime.toLocalDateTime
  * browser. See [googleCalendarUrl] below.
  */
 interface CalendarLauncher {
-    fun addToCalendar(event: EventDescriptor)
+    @OptIn(ExperimentalUuidApi::class)
+    fun addToCalendar(event: EventDescriptor, messageId: Uuid)
 }
 
 @Composable

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventComposerSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventComposerSheet.kt
@@ -45,13 +45,15 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.api.client.location.LocationPreviewProvider
 import id.homebase.api.util.truncateToCodePoints
 import id.homebase.chat.location.LocationResult
@@ -126,7 +128,6 @@ private fun EventComposerContent(
     onSent: () -> Unit,
 ) {
     val sender: ChatMessageSenderService = koinInject()
-    val ownerSession: OwnerSessionRepository = koinInject()
     val scope = rememberCoroutineScope()
 
     var title by remember { mutableStateOf("") }
@@ -201,9 +202,7 @@ private fun EventComposerContent(
                 val tz = runCatching { TimeZone.of(timezone) }.getOrDefault(systemTz)
                 val startUtcMs = startDateTime.toInstant(tz).toEpochMilliseconds()
                 val endUtcMs = if (hasEndTime) endDateTime.toInstant(tz).toEpochMilliseconds() else null
-                val authorOdinId = ownerSession.user.value?.odinId?.domainName ?: ""
                 val descriptor = EventDescriptor(
-                    eventId = Uuid.random().toString(),
                     title = title.truncateToCodePoints(MAX_TITLE_CODEPOINTS),
                     description = description.truncateToCodePoints(MAX_DESCRIPTION_CODEPOINTS),
                     startUtcMs = startUtcMs,
@@ -213,8 +212,6 @@ private fun EventComposerContent(
                     lat = locationLat,
                     lon = locationLon,
                     meetingUrl = meetingUrl.takeIf { it.isNotBlank() },
-                    createdByOdinId = authorOdinId,
-                    createdAtUtcMs = Clock.System.now().toEpochMilliseconds(),
                 )
                 runCatching {
                     sender.sendNewTypedMessage(
@@ -259,6 +256,8 @@ private fun EventComposerContent(
                 onValueChange = { title = it },
                 label = { Text(stringResource(MR.string.chat_event_field_title)) },
                 singleLine = true,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+                keyboardActions = KeyboardActions(onSend = { doSend() }),
                 modifier = Modifier.fillMaxWidth(),
             )
             OutlinedTextField(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventComposerSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventComposerSheet.kt
@@ -45,11 +45,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -256,8 +253,6 @@ private fun EventComposerContent(
                 onValueChange = { title = it },
                 label = { Text(stringResource(MR.string.chat_event_field_title)) },
                 singleLine = true,
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
-                keyboardActions = KeyboardActions(onSend = { doSend() }),
                 modifier = Modifier.fillMaxWidth(),
             )
             OutlinedTextField(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventDescriptor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventDescriptor.kt
@@ -8,12 +8,14 @@ import kotlinx.serialization.Serializable
  * ChatEventMessageDataType`), so it loads with the message index — no payload
  * fetch on scroll.
  *
- * All fields except [eventId], [title], [startUtcMs], [timezone],
- * [createdByOdinId], [createdAtUtcMs] are optional.
+ * Identity / sender / creation time are NOT in the descriptor — read them
+ * from the surrounding HomebaseFile envelope (`uniqueId`,
+ * `fileMetadata.originalAuthor`, `userDate`). See the "Don't duplicate
+ * envelope fields in the descriptor" rule under "Adding a New Typed Message
+ * Kind" in `CLAUDE.md`.
  */
 @Serializable
 data class EventDescriptor(
-    val eventId: String,
     val title: String,
     val description: String = "",
     val startUtcMs: Long,
@@ -23,12 +25,12 @@ data class EventDescriptor(
     val lat: Double? = null,
     val lon: Double? = null,
     val meetingUrl: String? = null,
-    val createdByOdinId: String,
-    val createdAtUtcMs: Long,
     /**
-     * Schema version for forward compatibility. Bump when the descriptor shape
-     * changes in a way receivers need to know about. Receivers ignoring this
-     * just see the new optional fields as default values.
+     * Schema version for forward compatibility. Bumped to 2 when the legacy
+     * `eventId` / `createdByOdinId` / `createdAtUtcMs` fields were removed
+     * (read those values from the message envelope instead). Older clients
+     * that still require those fields in their data class will fail to
+     * deserialize and render the "update the app" chip.
      */
-    val schemaVersion: Int = 1,
+    val schemaVersion: Int = 2,
 )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventDetailDialog.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventDetailDialog.kt
@@ -233,7 +233,7 @@ private fun EventDetailContent(
                 icon = Icons.Default.CalendarMonth,
                 label = stringResource(MR.string.chat_event_download_ics),
                 actionLabel = null,
-                onClick = { calendarLauncher.addToCalendar(descriptor) },
+                onClick = { calendarLauncher.addToCalendar(descriptor, messageId) },
             )
 
             Spacer(Modifier.height(24.dp))

--- a/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/event/CalendarLauncher.jvm.kt
+++ b/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/event/CalendarLauncher.jvm.kt
@@ -9,7 +9,8 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
-import java.util.UUID
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 private const val TAG = "CalendarLauncher.jvm"
 
@@ -18,10 +19,11 @@ actual fun rememberCalendarLauncher(): CalendarLauncher {
     return remember { JvmCalendarLauncher() }
 }
 
+@OptIn(ExperimentalUuidApi::class)
 private class JvmCalendarLauncher : CalendarLauncher {
-    override fun addToCalendar(event: EventDescriptor) {
+    override fun addToCalendar(event: EventDescriptor, messageId: Uuid) {
         try {
-            val ics = buildIcs(event)
+            val ics = buildIcs(event, messageId)
             val tempFile = File.createTempFile("homebase_event_", ".ics")
             tempFile.writeText(ics, Charsets.UTF_8)
             tempFile.deleteOnExit()
@@ -41,14 +43,14 @@ private class JvmCalendarLauncher : CalendarLauncher {
      * descriptor's IANA zone — the wall-clock time the user picked is
      * preserved by the UTC milliseconds.
      */
-    private fun buildIcs(event: EventDescriptor): String {
+    private fun buildIcs(event: EventDescriptor, messageId: Uuid): String {
         val fmt = SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'", Locale.US).apply {
             timeZone = TimeZone.getTimeZone("UTC")
         }
         val now = fmt.format(Date())
         val start = fmt.format(Date(event.startUtcMs))
         val end = fmt.format(Date(event.endUtcMs ?: (event.startUtcMs + 60L * 60L * 1000L)))
-        val uid = "${event.eventId}@homebase"
+        val uid = "$messageId@homebase"
 
         return buildString {
             append("BEGIN:VCALENDAR\r\n")

--- a/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/event/CalendarLauncher.native.kt
+++ b/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/event/CalendarLauncher.native.kt
@@ -3,6 +3,8 @@ package id.homebase.chat.event
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import co.touchlab.kermit.Logger
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.ObjCAction
@@ -23,9 +25,9 @@ actual fun rememberCalendarLauncher(): CalendarLauncher {
     return remember { IosCalendarLauncher() }
 }
 
-@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class, ExperimentalUuidApi::class)
 private class IosCalendarLauncher : CalendarLauncher {
-    override fun addToCalendar(event: EventDescriptor) {
+    override fun addToCalendar(event: EventDescriptor, messageId: Uuid) {
         val store = EKEventStore()
         // Request access; permission prompt is gated by NSCalendarsUsageDescription
         // in the host app's Info.plist. The completion fires off-main, so log


### PR DESCRIPTION
Drop three EventDescriptor fields that duplicate data already on the HomebaseFile envelope:

  - eventId          → HomebaseFile.uniqueId
  - createdByOdinId  → HomebaseFile.fileMetadata.originalAuthor
  - createdAtUtcMs   → message userDate / fileMetadata.created

createdByOdinId and createdAtUtcMs had zero readers anywhere in the codebase. eventId had one reader: the JVM iCal launcher used it as the RFC-5545 UID line. CalendarLauncher.addToCalendar now takes messageId: Uuid alongside the descriptor; the JVM .ics emits "$messageId@homebase" as its UID instead. The Android intent and iOS EventKit paths already ignored the field. EventDetailDialog already had messageId in scope.

schemaVersion bumped 1 → 2 to mark the wire change.

Wire compat:
  Old → New  ✓ ignoreUnknownKeys = true on OdinSystemSerializer drops
              the legacy fields silently.
  New → Old  Old client throws MissingFieldException; parseEvent's
              catch returns Event(descriptor = null); receiver renders
              the existing UnparseableEventBubble "update the app"
              chip. Accepted: small affected user base.

Also adds a "don't duplicate envelope fields" rule to CLAUDE.md under "Adding a New Typed Message Kind" so new typed kinds (Groodle, future polls/doodles) start lean. EventComposerSheet drops its now-unused OwnerSessionRepository injection.

Verified: ./gradlew homebase-chat:jvmTest --rerun-tasks BUILD SUCCESSFUL.