### PR TITLE
refactor(sync): silent DriveSync; mandatory mount at auth time

### DIFF
--- a/ADDING_ADDON_APPS.md
+++ b/ADDING_ADDON_APPS.md
@@ -490,9 +490,17 @@ class FooStream(
     private suspend fun observeEvents() {
         eventBus.events.collect { event ->
             when (event) {
-                // Incremental: merge new/updated files into in-memory state
-                is BackendEvent.DriveEvent.BatchReceived ->
+                // Incremental: merge new/updated files into in-memory state.
+                // BatchReceived is a DataEvent (WS push + OptimisticWriter).
+                // DriveSync itself is silent — see DriveEvent.Stopped below.
+                is BackendEvent.DataEvent.BatchReceived ->
                     if (event.driveId == driveId) processBatch(event.batchData)
+                // Full reload at end of a DriveSync round, gated on totalCount > 0
+                // (a no-op reconnect catch-up adds nothing to the local index).
+                is BackendEvent.DriveEvent.Stopped ->
+                    if (event.driveId == driveId &&
+                        event.result is BackendEvent.DriveResult.Success &&
+                        event.totalCount > 0) loadAll()
                 // Full reload: outbox confirmed, DB has authoritative state
                 is BackendEvent.OutboxEvent.ItemCompleted ->
                     if (event.driveId == driveId) loadAll()

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/eventbus/BackendEvent.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/eventbus/BackendEvent.kt
@@ -1,6 +1,5 @@
 package id.homebase.api.client.eventbus
 
-import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.api.client.drives.HomebaseFile
 import id.homebase.api.client.websockets.Introduction
 import id.homebase.api.common.OdinId
@@ -8,11 +7,6 @@ import id.homebase.api.video.VideoProcessingPhase
 import kotlin.uuid.Uuid
 
 sealed interface BackendEvent {
-    enum class SyncSource {
-        DriveSync,
-        WebSocket
-    }
-
     sealed interface DriveResult {
         data object Success : DriveResult
         data class Failure(
@@ -48,29 +42,54 @@ sealed interface BackendEvent {
 
     }
 
-    // A DriveEvent event happens on a drive when either sync() has received a batch of data
-    // from the host, or when the websocket listener has received some data.
+    /**
+     * Sync-state-machine signals from [DriveSync.performSync]: drive started a
+     * sync round, made progress through a batch upsert, finished (success or
+     * failure). Consumed by [DriveSyncManager] to drive `DriveStatus` /
+     * `SyncState` / the login-screen progress UI. Carry no file data — that
+     * lives in [DataEvent].
+     */
     sealed interface DriveEvent : BackendEvent {
-        val driveId: Uuid  // Common property for all sync events (implement in each data class)
+        val driveId: Uuid
 
         data class Started(
             override val driveId: Uuid,
-        ) : DriveEvent // Only raised by Drive.sync()
+        ) : DriveEvent
+
+        /**
+         * Per-batch progress signal during [DriveSync.performSync]. [totalCount]
+         * is the running total of records upserted in this sync round (not the
+         * batch size). [DriveSyncManager] uses it to advance
+         * `Synchronizing(count = totalCount)` so the login-screen
+         * `DriveProgressRow` shows "N records" while sync is running.
+         */
+        data class Progress(
+            override val driveId: Uuid,
+            val totalCount: Int,
+        ) : DriveEvent
 
         data class Stopped(
             override val driveId: Uuid,
             val totalCount: Int,  // records fetched so far — always present (0 if failed immediately)
             val result: DriveResult
-        ) : DriveEvent  // Only raised by Drive.sync() when a drive finishes (success or failure)
+        ) : DriveEvent
+    }
+
+    /**
+     * Data-arrival signals: file headers have been written to `DriveMainIndex`
+     * and are ready for consumers to react to. Emitted by:
+     *  - [DriveWebSocketUpsertWorker]: per drained batch of WS-pushed file headers
+     *  - [OptimisticWriter]: per in-process optimistic write
+     * NOT emitted by [DriveSync.performSync] (silent-DriveSync contract —
+     * consumers reload from local DB on [DriveEvent.Stopped] with Success).
+     */
+    sealed interface DataEvent : BackendEvent {
+        val driveId: Uuid
 
         data class BatchReceived(
             override val driveId: Uuid,
-            val totalCount: Int,
-            val batchCount: Int,
-            val latestModified: UnixTimeUtc?,
             val batchData: List<HomebaseFile>,
-            val source: SyncSource = SyncSource.DriveSync
-        ) : DriveEvent
+        ) : DataEvent
     }
 
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/eventbus/EventBus.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/eventbus/EventBus.kt
@@ -1,8 +1,11 @@
 package id.homebase.api.client.eventbus
 
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlin.time.TimeSource
 
 class EventBus(
     replay: Int = 1,
@@ -12,7 +15,32 @@ class EventBus(
         MutableSharedFlow<BackendEvent>(replay = replay, extraBufferCapacity = extraBufferCapacity)
     val events: SharedFlow<BackendEvent> = _events.asSharedFlow()
 
-    suspend fun emit(event: BackendEvent) = _events.emit(event)
+    /** Live subscriber count. Useful for diagnostics — if `emit` is suspending and
+     *  this returns N, then one of those N collectors is more than (replay +
+     *  extraBufferCapacity) events behind. */
+    val subscriptionCount: StateFlow<Int> = _events.subscriptionCount
+
+    /**
+     * Emit, fast-path through tryEmit first so the producer doesn't park on a slow
+     * subscriber unless the buffer is actually full. When the buffer IS full, we log
+     * the event class + subscriber count + the block duration so a post-mortem can
+     * identify which event type is being back-pressured and for how long. Without this
+     * instrumentation a stuck subscriber silently freezes every emitter on the bus.
+     */
+    suspend fun emit(event: BackendEvent) {
+        if (_events.tryEmit(event)) return
+        val subscribers = _events.subscriptionCount.value
+        val eventClass = event::class.simpleName ?: "?"
+        Logger.w(tag = "EventBus") {
+            "EventBus.emit($eventClass) BUFFER FULL — suspending (subscribers=$subscribers)"
+        }
+        val start = TimeSource.Monotonic.markNow()
+        _events.emit(event)
+        val elapsed = start.elapsedNow()
+        Logger.w(tag = "EventBus") {
+            "EventBus.emit($eventClass) unblocked after $elapsed (subscribers=$subscribers)"
+        }
+    }
 
     /** Non-suspending emit. Returns false (and drops the event) when the buffer is full
      *  because a subscriber is slow. Use in paths that must not park on a slow collector —

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
@@ -23,6 +23,7 @@ import io.ktor.websocket.Frame
 import io.ktor.websocket.close
 import io.ktor.websocket.readText
 import kotlin.concurrent.Volatile
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -50,6 +51,17 @@ class OdinWebSocketClient(
     private val onDisconnected: () -> Unit = {},
     private val onConnectError: (Throwable) -> Unit = {},
 ) {
+    /**
+     * Monotonic id assigned at construction. Lets the AuthLifecycle log narrative match
+     * up "WS[N] created", "WS[N] start()", "WS[N] handshake successful", "WS[N] close()",
+     * "WS[N] disconnected" across a single OdinWebSocketClient instance — and notice when
+     * a stale instance from a previous session is being torn down.
+     */
+    val instanceId: Long = nextInstanceId.incrementAndGet()
+
+    init {
+        Logger.i(tag = "WebSocket") { "WS[$instanceId] ctor (drives=${drives.size})" }
+    }
 
     private var reconnectDelayMs = 1_000L
     private val MAX_RECONNECT_DELAY_MS = 5_000L
@@ -68,7 +80,7 @@ class OdinWebSocketClient(
     // Per-drive WS upsert workers. Lazily created on the first file
     // event for a drive (see [getOrCreateWorker]). Each worker
     // batches incoming files into one DB transaction and emits a
-    // single [BackendEvent.DriveEvent.BatchReceived] per drain;
+    // single [BackendEvent.DataEvent.BatchReceived] per drain;
     // shape mirrors [DriveSync].
     //
     // Cleared in [disconnect]. Mount/unmount of drives is handled
@@ -134,11 +146,27 @@ class OdinWebSocketClient(
     }
 
     fun start() {
-        if (connectionJob?.isActive == true) return
+        val active = connectionJob?.isActive == true
+        Logger.i(tag = "WebSocket") { "WS[$instanceId] start() (jobActive=$active)" }
+        if (active) return
 
         connectionJob = scope.launch {
+            // Logged immediately on dispatch so we can tell from logs whether
+            // the connection loop ever actually ran. If "loop dispatched" never
+            // appears after a "start()" log line, the coroutine was cancelled
+            // before reaching its body (e.g. a refreshWsSubscription-driven
+            // close() racing with construction).
+            Logger.i(tag = "WebSocket") { "WS[$instanceId] connection loop dispatched" }
             while (true) {
-                eventBus.emit(BackendEvent.Connecting)
+                // tryEmit, not emit. The WS lifecycle is the source of truth for
+                // connection state (see [connectionState]); the bus emission is an
+                // informational mirror for collectors that care. A blocking emit
+                // here parks the entire WS connect on whatever the slowest
+                // unrelated subscriber is doing — which is what locked up the
+                // post-login sync when a singleton's eventBus collector got stuck
+                // mid-batch during the logout DB wipe. tryEmit drops the event
+                // (returns false) when the buffer is full rather than suspend.
+                eventBus.tryEmit(BackendEvent.Connecting)
 
                 try {
                     val connected = connectOnce()
@@ -152,12 +180,14 @@ class OdinWebSocketClient(
                     throw e
                 } catch (e: Exception) {
                     onConnectError(e)
-                    Logger.e(e) { "WebSocket connect failed ${e.message}" }
+                    Logger.e(throwable = e, tag = "WebSocket") {
+                        "WS[$instanceId] connect loop caught exception: ${e.message}"
+                    }
                 }
 
-                eventBus.emit(BackendEvent.ConnectionOffline)
+                eventBus.tryEmit(BackendEvent.ConnectionOffline)
 
-                Logger.w { "WebSocket disconnected, retrying in ${reconnectDelayMs}ms" }
+                Logger.w(tag = "WebSocket") { "WS[$instanceId] disconnected, retrying in ${reconnectDelayMs}ms" }
 
                 // The sleep is launched as a child of the connection job so
                 // wakeForReconnect() can cancel just this delay (e.g. when the
@@ -201,7 +231,7 @@ class OdinWebSocketClient(
     private suspend fun connectOnce(): Boolean {
         val creds = credentialsManager.getActiveCredentials()
             ?: run {
-                Logger.w { "No active credentials, cannot connect WebSocket" }
+                Logger.w(tag = "WebSocket") { "WS[$instanceId] No active credentials, cannot connect" }
                 return false
             }
 
@@ -215,7 +245,7 @@ class OdinWebSocketClient(
         _connectionState.value = WebSocketState.Connecting
 
         val wsUrl = "wss://${identity}/api/apps/v1/notify/ws"
-        Logger.i { "Connecting to WebSocket at $wsUrl" }
+        Logger.i(tag = "WebSocket") { "WS[$instanceId] Connecting to WebSocket at $wsUrl" }
 
         val appCookieName = "BX0900"
 
@@ -575,8 +605,8 @@ class OdinWebSocketClient(
             }
         }
 
-        Logger.i {
-            "WSFileEvent: syncDrive($driveId) — " +
+        Logger.i(tag = "WebSocket") {
+            "WSFileEvent: syncDrive($driveId) fallback — " +
                 "notificationType=${notification.notificationType} " +
                 "headerPresent=${header != null}"
         }
@@ -619,7 +649,7 @@ class OdinWebSocketClient(
     }
 
     private suspend fun onHandshakeSuccess() {
-        Logger.i { "Device handshake successful" }
+        Logger.i(tag = "WebSocket") { "WS[$instanceId] handshake successful" }
         handshakeDone = true
         pingSupervisor.notifySessionReconnected()
         pingSupervisor.start()
@@ -654,7 +684,7 @@ class OdinWebSocketClient(
         wsUpsertWorkers.clear()
         workersSnapshot.forEach { it.cancel() }
         _connectionState.value = WebSocketState.Disconnected
-        Logger.i { "WebSocket disconnected" }
+        Logger.i(tag = "WebSocket") { "WS[$instanceId] disconnected" }
     }
 
     /**
@@ -761,7 +791,13 @@ class OdinWebSocketClient(
      * Close the client and release resources
      */
     fun close() {
+        Logger.i(tag = "WebSocket") { "WS[$instanceId] close()" }
         disconnect()
         client.close()
+    }
+
+    companion object {
+        // Process-lifetime counter for instanceId. Starts at 1 on first construction.
+        private val nextInstanceId = atomic(0L)
     }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
@@ -158,9 +158,7 @@ class DriveSync(
                         recordsRead = searchResults.size
                         totalCount += recordsRead
                         val batchCursorToSave = cursor
-                        val batchTotalCount = totalCount
-                        val batchRecordsRead = recordsRead
-                        val latestModified = searchResults.last().fileMetadata.updated
+                        val batchTotalCount = totalCount  // captured for the async closure
 
                         pendingDbJob = scope.async {
                             val (_, upsertElapsed) = measureTimedValue {
@@ -171,22 +169,18 @@ class DriveSync(
                                     cursor = batchCursorToSave
                                 )
                             }
-                            // Wall-clock for the batch upsert (queue wait +
-                            // SQLite transaction). Lets us tell whether sync's
-                            // 100+-row catch-up batches are starving concurrent
-                            // UI reads on the shared DB dispatcher.
                             Logger.i {
                                 "DriveSync: batch upsert drive=$driveId rows=${searchResults.size} took=$upsertElapsed"
                             }
-
+                            // DriveSync is a silent batched DB write — no per-batch
+                            // BatchReceived (consumers reload from DriveMainIndex on
+                            // Stopped(Success); live per-file events come via
+                            // DriveWebSocketUpsertWorker WS push). The one signal we
+                            // DO emit per batch is a payload-free Progress event so
+                            // DriveSyncManager can advance Synchronizing(count) for
+                            // the login-screen progress UI.
                             eventBus.emit(
-                                BackendEvent.DriveEvent.BatchReceived(
-                                    driveId = driveId,
-                                    totalCount = batchTotalCount,
-                                    batchCount = batchRecordsRead,
-                                    latestModified = latestModified,
-                                    batchData = searchResults
-                                )
+                                BackendEvent.DriveEvent.Progress(driveId, batchTotalCount)
                             )
                         }
                     }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
@@ -30,14 +30,26 @@ class DriveSyncManager(
     private val eventBus: EventBus,
     private val scope: CoroutineScope,
     private val databaseManager: DatabaseManager,
-    private val drives: Map<Uuid, String>,
+    // Mandatory drives this app always syncs (chat, contacts, ...). The list is an
+    // invariant of the sync engine — encoded in the constructor rather than passed at
+    // each start() so that no caller can forget them. Mounting happens via
+    // [ensureMandatoryMounted], which the auth flow calls right after credentials become
+    // valid (before the WebSocket handshake), so these drives appear in [driveStatuses]
+    // independently of WS state.
+    private val mandatoryDrives: Map<Uuid, String>,
 ) {
     // Immutable map reference — always replaced, never mutated in-place, preventing CME.
     // All writes are serialized via driveSyncsMutex, which provides the happens-before
     // guarantee needed for non-mutex readers (syncDrive, pause, clearStorage).
     private var driveSyncs: Map<Uuid, DriveSync> = emptyMap()
     private val driveSyncsMutex = Mutex()
-    @kotlin.concurrent.Volatile private var isRunning = false
+    @kotlin.concurrent.Volatile private var _isRunning = false
+
+    /**
+     * Whether [start] has flipped the manager into the running state. Read-only for
+     * external callers (the snapshot logging in [AuthConnectionCoordinator] uses this).
+     */
+    val isRunning: Boolean get() = _isRunning
 
     // Set by clearStorage(), consumed by the next start(). Lets a freshly constructed
     // DriveSync detect and loudly complain if a cursor survived logout.
@@ -57,6 +69,11 @@ class DriveSyncManager(
         scope.launch {
             var previous: SyncState = SyncState.Idle
             syncState.collect { current ->
+                if (previous::class != current::class) {
+                    Logger.i(tag = "DriveSync") {
+                        "syncState ${previous::class.simpleName} -> ${current::class.simpleName}"
+                    }
+                }
                 when {
                     previous !is SyncState.Syncing && current is SyncState.Syncing ->
                         eventBus.emit(BackendEvent.SyncAllStarted)
@@ -75,16 +92,15 @@ class DriveSyncManager(
                     is BackendEvent.DriveEvent.Started       -> updateState(event.driveId) {
                         it.copy(state = DriveState.Synchronizing())
                     }
-                    is BackendEvent.DriveEvent.BatchReceived -> {
-                        // Only update progress count during an active sync (Started already fired).
-                        // Don't let stray BatchReceived from OptimisticWriter transition
-                        // a Completed/Failed drive back to Synchronizing.
-                        // Ignore events whose totalCount is below the count we've already
-                        // shown — real-time WebSocket pushes and optimistic writes emit
-                        // totalCount=1 and would otherwise snap the progress bar backwards
-                        // mid-backfill.
+                    is BackendEvent.DriveEvent.Progress -> {
+                        // Only advance during an active sync (Started already fired).
+                        // A stray Progress shouldn't re-animate a Completed/Failed drive,
+                        // and we never want the count to go backwards mid-sync.
                         val current = _driveStatuses.value[event.driveId]?.state
                         if (current is DriveState.Synchronizing && event.totalCount >= current.count) {
+                            Logger.d(tag = "DriveSync") {
+                                "Progress drive=${event.driveId} count=${event.totalCount}"
+                            }
                             updateState(event.driveId) {
                                 it.copy(state = DriveState.Synchronizing(count = event.totalCount))
                             }
@@ -98,15 +114,19 @@ class DriveSyncManager(
                             updateState(event.driveId) {
                                 it.copy(state = DriveState.Failed(r.errorMessage))
                             }
-                            Logger.w { "DriveSyncManager: drive ${event.driveId} failed: ${r.errorMessage}, scheduling retry in 1s" }
+                            Logger.w(tag = "DriveSync") {
+                                "drive ${event.driveId} failed: ${r.errorMessage}, scheduling retry in 1s"
+                            }
                             scope.launch {
                                 delay(1000L)
-                                Logger.i { "DriveSyncManager: retrying drive ${event.driveId}" }
+                                Logger.i(tag = "DriveSync") { "retrying drive ${event.driveId}" }
                                 driveSyncsMutex.withLock { driveSyncs[event.driveId] }?.sync()
                             }
                         }
                         is BackendEvent.DriveResult.PermissionDenied -> {
-                            Logger.w { "DriveSyncManager: drive ${event.driveId} denied (403) — unmounting for this session" }
+                            Logger.w(tag = "DriveSync") {
+                                "drive ${event.driveId} denied (403) — unmounting for this session"
+                            }
                             scope.launch { unmountDrive(event.driveId) }
                         }
                     }
@@ -123,59 +143,68 @@ class DriveSyncManager(
         }
     }
 
+    /**
+     * Register the mandatory drives ([mandatoryDrives]) into [driveSyncs] so they
+     * surface in [driveStatuses] as [DriveState.Initialized]. Safe to call before
+     * [start]; the network kick is deferred until [start] flips [_isRunning] true
+     * and the caller invokes [syncAll]. Idempotent — repeat invocations are no-ops
+     * via [mountDrive]'s alreadyExists guard.
+     *
+     * Called by [AuthConnectionCoordinator] right after credentials become valid
+     * (before [connect]). This guarantees the mandatory drives are present
+     * regardless of whether the WebSocket handshake ever completes.
+     */
+    suspend fun ensureMandatoryMounted() {
+        Logger.i(tag = "DriveSync") {
+            "ensureMandatoryMounted begin (${mandatoryDrives.size} drives, driveSyncs.size=${driveSyncs.size})"
+        }
+        mandatoryDrives.forEach { (driveId, label) -> mountDrive(driveId, label) }
+        Logger.i(tag = "DriveSync") {
+            "ensureMandatoryMounted done (driveSyncs.size=${driveSyncs.size})"
+        }
+    }
+
     suspend fun start() {
         // getActiveCredentials() + null-check instead of requireActiveCredentials()
         // so a logout race can't crash the caller. Not all callers try-catch this.
         val credentials = credentialsManager.getActiveCredentials() ?: run {
-            Logger.w { "DriveSyncManager.start() skipped — no active credentials" }
+            Logger.w(tag = "DriveSync") {
+                "start() skipped — no active credentials (driveSyncs.size=${driveSyncs.size})"
+            }
             return
         }
-        val identityId = credentials.getIdentityId()
-
-        val freshLogin = expectFreshCursors
-        expectFreshCursors = false
-
-        drives.forEach { (driveId, label) ->
-            val alreadyExists = driveSyncsMutex.withLock { driveSyncs.containsKey(driveId) }
-            if (alreadyExists) {
-                Logger.w { "DriveSync for drive=$driveId already exists, skipping" }
-                return@forEach
-            }
-
-            runCatching {
-                DriveSync(
-                    identityId = identityId,
-                    driveId = driveId,
-                    driveQueryProvider = driveQueryProvider,
-                    databaseManager = databaseManager,
-                    eventBus = eventBus,
-                    scope = scope,
-                    expectFreshCursor = freshLogin,
-                )
-            }.onSuccess { sync ->
-                driveSyncsMutex.withLock { driveSyncs = driveSyncs + (driveId to sync) }
-                _driveStatuses.update { current ->
-                    current + (driveId to DriveStatus(driveId, label, DriveState.Initialized))
-                }
-            }.onFailure { e ->
-                Logger.e(
-                    "Failed to create DriveSync for drive=$driveId: ${e.message}",
-                    e
-                )
-            }
+        Logger.i(tag = "DriveSync") {
+            "start() (isRunning before=$_isRunning, driveSyncs.size=${driveSyncs.size}, " +
+                "identity=${credentials.domain})"
         }
-        isRunning = true
-        // Note: drives registered via mountDrive() while isRunning was false
-        // (bootstrap pre-mounts, or add-on activations during a paused window)
-        // sit in driveSyncs with their initial sync deferred. The caller is
-        // expected to follow start() with syncAll(), which iterates the full
-        // map and kicks each — same path that handles the mandatory drives
-        // we just added above. Both production callers (AuthConnectionCoordinator
-        // and BackgroundSyncOrchestrator) already do this.
+
+        // Catch-up loop: anything in [mandatoryDrives] that wasn't already registered
+        // via [ensureMandatoryMounted] (e.g. a test that goes straight to start()) is
+        // mounted here as a safety net. expectFreshCursors signalling moves into the
+        // per-mount path via mountDrive() so it applies to mandatory and optional
+        // drives uniformly.
+        ensureMandatoryMounted()
+
+        _isRunning = true
+        expectFreshCursors = false
+        Logger.i(tag = "DriveSync") {
+            "start() done (isRunning=true, driveSyncs.size=${driveSyncs.size})"
+        }
+        // Drives registered via mountDrive() while _isRunning was false (bootstrap
+        // pre-mounts, add-on activations during a paused window, or the mandatory
+        // ensureMandatoryMounted above) sit in driveSyncs with their initial sync
+        // deferred. The caller is expected to follow start() with syncAll(), which
+        // iterates the full map and kicks each. Both production callers
+        // (AuthConnectionCoordinator and BackgroundSyncOrchestrator) already do this.
     }
 
     suspend fun syncAll() {
-        if (!isRunning) { Logger.w { "syncAll() skipped — not running" }; return }
+        if (!_isRunning) {
+            Logger.w(tag = "DriveSync") {
+                "syncAll() skipped — not running (driveSyncs.size=${driveSyncs.size})"
+            }
+            return
+        }
         val snapshot = driveSyncsMutex.withLock { driveSyncs.values.toList() }
         val jobs = snapshot.mapNotNull { it.sync() }
         jobs.joinAll()
@@ -192,13 +221,21 @@ class DriveSyncManager(
     }
 
     fun syncDrive(driveId: Uuid) {
-        if (!isRunning) { Logger.w { "syncDrive() skipped — not running" }; return }
+        if (!_isRunning) {
+            Logger.w(tag = "DriveSync") {
+                "syncDrive($driveId) skipped — not running (driveSyncs.size=${driveSyncs.size})"
+            }
+            return
+        }
         val d = driveSyncs[driveId] ?: throw Exception("syncDrive() invalid driveId: $driveId")
         d.sync()
     }
 
     fun pause() {
-        isRunning = false
+        Logger.i(tag = "DriveSync") {
+            "pause() (isRunning before=$_isRunning, driveSyncs.size=${driveSyncs.size})"
+        }
+        _isRunning = false
         driveSyncs.values.forEach { it.cancel() }
         _driveStatuses.update { statuses ->
             statuses.mapValues { (_, status) ->
@@ -210,7 +247,10 @@ class DriveSyncManager(
     }
 
     suspend fun stop() {
-        isRunning = false
+        Logger.i(tag = "DriveSync") {
+            "stop() (isRunning before=$_isRunning, driveSyncs.size=${driveSyncs.size})"
+        }
+        _isRunning = false
         val old = driveSyncsMutex.withLock {
             val snapshot = driveSyncs
             driveSyncs = emptyMap()
@@ -222,41 +262,82 @@ class DriveSyncManager(
     }
 
     /**
-     * Dynamically mounts a drive into the sync engine (e.g. when an add-on is activated
-     * mid-session, or during cold-boot bootstrap before [start] has flipped
-     * [isRunning] true).
+     * Mounts a drive into the sync engine. Idempotent — repeat calls for the
+     * same `driveId` are no-ops and return `false`.
      *
      * Splits cleanly into "register" (in-memory bookkeeping — always runs once
      * credentials exist) and "kick a sync" (network I/O — only runs while the
-     * manager is in the running state). A drive registered while paused/not-yet-
-     * started is picked up by the next [start]'s catch-up loop.
+     * manager is in the running state). A drive registered while paused/not-
+     * yet-started is picked up by the next [start]'s catch-up loop.
+     *
+     * @return `true` if this call actually registered a new drive, `false` if
+     *   the drive was already mounted (or could not be mounted because
+     *   credentials are missing / construction failed). Callers like
+     *   [AuthConnectionCoordinator.mountDrive] use the return value to decide
+     *   whether to trigger a WebSocket-subscription refresh — redundant mount
+     *   calls (e.g. from a ViewModel reacting to driveStatuses) must NOT cause
+     *   a reconnect, or they will tear down an in-flight WS handshake.
      */
-    suspend fun mountDrive(driveId: Uuid, label: String) {
-        val alreadyExists = driveSyncsMutex.withLock { driveSyncs.containsKey(driveId) }
-        if (alreadyExists) return
-
+    suspend fun mountDrive(driveId: Uuid, label: String): Boolean {
         // getActiveCredentials() instead of requireActiveCredentials() — a logout
         // race during add-on activation should be a deferred mount, not a crash.
         val identityId = credentialsManager.getActiveCredentials()?.getIdentityId() ?: run {
-            Logger.w { "mountDrive($driveId) skipped — no active credentials" }
-            return
+            Logger.w(tag = "DriveSync") {
+                "mountDrive($driveId, $label) skipped — no active credentials"
+            }
+            return false
         }
 
-        val sync = try {
-            DriveSync(identityId, driveId, driveQueryProvider, databaseManager, eventBus, scope)
-        } catch (e: CancellationException) {
-            // Don't swallow cancellation — let the caller's scope tear down cleanly.
-            throw e
-        } catch (e: Exception) {
-            Logger.e("DriveSyncManager: mountDrive failed for $driveId: ${e.message}", e)
-            return
+        // expectFreshCursors is set by clearStorage() (logout) and consumed by the
+        // next batch of mounts. Applies to mandatory AND optional drives so a
+        // surviving cursor on any of them is logged loudly. start() resets the flag
+        // once all post-login mounts are done.
+        val freshLogin = expectFreshCursors
+
+        // The alreadyExists check and the insertion happen inside the same
+        // mutex block so two parallel mountDrive calls for the same driveId
+        // can't both pass the guard and register twice. Withdraws the
+        // alreadyExists race that was previously possible.
+        val sync = driveSyncsMutex.withLock {
+            val sizeBefore = driveSyncs.size
+            if (driveSyncs.containsKey(driveId)) {
+                Logger.w(tag = "DriveSync") {
+                    "mountDrive($driveId, $label) — already mounted, no-op (driveSyncs.size=$sizeBefore)"
+                }
+                return false
+            }
+            val newSync = try {
+                DriveSync(
+                    identityId = identityId,
+                    driveId = driveId,
+                    driveQueryProvider = driveQueryProvider,
+                    databaseManager = databaseManager,
+                    eventBus = eventBus,
+                    scope = scope,
+                    expectFreshCursor = freshLogin,
+                )
+            } catch (e: CancellationException) {
+                // Don't swallow cancellation — let the caller's scope tear down cleanly.
+                throw e
+            } catch (e: Exception) {
+                Logger.e(tag = "DriveSync", throwable = e) {
+                    "mountDrive($driveId, $label) — construction failed: ${e.message}"
+                }
+                return false
+            }
+            driveSyncs = driveSyncs + (driveId to newSync)
+            Logger.i(tag = "DriveSync") {
+                "mountDrive($driveId, $label) registered " +
+                    "(driveSyncs.size=$sizeBefore -> ${sizeBefore + 1}, freshLogin=$freshLogin, isRunning=$_isRunning)"
+            }
+            newSync
         }
-        driveSyncsMutex.withLock { driveSyncs = driveSyncs + (driveId to sync) }
         _driveStatuses.update { it + (driveId to DriveStatus(driveId, label, DriveState.Initialized)) }
 
         // Defer the network kick if the manager isn't running yet — start()'s
         // catch-up loop will pick it up when isRunning flips true.
-        if (isRunning) sync.sync()
+        if (_isRunning) sync.sync()
+        return true
     }
 
     /**
@@ -272,7 +353,7 @@ class DriveSyncManager(
         } ?: return
         sync.cancel()
         _driveStatuses.update { it - driveId }
-        Logger.i { "DriveSyncManager: unmounted drive $driveId" }
+        Logger.i(tag = "DriveSync") { "unmountDrive($driveId)" }
     }
 
     // Runs under NonCancellable because the typical caller is

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveWebSocketUpsertWorker.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveWebSocketUpsertWorker.kt
@@ -142,18 +142,14 @@ class DriveWebSocketUpsertWorker(
                     cursor = null,
                 )
             }
-            Logger.i {
-                "WSPush: batch upsert drive=$driveId rows=${batch.size} took=$upsertElapsed"
+            Logger.i(tag = "WSPush") {
+                "WSPush: drainOnce drive=$driveId rows=${batch.size} took=$upsertElapsed (emitting BatchReceived)"
             }
 
             eventBus.emit(
-                BackendEvent.DriveEvent.BatchReceived(
+                BackendEvent.DataEvent.BatchReceived(
                     driveId = driveId,
-                    totalCount = batch.size,
-                    batchCount = batch.size,
-                    latestModified = batch.last().fileMetadata.updated,
                     batchData = batch,
-                    source = BackendEvent.SyncSource.WebSocket,
                 )
             )
         } catch (e: Exception) {

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncManagerTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncManagerTest.kt
@@ -59,7 +59,7 @@ class DriveSyncManagerTest {
                 eventBus = EventBus(),
                 scope = backgroundScope,
                 databaseManager = db,
-                drives = mapOf(driveId to "Test Drive"),
+                mandatoryDrives = mapOf(driveId to "Test Drive"),
             )
 
             manager.start()
@@ -97,7 +97,7 @@ class DriveSyncManagerTest {
                 eventBus = eventBus,
                 scope = backgroundScope,
                 databaseManager = db,
-                drives = mapOf(driveId to "Test Drive"),
+                mandatoryDrives = mapOf(driveId to "Test Drive"),
             )
 
             manager.start()
@@ -127,7 +127,7 @@ class DriveSyncManagerTest {
         credentialsManager: CredentialsManager,
         eventBus: EventBus,
         scope: CoroutineScope,
-        drives: Map<Uuid, String> = emptyMap(),
+        mandatoryDrives: Map<Uuid, String> = emptyMap(),
     ): DriveSyncManager {
         val mockEngine = MockEngine { awaitCancellation() }
         val httpClient = HttpClient(mockEngine)
@@ -138,7 +138,7 @@ class DriveSyncManagerTest {
             eventBus = eventBus,
             scope = scope,
             databaseManager = db,
-            drives = drives,
+            mandatoryDrives = mandatoryDrives,
         )
     }
 
@@ -594,6 +594,170 @@ class DriveSyncManagerTest {
             eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId1, 0, BackendEvent.DriveResult.Success))
             runCurrent()
             assertEquals(1, manager.numberOfDrivesSyncing())
+        }
+        db.close()
+    }
+
+    @Test
+    fun ensureMandatoryMountedRegistersDrivesWithoutStarting() {
+        // The bug from the second-login repro: mandatory drives were only mounted inside
+        // start(), and start() only ran from the WS onConnected callback. If the handshake
+        // didn't complete, the mandatory drives never showed up in driveStatuses.
+        // ensureMandatoryMounted() decouples the mount from the running flag — drives must
+        // appear as Initialized even without start() / syncAll() running.
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val driveA = Uuid.random()
+            val driveB = Uuid.random()
+            val manager = buildManager(
+                db, buildCredentials(), EventBus(), backgroundScope,
+                mandatoryDrives = mapOf(driveA to "Chat", driveB to "Contact"),
+            )
+
+            manager.ensureMandatoryMounted()
+            runCurrent()
+
+            assertEquals(DriveState.Initialized, manager.driveStatuses.value[driveA]?.state)
+            assertEquals(DriveState.Initialized, manager.driveStatuses.value[driveB]?.state)
+            assertFalse(manager.isRunning, "ensureMandatoryMounted must not flip isRunning")
+        }
+        db.close()
+    }
+
+    @Test
+    fun mountDriveReturnsFalseOnSecondCall() {
+        // The post-login WS-reconnect regression: VaultViewModel reactively called
+        // AuthConnectionCoordinator.mountDrive(vault) the moment the vault drive appeared
+        // in driveStatuses, while AuthConnectionCoordinator had ALREADY mounted it during
+        // bootstrap. AuthCC.mountDrive needs to know "was anything actually new?" to skip
+        // the refreshWsSubscription.trigger() that would tear down an in-flight WS
+        // handshake. The return value of DriveSyncManager.mountDrive is that signal.
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val manager = buildManager(db, buildCredentials(), EventBus(), backgroundScope)
+            val driveId = Uuid.random()
+
+            val first = manager.mountDrive(driveId, "Vault")
+            val second = manager.mountDrive(driveId, "Vault")
+
+            assertTrue(first, "first mount must report newly-mounted")
+            assertFalse(second, "second mount of same drive must report already-mounted")
+            assertEquals(1, manager.driveStatuses.value.size)
+        }
+        db.close()
+    }
+
+    @Test
+    fun ensureMandatoryMountedIsIdempotent() {
+        // start() calls ensureMandatoryMounted() as a safety net. If AuthConnectionCoordinator
+        // also calls it earlier (the new primary path), the second invocation from start()
+        // must be a no-op rather than a failure or duplicate registration.
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val driveA = Uuid.random()
+            val manager = buildManager(
+                db, buildCredentials(), EventBus(), backgroundScope,
+                mandatoryDrives = mapOf(driveA to "Chat"),
+            )
+
+            manager.ensureMandatoryMounted()
+            runCurrent()
+            manager.ensureMandatoryMounted()
+            runCurrent()
+            manager.start()
+            runCurrent()
+
+            assertEquals(1, manager.driveStatuses.value.size)
+            assertEquals(DriveState.Initialized, manager.driveStatuses.value[driveA]?.state)
+            assertTrue(manager.isRunning)
+        }
+        db.close()
+    }
+
+    @Test
+    fun progressEventAdvancesSynchronizingCount() {
+        // Drive.performSync emits Started → Progress(N) per batch upsert →
+        // Stopped(Success, finalCount). DriveSyncManager translates that into
+        // driveStatuses: Initialized → Synchronizing(count=0) → Synchronizing(count=N) →
+        // Completed(totalCount=finalCount). The Synchronizing.count drives
+        // LoginScreen's DriveProgressRow ("N records").
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val driveId = Uuid.random()
+            val manager = buildManager(
+                db, buildCredentials(), eventBus, backgroundScope,
+                mandatoryDrives = mapOf(driveId to "Chat"),
+            )
+            manager.start()
+            runCurrent()
+
+            // Synchronizing(count=0) after Started.
+            eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
+            runCurrent()
+            assertEquals(
+                DriveState.Synchronizing(count = 0),
+                manager.driveStatuses.value[driveId]?.state,
+            )
+
+            // First batch landed: count advances to 500.
+            eventBus.emit(BackendEvent.DriveEvent.Progress(driveId, totalCount = 500))
+            runCurrent()
+            assertEquals(
+                DriveState.Synchronizing(count = 500),
+                manager.driveStatuses.value[driveId]?.state,
+            )
+
+            // Second batch: count advances to 1500.
+            eventBus.emit(BackendEvent.DriveEvent.Progress(driveId, totalCount = 1500))
+            runCurrent()
+            assertEquals(
+                DriveState.Synchronizing(count = 1500),
+                manager.driveStatuses.value[driveId]?.state,
+            )
+
+            // Stopped(Success): transitions to Completed with the final total.
+            eventBus.emit(
+                BackendEvent.DriveEvent.Stopped(driveId, 1500, BackendEvent.DriveResult.Success)
+            )
+            runCurrent()
+            assertEquals(
+                DriveState.Completed(totalCount = 1500),
+                manager.driveStatuses.value[driveId]?.state,
+            )
+        }
+        db.close()
+    }
+
+    @Test
+    fun progressEventIsIgnoredWhenCountWouldGoBackwards() {
+        // A stray Progress event with totalCount < current.count must not snap the
+        // progress bar backwards mid-sync. Real-world cause: late-arriving
+        // out-of-order BatchReceived emits from optimistic writes had totalCount=1
+        // pre-branch and would have undone real progress. Now the same guard
+        // protects DriveEvent.Progress.
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val driveId = Uuid.random()
+            val manager = buildManager(
+                db, buildCredentials(), eventBus, backgroundScope,
+                mandatoryDrives = mapOf(driveId to "Chat"),
+            )
+            manager.start()
+            runCurrent()
+
+            eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
+            eventBus.emit(BackendEvent.DriveEvent.Progress(driveId, totalCount = 500))
+            runCurrent()
+
+            // Stray Progress with a smaller count — must not regress.
+            eventBus.emit(BackendEvent.DriveEvent.Progress(driveId, totalCount = 1))
+            runCurrent()
+            assertEquals(
+                DriveState.Synchronizing(count = 500),
+                manager.driveStatuses.value[driveId]?.state,
+            )
         }
         db.close()
     }

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveWebSocketUpsertWorkerTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveWebSocketUpsertWorkerTest.kt
@@ -34,8 +34,7 @@ import kotlin.uuid.Uuid
 /**
  * Locks down [DriveWebSocketUpsertWorker]'s contract:
  *  - one batch upsert per drain (queue + single-flight Mutex),
- *  - a [BackendEvent.DriveEvent.BatchReceived] with
- *    `source = SyncSource.WebSocket` per drain,
+ *  - a [BackendEvent.DataEvent.BatchReceived] per drain,
  *  - works for any drive id (not just chat),
  *  - cancel() prevents pending work.
  *
@@ -67,10 +66,10 @@ class DriveWebSocketUpsertWorkerTest {
         val driveId = Uuid.random()
         val eventBus = EventBus()
 
-        val firstBatch = CompletableDeferred<BackendEvent.DriveEvent.BatchReceived>()
+        val firstBatch = CompletableDeferred<BackendEvent.DataEvent.BatchReceived>()
         val collector = launch {
             eventBus.events.collect { event ->
-                if (event is BackendEvent.DriveEvent.BatchReceived) {
+                if (event is BackendEvent.DataEvent.BatchReceived) {
                     firstBatch.complete(event)
                 }
             }
@@ -134,11 +133,11 @@ class DriveWebSocketUpsertWorkerTest {
         val driveId = Uuid.random()
         val eventBus = EventBus()
 
-        val collected = mutableListOf<BackendEvent.DriveEvent.BatchReceived>()
+        val collected = mutableListOf<BackendEvent.DataEvent.BatchReceived>()
         val firstBatch = CompletableDeferred<Unit>()
         val collector = launch(dispatcher) {
             eventBus.events.collect { event ->
-                if (event is BackendEvent.DriveEvent.BatchReceived) {
+                if (event is BackendEvent.DataEvent.BatchReceived) {
                     collected.add(event)
                     if (collected.size == 1) firstBatch.complete(Unit)
                 }
@@ -183,10 +182,10 @@ class DriveWebSocketUpsertWorkerTest {
         val driveId = Uuid.random()
         val eventBus = EventBus()
 
-        val firstBatch = CompletableDeferred<BackendEvent.DriveEvent.BatchReceived>()
+        val firstBatch = CompletableDeferred<BackendEvent.DataEvent.BatchReceived>()
         val collector = launch {
             eventBus.events.collect { event ->
-                if (event is BackendEvent.DriveEvent.BatchReceived) firstBatch.complete(event)
+                if (event is BackendEvent.DataEvent.BatchReceived) firstBatch.complete(event)
             }
         }
 
@@ -202,11 +201,7 @@ class DriveWebSocketUpsertWorkerTest {
 
         val batch = withTimeoutOrNull(5.seconds) { firstBatch.await() }
         assertNotNull(batch)
-        assertEquals(
-            BackendEvent.SyncSource.WebSocket, batch.source,
-            "downstream consumers (dirty-bit gating) branch on this field; " +
-                "WebSocket source must be set"
-        )
+        assertEquals(driveId, batch.driveId, "batch must be tagged with the drive id")
 
         collector.cancel()
     }
@@ -218,10 +213,10 @@ class DriveWebSocketUpsertWorkerTest {
         val driveBeta = Uuid.random()
         val eventBus = EventBus()
 
-        val collected = mutableListOf<BackendEvent.DriveEvent.BatchReceived>()
+        val collected = mutableListOf<BackendEvent.DataEvent.BatchReceived>()
         val collector = launch {
             eventBus.events.collect { event ->
-                if (event is BackendEvent.DriveEvent.BatchReceived) collected.add(event)
+                if (event is BackendEvent.DataEvent.BatchReceived) collected.add(event)
             }
         }
         delay(20)
@@ -278,10 +273,10 @@ class DriveWebSocketUpsertWorkerTest {
         val driveId = Uuid.random()
         val eventBus = EventBus()
 
-        val collected = mutableListOf<BackendEvent.DriveEvent.BatchReceived>()
+        val collected = mutableListOf<BackendEvent.DataEvent.BatchReceived>()
         val collector = launch {
             eventBus.events.collect { event ->
-                if (event is BackendEvent.DriveEvent.BatchReceived) collected.add(event)
+                if (event is BackendEvent.DataEvent.BatchReceived) collected.add(event)
             }
         }
         delay(20)
@@ -318,10 +313,10 @@ class DriveWebSocketUpsertWorkerTest {
         val driveId = Uuid.random()
         val eventBus = EventBus()
 
-        val collected = mutableListOf<BackendEvent.DriveEvent.BatchReceived>()
+        val collected = mutableListOf<BackendEvent.DataEvent.BatchReceived>()
         val collector = launch {
             eventBus.events.collect { event ->
-                if (event is BackendEvent.DriveEvent.BatchReceived) collected.add(event)
+                if (event is BackendEvent.DataEvent.BatchReceived) collected.add(event)
             }
         }
         delay(20)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -53,23 +53,29 @@ class ChatMessageStream(
     init {
         scope.launch {
             eventBus.events.collect { event ->
-                if (event is BackendEvent.OutboxEvent.OptimisticRollback && event.driveId == chatDrive) {
-                    paginatedState.removeMessage(event.uniqueId)
-                    return@collect
-                }
-
-                if (event !is BackendEvent.DriveEvent || event.driveId != chatDrive) return@collect
-
                 when (event) {
-                    is BackendEvent.DriveEvent.Started -> {}
+                    is BackendEvent.OutboxEvent.OptimisticRollback -> {
+                        if (event.driveId == chatDrive) {
+                            paginatedState.removeMessage(event.uniqueId)
+                        }
+                    }
 
                     is BackendEvent.DriveEvent.Stopped -> {
-                        Logger.d("ChatMessageStream: Stopped(totalCount=${event.totalCount})")
+                        if (event.driveId == chatDrive) {
+                            Logger.d("ChatMessageStream: Stopped(totalCount=${event.totalCount})")
+                        }
                     }
 
-                    is BackendEvent.DriveEvent.BatchReceived -> {
+                    is BackendEvent.DataEvent.BatchReceived -> {
+                        if (event.driveId != chatDrive) return@collect
+                        // Every BatchReceived is a live WS-push event (DriveSync is
+                        // silent). The window gate inside processIncrementalBatch
+                        // no-ops batches for conversations the user hasn't opened.
                         processIncrementalBatch(event.batchData)
                     }
+
+                    // Started / Progress are state-machine signals we don't act on.
+                    else -> {}
                 }
             }
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -110,21 +110,7 @@ class ConversationStream(
     var onIncomingHealRequest: (suspend (status: StatusMessageData, sender: OdinId, messageFile: HomebaseFile) -> Unit)? = null
     // endregion
 
-    // region Placeholder reconciliation
-    // Conversation IDs whose in-memory placeholder hasn't yet been replaced
-    // by a real fileType=8888 file from the sync stream. Populated when the
-    // orphan branch in processMessageBatchIncrementally creates a placeholder;
-    // drained in processConversationBatchIncrementally when a real file
-    // arrives with a matching id; any remaining ids at DriveEvent.Stopped
-    // get persisted to local DB so the conversation survives an app restart.
-    //
-    // Only mutated from inside the sequential `eventBus.events.collect { ... }`
-    // loop in init, so no synchronization is needed. The reconciliation
-    // coroutine takes a snapshot before the set is cleared.
-    private val placeholderIds = mutableSetOf<Uuid>()
-    // endregion
-
-    // region Orphan-recovery: read-path dedup of recover attempts
+// region Orphan-recovery: read-path dedup of recover attempts
     // [loadBasicConversations] triggers [onRecoverConversation] for any row
     // that mapped to [ConversationState.Invalid] (the mapper's catch-all for
     // unmappable conversation files — e.g. a 1:1 whose other participant is
@@ -171,71 +157,77 @@ class ConversationStream(
     // endregion
 
 
-    // The full conversation list is loaded once from the local DB on authentication
-    // (via start(), called from onPostAuthenticated in AppModule).
+    // Two paths converge on _conversations:
     //
-    // After that, all updates — whether from a reconnect syncAll() or a single WS
-    // file notification — arrive as BatchReceived events and are applied incrementally.
-    // We intentionally do NOT re-read the full list on DriveEvent.Stopped; the
-    // incremental BatchReceived path is sufficient and avoids an expensive full reload
-    // on every incoming message. Unread counts are re-enriched at end-of-sync only
-    // when [hasDirtyUnread] is true (see the dirty-bit region) — i.e. when a
-    // conversation file's lastRead actually advanced during the round, which is
-    // the only case `enrichAllConversationsWithUnreadCounts` materially changes.
+    // 1) Live updates — WS-push [DataEvent.BatchReceived] events drive incremental
+    //    in-memory mutations via processConversationBatchIncrementally /
+    //    processMessageBatchIncrementally / processAdminFileBatch. This is the
+    //    steady-state channel (per-file events from DriveWebSocketUpsertWorker and
+    //    in-process OptimisticWriter writes).
+    //
+    // 2) DriveSync catch-up — [DriveEvent.Stopped(Success)] for the chat drive
+    //    fires the full reload pipeline (loadBasicConversations →
+    //    enrichWithLastMessages → enrichWithAdmins → conditional
+    //    enrichAllConversationsWithUnreadCounts). This is the silent-DriveSync
+    //    contract: DriveSync.performSync emits no per-batch BatchReceived events
+    //    (DataEvent or DriveEvent) — it just upserts file headers into
+    //    DriveMainIndex and signals Stopped, and we converge the in-memory model
+    //    from the DB then.
+    //
+    // The unread-count step in (2) is gated on [hasDirtyUnread] — it's the
+    // ~500ms full-DB pass and only materially changes the result when a
+    // conversation file's lastRead actually advanced during the round
+    // (peer-device mark-as-read echo). The other three steps are unconditional
+    // because DriveSync may have changed conversation files, last-messages, or
+    // admin membership without touching lastRead.
     init {
         scope.launch {
             eventBus.events.collect { event ->
-
-                if (event !is BackendEvent.DriveEvent || event.driveId != chatDrive) return@collect
-
                 when (event) {
-                    is BackendEvent.DriveEvent.Started -> {}
-
                     is BackendEvent.DriveEvent.Stopped -> {
+                        if (event.driveId != chatDrive) return@collect
                         Logger.d("ConversationStream: Stopped(totalCount=${event.totalCount})")
-                        if (event.result is BackendEvent.DriveResult.Success) {
-                            // If placeholders remain after sync completion, the real
-                            // conversation files genuinely didn't arrive — persist
-                            // the placeholders to local DB so they survive restart.
-                            // Only on success: on failure we'd prefer to retry on the
-                            // next sync rather than commit a speculative placeholder.
-                            if (placeholderIds.isNotEmpty()) {
-                                val toReconcile = placeholderIds.toSet()
-                                placeholderIds.clear()
-                                scope.launch {
-                                    try {
-                                        reconcileUnresolvedPlaceholders(toReconcile)
-                                    } catch (e: Exception) {
-                                        Logger.e(e) {
-                                            "ConversationStream: placeholder reconciliation FAILED: ${e.message}"
-                                        }
+                        // Silent-DriveSync contract: the chat-drive DriveSync just
+                        // landed N files in DriveMainIndex with no per-batch
+                        // BatchReceived emits. Reload the conversation list from DB
+                        // to converge to the post-sync snapshot — but only when the
+                        // round actually upserted records. totalCount=0 means the
+                        // cursor was already at HEAD (a common no-op reconnect
+                        // catch-up); DB state is unchanged, so the four-step
+                        // pipeline would be pure busywork.
+                        //
+                        // First three steps unconditional (DriveSync may have
+                        // changed conversation files, last-messages, or admin
+                        // membership without dirtying lastRead). The unread-count
+                        // recount is the ~500ms full-DB pass and is gated on
+                        // [hasDirtyUnread] — it only materially changes the result
+                        // when a conversation file's lastRead actually advanced
+                        // during the round (peer-device mark-as-read echo).
+                        if (event.result is BackendEvent.DriveResult.Success && event.totalCount > 0) {
+                            scope.launch {
+                                try {
+                                    loadBasicConversations()
+                                    enrichWithLastMessages()
+                                    enrichWithAdmins()
+                                    if (hasDirtyUnread()) {
+                                        enrichAllConversationsWithUnreadCounts(trigger = "DriveSyncStopped")
                                     }
-                                }
-                            }
-                            // Re-enrich unread counts at end of round, but only
-                            // if a conversation file's lastRead actually advanced
-                            // during the round (peer-device mark-as-read echo).
-                            // [markUnreadDirty] is called from
-                            // [processConversationBatchIncrementally] when that
-                            // happens. Anything else the round brought —
-                            // metadata-only conversation updates, message-only
-                            // batches, admin files — leaves the dirty set empty
-                            // and skips the ~500ms full-DB recount.
-                            if (hasDirtyUnread()) {
-                                scope.launch {
-                                    try {
-                                        enrichAllConversationsWithUnreadCounts(trigger = "Stopped")
-                                    } catch (e: Exception) {
-                                        Logger.e(e) {
-                                            "ConversationStream: post-Stopped enrich failed: ${e.message}"
-                                        }
+                                } catch (e: Exception) {
+                                    Logger.e(e) {
+                                        "ConversationStream: post-Stopped reload FAILED: ${e.message}"
                                     }
                                 }
                             }
                         }
                     }
 
-                    is BackendEvent.DriveEvent.BatchReceived -> {
+                    is BackendEvent.DataEvent.BatchReceived -> {
+                        if (event.driveId != chatDrive) return@collect
+                        // Every BatchReceived is a live event from the WS push path
+                        // (DriveWebSocketUpsertWorker or its in-process analog
+                        // OptimisticWriter). DriveSync.performSync is silent — the
+                        // matching DriveEvent.Stopped(Success) above does a full DB
+                        // reload to cover that path.
                         val conversationFiles =
                             event.batchData.filter {
                                 it.fileMetadata.appData.fileType ==
@@ -259,7 +251,7 @@ class ConversationStream(
                         )
 
                         if (conversationFiles.isNotEmpty())
-                            processConversationBatchIncrementally(conversationFiles, event.source)
+                            processConversationBatchIncrementally(conversationFiles)
 
                         if (messageFiles.isNotEmpty())
                             processMessageBatchIncrementally(messageFiles)
@@ -267,6 +259,9 @@ class ConversationStream(
                         if (adminFiles.isNotEmpty())
                             processAdminFileBatch(adminFiles)
                     }
+
+                    // Started / Progress are state-machine signals we don't act on.
+                    else -> {}
                 }
             }
         }
@@ -493,7 +488,6 @@ class ConversationStream(
                 //      restores it.
                 Logger.w("ConversationStream: orphaned conversation ${m.conversationId} from=${m.originalAuthor} isOneToOne=$isOneToOne, creating placeholder")
                 insertNewConversation(emptyConversation)
-                placeholderIds += m.conversationId
 
                 // Fire-and-forget local-only recovery. recoveryAttemptedIds
                 // dedups within a session — exactly one attempt per missing
@@ -610,7 +604,6 @@ class ConversationStream(
         _conversations.value = current.copy(
             items = current.items.filterNot { it.id == conversationId }
         )
-        placeholderIds -= conversationId
     }
 
     private suspend fun processAdminFileBatch(adminFiles: List<HomebaseFile>) {
@@ -622,7 +615,6 @@ class ConversationStream(
 
     private suspend fun processConversationBatchIncrementally(
         conversationFiles: List<HomebaseFile>,
-        source: BackendEvent.SyncSource,
     ) {
         // For each file in the batch, map to model (fetch last message from DB if needed)
         val incomingConversations =
@@ -648,9 +640,6 @@ class ConversationStream(
                 }
                 updateConversation(matchingConversation, c)
             }
-            // A real file has now arrived for this id; it no longer needs
-            // reconciliation. Safe whether or not it was ever a placeholder.
-            placeholderIds -= c.id
         }
 
         // Sort by descending timestamp (adjust based on your UI needs)
@@ -665,15 +654,10 @@ class ConversationStream(
         // should per-batch arrivals drive enrichment.
         if (!_conversations.value.enrichment.hasUnreadCounts) return
 
-        // Source-aware checkpoint:
-        //
-        // - DriveSync: nothing to do here. The matching DriveEvent.Stopped
-        //   handler will inspect [hasDirtyUnread] at end of the sync round
-        //   and run a single enrichAll for the whole round.
-        // - WebSocket: there is no Started/Stopped envelope — this batch IS
-        //   the whole event. If anything in it dirtied an unread count, run
-        //   enrichAll right here.
-        if (source == BackendEvent.SyncSource.WebSocket && hasDirtyUnread()) {
+        // Every BatchReceived is a live WS-push event (DriveSync is silent).
+        // There's no Started/Stopped envelope to defer to — this batch IS the
+        // whole event. If anything dirtied an unread count, run enrichAll now.
+        if (hasDirtyUnread()) {
             scope.launch {
                 try {
                     enrichAllConversationsWithUnreadCounts(trigger = "WebSocketBatch")
@@ -693,45 +677,6 @@ class ConversationStream(
 
         _conversations.value = _conversations.value.copy(items = currentList)
     }
-
-    // region Placeholder reconciliation
-    /**
-     * Persist any in-memory placeholders whose real conversation file did
-     * not arrive during the just-completed drive sync. Fired from the
-     * [BackendEvent.DriveEvent.Stopped] handler for the chat drive.
-     *
-     * Each placeholder is written as a local-only row via
-     * [OptimisticWriter.writeLocalOnlyConversationPlaceholder] — NO outbox
-     * enqueue, NO server distribution. The row's `modified` timestamp is
-     * set to 0 so a later-arriving real server file cleanly supersedes it
-     * via the DriveMainIndex upsert guard.
-     */
-    private suspend fun reconcileUnresolvedPlaceholders(ids: Set<Uuid>) {
-        if (ids.isEmpty()) return
-        Logger.i("ConversationStream: reconciling ${ids.size} placeholder(s) — persisting to local DB")
-
-        for (id in ids) {
-            val existing = _conversations.value.items.find { it.id == id }
-            if (existing == null) {
-                Logger.w("ConversationStream: placeholder $id vanished before reconciliation, skipping")
-                continue
-            }
-            val participants = existing.participants.filterNotNull()
-            try {
-                optimisticWriter.writeLocalOnlyConversationPlaceholder(
-                    driveId = chatDrive,
-                    conversationId = id,
-                    participants = participants,
-                    isGroup = existing.isGroup,
-                )
-            } catch (e: Exception) {
-                Logger.e(e) {
-                    "ConversationStream: failed to persist placeholder id=$id: ${e.message}"
-                }
-            }
-        }
-    }
-    // endregion
 
     private suspend fun updateConversation(
         existing: ConversationUiModel,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/DriveContactService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/DriveContactService.kt
@@ -71,11 +71,15 @@ class DriveContactService(
             eventBus.events.collect { event ->
                 if (event is BackendEvent.DriveEvent.Stopped &&
                     event.result is BackendEvent.DriveResult.Success &&
-                    event.driveId == contactDrive
+                    event.driveId == contactDrive &&
+                    event.totalCount > 0
                 ) {
                     // Never do blocking IO inside a SharedFlow collect body: refresh()
                     // calls QueryBatch which hangs on partial connectivity, parking the
-                    // 11-slot EventBus buffer and cascading to stall the chat Send path.
+                    // EventBus buffer and cascading to stall the chat Send path.
+                    // Also gated on totalCount > 0 — a no-op reconnect catch-up
+                    // (cursor at HEAD) would re-query the same contact set we already
+                    // have in memory.
                     scope.launch { refresh() }
                 }
             }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
@@ -127,13 +127,9 @@ class OptimisticWriter(
             )
 
             eventBus.emit(
-                BackendEvent.DriveEvent.BatchReceived(
+                BackendEvent.DataEvent.BatchReceived(
                     driveId = driveId,
-                    totalCount = batch.size,
-                    batchCount = batch.size,
-                    latestModified = created,
                     batchData = batch,
-                    source = BackendEvent.SyncSource.WebSocket
                 )
             )
 
@@ -144,12 +140,12 @@ class OptimisticWriter(
     }
 
     /**
-     * Persist a local-only conversation-file placeholder for an orphaned
-     * conversation (one whose messages arrived but whose conversation file
-     * never synced down). Called by the post-sync reconciliation in
-     * [id.homebase.chat.services.convo.ConversationStream] after the chat
-     * drive emits [BackendEvent.DriveEvent.Stopped] with any placeholders
-     * still unresolved.
+     * Persist a local-only conversation-file placeholder for a conversation
+     * that needs to surface in the UI before (or instead of) a real server
+     * file. Live callers:
+     *   - [id.homebase.chat.services.convo.ConversationService.recoverConversation]:
+     *     explicit local recovery (e.g. orphan-branch fallback when a message
+     *     arrived for a conversation whose definition file never synced).
      *
      * Strictly local: no `outboxSync.tryEnqueue`, no server distribution,
      * no `isPendingSendTag`. The row exists only so the conversation
@@ -408,13 +404,9 @@ class OptimisticWriter(
             )
 
             eventBus.emit(
-                BackendEvent.DriveEvent.BatchReceived(
+                BackendEvent.DataEvent.BatchReceived(
                     driveId = driveId,
-                    totalCount = batch.size,
-                    batchCount = batch.size,
-                    latestModified = lastModified,
                     batchData = batch,
-                    source = BackendEvent.SyncSource.WebSocket
                 )
             )
 
@@ -494,13 +486,9 @@ class OptimisticWriter(
             )
 
             eventBus.emit(
-                BackendEvent.DriveEvent.BatchReceived(
+                BackendEvent.DataEvent.BatchReceived(
                     driveId = driveId,
-                    totalCount = batch.size,
-                    batchCount = batch.size,
-                    latestModified = lastModified,
                     batchData = batch,
-                    source = BackendEvent.SyncSource.DriveSync
                 )
             )
         } catch (e: Exception) {
@@ -524,13 +512,9 @@ class OptimisticWriter(
             )
 
             eventBus.emit(
-                BackendEvent.DriveEvent.BatchReceived(
+                BackendEvent.DataEvent.BatchReceived(
                     driveId = driveId,
-                    totalCount = batch.size,
-                    batchCount = batch.size,
-                    latestModified = original.fileMetadata.updated,
                     batchData = batch,
-                    source = BackendEvent.SyncSource.WebSocket
                 )
             )
         } catch (e: Exception) {
@@ -620,13 +604,9 @@ class OptimisticWriter(
             )
 
             eventBus.emit(
-                BackendEvent.DriveEvent.BatchReceived(
+                BackendEvent.DataEvent.BatchReceived(
                     driveId = driveId,
-                    totalCount = batch.size,
-                    batchCount = batch.size,
-                    latestModified = lastModified,
                     batchData = batch,
-                    source = BackendEvent.SyncSource.DriveSync
                 )
             )
         } catch (e: Exception) {
@@ -718,13 +698,9 @@ class OptimisticWriter(
                 cursor = null
             )
             eventBus.emit(
-                BackendEvent.DriveEvent.BatchReceived(
+                BackendEvent.DataEvent.BatchReceived(
                     driveId = driveId,
-                    totalCount = batch.size,
-                    batchCount = batch.size,
-                    latestModified = lastModified,
                     batchData = batch,
-                    source = BackendEvent.SyncSource.DriveSync
                 )
             )
             Logger.d(tag = "MarkAsRead") {
@@ -780,13 +756,9 @@ class OptimisticWriter(
             )
 
             eventBus.emit(
-                BackendEvent.DriveEvent.BatchReceived(
+                BackendEvent.DataEvent.BatchReceived(
                     driveId = driveId,
-                    totalCount = batch.size,
-                    batchCount = batch.size,
-                    latestModified = lastModified,
                     batchData = batch,
-                    source = BackendEvent.SyncSource.DriveSync
                 )
             )
         } catch (e: Exception) {

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -67,6 +67,7 @@ class AuthConnectionCoordinator(
         .stateIn(scope, SharingStarted.Eagerly, false)
 
     init {
+        Logger.i(tag = "AuthLifecycle") { "AuthCC: collector started" }
         scope.launch {
             youAuthFlowManager.authState.collect {
                 onAuthStateChanged(it)
@@ -92,9 +93,18 @@ class AuthConnectionCoordinator(
     }
 
     suspend fun onAuthStateChanged(state: YouAuthState) {
+        Logger.i(tag = "AuthLifecycle") { "AuthCC: onAuthStateChanged(${state::class.simpleName})" }
+        logLifecycleSnapshot("onAuthStateChanged:${state::class.simpleName}")
         when (state) {
             is YouAuthState.Authenticated -> {
                 onPostAuthenticated()
+
+                // Mount mandatory drives FIRST — before bootstrap, before any network I/O.
+                // Encodes the invariant that this app's sync engine always syncs these
+                // drives; nothing about the WS handshake or the registry should be able to
+                // prevent them from appearing in driveStatuses.
+                driveSyncManager.ensureMandatoryMounted()
+
                 // Resolve the cross-device registry: local DB on cold boot (free), or one
                 // targeted server fetch on fresh login. Either way we have the canonical
                 // list before opening the WebSocket, so the first WS connect already
@@ -107,6 +117,7 @@ class AuthConnectionCoordinator(
                 for (drive in initialDrives) {
                     driveSyncManager.mountDrive(drive.drive.alias, drive.label)
                 }
+                logLifecycleSnapshot("drives mounted")
                 connect(extraDrives = initialDrives)
                 // Observe cross-device registry changes. We seed the diff baseline with the
                 // bootstrap result so the chat-drive sync that later writes the same file
@@ -125,6 +136,27 @@ class AuthConnectionCoordinator(
             else -> {
                 disconnect()
             }
+        }
+    }
+
+    /**
+     * Single-line summary of session-critical state. Fired at every auth transition and
+     * after each [_connectionState] mutation so a grep on `AuthLifecycle SNAPSHOT` gives
+     * a complete narrative of the mount / connect / sync flow.
+     */
+    private fun logLifecycleSnapshot(label: String) {
+        val statuses = driveSyncManager.driveStatuses.value
+        val statusesSummary = if (statuses.isEmpty()) "{}" else statuses.entries.joinToString(
+            prefix = "{", postfix = "}", separator = ", "
+        ) { (id, s) -> "$id:${s.state::class.simpleName}" }
+        val cs = _connectionState.value
+        Logger.i(tag = "AuthLifecycle") {
+            "AuthCC: SNAPSHOT[$label] " +
+                "authState=${youAuthFlowManager.authState.value::class.simpleName} " +
+                "isConnecting=${cs.isConnecting} isConnected=${cs.isConnected} " +
+                "wsClient=${wsClient?.let { "WS[${it.instanceId}]" } ?: "null"} " +
+                "dsmRunning=${driveSyncManager.isRunning} " +
+                "driveStatuses=$statusesSummary"
         }
     }
 
@@ -158,7 +190,20 @@ class AuthConnectionCoordinator(
      *   `driveRegistry.loadDrives()`, which reads the (now-populated) local index.
      */
     private suspend fun connect(extraDrives: List<LabeledDrive>? = null) {
-        if (wsClient != null) return
+        Logger.i(tag = "AuthLifecycle") {
+            "AuthCC: connect() called (wsClient=${wsClient?.let { "WS[${it.instanceId}]" } ?: "null"}, " +
+                "extraDrives=${extraDrives?.size})"
+        }
+        if (wsClient != null) {
+            // This guard is what would surface the "stale wsClient from previous session"
+            // hypothesis. If a logout's disconnect() left wsClient non-null, every
+            // subsequent login no-ops here and the WS handshake never happens — which is
+            // exactly the second-login symptom we're tracking down.
+            Logger.w(tag = "AuthLifecycle") {
+                "AuthCC: connect() SHORT-CIRCUITED — wsClient[${wsClient!!.instanceId}] already exists"
+            }
+            return
+        }
 
         val optionalDrives = extraDrives ?: driveRegistry.loadDrives()
         _connectionState.update { it.copy(isConnecting = true) }
@@ -181,7 +226,11 @@ class AuthConnectionCoordinator(
                 //                                         a clean send window.
                 //   4. outboxSync.send()                — flush the outbox queue.
                 onConnected = {
+                    Logger.i(tag = "AuthLifecycle") {
+                        "AuthCC: onConnected fired for ${wsClient?.let { "WS[${it.instanceId}]" } ?: "null-wsClient"}"
+                    }
                     _connectionState.update { it.copy(isConnected = true) }
+                    logLifecycleSnapshot("onConnected")
                     scope.launch {
                         try {
                             // start() must be called on every (re)connect — not just the first —
@@ -199,8 +248,9 @@ class AuthConnectionCoordinator(
                             wsClient?.processAllInboxes()
 
                             driveSyncManager.syncAll()
+                            Logger.i(tag = "AuthLifecycle") { "AuthCC: onConnected post-sync done" }
                         } catch (e: Exception) {
-                            Logger.e(e) { "syncAll() failed on connect" }
+                            Logger.e(throwable = e, tag = "AuthLifecycle") { "AuthCC: syncAll() failed on connect" }
                         } finally {
                             if (_connectionState.value.isConnected) {
                                 _connectionState.update { it.copy(isConnecting = false) }
@@ -212,15 +262,26 @@ class AuthConnectionCoordinator(
                     }
                 },
                 onDisconnected = {
+                    Logger.i(tag = "AuthLifecycle") {
+                        "AuthCC: onDisconnected fired for ${wsClient?.let { "WS[${it.instanceId}]" } ?: "null-wsClient"}"
+                    }
                     outboxSync.setOnline(false)
                     _connectionState.update { it.copy(isConnected = false, isConnecting = false) }
                     driveSyncManager.pause()
+                    logLifecycleSnapshot("onDisconnected")
                 },
-                onConnectError = {
+                onConnectError = { e ->
+                    Logger.w(throwable = e, tag = "AuthLifecycle") {
+                        "AuthCC: onConnectError for ${wsClient?.let { "WS[${it.instanceId}]" } ?: "null-wsClient"}: ${e.message}"
+                    }
                     outboxSync.setOnline(false)
                     _connectionState.update { it.copy(isConnected = false, isConnecting = false) }
+                    logLifecycleSnapshot("onConnectError")
                 }
-            ).also { it.start() }
+            ).also {
+                Logger.i(tag = "AuthLifecycle") { "AuthCC: WS[${it.instanceId}] created, start() invoked" }
+                it.start()
+            }
     }
 
     fun setForeground(foreground: Boolean) {
@@ -240,7 +301,20 @@ class AuthConnectionCoordinator(
      */
     suspend fun mountDrive(drive: LabeledDrive, persist: Boolean = true) {
         if (persist) driveRegistry.addDrive(drive)
-        driveSyncManager.mountDrive(drive.drive.alias, drive.label)
+        val newlyMounted = driveSyncManager.mountDrive(drive.drive.alias, drive.label)
+        if (!newlyMounted) {
+            // Redundant mount — drive was already in DSM. Skipping the refresh
+            // trigger is critical: refreshWsSubscription.trigger() would close
+            // an in-flight WebSocket connection 500ms later, which is exactly
+            // the regression that broke the post-login sync when VaultViewModel
+            // reactively re-mounted a drive that AuthCC had already mounted at
+            // login time. Logged loud so we can spot redundant callers.
+            Logger.w(tag = "AuthLifecycle") {
+                "AuthCC: mountDrive(${drive.drive.alias}, ${drive.label}) — already mounted, " +
+                    "skipping WS-refresh trigger"
+            }
+            return
+        }
         refreshWsSubscription.trigger()
     }
 
@@ -275,6 +349,9 @@ class AuthConnectionCoordinator(
     }
 
     private suspend fun disconnect() {
+        Logger.i(tag = "AuthLifecycle") {
+            "AuthCC: disconnect() begin (wsClient=${wsClient?.let { "WS[${it.instanceId}]" } ?: "null"})"
+        }
         refreshWsSubscription.cancel()
         driveRegistry.stop()
         outboxSync.setOnline(false)
@@ -285,6 +362,8 @@ class AuthConnectionCoordinator(
         wsClient?.close()
         wsClient = null
         driveSyncManager.stop()
+        Logger.i(tag = "AuthLifecycle") { "AuthCC: disconnect() end (wsClient nulled)" }
+        logLifecycleSnapshot("disconnect end")
     }
 
     companion object {

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/DriveRegistry.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/DriveRegistry.kt
@@ -123,21 +123,32 @@ class DriveRegistry(
      * chat-drive sync later writes the same file into the local index).
      */
     suspend fun bootstrap(): List<LabeledDrive> {
+        Logger.i(tag = "DriveRegistry") { "bootstrap() begin" }
         val local = loadDrives()
-        if (local.isNotEmpty()) return local
+        Logger.i(tag = "DriveRegistry") { "bootstrap local-DB returned ${local.size} drive(s)" }
+        if (local.isNotEmpty()) {
+            Logger.i(tag = "DriveRegistry") { "bootstrap() end (local, ${local.size} drive(s))" }
+            return local
+        }
         val chatDriveId = SystemDriveConstants.chatDrive.alias
+        Logger.i(tag = "DriveRegistry") { "bootstrap falling back to server fetch" }
         val server = try {
             getFileHeaderByUid(chatDriveId, REGISTRY_UNIQUE_ID)
         } catch (e: CancellationException) {
             // Don't swallow cancellation — let the caller's scope tear down cleanly.
             throw e
         } catch (e: Exception) {
-            Logger.w(tag = TAG, throwable = e) {
-                "bootstrap: server fetch failed — falling back to empty (observer will pick up after first sync)"
+            Logger.w(tag = "DriveRegistry", throwable = e) {
+                "bootstrap server fetch failed — falling back to empty (observer will pick up after first sync)"
             }
             return emptyList()
-        } ?: return emptyList()
-        return parseRegistryContent(server)
+        } ?: run {
+            Logger.i(tag = "DriveRegistry") { "bootstrap() end (server returned no registry file, 0 drives)" }
+            return emptyList()
+        }
+        val parsed = parseRegistryContent(server)
+        Logger.i(tag = "DriveRegistry") { "bootstrap() end (server, ${parsed.size} drive(s))" }
+        return parsed
     }
 
     /**
@@ -190,15 +201,36 @@ class DriveRegistry(
         }
         observerJob = scope.launch {
             eventBus.events.collect { event ->
-                if (event !is BackendEvent.DriveEvent.BatchReceived) return@collect
-                if (event.driveId != SystemDriveConstants.chatDrive.alias) return@collect
-                // Match on the well-known uniqueId — stronger than matching on fileType
-                // alone. There is exactly one registry file per identity.
-                val touchesRegistry = event.batchData.any {
-                    it.fileMetadata.appData.uniqueId == REGISTRY_UNIQUE_ID
+                val chatDriveAlias = SystemDriveConstants.chatDrive.alias
+                when (event) {
+                    is BackendEvent.DataEvent.BatchReceived -> {
+                        if (event.driveId != chatDriveAlias) return@collect
+                        // Live WS-push event (DriveSync is silent). Match on the
+                        // well-known uniqueId — stronger than matching on fileType
+                        // alone. There is exactly one registry file per identity.
+                        val touchesRegistry = event.batchData.any {
+                            it.fileMetadata.appData.uniqueId == REGISTRY_UNIQUE_ID
+                        }
+                        if (!touchesRegistry) return@collect
+                        reconcile(onMount, onUnmount)
+                    }
+
+                    is BackendEvent.DriveEvent.Stopped -> {
+                        if (event.driveId != chatDriveAlias) return@collect
+                        // Silent-DriveSync contract: DriveSync runs landed N files
+                        // in DriveMainIndex without per-batch events; the registry
+                        // file may be among them. Reconcile on Success to pick up
+                        // any cross-device drive add/remove. Gated on totalCount > 0
+                        // because totalCount=0 means the cursor was already at HEAD —
+                        // no files were upserted this round, so the registry file is
+                        // unchanged and the reconcile diff would be empty anyway.
+                        if (event.result is BackendEvent.DriveResult.Success && event.totalCount > 0) {
+                            reconcile(onMount, onUnmount)
+                        }
+                    }
+
+                    else -> { /* Started / Progress / other events: no-op */ }
                 }
-                if (!touchesRegistry) return@collect
-                reconcile(onMount, onUnmount)
             }
         }
     }

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/sync/DriveRegistryTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/sync/DriveRegistryTest.kt
@@ -398,11 +398,8 @@ class DriveRegistryTest {
         val registryFile = buildRegistryFile(listOf(feedLabeledDrive))
         launch {
             eventBus.emit(
-                BackendEvent.DriveEvent.BatchReceived(
+                BackendEvent.DataEvent.BatchReceived(
                     driveId = SystemDriveConstants.chatDrive.alias,
-                    totalCount = 1,
-                    batchCount = 1,
-                    latestModified = null,
                     batchData = listOf(registryFile),
                 )
             )
@@ -430,17 +427,14 @@ class DriveRegistryTest {
         )
         advanceUntilIdle()
 
-        // Simulate another device activating Feed: chat-drive sync writes the registry
-        // file to our local DB and emits BatchReceived.
+        // Simulate another device activating Feed: chat-drive WS push delivers the
+        // updated registry file via a BatchReceived event.
         seedRegistryFile(db, listOf(feedLabeledDrive))
         val registryFile = buildRegistryFile(listOf(feedLabeledDrive))
         launch {
             eventBus.emit(
-                BackendEvent.DriveEvent.BatchReceived(
+                BackendEvent.DataEvent.BatchReceived(
                     driveId = SystemDriveConstants.chatDrive.alias,
-                    totalCount = 1,
-                    batchCount = 1,
-                    latestModified = null,
                     batchData = listOf(registryFile),
                 )
             )
@@ -470,17 +464,14 @@ class DriveRegistryTest {
         )
         advanceUntilIdle()
 
-        // Another device calls removeDrive(vault) — the registry file is updated in
-        // the sync pipeline and a BatchReceived event is emitted with the shrunk list.
+        // Another device calls removeDrive(vault) — WS push delivers the shrunk
+        // registry file via a BatchReceived event.
         seedRegistryFile(db, listOf(feedLabeledDrive))
         val updatedFile = buildRegistryFile(listOf(feedLabeledDrive))
         launch {
             eventBus.emit(
-                BackendEvent.DriveEvent.BatchReceived(
+                BackendEvent.DataEvent.BatchReceived(
                     driveId = SystemDriveConstants.chatDrive.alias,
-                    totalCount = 1,
-                    batchCount = 1,
-                    latestModified = null,
                     batchData = listOf(updatedFile),
                 )
             )
@@ -512,11 +503,8 @@ class DriveRegistryTest {
         val registryFile = buildRegistryFile(listOf(feedLabeledDrive))
         launch {
             eventBus.emit(
-                BackendEvent.DriveEvent.BatchReceived(
+                BackendEvent.DataEvent.BatchReceived(
                     driveId = Uuid.random(),  // not the chat drive
-                    totalCount = 1,
-                    batchCount = 1,
-                    latestModified = null,
                     batchData = listOf(registryFile),
                 )
             )
@@ -553,11 +541,8 @@ class DriveRegistryTest {
         )
         launch {
             eventBus.emit(
-                BackendEvent.DriveEvent.BatchReceived(
+                BackendEvent.DataEvent.BatchReceived(
                     driveId = SystemDriveConstants.chatDrive.alias,
-                    totalCount = 1,
-                    batchCount = 1,
-                    latestModified = null,
                     batchData = listOf(otherFile),
                 )
             )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -128,13 +128,14 @@ val appModule = module {
         )
     }
 
-    // Seeded with mandatory drives only — optional drives from the registry are cold-loaded
-    // into DriveSyncManager by AuthConnectionCoordinator after authentication, because
-    // reading the registry requires active credentials (not available at Koin time).
+    // Mandatory drives (chat, contacts) are baked into the constructor as an invariant
+    // of the sync engine. Optional drives from the cross-device registry are mounted
+    // dynamically by AuthConnectionCoordinator after authentication, because reading
+    // the registry requires active credentials (not available at Koin time).
     single {
         DriveSyncManager(
             get(), get(), get(), get(), get(),
-            mandatorySyncDrives.associate { it.drive.alias to it.label },
+            mandatoryDrives = mandatorySyncDrives.associate { it.drive.alias to it.label },
         )
     }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultStream.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultStream.kt
@@ -169,9 +169,32 @@ class VaultStream(
     private suspend fun observeEvents() {
         eventBus.events.collect { event ->
             when (event) {
-                is BackendEvent.DriveEvent.BatchReceived -> {
+                is BackendEvent.DataEvent.BatchReceived -> {
                     if (event.driveId != driveId) return@collect
+                    // Every BatchReceived is a live WS-push event (DriveSync is
+                    // silent — see DriveSync.kt). Drives incremental section/entry
+                    // updates in steady state.
                     processBatchIncrementally(event.batchData)
+                }
+
+                is BackendEvent.DriveEvent.Stopped -> {
+                    if (event.driveId != driveId) return@collect
+                    // Silent-DriveSync contract: when the vault drive finishes
+                    // a DriveSync round, reload the full vault state from DB so
+                    // sections + entries reflect the just-landed files. No-op on
+                    // failure — retry on next sync round. Gated on totalCount > 0
+                    // because totalCount=0 means no files were upserted this round
+                    // (cursor at HEAD) — DB state is unchanged from what we already
+                    // have in memory.
+                    if (event.result is BackendEvent.DriveResult.Success && event.totalCount > 0) {
+                        try {
+                            loadAll()
+                        } catch (e: Exception) {
+                            Logger.e(e) {
+                                "VaultStream: post-Stopped reload FAILED: ${e.message}"
+                            }
+                        }
+                    }
                 }
 
                 is BackendEvent.OutboxEvent.ItemFailed -> {

--- a/homebase-core/src/jvmMain/kotlin/id/homebase/core/notifications/DesktopChatNotificationBridge.kt
+++ b/homebase-core/src/jvmMain/kotlin/id/homebase/core/notifications/DesktopChatNotificationBridge.kt
@@ -54,13 +54,13 @@ class DesktopChatNotificationBridge(
         }
         scope.launch {
             eventBus.events
-                .filterIsInstance<BackendEvent.DriveEvent.BatchReceived>()
+                .filterIsInstance<BackendEvent.DataEvent.BatchReceived>()
                 .filter { it.driveId == chatDriveId }
                 .collect { event -> handleBatch(event) }
         }
     }
 
-    private suspend fun handleBatch(event: BackendEvent.DriveEvent.BatchReceived) {
+    private suspend fun handleBatch(event: BackendEvent.DataEvent.BatchReceived) {
         val domain = try {
             credentialsManager.requireActiveDomain()
         } catch (e: Exception) {


### PR DESCRIPTION
Unfortunately a bigger PR than I liked, but the mounting issues, and event bus overflows during syncs, were interconnected. Got exposed on Samwise due to all his orphaned conversations. The new paradigm is that DriveSync doesn't emit data-batches. Only websocket and code emits data-batches. After a driveSync.Stopped event, if the totalCount > 0 you might need to "refresh your data" (depends on your app). TotalCount can be anything from 30,000+ to 1 or 0.

Fixes a second-login regression where mandatory drives (chat, contacts) never mounted on the second login of a session: mounting was buried inside DriveSyncManager.start(), which only ran after the WebSocket handshake completed. If the handshake stalled (which it did, for unrelated back-pressure reasons we also fix here), the mandatory drives were stuck at "Initialized" forever.

DriveSyncManager
* Renamed the `drives` ctor param to `mandatoryDrives` and made it the single source of truth for the engine's invariant drives.
* New `ensureMandatoryMounted()` registers them as `Initialized` in driveSyncs. AuthConnectionCoordinator calls it the moment credentials become valid (before bootstrap, before WS connect), so the drives show up in driveStatuses independently of WS state.
* mountDrive() is now atomic: the alreadyExists check and the map insertion happen inside the same mutex block, retiring the previous double-register race.
* mountDrive() returns `Boolean` so AuthCC.mountDrive can skip refreshWsSubscription.trigger() on idempotent calls — the previously unconditional trigger was tearing down in-flight WS handshakes when VaultViewModel reactively re-mounted a drive AuthCC had already mounted.
* `expectFreshCursors` threaded through mountDrive (applies to mandatory AND optional drives now, was previously mandatory-only).
* `isRunning` exposed read-only for the snapshot-logging consumer.

BackendEvent: DriveEvent vs. DataEvent split
* DriveEvent: pure state-machine signals — Started / Progress(driveId, totalCount) / Stopped. No payload.
* DataEvent.BatchReceived(driveId, batchData): the data channel. Emitted only by DriveWebSocketUpsertWorker (WS push) and OptimisticWriter (in-process). DriveSync.performSync is silent.
* SyncSource enum removed. Was load-bearing in a buggy way: OptimisticWriter had 4 emits mis-tagged source=DriveSync that the consumer-side source filter would have silently dropped, breaking optimistic delete + reaction UI.
* Dead fields (totalCount, batchCount, latestModified) dropped from BatchReceived — only `latestModified` was set anywhere, never read.

DriveSync.performSync
* Now emits Started + per-batch DriveEvent.Progress(running total) + Stopped. The per-batch BatchReceived emit (and its wrong-date orphan-placeholder domino) is gone.
* Consumers reload from local DB on Stopped(Success, totalCount > 0):
  - ConversationStream: loadBasicConversations + enrichLastMessages + enrichAdmins (unconditional) + enrichUnreadCounts (gated on hasDirtyUnread — only fires on peer-device mark-as-read echoes).
  - VaultStream: loadAll().
  - DriveRegistry: reconcile().
  - DriveContactService: refresh().
* `totalCount > 0` gate skips no-op reconnect catch-ups (cursor already at HEAD, nothing landed in the index → reload would be busywork).

OdinWebSocketClient
* Per-instance `instanceId` so log lines (ctor, start, connect, handshake, disconnect, close) thread together across reconnects.
* WS-loop emits switched to `tryEmit` for Connecting/ConnectionOffline. The WS lifecycle is the source of truth via connectionState; the bus emission is an informational mirror that must not park on a slow subscriber.

AuthConnectionCoordinator
* `onAuthStateChanged(Authenticated)` reorders to: mount mandatory → bootstrap registry → mount optional → connect WS. Mandatory drives appear in driveStatuses before any network I/O.
* AuthCC.mountDrive checks DSM.mountDrive's Boolean return: skips the refresh-trigger on idempotent calls. Fixes the VaultViewModel race.
* New logLifecycleSnapshot() helper fires at every state transition, dumping authState/isConnecting/isConnected/wsClient[id]/dsmRunning/ driveStatuses summary as one log line.

EventBus
* emit() fast-paths through tryEmit; logs BUFFER FULL + elapsed duration on the suspending fallback. Acts as a regression alarm for back-pressure issues; buffer size kept at the original 10.
* subscriptionCount exposed for diagnostics.

Side-effect fixes
* "All conversations show today's date" symptom (orphan placeholders written with metadata.created=now during initial sync) is gone — no per-batch processing during DriveSync, so the orphan branch can't fire for messages whose conversation file arrives later in cursor order.
* Optimistic delete + reaction-toggle UI updates work again (OptimisticWriter's 4 source=DriveSync emits would have been silently dropped by the consumer-side filter we introduced and then removed).

Logging
* Per-component tags: AuthLifecycle (AuthCC), DriveSync (DSM), WebSocket (WS), WSPush (DriveWebSocketUpsertWorker), DriveRegistry, EventBus. Each grep-able independently.

Tests
* DriveSyncManagerTest: ensureMandatoryMountedRegistersDrivesWithoutStarting, mountDriveReturnsFalseOnSecondCall, ensureMandatoryMountedIsIdempotent, progressEventAdvancesSynchronizingCount, progressEventIsIgnoredWhenCountWouldGoBackwards.
* DriveRegistryTest + DriveWebSocketUpsertWorkerTest: type-renames and drop-of-removed-fields.

Verification
* ./gradlew homebase-api:jvmTest homebase-chat:jvmTest homebase-common:jvmTest --rerun-tasks ✓
* ./gradlew homebase-core:jvmJar ✓
* Manual: logout → login on same process → mandatory drives mount and sync cleanly (the original repro). Conversation dates correct. Initial login progress bar shows record count (DriveEvent.Progress).