### PR TITLE
feat(chat): persist scroll position by message uniqueId, not list index

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
@@ -109,10 +109,23 @@ sealed interface ConversationListUiAction {
 
     data object CloseFullScreenOverlay : ConversationListUiAction
 
+    /**
+     * Persist where the user is reading in this conversation. The anchor is
+     * the uniqueId of the topmost visible message (resolved by the pane from
+     * its [androidx.compose.foundation.lazy.LazyListState]); the offset is
+     * pixel offset within that anchor item. On next open we look the anchor
+     * up against the freshly-loaded message list to recover the index — that
+     * keeps the saved position meaningful even when new messages arrived
+     * between sessions or when paging eventually shifts indices on prepend.
+     *
+     * `anchorMessageId == null` means the pane couldn't resolve the visible
+     * window to a real message (empty list, all-non-message rows) and the VM
+     * should ignore the dispatch.
+     */
     data class SaveScrollPosition(
         val conversationId: Uuid,
-        val firstVisibleItemIndex: Int,
-        val firstVisibleItemScrollOffset: Int
+        val anchorMessageId: Uuid?,
+        val firstVisibleItemScrollOffset: Int,
     ) : ConversationListUiAction
 
     data object ClearScrollTrigger : ConversationListUiAction

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -787,23 +787,29 @@ class ConversationListViewModel(
             }
 
             is ConversationListUiAction.SaveScrollPosition -> {
-                _messagesUiState.update {
-                    it.copy(
-                        scrollPosition = ScrollPosition(
-                            firstVisibleItemIndex = action.firstVisibleItemIndex,
-                            firstVisibleItemScrollOffset = action.firstVisibleItemScrollOffset,
+                // Pane resolves the visible-window index to a message anchor
+                // before dispatch. A null anchor means the visible window had
+                // nothing resolvable (empty list, all-non-message rows) — skip
+                // the write rather than overwrite the previous good anchor.
+                //
+                // No in-memory _messagesUiState update either: scrollPosition
+                // in MessageListUiState is only consumed when (a) priming the
+                // LazyListState on conversation switch (re-read from prefs
+                // there) or (b) honouring a programmatic triggerScroll.
+                // Neither benefits from the user-scroll debounce — and
+                // writing it here would cause a needless recomposition every
+                // 300 ms while the user is reading.
+                val anchor = action.anchorMessageId
+                if (anchor != null) {
+                    viewModelScope.launch {
+                        userPreferences.setConversationScrollAnchor(
+                            action.conversationId.toString(), anchor
                         )
-                    )
-                }
-
-                // Persist to user settings
-                viewModelScope.launch {
-                    userPreferences.setConversationScrollIndex(
-                        action.conversationId.toString(), action.firstVisibleItemIndex
-                    )
-                    userPreferences.setConversationScrollOffset(
-                        action.conversationId.toString(), action.firstVisibleItemScrollOffset
-                    )
+                        userPreferences.setConversationScrollOffset(
+                            action.conversationId.toString(),
+                            action.firstVisibleItemScrollOffset
+                        )
+                    }
                 }
             }
 
@@ -2626,9 +2632,12 @@ class ConversationListViewModel(
                             // ChatMessagesData.Messages emission retries the
                             // lookup (messages stream re-emits on each sync
                             // batch). Clear only once the message is found.
-                            val indexOfMessageForScroll = if (messageIdForScrollNullable != null) {
+                            // Capture the requested scroll-to-message id BEFORE we null it
+                            // so we can persist it as the new anchor below.
+                            val targetMessageId = messageIdForScrollNullable
+                            val indexOfMessageForScroll = if (targetMessageId != null) {
                                 val messageIndex = messagesModels.indexOfLast {
-                                    it is MessageListContentModel.Message && it.message.id == messageIdForScrollNullable
+                                    it is MessageListContentModel.Message && it.message.id == targetMessageId
                                 }
                                 if (messageIndex >= 0) {
                                     messageIdForScrollNullable = null
@@ -2643,7 +2652,7 @@ class ConversationListViewModel(
                             val newScroll = if (indexOfMessageForScroll == null) {
                                 if (setInitialScroll && !scrollToBottom) {
                                     Logger.i("Getting saved scroll position")
-                                    getScrollPosition(conversationId)
+                                    getScrollPosition(conversationId, messagesModels)
                                 } else {
                                     Logger.i("No saved scroll position")
                                     null
@@ -2656,14 +2665,18 @@ class ConversationListViewModel(
                                 )
                             }
 
-                            if (newScroll != null) {
-                                userPreferences.setConversationScrollIndex(
+                            // Persist the anchor only when we just landed on a freshly
+                            // requested message (the messageIdForScroll path). The
+                            // saved-anchor path doesn't need to re-persist itself, and
+                            // the user-scroll path persists via SaveScrollPosition.
+                            if (indexOfMessageForScroll != null && targetMessageId != null) {
+                                userPreferences.setConversationScrollAnchor(
                                     conversationId.toString(),
-                                    newScroll.firstVisibleItemIndex
+                                    targetMessageId,
                                 )
                                 userPreferences.setConversationScrollOffset(
                                     conversationId.toString(),
-                                    newScroll.firstVisibleItemScrollOffset
+                                    newScroll!!.firstVisibleItemScrollOffset,
                                 )
                             }
 
@@ -2710,19 +2723,28 @@ class ConversationListViewModel(
         }
     }
 
-    private fun getScrollPosition(conversationId: Uuid): ScrollPosition? {
-        val firstVisibleItemIndex =
-            userPreferences.getConversationScrollIndex(conversationId.toString())
+    /**
+     * Resolve the persisted scroll anchor for [conversationId] against the
+     * freshly-loaded [messages] list. The anchor is a message uniqueId — we
+     * scan the list for the matching [MessageListContentModel.Message] and
+     * return its index. Returns `null` when no anchor was saved, when the
+     * anchor isn't in the current window (deleted, not-yet-synced, or one of
+     * the rare race cases), or when the offset wasn't saved alongside it.
+     * The caller falls through to the "land at bottom" path in those cases.
+     */
+    private fun getScrollPosition(
+        conversationId: Uuid,
+        messages: List<MessageListContentModel>,
+    ): ScrollPosition? {
+        val anchor =
+            userPreferences.getConversationScrollAnchor(conversationId.toString()) ?: return null
         val firstVisibleItemScrollOffset =
-            userPreferences.getConversationScrollOffset(conversationId.toString())
-
-        if (firstVisibleItemIndex != null && firstVisibleItemScrollOffset != null) {
-            return ScrollPosition(
-                firstVisibleItemIndex = firstVisibleItemIndex,
-                firstVisibleItemScrollOffset = firstVisibleItemScrollOffset
-            )
-        }
-        return null
+            userPreferences.getConversationScrollOffset(conversationId.toString()) ?: return null
+        val resolvedIndex = resolveAnchorIndex(messages, anchor) ?: return null
+        return ScrollPosition(
+            firstVisibleItemIndex = resolvedIndex,
+            firstVisibleItemScrollOffset = firstVisibleItemScrollOffset,
+        )
     }
 
     private fun sendEvent(event: ConversationListUiEvent) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ScrollAnchorResolver.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ScrollAnchorResolver.kt
@@ -1,0 +1,59 @@
+package id.homebase.chat.conversationlist
+
+import kotlin.uuid.Uuid
+
+/**
+ * Helpers for the index ↔ uniqueId mapping that anchored scroll persistence
+ * needs. The list shape is stable across sessions only at the message level —
+ * separators, headers, and unread markers are rebuilt from message data on
+ * each open and are not stable anchors.
+ *
+ * Used by [id.homebase.chat.widget.ConversationMessagesPane] (when persisting
+ * the current scroll position — index → anchor) and by
+ * [ConversationListViewModel.getScrollPosition] (when restoring — anchor →
+ * index).
+ */
+
+/**
+ * Walk forward from [fromIndex] until a [MessageListContentModel.Message] is
+ * reached and return its uniqueId, or `null` if none exists at or after that
+ * position. Walking forward (not backward) means a date-separator at the top
+ * of the visible window resolves to the FIRST message below it — which is
+ * what the user is actually reading.
+ */
+internal fun resolveAnchorMessageId(
+    messages: List<MessageListContentModel>,
+    fromIndex: Int,
+): Uuid? {
+    if (fromIndex < 0) return null
+    var i = fromIndex
+    while (i < messages.size) {
+        val item = messages[i]
+        if (item is MessageListContentModel.Message) {
+            return item.message.id
+        }
+        i++
+    }
+    return null
+}
+
+/**
+ * Find the index of the [MessageListContentModel.Message] whose uniqueId
+ * matches [anchorMessageId]. Returns `null` if the anchor isn't in the list
+ * (e.g. the message was deleted or hasn't been synced down yet) — the
+ * caller should fall back to the default landing position in that case.
+ */
+internal fun resolveAnchorIndex(
+    messages: List<MessageListContentModel>,
+    anchorMessageId: Uuid,
+): Int? {
+    var i = 0
+    while (i < messages.size) {
+        val item = messages[i]
+        if (item is MessageListContentModel.Message && item.message.id == anchorMessageId) {
+            return i
+        }
+        i++
+    }
+    return null
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import associateNotNull
@@ -32,6 +33,7 @@ import id.homebase.chat.conversationlist.ConversationListUiAction.UnAttachFile
 import id.homebase.chat.conversationlist.FullScreenOverlay
 import id.homebase.chat.conversationlist.MessageListContentModel
 import id.homebase.chat.conversationlist.MessageListUiState
+import id.homebase.chat.conversationlist.resolveAnchorMessageId
 import id.homebase.chat.services.convo.EnrichedConversationUiModel
 import id.homebase.core.HomebaseConstants
 import id.homebase.core.util.boundedFirstVisibleItemIndex
@@ -109,6 +111,13 @@ fun ConversationMessagesPane(
         }
     }
 
+    // The LaunchedEffect below is keyed only on `listState`, so its captured
+    // `uiState.messages` would freeze at composition time. `rememberUpdatedState`
+    // gives the lambda a State handle whose `.value` reads the latest messages
+    // list at each emission — so the index → anchor resolution always uses the
+    // currently-rendered window, not a stale one.
+    val latestMessages = rememberUpdatedState(uiState.messages)
+
     // Save scroll position when it changes
     LaunchedEffect(listState) {
         val conversationId = conversation.conversation.id
@@ -127,14 +136,17 @@ fun ConversationMessagesPane(
                 // Only save if we're still viewing the same conversation, messages are loaded,
                 // and not restoring
                 if (index != null && !uiState.isLoadingMessages) {
-                    Logger.i("Scroll changed: id=${conversationId} -> $index:$offset")
-                    onUiAction(
-                        SaveScrollPosition(
-                            conversationId = conversationId,
-                            firstVisibleItemIndex = index,
-                            firstVisibleItemScrollOffset = offset
+                    val anchorId = resolveAnchorMessageId(latestMessages.value, index)
+                    if (anchorId != null) {
+                        Logger.i("Scroll changed: id=${conversationId} -> anchor=$anchorId offset=$offset (idx=$index)")
+                        onUiAction(
+                            SaveScrollPosition(
+                                conversationId = conversationId,
+                                anchorMessageId = anchorId,
+                                firstVisibleItemScrollOffset = offset,
+                            )
                         )
-                    )
+                    }
                 }
             }
     }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/ScrollAnchorResolverTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/ScrollAnchorResolverTest.kt
@@ -1,0 +1,138 @@
+package id.homebase.chat.conversationlist
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.common.OdinId
+import id.homebase.chat.data.MessageUiModel
+import id.homebase.chat.services.MessageAppData
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * Index ↔ anchor-uniqueId mapping used by anchored scroll persistence.
+ * See [ScrollAnchorResolver] for the production helpers; the pane uses
+ * [resolveAnchorMessageId] when persisting (snapshotFlow → SaveScrollPosition)
+ * and the VM uses [resolveAnchorIndex] when restoring (getScrollPosition).
+ */
+class ScrollAnchorResolverTest {
+
+    private val alice = OdinId("alice.test")
+    private val baseTime = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+
+    private fun message(id: Uuid = Uuid.random()): MessageListContentModel.Message =
+        MessageListContentModel.Message(
+            message = MessageUiModel(
+                id = id,
+                globalTransitId = null,
+                fileId = Uuid.random(),
+                conversationId = Uuid.random(),
+                content = "test",
+                userDate = baseTime,
+                modified = null,
+                created = baseTime,
+                originalAuthor = alice,
+                sender = alice,
+                displayName = alice.domainName,
+                localReadTimestamp = null,
+                isDeleted = false,
+                isPendingSend = false,
+                versionTag = Uuid.NIL,
+                messageAppData = MessageAppData(),
+                reactionPreview = null,
+                previewThumbnail = null,
+                payloads = null,
+                keyHeader = KeyHeader.empty(),
+                hasMore = false,
+            ),
+        )
+
+    // ---- resolveAnchorMessageId (index → uniqueId, used on persist) ----
+
+    @Test
+    fun resolveAnchorMessageId_returnsIdAtExactIndex() {
+        val m1 = message()
+        val m2 = message()
+        val list = listOf<MessageListContentModel>(m1, m2)
+        assertEquals(m2.message.id, resolveAnchorMessageId(list, fromIndex = 1))
+    }
+
+    @Test
+    fun resolveAnchorMessageId_walksForwardPastSeparators() {
+        // Date separator at the top of the visible window — anchor should be
+        // the FIRST message below it (what the user is actually reading), not
+        // the separator and not whatever is above.
+        val msg = message()
+        val list = listOf<MessageListContentModel>(
+            MessageListContentModel.Section(date = kotlinx.datetime.LocalDate(2026, 1, 1)),
+            msg,
+        )
+        assertEquals(msg.message.id, resolveAnchorMessageId(list, fromIndex = 0))
+    }
+
+    @Test
+    fun resolveAnchorMessageId_returnsNullWhenNoMessageAtOrAfter() {
+        val list = listOf<MessageListContentModel>(
+            MessageListContentModel.Header,
+            MessageListContentModel.UnreadSeparator,
+        )
+        assertNull(resolveAnchorMessageId(list, fromIndex = 0))
+    }
+
+    @Test
+    fun resolveAnchorMessageId_returnsNullForNegativeIndex() {
+        val list = listOf<MessageListContentModel>(message())
+        assertNull(resolveAnchorMessageId(list, fromIndex = -1))
+    }
+
+    @Test
+    fun resolveAnchorMessageId_returnsNullForOutOfBoundsIndex() {
+        val list = listOf<MessageListContentModel>(message())
+        assertNull(resolveAnchorMessageId(list, fromIndex = 5))
+    }
+
+    @Test
+    fun resolveAnchorMessageId_returnsNullForEmptyList() {
+        assertNull(resolveAnchorMessageId(emptyList(), fromIndex = 0))
+    }
+
+    // ---- resolveAnchorIndex (uniqueId → index, used on restore) ----
+
+    @Test
+    fun resolveAnchorIndex_findsMessageInTheMiddle() {
+        val target = message()
+        val list = listOf<MessageListContentModel>(
+            MessageListContentModel.Header,
+            message(),
+            target,
+            message(),
+        )
+        assertEquals(2, resolveAnchorIndex(list, target.message.id))
+    }
+
+    @Test
+    fun resolveAnchorIndex_returnsNullForUnknownAnchor() {
+        // Saved anchor isn't in the current window — message was deleted or
+        // hasn't synced down yet. Caller falls through to "land at bottom."
+        val list = listOf<MessageListContentModel>(message(), message())
+        assertNull(resolveAnchorIndex(list, anchorMessageId = Uuid.random()))
+    }
+
+    @Test
+    fun resolveAnchorIndex_returnsNullForEmptyList() {
+        assertNull(resolveAnchorIndex(emptyList(), anchorMessageId = Uuid.random()))
+    }
+
+    @Test
+    fun resolveAnchorIndex_skipsNonMessageRowsWithMatchingPosition() {
+        // Defensive: only Message rows are valid anchors. A Section/System row
+        // with the same string-id as some message must NOT match.
+        val target = message()
+        val list = listOf<MessageListContentModel>(
+            MessageListContentModel.System(text = "joined", userDate = baseTime, index = 0),
+            target,
+        )
+        assertEquals(1, resolveAnchorIndex(list, target.message.id))
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/settings/UserPreferences.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/settings/UserPreferences.kt
@@ -3,6 +3,7 @@ package id.homebase.core.settings
 import com.russhwolf.settings.Settings
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlin.uuid.Uuid
 
 class UserPreferences(private val settings: Settings) {
     private val _preferenceState = MutableStateFlow(
@@ -53,12 +54,34 @@ class UserPreferences(private val settings: Settings) {
         set(value) = settings.putBoolean("notification_include_muted_badge", value)
 
    
-    fun getConversationScrollIndex(conversationId: String): Int? {
-        return settings.getIntOrNull("conversationScrollIndex-$conversationId")
+    /**
+     * Per-conversation scroll anchor — the uniqueId of the message the user
+     * was looking at. Resolved to a list index against the freshly-loaded
+     * messages on next open. Stored as a string (UUID) under
+     * `conversationScrollAnchor-<conversationId>`.
+     *
+     * Replaces the older `conversationScrollIndex-*` int key, which was
+     * meaningless across sessions because new messages between sessions
+     * shift indices. The old key is abandoned with no migration: the first
+     * open after upgrade falls through to "land at bottom" once.
+     */
+    fun getConversationScrollAnchor(conversationId: String): Uuid? {
+        val raw = settings.getStringOrNull("conversationScrollAnchor-$conversationId")
+            ?: return null
+        return try {
+            Uuid.parse(raw)
+        } catch (_: IllegalArgumentException) {
+            null
+        }
     }
 
-    fun setConversationScrollIndex(conversationId: String, position: Int) {
-        settings.putInt("conversationScrollIndex-$conversationId", position)
+    fun setConversationScrollAnchor(conversationId: String, anchor: Uuid?) {
+        val key = "conversationScrollAnchor-$conversationId"
+        if (anchor == null) {
+            settings.remove(key)
+        } else {
+            settings.putString(key, anchor.toString())
+        }
     }
 
     fun getConversationScrollOffset(conversationId: String): Int? {

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/settings/UserPreferencesScrollAnchorTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/settings/UserPreferencesScrollAnchorTest.kt
@@ -1,0 +1,103 @@
+package id.homebase.core.settings
+
+import com.russhwolf.settings.Settings
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.uuid.Uuid
+
+/**
+ * Round-trip coverage for [UserPreferences.getConversationScrollAnchor] and
+ * [UserPreferences.setConversationScrollAnchor]. Replaces the older
+ * `(scrollIndex: Int, scrollOffset: Int)` shape — see CLAUDE.md / PR 2 for
+ * why anchor-by-message-id beats index-by-position across sessions.
+ */
+class UserPreferencesScrollAnchorTest {
+
+    private val convoId = "11111111-1111-1111-1111-111111111111"
+
+    private fun prefs(seed: Map<String, Any> = emptyMap()): Pair<UserPreferences, InMemorySettings> {
+        val backing = InMemorySettings(seed)
+        return UserPreferences(backing) to backing
+    }
+
+    @Test
+    fun missingAnchor_returnsNull() {
+        val (prefs, _) = prefs()
+        assertNull(prefs.getConversationScrollAnchor(convoId))
+    }
+
+    @Test
+    fun setAnchor_thenGet_roundtrips() {
+        val (prefs, _) = prefs()
+        val anchor = Uuid.parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        prefs.setConversationScrollAnchor(convoId, anchor)
+        assertEquals(anchor, prefs.getConversationScrollAnchor(convoId))
+    }
+
+    @Test
+    fun setAnchorNull_clearsStoredValue() {
+        val (prefs, _) = prefs()
+        val anchor = Uuid.random()
+        prefs.setConversationScrollAnchor(convoId, anchor)
+        prefs.setConversationScrollAnchor(convoId, null)
+        assertNull(prefs.getConversationScrollAnchor(convoId))
+    }
+
+    @Test
+    fun corruptStoredValue_returnsNullInsteadOfThrowing() {
+        // Possible if a Settings backend ever stored a non-UUID string under
+        // this key — fail soft so the caller falls back to the default
+        // landing position rather than crashing on conversation open.
+        val (prefs, _) = prefs(mapOf("conversationScrollAnchor-$convoId" to "not-a-uuid"))
+        assertNull(prefs.getConversationScrollAnchor(convoId))
+    }
+
+    @Test
+    fun anchorAndOffset_areKeyedIndependentlyPerConversation() {
+        val (prefs, _) = prefs()
+        val a = Uuid.random()
+        val b = Uuid.random()
+        prefs.setConversationScrollAnchor("convo-a", a)
+        prefs.setConversationScrollAnchor("convo-b", b)
+        prefs.setConversationScrollOffset("convo-a", 11)
+        prefs.setConversationScrollOffset("convo-b", 22)
+
+        assertEquals(a, prefs.getConversationScrollAnchor("convo-a"))
+        assertEquals(b, prefs.getConversationScrollAnchor("convo-b"))
+        assertEquals(11, prefs.getConversationScrollOffset("convo-a"))
+        assertEquals(22, prefs.getConversationScrollOffset("convo-b"))
+    }
+}
+
+/**
+ * Minimal in-memory [Settings] for unit tests. Pulling the official
+ * `multiplatform-settings-test` artifact for one test file would add a
+ * dependency just to get `MapSettings`; this is simpler.
+ */
+private class InMemorySettings(seed: Map<String, Any> = emptyMap()) : Settings {
+    private val backing: MutableMap<String, Any> = seed.toMutableMap()
+    override val keys: Set<String> get() = backing.keys.toSet()
+    override val size: Int get() = backing.size
+    override fun clear() = backing.clear()
+    override fun remove(key: String) { backing.remove(key) }
+    override fun hasKey(key: String): Boolean = backing.containsKey(key)
+    override fun putInt(key: String, value: Int) { backing[key] = value }
+    override fun getInt(key: String, defaultValue: Int): Int = (backing[key] as? Int) ?: defaultValue
+    override fun getIntOrNull(key: String): Int? = backing[key] as? Int
+    override fun putLong(key: String, value: Long) { backing[key] = value }
+    override fun getLong(key: String, defaultValue: Long): Long = (backing[key] as? Long) ?: defaultValue
+    override fun getLongOrNull(key: String): Long? = backing[key] as? Long
+    override fun putString(key: String, value: String) { backing[key] = value }
+    override fun getString(key: String, defaultValue: String): String = (backing[key] as? String) ?: defaultValue
+    override fun getStringOrNull(key: String): String? = backing[key] as? String
+    override fun putFloat(key: String, value: Float) { backing[key] = value }
+    override fun getFloat(key: String, defaultValue: Float): Float = (backing[key] as? Float) ?: defaultValue
+    override fun getFloatOrNull(key: String): Float? = backing[key] as? Float
+    override fun putDouble(key: String, value: Double) { backing[key] = value }
+    override fun getDouble(key: String, defaultValue: Double): Double = (backing[key] as? Double) ?: defaultValue
+    override fun getDoubleOrNull(key: String): Double? = backing[key] as? Double
+    override fun putBoolean(key: String, value: Boolean) { backing[key] = value }
+    override fun getBoolean(key: String, defaultValue: Boolean): Boolean = (backing[key] as? Boolean) ?: defaultValue
+    override fun getBooleanOrNull(key: String): Boolean? = backing[key] as? Boolean
+}


### PR DESCRIPTION
Restoring scroll position by saved index broke whenever new messages arrived between sessions: index N pointed at a different message after reopen, so users landed at "the message that happens to be at index 50 now," not "where I was reading." Switch the per-conversation persisted anchor to the uniqueId of the topmost-visible message; resolve it back to a list index against the freshly-loaded messages on next open.

Also drops the in-memory _messagesUiState.scrollPosition write inside SaveScrollPosition — that update was only consumed by paths that re-read the prefs anyway, and writing it every 300 ms during scroll was a recomposition for nothing.

The change is purely client-local (UserPreferences key/value); no wire format, conversation JSON, drive, or DB shape changes. Old conversationScrollIndex-* keys are abandoned without migration: first open after upgrade falls through to "land at bottom" once.

Sets up the slot real paging will need: anchor by stable identifier survives prepends and cross-page lookup; raw index never could.

There was a pre-existing scroll bug where switching between conversations in the desktop client randomly leads to one of them scrolling to the bottom. 