### PR TITLE
fix(chat): detect non-filesystem paths by scheme, not leading slash

### DIFF
--- a/homebase-chat/src/androidMain/kotlin/id/homebase/chat/services/FileExistence.android.kt
+++ b/homebase-chat/src/androidMain/kotlin/id/homebase/chat/services/FileExistence.android.kt
@@ -1,6 +1,9 @@
 package id.homebase.chat.services
 
 internal actual fun fileExists(path: String): Boolean {
-    if (!path.startsWith("/")) return true
+    // Non-filesystem references (content://, file://, http(s)://, …) are
+    // opaque from here — assume they're valid and let the consumer
+    // resolve them. Filesystem paths fall through to the real check.
+    if (path.contains("://")) return true
     return java.io.File(path).exists()
 }

--- a/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/services/FileExistence.jvm.kt
+++ b/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/services/FileExistence.jvm.kt
@@ -1,6 +1,10 @@
 package id.homebase.chat.services
 
 internal actual fun fileExists(path: String): Boolean {
-    if (!path.startsWith("/")) return true
+    // Non-filesystem references (content://, file://, http(s)://, …) are
+    // opaque from here — assume they're valid and let the consumer
+    // resolve them. Filesystem paths (POSIX "/x/y", Windows "C:\x") fall
+    // through to the real existence check.
+    if (path.contains("://")) return true
     return java.io.File(path).exists()
 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/FileExistenceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/FileExistenceTest.kt
@@ -1,0 +1,82 @@
+package id.homebase.chat.services
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Covers the scheme-vs-filesystem heuristic in jvmMain's [fileExists].
+ * The androidMain implementation is byte-identical, so this also documents
+ * the contract that the Android actual must uphold.
+ */
+class FileExistenceTest {
+
+    // region Scheme-prefixed (opaque) references are assumed valid
+
+    @Test
+    fun contentUri_isAssumedValid() {
+        assertTrue(fileExists("content://media/external/images/media/12345"))
+    }
+
+    @Test
+    fun fileUri_isAssumedValid() {
+        // Even if the underlying file doesn't exist — we don't resolve file://
+        // here; the consumer does.
+        assertTrue(fileExists("file:///nonexistent/path/image.jpg"))
+    }
+
+    @Test
+    fun httpUrl_isAssumedValid() {
+        assertTrue(fileExists("https://example.com/image.jpg"))
+        assertTrue(fileExists("http://example.com/image.jpg"))
+    }
+
+    // endregion
+
+    // region Filesystem paths fall through to the real existence check
+
+    @Test
+    fun existingTempFile_returnsTrue() {
+        val file = File.createTempFile("file_existence_test_", ".jpg").also { it.deleteOnExit() }
+        try {
+            assertTrue(fileExists(file.absolutePath))
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun deletedTempFile_returnsFalse() {
+        val file = File.createTempFile("file_existence_test_", ".jpg")
+        val path = file.absolutePath
+        file.delete()
+        assertFalse(fileExists(path))
+    }
+
+    @Test
+    fun nonexistentPosixPath_returnsFalse() {
+        assertFalse(fileExists("/definitely/does/not/exist/image.jpg"))
+    }
+
+    @Test
+    fun nonexistentWindowsPath_returnsFalse() {
+        // Regression for the previous heuristic (`!path.startsWith("/")`) which
+        // returned `true` for any Windows path because it doesn't start with /,
+        // bypassing the existence check on Windows desktop entirely.
+        val path = "C:\\definitely\\does\\not\\exist\\image.jpg"
+        assertFalse(fileExists(path))
+    }
+
+    // endregion
+
+    // region Edge cases
+
+    @Test
+    fun emptyPath_returnsFalse() {
+        // No scheme, no file — must fall through to the real check, which says no.
+        assertFalse(fileExists(""))
+    }
+
+    // endregion
+}


### PR DESCRIPTION
PR #507 introduced `fileExists()` to let LocalAttachmentContextStore auto-evict stale temp-file paths after process death. The heuristic for skipping the existence check was `!path.startsWith("/")`, intended to short-circuit Android `content://` URIs (which `java.io.File.exists()` always reports as missing).

That heuristic is POSIX-only. On the Windows desktop build, real filesystem paths look like `C:\Users\...\file.jpg` and also don't start with `/`, so the check returned `true` unconditionally — meaning the store never evicted stale entries on Windows, defeating the whole purpose of the fix on that platform.

Switch to `path.contains("://")`, which correctly identifies opaque scheme-prefixed references (`content://`, `file://`, `http(s)://`, …) and lets every real filesystem path — POSIX `/x/y` AND Windows `C:\x` — fall through to the actual `File.exists()` check.

The iOS actual (`FileExistence.native.kt`) is untouched: on Darwin, `startsWith("/")` correctly classifies every real filesystem path.

Tests
-----
Adds `FileExistenceTest` covering:
  * scheme-prefixed URIs (content, file, http, https) → assumed valid
  * existing temp file → true
  * deleted temp file → false
  * nonexistent POSIX path → false
  * nonexistent Windows path (`C:\...`) → false  ← regression guard
  * empty string → false

The Android actual is byte-identical to the JVM actual, so this jvmTest covers the contract for both.