### PR TITLE
Unify drive mounting through a single mountDrive() path

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
@@ -30,7 +30,10 @@ class DriveSyncManager(
     private val eventBus: EventBus,
     private val scope: CoroutineScope,
     private val databaseManager: DatabaseManager,
-    private val drives: Map<Uuid, String>,
+    // The drives this manager is responsible for syncing on every (re)connect.
+    // Optional add-on drives discovered from the cross-device registry are added
+    // via [mountDrive] — same code path, just a different caller.
+    private val mandatoryDrives: Map<Uuid, String>,
 ) {
     // Immutable map reference — always replaced, never mutated in-place, preventing CME.
     // All writes are serialized via driveSyncsMutex, which provides the happens-before
@@ -126,52 +129,29 @@ class DriveSyncManager(
     suspend fun start() {
         // getActiveCredentials() + null-check instead of requireActiveCredentials()
         // so a logout race can't crash the caller. Not all callers try-catch this.
-        val credentials = credentialsManager.getActiveCredentials() ?: run {
+        if (credentialsManager.getActiveCredentials() == null) {
             Logger.w { "DriveSyncManager.start() skipped — no active credentials" }
             return
         }
-        val identityId = credentials.getIdentityId()
 
-        val freshLogin = expectFreshCursors
+        // Defensive top-up: callers (AuthConnectionCoordinator, BackgroundSyncOrchestrator)
+        // are expected to mountDrive() the mandatory set before start(), but mounting
+        // them here too is idempotent (mountDrive early-returns on already-mounted
+        // drives) and keeps the manager robust to callers that forget.
+        for ((driveId, label) in mandatoryDrives) {
+            mountDrive(driveId, label)
+        }
+
+        isRunning = true
+
+        // Consume the "first start after logout" signal. Any mount that happened
+        // between clearStorage() and here saw expectFreshCursors=true; subsequent
+        // mid-session mounts (add-on activations, observer callbacks) should not.
         expectFreshCursors = false
 
-        drives.forEach { (driveId, label) ->
-            val alreadyExists = driveSyncsMutex.withLock { driveSyncs.containsKey(driveId) }
-            if (alreadyExists) {
-                Logger.w { "DriveSync for drive=$driveId already exists, skipping" }
-                return@forEach
-            }
-
-            runCatching {
-                DriveSync(
-                    identityId = identityId,
-                    driveId = driveId,
-                    driveQueryProvider = driveQueryProvider,
-                    databaseManager = databaseManager,
-                    eventBus = eventBus,
-                    scope = scope,
-                    expectFreshCursor = freshLogin,
-                )
-            }.onSuccess { sync ->
-                driveSyncsMutex.withLock { driveSyncs = driveSyncs + (driveId to sync) }
-                _driveStatuses.update { current ->
-                    current + (driveId to DriveStatus(driveId, label, DriveState.Initialized))
-                }
-            }.onFailure { e ->
-                Logger.e(
-                    "Failed to create DriveSync for drive=$driveId: ${e.message}",
-                    e
-                )
-            }
-        }
-        isRunning = true
-        // Note: drives registered via mountDrive() while isRunning was false
-        // (bootstrap pre-mounts, or add-on activations during a paused window)
-        // sit in driveSyncs with their initial sync deferred. The caller is
-        // expected to follow start() with syncAll(), which iterates the full
-        // map and kicks each — same path that handles the mandatory drives
-        // we just added above. Both production callers (AuthConnectionCoordinator
-        // and BackgroundSyncOrchestrator) already do this.
+        // Callers are expected to follow start() with syncAll() to kick the initial
+        // sync on every mounted drive. mountDrive() is now the sole DriveSync
+        // construction site.
     }
 
     suspend fun syncAll() {
@@ -222,14 +202,21 @@ class DriveSyncManager(
     }
 
     /**
-     * Dynamically mounts a drive into the sync engine (e.g. when an add-on is activated
-     * mid-session, or during cold-boot bootstrap before [start] has flipped
-     * [isRunning] true).
+     * Mounts a drive into the sync engine — the sole [DriveSync] construction
+     * site. Called by [start] for mandatory drives, by [AuthConnectionCoordinator]
+     * during cold-boot bootstrap for optional add-on drives, and by add-on
+     * activation paths mid-session.
      *
      * Splits cleanly into "register" (in-memory bookkeeping — always runs once
      * credentials exist) and "kick a sync" (network I/O — only runs while the
      * manager is in the running state). A drive registered while paused/not-yet-
-     * started is picked up by the next [start]'s catch-up loop.
+     * started is picked up by the subsequent [syncAll] call after [start] flips
+     * [isRunning] true.
+     *
+     * Reads [expectFreshCursors] so any mount during the post-logout/pre-first-
+     * start window applies the stale-cursor safety check uniformly to mandatory
+     * and optional drives. [start] clears the flag once the first session-start
+     * sweep has run, so subsequent mid-session mounts default to false.
      */
     suspend fun mountDrive(driveId: Uuid, label: String) {
         val alreadyExists = driveSyncsMutex.withLock { driveSyncs.containsKey(driveId) }
@@ -243,7 +230,15 @@ class DriveSyncManager(
         }
 
         val sync = try {
-            DriveSync(identityId, driveId, driveQueryProvider, databaseManager, eventBus, scope)
+            DriveSync(
+                identityId = identityId,
+                driveId = driveId,
+                driveQueryProvider = driveQueryProvider,
+                databaseManager = databaseManager,
+                eventBus = eventBus,
+                scope = scope,
+                expectFreshCursor = expectFreshCursors,
+            )
         } catch (e: CancellationException) {
             // Don't swallow cancellation — let the caller's scope tear down cleanly.
             throw e
@@ -254,8 +249,8 @@ class DriveSyncManager(
         driveSyncsMutex.withLock { driveSyncs = driveSyncs + (driveId to sync) }
         _driveStatuses.update { it + (driveId to DriveStatus(driveId, label, DriveState.Initialized)) }
 
-        // Defer the network kick if the manager isn't running yet — start()'s
-        // catch-up loop will pick it up when isRunning flips true.
+        // Defer the network kick if the manager isn't running yet — the caller's
+        // post-start syncAll() will pick it up when isRunning flips true.
         if (isRunning) sync.sync()
     }
 

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncManagerTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncManagerTest.kt
@@ -59,7 +59,7 @@ class DriveSyncManagerTest {
                 eventBus = EventBus(),
                 scope = backgroundScope,
                 databaseManager = db,
-                drives = mapOf(driveId to "Test Drive"),
+                mandatoryDrives = mapOf(driveId to "Test Drive"),
             )
 
             manager.start()
@@ -97,7 +97,7 @@ class DriveSyncManagerTest {
                 eventBus = eventBus,
                 scope = backgroundScope,
                 databaseManager = db,
-                drives = mapOf(driveId to "Test Drive"),
+                mandatoryDrives = mapOf(driveId to "Test Drive"),
             )
 
             manager.start()
@@ -138,7 +138,7 @@ class DriveSyncManagerTest {
             eventBus = eventBus,
             scope = scope,
             databaseManager = db,
-            drives = drives,
+            mandatoryDrives = drives,
         )
     }
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -100,6 +100,13 @@ class AuthConnectionCoordinator(
                 // list before opening the WebSocket, so the first WS connect already
                 // subscribes to the full set — no late observer-driven reconnect.
                 val initialDrives = driveRegistry.bootstrap()
+                // Mandatory drives first, then optional. Both go through the same
+                // mountDrive() code path so failure modes are symmetric. start()
+                // (called later in connect()'s onConnected) is a no-op on already-
+                // mounted drives.
+                for (drive in mandatorySyncDrives) {
+                    driveSyncManager.mountDrive(drive.drive.alias, drive.label)
+                }
                 for (drive in initialDrives) {
                     driveSyncManager.mountDrive(drive.drive.alias, drive.label)
                 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/BackgroundSyncOrchestrator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/BackgroundSyncOrchestrator.kt
@@ -6,6 +6,7 @@ import id.homebase.api.client.drives.files.DriveFileHttpProvider
 import id.homebase.api.sync.DriveSyncManager
 import id.homebase.core.auth.AuthConnectionCoordinator
 import id.homebase.core.config.chatTargetDrive
+import id.homebase.core.config.mandatorySyncDrives
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -16,6 +17,7 @@ class BackgroundSyncOrchestrator(
     private val driveSyncManager: DriveSyncManager,
     private val driveFileHttpProvider: DriveFileHttpProvider,
     private val authConnectionCoordinator: AuthConnectionCoordinator,
+    private val driveRegistry: DriveRegistry,
 ) {
     suspend fun syncIfAuthenticated(): SyncOutcome {
         Logger.d(tag = "BackgroundSync") { "syncIfAuthenticated: checking..." }
@@ -31,6 +33,17 @@ class BackgroundSyncOrchestrator(
         }
         Logger.i(tag = "BackgroundSync") { "syncIfAuthenticated: WS offline — running background sync" }
         return runCatching {
+            // Mount mandatory + optional drives through the same single code path
+            // AuthConnectionCoordinator uses on its Authenticated transition. This
+            // makes background sync self-sufficient on every platform: when the
+            // app is launched directly into a background-fetch window (no prior
+            // WS session), optional drives like Vault/Moments still sync.
+            for (drive in mandatorySyncDrives) {
+                driveSyncManager.mountDrive(drive.drive.alias, drive.label)
+            }
+            for (drive in driveRegistry.bootstrap()) {
+                driveSyncManager.mountDrive(drive.drive.alias, drive.label)
+            }
             driveSyncManager.start()
 
             // processInbox no longer needed — server auto-processes on QueryBatch.

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -110,13 +110,14 @@ val appModule = module {
         )
     }
 
-    // Seeded with mandatory drives only — optional drives from the registry are cold-loaded
-    // into DriveSyncManager by AuthConnectionCoordinator after authentication, because
-    // reading the registry requires active credentials (not available at Koin time).
+    // Seeded with mandatory drives only — optional drives from the registry are
+    // mounted (via DriveSyncManager.mountDrive) by AuthConnectionCoordinator and
+    // BackgroundSyncOrchestrator after authentication, because reading the
+    // registry requires active credentials (not available at Koin time).
     single {
         DriveSyncManager(
             get(), get(), get(), get(), get(),
-            mandatorySyncDrives.associate { it.drive.alias to it.label },
+            mandatoryDrives = mandatorySyncDrives.associate { it.drive.alias to it.label },
         )
     }
 


### PR DESCRIPTION
DriveSyncManager had two drive-registration code paths: start() iterated a constructor-injected `drives: Map<Uuid, String>` and inline-constructed DriveSync for the mandatory set; mountDrive() constructed DriveSync separately for the optional add-on drives discovered from the cross-device registry. Two construction sites meant two error-handling styles (`runCatching{}.onFailure` vs `try/catch`) and asymmetric failure modes — a thrown DriveSync constructor exception in one path could silently leave its drives unsynced while the other path's drives synced normally, producing puzzling "only Vault and Moments are syncing" observations.

This refactor collapses to one construction path:

- mountDrive() is now the sole DriveSync construction site.
- start() bails on no-credentials, then calls mountDrive() for each entry in the renamed `mandatoryDrives` constructor parameter (idempotent — already-mounted drives early-return), flips isRunning=true, and resets expectFreshCursors=false.
- mountDrive() now reads expectFreshCursors so the post-logout stale- cursor safety net (previously only applied inside start()) covers mandatory and optional drives uniformly. start() consumes the flag once the session's first sweep has run, so subsequent mid-session mounts default to false.

Callers updated to mount everything up front, in the same order, via the same path:

- AuthConnectionCoordinator.onAuthStateChanged(Authenticated) now loops mandatorySyncDrives + driveRegistry.bootstrap() through mountDrive() before connect(). The later start() call in the WS onConnected callback is a no-op on the already-mounted drives — it just flips isRunning.
- BackgroundSyncOrchestrator gained a DriveRegistry dependency and performs the same mount dance before start()+syncAll(). Background sync is now self-sufficient on every platform (Android, Desktop, iOS) — optional drives like Vault sync on background-fetch entry even without a prior WebSocket session.

DriveSyncManagerTest's three constructor call sites were updated to the new `mandatoryDrives = ...` named arg. All assertions unchanged.

Verified: homebase-api / homebase-common / homebase-core compile clean on jvm, android, iosArm64; jvmTest green for homebase-api, homebase-common, homebase-chat, homebase-auth; androidApp:assembleDebug and desktopApp:assemble both green.