### PR TITLE
perf(sync): coalesce concurrent DriveRegistry.bootstrap() calls

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
@@ -62,9 +62,6 @@ class DriveSyncManager(
         .map { computeSyncState(it) }
         .stateIn(scope, SharingStarted.Eagerly, SyncState.Idle)
 
-    fun numberOfDrivesSyncing(): Int =
-        _driveStatuses.value.values.count { it.state is DriveState.Synchronizing }
-
     init {
         scope.launch {
             var previous: SyncState = SyncState.Idle

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncManagerTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncManagerTest.kt
@@ -570,35 +570,6 @@ class DriveSyncManagerTest {
     }
 
     @Test
-    fun numberOfDrivesSyncingReturnsCorrectCount() {
-        val db = DatabaseManager({ createInMemoryDatabase() })
-
-        runTest() {
-            val eventBus = EventBus()
-            val driveId1 = Uuid.random()
-            val driveId2 = Uuid.random()
-            val manager = buildManager(db, buildCredentials(), eventBus, backgroundScope, mapOf(driveId1 to "Drive 1", driveId2 to "Drive 2"))
-            manager.start()
-            runCurrent()
-
-            assertEquals(0, manager.numberOfDrivesSyncing())
-
-            eventBus.emit(BackendEvent.DriveEvent.Started(driveId1))
-            runCurrent()
-            assertEquals(1, manager.numberOfDrivesSyncing())
-
-            eventBus.emit(BackendEvent.DriveEvent.Started(driveId2))
-            runCurrent()
-            assertEquals(2, manager.numberOfDrivesSyncing())
-
-            eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId1, 0, BackendEvent.DriveResult.Completed))
-            runCurrent()
-            assertEquals(1, manager.numberOfDrivesSyncing())
-        }
-        db.close()
-    }
-
-    @Test
     fun ensureMandatoryMountedRegistersDrivesWithoutStarting() {
         // The bug from the second-login repro: mandatory drives were only mounted inside
         // start(), and start() only ran from the WS onConnected callback. If the handshake

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/DriveRegistry.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/DriveRegistry.kt
@@ -21,13 +21,16 @@ import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.core.config.LabeledDrive
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlin.uuid.Uuid
 
 /**
@@ -84,6 +87,9 @@ class DriveRegistry(
     private val stateMutex = Mutex()
     private var observerJob: Job? = null
 
+    private val bootstrapMutex = Mutex()
+    private var bootstrapInFlight: CompletableDeferred<List<LabeledDrive>>? = null
+
     /**
      * Alias-set of drives last surfaced to callers. The diff baseline for the observer.
      * Guarded by [stateMutex].
@@ -121,33 +127,71 @@ class DriveRegistry(
      * (so the WS subscribes to the full set on the first connect) and [start]'s
      * `initialBaseline` (so the observer doesn't fire spurious onMount when the
      * chat-drive sync later writes the same file into the local index).
+     *
+     * Concurrent callers (AuthConnectionCoordinator and VaultViewModel both fire
+     * `bootstrap()` on fresh login within ~100 ms) share a single in-flight result:
+     * the second caller awaits the first's deferred instead of issuing its own server
+     * round-trip. Once the in-flight call completes the deferred is cleared, so a
+     * subsequent call (e.g. after the local DB becomes populated) runs fresh.
      */
     suspend fun bootstrap(): List<LabeledDrive> {
-        Logger.i(tag = "DriveRegistry") { "bootstrap() begin" }
+        val (deferred, isLeader) = bootstrapMutex.withLock {
+            val existing = bootstrapInFlight
+            if (existing != null) {
+                existing to false
+            } else {
+                val fresh = CompletableDeferred<List<LabeledDrive>>()
+                bootstrapInFlight = fresh
+                fresh to true
+            }
+        }
+        if (!isLeader) {
+            Logger.i(tag = TAG) { "bootstrap() coalesced onto in-flight call — awaiting result" }
+            return deferred.await()
+        }
+        try {
+            val result = runBootstrap()
+            deferred.complete(result)
+            return result
+        } catch (t: Throwable) {
+            // Includes CancellationException — followers share the same fate.
+            deferred.completeExceptionally(t)
+            throw t
+        } finally {
+            withContext(NonCancellable) {
+                bootstrapMutex.withLock {
+                    if (bootstrapInFlight === deferred) bootstrapInFlight = null
+                }
+            }
+        }
+    }
+
+    private suspend fun runBootstrap(): List<LabeledDrive> {
+        Logger.i(tag = TAG) { "bootstrap() begin" }
         val local = loadDrives()
-        Logger.i(tag = "DriveRegistry") { "bootstrap local-DB returned ${local.size} drive(s)" }
+        Logger.i(tag = TAG) { "bootstrap local-DB returned ${local.size} drive(s)" }
         if (local.isNotEmpty()) {
-            Logger.i(tag = "DriveRegistry") { "bootstrap() end (local, ${local.size} drive(s))" }
+            Logger.i(tag = TAG) { "bootstrap() end (local, ${local.size} drive(s))" }
             return local
         }
         val chatDriveId = SystemDriveConstants.chatDrive.alias
-        Logger.i(tag = "DriveRegistry") { "bootstrap falling back to server fetch" }
+        Logger.i(tag = TAG) { "bootstrap falling back to server fetch" }
         val server = try {
             getFileHeaderByUid(chatDriveId, REGISTRY_UNIQUE_ID)
         } catch (e: CancellationException) {
             // Don't swallow cancellation — let the caller's scope tear down cleanly.
             throw e
         } catch (e: Exception) {
-            Logger.w(tag = "DriveRegistry", throwable = e) {
+            Logger.w(tag = TAG, throwable = e) {
                 "bootstrap server fetch failed — falling back to empty (observer will pick up after first sync)"
             }
             return emptyList()
         } ?: run {
-            Logger.i(tag = "DriveRegistry") { "bootstrap() end (server returned no registry file, 0 drives)" }
+            Logger.i(tag = TAG) { "bootstrap() end (server returned no registry file, 0 drives)" }
             return emptyList()
         }
         val parsed = parseRegistryContent(server)
-        Logger.i(tag = "DriveRegistry") { "bootstrap() end (server, ${parsed.size} drive(s))" }
+        Logger.i(tag = TAG) { "bootstrap() end (server, ${parsed.size} drive(s))" }
         return parsed
     }
 


### PR DESCRIPTION
On fresh login, both AuthConnectionCoordinator and VaultViewModel call DriveRegistry.bootstrap() within ~100 ms of each other. Before this change, both callers raced past the local-DB short-circuit (empty on fresh login) and each issued its own getFileHeaderByUid() HTTP request to fetch the registry file, returning the same payload twice.

Add an in-flight CompletableDeferred guarded by a dedicated Mutex:
  - First caller becomes the leader, runs the original logic, and completes the deferred with the result.
  - Concurrent callers become followers and await the leader's result instead of duplicating the work. A new log line "bootstrap() coalesced onto in-flight call — awaiting result" makes the coalescing visible.
  - The deferred is cleared in a withContext(NonCancellable) finally so a transient server failure (or cancellation) doesn't poison subsequent calls; the next bootstrap() runs fresh.
  - Exceptions (including CancellationException) propagate to all waiters via completeExceptionally — followers share the leader's fate within a single in-flight window.

Verified against homebase.log:
  before: 2× "bootstrap falling back to server fetch" per fresh login
  after:  1× "bootstrap falling back to server fetch", 1× "coalesced
          onto in-flight call — awaiting result"

Also delete DriveSyncManager.numberOfDrivesSyncing() and its test — the method has no production caller (the orphan-persistence gate that used it was removed earlier) and the test only exercises the method itself.