### PR TITLE
Chat paginated message window UI

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
@@ -172,6 +172,20 @@ sealed interface ConversationListUiAction {
     data class ShowReactionDetails(val messageId: Uuid) : ConversationListUiAction
     data class DecryptFile(val messageId: Uuid, val payloadKey: String) : ConversationListUiAction
     data class ScrollToMessageId(val messageId: Uuid) : ConversationListUiAction
+
+    /** Fetch the next page of older messages into the visible window. */
+    data class LoadOlderMessages(val conversationId: Uuid) : ConversationListUiAction
+
+    /** Fetch the next page of newer messages into the visible window. */
+    data class LoadNewerMessages(val conversationId: Uuid) : ConversationListUiAction
+
+    /**
+     * Reload the latest page from disk, replacing the loaded window. Dispatched
+     * by the scroll-to-bottom FAB when the user is deep in history
+     * (`hasNewerMessages = true`); a plain `animateScrollToItem(last)` would
+     * land at the bottom of the loaded window, not the latest message.
+     */
+    data class ScrollToLatest(val conversationId: Uuid) : ConversationListUiAction
     data object HideReactionDetails : ConversationListUiAction
     data class StartRecording(val conversationId: Uuid) : ConversationListUiAction
     data object StopRecording : ConversationListUiAction

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -85,6 +85,19 @@ data class MessageListUiState(
     val isSendingMessage: Boolean = false,
     val pendingOutgoing: ImmutableList<PendingOutgoingMessage> = persistentListOf(),
     val highlightedMessageId: Uuid? = null,
+    /** True if more messages exist before the loaded window's first message.
+     *  Drives the top loading-spinner row and the proximity hook's
+     *  loadOlder trigger. */
+    val hasOlderMessages: Boolean = false,
+    /** True if more messages exist after the loaded window's last message.
+     *  Set when the user opens around an anchor (centered window) or after
+     *  trim discards the newer slice; drives the bottom spinner, the FAB's
+     *  ScrollToLatest branch, and gates auto-follow on incoming messages. */
+    val hasNewerMessages: Boolean = false,
+    /** A loadOlder fetch is in flight; suppresses re-entry. */
+    val isLoadingOlder: Boolean = false,
+    /** A loadNewer fetch is in flight; suppresses re-entry. */
+    val isLoadingNewer: Boolean = false,
 )
 
 @Immutable
@@ -163,6 +176,12 @@ sealed class MessageListContentModel(val id: String) {
     ) : MessageListContentModel(message.id.toString() + message.versionTag.toString() + message.hasMore)
 
     data object UnreadSeparator : MessageListContentModel("unread-separator")
+
+    /** Spinner row at the top of the list while older messages are loading. */
+    data object LoadingOlder : MessageListContentModel("loading-older")
+
+    /** Spinner row at the bottom of the list while newer messages are loading. */
+    data object LoadingNewer : MessageListContentModel("loading-newer")
 }
 
 @Immutable

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -746,6 +746,18 @@ class ConversationListViewModel(
 
             is ConversationListUiAction.ScrollToMessageId -> messageActionsHandler.handleScrollToMessageId(action)
 
+            is ConversationListUiAction.LoadOlderMessages -> {
+                viewModelScope.launch { chatMessageStream.loadOlderMessages(action.conversationId) }
+            }
+
+            is ConversationListUiAction.LoadNewerMessages -> {
+                viewModelScope.launch { chatMessageStream.loadNewerMessages(action.conversationId) }
+            }
+
+            is ConversationListUiAction.ScrollToLatest -> {
+                viewModelScope.launch { chatMessageStream.loadConversation(action.conversationId) }
+            }
+
             is ConversationListUiAction.ClearHighlightedMessage -> messageActionsHandler.handleClearHighlightedMessage()
 
             is ConversationListUiAction.SaveFile -> mediaDownloadHandler.handleSaveFile(action)
@@ -1051,7 +1063,20 @@ class ConversationListViewModel(
                 var setInitialScroll = true
 
                 if (!hasCachedMessages) {
-                    chatMessageStream.loadConversation(conversationId)
+                    val savedAnchor = if (!scrollToBottom) {
+                        userPreferences.getConversationScrollAnchor(conversationId.toString())
+                    } else null
+                    val anchorTarget = messageIdForScroll ?: savedAnchor
+                    if (anchorTarget != null) {
+                        // Around-anchor open: load a centered window so the
+                        // user lands exactly where they left off, even if many
+                        // newer messages arrived since. The fallback inside
+                        // loadConversationAroundMessage covers the case where
+                        // the anchor's message has been purged from the DB.
+                        chatMessageStream.loadConversationAroundMessage(conversationId, anchorTarget)
+                    } else {
+                        chatMessageStream.loadConversation(conversationId)
+                    }
                 }
 
                 chatMessageStream.observeMessages(conversationId).collect { messageState ->
@@ -1065,7 +1090,8 @@ class ConversationListViewModel(
                                 .find { it.conversation.id == conversationId }
                                 ?.conversation?.exitedAt
 
-                            val windowMessages = messageState.window.messages
+                            val window = messageState.window
+                            val windowMessages = window.messages
                             val messagesModels = withContext(Dispatchers.Default) {
                                 val filteredByExit = if (exitedAt != null)
                                     windowMessages.filter { it.userDate <= exitedAt }
@@ -1082,8 +1108,17 @@ class ConversationListViewModel(
                                         val date = message.userDate.toLocalDateTime(timezone).date
                                         date
                                     }
-                                val models: MutableList<MessageListContentModel> =
-                                    mutableListOf(MessageListContentModel.Header)
+                                // Top of the list: spinner while older messages page in,
+                                // Header (avatar + group title) only once we've reached the
+                                // start of the conversation. Otherwise the Header would sit
+                                // ambiguously between loaded pages and read as "you've
+                                // reached the beginning" when you haven't.
+                                val models: MutableList<MessageListContentModel> = mutableListOf()
+                                if (window.hasOlderMessages) {
+                                    models.add(MessageListContentModel.LoadingOlder)
+                                } else {
+                                    models.add(MessageListContentModel.Header)
+                                }
 
                                 var systemIndex = 0
                                 models.addAll(groupedMessages.flatMap { (date, messages) ->
@@ -1108,6 +1143,9 @@ class ConversationListViewModel(
                                             item
                                     }
                                 })
+                                if (window.hasNewerMessages) {
+                                    models.add(MessageListContentModel.LoadingNewer)
+                                }
                                 models
                             }
 
@@ -1205,6 +1243,10 @@ class ConversationListViewModel(
                                     messages = messagesModels.toPersistentList(),
                                     scrollPosition = newScroll
                                         ?: it.scrollPosition?.takeIf { pos -> pos.triggerScroll },
+                                    hasOlderMessages = window.hasOlderMessages,
+                                    hasNewerMessages = window.hasNewerMessages,
+                                    isLoadingOlder = window.isLoadingOlder,
+                                    isLoadingNewer = window.isLoadingNewer,
                                 )
                             }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -1067,6 +1067,11 @@ class ConversationListViewModel(
                         userPreferences.getConversationScrollAnchor(conversationId.toString())
                     } else null
                     val anchorTarget = messageIdForScroll ?: savedAnchor
+                    Logger.d(tag = "ChatPaging") {
+                        "open conversationId=$conversationId hasCached=false scrollToBottom=$scrollToBottom " +
+                            "savedAnchor=$savedAnchor messageIdForScroll=$messageIdForScroll → " +
+                            (if (anchorTarget != null) "loadAround($anchorTarget)" else "loadLatest")
+                    }
                     if (anchorTarget != null) {
                         // Around-anchor open: load a centered window so the
                         // user lands exactly where they left off, even if many
@@ -1076,6 +1081,10 @@ class ConversationListViewModel(
                         chatMessageStream.loadConversationAroundMessage(conversationId, anchorTarget)
                     } else {
                         chatMessageStream.loadConversation(conversationId)
+                    }
+                } else {
+                    Logger.d(tag = "ChatPaging") {
+                        "open conversationId=$conversationId hasCached=true → reuse window"
                     }
                 }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -120,10 +120,20 @@ class ChatMessageStream(
      * in flight.
      */
     suspend fun loadOlderMessages(conversationId: Uuid) {
-        val window = paginatedState.getWindow(conversationId) ?: return
-        if (window.isLoadingOlder || !window.hasOlderMessages) return
+        val window = paginatedState.getWindow(conversationId) ?: run {
+            Logger.d(tag = "ChatPaging") { "loadOlder($conversationId) skip: no window" }
+            return
+        }
+        if (window.isLoadingOlder || !window.hasOlderMessages) {
+            Logger.d(tag = "ChatPaging") {
+                "loadOlder($conversationId) skip: isLoadingOlder=${window.isLoadingOlder} hasOlder=${window.hasOlderMessages}"
+            }
+            return
+        }
+        val sizeBefore = window.messages.size
         paginatedState.setLoadingOlder(conversationId, true)
         try {
+            val start = TimeSource.Monotonic.markNow()
             val result = fetchMessages(
                 conversationId = conversationId,
                 limit = PaginatedConversationState.PAGE_SIZE,
@@ -136,6 +146,12 @@ class ChatMessageStream(
                 olderCursor = result.cursor,
                 hasMore = result.hasMoreRows,
             )
+            val after = paginatedState.getWindow(conversationId)
+            Logger.d(tag = "ChatPaging") {
+                "loadOlder($conversationId) +${result.records.size} hasMore=${result.hasMoreRows} " +
+                    "windowSize=$sizeBefore→${after?.messages?.size} " +
+                    "hasNewer=${after?.hasNewerMessages} took=${start.elapsedNow()}"
+            }
         } catch (t: Throwable) {
             paginatedState.setLoadingOlder(conversationId, false)
             throw t
@@ -149,10 +165,20 @@ class ChatMessageStream(
      * in flight.
      */
     suspend fun loadNewerMessages(conversationId: Uuid) {
-        val window = paginatedState.getWindow(conversationId) ?: return
-        if (window.isLoadingNewer || !window.hasNewerMessages) return
+        val window = paginatedState.getWindow(conversationId) ?: run {
+            Logger.d(tag = "ChatPaging") { "loadNewer($conversationId) skip: no window" }
+            return
+        }
+        if (window.isLoadingNewer || !window.hasNewerMessages) {
+            Logger.d(tag = "ChatPaging") {
+                "loadNewer($conversationId) skip: isLoadingNewer=${window.isLoadingNewer} hasNewer=${window.hasNewerMessages}"
+            }
+            return
+        }
+        val sizeBefore = window.messages.size
         paginatedState.setLoadingNewer(conversationId, true)
         try {
+            val start = TimeSource.Monotonic.markNow()
             val result = fetchMessages(
                 conversationId = conversationId,
                 limit = PaginatedConversationState.PAGE_SIZE,
@@ -165,6 +191,12 @@ class ChatMessageStream(
                 newerCursor = result.cursor,
                 hasMore = result.hasMoreRows,
             )
+            val after = paginatedState.getWindow(conversationId)
+            Logger.d(tag = "ChatPaging") {
+                "loadNewer($conversationId) +${result.records.size} hasMore=${result.hasMoreRows} " +
+                    "windowSize=$sizeBefore→${after?.messages?.size} " +
+                    "hasOlder=${after?.hasOlderMessages} took=${start.elapsedNow()}"
+            }
         } catch (t: Throwable) {
             paginatedState.setLoadingNewer(conversationId, false)
             throw t
@@ -179,8 +211,11 @@ class ChatMessageStream(
      * [loadConversation].
      */
     suspend fun loadConversationAroundMessage(conversationId: Uuid, messageUniqueId: Uuid) {
+        val start = TimeSource.Monotonic.markNow()
         val target = getMessage(messageUniqueId) ?: run {
-            Logger.d("ChatMessageStream: anchor message $messageUniqueId not in DB; falling back to loadConversation")
+            Logger.d(tag = "ChatPaging") {
+                "loadAround($conversationId, $messageUniqueId) anchor not in DB; falling back to loadConversation"
+            }
             loadConversation(conversationId)
             return
         }
@@ -213,6 +248,10 @@ class ChatMessageStream(
             newerCursor = newerHalf.cursor,
             hasNewerMessages = newerHalf.hasMoreRows,
         )
+        Logger.d(tag = "ChatPaging") {
+            "loadAround($conversationId, $messageUniqueId) older=${olderHalf.records.size}+anchor+newer=${newerHalf.records.size} " +
+                "windowSize=${combined.size} hasOlder=${olderHalf.hasMoreRows} hasNewer=${newerHalf.hasMoreRows} took=${start.elapsedNow()}"
+        }
     }
 
 // ---------- EVENT HANDLING ----------

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -93,18 +93,23 @@ class ChatMessageStream(
     // Called when the user opens a conversation (ConversationListViewModel.selectConversation).
     // Do NOT call from DriveEvent.Stopped or other sync events — see init block above.
     //
-    // PR-A keeps the current 1000-message cap and always sets hasOlderMessages=false /
-    // hasNewerMessages=false. PR-B will lower the limit to PaginatedConversationState.PAGE_SIZE
-    // and propagate the cursor + hasMoreRows flag so the UI can page older messages on scroll.
+    // Loads the latest [PaginatedConversationState.PAGE_SIZE] messages and stores
+    // them as a window with hasOlderMessages = result.hasMoreRows. Older messages
+    // are paged in via loadOlderMessages when the user scrolls near the top.
     suspend fun loadConversation(conversationId: Uuid) {
         val start = TimeSource.Monotonic.markNow()
         Logger.d("ChatMessageStream: loadConversation($conversationId)")
-        val result = fetchMessages(conversationId)
+        val result = fetchMessages(
+            conversationId = conversationId,
+            limit = PaginatedConversationState.PAGE_SIZE,
+        )
         val elapsed = start.elapsedNow()
-        Logger.d("ChatMessageStream: loadConversation($conversationId) → ${result.records.size} messages in $elapsed")
+        Logger.d("ChatMessageStream: loadConversation($conversationId) → ${result.records.size} messages in $elapsed (hasMore=${result.hasMoreRows})")
         paginatedState.setInitialWindow(
             conversationId = conversationId,
             messages = result.records,
+            olderCursor = result.cursor,
+            hasOlderMessages = result.hasMoreRows,
         )
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/PaginatedConversationState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/PaginatedConversationState.kt
@@ -1,5 +1,6 @@
 package id.homebase.chat.services
 
+import co.touchlab.kermit.Logger
 import id.homebase.api.client.drives.query.QueryBatchCursor
 import id.homebase.api.client.drives.query.TimeRowCursor
 import id.homebase.api.common.time.UnixTimeUtc
@@ -216,6 +217,10 @@ class PaginatedConversationState(
         val newerCursor = QueryBatchCursor(
             paging = TimeRowCursor(UnixTimeUtc(boundary.userDate), 0L)
         )
+        Logger.d(tag = "ChatPaging") {
+            "trimTail dropped=${messages.size - trimmed.size} kept=${trimmed.size} " +
+                "boundaryUserDate=${boundary.userDate} → newer cursor recovered (hasNewer=true)"
+        }
         return Triple(trimmed, newerCursor, true)
     }
 
@@ -243,6 +248,10 @@ class PaginatedConversationState(
         val olderCursor = QueryBatchCursor(
             paging = TimeRowCursor(UnixTimeUtc(boundary.userDate), Long.MAX_VALUE)
         )
+        Logger.d(tag = "ChatPaging") {
+            "trimHead dropped=${messages.size - trimmed.size} kept=${trimmed.size} " +
+                "boundaryUserDate=${boundary.userDate} → older cursor recovered (hasOlder=true)"
+        }
         return Triple(trimmed, olderCursor, true)
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -353,13 +353,21 @@ fun ConversationContent(
     // Auto-follow: when the list grows (new sent or received message) and the
     // user was already at the bottom, scroll to the new last item. If the user
     // is reading history further up, leave them alone.
+    //
+    // When `hasNewerMessages == true` the user is paged backwards into history;
+    // the bottom of the loaded window is NOT the latest message, and ChatMessageStream
+    // gates incoming-stream upserts on the same flag — so the only way the list
+    // grows here is via prepend, which the user wouldn't want auto-followed.
+    val hasNewerForAutoFollow = rememberUpdatedState(uiState.hasNewerMessages)
     LaunchedEffect(listState, conversation.conversation.id) {
         var previousTotal = 0
         var wasAtBottom = false
         snapshotFlow {
             listState.layoutInfo.totalItemsCount to listState.canScrollForward
         }.collect { (total, canScrollForward) ->
-            if (total > previousTotal && previousTotal > 0 && wasAtBottom) {
+            if (total > previousTotal && previousTotal > 0 && wasAtBottom &&
+                !hasNewerForAutoFollow.value
+            ) {
                 listState.animateScrollToItem(total - 1)
             }
             // canScrollForward == false means the user is at the absolute end
@@ -1030,6 +1038,21 @@ fun ConversationContent(
                                             )
                                         }
                                     }
+
+                                    is MessageListContentModel.LoadingOlder,
+                                    is MessageListContentModel.LoadingNewer -> {
+                                        Box(
+                                            modifier = (if (animationsEnabled) Modifier.animateItem() else Modifier)
+                                                .fillMaxWidth()
+                                                .padding(vertical = 16.dp),
+                                            contentAlignment = Alignment.Center,
+                                        ) {
+                                            CircularProgressIndicator(
+                                                modifier = Modifier.size(24.dp),
+                                                strokeWidth = 2.dp,
+                                            )
+                                        }
+                                    }
                                 }
                             }
                             // If only one message item (the header) show no messages info
@@ -1084,8 +1107,17 @@ fun ConversationContent(
                             modifier = Modifier.align(Alignment.BottomEnd)
                                 .padding(end = 16.dp, bottom = 16.dp),
                             onClick = {
-                                coroutineScope.launch {
-                                    listState.animateScrollToItem(listState.layoutInfo.totalItemsCount - 1)
+                                if (uiState.hasNewerMessages) {
+                                    // Deep in history: the bottom of the loaded
+                                    // window isn't the latest message, so a plain
+                                    // animateScrollToItem(last) would land mid-history.
+                                    // Reload the latest page instead — the existing
+                                    // auto-follow then snaps the user to the bottom.
+                                    onUiAction(ConversationListUiAction.ScrollToLatest(conversation.conversation.id))
+                                } else {
+                                    coroutineScope.launch {
+                                        listState.animateScrollToItem(listState.layoutInfo.totalItemsCount - 1)
+                                    }
                                 }
                             },
                         )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
@@ -34,6 +34,7 @@ import id.homebase.chat.conversationlist.FullScreenOverlay
 import id.homebase.chat.conversationlist.MessageListContentModel
 import id.homebase.chat.conversationlist.MessageListUiState
 import id.homebase.chat.conversationlist.resolveAnchorMessageId
+import id.homebase.chat.services.PaginatedConversationState
 import id.homebase.chat.services.convo.EnrichedConversationUiModel
 import id.homebase.core.HomebaseConstants
 import id.homebase.core.util.boundedFirstVisibleItemIndex
@@ -158,6 +159,40 @@ fun ConversationMessagesPane(
                 uiState.scrollPosition.firstVisibleItemScrollOffset
             )
             onUiAction(ConversationListUiAction.ClearScrollTrigger)
+        }
+    }
+
+    // Proximity-trigger: when the visible window approaches either end and the
+    // window has more pages on that side, dispatch a load. The flag reads use
+    // rememberUpdatedState so the collect block always sees the latest values
+    // without restarting the snapshotFlow on every uiState mutation. The
+    // snapshotFlow body intentionally returns a tiny `Pair<Boolean, Boolean>`
+    // — snapshotFlow's structural dedup makes that O(1), unlike a list-shaped
+    // emission which would re-cost a full equals on every scroll tick.
+    val hasOlderState = rememberUpdatedState(uiState.hasOlderMessages)
+    val hasNewerState = rememberUpdatedState(uiState.hasNewerMessages)
+    val isLoadingOlderState = rememberUpdatedState(uiState.isLoadingOlder)
+    val isLoadingNewerState = rememberUpdatedState(uiState.isLoadingNewer)
+    LaunchedEffect(listState, conversation.conversation.id) {
+        val conversationId = conversation.conversation.id
+        val threshold = PaginatedConversationState.LOAD_MORE_THRESHOLD
+        snapshotFlow {
+            val info = listState.layoutInfo
+            val total = info.totalItemsCount
+            if (total == 0) return@snapshotFlow false to false
+            val firstIdx = listState.boundedFirstVisibleItemIndex(total)
+                ?: return@snapshotFlow false to false
+            val lastIdx = info.visibleItemsInfo.lastOrNull()?.index ?: firstIdx
+            val nearTop = firstIdx < threshold
+            val nearBottom = lastIdx > total - 1 - threshold
+            nearTop to nearBottom
+        }.collect { (nearTop, nearBottom) ->
+            if (nearTop && hasOlderState.value && !isLoadingOlderState.value) {
+                onUiAction(ConversationListUiAction.LoadOlderMessages(conversationId))
+            }
+            if (nearBottom && hasNewerState.value && !isLoadingNewerState.value) {
+                onUiAction(ConversationListUiAction.LoadNewerMessages(conversationId))
+            }
         }
     }
 


### PR DESCRIPTION
  Cursor-paged message loading replaces the 1000-message cap

  Initial conversation load drops from 1000 messages to 75. Older / newer pages stream in on demand as you scroll toward either edge of the loaded window.
  Conversations of any length are now fully traversable — and you land back exactly where you left off, even if many newer messages arrived between
  sessions.

  Builds on PR #493 (which introduced PaginatedConversationState behind ChatMessageStream with no UX change). This PR turns paging on at the UI layer.

  What changed

  UX

  - Open with no saved anchor → land on the latest 75 messages (today's behavior, just fewer rows up front).
  - Open with a saved anchor → load a centered window AROUND the anchor via loadConversationAroundMessage (~37 older + the anchor + ~37 newer) so you land
  exactly where you left off, even after dozens of new messages arrived between sessions. Falls back to latest page if the anchor is no longer in the local
  DB.
  - Scroll within 15 items of either edge → dispatch LoadOlderMessages / LoadNewerMessages. Spinner row appears at that end while the fetch is in flight
  (the Header is hidden until you've reached the start of the conversation, so it doesn't read as "you've reached the beginning" mid-history).
  - Window grows freely up to MAX_WINDOW_SIZE (300); past that, the opposite edge is trimmed and a recovered cursor lets a future load on that side refill
  the trimmed slice.
  - Scroll-to-bottom FAB: when deep in history (hasNewerMessages = true), the bottom of the loaded window isn't the latest message, so a plain
  animateScrollToItem(last) would land mid-history. The FAB now dispatches ScrollToLatest, which calls loadConversation to pull the latest page; auto-follow
   then snaps you to the bottom.
  - Auto-follow on incoming messages is gated by !hasNewerMessages so you reading history aren't yanked to the bottom; ChatMessageStream already gates
  upstream upserts on the same flag (PR #493).

  Code

  - 3 new UiActions (LoadOlderMessages, LoadNewerMessages, ScrollToLatest) + 4 paging fields on MessageListUiState + LoadingOlder / LoadingNewer content
  models.
  - VM: 3 one-line arms delegating to ChatMessageStream; loadMessagesForConversation gained the around-anchor branch; the message-stream consumer now
  injects the spinner content models at the ends and surfaces window flags into UiState.
  - ChatMessagesPane: new LaunchedEffect with a snapshotFlow emitting a tiny Pair<Boolean,Boolean> (nearTop, nearBottom) — small emission for cheap
  structural dedup per the CLAUDE.md snapshotFlow gotcha. Latest flag reads via rememberUpdatedState so the collect block sees fresh values without
  restarting the flow on every uiState mutation. Uses boundedFirstVisibleItemIndex per the Int.MAX_VALUE-sentinel guidance.
  - ConversationContent: spinner items use CircularProgressIndicator(size=24, strokeWidth=2); FAB onClick branches on hasNewerMessages.

  Logging (ChatPaging tag — all entries grep-friendly)

  Added in a follow-up commit on the branch so the on-device log can verify the design end-to-end:
  - open conversationId=… hasCached=… scrollToBottom=… savedAnchor=… messageIdForScroll=… → loadAround(…)/loadLatest/reuse window
  - loadAround(…) older=N+anchor+newer=M windowSize=X hasOlder=… hasNewer=… took=…ms
  - loadOlder/loadNewer(…) +N hasMore=… windowSize=W→W+N hasNewer/Older=… took=…ms (also logs skip reasons if gated)
  - trimTail/trimHead dropped=N kept=300 boundaryUserDate=… → newer/older cursor recovered

  Testing

  Unit / integration (jvmTest)

  - PaginatedConversationStateTest (12 pure-logic tests, landed in PR #493)
  - ChatMessageStreamPagingTest:
    - Existing cursor-traversal tests still green
    - 2 new OldestFirst regressions
    - 2 DB-backed integration walks with pageSize=10, maxWindowSize=25, total=35 messages — exercises trim during older walk + recovery via the newer
  cursor; and an anchored open that walks both directions to reach every seeded row including the anchor

  Manual — desktop app, real conversation (Todd, ~16 days of history)

  Captured via the new ChatPaging-tagged log entries:

  Cold-start opens (12 conversations) — every one took the around-anchor path:
  - older=37+anchor+newer=N (typical, hasNewer=false) when user closed at the bottom
  - older=0+anchor+newer=37 for a conversation where the anchor was the very first message
  - older=32+anchor+newer=6 for a conversation under PAGE_SIZE total
  - savedAnchor=null → loadLatest for never-scrolled conversations
  - Open latency: 315ms-773ms typical, 1.43s outlier on first cold-start open

  Re-opens hit hasCached=true → reuse window instantly.

  Older walk (16 cycles, 16 days back to 2026-04-24):
  loadOlder +75 windowSize=44→119 took=113ms
  loadOlder +75 windowSize=119→194 took=121ms
  loadOlder +75 windowSize=194→269 took=123ms
  trimTail dropped=44 kept=300 → newer cursor recovered (hasNewer=true)
  loadOlder +75 windowSize=269→300 took=128ms
  ... (12 more trim+load cycles, each 105-128ms)

  Newer walk back to today (14 cycles):
  trimHead dropped=74 kept=300 → older cursor recovered (hasOlder=true)
  loadNewer +75 windowSize=300→300 took=109ms
  ... (12 more cycles, 105-115ms each) ...
  trimHead dropped=58 kept=300 boundaryUserDate=2026-05-07T15:37
  loadNewer +59 hasMore=false windowSize=300→300 took=108ms   ← partial fetch = EOF

  What the log verified

  - ✅ Around-anchor open correctly takes the anchor path on cold start; reuses cached window on re-open
  - ✅ scrollToBottom=true notification-tap path correctly skips around-anchor (verified from a prior run)
  - ✅ Initial load = 75 messages with hasMore=true propagated correctly
  - ✅ Older walk: trim engages exactly when math says (initial 44 + 4×75 = 344 → first trim drops 44 to keep 300); subsequent trims drop 75
  - ✅ hasNewer flips to true after first trim, recovered cursor in place
  - ✅ Newer walk round-trip: hasNewer=true from the older walk's trim is used by loadNewer; trim engages on the head this time
  - ✅ EOF detection: partial +59 hasMore=false correctly clears hasNewerMessages
  - ✅ Memory bounded: window held at 300 throughout the entire ~1244-message walk (older walk + newer walk combined)
  - ✅ Performance: every load 105-130ms, no perceptible UI lag during scrolling
  - ✅ Tied-userDate dedup: dropped=74/58 instead of 75/59 is by design — the boundary-anchored cursor returns the boundary row again, distinctBy { it.id }
  drops it. Costs 1 extra row fetched per cycle, no correctness impact

  What I did NOT verify

  - iOS / Android UI smoke (couldn't run the UI from the dev machine)
  - Real-time message arriving while deep in history with hasNewerMessages=true — the upstream gate from PR #493 should hold the message until
  ScrollToLatest, but not exercised in this session
