### PR TITLE
Vault gallery UI improvements and bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ replay_pid*.log
 /.agent
 /.superpowers
 .worktrees
+/docs/superpowers

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -735,6 +735,9 @@
     <string name="vault_gallery_delete_page_confirm">Delete this page? This cannot be undone.</string>
     <string name="vault_gallery_delete_last_page_confirm">This is the last page. Deleting it will remove the entire entry.</string>
     <string name="vault_gallery_share_page">Share this page</string>
+    <string name="vault_gallery_save_page">Save to device</string>
+    <string name="vault_gallery_delete_file">Delete file</string>
+    <string name="vault_gallery_delete_all">Delete all</string>
 
     <!-- Vault Notes -->
     <string name="vault_notes_label">Notes</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -238,8 +238,9 @@ fun AppNavHost(
                     navController.popBackStack()
                 }
 
-                is VaultUiEvent.ShareFileReady, is VaultUiEvent.Error -> { /* handled by VaultScreen */
-                }
+                is VaultUiEvent.ShareFileReady,
+                is VaultUiEvent.SaveFileReady,
+                is VaultUiEvent.Error -> { /* handled by VaultScreen */ }
             }
         }
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultContent.kt
@@ -7,7 +7,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -32,6 +34,7 @@ fun VaultContent(
     onDeleteSection: (VaultSection) -> Unit,
     onAddSection: () -> Unit,
     modifier: Modifier = Modifier,
+    lazyListState: LazyListState = rememberLazyListState(),
     sharedTransitionScope: SharedTransitionScope? = null,
     animatedVisibilityScope: AnimatedVisibilityScope? = null,
 ) {
@@ -54,6 +57,7 @@ fun VaultContent(
 
         else -> {
             LazyColumn(
+                state = lazyListState,
                 modifier = modifier,
                 contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -119,6 +120,10 @@ fun VaultScreen(
                 is VaultUiEvent.CloseOnboarding -> { /* handled elsewhere */ }
             }
         }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose { viewModel.onAction(VaultUiAction.CloseOverlay) }
     }
 
     BackHandler(enabled = uiState.fullScreenOverlay != null) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultScreen.kt
@@ -127,6 +127,12 @@ fun VaultScreen(
                 is VaultUiEvent.ShareFileReady -> {
                     fileSystemHandler.shareFile(Path(event.filePath))
                 }
+                is VaultUiEvent.SaveFileReady -> {
+                    fileSystemHandler.saveFile(
+                        file = Path(event.filePath),
+                        suggestedName = event.fileName,
+                    )
+                }
                 is VaultUiEvent.Error -> {
                     pendingError = event.error
                 }
@@ -269,6 +275,9 @@ fun VaultScreen(
                             onDismiss = { viewModel.onAction(VaultUiAction.CloseOverlay) },
                             onSharePage = { key ->
                                 viewModel.onAction(VaultUiAction.SharePage(overlay.file, key))
+                            },
+                            onSavePage = { key ->
+                                viewModel.onAction(VaultUiAction.SavePage(overlay.file, key))
                             },
                             onDeletePage = { key ->
                                 viewModel.onAction(VaultUiAction.DeletePage(overlay.file, key))

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultScreen.kt
@@ -25,10 +25,12 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -96,6 +98,18 @@ fun VaultScreen(
     val snackbarHostState = remember { SnackbarHostState() }
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val vaultListState = rememberLazyListState()
+    var savedScrollIndex by remember { mutableIntStateOf(0) }
+    var savedScrollOffset by remember { mutableIntStateOf(0) }
+
+    LaunchedEffect(uiState.fullScreenOverlay) {
+        if (uiState.fullScreenOverlay != null) {
+            savedScrollIndex = vaultListState.firstVisibleItemIndex
+            savedScrollOffset = vaultListState.firstVisibleItemScrollOffset
+        } else if (savedScrollIndex > 0 || savedScrollOffset > 0) {
+            vaultListState.scrollToItem(savedScrollIndex, savedScrollOffset)
+        }
+    }
 
     var pendingError by remember { mutableStateOf<VaultError?>(null) }
 
@@ -244,6 +258,7 @@ fun VaultScreen(
                             onDeleteSection = { sectionToDelete = it },
                             onAddSection = { showNewSectionSheet = true },
                             modifier = contentModifier,
+                            lazyListState = vaultListState,
                             sharedTransitionScope = this@SharedTransitionLayout,
                             animatedVisibilityScope = this@AnimatedContent,
                         )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultUiState.kt
@@ -57,6 +57,7 @@ sealed interface VaultUiAction {
     data class EntryClicked(val file: VaultEntry) : VaultUiAction
     data class ShareFile(val file: VaultEntry) : VaultUiAction
     data class SharePage(val file: VaultEntry, val payloadKey: String) : VaultUiAction
+    data class SavePage(val file: VaultEntry, val payloadKey: String) : VaultUiAction
     data class RenameFile(val file: VaultEntry, val newName: String) : VaultUiAction
     data class DeleteFile(val file: VaultEntry) : VaultUiAction
     data object CloseOverlay : VaultUiAction
@@ -70,6 +71,10 @@ sealed interface VaultUiEvent {
         val filePath: String,
         val fileName: String,
         val contentType: String,
+    ) : VaultUiEvent
+    data class SaveFileReady(
+        val filePath: String,
+        val fileName: String,
     ) : VaultUiEvent
     data class Error(val error: VaultError) : VaultUiEvent
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
@@ -202,6 +202,7 @@ class VaultViewModel(
             is VaultUiAction.UpdateNotes,
             is VaultUiAction.UpdateLabel,
             is VaultUiAction.SharePage,
+            is VaultUiAction.SavePage,
             is VaultUiAction.ShareFile,
             is VaultUiAction.RenameFile,
             is VaultUiAction.DeleteFile,
@@ -237,6 +238,7 @@ class VaultViewModel(
             is VaultUiAction.UpdateNotes -> handleUpdateNotes(action)
             is VaultUiAction.UpdateLabel -> handleUpdateLabel(action)
             is VaultUiAction.SharePage -> handleSharePage(action)
+            is VaultUiAction.SavePage -> handleSavePage(action)
             is VaultUiAction.EntryClicked -> handleEntryClicked(action)
             is VaultUiAction.ShareFile -> handleShareFile(action)
             is VaultUiAction.RenameFile -> handleRenameFile(action)
@@ -556,6 +558,19 @@ class VaultViewModel(
                 val contentType = descriptor?.contentType ?: action.file.contentType
                 _events.tryEmit(
                     VaultUiEvent.ShareFileReady(tempPath, action.file.fileName, contentType),
+                )
+            } else {
+                _events.tryEmit(VaultUiEvent.Error(VaultError.DownloadPageFailed))
+            }
+        }
+    }
+
+    private fun handleSavePage(action: VaultUiAction.SavePage) {
+        viewModelScope.launch {
+            val tempPath = vaultUploaderService.downloadPayload(action.file, action.payloadKey)
+            if (tempPath != null) {
+                _events.tryEmit(
+                    VaultUiEvent.SaveFileReady(tempPath, action.file.fileName),
                 )
             } else {
                 _events.tryEmit(VaultUiEvent.Error(VaultError.DownloadPageFailed))

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/components/VaultFileIcon.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/components/VaultFileIcon.kt
@@ -26,6 +26,8 @@ import id.homebase.core.util.formatFileSize
 import id.homebase.core.util.formatShortDate
 import id.homebase.resources.MR
 import id.homebase.resources.vault_delete_confirm_action
+import id.homebase.resources.vault_gallery_delete_all
+import id.homebase.resources.vault_gallery_delete_file
 import id.homebase.resources.vault_more_options
 import id.homebase.resources.vault_rename_action
 import id.homebase.resources.vault_share
@@ -60,6 +62,7 @@ fun VaultFileDropdownMenu(
     file: VaultEntry,
     onShare: (VaultEntry) -> Unit,
     onDelete: (VaultEntry) -> Unit,
+    onDeletePage: (() -> Unit)? = null,
     iconTint: Color = MaterialTheme.colorScheme.onSurfaceVariant,
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -76,17 +79,37 @@ fun VaultFileDropdownMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
         ) {
-            DropdownMenuItem(
-                text = { Text(stringResource(MR.string.vault_share)) },
-                onClick = {
-                    expanded = false
-                    onShare(file)
-                },
-            )
+            if (onDeletePage == null) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(MR.string.vault_share)) },
+                    onClick = {
+                        expanded = false
+                        onShare(file)
+                    },
+                )
+            }
+            if (onDeletePage != null) {
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = stringResource(MR.string.vault_gallery_delete_file),
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        onDeletePage()
+                    },
+                )
+            }
             DropdownMenuItem(
                 text = {
                     Text(
-                        text = stringResource(MR.string.vault_delete_confirm_action),
+                        text = if (onDeletePage != null) {
+                            stringResource(MR.string.vault_gallery_delete_all)
+                        } else {
+                            stringResource(MR.string.vault_delete_confirm_action)
+                        },
                         color = MaterialTheme.colorScheme.error,
                     )
                 },

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultGalleryScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultGalleryScreen.kt
@@ -30,8 +30,8 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -70,10 +70,13 @@ import id.homebase.core.ui.screens.vault.model.VaultEntry
 import id.homebase.resources.MR
 import id.homebase.resources.menu_back
 import id.homebase.resources.vault_delete_confirm_action
+import id.homebase.resources.vault_delete_confirm_message
+import id.homebase.resources.vault_delete_confirm_title
 import id.homebase.resources.vault_gallery_delete_last_page_confirm
 import id.homebase.resources.vault_gallery_delete_page
 import id.homebase.resources.vault_gallery_delete_page_confirm
 import id.homebase.resources.vault_gallery_page_counter
+import id.homebase.resources.vault_gallery_save_page
 import id.homebase.resources.vault_gallery_share_page
 import id.homebase.resources.vault_permission_cancel
 import id.homebase.chat.services.LocalAttachmentContextStore
@@ -90,6 +93,7 @@ fun VaultGalleryScreen(
     initialPage: Int,
     onDismiss: () -> Unit,
     onSharePage: (payloadKey: String) -> Unit,
+    onSavePage: (payloadKey: String) -> Unit,
     onDeletePage: (payloadKey: String) -> Unit,
     onAppendPages: () -> Unit,
     onUpdateLabel: (String?) -> Unit,
@@ -119,6 +123,7 @@ fun VaultGalleryScreen(
 
     var showUI by remember { mutableStateOf(true) }
     var pageToDelete by remember { mutableStateOf<String?>(null) }
+    var showDeleteEntryConfirm by remember { mutableStateOf(false) }
     val sheetPeekHeight by animateDpAsState(if (showUI) 120.dp else 0.dp)
     val scaffoldState = rememberBottomSheetScaffoldState()
     val scope = rememberCoroutineScope()
@@ -300,17 +305,18 @@ fun VaultGalleryScreen(
                                         contentDescription = stringResource(MR.string.vault_gallery_share_page),
                                     )
                                 }
-                                IconButton(onClick = { pageToDelete = currentDescriptor.key }) {
+                                IconButton(onClick = { onSavePage(currentDescriptor.key) }) {
                                     Icon(
-                                        imageVector = Icons.Default.Delete,
-                                        contentDescription = stringResource(MR.string.vault_gallery_delete_page),
+                                        imageVector = Icons.Outlined.Download,
+                                        contentDescription = stringResource(MR.string.vault_gallery_save_page),
                                     )
                                 }
                             }
                             VaultFileDropdownMenu(
                                 file = file,
                                 onShare = { currentDescriptor?.let { onSharePage(it.key) } },
-                                onDelete = { onDeleteEntry() },
+                                onDelete = { showDeleteEntryConfirm = true },
+                                onDeletePage = { currentDescriptor?.let { pageToDelete = it.key } },
                                 iconTint = MaterialTheme.colorScheme.onSurface,
                             )
                         },
@@ -354,6 +360,36 @@ fun VaultGalleryScreen(
             },
             dismissButton = {
                 TextButton(onClick = { pageToDelete = null }) {
+                    Text(stringResource(MR.string.vault_permission_cancel))
+                }
+            },
+        )
+    }
+
+    if (showDeleteEntryConfirm) {
+        AlertDialog(
+            onDismissRequest = { showDeleteEntryConfirm = false },
+            title = {
+                Text(stringResource(MR.string.vault_delete_confirm_title))
+            },
+            text = {
+                Text(stringResource(MR.string.vault_delete_confirm_message, file.label ?: file.fileName))
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showDeleteEntryConfirm = false
+                        onDeleteEntry()
+                    },
+                ) {
+                    Text(
+                        text = stringResource(MR.string.vault_delete_confirm_action),
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteEntryConfirm = false }) {
                     Text(stringResource(MR.string.vault_permission_cancel))
                 }
             },


### PR DESCRIPTION
## Summary

- **Fix: bottom bar disappearing** — When VaultScreen leaves composition (e.g. navigating to Chat), the overlay state was never cleared. AppNavHost reads `fullScreenOverlay` to hide the bottom bar, so the stale state kept it hidden permanently. Added `DisposableEffect` to fire `CloseOverlay` on dispose.
- **Fix: scroll position reset** — `AnimatedContent` disposes `VaultContent` when the gallery opens, losing the `LazyColumn` scroll position. Now saves `firstVisibleItemIndex`/offset when the overlay opens and restores via `scrollToItem` when it closes, matching chat's `ConversationMessagesPane` pattern.
- **Feat: replace gallery delete icon with save button** — The delete `IconButton` is replaced with a download/save button that calls `FileSystemHandler.saveFile()` (saves to MediaStore/Photos). Delete actions moved to the MoreVert dropdown as "Delete file" (current page) and "Delete all" (entire entry), both with confirmation dialogs.
- **Chore: add docs/superpowers to gitignore**

## Test plan

- [ ] Open vault, scroll down, tap an entry to open gallery, go back — scroll position should be preserved
- [ ] Open vault gallery, navigate to Chat via bottom bar, verify bottom bar is still visible
- [ ] In gallery, tap the download icon — file should save to device storage
- [ ] In gallery, tap MoreVert → "Delete file" — should show confirmation dialog, then delete the page
- [ ] In gallery, tap MoreVert → "Delete all" — should show confirmation dialog, then delete the entire entry
- [ ] Share icon button still works as before
- [ ] Vault entry card dropdown (non-gallery) still shows Share and Delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)