### PR TITLE
chore(ios): clean up Swift compile warnings

### DIFF
--- a/iosApp/ShareExtension/ShareViewController.swift
+++ b/iosApp/ShareExtension/ShareViewController.swift
@@ -66,7 +66,7 @@ class ShareViewController: UIViewController {
 
     private func handleSelection(conversationIds: [String]) {
         guard let extensionContext = extensionContext,
-              let firstId = conversationIds.first else {
+              !conversationIds.isEmpty else {
             cancelExtension()
             return
         }

--- a/iosApp/iosApp/FFmpegKitBridgeImpl.swift
+++ b/iosApp/iosApp/FFmpegKitBridgeImpl.swift
@@ -79,13 +79,13 @@ class FFmpegKitBridgeImpl: FFmpegKitBridge {
 
             // Get width/height
             let width: KotlinInt? = {
-                if let w = stream.getWidth() as? NSNumber {
+                if let w = stream.getWidth() {
                     return KotlinInt(value: w.int32Value)
                 }
                 return nil
             }()
             let height: KotlinInt? = {
-                if let h = stream.getHeight() as? NSNumber {
+                if let h = stream.getHeight() {
                     return KotlinInt(value: h.int32Value)
                 }
                 return nil

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -52,7 +52,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
           identifier: "MESSAGE_CATEGORY",
           actions: [replyAction, markReadAction],
           intentIdentifiers: [],
-          options: .allowAnnouncement
+          options: []
       )
       UNUserNotificationCenter.current().setNotificationCategories([messageCategory])
   }


### PR DESCRIPTION
Three small, unrelated warnings flagged by the iOS CI build:

1. ShareViewController.swift:69 — `firstId` was bound in a guard but never used. Downstream we use `conversationIds.joined(separator: ",")`, not the first element. Replace the binding with a non-empty check (`!conversationIds.isEmpty`) so the guard still rejects the empty case.

2. FFmpegKitBridgeImpl.swift:82,88 — `stream.getWidth()` / `getHeight()` already return `NSNumber?`, so `as? NSNumber` was a no-op conditional downcast. Drop the cast and unwrap directly.

3. iOSApp.swift:55 — `.allowAnnouncement` was deprecated in iOS 15 ("Announcement option is ignored"). Replace with `[]`. No behavioral change on iOS 15+, where the option was already a no-op.

Pure warning hygiene, zero behavior change. Split out from the Event descriptor refactor so each PR stays focused on a single surface area.