### PR TITLE
Event polish: reply chip, viewer-local timezones, .ics fix

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -991,11 +991,13 @@ internal class MessageActionsHandler(
             try {
                 val payloadBundle = payloadRenderers.toCombinedPayloadBundle(fileOperationsProvider)
 
+                val eventDescriptor = (replyTo.messageContent as? MessageContent.Event)?.descriptor
                 val replyPreview = ReplyPreview(
                     replyUniqueId = replyTo.id,
                     authorOdinId = replyTo.originalAuthor?.domainName ?: "null",
                     message = replyTo.content.truncateToCodePoints(80),
-                    previewThumbnail = replyTo.previewThumbnail
+                    previewThumbnail = replyTo.previewThumbnail,
+                    eventStartUtcMs = eventDescriptor?.startUtcMs,
                 )
                 val newMessageId = Uuid.random()
                 pendingMessageId = newMessageId

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -19,6 +19,7 @@ import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.LocalAttachmentContext
 import id.homebase.chat.services.LocalAttachmentContextStore
 import id.homebase.chat.services.MAX_REACTIONS_PER_USER_PER_MESSAGE
+import id.homebase.chat.services.ReplyContext
 import id.homebase.chat.services.ReplyPreview
 import id.homebase.chat.services.content.MessageContent
 import id.homebase.chat.services.builder.AttachmentInput
@@ -997,7 +998,7 @@ internal class MessageActionsHandler(
                     authorOdinId = replyTo.originalAuthor?.domainName ?: "null",
                     message = replyTo.content.truncateToCodePoints(80),
                     previewThumbnail = replyTo.previewThumbnail,
-                    eventStartUtcMs = eventDescriptor?.startUtcMs,
+                    context = eventDescriptor?.let { ReplyContext.event(it.startUtcMs) },
                 )
                 val newMessageId = Uuid.random()
                 pendingMessageId = newMessageId

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventBubble.kt
@@ -3,7 +3,6 @@ package id.homebase.chat.event
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -42,10 +41,9 @@ import id.homebase.resources.MR
 import id.homebase.resources.chat_event_live_now
 import id.homebase.resources.chat_event_past
 import id.homebase.resources.chat_event_starting_soon
+import id.homebase.resources.chat_event_scheduled_in_zone
 import id.homebase.resources.chat_event_unparseable
-import id.homebase.resources.chat_event_your_time_in_zone
 import kotlin.time.Clock
-import kotlin.time.Instant
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
 import kotlin.uuid.ExperimentalUuidApi
@@ -53,8 +51,6 @@ import kotlin.uuid.Uuid
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
 
 /**
@@ -102,15 +98,9 @@ fun EventBubble(
     var showDetail by remember(messageId) { mutableStateOf(false) }
     val canOpenDetail = messageId != null && conversationId != null
 
-    val tz = remember(descriptor.timezone) {
-        runCatching { TimeZone.of(descriptor.timezone) }.getOrElse { TimeZone.currentSystemDefault() }
-    }
-    val startLocal = remember(descriptor.startUtcMs, tz) {
-        Instant.fromEpochMilliseconds(descriptor.startUtcMs).toLocalDateTime(tz)
-    }
-    val endLocal = remember(descriptor.endUtcMs, tz) {
-        descriptor.endUtcMs?.let { Instant.fromEpochMilliseconds(it).toLocalDateTime(tz) }
-    }
+    val times = rememberEventTimes(descriptor)
+    val startLocal = times.viewerStartLocal
+    val endLocal = times.viewerEndLocal
 
     // 30-second ticker drives the live/starting-soon/past pill. Recomposes
     // only the pill subtree (the title and time rows are stable).
@@ -146,7 +136,7 @@ fun EventBubble(
     val effectiveContent = if (isPast) contentColor.copy(alpha = 0.55f) else contentColor
 
     Row(modifier = baseModifier, verticalAlignment = Alignment.Top) {
-        DateChip(startLocal, effectiveContent)
+        EventDateChip(local = startLocal, contentColor = effectiveContent)
         Spacer(Modifier.width(12.dp))
         Column(modifier = Modifier.fillMaxWidth()) {
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -163,21 +153,19 @@ fun EventBubble(
                 LiveStatusPill(phase = phase)
             }
             Spacer(Modifier.height(4.dp))
-            TimeRow(startLocal = startLocal, endLocal = endLocal, timezone = descriptor.timezone, contentColor = effectiveContent)
-            // When the event's IANA zone differs from the device zone, show the
-            // device-local time on a second line so cross-zone events read at
-            // a glance ("Tue 18:00 CET (your time: Tue 12:00 EST)").
-            val deviceTz = remember { TimeZone.currentSystemDefault() }
-            if (deviceTz.id != tz.id) {
-                val deviceLocal = remember(descriptor.startUtcMs, deviceTz) {
-                    Instant.fromEpochMilliseconds(descriptor.startUtcMs).toLocalDateTime(deviceTz)
-                }
+            // Primary time row is the viewer's local clock. Author's authoring
+            // zone is surfaced below as "Scheduled: …" only when it differs —
+            // that way cross-zone viewers read the event like a local calendar
+            // entry without losing the organizer's intended wall-clock.
+            TimeRow(startLocal = startLocal, endLocal = endLocal, timezone = times.viewerTz.id, contentColor = effectiveContent)
+            if (times.authoredStartLocal != null && times.authoredTzId != null) {
                 Spacer(Modifier.height(2.dp))
+                val authoredDayTime = "${times.authoredStartLocal.dayOfWeek.name.take(3)} ${formatTime(times.authoredStartLocal)}"
                 Text(
                     text = stringResource(
-                        MR.string.chat_event_your_time_in_zone,
-                        formatTime(deviceLocal),
-                        shortZone(deviceTz.id),
+                        MR.string.chat_event_scheduled_in_zone,
+                        authoredDayTime,
+                        shortZone(times.authoredTzId),
                     ),
                     style = MaterialTheme.typography.labelSmall,
                     color = effectiveContent.copy(alpha = 0.6f),
@@ -203,32 +191,6 @@ fun EventBubble(
             counts = remember(reactionSummary) { EventRsvp.counts(reactionSummary) },
             onDismiss = { showDetail = false },
             organizer = organizer,
-        )
-    }
-}
-
-@Composable
-private fun DateChip(local: LocalDateTime, contentColor: androidx.compose.ui.graphics.Color) {
-    Column(
-        modifier = Modifier
-            .clip(RoundedCornerShape(10.dp))
-            .background(MaterialTheme.colorScheme.primaryContainer)
-            .size(width = 56.dp, height = 64.dp)
-            .padding(vertical = 8.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-    ) {
-        Text(
-            text = local.month.name.take(3),
-            style = MaterialTheme.typography.labelSmall,
-            fontWeight = FontWeight.SemiBold,
-            color = MaterialTheme.colorScheme.onPrimaryContainer,
-        )
-        Text(
-            text = local.day.toString(),
-            style = MaterialTheme.typography.headlineSmall,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onPrimaryContainer,
         )
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventComposerSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventComposerSheet.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -290,7 +289,7 @@ private fun EventComposerContent(
 
             Box(modifier = Modifier.fillMaxWidth()) {
                 OutlinedTextField(
-                    value = timezone,
+                    value = friendlyZoneLabel(timezone),
                     onValueChange = {},
                     readOnly = true,
                     label = { Text(stringResource(MR.string.chat_event_field_timezone)) },
@@ -301,21 +300,16 @@ private fun EventComposerContent(
                         .matchParentSize()
                         .clickable(onClick = { tzExpanded = true })
                 )
-                androidx.compose.material3.DropdownMenu(
-                    expanded = tzExpanded,
-                    onDismissRequest = { tzExpanded = false },
-                ) {
-                    val zones = remember { TimeZone.availableZoneIds.sorted() }
-                    zones.forEach { id ->
-                        DropdownMenuItem(
-                            text = { Text(id) },
-                            onClick = {
-                                timezone = id
-                                tzExpanded = false
-                            }
-                        )
-                    }
-                }
+            }
+            if (tzExpanded) {
+                TimezonePickerSheet(
+                    currentZoneId = timezone,
+                    onPick = { picked ->
+                        timezone = picked
+                        tzExpanded = false
+                    },
+                    onDismiss = { tzExpanded = false },
+                )
             }
 
             OutlinedTextField(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventDateChip.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventDateChip.kt
@@ -1,0 +1,67 @@
+package id.homebase.chat.event
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import kotlinx.datetime.LocalDateTime
+
+@Composable
+fun EventDateChip(
+    local: LocalDateTime,
+    modifier: Modifier = Modifier,
+    containerColor: Color = MaterialTheme.colorScheme.primaryContainer,
+    contentColor: Color = MaterialTheme.colorScheme.onPrimaryContainer,
+    shape: Shape = RoundedCornerShape(10.dp),
+    compact: Boolean = false,
+    fillHeight: Boolean = false,
+) {
+    val width = if (compact) 40.dp else 56.dp
+    val height = if (compact) 44.dp else 64.dp
+    val verticalPadding = if (compact) 4.dp else 8.dp
+    val monthStyle = MaterialTheme.typography.labelSmall
+    val dayStyle = if (compact) MaterialTheme.typography.titleMedium else MaterialTheme.typography.headlineSmall
+
+    val sizeModifier = if (fillHeight) {
+        Modifier.width(width).fillMaxHeight()
+    } else {
+        Modifier.size(width = width, height = height)
+    }
+
+    Column(
+        modifier = modifier
+            .clip(shape)
+            .background(containerColor)
+            .then(sizeModifier)
+            .padding(vertical = verticalPadding),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = local.month.name.take(3),
+            style = monthStyle,
+            fontWeight = FontWeight.SemiBold,
+            color = contentColor,
+        )
+        Text(
+            text = local.day.toString(),
+            style = dayStyle,
+            fontWeight = FontWeight.Bold,
+            color = contentColor,
+        )
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventDetailDialog.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventDetailDialog.kt
@@ -65,14 +65,12 @@ import id.homebase.resources.chat_event_rsvp_maybe
 import id.homebase.resources.chat_event_rsvp_no
 import id.homebase.resources.chat_event_rsvp_summary
 import id.homebase.resources.chat_event_rsvp_yes
+import id.homebase.resources.chat_event_scheduled_in_zone
 import id.homebase.resources.menu_back
-import kotlin.time.Instant
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 
@@ -145,15 +143,7 @@ private fun EventDetailContent(
         value = runCatching { actionService.getReactions(messageId) }.getOrDefault(emptyList())
     }
 
-    val tz = remember(descriptor.timezone) {
-        runCatching { TimeZone.of(descriptor.timezone) }.getOrElse { TimeZone.currentSystemDefault() }
-    }
-    val startLocal = remember(descriptor.startUtcMs, tz) {
-        Instant.fromEpochMilliseconds(descriptor.startUtcMs).toLocalDateTime(tz)
-    }
-    val endLocal = remember(descriptor.endUtcMs, tz) {
-        descriptor.endUtcMs?.let { Instant.fromEpochMilliseconds(it).toLocalDateTime(tz) }
-    }
+    val times = rememberEventTimes(descriptor)
     val currentRsvp = remember(ownReactions) { EventRsvp.currentRsvp(ownReactions) }
 
     Scaffold(
@@ -179,7 +169,7 @@ private fun EventDetailContent(
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = 20.dp),
         ) {
-            HeroHeader(descriptor = descriptor, startLocal = startLocal, endLocal = endLocal)
+            HeroHeader(descriptor = descriptor, times = times)
 
             organizer?.let { host ->
                 Spacer(Modifier.height(12.dp))
@@ -487,9 +477,10 @@ private suspend fun applyRsvp(
 @Composable
 private fun HeroHeader(
     descriptor: EventDescriptor,
-    startLocal: LocalDateTime,
-    endLocal: LocalDateTime?,
+    times: EventTimes,
 ) {
+    val startLocal = times.viewerStartLocal
+    val endLocal = times.viewerEndLocal
     Row(verticalAlignment = Alignment.CenterVertically) {
         Box(
             modifier = Modifier
@@ -531,9 +522,25 @@ private fun HeroHeader(
                 )
                 Spacer(Modifier.width(6.dp))
                 Text(
-                    text = formatHero(startLocal, endLocal, descriptor.timezone),
+                    text = formatHero(startLocal, endLocal, times.viewerTz.id),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (times.authoredStartLocal != null && times.authoredTzId != null) {
+                Spacer(Modifier.height(2.dp))
+                val authoredDayTime = "${times.authoredStartLocal.dayOfWeek.name.take(3)} " +
+                    times.authoredStartLocal.hour.toString().padStart(2, '0') + ":" +
+                    times.authoredStartLocal.minute.toString().padStart(2, '0')
+                val authoredZoneShort = times.authoredTzId.substringAfterLast('/').replace('_', ' ')
+                Text(
+                    text = stringResource(
+                        MR.string.chat_event_scheduled_in_zone,
+                        authoredDayTime,
+                        authoredZoneShort,
+                    ),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.75f),
                 )
             }
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventTimes.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventTimes.kt
@@ -1,0 +1,59 @@
+package id.homebase.chat.event
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import kotlin.time.Instant
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+/**
+ * Viewer-first timezone view of an Event.
+ *
+ * `viewer*` fields are always populated, in the device's current zone.
+ * `authored*` fields are populated only when the event's authored zone
+ * differs from the device zone — letting callers conditionally render a
+ * "Scheduled: …" tagline that shows the organizer's intended clock without
+ * displacing the viewer's local time.
+ */
+data class EventTimes(
+    val viewerStartLocal: LocalDateTime,
+    val viewerEndLocal: LocalDateTime?,
+    val viewerTz: TimeZone,
+    val authoredStartLocal: LocalDateTime?,
+    val authoredEndLocal: LocalDateTime?,
+    val authoredTzId: String?,
+)
+
+/**
+ * Pure variant — testable. The composable [rememberEventTimes] is a thin
+ * wrapper that supplies `TimeZone.currentSystemDefault()` and memoizes.
+ */
+fun computeEventTimes(descriptor: EventDescriptor, viewerTz: TimeZone): EventTimes {
+    val authoredTz = runCatching { TimeZone.of(descriptor.timezone) }.getOrElse { viewerTz }
+    val viewerStart = Instant.fromEpochMilliseconds(descriptor.startUtcMs).toLocalDateTime(viewerTz)
+    val viewerEnd = descriptor.endUtcMs?.let {
+        Instant.fromEpochMilliseconds(it).toLocalDateTime(viewerTz)
+    }
+    val zonesDiffer = authoredTz.id != viewerTz.id
+    val authoredStart = if (zonesDiffer) {
+        Instant.fromEpochMilliseconds(descriptor.startUtcMs).toLocalDateTime(authoredTz)
+    } else null
+    val authoredEnd = if (zonesDiffer) {
+        descriptor.endUtcMs?.let { Instant.fromEpochMilliseconds(it).toLocalDateTime(authoredTz) }
+    } else null
+    return EventTimes(
+        viewerStartLocal = viewerStart,
+        viewerEndLocal = viewerEnd,
+        viewerTz = viewerTz,
+        authoredStartLocal = authoredStart,
+        authoredEndLocal = authoredEnd,
+        authoredTzId = if (zonesDiffer) authoredTz.id else null,
+    )
+}
+
+@Composable
+fun rememberEventTimes(descriptor: EventDescriptor): EventTimes =
+    remember(descriptor.startUtcMs, descriptor.endUtcMs, descriptor.timezone) {
+        computeEventTimes(descriptor, TimeZone.currentSystemDefault())
+    }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventTimes.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventTimes.kt
@@ -57,3 +57,18 @@ fun rememberEventTimes(descriptor: EventDescriptor): EventTimes =
     remember(descriptor.startUtcMs, descriptor.endUtcMs, descriptor.timezone) {
         computeEventTimes(descriptor, TimeZone.currentSystemDefault())
     }
+
+/**
+ * Convert a UTC instant to a date in the viewer's local zone. Used by the
+ * reply chip's self-contained path, where only the start instant is
+ * carried on the wire — authoring zone isn't needed because the chip
+ * renders in the viewer's zone, and viewer→viewer is just a UTC→local
+ * conversion.
+ */
+@Composable
+fun rememberViewerLocalDate(startUtcMs: Long): LocalDateTime {
+    val viewerTz = TimeZone.currentSystemDefault()
+    return remember(startUtcMs, viewerTz) {
+        Instant.fromEpochMilliseconds(startUtcMs).toLocalDateTime(viewerTz)
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/TimezonePicker.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/TimezonePicker.kt
@@ -244,9 +244,10 @@ private fun ZoneRow(zoneId: String, selected: Boolean, now: Instant, onClick: ()
             .clickable(onClick = onClick)
             .padding(horizontal = 20.dp, vertical = 10.dp),
     ) {
+        val cityWithOffset = "${cityName(zoneId)} · ${currentOffsetLabel(zoneId, now)}"
         Column {
             Text(
-                text = "${cityName(zoneId)} · ${currentOffsetLabel(zoneId, now)}",
+                text = cityWithOffset,
                 style = MaterialTheme.typography.bodyLarge,
                 color = onBg,
             )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/TimezonePicker.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/TimezonePicker.kt
@@ -1,0 +1,278 @@
+package id.homebase.chat.event
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import id.homebase.resources.MR
+import id.homebase.resources.chat_event_tz_picker_search
+import id.homebase.resources.chat_event_tz_picker_title
+import id.homebase.resources.chat_event_tz_region_africa
+import id.homebase.resources.chat_event_tz_region_americas
+import id.homebase.resources.chat_event_tz_region_antarctica
+import id.homebase.resources.chat_event_tz_region_arctic
+import id.homebase.resources.chat_event_tz_region_asia
+import id.homebase.resources.chat_event_tz_region_atlantic
+import id.homebase.resources.chat_event_tz_region_australia
+import id.homebase.resources.chat_event_tz_region_europe
+import id.homebase.resources.chat_event_tz_region_indian
+import id.homebase.resources.chat_event_tz_region_pacific
+import id.homebase.resources.chat_event_tz_suggested
+import kotlin.time.Clock
+import kotlin.time.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.offsetIn
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Friendly label for the form field and picker rows:
+ * "Europe/Copenhagen" → "Copenhagen (GMT+2)".
+ */
+internal fun friendlyZoneLabel(zoneId: String, now: Instant = Clock.System.now()): String {
+    val city = cityName(zoneId)
+    return "$city (${currentOffsetLabel(zoneId, now)})"
+}
+
+/**
+ * Offset of `zoneId` at `now`, formatted as `GMT±H` or `GMT±H:MM`
+ * (half-hour zones — India, Nepal, Newfoundland, Chatham — preserved).
+ */
+internal fun currentOffsetLabel(zoneId: String, now: Instant = Clock.System.now()): String {
+    val tz = runCatching { TimeZone.of(zoneId) }.getOrNull() ?: return "GMT"
+    val totalMinutes = now.offsetIn(tz).totalSeconds / 60
+    val sign = if (totalMinutes < 0) "-" else "+"
+    val absMin = kotlin.math.abs(totalMinutes)
+    val hours = absMin / 60
+    val mins = absMin % 60
+    return if (mins == 0) "GMT$sign$hours"
+    else "GMT$sign$hours:${mins.toString().padStart(2, '0')}"
+}
+
+/** Last IANA segment with underscores → spaces. UTC and other no-slash zones pass through. */
+internal fun cityName(zoneId: String): String =
+    if ('/' in zoneId) zoneId.substringAfterLast('/').replace('_', ' ') else zoneId
+
+/** Continent display name (English; the UI maps these to localized strings). */
+internal fun continentDisplayName(zoneId: String): String = when (zoneId.substringBefore('/', missingDelimiterValue = "")) {
+    "Africa" -> "Africa"
+    "America" -> "Americas"
+    "Antarctica" -> "Antarctica"
+    "Arctic" -> "Arctic"
+    "Asia" -> "Asia"
+    "Atlantic" -> "Atlantic"
+    "Australia" -> "Australia"
+    "Europe" -> "Europe"
+    "Indian" -> "Indian Ocean"
+    "Pacific" -> "Pacific"
+    else -> "Other"
+}
+
+/**
+ * Substring match (case-insensitive) against the IANA id, the friendly
+ * label (with offset), and the continent name. Lets users type either
+ * "kol", "kolkata", "asia", or "+5:30" to find Asia/Kolkata.
+ */
+internal fun matchesQuery(zoneId: String, query: String, now: Instant = Clock.System.now()): Boolean {
+    if (query.isBlank()) return true
+    val q = query.trim().lowercase()
+    if (zoneId.lowercase().contains(q)) return true
+    if (friendlyZoneLabel(zoneId, now).lowercase().contains(q)) return true
+    if (continentDisplayName(zoneId).lowercase().contains(q)) return true
+    return false
+}
+
+/** Filter to the user-facing IANA prefixes; drops Etc, SystemV and legacy aliases. */
+private fun isMainZone(zoneId: String): Boolean {
+    if ('/' !in zoneId) return false
+    val prefix = zoneId.substringBefore('/')
+    return prefix in mainPrefixes
+}
+
+private val mainPrefixes = setOf(
+    "Africa", "America", "Antarctica", "Arctic", "Asia",
+    "Atlantic", "Australia", "Europe", "Indian", "Pacific",
+)
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+fun TimezonePickerSheet(
+    currentZoneId: String,
+    onPick: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val deviceZoneId = remember { TimeZone.currentSystemDefault().id }
+    val now = remember { Clock.System.now() }
+
+    var query by remember { mutableStateOf("") }
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
+    // All "main" zones sorted by city name within each continent. UTC is
+    // surfaced separately in Suggested, not in the main grouped list.
+    val allMainZones = remember {
+        TimeZone.availableZoneIds
+            .filter { isMainZone(it) }
+            .sortedWith(compareBy({ continentDisplayName(it) }, { cityName(it) }))
+    }
+
+    val filtered by remember(query) {
+        derivedStateOf {
+            if (query.isBlank()) allMainZones
+            else allMainZones.filter { matchesQuery(it, query, now) }
+        }
+    }
+
+    val grouped by remember(filtered) {
+        derivedStateOf { filtered.groupBy(::continentDisplayName) }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(modifier = Modifier.fillMaxWidth().heightIn(min = 320.dp, max = 640.dp)) {
+            Text(
+                text = stringResource(MR.string.chat_event_tz_picker_title),
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
+            )
+            OutlinedTextField(
+                value = query,
+                onValueChange = { query = it },
+                singleLine = true,
+                placeholder = { Text(stringResource(MR.string.chat_event_tz_picker_search)) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 4.dp)
+                    .focusRequester(focusRequester),
+            )
+
+            val lazyState = rememberLazyListState()
+            LazyColumn(modifier = Modifier.fillMaxWidth(), state = lazyState) {
+                if (query.isBlank()) {
+                    stickyHeader {
+                        SectionHeader(stringResource(MR.string.chat_event_tz_suggested))
+                    }
+                    item {
+                        ZoneRow(
+                            zoneId = deviceZoneId,
+                            selected = deviceZoneId == currentZoneId,
+                            now = now,
+                            onClick = { onPick(deviceZoneId) },
+                        )
+                    }
+                    item {
+                        ZoneRow(
+                            zoneId = "UTC",
+                            selected = currentZoneId == "UTC",
+                            now = now,
+                            onClick = { onPick("UTC") },
+                        )
+                    }
+                }
+
+                grouped.forEach { (continent, zones) ->
+                    stickyHeader(key = "h-$continent") {
+                        SectionHeader(localizedContinentName(continent))
+                    }
+                    items(zones, key = { it }) { zoneId ->
+                        ZoneRow(
+                            zoneId = zoneId,
+                            selected = zoneId == currentZoneId,
+                            now = now,
+                            onClick = { onPick(zoneId) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(label: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = 20.dp, vertical = 8.dp),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.primary,
+        )
+    }
+}
+
+@Composable
+private fun ZoneRow(zoneId: String, selected: Boolean, now: Instant, onClick: () -> Unit) {
+    val bg = if (selected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surface
+    val onBg = if (selected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(bg)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 20.dp, vertical = 10.dp),
+    ) {
+        Column {
+            Text(
+                text = "${cityName(zoneId)} · ${currentOffsetLabel(zoneId, now)}",
+                style = MaterialTheme.typography.bodyLarge,
+                color = onBg,
+            )
+            Text(
+                text = zoneId,
+                style = MaterialTheme.typography.labelSmall,
+                color = onBg.copy(alpha = 0.6f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun localizedContinentName(english: String): String {
+    val resource: StringResource = when (english) {
+        "Africa" -> MR.string.chat_event_tz_region_africa
+        "Americas" -> MR.string.chat_event_tz_region_americas
+        "Antarctica" -> MR.string.chat_event_tz_region_antarctica
+        "Arctic" -> MR.string.chat_event_tz_region_arctic
+        "Asia" -> MR.string.chat_event_tz_region_asia
+        "Atlantic" -> MR.string.chat_event_tz_region_atlantic
+        "Australia" -> MR.string.chat_event_tz_region_australia
+        "Europe" -> MR.string.chat_event_tz_region_europe
+        "Indian Ocean" -> MR.string.chat_event_tz_region_indian
+        "Pacific" -> MR.string.chat_event_tz_region_pacific
+        else -> return english
+    }
+    return stringResource(resource)
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ReplyContext.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ReplyContext.kt
@@ -1,0 +1,76 @@
+package id.homebase.chat.services
+
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.longOrNull
+import kotlinx.serialization.json.put
+
+/**
+ * Typed view of [ReplyPreview.context]. Each known reply kind has its
+ * own variant; an unknown `kind` string falls through to [Unknown] so
+ * a renderer that doesn't recognise a future shape can degrade
+ * gracefully (default reply preview) rather than crash.
+ *
+ * Wire form is a small JsonObject with a "kind" string discriminator:
+ *
+ *     {"kind":"event","startUtcMs":1747094400000}
+ *     {"kind":"dice","faces":[6,4,3]}              // future
+ *     {"kind":"doodle","w":256,"h":256}            // future
+ *
+ * Adding a new kind:
+ *   1. Add a const KIND_X here.
+ *   2. Add a sealed subtype.
+ *   3. Add a parser arm in [fromJson].
+ *   4. Add a builder companion function (mirrors [event]).
+ *   5. Wire the dispatch in InlineReplyPreview / ReplyPreviewBar.
+ *
+ * Extending an existing kind (additive-only):
+ *   - You can add new optional fields to a kind's JSON shape at any
+ *     time — older clients ignore unknown keys and keep parsing the
+ *     fields they know (pinned by ReplyContextTest's forward-compat
+ *     case). Pull the new fields out in [fromJson] and add them to the
+ *     sealed subtype.
+ *   - Do NOT remove or rename existing fields, and do NOT change their
+ *     types. That breaks older parsers in the field. If you genuinely
+ *     need to replace a field, ship the new field alongside the old
+ *     and deprecate the old one over time.
+ */
+sealed interface ReplyContext {
+
+    /** Event reply: chip renders the viewer-local month/day from `startUtcMs`. */
+    data class Event(val startUtcMs: Long) : ReplyContext
+
+    /** Reply context whose `kind` we don't recognise — render as a default reply preview. */
+    data object Unknown : ReplyContext
+
+    companion object {
+        const val KIND_EVENT = "event"
+
+        /**
+         * Parse a wire-side [JsonElement] into a typed [ReplyContext].
+         *
+         * Returns `null` when no context was attached (pre-feature senders or
+         * non-typed replies). Returns [Unknown] when the discriminator is
+         * present but unrecognised — that lets renderers degrade gracefully.
+         */
+        fun fromJson(element: JsonElement?): ReplyContext? {
+            val obj = element as? JsonObject ?: return null
+            val kind = (obj["kind"] as? JsonPrimitive)?.content ?: return Unknown
+            return when (kind) {
+                KIND_EVENT -> {
+                    val ts = (obj["startUtcMs"] as? JsonPrimitive)?.longOrNull
+                    if (ts != null) Event(ts) else Unknown
+                }
+                else -> Unknown
+            }
+        }
+
+        /** Build an Event-kind context for [ReplyPreview.context]. */
+        fun event(startUtcMs: Long): JsonObject = buildJsonObject {
+            put("kind", KIND_EVENT)
+            put("startUtcMs", startUtcMs)
+        }
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ReplyPreview.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ReplyPreview.kt
@@ -3,6 +3,7 @@ package id.homebase.chat.services
 import androidx.compose.runtime.Immutable
 import id.homebase.api.client.drives.upload.EmbeddedThumb
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 import kotlin.uuid.Uuid
 
 @Serializable
@@ -13,12 +14,10 @@ data class ReplyPreview(
     val message: String, // chopped chars (IDK how many you use? 40? 80? use truncateToCodePoints(80)
     val previewThumbnail: EmbeddedThumb? =
         null, // Real thumb via replyUniqueId, null for text-only messages
-    // When the replied-to message is an Event, the start instant (UTC) lets
-    // the reply chip render the viewer's local month/day without looking up
-    // the parent message (which may be paged out, deleted, or never
-    // received). Null for non-Event replies and for replies sent by older
-    // clients — consumer falls back to parent-message lookup in that case.
-    // Authoring zone is intentionally not carried: the chip displays in the
-    // viewer's local zone, so UTC alone is sufficient.
-    val eventStartUtcMs: Long? = null,
+    // Kind-specific extras the reply preview renderer can use without
+    // looking up the parent message. Small JsonObject with a "kind"
+    // discriminator; see [ReplyContext] for known shapes. Null for plain
+    // text/media replies and for replies sent by clients that pre-date
+    // this field — consumers fall back to default rendering in that case.
+    val context: JsonElement? = null,
 ) // Tiny tiny thumb, can be even smaller than tinyThumb even a 1px color

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ReplyPreview.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ReplyPreview.kt
@@ -12,5 +12,13 @@ data class ReplyPreview(
     val authorOdinId: String, // frodo.baggins.demo.rocks
     val message: String, // chopped chars (IDK how many you use? 40? 80? use truncateToCodePoints(80)
     val previewThumbnail: EmbeddedThumb? =
-        null // Real thumb via replyUniqueId, null for text-only messages
+        null, // Real thumb via replyUniqueId, null for text-only messages
+    // When the replied-to message is an Event, the start instant (UTC) lets
+    // the reply chip render the viewer's local month/day without looking up
+    // the parent message (which may be paged out, deleted, or never
+    // received). Null for non-Event replies and for replies sent by older
+    // clients — consumer falls back to parent-message lookup in that case.
+    // Authoring zone is intentionally not carried: the chip displays in the
+    // viewer's local zone, so UTC alone is sufficient.
+    val eventStartUtcMs: Long? = null,
 ) // Tiny tiny thumb, can be even smaller than tinyThumb even a 1px color

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -70,6 +70,7 @@ import id.homebase.chat.conversationlist.UploadStatus
 import id.homebase.chat.data.MessageUiModel
 import id.homebase.chat.event.EventDateChip
 import id.homebase.chat.event.rememberEventTimes
+import id.homebase.chat.event.rememberViewerLocalDate
 import id.homebase.chat.services.ChatDeliveryStatus
 import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.MessageAppData
@@ -935,8 +936,18 @@ fun InlineReplyPreview(
         firstPayload = mediaPayloads.firstOrNull(),
         hasMultiplePayloads = mediaPayloads.size > 1,
     )
-    val eventDescriptor = (replyMessage?.messageContent as? MessageContent.Event)?.descriptor
-    val eventStartLocal = eventDescriptor?.let { rememberEventTimes(it).viewerStartLocal }
+    // Prefer the self-contained wire field on ReplyPreview (so the chip
+    // renders even when the parent event message is paged out, deleted, or
+    // never received). Fall back to the parent-message lookup for replies
+    // sent by older clients that don't populate it.
+    val eventStartLocal = when {
+        replyPreview.eventStartUtcMs != null ->
+            rememberViewerLocalDate(replyPreview.eventStartUtcMs)
+        else -> {
+            val eventDescriptor = (replyMessage?.messageContent as? MessageContent.Event)?.descriptor
+            eventDescriptor?.let { rememberEventTimes(it).viewerStartLocal }
+        }
+    }
     val displayMessage = resolveReplyContentText(
         replyText = replyPreview.message,
         contentLabelText = contentLabel?.text,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalClipboard
@@ -67,10 +68,13 @@ import id.homebase.chat.conversationlist.DecryptedFileKey
 import id.homebase.chat.conversationlist.MessageClusterPosition
 import id.homebase.chat.conversationlist.UploadStatus
 import id.homebase.chat.data.MessageUiModel
+import id.homebase.chat.event.EventDateChip
+import id.homebase.chat.event.rememberEventTimes
 import id.homebase.chat.services.ChatDeliveryStatus
 import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.MessageAppData
 import id.homebase.chat.services.ReplyPreview
+import id.homebase.chat.services.content.MessageContent
 import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.PublicAvatar
 import id.homebase.core.clipboard.clipEntryOf
@@ -931,6 +935,8 @@ fun InlineReplyPreview(
         firstPayload = mediaPayloads.firstOrNull(),
         hasMultiplePayloads = mediaPayloads.size > 1,
     )
+    val eventDescriptor = (replyMessage?.messageContent as? MessageContent.Event)?.descriptor
+    val eventStartLocal = eventDescriptor?.let { rememberEventTimes(it).viewerStartLocal }
     val displayMessage = resolveReplyContentText(
         replyText = replyPreview.message,
         contentLabelText = contentLabel?.text,
@@ -997,8 +1003,21 @@ fun InlineReplyPreview(
                     }
                 }
             }
-        // Thumbnail image — prefer HomebaseImage, fall back to embedded bitmap
-        if (imageData != null) {
+        // Event date badge takes the trailing slot for event replies; it spans
+        // the full bubble height and runs flush to the right edge — the parent
+        // Row's clip(RoundedCornerShape(...)) carves the chip's right corners
+        // to match the bubble, while RectangleShape here keeps the left side
+        // flat so the chip reads as part of the bubble.
+        if (eventStartLocal != null) {
+            EventDateChip(
+                local = eventStartLocal,
+                compact = true,
+                fillHeight = true,
+                shape = RectangleShape,
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                contentColor = MaterialTheme.colorScheme.onSurface,
+            )
+        } else if (imageData != null) {
             HomebaseImage(
                 imageData = imageData,
                 modifier = Modifier

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -74,6 +74,7 @@ import id.homebase.chat.event.rememberViewerLocalDate
 import id.homebase.chat.services.ChatDeliveryStatus
 import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.MessageAppData
+import id.homebase.chat.services.ReplyContext
 import id.homebase.chat.services.ReplyPreview
 import id.homebase.chat.services.content.MessageContent
 import id.homebase.core.avatars.AvatarOptions
@@ -936,14 +937,16 @@ fun InlineReplyPreview(
         firstPayload = mediaPayloads.firstOrNull(),
         hasMultiplePayloads = mediaPayloads.size > 1,
     )
-    // Prefer the self-contained wire field on ReplyPreview (so the chip
-    // renders even when the parent event message is paged out, deleted, or
-    // never received). Fall back to the parent-message lookup for replies
-    // sent by older clients that don't populate it.
-    val eventStartLocal = when {
-        replyPreview.eventStartUtcMs != null ->
-            rememberViewerLocalDate(replyPreview.eventStartUtcMs)
-        else -> {
+    // Dispatch on the typed ReplyContext carried on the wire — that's how
+    // the renderer knows it's an event reply without looking up the parent.
+    // Pre-context senders leave it null; we fall back to a parent-message
+    // lookup so old replies still get the chip when the parent is in
+    // memory. Future kinds parse as Unknown → default reply preview, no
+    // crash.
+    val eventStartLocal = when (val ctx = ReplyContext.fromJson(replyPreview.context)) {
+        is ReplyContext.Event -> rememberViewerLocalDate(ctx.startUtcMs)
+        ReplyContext.Unknown -> null
+        null -> {
             val eventDescriptor = (replyMessage?.messageContent as? MessageContent.Event)?.descriptor
             eventDescriptor?.let { rememberEventTimes(it).viewerStartLocal }
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ReplyPreviewBar.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ReplyPreviewBar.kt
@@ -27,7 +27,10 @@ import androidx.compose.ui.unit.dp
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.util.truncateToCodePoints
 import id.homebase.chat.data.MessageUiModel
+import id.homebase.chat.event.EventDateChip
+import id.homebase.chat.event.rememberEventTimes
 import id.homebase.chat.services.ChatProtocol
+import id.homebase.chat.services.content.MessageContent
 import id.homebase.core.config.chatTargetDrive
 import id.homebase.core.image.HomebaseImage
 import id.homebase.core.image.HomebaseImageData
@@ -101,6 +104,9 @@ fun ReplyPreviewBar(message: MessageUiModel, onDismiss: () -> Unit, modifier: Mo
 
     val previewText = contentLabel?.text ?: message.content.truncateToCodePoints(80)
 
+    val eventDescriptor = (message.messageContent as? MessageContent.Event)?.descriptor
+    val eventStartLocal = eventDescriptor?.let { rememberEventTimes(it).viewerStartLocal }
+
     Surface(
         modifier = modifier.fillMaxWidth(),
         shape = RoundedCornerShape(12.dp),
@@ -147,8 +153,12 @@ fun ReplyPreviewBar(message: MessageUiModel, onDismiss: () -> Unit, modifier: Mo
                 }
             }
 
-            // Thumbnail if visual media
-            if (thumbnailData != null) {
+            // Event date badge — replaces media thumbnail when replying to an event
+            if (eventStartLocal != null) {
+                Spacer(modifier = Modifier.width(8.dp))
+                EventDateChip(local = eventStartLocal)
+            } else if (thumbnailData != null) {
+                // Thumbnail if visual media
                 Spacer(modifier = Modifier.width(8.dp))
                 HomebaseImage(
                     imageData = thumbnailData,

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/event/EventTimesTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/event/EventTimesTest.kt
@@ -1,0 +1,44 @@
+package id.homebase.chat.event
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+
+class EventTimesTest {
+
+    /**
+     * Tokyo author schedules May 12 09:00 JST. A viewer in Los Angeles is
+     * still on May 11 17:00 PDT at that instant. The reply chip / bubble
+     * should show the viewer's date (May 11), while the "Scheduled: …"
+     * tagline carries the author's day-of-week + time (Tue 09:00 Tokyo).
+     */
+    @Test
+    fun cross_zone_event_shows_viewer_local_date_and_carries_author_tagline() {
+        val tokyo = TimeZone.of("Asia/Tokyo")
+        val la = TimeZone.of("America/Los_Angeles")
+        val authored = LocalDateTime(2026, 5, 12, 9, 0)
+        val startUtcMs = authored.toInstant(tokyo).toEpochMilliseconds()
+
+        val descriptor = EventDescriptor(
+            title = "Standup",
+            startUtcMs = startUtcMs,
+            timezone = tokyo.id,
+        )
+
+        val times = computeEventTimes(descriptor, viewerTz = la)
+
+        assertEquals(LocalDateTime(2026, 5, 11, 17, 0), times.viewerStartLocal)
+        assertEquals(la, times.viewerTz)
+
+        assertNotNull(times.authoredStartLocal, "authoredStartLocal must be non-null when zones differ")
+        assertEquals(LocalDateTime(2026, 5, 12, 9, 0), times.authoredStartLocal)
+        assertEquals(tokyo.id, times.authoredTzId)
+
+        assertNull(times.viewerEndLocal)
+        assertNull(times.authoredEndLocal)
+    }
+}

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/event/GoogleCalendarUrlTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/event/GoogleCalendarUrlTest.kt
@@ -1,0 +1,75 @@
+package id.homebase.chat.event
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+
+/**
+ * Pins the Google Calendar "add to calendar" URL format. Google parses
+ * `dates=` as compact UTC and uses `ctz=` to pre-select the zone in the
+ * create-event form — so the URL must carry both the exact UTC instant
+ * and the author's IANA zone.
+ */
+class GoogleCalendarUrlTest {
+
+    @Test
+    fun tokyo_event_url_carries_utc_dates_and_ctz_in_authors_zone() {
+        val startMs = LocalDateTime(2026, 5, 12, 9, 0)
+            .toInstant(TimeZone.of("Asia/Tokyo"))
+            .toEpochMilliseconds()
+        val descriptor = EventDescriptor(
+            title = "Team Standup",
+            description = "weekly sync",
+            startUtcMs = startMs,
+            endUtcMs = startMs + 60 * 60_000L,
+            timezone = "Asia/Tokyo",
+            locationText = "Shibuya HQ",
+        )
+
+        val url = googleCalendarUrl(descriptor)
+
+        assertTrue(url.startsWith("https://calendar.google.com/calendar/render?"), "endpoint wrong: $url")
+        // 09:00 JST == 00:00 UTC; +1h == 01:00 UTC. The "/" between start and end
+        // is URL-encoded to %2F by urlEncode (it doesn't whitelist slash).
+        assertTrue("dates=20260512T000000Z%2F20260512T010000Z" in url, "UTC dates wrong: $url")
+        assertTrue("ctz=Asia%2FTokyo" in url, "ctz must be the author's IANA zone (URL-encoded): $url")
+        assertTrue("text=Team+Standup" in url, "spaces in title must encode as '+': $url")
+        assertTrue("details=weekly+sync" in url)
+        assertTrue("location=Shibuya+HQ" in url)
+    }
+
+    @Test
+    fun missing_end_defaults_to_start_plus_one_hour() {
+        val startMs = LocalDateTime(2026, 5, 12, 9, 0)
+            .toInstant(TimeZone.UTC)
+            .toEpochMilliseconds()
+        val url = googleCalendarUrl(
+            EventDescriptor(
+                title = "x",
+                description = "",
+                startUtcMs = startMs,
+                endUtcMs = null,
+                timezone = "UTC",
+            )
+        )
+        assertTrue("dates=20260512T090000Z%2F20260512T100000Z" in url, "1h default wrong: $url")
+    }
+
+    @Test
+    fun special_chars_in_title_are_percent_encoded() {
+        val url = googleCalendarUrl(
+            EventDescriptor(
+                title = "Q&A: TZ test (½h)",
+                description = "",
+                startUtcMs = 0L,
+                timezone = "UTC",
+            )
+        )
+        // & and : and ( ) and ½ must not appear unencoded as URL syntax chars.
+        val textParam = url.substringAfter("text=").substringBefore("&")
+        assertEquals("Q%26A%3A+TZ+test+%28%C2%BDh%29", textParam, "title encoding wrong: $textParam")
+    }
+}

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/event/TimezonePickerHelpersTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/event/TimezonePickerHelpersTest.kt
@@ -1,0 +1,68 @@
+package id.homebase.chat.event
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+
+class TimezonePickerHelpersTest {
+
+    // May 15, noon UTC — gives:
+    //   Europe/Copenhagen → CEST → GMT+2
+    //   America/Los_Angeles → PDT  → GMT-7
+    //   Asia/Kolkata        → IST  → GMT+5:30
+    private val mayInstant =
+        LocalDateTime(2026, 5, 15, 12, 0).toInstant(TimeZone.UTC)
+
+    // Jan 15, noon UTC — gives:
+    //   Europe/Copenhagen → CET → GMT+1
+    //   America/Los_Angeles → PST → GMT-8
+    private val janInstant =
+        LocalDateTime(2026, 1, 15, 12, 0).toInstant(TimeZone.UTC)
+
+    @Test
+    fun friendly_label_copenhagen_summer() {
+        assertEquals("Copenhagen (GMT+2)", friendlyZoneLabel("Europe/Copenhagen", mayInstant))
+    }
+
+    @Test
+    fun friendly_label_kolkata_half_hour_offset() {
+        // Pins the half-hour offset path — easy to break with a "minutes / 60" refactor.
+        assertEquals("Kolkata (GMT+5:30)", friendlyZoneLabel("Asia/Kolkata", mayInstant))
+    }
+
+    @Test
+    fun friendly_label_los_angeles_winter() {
+        assertEquals("Los Angeles (GMT-8)", friendlyZoneLabel("America/Los_Angeles", janInstant))
+    }
+
+    @Test
+    fun friendly_label_los_angeles_summer() {
+        assertEquals("Los Angeles (GMT-7)", friendlyZoneLabel("America/Los_Angeles", mayInstant))
+    }
+
+    @Test
+    fun friendly_label_utc_special_case() {
+        // No slash — passes through whole and gets GMT+0.
+        assertEquals("UTC (GMT+0)", friendlyZoneLabel("UTC", mayInstant))
+    }
+
+    @Test
+    fun matches_query_by_city_prefix() {
+        assertTrue(matchesQuery("Asia/Kolkata", "kol", mayInstant))
+    }
+
+    @Test
+    fun matches_query_by_offset_string() {
+        // Offset substring should land — lets users type "+5:30" to find IST.
+        assertTrue(matchesQuery("Asia/Kolkata", "+5:30", mayInstant))
+    }
+
+    @Test
+    fun matches_query_rejects_unrelated_continent() {
+        assertFalse(matchesQuery("Europe/Berlin", "asia", mayInstant))
+    }
+}

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/services/ReplyContextTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/services/ReplyContextTest.kt
@@ -1,0 +1,82 @@
+package id.homebase.chat.services
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+class ReplyContextTest {
+
+    @Test
+    fun null_input_returns_null() {
+        // No context attached at all — pre-feature senders, plain replies.
+        assertNull(ReplyContext.fromJson(null))
+    }
+
+    @Test
+    fun event_kind_parses_to_typed_event() {
+        val json = buildJsonObject {
+            put("kind", "event")
+            put("startUtcMs", 1747094400000L)
+        }
+        val ctx = ReplyContext.fromJson(json)
+        assertIs<ReplyContext.Event>(ctx)
+        assertEquals(1747094400000L, ctx.startUtcMs)
+    }
+
+    @Test
+    fun event_kind_missing_start_falls_to_unknown() {
+        val json = buildJsonObject { put("kind", "event") }
+        // Malformed event context shouldn't crash the renderer — degrade to Unknown.
+        assertEquals(ReplyContext.Unknown, ReplyContext.fromJson(json))
+    }
+
+    @Test
+    fun unknown_kind_falls_to_unknown() {
+        // A future "doodle" or "poll" kind on an old client falls through here.
+        val json = buildJsonObject { put("kind", "doodle") }
+        assertEquals(ReplyContext.Unknown, ReplyContext.fromJson(json))
+    }
+
+    @Test
+    fun missing_kind_field_falls_to_unknown() {
+        val json = buildJsonObject { put("startUtcMs", 1747094400000L) }
+        assertEquals(ReplyContext.Unknown, ReplyContext.fromJson(json))
+    }
+
+    @Test
+    fun non_object_input_returns_null() {
+        // A bare primitive isn't a valid context — treat as "no context".
+        assertNull(ReplyContext.fromJson(JsonPrimitive("event")))
+    }
+
+    @Test
+    fun event_builder_round_trips() {
+        val built: JsonObject = ReplyContext.event(1747094400000L)
+        val parsed = ReplyContext.fromJson(built)
+        assertEquals(ReplyContext.Event(1747094400000L), parsed)
+    }
+
+    @Test
+    fun event_kind_ignores_unknown_fields_for_forward_compat() {
+        // If a future client adds optional fields to the event context (e.g.
+        // durationMin, colorHint, recurrenceRule), this client must keep
+        // parsing the fields it knows and ignore the rest — that's how
+        // additive-only changes ship without coordination. Pin the
+        // behaviour so a future refactor can't quietly tighten the parser.
+        val json = buildJsonObject {
+            put("kind", "event")
+            put("startUtcMs", 1747094400000L)
+            put("durationMin", 60)
+            put("colorHint", "#FF0000")
+            put("organizerOdinId", "frodo.baggins.demo.rocks")
+        }
+        val ctx = ReplyContext.fromJson(json)
+        assertIs<ReplyContext.Event>(ctx)
+        assertEquals(1747094400000L, ctx.startUtcMs)
+    }
+}

--- a/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/event/CalendarLauncher.jvm.kt
+++ b/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/event/CalendarLauncher.jvm.kt
@@ -6,6 +6,10 @@ import co.touchlab.kermit.Logger
 import java.awt.Desktop
 import java.io.File
 import java.text.SimpleDateFormat
+import java.time.Instant as JInstant
+import java.time.LocalDateTime as JLocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
@@ -36,48 +40,101 @@ private class JvmCalendarLauncher : CalendarLauncher {
             Logger.e(tag = TAG, throwable = t) { "Failed to generate / open .ics" }
         }
     }
-
-    /**
-     * RFC-5545 compliant .ics for a single VEVENT. Date/time is emitted as
-     * UTC ("Z" suffix) which all calendar apps accept regardless of the
-     * descriptor's IANA zone — the wall-clock time the user picked is
-     * preserved by the UTC milliseconds.
-     */
-    private fun buildIcs(event: EventDescriptor, messageId: Uuid): String {
-        val fmt = SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'", Locale.US).apply {
-            timeZone = TimeZone.getTimeZone("UTC")
-        }
-        val now = fmt.format(Date())
-        val start = fmt.format(Date(event.startUtcMs))
-        val end = fmt.format(Date(event.endUtcMs ?: (event.startUtcMs + 60L * 60L * 1000L)))
-        val uid = "$messageId@homebase"
-
-        return buildString {
-            append("BEGIN:VCALENDAR\r\n")
-            append("VERSION:2.0\r\n")
-            append("PRODID:-//Homebase//Chat//EN\r\n")
-            append("CALSCALE:GREGORIAN\r\n")
-            append("BEGIN:VEVENT\r\n")
-            append("UID:").append(uid).append("\r\n")
-            append("DTSTAMP:").append(now).append("\r\n")
-            append("DTSTART:").append(start).append("\r\n")
-            append("DTEND:").append(end).append("\r\n")
-            append("SUMMARY:").append(escapeIcs(event.title)).append("\r\n")
-            if (event.description.isNotBlank()) {
-                append("DESCRIPTION:").append(escapeIcs(event.description)).append("\r\n")
-            }
-            event.locationText?.let { append("LOCATION:").append(escapeIcs(it)).append("\r\n") }
-            event.meetingUrl?.let { append("URL:").append(it).append("\r\n") }
-            append("END:VEVENT\r\n")
-            append("END:VCALENDAR\r\n")
-        }
-    }
-
-    /** Escape per RFC-5545 §3.3.11: backslash, semicolon, comma, newlines. */
-    private fun escapeIcs(s: String): String =
-        s.replace("\\", "\\\\")
-            .replace(";", "\\;")
-            .replace(",", "\\,")
-            .replace("\r\n", "\\n")
-            .replace("\n", "\\n")
 }
+
+/**
+ * RFC-5545 compliant .ics for a single VEVENT.
+ *
+ * When `event.timezone` parses as a valid IANA zone we emit
+ * `DTSTART;TZID=…:<local>` plus a `VTIMEZONE` block so importing
+ * calendars preserve the **author's** wall-clock and zone label
+ * (e.g. "Tue 09:00 JST" stays "JST" in Outlook even on a Berlin
+ * machine). When the zone is unparseable we fall back to plain UTC
+ * (`…Z` suffix) — the moment in time is still exact, just unlabeled.
+ *
+ * Single-instance events only: the VTIMEZONE block declares a single
+ * STANDARD sub-component carrying the offset valid at the event
+ * start. No DST transitions are encoded because none of our events
+ * recur — they're single VEVENTs whose start/end are minutes to
+ * hours apart, so they share one offset.
+ *
+ * `dtstampOverride` is for tests — production calls let it default
+ * to `null` and stamps with `Date()`.
+ */
+@OptIn(ExperimentalUuidApi::class)
+internal fun buildIcs(
+    event: EventDescriptor,
+    messageId: Uuid,
+    dtstampOverride: Date? = null,
+): String {
+    val utcFmt = SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'", Locale.US).apply {
+        timeZone = TimeZone.getTimeZone("UTC")
+    }
+    val dtstamp = utcFmt.format(dtstampOverride ?: Date())
+    val endMs = event.endUtcMs ?: (event.startUtcMs + 60L * 60L * 1000L)
+    val uid = "$messageId@homebase"
+
+    val zoneId = runCatching { ZoneId.of(event.timezone) }.getOrNull()
+
+    return buildString {
+        append("BEGIN:VCALENDAR\r\n")
+        append("VERSION:2.0\r\n")
+        append("PRODID:-//Homebase//Chat//EN\r\n")
+        append("CALSCALE:GREGORIAN\r\n")
+        if (zoneId != null) {
+            appendVTimezone(zoneId, JInstant.ofEpochMilli(event.startUtcMs))
+        }
+        append("BEGIN:VEVENT\r\n")
+        append("UID:").append(uid).append("\r\n")
+        append("DTSTAMP:").append(dtstamp).append("\r\n")
+        if (zoneId != null) {
+            append("DTSTART;TZID=").append(zoneId.id).append(":")
+                .append(formatLocal(event.startUtcMs, zoneId)).append("\r\n")
+            append("DTEND;TZID=").append(zoneId.id).append(":")
+                .append(formatLocal(endMs, zoneId)).append("\r\n")
+        } else {
+            append("DTSTART:").append(utcFmt.format(Date(event.startUtcMs))).append("\r\n")
+            append("DTEND:").append(utcFmt.format(Date(endMs))).append("\r\n")
+        }
+        append("SUMMARY:").append(escapeIcs(event.title)).append("\r\n")
+        if (event.description.isNotBlank()) {
+            append("DESCRIPTION:").append(escapeIcs(event.description)).append("\r\n")
+        }
+        event.locationText?.let { append("LOCATION:").append(escapeIcs(it)).append("\r\n") }
+        event.meetingUrl?.let { append("URL:").append(it).append("\r\n") }
+        append("END:VEVENT\r\n")
+        append("END:VCALENDAR\r\n")
+    }
+}
+
+private val localFmt = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss", Locale.US)
+
+private fun formatLocal(epochMs: Long, zone: ZoneId): String =
+    JLocalDateTime.ofInstant(JInstant.ofEpochMilli(epochMs), zone).format(localFmt)
+
+private fun StringBuilder.appendVTimezone(zone: ZoneId, at: JInstant) {
+    val offsetSeconds = zone.rules.getOffset(at).totalSeconds
+    val sign = if (offsetSeconds < 0) "-" else "+"
+    val absMin = kotlin.math.abs(offsetSeconds) / 60
+    val hh = (absMin / 60).toString().padStart(2, '0')
+    val mm = (absMin % 60).toString().padStart(2, '0')
+    val offset = "$sign$hh$mm"
+    val tzName = zone.id.substringAfterLast('/').replace('_', ' ')
+    append("BEGIN:VTIMEZONE\r\n")
+    append("TZID:").append(zone.id).append("\r\n")
+    append("BEGIN:STANDARD\r\n")
+    append("DTSTART:19700101T000000\r\n")
+    append("TZOFFSETFROM:").append(offset).append("\r\n")
+    append("TZOFFSETTO:").append(offset).append("\r\n")
+    append("TZNAME:").append(tzName).append("\r\n")
+    append("END:STANDARD\r\n")
+    append("END:VTIMEZONE\r\n")
+}
+
+/** Escape per RFC-5545 §3.3.11: backslash, semicolon, comma, newlines. */
+private fun escapeIcs(s: String): String =
+    s.replace("\\", "\\\\")
+        .replace(";", "\\;")
+        .replace(",", "\\,")
+        .replace("\r\n", "\\n")
+        .replace("\n", "\\n")

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/event/IcsExportTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/event/IcsExportTest.kt
@@ -1,0 +1,97 @@
+package id.homebase.chat.event
+
+import java.util.Date
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+
+/**
+ * Pins the wire format of the .ics export. These assertions describe
+ * what RFC-5545 consumers (Apple Calendar, Outlook, Google Calendar,
+ * Thunderbird, GNOME Calendar) actually read, so a change here
+ * means the imported invite would land at the wrong time or with
+ * the wrong zone label.
+ */
+@OptIn(ExperimentalUuidApi::class)
+class IcsExportTest {
+
+    private val fixedUid = Uuid.fromLongs(1L, 2L)
+    private val fixedStamp = Date(0L)
+
+    private fun descriptor(
+        tz: String,
+        local: LocalDateTime,
+        durationMin: Long = 60,
+    ): EventDescriptor {
+        val zone = runCatching { TimeZone.of(tz) }.getOrDefault(TimeZone.UTC)
+        val startMs = local.toInstant(zone).toEpochMilliseconds()
+        return EventDescriptor(
+            title = "Standup",
+            description = "",
+            startUtcMs = startMs,
+            endUtcMs = startMs + durationMin * 60_000L,
+            timezone = tz,
+        )
+    }
+
+    @Test
+    fun tokyo_event_emits_tzid_local_times_and_vtimezone_with_plus_0900() {
+        val ics = buildIcs(
+            event = descriptor("Asia/Tokyo", LocalDateTime(2026, 5, 12, 9, 0)),
+            messageId = fixedUid,
+            dtstampOverride = fixedStamp,
+        )
+
+        assertTrue("BEGIN:VTIMEZONE" in ics, "VTIMEZONE block missing:\n$ics")
+        assertTrue("TZID:Asia/Tokyo" in ics, "TZID line missing")
+        assertTrue("TZOFFSETFROM:+0900" in ics, "JST offset wrong")
+        assertTrue("TZOFFSETTO:+0900" in ics)
+        assertTrue("DTSTART;TZID=Asia/Tokyo:20260512T090000" in ics, "DTSTART wrong:\n$ics")
+        assertTrue("DTEND;TZID=Asia/Tokyo:20260512T100000" in ics)
+        // DTSTART must NOT be UTC when a zone is supplied.
+        assertFalse("DTSTART:20260512" in ics, "should not emit UTC DTSTART alongside TZID:\n$ics")
+    }
+
+    @Test
+    fun los_angeles_event_emits_negative_offset() {
+        // May is PDT (UTC−7).
+        val ics = buildIcs(
+            event = descriptor("America/Los_Angeles", LocalDateTime(2026, 5, 12, 9, 0)),
+            messageId = fixedUid,
+            dtstampOverride = fixedStamp,
+        )
+        assertTrue("TZID:America/Los_Angeles" in ics)
+        assertTrue("TZOFFSETFROM:-0700" in ics, "PDT offset wrong:\n$ics")
+        assertTrue("DTSTART;TZID=America/Los_Angeles:20260512T090000" in ics)
+    }
+
+    @Test
+    fun unparseable_zone_falls_back_to_utc_dtstart_with_no_vtimezone() {
+        // Bogus zone string — should not throw, should not emit VTIMEZONE,
+        // should still emit a valid UTC DTSTART so the moment in time is preserved.
+        val tokyoMs = LocalDateTime(2026, 5, 12, 9, 0)
+            .toInstant(TimeZone.of("Asia/Tokyo"))
+            .toEpochMilliseconds()
+        val ics = buildIcs(
+            event = EventDescriptor(
+                title = "Standup",
+                description = "",
+                startUtcMs = tokyoMs,
+                endUtcMs = tokyoMs + 60 * 60_000L,
+                timezone = "Definitely/Not/A/Zone",
+            ),
+            messageId = fixedUid,
+            dtstampOverride = fixedStamp,
+        )
+        assertFalse("BEGIN:VTIMEZONE" in ics, "should skip VTIMEZONE on unparseable zone:\n$ics")
+        assertFalse("TZID=" in ics, "should not emit TZID on unparseable zone:\n$ics")
+        // 2026-05-12 09:00 JST == 2026-05-12 00:00 UTC.
+        assertTrue("DTSTART:20260512T000000Z" in ics, "UTC fallback wrong:\n$ics")
+        assertTrue("DTEND:20260512T010000Z" in ics)
+    }
+}

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -553,6 +553,19 @@
     <string name="chat_event_add_end_time">Add end time</string>
     <string name="chat_event_remove_end_time">Remove end time</string>
     <string name="chat_event_organized_by">Organized by</string>
+    <string name="chat_event_tz_picker_title">Time zone</string>
+    <string name="chat_event_tz_picker_search">Search city or zone</string>
+    <string name="chat_event_tz_suggested">Suggested</string>
+    <string name="chat_event_tz_region_africa">Africa</string>
+    <string name="chat_event_tz_region_americas">Americas</string>
+    <string name="chat_event_tz_region_antarctica">Antarctica</string>
+    <string name="chat_event_tz_region_arctic">Arctic</string>
+    <string name="chat_event_tz_region_asia">Asia</string>
+    <string name="chat_event_tz_region_atlantic">Atlantic</string>
+    <string name="chat_event_tz_region_australia">Australia</string>
+    <string name="chat_event_tz_region_europe">Europe</string>
+    <string name="chat_event_tz_region_indian">Indian Ocean</string>
+    <string name="chat_event_tz_region_pacific">Pacific</string>
 
     <!-- Dice attachment -->
     <string name="chat_dice_share">Dice</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -549,7 +549,7 @@
     <string name="chat_event_rsvp_summary">%1$s going · %2$s no · %3$s maybe</string>
     <string name="chat_event_unparseable">Unable to display this event. Please update the app.</string>
     <string name="chat_event_send">Send event</string>
-    <string name="chat_event_your_time_in_zone">your time: %1$s %2$s</string>
+    <string name="chat_event_scheduled_in_zone">Scheduled: %1$s %2$s</string>
     <string name="chat_event_add_end_time">Add end time</string>
     <string name="chat_event_remove_end_time">Remove end time</string>
     <string name="chat_event_organized_by">Organized by</string>


### PR DESCRIPTION
Three related improvements to the Event message kind:

1. Reply previews show an Event date badge

When replying to an Event, both the composer reply bar and the inline reply preview (inside a message bubble) render the Event's date chip in the trailing slot instead of the standard reply preview content. The inline chip spans the full bubble height, runs flush to the right edge, and uses RectangleShape so the parent bubble's clip carves the right corners automatically. New file EventDateChip.kt extracts and parameterizes the date-chip composable previously private to EventBubble (compact mode, optional shape, optional fillHeight, overridable container/content colors).

2. Display Events in the viewer's local timezone

Previously every Event surface (bubble, detail dialog, reply chip, hero header) rendered date and time in the AUTHOR's IANA zone, with a small "your time: HH:mm" hint in the bubble only — time-only, no date. A cross-zone viewer (Tokyo author, SF viewer) had to do the date math themselves.

Flipped the polarity in every surface. EventTimes.kt introduces rememberEventTimes(descriptor) which returns viewer-local times always, plus author-local times and zone id only when zones differ. The bubble + detail dialog + reply chip all render the viewer's local date and clock; the author's authoring zone is surfaced as a secondary "Scheduled: Sat 09:00 JST" tagline only when the zones differ. Storage is unchanged: descriptor.startUtcMs (UTC epoch ms) and descriptor.timezone (author's IANA zone) are still preserved on the wire and used as-is by every export path (Android intent, iOS EventKit, Google Calendar URL, .ics).

Added EventTimesTest.kt with the Tokyo -> Los Angeles cross-zone- date-differs case as a regression guard.

3. .ics export preserves the author's timezone

CalendarLauncher.jvm.kt previously emitted DTSTART/DTEND as plain UTC (Z suffix) with no TZID and no VTIMEZONE block. The moment in time was exact, but the author's zone label was lost on import: a Tokyo 09:00 JST event imported into Outlook on a Berlin desktop would render as 01:00 CET instead of "09:00 Tokyo time". The other platforms (Android intent, iOS EventKit, Google Calendar URL) all already pass the IANA zone through, so this brought desktop into line.

Now emits DTSTART;TZID=Asia/Tokyo:<local> with a minimal VTIMEZONE block carrying the offset valid at the event start. Unparseable zones fall back to the old UTC-only path. Single-instance events only — no DST transitions needed because start/end are minutes-to- hours apart.

Added IcsExportTest.kt (jvmTest) for the .ics format and GoogleCalendarUrlTest.kt (commonTest) for the Google Calendar URL template — both pin the wire shape so future refactors can't silently produce broken calendar invites.

String change: chat_event_your_time_in_zone removed (its role is the primary time row now); chat_event_scheduled_in_zone added for the cross-zone author tagline.