### PR TITLE
fix(chat): cap media viewer caption height to prevent text-image overlap

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenMediaViewer.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenMediaViewer.kt
@@ -22,10 +22,13 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -52,7 +55,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.dp
 import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
 import com.mohamedrejeb.richeditor.model.RichTextState
@@ -278,10 +283,16 @@ fun FullScreenMediaViewer(
                     .padding(16.dp)
             ) {
                 if (data.content.isNotBlank()) {
+                    val maxCaptionHeight = with(LocalDensity.current) {
+                        (viewportHeight * 0.15f).toDp().coerceAtLeast(60.dp)
+                    }
                     RichText(
                         state = textState,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.fillMaxWidth().padding(16.dp)
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = maxCaptionHeight)
+                            .verticalScroll(rememberScrollState())
                     )
                 }
                 // Gallery row at bottom


### PR DESCRIPTION
## Summary
- Long message captions in `FullScreenMediaViewer` grew unbounded, overlapping the image when viewing a picture with long text
- Capped the `RichText` caption height to 15% of viewport (min 60dp) using the existing `BoxWithConstraints` viewport dimensions — adapts to phones, tablets, desktop, and landscape
- Made the caption vertically scrollable so full text remains accessible
- Removed redundant inner padding (parent Column already provides 16dp)

## Test plan
- [x] Send a picture with a long text caption, tap to view fullscreen — text stays within the bottom panel
- [x] Verify short captions still display normally without unnecessary whitespace
- [ ] Test on landscape orientation — caption cap adjusts proportionally
- [x] Test with multiple image payloads (gallery row + caption + share button all fit)
- [x] Verify caption is scrollable when text exceeds the height cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)