### PR TITLE
chore: remove WSDiag debugging scaffolding

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
@@ -319,9 +319,6 @@ class OdinWebSocketClient(
     }
 
     private suspend fun handleNotification(notification: ClientNotificationPayload) {
-        Logger.i(tag = "WSDiag") {
-            "WS recv type=${notification.notificationType} dataLen=${notification.data.length}"
-        }
         notificationBufferMutex.withLock {
             notificationBuffer += notification
         }
@@ -596,11 +593,6 @@ class OdinWebSocketClient(
             OdinSystemSerializer.deserialize<ClientDriveNotification>(notification.data)
         val driveId = fileNotification.targetDrive!!.alias
         val header = fileNotification.header
-
-        Logger.i(tag = "WSDiag") {
-            "WS file event type=${notification.notificationType} drive=$driveId " +
-                "headerPresent=${header != null} fileId=${header?.fileId}"
-        }
 
         if (header != null) {
             val worker = getOrCreateWorker(driveId)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveWebSocketUpsertWorker.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveWebSocketUpsertWorker.kt
@@ -145,9 +145,6 @@ class DriveWebSocketUpsertWorker(
             Logger.i(tag = "WSPush") {
                 "WSPush: drainOnce drive=$driveId rows=${batch.size} took=$upsertElapsed (emitting BatchReceived)"
             }
-            Logger.i(tag = "WSDiag") {
-                "WSPush upsert drive=$driveId rows=${batch.size}"
-            }
 
             eventBus.emit(
                 BackendEvent.DataEvent.BatchReceived(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -70,10 +70,6 @@ class ChatMessageStream(
                     is BackendEvent.DriveEvent.Stopped -> {
                         if (event.driveId != chatDrive) return@collect
                         Logger.d("ChatMessageStream: Stopped(totalCount=${event.totalCount}, result=${event.result})")
-                        Logger.i(tag = "WSDiag") {
-                            "ChatMessageStream: Stopped chatDrive totalCount=${event.totalCount} " +
-                                "result=${event.result} willRefreshWindows=${event.totalCount > 0}"
-                        }
                         // Silent-DriveSync contract: the chat-drive DriveSync just
                         // landed N files in DriveMainIndex with no per-batch
                         // BatchReceived emits. Re-query the newest page for every
@@ -96,14 +92,6 @@ class ChatMessageStream(
 
                     is BackendEvent.DataEvent.BatchReceived -> {
                         if (event.driveId != chatDrive) return@collect
-                        Logger.i(tag = "WSDiag") {
-                            val convoIds = event.batchData
-                                .map { it.fileMetadata.appData.groupId }
-                                .distinct()
-                            val openWindows = paginatedState.windows.value.keys
-                            "ChatMessageStream: BatchReceived chatDrive rows=${event.batchData.size} " +
-                                "convoIds=$convoIds openWindows=$openWindows"
-                        }
                         // Every BatchReceived is a live WS-push event (DriveSync is
                         // silent). The window gate inside processIncrementalBatch
                         // no-ops batches for conversations the user hasn't opened.
@@ -347,18 +335,8 @@ class ChatMessageStream(
         val grouped = messages.groupBy { it.conversationId }
         Logger.d("ChatMessageStream: processIncrementalBatch ${messages.size} messages across ${grouped.size} conversation(s)")
         grouped.forEach { (conversationId, msgs) ->
-            if (isConversationLeft(conversationId)) {
-                Logger.i(tag = "WSDiag") {
-                    "ChatMessageStream: skip convoId=$conversationId (user left); rows=${msgs.size}"
-                }
-                return@forEach
-            }
-            val window = paginatedState.getWindow(conversationId) ?: run {
-                Logger.i(tag = "WSDiag") {
-                    "ChatMessageStream: window-gate skip convoId=$conversationId (no open window); rows=${msgs.size}"
-                }
-                return@forEach
-            }
+            if (isConversationLeft(conversationId)) return@forEach
+            val window = paginatedState.getWindow(conversationId) ?: return@forEach
             // Gate: when the user has paged backwards (hasNewerMessages == true), the
             // window doesn't include the latest messages. Stream events that arrive while
             // the user is deep in history would land out of order; defer them until the

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -186,10 +186,6 @@ class ConversationStream(
                     is BackendEvent.DriveEvent.Stopped -> {
                         if (event.driveId != chatDrive) return@collect
                         Logger.d("ConversationStream: Stopped(totalCount=${event.totalCount})")
-                        Logger.i(tag = "WSDiag") {
-                            "ConversationStream: Stopped chatDrive totalCount=${event.totalCount} " +
-                                "willReload=${event.totalCount > 0}"
-                        }
                         // Silent-DriveSync contract: the chat-drive DriveSync just
                         // landed N files in DriveMainIndex with no per-batch
                         // BatchReceived emits. Reload the conversation list from DB
@@ -260,10 +256,6 @@ class ConversationStream(
                                     "${event.batchData.size} files " +
                                     "(conversations=${conversationFiles.size}, messages=${messageFiles.size}, adminFiles=${adminFiles.size})"
                         )
-                        Logger.i(tag = "WSDiag") {
-                            "ConversationStream: BatchReceived chatDrive rows=${event.batchData.size} " +
-                                "conversations=${conversationFiles.size} messages=${messageFiles.size} admins=${adminFiles.size}"
-                        }
 
                         if (conversationFiles.isNotEmpty())
                             processConversationBatchIncrementally(conversationFiles)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/DriveContactService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/DriveContactService.kt
@@ -69,17 +69,6 @@ class DriveContactService(
     init {
         scope.launch {
             eventBus.events.collect { event ->
-                if (event is BackendEvent.DriveEvent.Stopped && event.driveId == contactDrive) {
-                    Logger.i(tag = "WSDiag") {
-                        "DriveContactService: Stopped contactDrive totalCount=${event.totalCount} " +
-                            "result=${event.result} willRefresh=${event.totalCount > 0}"
-                    }
-                } else if (event is BackendEvent.DataEvent.BatchReceived && event.driveId == contactDrive) {
-                    Logger.i(tag = "WSDiag") {
-                        "DriveContactService: BatchReceived contactDrive rows=${event.batchData.size} " +
-                            "— triggering refresh"
-                    }
-                }
                 // Two refresh triggers, by design — after the silent-DriveSync (e7f46062)
                 // and pure-push chat-drive (736b4f07) refactors, contact rows land via two
                 // event classes and we must converge from both:
@@ -129,15 +118,10 @@ class DriveContactService(
     }
 
     private suspend fun refresh() {
-        val beforeSize = _contacts.value.size
-        Logger.i(tag = "WSDiag") { "DriveContactService.refresh() start beforeSize=$beforeSize" }
         val result = fetchContacts()
         _contacts.value = result.records
         contactByOdinId.value =
             result.records.associateBy { it.odinId }
-        Logger.i(tag = "WSDiag") {
-            "DriveContactService.refresh() done newSize=${result.records.size} (was $beforeSize)"
-        }
     }
 
 


### PR DESCRIPTION
The WSDiag-tagged log sites were added to diagnose the two reported symptoms behind this PR (new identity not appearing in the address book; first message not appearing in the chat window). Both are now resolved:

- Symptom 1 is fixed by the actual contact-refresh-on-pure-push code in the prior commit on this branch.
- Symptom 2 turned out to be by-design: the connection-request "intro message" rides on ConnectionRequestHeader.message, not as a chat message, so the chat window correctly shows only the ConversationStarted status banner until either side sends a real chat message.

The instrumentation has served its purpose; remove it so the PR is a clean fix-only diff. Touches the same 5 files as the previous commit. Behavior-neutral.