### PR TITLE
fix(ios): target CAMetalLayer directly for cold-start text rendering

### DIFF
--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/MainViewController.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/MainViewController.kt
@@ -43,12 +43,11 @@ fun initializeApp() {
     if (appInitialized) return
     appInitialized = true
 
-    val startTime = platform.Foundation.NSDate().timeIntervalSince1970
+    val startMark = kotlin.time.TimeSource.Monotonic.markNow()
     Logger.i(tag = "TextRendering") { "initializeApp() started" }
 
     initKoin()
-    val afterKoin = platform.Foundation.NSDate().timeIntervalSince1970
-    Logger.i(tag = "TextRendering") { "Koin init: ${((afterKoin - startTime) * 1000).toLong()}ms" }
+    Logger.i(tag = "TextRendering") { "Koin init: ${startMark.elapsedNow().inWholeMilliseconds}ms" }
 
     // Initialize file logging first
     try {
@@ -69,13 +68,12 @@ fun initializeApp() {
     // Set up crash handler
     setupIOSCrashHandler()
 
-    val beforeDb = platform.Foundation.NSDate().timeIntervalSince1970
+    val dbMark = kotlin.time.TimeSource.Monotonic.markNow()
     runBlocking {
         DatabaseManager.initializeWithRecovery(DatabaseDriverFactory())
     }
-    val afterDb = platform.Foundation.NSDate().timeIntervalSince1970
-    Logger.i(tag = "TextRendering") { "DB init (runBlocking): ${((afterDb - beforeDb) * 1000).toLong()}ms" }
-    Logger.i(tag = "TextRendering") { "initializeApp() total: ${((afterDb - startTime) * 1000).toLong()}ms" }
+    Logger.i(tag = "TextRendering") { "DB init (runBlocking): ${dbMark.elapsedNow().inWholeMilliseconds}ms" }
+    Logger.i(tag = "TextRendering") { "initializeApp() total: ${startMark.elapsedNow().inWholeMilliseconds}ms" }
 }
 
 @OptIn(ExperimentalForeignApi::class)

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/MainViewController.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/MainViewController.kt
@@ -43,7 +43,12 @@ fun initializeApp() {
     if (appInitialized) return
     appInitialized = true
 
+    val startTime = platform.Foundation.NSDate().timeIntervalSince1970
+    Logger.i(tag = "TextRendering") { "initializeApp() started" }
+
     initKoin()
+    val afterKoin = platform.Foundation.NSDate().timeIntervalSince1970
+    Logger.i(tag = "TextRendering") { "Koin init: ${((afterKoin - startTime) * 1000).toLong()}ms" }
 
     // Initialize file logging first
     try {
@@ -64,9 +69,13 @@ fun initializeApp() {
     // Set up crash handler
     setupIOSCrashHandler()
 
+    val beforeDb = platform.Foundation.NSDate().timeIntervalSince1970
     runBlocking {
         DatabaseManager.initializeWithRecovery(DatabaseDriverFactory())
     }
+    val afterDb = platform.Foundation.NSDate().timeIntervalSince1970
+    Logger.i(tag = "TextRendering") { "DB init (runBlocking): ${((afterDb - beforeDb) * 1000).toLong()}ms" }
+    Logger.i(tag = "TextRendering") { "initializeApp() total: ${((afterDb - startTime) * 1000).toLong()}ms" }
 }
 
 @OptIn(ExperimentalForeignApi::class)

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1,6 +1,10 @@
 import UIKit
 import SwiftUI
+import QuartzCore
 import ComposeApp
+import os.log
+
+private let textRenderLog = OSLog(subsystem: "id.homebase.feed", category: "TextRendering")
 
 struct ComposeView: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewController {
@@ -34,14 +38,14 @@ struct ContentView: View {
             }
         }
         .onAppear {
-            // Cold-start: .onChange(of: scenePhase) won't fire when .active
-            // is already the initial phase, so the glyph-atlas stays stale.
-            // Post a delayed nudge to cover the first-launch path.
+            os_log("onAppear fired — scheduling cold-start Metal nudge (150ms)", log: textRenderLog, type: .info)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                nudgeMetalLayer()
+                os_log("Cold-start nudge firing at 150ms", log: textRenderLog, type: .info)
+                nudgeMetalLayer(trigger: "onAppear")
             }
         }
         .onChange(of: scenePhase) { _, newPhase in
+            os_log("scenePhase changed to %{public}@", log: textRenderLog, type: .info, String(describing: newPhase))
             switch newPhase {
             case .inactive:
                 if VaultPrivacyBridge.shared.shouldProtect {
@@ -53,17 +57,53 @@ struct ContentView: View {
                 withAnimation(.easeOut(duration: 0.15)) {
                     showPrivacyOverlay = false
                 }
-                nudgeMetalLayer()
+                nudgeMetalLayer(trigger: "scenePhase→active")
             default:
                 break
             }
         }
     }
 
-    private func nudgeMetalLayer() {
-        let view = MainViewControllerRef.shared.instance?.view
-        view?.setNeedsLayout()
-        view?.layer.setNeedsDisplay()
+    private func nudgeMetalLayer(trigger: String) {
+        guard let view = MainViewControllerRef.shared.instance?.view else {
+            os_log("[%{public}@] MainViewControllerRef.instance is nil — nudge skipped", log: textRenderLog, type: .fault, trigger)
+            return
+        }
+
+        let inWindow = view.window != nil
+        os_log("[%{public}@] root view found (inWindow=%{public}@, frame=%{public}@)", log: textRenderLog, type: .info,
+               trigger, String(describing: inWindow), String(describing: view.frame))
+
+        view.layoutIfNeeded()
+
+        var metalViewCount = 0
+        forceSkiaRedraw(in: view, trigger: trigger, count: &metalViewCount)
+
+        if metalViewCount == 0 {
+            os_log("[%{public}@] ⚠️ NO CAMetalLayer view found in hierarchy — nudge had no target", log: textRenderLog, type: .error, trigger)
+        } else {
+            os_log("[%{public}@] nudged %d CAMetalLayer-backed view(s)", log: textRenderLog, type: .info, trigger, metalViewCount)
+        }
+    }
+
+    private func forceSkiaRedraw(in view: UIView, trigger: String, count: inout Int) {
+        if let metalLayer = view.layer as? CAMetalLayer {
+            count += 1
+            let hasDevice = metalLayer.device != nil
+            let drawableSize = metalLayer.drawableSize
+            let fbOnly = metalLayer.framebufferOnly
+            os_log("[%{public}@] found CAMetalLayer view: type=%{public}@, device=%{public}@, drawableSize=%.0fx%.0f, framebufferOnly=%{public}@",
+                   log: textRenderLog, type: .info,
+                   trigger,
+                   String(describing: type(of: view)),
+                   String(describing: hasDevice),
+                   drawableSize.width, drawableSize.height,
+                   String(describing: fbOnly))
+            view.setNeedsDisplay()
+        }
+        for subview in view.subviews {
+            forceSkiaRedraw(in: subview, trigger: trigger, count: &count)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- **Root cause:** The existing Metal layer nudge called `setNeedsDisplay()` on the root `CALayer`, which never propagated to Skiko's `CAMetalLayer` sublayer where text glyphs are actually rendered. The nudge was effectively a no-op.
- **Fix:** Walk the subview tree to find the view backed by `CAMetalLayer` (Skiko's `SkikoUIView`) and call `setNeedsDisplay()` on it directly, triggering Skiko's `display(_:)` override and forcing a full glyph atlas rebuild.
- **Diagnostics:** Added structured `os_log` logging (category: `TextRendering`) in Swift and Kermit timing logs in Kotlin to trace nudge targets, Metal layer state, and `initializeApp()` timing for future debugging.

### Key changes

| File | Change |
|---|---|
| `ContentView.swift` | `forceSkiaRedraw(in:)` walks subviews to find `CAMetalLayer`-backed view; `layoutIfNeeded()` replaces `setNeedsLayout()` for immediate layout; `os_log` diagnostics for nudge lifecycle |
| `MainViewController.kt` | Timing logs around Koin init and DB `runBlocking` to detect if 150ms nudge delay races against init |

### What to look for in logs when text is blank

| Log pattern | Diagnosis |
|---|---|
| `instance is nil — nudge skipped` | Nudge fired too early |
| `NO CAMetalLayer view found` | Skiko view not in hierarchy yet |
| `DB init (runBlocking): >150ms` | Nudge delay too short for device |
| `framebufferOnly=true` | Skiko bug — pixel readback disabled |
| `drawableSize=0x0` | Layer not sized yet |

## Test plan

- [ ] Kill app completely, send message from another account, tap notification — text should be visible on conversation list
- [ ] Repeat with Low Power Mode enabled
- [ ] Repeat on older device (iPhone SE / iPhone 8) if available
- [ ] Check Xcode console for `TextRendering` logs — verify `CAMetalLayer` view is found and nudged
- [ ] Verify `initializeApp()` total time in logs vs the 150ms nudge delay
- [ ] Check `log stream --predicate 'category == "TextRendering"'` on device via Console.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)