### PR TITLE
Restore processInbox pokes (revert 18483c4e blocks #2 and #3)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
@@ -463,14 +463,21 @@ class OdinWebSocketClient(
                 notification.data
             )
 
-        // processInbox no longer needed — server auto-processes on QueryBatch.
-        // notify(
-        //     command = "processInbox",
-        //     payload = ProcessInboxPayload(
-        //         targetDrive = n.targetDrive,
-        //         batchSize = 100
-        //     )
-        // )
+        // Reverts block #3 of commit 18483c4e. The WS push path bypasses
+        // QueryBatch in steady state, so the server's "auto-process inbox on
+        // QueryBatch" never fires for a recipient sitting in an already-loaded
+        // conversation — the inboxItemReceived notification arrives but no
+        // fileAdded follows, and the message body never makes it to the
+        // WebSocket. Send the explicit processInbox ack so the server moves
+        // the inbox entry onto the drive. Remove once the server-side
+        // auto-process behaviour is fixed.
+        notify(
+            command = "processInbox",
+            payload = ProcessInboxPayload(
+                targetDrive = n.targetDrive,
+                batchSize = 100
+            )
+        )
     }
 
     /**
@@ -736,16 +743,18 @@ class OdinWebSocketClient(
      * Call this right after a successful handshake / reconnect.
      */
     suspend fun processAllInboxes() {
-        // processInbox no longer needed — server auto-processes on QueryBatch.
-        // for (drive in drives) {
-        //     notify(
-        //         command = "processInbox",
-        //         payload = ProcessInboxPayload(
-        //             targetDrive = drive,
-        //             batchSize = 100
-        //         )
-        //     )
-        // }
+        // Reverts block #2 of commit 18483c4e — see AuthConnectionCoordinator
+        // for the rationale. Called on every (re)connect to flush any inbox
+        // backlog accumulated while we were offline, before syncAll() runs.
+        for (drive in drives) {
+            notify(
+                command = "processInbox",
+                payload = ProcessInboxPayload(
+                    targetDrive = drive,
+                    batchSize = 100
+                )
+            )
+        }
     }
 
     /**

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -185,8 +185,14 @@ class AuthConnectionCoordinator(
                             // would silently skip if isRunning is still false.
                             driveSyncManager.start()
 
-                            // processInbox no longer needed — server auto-processes on QueryBatch.
-                            // wsClient?.processAllInboxes()
+                            // Reverts block #2 of commit 18483c4e. The WS push path is
+                            // engineered to bypass QueryBatch in steady state, so the
+                            // server's "auto-process inbox on QueryBatch" doesn't fire
+                            // for backlog accumulated while we were offline. Poke each
+                            // subscribed drive explicitly so syncAll() below sees the
+                            // freshly-processed items. Remove once the server-side
+                            // auto-process behaviour is fixed.
+                            wsClient?.processAllInboxes()
 
                             driveSyncManager.syncAll()
                         } catch (e: Exception) {


### PR DESCRIPTION
Commit 18483c4e disabled three client-side processInbox callsites on the
assumption that the server auto-processes inbox items whenever the
client issues a QueryBatch. Empirical testing shows that assumption
holds for some sync paths but not for real-time WS push: when a
recipient is sitting in an already-loaded conversation, no QueryBatch
fires near each inbound message, so inbox items queued on the server
never move onto the drive — the inboxItemReceived notification arrives,
but no fileAdded follows and the message body never reaches the client.
Reconnect-while-offline is the same hole on a larger scale: any drive
whose conversation isn't opened immediately after handshake keeps its
inbox backlog stuck.

This restores two of the three blocks called out in the original
commit's documented rollback order (#3 then #2), leaving block #1 (the
HTTP background-fetch poke in BackgroundSyncOrchestrator) commented
out — iOS background fetch already issues syncAll(), so QueryBatch
flushes that path reliably enough today.

What changes:
- OdinWebSocketClient.handleProcessInbox: send the explicit processInbox
  ack on every inboxItemReceived notification, so the server moves the
  inbox entry onto the drive and emits the corresponding fileAdded.
- OdinWebSocketClient.processAllInboxes: re-fill the body so the call
  from AuthConnectionCoordinator actually pokes every subscribed drive.
- AuthConnectionCoordinator.onConnected: call processAllInboxes()
  between driveSyncManager.start() and syncAll() so the reconnect-time
  backlog is flushed before the sync sweep runs.

Both new pathways carry "Remove once the server-side auto-process
behaviour is fixed" markers so they're easy to find later. The
commented HTTP block in BackgroundSyncOrchestrator is intentionally
left as-is for the same followup.

Verified by sending five rapid messages to a recipient who has the
conversation open: pre-fix only the first message that happened to
coincide with a sync round arrived; post-fix all five arrive promptly
with correct sender attribution.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>