### PR TITLE
Consolidate notification arrival/tap entry points across platforms

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/DriveFcmService.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/DriveFcmService.kt
@@ -1,6 +1,7 @@
 package id.homebase.feed
 
 import androidx.work.Constraints
+import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
@@ -8,7 +9,6 @@ import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
-import com.mmk.kmpnotifier.notification.NotifierManager
 import id.homebase.core.notifications.NotificationService
 import org.koin.android.ext.android.inject
 
@@ -23,7 +23,16 @@ class DriveFcmService : FirebaseMessagingService() {
     }
 
     override fun onMessageReceived(message: RemoteMessage) {
-        // Schedule background sync
+        // Hand the FCM payload to the shared NotificationEntry via a worker —
+        // the worker runs the same onPushArrived(...) body iOS calls inline,
+        // and WorkManager gives us OS-budgeted background guarantees that
+        // FCM's onMessageReceived callback by itself does not.
+        val inputData = Data.Builder().apply {
+            putString(KEY_TITLE, message.notification?.title)
+            putString(KEY_BODY, message.notification?.body)
+            for ((k, v) in message.data) putString("$KEY_DATA_PREFIX$k", v)
+        }.build()
+
         WorkManager.getInstance(applicationContext)
             .enqueueUniqueWork(
                 WORK_TAG,
@@ -35,18 +44,15 @@ class DriveFcmService : FirebaseMessagingService() {
                             .setRequiredNetworkType(NetworkType.CONNECTED)
                             .build()
                     )
+                    .setInputData(inputData)
                     .build()
             )
-
-        // Forward to NotificationService for notification display
-        notificationService.onFcmMessageReceived(
-            title = message.notification?.title,
-            body = message.notification?.body,
-            data = message.data,
-        )
     }
 
     companion object {
         const val WORK_TAG = "drive_fcm_sync"
+        const val KEY_TITLE = "fcm_title"
+        const val KEY_BODY = "fcm_body"
+        const val KEY_DATA_PREFIX = "fcm_data_"
     }
 }

--- a/androidApp/src/main/kotlin/id/homebase/feed/DriveSyncWorker.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/DriveSyncWorker.kt
@@ -8,7 +8,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import co.touchlab.kermit.Logger
-import id.homebase.core.sync.BackgroundSyncOrchestrator
+import id.homebase.core.notifications.NotificationEntry
 import id.homebase.core.sync.SyncOutcome
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
@@ -18,8 +18,15 @@ class DriveSyncWorker(appContext: Context, params: WorkerParameters) :
 
     override suspend fun doWork(): Result {
         Logger.i(tag = "DriveSyncWorker") { "doWork: starting (attempt=$runAttemptCount)" }
-        val orchestrator: BackgroundSyncOrchestrator = get()
-        return when (val outcome = orchestrator.syncIfAuthenticated()) {
+        val title = inputData.getString(DriveFcmService.KEY_TITLE)
+        val body = inputData.getString(DriveFcmService.KEY_BODY)
+        val data = inputData.keyValueMap
+            .filterKeys { it.startsWith(DriveFcmService.KEY_DATA_PREFIX) }
+            .mapKeys { (k, _) -> k.removePrefix(DriveFcmService.KEY_DATA_PREFIX) }
+            .mapValues { (_, v) -> v?.toString() ?: "" }
+
+        val entry: NotificationEntry = get()
+        return when (val outcome = entry.onPushArrived(title, body, data)) {
             is SyncOutcome.Success -> {
                 Logger.i(tag = "DriveSyncWorker") { "doWork: success" }
                 Result.success()

--- a/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
@@ -22,6 +22,7 @@ import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.youauth.YouAuthFlowManager
 import id.homebase.core.App
+import id.homebase.core.notifications.NotificationEntry
 import id.homebase.core.notifications.NotificationIntentDecision
 import id.homebase.core.notifications.NotificationNavigationEvent
 import id.homebase.core.notifications.NotificationService
@@ -42,6 +43,7 @@ class MainActivity : AppCompatActivity() {
 
     val youAuthFlowManager: YouAuthFlowManager by inject()
     private val notificationService: NotificationService by inject()
+    private val notificationEntry: NotificationEntry by inject()
     private val eventBus: EventBus by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -201,7 +203,7 @@ class MainActivity : AppCompatActivity() {
                 Logger.i(tag = "MainActivity") {
                     "Notification intent detected (conversation: $conversationId)"
                 }
-                notificationService.handleNotificationClicked(decision.payload)
+                notificationEntry.onNotificationTappedAsync(decision.payload)
             }
         }
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationEntry.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationEntry.kt
@@ -1,0 +1,115 @@
+package id.homebase.core.notifications
+
+import co.touchlab.kermit.Logger
+import com.mmk.kmpnotifier.notification.PayloadData
+import id.homebase.core.auth.AuthConnectionCoordinator
+import id.homebase.core.sync.BackgroundSyncOrchestrator
+import id.homebase.core.sync.SyncOutcome
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.koin.mp.KoinPlatformTools
+
+/**
+ * Single shared entry point that every platform glue funnels into for the two
+ * notification lifecycle events: silent-push *arrival* and user *tap*. Each
+ * platform calls exactly one method per event with the same payload shape,
+ * which means adding a fourth platform (or fixing a bug across all three) is
+ * one place.
+ *
+ * This class is composition over [NotificationService] +
+ * [BackgroundSyncOrchestrator], not a replacement. The shared work — building
+ * the system notification, setting [PendingNotificationTap], running sync —
+ * still lives where it did. What this consolidates is the *order* and the
+ * *threading model* of those calls, so platform code no longer has to remember
+ * "show then sync" vs "sync then show" or "use WorkManager vs direct call."
+ *
+ * On Android, FCM arrival enqueues a `DriveSyncWorker` whose body invokes
+ * [onPushArrived]. On iOS, `didReceiveRemoteNotification(... fetchCompletionHandler:)`
+ * invokes [onPushArrivedAsync] inside the 30 s background-fetch window. On
+ * tap (Android `MainActivity`, iOS `UNUserNotificationCenterDelegate.didReceive`,
+ * Desktop `NotificationClickRouter`), each glue invokes [onNotificationTappedAsync].
+ *
+ * The Swift-friendly `*Async` callback variants exist because Kotlin suspend
+ * is not directly callable from Swift; they mirror the pattern already used
+ * by [BackgroundSyncOrchestrator.triggerSync].
+ */
+class NotificationEntry(
+    private val notificationService: NotificationService,
+    private val orchestrator: BackgroundSyncOrchestrator,
+    private val authConnectionCoordinator: AuthConnectionCoordinator,
+) {
+
+    /**
+     * Called when the OS delivers a silent push / FCM data message in the
+     * background. Builds/refreshes the system notification and triggers a
+     * background sync. The sync skips itself when WS is online (see
+     * [BackgroundSyncOrchestrator.syncIfAuthenticated]).
+     */
+    suspend fun onPushArrived(
+        title: String?,
+        body: String?,
+        data: Map<String, String>,
+    ): SyncOutcome {
+        Logger.i(tag = "NotificationEntry") {
+            "onPushArrived title=$title body=$body data.size=${data.size}"
+        }
+        notificationService.onFcmMessageReceived(title, body, data)
+        return orchestrator.syncIfAuthenticated()
+    }
+
+    /**
+     * Called when the user taps a delivered notification, on any platform,
+     * whether the app was killed, backgrounded, or foregrounded. Routes to
+     * [NotificationService.handleNotificationClicked] which sets
+     * [PendingNotificationTap] (resolved by `ConversationListViewModel` for
+     * navigation). Defensively triggers a sync if WS is offline so the
+     * navigation lands on a fresh DB row rather than a stale placeholder.
+     */
+    suspend fun onNotificationTapped(payload: PayloadData) {
+        Logger.i(tag = "NotificationEntry") {
+            "onNotificationTapped wsOnline=${authConnectionCoordinator.isOnline.value}"
+        }
+        notificationService.handleNotificationClicked(payload)
+        if (!authConnectionCoordinator.isOnline.value) {
+            orchestrator.syncIfAuthenticated()
+        }
+    }
+
+    /** Swift-callable bridge for [onPushArrived]. */
+    fun onPushArrivedAsync(
+        title: String?,
+        body: String?,
+        data: Map<String, String>,
+        onComplete: (success: Boolean) -> Unit,
+    ) {
+        CoroutineScope(Dispatchers.Default).launch {
+            val outcome = runCatching { onPushArrived(title, body, data) }
+                .getOrElse { SyncOutcome.Failed(it) }
+            onComplete(outcome is SyncOutcome.Success)
+        }
+    }
+
+    /** Swift-callable bridge for [onNotificationTapped]. */
+    fun onNotificationTappedAsync(
+        payload: PayloadData,
+        onComplete: () -> Unit = {},
+    ) {
+        CoroutineScope(Dispatchers.Default).launch {
+            try {
+                onNotificationTapped(payload)
+            } catch (e: Throwable) {
+                Logger.e(tag = "NotificationEntry") {
+                    "onNotificationTapped failed: ${e.message}"
+                }
+            } finally {
+                onComplete()
+            }
+        }
+    }
+
+    companion object {
+        fun fromKoin(): NotificationEntry =
+            KoinPlatformTools.defaultContext().get().get()
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
@@ -95,8 +95,14 @@ class NotificationService(
                 if (id != null) conversationMessageCounts.remove(id.toString())
             }
         }
-        // Route clicks from platform backends (Nucleus on JVM) back to this service.
-        NotificationClickRouter.handler = { data -> handleNotificationClicked(data) }
+        // Route clicks from platform backends (Nucleus on JVM) through the shared
+        // NotificationEntry so every platform's tap path lands in the same place,
+        // with the same defensive-sync semantics. Lazy Koin lookup avoids a
+        // construction-time circular dep: NotificationEntry holds a
+        // NotificationService reference, so this side can only resolve it after
+        // Koin has wired both. By the time the click handler fires (in response
+        // to a user gesture) Koin has long since completed its graph.
+        NotificationClickRouter.handler = { data -> NotificationEntry.fromKoin().onNotificationTappedAsync(data) }
     }
 
     /** Clears the accumulated message count for a conversation (e.g. on mark-as-read). */
@@ -131,7 +137,10 @@ class NotificationService(
 
             override fun onNotificationClicked(data: PayloadData) {
                 Logger.i(tag = "NotificationService") { "Notification clicked: $data" }
-                handleNotificationClicked(data)
+                // Route through NotificationEntry so iOS taps (which arrive via
+                // KMPNotifier) hit the same defensive-sync path as Android /
+                // Desktop taps. See NotificationClickRouter.handler comment above.
+                NotificationEntry.fromKoin().onNotificationTappedAsync(data)
             }
 
             override fun onPushNotification(title: String?, body: String?) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -60,6 +60,7 @@ import id.homebase.core.config.mandatorySyncDrives
 import id.homebase.core.sync.DriveRegistry
 import id.homebase.core.connections.ConnectRequestViewModel
 import id.homebase.core.image.HomebaseImageLoader
+import id.homebase.core.notifications.NotificationEntry
 import id.homebase.core.notifications.NotificationService
 import id.homebase.core.notifications.PendingNotificationTap
 import id.homebase.core.settings.UserPreferences
@@ -241,6 +242,7 @@ val appModule = module {
     // Use the explicit lambda form so the defaults take effect.
     single { PendingNotificationTap() }
     singleOf(::NotificationService)
+    singleOf(::NotificationEntry)
     singleOf(::ConnectionRequestService)
     singleOf(::NotificationActionBridge)
 

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -138,9 +138,22 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
   func application(_ application: UIApplication,
                    didReceiveRemoteNotification userInfo: [AnyHashable : Any],
                    fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
-      NotifierManager.shared.onApplicationDidReceiveRemoteNotification(userInfo: userInfo)
-      let orchestrator = BackgroundSyncOrchestrator.companion.fromKoin()
-      orchestrator.triggerSync { success in
+      // Funnel into the shared NotificationEntry.onPushArrived so iOS goes
+      // through the same code path as Android (DriveSyncWorker invokes the
+      // same method). onPushArrived runs both the rich-notification display
+      // (NotificationService.onFcmMessageReceived → handleIncomingPayload)
+      // and the background sync (BackgroundSyncOrchestrator.syncIfAuthenticated).
+      let aps = userInfo["aps"] as? [String: Any]
+      let alert = aps?["alert"] as? [String: Any]
+      let title = alert?["title"] as? String
+      let body = alert?["body"] as? String
+      var data: [String: String] = [:]
+      for (k, v) in userInfo {
+          guard let key = k as? String, key != "aps" else { continue }
+          if let str = v as? String { data[key] = str }
+      }
+      let entry = NotificationEntry.companion.fromKoin()
+      entry.onPushArrivedAsync(title: title, body: body, data: data) { success in
           completionHandler(success == true ? .newData : .failed)
       }
   }


### PR DESCRIPTION
Each platform used to wire up notification handling along its own native glue: Android FCM service did show-then-enqueue, iOS AppDelegate did NotifierManager-then-triggerSync, Desktop click router went straight to NotificationService.handleNotificationClicked. The shared work (rich notification rendering, PendingNotificationTap navigation, drive sync) already lived in commonMain, but every platform had to remember a slightly different sequence of calls.

This introduces a single shared NotificationEntry class that every platform funnels into for the two lifecycle events:
- onPushArrived(title, body, data): show the system notification, then trigger BackgroundSyncOrchestrator.syncIfAuthenticated().
- onNotificationTapped(payload): route through NotificationService.handleNotificationClicked, then defensively sync if WS is offline so navigation lands on a fresh DB row rather than a stale placeholder.

Both methods have Swift-callable *Async variants mirroring the existing BackgroundSyncOrchestrator.triggerSync pattern (Kotlin suspend isn't directly callable from Swift).

What each glue now looks like:
- Android FCM arrival: DriveFcmService enqueues DriveSyncWorker with the FCM title/body/data marshalled through Data; the worker's doWork body is a single onPushArrived(...) call. Display moves from the FCM service callback into the (expedited) worker — typically sub-second with quota, traded for OS-budgeted background guarantees and a single shared codepath with the other platforms.
- Android user tap: MainActivity.handleNotificationIntent calls notificationEntry.onNotificationTappedAsync(payload). Unchanged path to ConversationListViewModel via PendingNotificationTap.
- iOS silent-push arrival: AppDelegate.didReceiveRemoteNotification parses title/body/data from userInfo and calls NotificationEntry.companion.fromKoin().onPushArrivedAsync(...). The NotifierManager.shared.onApplicationDidReceiveRemoteNotification call is removed from arrival (KMPNotifier's listener-dispatch path is no longer needed there because handleIncomingPayload is invoked directly via onFcmMessageReceived).
- iOS user tap: AppDelegate.userNotificationCenter(_:didReceive:) default branch still calls NotifierManager (KMPNotifier fires onNotificationClicked). The listener inside NotificationService now routes that through NotificationEntry.onNotificationTappedAsync — which gets iOS taps the same defensive-sync semantics as Android/Desktop without bypassing KMPNotifier.
- Desktop user click: NotificationClickRouter.handler (wired by NotificationService.init) now invokes NotificationEntry instead of NotificationService.handleNotificationClicked directly.

The NotificationEntry-from-NotificationService back-edge uses NotificationEntry.fromKoin() lazy lookup to avoid a constructor-time circular dep: NotificationEntry holds a NotificationService reference, so the listener inside NotificationService can only resolve the entry after Koin has wired both — by the time a notification fires, Koin has long since completed its graph.

The asymmetric platform glue around silent-push arrival vs user tap collapses to: each glue calls exactly one shared method per native event with the same payload shape. Adding a fourth platform, or threading a behaviour change through all three, is one place going forward.

What's explicitly left for follow-up:
- Block #1 of commit 18483c4e (HTTP processInbox poke in BackgroundSyncOrchestrator) — separate decision; orthogonal to entry consolidation.
- Server-side: QueryBatch should auto-process inbox items reliably so the WS processInbox ack (block #3) and reconnect poke (block #2) can be removed entirely.
- iOS NotificationActionBridge (reply / mark-as-read action handlers) remains a separate KMP bridge — adding Android equivalents will plug into the same NotificationEntry layer.