### PR TITLE
chore(wasm-prep): close expect/actual gaps in wasmJsMain (step 2)

### DIFF
--- a/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/Util.web.kt
+++ b/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/Util.web.kt
@@ -1,12 +1,15 @@
 package id.homebase.api
 
-actual fun getPlatform(): Platform {
-    TODO("Not yet implemented")
+private object WebPlatform : Platform {
+    override val name: PlatformType = PlatformType.JS
 }
 
-actual fun isAndroid(): Boolean {
-    TODO("Not yet implemented")
-}
+actual fun getPlatform(): Platform = WebPlatform
+
+actual fun isAndroid(): Boolean = false
+
+actual fun isIos(): Boolean = false
 
 actual fun showMessage(title: String, message: String) {
+    // No-op for now; a later step can wire this to window.alert or a snackbar.
 }

--- a/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/common/AsciiDomainName.web.kt
+++ b/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/common/AsciiDomainName.web.kt
@@ -1,0 +1,10 @@
+package id.homebase.api.common
+
+// Pre-flight stub: passes through input unchanged. Domains used in chat are
+// already in puny-code on the wire, so toAscii on an already-ascii string is
+// a no-op; toUnicode would need a real IDN library (e.g. a wasmJs port of
+// ICU) but isn't required for the initial wasm bring-up.
+actual object Idn {
+    actual fun toAscii(idn: String): String = idn
+    actual fun toUnicode(puny: String): String = puny
+}

--- a/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/video/FFmpegUtils.web.kt
+++ b/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/video/FFmpegUtils.web.kt
@@ -1,0 +1,38 @@
+package id.homebase.api.video
+
+import id.homebase.api.client.KeyHeader
+
+// Pre-flight stub. Video processing on the web will require a separate
+// strategy (ffmpeg.wasm, MediaRecorder, or server-side transcoding) — out
+// of scope for the pre-flight pass.
+actual object FFmpegUtils {
+    actual fun getUniqueId(filePath: String): String = filePath
+
+    actual suspend fun grabThumbnail(inputPath: String): String? = null
+
+    actual suspend fun getRotationFromFile(filePath: String): Int = 0
+
+    actual suspend fun compressVideo(
+        inputPath: String,
+        onProgress: ((Float) -> Unit)?,
+        trimStartMs: Long?,
+        trimEndMs: Long?,
+    ): String? = null
+
+    actual suspend fun getDurationMs(inputPath: String): Long = 0L
+
+    actual suspend fun segmentAndEncryptVideo(
+        inputPath: String,
+        keyHeader: KeyHeader,
+        onProgress: ((Float) -> Unit)?,
+    ): Pair<String, String>? = null
+
+    actual suspend fun segmentVideo(
+        inputPath: String,
+        onProgress: ((Float) -> Unit)?,
+    ): Pair<String, String>? = null
+
+    actual suspend fun cacheInputVideo(fileName: String, data: ByteArray): String = fileName
+
+    actual suspend fun remuxHlsToMp4(playlistPath: String, outputPath: String): Boolean = false
+}

--- a/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/video/VideoThumbnailExtractor.web.kt
+++ b/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/video/VideoThumbnailExtractor.web.kt
@@ -1,0 +1,18 @@
+package id.homebase.api.video
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+
+// Pre-flight stub. Browser-side poster frames will need a strategy based on
+// HTMLVideoElement + canvas.toBlob (or OffscreenCanvas) — out of scope for
+// the pre-flight pass.
+actual object VideoThumbnailExtractor {
+    actual suspend fun extractPosterFrame(videoPath: String): ByteArray? = null
+
+    actual fun extractThumbnailStrip(
+        filePath: String,
+        durationMs: Long,
+        frameCount: Int,
+        targetHeightPx: Int,
+    ): Flow<IndexedFrame> = emptyFlow()
+}

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/event/CalendarLauncher.web.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/event/CalendarLauncher.web.kt
@@ -1,0 +1,20 @@
+package id.homebase.chat.event
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+// Web actual: no native calendar API, but the chat UI's "Add to calendar"
+// detail dialog already offers a separate Google Calendar action that opens
+// `googleCalendarUrl(event)` via the URI handler — so this launcher can be a
+// no-op without losing functionality.
+@Composable
+actual fun rememberCalendarLauncher(): CalendarLauncher = remember {
+    object : CalendarLauncher {
+        @OptIn(ExperimentalUuidApi::class)
+        override fun addToCalendar(event: EventDescriptor, messageId: Uuid) {
+            // No-op: use googleCalendarUrl(event) via the URI handler instead.
+        }
+    }
+}

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/location/LocationLauncher.web.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/location/LocationLauncher.web.kt
@@ -1,0 +1,19 @@
+package id.homebase.chat.location
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+
+// Web actual. The browser's Geolocation API (navigator.geolocation) could be
+// wired here in a follow-up, but it requires HTTPS and an explicit permission
+// prompt — out of scope for the pre-flight. Report PermissionDenied so the UI
+// surfaces a "Location not available" path.
+@Composable
+actual fun rememberCurrentLocationLauncher(
+    onResult: (LocationResult) -> Unit,
+): LocationLauncher = remember(onResult) {
+    object : LocationLauncher {
+        override fun launch() {
+            onResult(LocationResult.PermissionDenied)
+        }
+    }
+}

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/services/FileExistence.web.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/services/FileExistence.web.kt
@@ -1,0 +1,7 @@
+package id.homebase.chat.services
+
+// In a browser, an "in-process file path" only exists in our in-memory
+// FileSystem (see step 5 of the wasm pre-flight plan). Until that's wired,
+// treat scheme-prefixed URIs (blob:, http(s):, data:) as opaque-but-valid,
+// and assume any non-scheme path is missing.
+internal actual fun fileExists(path: String): Boolean = path.contains("://")

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/services/ShareSuggestionDonor.web.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/services/ShareSuggestionDonor.web.kt
@@ -1,0 +1,16 @@
+package id.homebase.chat.services
+
+import kotlin.uuid.Uuid
+
+// Browsers don't have a share-suggestions surface analogous to Siri/Android
+// shortcuts, so this is a no-op like the Android/Desktop actuals.
+actual class ShareSuggestionDonor actual constructor() {
+    actual fun donateAfterSend(
+        conversationId: Uuid,
+        conversationName: String,
+        isGroup: Boolean,
+        participantNames: List<String>,
+    ) {
+        // No-op on web.
+    }
+}

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/services/XorIdUtil.web.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/services/XorIdUtil.web.kt
@@ -1,0 +1,97 @@
+package id.homebase.chat.services
+
+// Pure-Kotlin SHA-256. Used because:
+//   * The commonMain `expect fun sha256(input: ByteArray): ByteArray` is
+//     synchronous, but WebCrypto (the obvious wasmJs choice) is async only.
+//   * okio's `ByteString.sha256()` would do the job, but homebase-chat does
+//     not have a direct okio dependency (api/okio is `implementation` in
+//     homebase-api, so it does not propagate).
+//   * Inputs from XorIdUtil are tiny (two lowercased domain strings plus a
+//     32-byte digest), so performance is not a concern.
+//
+// Reference: FIPS PUB 180-4 §6.2. Verified bit-for-bit against
+// MessageDigest.getInstance("SHA-256") for the strings that XorIdUtil
+// generates 1:1 conversation ids from.
+
+private val K = intArrayOf(
+    0x428a2f98.toInt(), 0x71374491.toInt(), -0x4a3f0431, -0x164a245b,
+    0x3956c25b.toInt(), 0x59f111f1.toInt(), -0x6dc07d5c, -0x54e3a12b,
+    -0x27f85568, 0x12835b01.toInt(), 0x243185be.toInt(), 0x550c7dc3.toInt(),
+    0x72be5d74.toInt(), -0x7f214e02, -0x6423f959, -0x3e640e8c,
+    -0x1b64963f, -0x1041b87a, 0x0fc19dc6.toInt(), 0x240ca1cc.toInt(),
+    0x2de92c6f.toInt(), 0x4a7484aa.toInt(), 0x5cb0a9dc.toInt(), 0x76f988da.toInt(),
+    -0x67c1aeae, -0x57ce3993, -0x4ffcd838, -0x40a68039,
+    -0x391ff40d, -0x2a586eb9, 0x06ca6351.toInt(), 0x14292967.toInt(),
+    0x27b70a85.toInt(), 0x2e1b2138.toInt(), 0x4d2c6dfc.toInt(), 0x53380d13.toInt(),
+    0x650a7354.toInt(), 0x766a0abb.toInt(), -0x7e3d36d2, -0x6d8dd37b,
+    -0x5d40175f, -0x57e599b5, -0x3db47490, -0x3893ae5d,
+    -0x2e6d17e7, -0x2966f9dc, -0xbf1ca7b, 0x106aa070.toInt(),
+    0x19a4c116.toInt(), 0x1e376c08.toInt(), 0x2748774c.toInt(), 0x34b0bcb5.toInt(),
+    0x391c0cb3.toInt(), 0x4ed8aa4a.toInt(), 0x5b9cca4f.toInt(), 0x682e6ff3.toInt(),
+    0x748f82ee.toInt(), 0x78a5636f.toInt(), -0x7b3787ec, -0x7338fdf8,
+    -0x6f410006, -0x5baf9315, -0x41065c09, -0x398e870e,
+)
+
+private fun rotr(x: Int, n: Int): Int = (x ushr n) or (x shl (32 - n))
+
+actual fun sha256(input: ByteArray): ByteArray {
+    // Pre-processing: pad to a multiple of 64 bytes.
+    val bitLen = input.size.toLong() * 8
+    val padLen = (56 - (input.size + 1) % 64 + 64) % 64
+    val padded = ByteArray(input.size + 1 + padLen + 8)
+    input.copyInto(padded)
+    padded[input.size] = 0x80.toByte()
+    for (i in 0 until 8) {
+        padded[padded.size - 1 - i] = (bitLen ushr (i * 8)).toByte()
+    }
+
+    var h0 = 0x6a09e667.toInt(); var h1 = -0x4498517b
+    var h2 = 0x3c6ef372.toInt(); var h3 = -0x5ab00ac6
+    var h4 = 0x510e527f.toInt(); var h5 = -0x64fa9774
+    var h6 = 0x1f83d9ab.toInt(); var h7 = 0x5be0cd19.toInt()
+
+    val w = IntArray(64)
+    var chunk = 0
+    while (chunk < padded.size) {
+        for (i in 0 until 16) {
+            val off = chunk + i * 4
+            w[i] = ((padded[off].toInt() and 0xff) shl 24) or
+                ((padded[off + 1].toInt() and 0xff) shl 16) or
+                ((padded[off + 2].toInt() and 0xff) shl 8) or
+                (padded[off + 3].toInt() and 0xff)
+        }
+        for (i in 16 until 64) {
+            val s0 = rotr(w[i - 15], 7) xor rotr(w[i - 15], 18) xor (w[i - 15] ushr 3)
+            val s1 = rotr(w[i - 2], 17) xor rotr(w[i - 2], 19) xor (w[i - 2] ushr 10)
+            w[i] = w[i - 16] + s0 + w[i - 7] + s1
+        }
+
+        var a = h0; var b = h1; var c = h2; var d = h3
+        var e = h4; var f = h5; var g = h6; var h = h7
+
+        for (i in 0 until 64) {
+            val s1 = rotr(e, 6) xor rotr(e, 11) xor rotr(e, 25)
+            val ch = (e and f) xor (e.inv() and g)
+            val temp1 = h + s1 + ch + K[i] + w[i]
+            val s0 = rotr(a, 2) xor rotr(a, 13) xor rotr(a, 22)
+            val maj = (a and b) xor (a and c) xor (b and c)
+            val temp2 = s0 + maj
+
+            h = g; g = f; f = e; e = d + temp1
+            d = c; c = b; b = a; a = temp1 + temp2
+        }
+
+        h0 += a; h1 += b; h2 += c; h3 += d
+        h4 += e; h5 += f; h6 += g; h7 += h
+        chunk += 64
+    }
+
+    val out = ByteArray(32)
+    intArrayOf(h0, h1, h2, h3, h4, h5, h6, h7).forEachIndexed { idx, v ->
+        out[idx * 4] = (v ushr 24).toByte()
+        out[idx * 4 + 1] = (v ushr 16).toByte()
+        out[idx * 4 + 2] = (v ushr 8).toByte()
+        out[idx * 4 + 3] = v.toByte()
+    }
+    return out
+}

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/video/LocalVideoPlayerSurface.web.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/video/LocalVideoPlayerSurface.web.kt
@@ -1,0 +1,29 @@
+package id.homebase.chat.widget.video
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+// Pre-flight stubs. HTMLVideoElement-based playback can be wired in later.
+@Composable
+actual fun LocalVideoPlayerSurface(
+    filePath: String,
+    modifier: Modifier,
+    onFirstFrameRendered: () -> Unit,
+) {
+    Box(modifier = modifier)
+}
+
+@Composable
+actual fun TrimmableVideoPlayerSurface(
+    filePath: String,
+    clipStartMs: Long,
+    clipEndMs: Long,
+    isPlaying: Boolean,
+    seekRequestMs: Long?,
+    onPositionMs: (Long) -> Unit,
+    modifier: Modifier,
+    onFirstFrameRendered: () -> Unit,
+) {
+    Box(modifier = modifier)
+}

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.web.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.web.kt
@@ -1,0 +1,17 @@
+package id.homebase.chat.widget.video
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import id.homebase.chat.conversationlist.FullScreenOverlay
+
+// Pre-flight stub. A real implementation would use HTMLVideoElement via a
+// Compose-html bridge — out of scope for the pre-flight.
+@Composable
+actual fun VideoPlayerSurface(
+    data: FullScreenOverlay.VideoPlayerData,
+    modifier: Modifier,
+    onProgress: (Float) -> Unit,
+) {
+    Box(modifier = modifier)
+}

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/audio/AudioPlayer.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/audio/AudioPlayer.web.kt
@@ -1,0 +1,16 @@
+package id.homebase.core.audio
+
+// Pre-flight stub. Browser audio playback will use HTMLAudioElement when wired
+// up properly; for now this no-ops so chat UI compiles without an audio
+// dependency on the web.
+private object NoopAudioPlayer : AudioPlayer {
+    override fun play(filePath: String) {}
+    override fun jump(seconds: Int) {}
+    override fun resume() {}
+    override fun pause() {}
+    override fun stop() {}
+    override fun release() {}
+    override fun setPlaybackObserver(observer: AudioPlaybackObserver) {}
+}
+
+actual fun getAudioPlayer(): AudioPlayer = NoopAudioPlayer

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/logging/ErrorCollectionHandler.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/logging/ErrorCollectionHandler.web.kt
@@ -1,0 +1,5 @@
+package id.homebase.core.logging
+
+actual fun setErrorCollectionEnabled(enabled: Boolean) {
+    // No-op on web — error collection backend (Sentry, etc.) is not wired here yet.
+}

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/test/TestHelpers.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/test/TestHelpers.web.kt
@@ -1,0 +1,5 @@
+package id.homebase.core.test
+
+actual fun setTestLocale(languageTag: String) {
+    // No-op on web; test infrastructure for wasmJs is not in place yet.
+}

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/util/Platform.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/util/Platform.web.kt
@@ -1,0 +1,6 @@
+package id.homebase.core.util
+
+actual object Platform {
+    actual val osName: String = "Web"
+    actual val osVersion: String = "Unknown"
+}

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/vault/VaultBiometricAuth.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/vault/VaultBiometricAuth.web.kt
@@ -1,0 +1,6 @@
+package id.homebase.core.vault
+
+// Browsers have no platform biometric prompt; callers fall through to proceed
+// when the result is Unavailable, which matches the desired UX.
+actual suspend fun authenticateBiometric(title: String, subtitle: String): BiometricResult =
+    BiometricResult.Unavailable

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/vault/VaultWindowPrivacy.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/vault/VaultWindowPrivacy.web.kt
@@ -1,0 +1,3 @@
+package id.homebase.core.vault
+
+actual val needsComposePrivacyOverlay: Boolean = false

--- a/homebase-core/src/wasmJsMain/kotlin/id/homebase/core/ui/screens/feed/PlatformWebView.web.kt
+++ b/homebase-core/src/wasmJsMain/kotlin/id/homebase/core/ui/screens/feed/PlatformWebView.web.kt
@@ -1,0 +1,20 @@
+package id.homebase.core.ui.screens.feed
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import io.github.kdroidfilter.webview.web.WebViewNavigator
+import io.github.kdroidfilter.webview.web.WebViewState
+
+// NOTE: The kdroidfilter `composenativewebview` dependency has no wasmJs
+// artifact, so this file's imports will fail when `wasmJs { browser() }` is
+// enabled. Step 9 of the wasm pre-flight plan decouples that dependency from
+// commonMain and refactors this expect to avoid the kdroidfilter types.
+// Until then this placeholder records intent only.
+@Composable
+actual fun PlatformWebView(
+    state: WebViewState,
+    navigator: WebViewNavigator,
+    modifier: Modifier,
+) {
+    error("PlatformWebView is not yet implemented on wasm — see step 9 of the wasm pre-flight plan.")
+}


### PR DESCRIPTION
Step 2 of the WASM pre-flight plan. Survey turned up every commonMain `expect` across homebase-api, homebase-common, homebase-core, and homebase-chat that did not yet have a wasmJsMain `actual`. Each gap is closed with a placeholder file that mirrors the actuals already provided for android / jvm / native:

- Util.web.kt: real implementations for getPlatform/isAndroid/isIos (and adds the missing `isIos` actual that would otherwise fail when wasmJs is enabled).
- All other new files are deliberate stubs — no-op composables, no-op service classes, "Unavailable" biometric result, "Web/Unknown" Platform values, empty video extraction flows, etc. They match the contract of the existing android/jvm/native actuals and let the wasmJs source set compile once the target is flipped on, without committing to a particular browser-API strategy in this PR.

- XorIdUtil.web.kt ships a pure-Kotlin SHA-256 (FIPS 180-4) because the commonMain `expect fun sha256(input: ByteArray): ByteArray` is synchronous, but WebCrypto is async-only and okio is `implementation` in homebase-api (does not propagate to chat). Inputs are tiny (two lowercased domain strings + a 32-byte digest), so perf is fine.

- homebase-auth and homebase-notifshared have zero commonMain expects, confirmed by grep — no wasmJsMain folder needed for either.

- PlatformWebView.web.kt is a placeholder. The kdroidfilter composenativewebview dependency has no wasmJs artifact, so the file's imports won't resolve once wasm is enabled. Step 9 of the plan decouples that dep from commonMain and refactors the expect signature; this file just records intent until then.

DatabaseDriverFactory.web.kt and WebFileOperationsProvider.kt keep their existing TODOs — those are reserved for steps 5 and 7. Likewise the TODO bodies in ImageUtil, SharedPreferences, FileUtilities, FileInput remain — they require browser-API decisions tied to later steps and the files already compile as far as the type-checker is concerned.

The wasmJs target remains commented out in every module, so no behavior changes on android / jvm / native. JVM tests pass.