### PR TITLE
feat(chat): event tweaks - mobile menu, organizer row, replies, reply-target opens detail

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
@@ -173,6 +173,18 @@ sealed interface ConversationListUiAction {
     data class DecryptFile(val messageId: Uuid, val payloadKey: String) : ConversationListUiAction
     data class ScrollToMessageId(val messageId: Uuid) : ConversationListUiAction
 
+    /**
+     * User tapped the inline reply-preview chip pinned above a message bubble.
+     * The handler resolves the target via [ChatMessageStream.getMessage]
+     * (in-memory window first, single DB read on miss) and chooses what to
+     * surface: a typed-content target like an Event opens its detail dialog,
+     * everything else falls back to [ScrollToMessageId].
+     */
+    data class OpenReplyTarget(val messageId: Uuid) : ConversationListUiAction
+
+    /** Dismiss the host-level Event detail dialog opened from a reply target. */
+    data object DismissEventDetailFromReply : ConversationListUiAction
+
     /** Fetch the next page of older messages into the visible window. */
     data class LoadOlderMessages(val conversationId: Uuid) : ConversationListUiAction
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -5,7 +5,9 @@ import androidx.compose.runtime.Immutable
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.auth.OwnerSession
 import id.homebase.api.client.drives.files.PayloadDescriptor
+import id.homebase.api.client.drives.files.ReactionSummary
 import id.homebase.api.common.OdinId
+import id.homebase.chat.event.EventDescriptor
 import id.homebase.api.video.VideoProcessingPhase
 import id.homebase.chat.data.ContactUiModel
 import id.homebase.chat.data.MessageUiModel
@@ -98,6 +100,27 @@ data class MessageListUiState(
     val isLoadingOlder: Boolean = false,
     /** A loadNewer fetch is in flight; suppresses re-entry. */
     val isLoadingNewer: Boolean = false,
+    /** Set when the user taps a reply-preview that points at an Event message;
+     *  the screen renders [id.homebase.chat.event.EventDetailDialog] keyed off
+     *  this state. Null means no host-level event detail is open. */
+    val replyTargetEventDetail: ReplyTargetEventDetail? = null,
+)
+
+/**
+ * Snapshot of an Event message resolved from a reply-preview tap. Carries
+ * everything [id.homebase.chat.event.EventDetailDialog] needs without holding
+ * a reference to the live MessageUiModel — the dialog's RSVP roster fetches
+ * fresh reactions, and the counts are aggregated up-front so closing the
+ * dialog doesn't re-render the host.
+ */
+@Immutable
+data class ReplyTargetEventDetail(
+    val descriptor: EventDescriptor,
+    val messageId: Uuid,
+    val conversationId: Uuid,
+    val ownReactions: ImmutableList<String>,
+    val reactionSummary: ReactionSummary?,
+    val organizer: OdinId?,
 )
 
 @Immutable

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -746,6 +746,10 @@ class ConversationListViewModel(
 
             is ConversationListUiAction.ScrollToMessageId -> messageActionsHandler.handleScrollToMessageId(action)
 
+            is ConversationListUiAction.OpenReplyTarget -> messageActionsHandler.handleOpenReplyTarget(action)
+
+            ConversationListUiAction.DismissEventDetailFromReply -> messageActionsHandler.handleDismissEventDetailFromReply()
+
             is ConversationListUiAction.LoadOlderMessages -> {
                 viewModelScope.launch { chatMessageStream.loadOlderMessages(action.conversationId) }
             }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -20,6 +20,7 @@ import id.homebase.chat.services.LocalAttachmentContext
 import id.homebase.chat.services.LocalAttachmentContextStore
 import id.homebase.chat.services.MAX_REACTIONS_PER_USER_PER_MESSAGE
 import id.homebase.chat.services.ReplyPreview
+import id.homebase.chat.services.content.MessageContent
 import id.homebase.chat.services.builder.AttachmentInput
 import id.homebase.chat.services.builder.MessageAttachmentBuilder
 import id.homebase.chat.services.convo.ConversationService
@@ -225,6 +226,56 @@ internal class MessageActionsHandler(
 
     fun handleClearHighlightedMessage() {
         messagesUiState.update { it.copy(highlightedMessageId = null) }
+    }
+
+    /**
+     * Tap on the inline reply-preview that's pinned above a message bubble.
+     * For an Event target we want to open the detail dialog directly (the
+     * user's intent is "show me that event", not "scroll me to it"); for any
+     * other content kind we keep today's scroll-to-message behavior.
+     *
+     * Resolution path: [ChatMessageStream.getMessage] short-circuits to the
+     * paginated in-memory window first and falls through to a single
+     * `selectHomebaseFileByUnique` DB read on miss — so the Event-out-of-window
+     * case still works without scrolling history into view.
+     */
+    fun handleOpenReplyTarget(action: ConversationListUiAction.OpenReplyTarget) {
+        scope.launch {
+            try {
+                val target = chatMessageStream.getMessage(action.messageId)
+                val event = target?.messageContent as? MessageContent.Event
+                val descriptor = event?.descriptor
+                if (target != null && descriptor != null) {
+                    messagesUiState.update {
+                        it.copy(
+                            replyTargetEventDetail = ReplyTargetEventDetail(
+                                descriptor = descriptor,
+                                messageId = target.id,
+                                conversationId = target.conversationId,
+                                ownReactions = target.ownReactions,
+                                reactionSummary = target.reactionPreview,
+                                organizer = target.originalAuthor,
+                            )
+                        )
+                    }
+                } else {
+                    handleScrollToMessageId(
+                        ConversationListUiAction.ScrollToMessageId(action.messageId)
+                    )
+                }
+            } catch (e: Exception) {
+                Logger.e(throwable = e, tag = TAG) {
+                    "Failed to open reply target ${action.messageId}: ${e.message}"
+                }
+                handleScrollToMessageId(
+                    ConversationListUiAction.ScrollToMessageId(action.messageId)
+                )
+            }
+        }
+    }
+
+    fun handleDismissEventDetailFromReply() {
+        messagesUiState.update { it.copy(replyTargetEventDetail = null) }
     }
 
     fun handleDeleteMessageForEveryone(action: ConversationListUiAction.DeleteMessageForEveryone) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventBubble.kt
@@ -1,7 +1,8 @@
 package id.homebase.chat.event
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -36,6 +37,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import id.homebase.api.client.drives.files.ReactionSummary
+import id.homebase.api.common.OdinId
 import id.homebase.resources.MR
 import id.homebase.resources.chat_event_live_now
 import id.homebase.resources.chat_event_past
@@ -78,7 +80,7 @@ import org.jetbrains.compose.resources.stringResource
  * @param containerColor Background color for the card (typically a Material 3
  *   surface variant).
  */
-@OptIn(ExperimentalUuidApi::class)
+@OptIn(ExperimentalUuidApi::class, ExperimentalFoundationApi::class)
 @Composable
 fun EventBubble(
     descriptor: EventDescriptor?,
@@ -87,6 +89,8 @@ fun EventBubble(
     conversationId: Uuid? = null,
     ownReactions: ImmutableList<String> = persistentListOf(),
     reactionSummary: ReactionSummary? = null,
+    organizer: OdinId? = null,
+    onLongClick: (() -> Unit)? = null,
     contentColor: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.onSurface,
     containerColor: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.surfaceContainerHigh,
 ) {
@@ -126,7 +130,18 @@ fun EventBubble(
         .widthIn(min = 240.dp, max = 320.dp)
         .clip(RoundedCornerShape(16.dp))
         .background(containerColor)
-        .let { if (canOpenDetail) it.clickable { showDetail = true } else it }
+        .let {
+            // combinedClickable (not clickable) so the parent message bubble's
+            // own combinedClickable.onLongClick still fires on mobile —
+            // Modifier.clickable consumes pointer events and otherwise swallows
+            // the long-press, leaving Events with no action menu on mobile.
+            if (canOpenDetail || onLongClick != null) {
+                it.combinedClickable(
+                    onClick = { if (canOpenDetail) showDetail = true },
+                    onLongClick = onLongClick,
+                )
+            } else it
+        }
         .padding(12.dp)
     val effectiveContent = if (isPast) contentColor.copy(alpha = 0.55f) else contentColor
 
@@ -187,6 +202,7 @@ fun EventBubble(
             ownReactions = ownReactions,
             counts = remember(reactionSummary) { EventRsvp.counts(reactionSummary) },
             onDismiss = { showDetail = false },
+            organizer = organizer,
         )
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventDetailDialog.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventDetailDialog.kt
@@ -60,6 +60,7 @@ import id.homebase.resources.chat_event_add_to_google_calendar
 import id.homebase.resources.chat_event_download_ics
 import id.homebase.resources.chat_event_join_meeting
 import id.homebase.resources.chat_event_open_in_maps
+import id.homebase.resources.chat_event_organized_by
 import id.homebase.resources.chat_event_rsvp_maybe
 import id.homebase.resources.chat_event_rsvp_no
 import id.homebase.resources.chat_event_rsvp_summary
@@ -95,6 +96,7 @@ fun EventDetailDialog(
     ownReactions: ImmutableList<String>,
     counts: EventRsvp.Counts,
     onDismiss: () -> Unit,
+    organizer: OdinId? = null,
 ) {
     Dialog(
         onDismissRequest = onDismiss,
@@ -107,6 +109,7 @@ fun EventDetailDialog(
             ownReactions = ownReactions,
             counts = counts,
             onDismiss = onDismiss,
+            organizer = organizer,
         )
     }
 }
@@ -120,6 +123,7 @@ private fun EventDetailContent(
     ownReactions: ImmutableList<String>,
     counts: EventRsvp.Counts,
     onDismiss: () -> Unit,
+    organizer: OdinId?,
 ) {
     val actionService: ChatMessageActionService = koinInject()
     val contactService: ContactService = koinInject()
@@ -176,6 +180,17 @@ private fun EventDetailContent(
                 .padding(horizontal = 20.dp),
         ) {
             HeroHeader(descriptor = descriptor, startLocal = startLocal, endLocal = endLocal)
+
+            organizer?.let { host ->
+                Spacer(Modifier.height(12.dp))
+                OrganizerRow(
+                    odinId = host,
+                    isOwner = host == selfOdinId,
+                    youLabel = stringResource(MR.string.you),
+                    organizedByLabel = stringResource(MR.string.chat_event_organized_by),
+                    contactService = contactService,
+                )
+            }
 
             if (descriptor.description.isNotBlank()) {
                 Spacer(Modifier.height(16.dp))
@@ -355,6 +370,52 @@ private fun RsvpSection(
                 isOwner = reactor.odinId == selfOdinId,
                 youLabel = youLabel,
                 contactService = contactService,
+            )
+        }
+    }
+}
+
+@Composable
+private fun OrganizerRow(
+    odinId: OdinId,
+    isOwner: Boolean,
+    youLabel: String,
+    organizedByLabel: String,
+    contactService: ContactService,
+) {
+    val resolvedName = contactService.resolveByOdinId(odinId)?.name ?: odinId.domainName
+    val avatarOptions = AvatarOptions(size = 32.dp)
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (isOwner) {
+            OwnerAvatar(
+                odinId = odinId,
+                profileImageData = null,
+                initials = resolvedName.initials(),
+                options = avatarOptions,
+                sharedTransitionScope = null,
+                animatedVisibilityScope = null,
+            )
+        } else {
+            PublicAvatar(
+                odinId = odinId,
+                initials = resolvedName.initials(),
+                options = avatarOptions,
+            )
+        }
+        Spacer(Modifier.width(12.dp))
+        Column {
+            Text(
+                text = organizedByLabel,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = if (isOwner) youLabel else resolvedName,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
             )
         }
     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/content/MessageContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/content/MessageContent.kt
@@ -40,6 +40,14 @@ sealed interface MessageContent {
      * "unsupported format" chip rather than the message disappearing.
      */
     data class Event(val descriptor: EventDescriptor?) : MessageContent {
+        override val actions: ActionPolicy = ActionPolicy(
+            allowEdit = false,            // events are immutable announcements
+            allowReply = true,            // organizer pings, RSVP nudges, follow-up Qs
+            allowForward = false,         // forwarding an event out of context loses RSVP
+            allowShare = false,           // copy-text of "Title @ time" adds little
+            allowInlineReactions = false, // RSVP happens in the detail dialog
+            allowReactionDetails = false, // RSVP rollup is the dialog's roster
+        )
         override val displayLabel: String get() = descriptor?.title ?: UNPARSEABLE_EVENT_LABEL
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -119,6 +119,8 @@ import id.homebase.chat.dice.DiceRollDescriptor
 import id.homebase.chat.dice.computeBattleChainCap
 import id.homebase.chat.services.content.MessageContent
 import id.homebase.chat.event.EventComposerSheet
+import id.homebase.chat.event.EventDetailDialog
+import id.homebase.chat.event.EventRsvp
 import id.homebase.chat.location.LocationResult
 import id.homebase.chat.location.rememberCurrentLocationLauncher
 import id.homebase.resources.chat_location_map_preview_unavailable
@@ -518,6 +520,22 @@ fun ConversationContent(
         uiState = uiState,
         onUiAction = onUiAction,
     )
+
+    // Host-level event detail opened via a reply-preview tap. The per-bubble
+    // EventBubble manages its own dialog for direct taps; this one covers the
+    // case where the original Event is the *target* of a reply (and may be
+    // outside the loaded message window — handler resolves via DB on miss).
+    uiState.replyTargetEventDetail?.let { detail ->
+        EventDetailDialog(
+            descriptor = detail.descriptor,
+            messageId = detail.messageId,
+            conversationId = detail.conversationId,
+            ownReactions = detail.ownReactions,
+            counts = remember(detail.reactionSummary) { EventRsvp.counts(detail.reactionSummary) },
+            onDismiss = { onUiAction(ConversationListUiAction.DismissEventDetailFromReply) },
+            organizer = detail.organizer,
+        )
+    }
 
     uiState.messageReactions?.let { reactions ->
         ReactionsBottomSheet(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -143,6 +143,8 @@ fun MessageBubbleRaw(
                 conversationId = message.conversationId,
                 ownReactions = message.ownReactions,
                 reactionSummary = message.reactionPreview,
+                organizer = message.originalAuthor,
+                onLongClick = onLongClick,
             )
             return
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageItem.kt
@@ -79,8 +79,12 @@ fun MessageItem(
         if (policy.allowReactionDetails) remember(message.id) { { onUiAction(ConversationListUiAction.ShowReactionDetails(messageId = message.id)) } } else null
     val onDecryptFile =
         remember(message.id) { { payload: PayloadDescriptor -> onUiAction(ConversationListUiAction.DecryptFile(messageId = message.id, payloadKey = payload.key)) } }
+    // Tapping the inline reply-preview chip pinned above a bubble. We route
+    // through OpenReplyTarget so the handler can branch on content kind: an
+    // Event target opens the detail dialog directly; everything else falls
+    // through to ScrollToMessageId.
     val onClickMessageId =
-        remember(message.id) { { messageId: Uuid -> onUiAction(ConversationListUiAction.ScrollToMessageId(messageId)) } }
+        remember(message.id) { { messageId: Uuid -> onUiAction(ConversationListUiAction.OpenReplyTarget(messageId)) } }
     val onMediaClick = remember(message.id) {
         { payload: PayloadDescriptor ->
             onUiAction(

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -552,6 +552,7 @@
     <string name="chat_event_your_time_in_zone">your time: %1$s %2$s</string>
     <string name="chat_event_add_end_time">Add end time</string>
     <string name="chat_event_remove_end_time">Remove end time</string>
+    <string name="chat_event_organized_by">Organized by</string>
 
     <!-- Dice attachment -->
     <string name="chat_dice_share">Dice</string>


### PR DESCRIPTION
Four fixes hit while exercising Events in "note to self":

1. Mobile long-press on an Event showed no action menu, so the message couldn't be deleted. Root cause: EventBubble's inner `.clickable { showDetail = true }` consumed pointer events before the parent message bubble's `combinedClickable.onLongClick` could fire. Desktop was fine because its menu opens via a hover MoreHoriz button outside the bubble subtree. Fix: switch EventBubble to `combinedClickable` and forward the parent's onLongClick. DiceRollBubble had no inner clickable, which is why long-press already worked there.

2. EventDetailDialog never showed the organizer. Added an "Organized by" row (32dp avatar + name, "You" for self) below the hero, sourced from `MessageUiModel.originalAuthor`. Reuses the OwnerAvatar/PublicAvatar pattern already used by ReactorRow.

3. Replies were disabled on Events (default StructuredOneShot policy). Flipped `allowReply = true` on `MessageContent.Event`; inline reactions/reaction-details stay off so RSVP-via-dialog remains the only reaction surface.

4. Tapping a reply-preview chip whose target is an Event now opens the EventDetailDialog directly instead of scrolling the list. New action `OpenReplyTarget(messageId)` resolves the parent via `ChatMessageStream.getMessage` (paginated in-memory window first, single `selectHomebaseFileByUnique` DB read on miss); Event targets set `MessageListUiState.replyTargetEventDetail` for a host-level dialog in ConversationContent, everything else falls through to the existing ScrollToMessageId path.