### PR TITLE
Recover from corrupted desktop database on startup

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
@@ -13,7 +13,6 @@ import com.mmk.kmpnotifier.notification.configuration.NotificationPlatformConfig
 import id.homebase.api.storage.SecureStorage
 import id.homebase.api.storage.SharedPreferences
 import id.homebase.api.sync.database.DatabaseDriverFactory
-import id.homebase.api.sync.database.DatabaseKeyManager
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.core.di.allModules
 import id.homebase.core.diagnostics.MainThreadWatchdog
@@ -48,28 +47,7 @@ class MainApplication : Application(), KoinComponent {
         SharedPreferences.initialize(this) // TODO: Maybe we should use injectable UserPreferences
 
         runBlocking {
-            val dbKey = DatabaseKeyManager.getOrGenerateKey()
-            try {
-                DatabaseManager.initialize {
-                    DatabaseDriverFactory(applicationContext).createDriver(dbKey)
-                }
-            } catch (e: Exception) {
-                Logger.e("MainApplication", e, "Database init failed, resetting")
-                // Delete the corrupted/undecryptable database file and its journal files
-                val dbFile = applicationContext.getDatabasePath("odin-2.db")
-                dbFile.delete()
-                java.io.File(dbFile.path + "-journal").delete()
-                java.io.File(dbFile.path + "-wal").delete()
-                java.io.File(dbFile.path + "-shm").delete()
-
-                // Clear the stale encryption key and generate a fresh one
-                DatabaseKeyManager.clearKey()
-                val freshKey = DatabaseKeyManager.getOrGenerateKey()
-
-                DatabaseManager.initialize {
-                    DatabaseDriverFactory(applicationContext).createDriver(freshKey)
-                }
-            }
+            DatabaseManager.initializeWithRecovery(DatabaseDriverFactory(applicationContext))
         }
 
         startKoin {

--- a/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
+++ b/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
@@ -24,7 +24,6 @@ import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.file.JvmFileSystemUtil
 import id.homebase.api.sync.database.DatabaseDriverFactory
-import id.homebase.api.sync.database.DatabaseKeyManager
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.app.lifecycle.rememberDesktopLifecycleOwner
 import id.homebase.core.App
@@ -117,27 +116,7 @@ fun main() {
     val config = DesktopPreferences()
 
     runBlocking {
-        val dbKey = DatabaseKeyManager.getOrGenerateKey()
-        try {
-            DatabaseManager.initialize { DatabaseDriverFactory().createDriver(dbKey) }
-        } catch (e: Exception) {
-            Logger.e("Main", e, "Database init failed, resetting")
-            // Delete the corrupted/undecryptable database file and its journal
-            // files. Path resolution goes through DatabaseDriverFactory.resolveDbFile
-            // so the two stay in lock-step. Mirrors the Android recovery path in
-            // MainApplication.onCreate.
-            val dbFile = DatabaseDriverFactory.resolveDbFile()
-            dbFile.delete()
-            File(dbFile.path + "-journal").delete()
-            File(dbFile.path + "-wal").delete()
-            File(dbFile.path + "-shm").delete()
-
-            // Clear the stale encryption key and generate a fresh one
-            DatabaseKeyManager.clearKey()
-            val freshKey = DatabaseKeyManager.getOrGenerateKey()
-
-            DatabaseManager.initialize { DatabaseDriverFactory().createDriver(freshKey) }
-        }
+        DatabaseManager.initializeWithRecovery(DatabaseDriverFactory())
     }
 
     application {

--- a/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
+++ b/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
@@ -118,7 +118,26 @@ fun main() {
 
     runBlocking {
         val dbKey = DatabaseKeyManager.getOrGenerateKey()
-        DatabaseManager.initialize { DatabaseDriverFactory().createDriver(dbKey) }
+        try {
+            DatabaseManager.initialize { DatabaseDriverFactory().createDriver(dbKey) }
+        } catch (e: Exception) {
+            Logger.e("Main", e, "Database init failed, resetting")
+            // Delete the corrupted/undecryptable database file and its journal
+            // files. Path resolution goes through DatabaseDriverFactory.resolveDbFile
+            // so the two stay in lock-step. Mirrors the Android recovery path in
+            // MainApplication.onCreate.
+            val dbFile = DatabaseDriverFactory.resolveDbFile()
+            dbFile.delete()
+            File(dbFile.path + "-journal").delete()
+            File(dbFile.path + "-wal").delete()
+            File(dbFile.path + "-shm").delete()
+
+            // Clear the stale encryption key and generate a fresh one
+            DatabaseKeyManager.clearKey()
+            val freshKey = DatabaseKeyManager.getOrGenerateKey()
+
+            DatabaseManager.initialize { DatabaseDriverFactory().createDriver(freshKey) }
+        }
     }
 
     application {

--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.android.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.android.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
+import java.io.File
 
 @Suppress(names = ["EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING"])
 actual class DatabaseDriverFactory(private val context: Context) {
@@ -11,7 +12,15 @@ actual class DatabaseDriverFactory(private val context: Context) {
         System.loadLibrary("sqlcipher")
         val factory = SupportOpenHelperFactory((passphrase ?: "").toByteArray())
         return AndroidSqliteDriver(
-            schema = OdinDatabase.Schema, context = context, name = "odin-2.db", factory = factory
+            schema = OdinDatabase.Schema, context = context, name = DB_FILE_NAME, factory = factory
         )
+    }
+
+    actual fun deleteOnDiskFiles() {
+        val dbFile = context.getDatabasePath(DB_FILE_NAME)
+        dbFile.delete()
+        File(dbFile.path + "-journal").delete()
+        File(dbFile.path + "-wal").delete()
+        File(dbFile.path + "-shm").delete()
     }
 }

--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.android.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.android.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
-import java.io.File
 
 @Suppress(names = ["EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING"])
 actual class DatabaseDriverFactory(private val context: Context) {
@@ -16,11 +15,5 @@ actual class DatabaseDriverFactory(private val context: Context) {
         )
     }
 
-    actual fun deleteOnDiskFiles() {
-        val dbFile = context.getDatabasePath(DB_FILE_NAME)
-        dbFile.delete()
-        File(dbFile.path + "-journal").delete()
-        File(dbFile.path + "-wal").delete()
-        File(dbFile.path + "-shm").delete()
-    }
+    actual fun dbFilePath(): String = context.getDatabasePath(DB_FILE_NAME).absolutePath
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.kt
@@ -2,7 +2,19 @@ package id.homebase.api.sync.database
 
 import app.cash.sqldelight.db.SqlDriver
 
+/** The on-disk database file name used by every platform's [DatabaseDriverFactory]. */
+internal const val DB_FILE_NAME = "odin-2.db"
+
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 expect class DatabaseDriverFactory {
     fun createDriver(passphrase: String? = null): SqlDriver
+
+    /**
+     * Delete the on-disk database file and its WAL/SHM/journal siblings.
+     * Used by [DatabaseManager.initializeWithRecovery] when the driver
+     * fails to open (corrupted file, undecryptable with the stored key,
+     * schema mismatch). Implementations should treat a missing file as a
+     * no-op rather than an error.
+     */
+    fun deleteOnDiskFiles()
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.kt
@@ -26,17 +26,28 @@ expect class DatabaseDriverFactory {
  * loop and suffix list live in commonMain because they aren't
  * platform-specific — only [DatabaseDriverFactory.dbFilePath] is. Missing
  * files are treated as a no-op (`mustExist = false`).
+ */
+internal fun DatabaseDriverFactory.deleteOnDiskFiles() {
+    deleteDatabaseFiles(dbFilePath())
+}
+
+/**
+ * Delete the database file at [dbFilePath] plus its WAL/SHM/journal
+ * siblings. Extracted from [DatabaseDriverFactory.deleteOnDiskFiles] so
+ * unit tests can exercise the suffix loop against a temp-directory path
+ * without instantiating a real factory (which would target the user's
+ * actual data directory).
  *
  * SQLite writes up to three side files alongside the primary database:
  *   - `-journal` (rollback journal mode)
  *   - `-wal` (write-ahead log mode)
  *   - `-shm` (WAL shared-memory index)
- * All three may exist at recovery time depending on which mode last touched
- * the file; deleting the primary alone would leave the others as zombies.
+ * All three may exist at recovery time depending on which mode last
+ * touched the file; deleting the primary alone would leave the others as
+ * zombies.
  */
-internal fun DatabaseDriverFactory.deleteOnDiskFiles() {
-    val path = dbFilePath()
+internal fun deleteDatabaseFiles(dbFilePath: String) {
     for (suffix in listOf("", "-journal", "-wal", "-shm")) {
-        SystemFileSystem.delete(Path(path + suffix), mustExist = false)
+        SystemFileSystem.delete(Path(dbFilePath + suffix), mustExist = false)
     }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.kt
@@ -1,6 +1,8 @@
 package id.homebase.api.sync.database
 
 import app.cash.sqldelight.db.SqlDriver
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 
 /** The on-disk database file name used by every platform's [DatabaseDriverFactory]. */
 internal const val DB_FILE_NAME = "odin-2.db"
@@ -10,11 +12,31 @@ expect class DatabaseDriverFactory {
     fun createDriver(passphrase: String? = null): SqlDriver
 
     /**
-     * Delete the on-disk database file and its WAL/SHM/journal siblings.
-     * Used by [DatabaseManager.initializeWithRecovery] when the driver
-     * fails to open (corrupted file, undecryptable with the stored key,
-     * schema mismatch). Implementations should treat a missing file as a
-     * no-op rather than an error.
+     * Absolute path to the on-disk database file on this platform. Used by
+     * [deleteOnDiskFiles] to clean up after a failed open in
+     * [DatabaseManager.initializeWithRecovery]. Each platform reports the
+     * exact path its `createDriver` opens (or would open) so the recovery
+     * deletes the file the driver was looking at.
      */
-    fun deleteOnDiskFiles()
+    fun dbFilePath(): String
+}
+
+/**
+ * Delete the on-disk database file plus its WAL/SHM/journal siblings. The
+ * loop and suffix list live in commonMain because they aren't
+ * platform-specific — only [DatabaseDriverFactory.dbFilePath] is. Missing
+ * files are treated as a no-op (`mustExist = false`).
+ *
+ * SQLite writes up to three side files alongside the primary database:
+ *   - `-journal` (rollback journal mode)
+ *   - `-wal` (write-ahead log mode)
+ *   - `-shm` (WAL shared-memory index)
+ * All three may exist at recovery time depending on which mode last touched
+ * the file; deleting the primary alone would leave the others as zombies.
+ */
+internal fun DatabaseDriverFactory.deleteOnDiskFiles() {
+    val path = dbFilePath()
+    for (suffix in listOf("", "-journal", "-wal", "-shm")) {
+        SystemFileSystem.delete(Path(path + suffix), mustExist = false)
+    }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
@@ -106,6 +106,32 @@ class DatabaseManager(
                 instance.wipeAndRecreate()
             }
         }
+
+        /**
+         * Open the database via [factory], using the key from
+         * [DatabaseKeyManager.getOrGenerateKey]. If the open throws (corrupted
+         * file, undecryptable with the stored key, schema mismatch), delete the
+         * on-disk files via [DatabaseDriverFactory.deleteOnDiskFiles], rotate
+         * the encryption key, and retry once. Replaces the recovery dance each
+         * platform entry point used to implement inline.
+         *
+         * The catch is `Exception` rather than `Throwable` to preserve parity
+         * with the prior per-platform implementations — `Error` (OOM,
+         * `StackOverflow`) is not swallowed.
+         */
+        suspend fun initializeWithRecovery(factory: DatabaseDriverFactory) {
+            val key = DatabaseKeyManager.getOrGenerateKey()
+            try {
+                initialize { factory.createDriver(key) }
+            } catch (e: Exception) {
+                Logger.withTag("DatabaseManager")
+                    .e(e) { "initializeWithRecovery: open failed, resetting" }
+                factory.deleteOnDiskFiles()
+                DatabaseKeyManager.clearKey()
+                val freshKey = DatabaseKeyManager.getOrGenerateKey()
+                initialize { factory.createDriver(freshKey) }
+            }
+        }
     }
 
     val appNotifications: AppNotificationsWrapper by lazy {

--- a/homebase-api/src/jvmMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.jvm.kt
+++ b/homebase-api/src/jvmMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.jvm.kt
@@ -8,12 +8,7 @@ import java.util.Properties
 
 actual class DatabaseDriverFactory {
     actual fun createDriver(passphrase: String?): SqlDriver {
-        val userHome = JvmFileSystemUtil.getAppDataDirectory()
-        val dbDir = File(userHome, "database")
-        if (!dbDir.exists()) {
-            dbDir.mkdirs()
-        }
-        val dbFile = File(dbDir, "odin-2.db")
+        val dbFile = resolveDbFile()
         val dbFileName = dbFile.absolutePath
 
         val jdbcUrl = if (passphrase.isNullOrEmpty()) {
@@ -26,5 +21,24 @@ actual class DatabaseDriverFactory {
         }
 
         return JdbcSqliteDriver(jdbcUrl, Properties())
+    }
+
+    companion object {
+        /**
+         * The on-disk location of the SQLite database for the JVM/Desktop target.
+         * Exposed as a companion-level helper so the corruption-recovery path in
+         * `desktopApp/Main` can locate the same file (plus its WAL/SHM/journal
+         * siblings) without re-stating the path and silently drifting from the
+         * factory's view. Mirrors the role of
+         * `Context.getDatabasePath("odin-2.db")` on Android.
+         */
+        fun resolveDbFile(): File {
+            val userHome = JvmFileSystemUtil.getAppDataDirectory()
+            val dbDir = File(userHome, "database")
+            if (!dbDir.exists()) {
+                dbDir.mkdirs()
+            }
+            return File(dbDir, "odin-2.db")
+        }
     }
 }

--- a/homebase-api/src/jvmMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.jvm.kt
+++ b/homebase-api/src/jvmMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.jvm.kt
@@ -23,20 +23,13 @@ actual class DatabaseDriverFactory {
         return JdbcSqliteDriver(jdbcUrl, Properties())
     }
 
-    actual fun deleteOnDiskFiles() {
-        val dbFile = resolveDbFile()
-        dbFile.delete()
-        File(dbFile.path + "-journal").delete()
-        File(dbFile.path + "-wal").delete()
-        File(dbFile.path + "-shm").delete()
-    }
+    actual fun dbFilePath(): String = resolveDbFile().absolutePath
 
     companion object {
         /**
          * The on-disk location of the SQLite database for the JVM/Desktop target.
-         * Exposed as a companion-level helper so [createDriver] and
-         * [deleteOnDiskFiles] share one source of truth for the path. Mirrors
-         * the role of `Context.getDatabasePath(DB_FILE_NAME)` on Android.
+         * Single source of truth shared by [createDriver] and [dbFilePath].
+         * Mirrors the role of `Context.getDatabasePath(DB_FILE_NAME)` on Android.
          */
         fun resolveDbFile(): File {
             val userHome = JvmFileSystemUtil.getAppDataDirectory()

--- a/homebase-api/src/jvmMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.jvm.kt
+++ b/homebase-api/src/jvmMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.jvm.kt
@@ -23,14 +23,20 @@ actual class DatabaseDriverFactory {
         return JdbcSqliteDriver(jdbcUrl, Properties())
     }
 
+    actual fun deleteOnDiskFiles() {
+        val dbFile = resolveDbFile()
+        dbFile.delete()
+        File(dbFile.path + "-journal").delete()
+        File(dbFile.path + "-wal").delete()
+        File(dbFile.path + "-shm").delete()
+    }
+
     companion object {
         /**
          * The on-disk location of the SQLite database for the JVM/Desktop target.
-         * Exposed as a companion-level helper so the corruption-recovery path in
-         * `desktopApp/Main` can locate the same file (plus its WAL/SHM/journal
-         * siblings) without re-stating the path and silently drifting from the
-         * factory's view. Mirrors the role of
-         * `Context.getDatabasePath("odin-2.db")` on Android.
+         * Exposed as a companion-level helper so [createDriver] and
+         * [deleteOnDiskFiles] share one source of truth for the path. Mirrors
+         * the role of `Context.getDatabasePath(DB_FILE_NAME)` on Android.
          */
         fun resolveDbFile(): File {
             val userHome = JvmFileSystemUtil.getAppDataDirectory()
@@ -38,7 +44,7 @@ actual class DatabaseDriverFactory {
             if (!dbDir.exists()) {
                 dbDir.mkdirs()
             }
-            return File(dbDir, "odin-2.db")
+            return File(dbDir, DB_FILE_NAME)
         }
     }
 }

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/DeleteDatabaseFilesTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/DeleteDatabaseFilesTest.kt
@@ -1,0 +1,100 @@
+package id.homebase.api.sync.database
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.createFile
+import kotlin.io.path.exists
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [deleteDatabaseFiles] — the suffix loop / file-system call
+ * that [DatabaseManager.initializeWithRecovery] uses to wipe a corrupted
+ * database. Targets the JVM actual but the body under test lives in
+ * commonMain, so iOS/Android take the same code path by symmetry.
+ *
+ * Tests against a temp directory rather than the factory's real path so
+ * they don't clobber a developer's local DB when running the suite.
+ */
+class DeleteDatabaseFilesTest {
+
+    private lateinit var tempDir: Path
+    private lateinit var dbPath: String
+
+    @BeforeTest
+    fun setUp() {
+        tempDir = Files.createTempDirectory("deleteDbTest")
+        dbPath = tempDir.resolve("odin-2.db").absolutePathString()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        // Defensive: even if a test failed mid-way, clean up its temp dir.
+        Files.walk(tempDir)
+            .sorted(Comparator.reverseOrder())
+            .forEach { Files.deleteIfExists(it) }
+    }
+
+    @Test
+    fun deletes_primary_and_all_three_siblings_when_all_present() {
+        Path.of("$dbPath").createFile()
+        Path.of("$dbPath-journal").createFile()
+        Path.of("$dbPath-wal").createFile()
+        Path.of("$dbPath-shm").createFile()
+
+        deleteDatabaseFiles(dbPath)
+
+        assertFalse(Path.of("$dbPath").exists(), "primary should be deleted")
+        assertFalse(Path.of("$dbPath-journal").exists(), "-journal should be deleted")
+        assertFalse(Path.of("$dbPath-wal").exists(), "-wal should be deleted")
+        assertFalse(Path.of("$dbPath-shm").exists(), "-shm should be deleted")
+    }
+
+    @Test
+    fun is_silent_no_op_when_no_files_exist() {
+        // No files created. Function must not throw — the `mustExist = false`
+        // contract on SystemFileSystem.delete is the load-bearing detail here.
+        deleteDatabaseFiles(dbPath)
+
+        assertFalse(Path.of(dbPath).exists())
+    }
+
+    @Test
+    fun deletes_primary_silently_skipping_missing_siblings() {
+        // Only the primary file exists; the three sibling suffixes are
+        // missing. Function must delete the primary and silently no-op the
+        // siblings (the common shape after a clean shutdown that left only
+        // the .db file and no WAL).
+        Path.of(dbPath).createFile()
+
+        deleteDatabaseFiles(dbPath)
+
+        assertFalse(Path.of(dbPath).exists(), "primary should be deleted")
+        // Sanity-check that we didn't accidentally create the siblings either.
+        assertFalse(Path.of("$dbPath-journal").exists())
+        assertFalse(Path.of("$dbPath-wal").exists())
+        assertFalse(Path.of("$dbPath-shm").exists())
+    }
+
+    @Test
+    fun deletes_only_files_matching_our_suffix_list() {
+        // Defense against future drift: if someone ever adds a new SQLite
+        // side file (e.g. `-jr`) we want a test failure, not silent
+        // partial cleanup. Today's contract: only the four known suffixes
+        // are touched.
+        Path.of(dbPath).createFile()
+        Path.of("$dbPath-journal").createFile()
+        val unrelated = tempDir.resolve("unrelated.txt")
+        unrelated.createFile()
+
+        deleteDatabaseFiles(dbPath)
+
+        assertFalse(Path.of(dbPath).exists())
+        assertFalse(Path.of("$dbPath-journal").exists())
+        assertTrue(unrelated.exists(), "unrelated files in the directory must survive")
+    }
+}

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.native.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.native.kt
@@ -3,16 +3,31 @@ package id.homebase.api.sync.database
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
 import co.touchlab.sqliter.DatabaseConfiguration
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSHomeDirectory
 
 actual class DatabaseDriverFactory {
     actual fun createDriver(passphrase: String?): SqlDriver {
         return NativeSqliteDriver(
-            schema = OdinDatabase.Schema, name = "odin-2.db", onConfiguration = { config ->
+            schema = OdinDatabase.Schema, name = DB_FILE_NAME, onConfiguration = { config ->
                 config.copy(
                     encryptionConfig = DatabaseConfiguration.Encryption(
                         key = passphrase ?: "", rekey = ""
                     )
                 )
             })
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    actual fun deleteOnDiskFiles() {
+        // NativeSqliteDriver resolves `name` to "${NSHomeDirectory()}/databases/<name>"
+        // under the hood; mirror that path here so deletion matches the live file.
+        val fileManager = NSFileManager.defaultManager
+        val dbDir = "${NSHomeDirectory()}/databases"
+        fileManager.removeItemAtPath("$dbDir/$DB_FILE_NAME", null)
+        fileManager.removeItemAtPath("$dbDir/$DB_FILE_NAME-journal", null)
+        fileManager.removeItemAtPath("$dbDir/$DB_FILE_NAME-wal", null)
+        fileManager.removeItemAtPath("$dbDir/$DB_FILE_NAME-shm", null)
     }
 }

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.native.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.native.kt
@@ -3,8 +3,6 @@ package id.homebase.api.sync.database
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
 import co.touchlab.sqliter.DatabaseConfiguration
-import kotlinx.cinterop.ExperimentalForeignApi
-import platform.Foundation.NSFileManager
 import platform.Foundation.NSHomeDirectory
 
 actual class DatabaseDriverFactory {
@@ -19,15 +17,8 @@ actual class DatabaseDriverFactory {
             })
     }
 
-    @OptIn(ExperimentalForeignApi::class)
-    actual fun deleteOnDiskFiles() {
-        // NativeSqliteDriver resolves `name` to "${NSHomeDirectory()}/databases/<name>"
-        // under the hood; mirror that path here so deletion matches the live file.
-        val fileManager = NSFileManager.defaultManager
-        val dbDir = "${NSHomeDirectory()}/databases"
-        fileManager.removeItemAtPath("$dbDir/$DB_FILE_NAME", null)
-        fileManager.removeItemAtPath("$dbDir/$DB_FILE_NAME-journal", null)
-        fileManager.removeItemAtPath("$dbDir/$DB_FILE_NAME-wal", null)
-        fileManager.removeItemAtPath("$dbDir/$DB_FILE_NAME-shm", null)
-    }
+    // NativeSqliteDriver resolves `name` to "${NSHomeDirectory()}/databases/<name>"
+    // under the hood; report the same path here so the shared recovery deletes
+    // the file the driver was looking at.
+    actual fun dbFilePath(): String = "${NSHomeDirectory()}/databases/$DB_FILE_NAME"
 }

--- a/homebase-api/src/webMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.web.kt
+++ b/homebase-api/src/webMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.web.kt
@@ -8,7 +8,7 @@ actual class DatabaseDriverFactory {
         TODO("Not yet implemented")
     }
 
-    actual fun deleteOnDiskFiles() {
+    actual fun dbFilePath(): String {
         TODO("Not yet implemented")
     }
 }

--- a/homebase-api/src/webMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.web.kt
+++ b/homebase-api/src/webMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.web.kt
@@ -7,4 +7,8 @@ actual class DatabaseDriverFactory {
     actual fun createDriver(passphrase: String?): SqlDriver {
         TODO("Not yet implemented")
     }
+
+    actual fun deleteOnDiskFiles() {
+        TODO("Not yet implemented")
+    }
 }

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/MainViewController.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/MainViewController.kt
@@ -4,7 +4,6 @@ import androidx.compose.ui.window.ComposeUIViewController
 import chat_kmp.homebase_common.BuildConfig
 import co.touchlab.kermit.Logger
 import id.homebase.api.sync.database.DatabaseDriverFactory
-import id.homebase.api.sync.database.DatabaseKeyManager
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.core.di.allModules
 import id.homebase.core.logging.LoggerConfig
@@ -19,7 +18,6 @@ import org.koin.core.context.startKoin
 import platform.Foundation.NSBundle
 import platform.Foundation.NSDocumentDirectory
 import platform.Foundation.NSFileManager
-import platform.Foundation.NSHomeDirectory
 import platform.Foundation.NSUserDomainMask
 import platform.UIKit.UIViewController
 
@@ -67,25 +65,7 @@ fun initializeApp() {
     setupIOSCrashHandler()
 
     runBlocking {
-        val dbKey = DatabaseKeyManager.getOrGenerateKey()
-        try {
-            DatabaseManager.initialize { DatabaseDriverFactory().createDriver(dbKey) }
-        } catch (e: Exception) {
-            Logger.e("MainViewController", e, "Database init failed, resetting")
-            // Delete the corrupted/undecryptable database file
-            val fileManager = NSFileManager.defaultManager
-            val dbDir = "${NSHomeDirectory()}/databases"
-            fileManager.removeItemAtPath("$dbDir/odin-2.db", null)
-            fileManager.removeItemAtPath("$dbDir/odin-2.db-journal", null)
-            fileManager.removeItemAtPath("$dbDir/odin-2.db-wal", null)
-            fileManager.removeItemAtPath("$dbDir/odin-2.db-shm", null)
-
-            // Clear the stale encryption key and generate a fresh one
-            DatabaseKeyManager.clearKey()
-            val freshKey = DatabaseKeyManager.getOrGenerateKey()
-
-            DatabaseManager.initialize { DatabaseDriverFactory().createDriver(freshKey) }
-        }
+        DatabaseManager.initializeWithRecovery(DatabaseDriverFactory())
     }
 }
 


### PR DESCRIPTION
Android's MainApplication.onCreate has had a database-init recovery path since the SQLCipher migration: if DatabaseManager.initialize throws on startup (corrupted file, undecryptable with the stored key, schema mismatch), the corrupted database and its WAL/SHM/journal siblings are deleted, the stale encryption key is cleared, a fresh key is minted, and init is retried. The Desktop entry point never grew the same guard — the same failure on JVM crashed the app on every cold start with no self-heal, requiring a manual delete of `%APPDATA%/HomebaseChatDev/database/` (or the macOS / Linux equivalents).

This adds the same try/catch around the Desktop DB init in `desktopApp/src/jvmMain/.../Main.kt`. To avoid the path being stated in two places (and silently drifting), the path-resolution logic moves out of `DatabaseDriverFactory.createDriver` into a `companion object` `resolveDbFile()` helper. The factory uses it for the live driver; the recovery block uses it to locate the file (and its journal siblings) for deletion. This mirrors how Android's `Context.getDatabasePath` is the single source of truth for both the driver and the recovery on that side.

Verified `desktopApp:assemble` and `homebase-api:compileKotlinJvm` are green. Behaviour for a healthy database is unchanged; the new code only fires when `initialize` throws.