### PR TITLE
fix(chat): carry reply context when sending image/file attachments

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -9,6 +9,7 @@ import id.homebase.api.common.OdinId
 import id.homebase.api.video.VideoProcessingPhase
 import id.homebase.chat.data.ContactUiModel
 import id.homebase.chat.data.MessageUiModel
+import id.homebase.chat.services.ReplyPreview
 import id.homebase.chat.services.convo.EnrichedConversationUiModel
 import id.homebase.core.avatars.AppConnectionStatus
 import id.homebase.core.gallery.GalleryImage
@@ -107,6 +108,7 @@ data class PendingOutgoingMessage(
     val text: String,
     val attachmentCount: Int,
     val sentAt: Instant,
+    val replyPreview: ReplyPreview? = null,
 )
 
 sealed interface MessageListUiSheet {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -752,14 +752,7 @@ internal class MessageActionsHandler(
                 text = content,
                 attachmentCount = files.size,
                 sentAt = Instant.fromEpochMilliseconds(sentAt.milliseconds),
-                replyPreview = replyTo?.let {
-                    ReplyPreview(
-                        replyUniqueId = it.id,
-                        authorOdinId = it.originalAuthor?.domainName ?: "null",
-                        message = it.content.truncateToCodePoints(80),
-                        previewThumbnail = it.previewThumbnail,
-                    )
-                },
+                replyPreview = replyTo?.toReplyPreview(),
             )
 
             // Register the placeholder, register upload progress, clear the
@@ -786,17 +779,11 @@ internal class MessageActionsHandler(
                         })
 
                     if (replyTo != null) {
-                        val replyPreview = ReplyPreview(
-                            replyUniqueId = replyTo.id,
-                            authorOdinId = replyTo.originalAuthor?.domainName ?: "null",
-                            message = replyTo.content.truncateToCodePoints(80),
-                            previewThumbnail = replyTo.previewThumbnail,
-                        )
                         Logger.d(tag = TAG) { "addMessageWithFiles: reply message=$newMessageId conversation=$conversationId replyTo=${replyTo.id}" }
                         chatMessageSenderService.replyToMessage(
                             messageUniqueId = newMessageId,
                             conversationId = conversationId,
-                            replyTo = replyPreview,
+                            replyTo = replyTo.toReplyPreview(),
                             messageText = content,
                             previousMessageUniqueId = null,
                             payloadBundle = bundle,
@@ -962,6 +949,13 @@ internal class MessageActionsHandler(
         }
     }
 
+    private fun MessageUiModel.toReplyPreview() = ReplyPreview(
+        replyUniqueId = id,
+        authorOdinId = originalAuthor?.domainName ?: "null",
+        message = content.truncateToCodePoints(80),
+        previewThumbnail = previewThumbnail,
+    )
+
     private fun replyToMessage(
         conversationId: Uuid,
         replyTo: MessageUiModel,
@@ -972,12 +966,6 @@ internal class MessageActionsHandler(
             try {
                 val payloadBundle = payloadRenderers.toCombinedPayloadBundle(fileOperationsProvider)
 
-                val replyPreview = ReplyPreview(
-                    replyUniqueId = replyTo.id,
-                    authorOdinId = replyTo.originalAuthor?.domainName ?: "null",
-                    message = replyTo.content.truncateToCodePoints(80),
-                    previewThumbnail = replyTo.previewThumbnail
-                )
                 val newMessageId = Uuid.random()
                 pendingMessageId = newMessageId
                 Logger.d(tag = TAG) { "replyToMessage: message=$newMessageId conversation=$conversationId replyTo=${replyTo.id}" }
@@ -985,7 +973,7 @@ internal class MessageActionsHandler(
                 chatMessageSenderService.replyToMessage(
                     messageUniqueId = newMessageId,
                     conversationId = conversationId,
-                    replyTo = replyPreview,
+                    replyTo = replyTo.toReplyPreview(),
                     messageText = content,
                     previousMessageUniqueId = null,
                     payloadBundle = payloadBundle,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -752,6 +752,14 @@ internal class MessageActionsHandler(
                 text = content,
                 attachmentCount = files.size,
                 sentAt = Instant.fromEpochMilliseconds(sentAt.milliseconds),
+                replyPreview = replyTo?.let {
+                    ReplyPreview(
+                        replyUniqueId = it.id,
+                        authorOdinId = it.originalAuthor?.domainName ?: "null",
+                        message = it.content.truncateToCodePoints(80),
+                        previewThumbnail = it.previewThumbnail,
+                    )
+                },
             )
 
             // Register the placeholder, register upload progress, clear the

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -379,11 +379,13 @@ internal class MessageActionsHandler(
 
     fun handleSendFile(action: ConversationListUiAction.SendFile) {
         messagesUiState.update { it.copy(scrollPosition = null, isSendingMessage = true) }
+        val replyTo = messagesUiState.value.replyToMessage
 
         addMessageWithFiles(
             conversationId = action.conversationId,
             content = action.message.trimEnd(),
             files = action.attachments,
+            replyTo = replyTo,
         )
         // Input is cleared inside addMessageWithFiles after
         // the send is successfully queued.
@@ -555,6 +557,7 @@ internal class MessageActionsHandler(
         conversationId: Uuid,
         content: String,
         files: List<AttachmentPendingFile>,
+        replyTo: MessageUiModel? = null,
     ) {
         val sentAt = UnixTimeUtc.now()
         scope.launch {
@@ -760,6 +763,7 @@ internal class MessageActionsHandler(
                     pendingOutgoing = (state.pendingOutgoing + placeholder).toPersistentList(),
                     fullScreenOverlay = null,
                     isSendingMessage = false,
+                    replyToMessage = if (replyTo != null) null else state.replyToMessage,
                 )
             }
             messageInputTextState.clear()
@@ -773,14 +777,33 @@ internal class MessageActionsHandler(
                             "${ChatProtocol.PAYLOAD_KEY_MESSAGE_WEB}$index"
                         })
 
-                    chatMessageSenderService.sendNewMessage(
-                        messageUniqueId = newMessageId,
-                        conversationId = conversationId,
-                        messageText = content,
-                        previousMessageUniqueId = null,
-                        payloadBundle = bundle,
-                        userDate = sentAt,
-                    )
+                    if (replyTo != null) {
+                        val replyPreview = ReplyPreview(
+                            replyUniqueId = replyTo.id,
+                            authorOdinId = replyTo.originalAuthor?.domainName ?: "null",
+                            message = replyTo.content.truncateToCodePoints(80),
+                            previewThumbnail = replyTo.previewThumbnail,
+                        )
+                        Logger.d(tag = TAG) { "addMessageWithFiles: reply message=$newMessageId conversation=$conversationId replyTo=${replyTo.id}" }
+                        chatMessageSenderService.replyToMessage(
+                            messageUniqueId = newMessageId,
+                            conversationId = conversationId,
+                            replyTo = replyPreview,
+                            messageText = content,
+                            previousMessageUniqueId = null,
+                            payloadBundle = bundle,
+                            userDate = sentAt,
+                        )
+                    } else {
+                        chatMessageSenderService.sendNewMessage(
+                            messageUniqueId = newMessageId,
+                            conversationId = conversationId,
+                            messageText = content,
+                            previousMessageUniqueId = null,
+                            payloadBundle = bundle,
+                            userDate = sentAt,
+                        )
+                    }
                     // Real optimistic bubble has landed — drop the placeholder.
                     messagesUiState.update { state ->
                         state.copy(
@@ -800,6 +823,7 @@ internal class MessageActionsHandler(
                             pendingOutgoing = state.pendingOutgoing
                                 .filterNot { it.id == newMessageId }
                                 .toPersistentList(),
+                            replyToMessage = replyTo ?: state.replyToMessage,
                         )
                     }
                     sendEvent(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -215,7 +215,7 @@ fun MessageBubbleRaw(
     val timestamp = formatMessageTimestamp(message.userDate)
     val messageInfoText =
         if (message.isEdited) "${stringResource(MR.string.chat_message_edited)} $timestamp" else timestamp
-    val mediaOnly = remember { !message.content.hasContent() && hasMedia }
+    val mediaOnly = remember { !message.content.hasContent() && hasMedia && message.messageAppData.replyPreview == null }
     val emojiOnly = remember { message.content.isEmojiContentOnly() && !hasMedia }
     val backgroundColor =
         if (emojiOnly) Color.Unspecified

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -374,14 +374,16 @@ fun MessageBubbleRaw(
                         }
                     },
                 ) { measurables, constraints ->
-                    val mediaPlaceable = measurables[1].measure(constraints)
-                    val replyPlaceable = measurables[0].measure(
-                        constraints.copy(
-                            minWidth = mediaPlaceable.width,
-                            maxWidth = mediaPlaceable.width,
-                        )
+                    val minContentWidth = Dimens.MediaBubble.minWidthWithContent.roundToPx()
+                        .coerceAtMost(constraints.maxWidth)
+                    val mediaPlaceable = measurables[1].measure(
+                        constraints.copy(minWidth = minContentWidth)
                     )
-                    layout(mediaPlaceable.width, replyPlaceable.height + mediaPlaceable.height) {
+                    val width = mediaPlaceable.width
+                    val replyPlaceable = measurables[0].measure(
+                        constraints.copy(minWidth = width, maxWidth = width)
+                    )
+                    layout(width, replyPlaceable.height + mediaPlaceable.height) {
                         replyPlaceable.placeRelative(0, 0)
                         mediaPlaceable.placeRelative(0, replyPlaceable.height)
                     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -216,6 +217,7 @@ fun MessageBubbleRaw(
     val messageInfoText =
         if (message.isEdited) "${stringResource(MR.string.chat_message_edited)} $timestamp" else timestamp
     val mediaOnly = remember { !message.content.hasContent() && hasMedia && message.messageAppData.replyPreview == null }
+    val replyMediaOnly = remember { !message.content.hasContent() && hasMedia && message.messageAppData.replyPreview != null }
     val emojiOnly = remember { message.content.isEmojiContentOnly() && !hasMedia }
     val backgroundColor =
         if (emojiOnly) Color.Unspecified
@@ -325,41 +327,63 @@ fun MessageBubbleRaw(
                         downloadingFiles = downloadingFiles,
                         uploadStatus = uploadStatus,
                     )
-                    Box(modifier = Modifier.matchParentSize().align(Alignment.BottomStart)) {
-                        Box(
-                            modifier = Modifier.fillMaxWidth().height(40.dp)
-                                .align(Alignment.BottomStart).background(
-                                    brush = Brush.verticalGradient(
-                                        colors = listOf(
-                                            Color.Transparent,
-                                            Color.Black.copy(
-                                                alpha = 0.6f
-                                            ),
-                                        )
-                                    )
-                                ),
-                        ) {
-                            Row(
-                                modifier = Modifier.align(Alignment.BottomEnd).padding(12.dp),
-                                verticalAlignment = Alignment.Bottom
-                            ) {
-                                Text(
-                                    text = messageInfoText,
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = HomebaseTheme.extendedColors.bubbleSentOnSurface.copy(
-                                        alpha = 0.7f
-                                    )
-                                )
-                                if (sentByYou) {
-                                    Spacer(modifier = Modifier.width(4.dp))
-                                    DeliveryStatus(
-                                        isPendingSend = isPendingSend,
-                                        deliveryStatus = message.messageAppData.deliveryStatus,
-                                        contentColor = contentColor.copy(alpha = 0.7f),
-                                    )
-                                }
-                            }
+                    MediaTimestampOverlay(
+                        messageInfoText = messageInfoText,
+                        sentByYou = sentByYou,
+                        isPendingSend = isPendingSend,
+                        deliveryStatus = message.messageAppData.deliveryStatus,
+                        contentColor = contentColor,
+                    )
+                }
+            } else if (replyMediaOnly && !message.isDeleted) {
+                val reply = message.messageAppData.replyPreview!!
+                Layout(
+                    content = {
+                        InlineReplyPreview(
+                            replyPreview = reply,
+                            sentByYou = sentByYou,
+                            onClick = { onClickMessageId(reply.replyUniqueId) },
+                            replyMessage = replyMessages[reply.replyUniqueId],
+                            driveId = chatTargetDrive.alias,
+                        )
+                        Box {
+                            MediaMessage(
+                                payloads = filteredPayloads?.toPersistentList() ?: persistentListOf(),
+                                fileId = message.fileId,
+                                decryptedFiles = decryptedFiles,
+                                keyHeader = message.keyHeader,
+                                driveId = chatTargetDrive.alias,
+                                previewThumbnail = message.previewThumbnail,
+                                onMediaClick = onMediaClick,
+                                onMediaLongPress = { _, _ -> handleLongClick() },
+                                onRequestDecryptedFile = onRequestDecryptedFile,
+                                shape = RoundedCornerShape(0.dp),
+                                sharedTransitionScope = sharedTransitionScope,
+                                animatedVisibilityScope = animatedVisibilityScope,
+                                messageId = message.id,
+                                downloadingFiles = downloadingFiles,
+                                uploadStatus = uploadStatus,
+                            )
+                            MediaTimestampOverlay(
+                                messageInfoText = messageInfoText,
+                                sentByYou = sentByYou,
+                                isPendingSend = isPendingSend,
+                                deliveryStatus = message.messageAppData.deliveryStatus,
+                                contentColor = contentColor,
+                            )
                         }
+                    },
+                ) { measurables, constraints ->
+                    val mediaPlaceable = measurables[1].measure(constraints)
+                    val replyPlaceable = measurables[0].measure(
+                        constraints.copy(
+                            minWidth = mediaPlaceable.width,
+                            maxWidth = mediaPlaceable.width,
+                        )
+                    )
+                    layout(mediaPlaceable.width, replyPlaceable.height + mediaPlaceable.height) {
+                        replyPlaceable.placeRelative(0, 0)
+                        mediaPlaceable.placeRelative(0, replyPlaceable.height)
                     }
                 }
             } else {
@@ -400,7 +424,7 @@ fun MessageBubbleRaw(
                                     previewThumbnail = message.previewThumbnail,
                                     onMediaClick = onMediaClick,
                                     keyHeader = message.keyHeader,
-                                    shape = if (authorName == null) RoundedCornerShape(
+                                    shape = if (authorName == null && message.messageAppData.replyPreview == null) RoundedCornerShape(
                                         topStart = Dimens.Message.cornerRadius,
                                         topEnd = Dimens.Message.cornerRadius
                                     ) else RoundedCornerShape(0.dp),
@@ -688,6 +712,48 @@ fun MessageBubbleRaw(
                             infoPlaceable.placeRelative(clampedInfoX, infoY)
                         }
                     }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BoxScope.MediaTimestampOverlay(
+    messageInfoText: String,
+    sentByYou: Boolean,
+    isPendingSend: Boolean,
+    deliveryStatus: Int,
+    contentColor: Color,
+) {
+    Box(modifier = Modifier.matchParentSize().align(Alignment.BottomStart)) {
+        Box(
+            modifier = Modifier.fillMaxWidth().height(40.dp)
+                .align(Alignment.BottomStart).background(
+                    brush = Brush.verticalGradient(
+                        colors = listOf(
+                            Color.Transparent,
+                            Color.Black.copy(alpha = 0.6f),
+                        )
+                    )
+                ),
+        ) {
+            Row(
+                modifier = Modifier.align(Alignment.BottomEnd).padding(12.dp),
+                verticalAlignment = Alignment.Bottom,
+            ) {
+                Text(
+                    text = messageInfoText,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = HomebaseTheme.extendedColors.bubbleSentOnSurface.copy(alpha = 0.7f),
+                )
+                if (sentByYou) {
+                    Spacer(modifier = Modifier.width(4.dp))
+                    DeliveryStatus(
+                        isPendingSend = isPendingSend,
+                        deliveryStatus = deliveryStatus,
+                        contentColor = contentColor.copy(alpha = 0.7f),
+                    )
                 }
             }
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/PendingMessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/PendingMessageBubble.kt
@@ -147,11 +147,8 @@ private fun MediaPlaceholderBubble(
                 fileId = message.id,
                 driveId = chatTargetDrive.alias,
                 keyHeader = fakeKeyHeader,
-                shape = if (hasText) {
-                    RoundedCornerShape(
-                        topStart = Dimens.Message.cornerRadius,
-                        topEnd = Dimens.Message.cornerRadius,
-                    )
+                shape = if (hasText || message.replyPreview != null) {
+                    RoundedCornerShape(0.dp)
                 } else {
                     bubbleShape
                 },

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/PendingMessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/PendingMessageBubble.kt
@@ -132,6 +132,15 @@ private fun MediaPlaceholderBubble(
         color = HomebaseTheme.extendedColors.bubbleSentSurface,
     ) {
         Column {
+            message.replyPreview?.let { reply ->
+                InlineReplyPreview(
+                    replyPreview = reply,
+                    sentByYou = true,
+                    onClick = {},
+                    replyMessage = null,
+                    driveId = chatTargetDrive.alias,
+                )
+            }
             MediaMessage(
                 payloads = syntheticPayloads,
                 decryptedFiles = persistentMapOf(),
@@ -166,7 +175,9 @@ private fun MediaPlaceholderBubble(
 }
 
 @Composable
-private fun GenericPendingBubble(message: PendingOutgoingMessage) {
+private fun GenericPendingBubble(
+    message: PendingOutgoingMessage,
+) {
     val shape = RoundedCornerShape(
         topStart = Dimens.Message.cornerRadius,
         topEnd = Dimens.Message.cornerRadius,
@@ -181,51 +192,62 @@ private fun GenericPendingBubble(message: PendingOutgoingMessage) {
         shape = shape,
         color = backgroundColor,
     ) {
-        Column(
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
-            verticalArrangement = Arrangement.spacedBy(6.dp),
-        ) {
-            if (message.attachmentCount > 0) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        imageVector = Icons.Default.AttachFile,
-                        contentDescription = null,
-                        tint = contentColor.copy(alpha = 0.75f),
-                        modifier = Modifier.size(16.dp),
+        Column {
+            message.replyPreview?.let { reply ->
+                InlineReplyPreview(
+                    replyPreview = reply,
+                    sentByYou = true,
+                    onClick = {},
+                    replyMessage = null,
+                    driveId = chatTargetDrive.alias,
+                )
+            }
+            Column(
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                if (message.attachmentCount > 0) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Default.AttachFile,
+                            contentDescription = null,
+                            tint = contentColor.copy(alpha = 0.75f),
+                            modifier = Modifier.size(16.dp),
+                        )
+                        Spacer(Modifier.width(6.dp))
+                        Text(
+                            text = if (message.attachmentCount == 1)
+                                stringResource(MR.string.pending_attachment_one)
+                            else
+                                stringResource(MR.string.pending_attachment_many, message.attachmentCount),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = contentColor.copy(alpha = 0.75f),
+                        )
+                    }
+                }
+                if (message.text.isNotEmpty()) {
+                    Text(
+                        text = message.text,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = contentColor,
+                    )
+                }
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(12.dp),
+                        strokeWidth = 1.5.dp,
+                        color = contentColor.copy(alpha = 0.7f),
                     )
                     Spacer(Modifier.width(6.dp))
                     Text(
-                        text = if (message.attachmentCount == 1)
-                            stringResource(MR.string.pending_attachment_one)
-                        else
-                            stringResource(MR.string.pending_attachment_many, message.attachmentCount),
-                        style = MaterialTheme.typography.labelMedium,
-                        color = contentColor.copy(alpha = 0.75f),
+                        text = stringResource(MR.string.upload_preparing),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = contentColor.copy(alpha = 0.7f),
                     )
                 }
-            }
-            if (message.text.isNotEmpty()) {
-                Text(
-                    text = message.text,
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = contentColor,
-                )
-            }
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.End,
-            ) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(12.dp),
-                    strokeWidth = 1.5.dp,
-                    color = contentColor.copy(alpha = 0.7f),
-                )
-                Spacer(Modifier.width(6.dp))
-                Text(
-                    text = stringResource(MR.string.upload_preparing),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = contentColor.copy(alpha = 0.7f),
-                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- **Bug**: Swiping to reply, then tapping + to add an image, then sending would send the image as a plain message (no reply context) and leave the reply bar stuck in the composer
- **Root cause**: `handleSendFile()` → `addMessageWithFiles()` bypassed the `replyToMessage` state entirely — only the text-send path (`handleSendMessage`) checked for reply context
- **Fix**: The file-send path now captures `replyToMessage`, builds a `ReplyPreview`, and calls `chatMessageSenderService.replyToMessage()` instead of `sendNewMessage()`. On failure, reply state is restored so the user can retry without re-swiping.

## Test plan
- [x] Swipe to reply on a message → tap + → pick an image → send → image arrives as a reply with reply context bubble
- [x] Same flow but with a video attachment
- [x] Same flow but with a file attachment
- [x] Send an image without replying (normal path) — still works as before
- [x] Reply + image send fails (e.g. airplane mode) → reply bar reappears so user can retry
- [x] Reply + text send still works as before (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)