### PR TITLE
ux(connect-request): auto-focus recipient field on sheet open

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/core/connections/ConnectRequestBottomSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/core/connections/ConnectRequestBottomSheet.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.remember
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextRange
@@ -197,6 +198,16 @@ private fun ComposeRequestSheetContent(
                 )
             )
         }
+        val recipientFocusRequester = remember { FocusRequester() }
+        // Auto-focus the recipient field on sheet open so the user can start typing
+        // immediately (and the soft keyboard pops on mobile). Only when no recipient
+        // was prefilled — if the sheet was opened with OpenDialogWithRecipient, the
+        // recipient is already known and stealing focus to it would be annoying.
+        LaunchedEffect(Unit) {
+            if (recipient.isEmpty()) {
+                recipientFocusRequester.requestFocus()
+            }
+        }
         HomebaseIdField(
             value = fieldValue,
             onValueChange = { incoming ->
@@ -209,6 +220,7 @@ private fun ComposeRequestSheetContent(
             placeholder = { Text(stringResource(MR.string.connections_recipient_placeholder)) },
             isError = isError,
             enabled = !isSending,
+            focusRequester = recipientFocusRequester,
             imeAction = ImeAction.Next,
         )
 


### PR DESCRIPTION
When the user opens the New Connection Request bottom sheet from the empty state in CreateConversationScreen, the recipient OdinId field now grabs focus immediately so they can start typing without a second tap. On mobile this also pops the soft keyboard.

Only fires when the sheet was opened with no prefilled recipient (ConnectRequestAction.OpenDialog). When the sheet is opened via OpenDialogWithRecipient(odinId) — i.e. from a known contact's profile — the recipient is already filled and stealing focus to the field would be obnoxious.

Uses the existing focusRequester hook on HomebaseIdField and the prior-art pattern from EditConversationGroupScreen.kt:101-105.