### PR TITLE
feat: enable multi-select in system gallery picker

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -200,6 +200,7 @@ import id.homebase.resources.search
 import id.homebase.resources.time_today
 import id.homebase.resources.time_yesterday
 import id.homebase.resources.you
+import io.github.vinceglb.filekit.dialogs.FileKitMode
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher
 import kotlinx.collections.immutable.persistentMapOf
@@ -504,12 +505,15 @@ fun ConversationContent(
             )
         }
     }
-    val galleryLauncher = rememberFilePickerLauncher(type = FileKitType.ImageAndVideo) { file ->
-        file?.let {
+    val galleryLauncher = rememberFilePickerLauncher(
+        type = FileKitType.ImageAndVideo,
+        mode = FileKitMode.Multiple(),
+    ) { files ->
+        files?.takeIf { it.isNotEmpty() }?.let {
             onUiAction(
                 ConversationListUiAction.AttachPlatformFile(
                     conversationId = conversation.conversation.id,
-                    files = listOf(file),
+                    files = it,
                     isImage = true,
                 )
             )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
@@ -39,6 +39,7 @@ import id.homebase.chat.services.convo.EnrichedConversationUiModel
 import id.homebase.core.HomebaseConstants
 import id.homebase.core.util.boundedFirstVisibleItemIndex
 import id.homebase.core.util.rememberCameraManager
+import io.github.vinceglb.filekit.dialogs.FileKitMode
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher
 import kotlinx.coroutines.Dispatchers
@@ -61,12 +62,15 @@ fun ConversationMessagesPane(
 ) {
     var currentGalleryPage by remember { mutableStateOf(0) }
 
-    val galleryLauncher = rememberFilePickerLauncher(type = FileKitType.ImageAndVideo) { file ->
-        file?.let {
+    val galleryLauncher = rememberFilePickerLauncher(
+        type = FileKitType.ImageAndVideo,
+        mode = FileKitMode.Multiple(),
+    ) { files ->
+        files?.takeIf { it.isNotEmpty() }?.let {
             onUiAction(
                 ConversationListUiAction.AttachPlatformFile(
                     conversationId = conversation.conversation.id,
-                    files = listOf(file),
+                    files = it,
                     isImage = true,
                 )
             )


### PR DESCRIPTION
## Summary
- Switch the FileKit gallery launcher from `FileKitMode.Single` to `FileKitMode.Multiple()` in both `ConversationContent` and `ConversationMessagesPane`
- Users can now select multiple photos/videos at once from the system gallery picker
- No downstream changes needed — `AttachPlatformFile` already accepts `List<PlatformFile>`

## Test plan
- [ ] Open a conversation, tap +, tap the Gallery icon — system picker should allow multi-select
- [ ] Select multiple photos → all appear in the attachment editor
- [ ] Select a single photo → still works as before
- [ ] Cancel the picker → no crash, no attachment added
- [ ] Test on both Android and iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)