### PR TITLE
fix: sanitize link preview text (HTML decode, truncate, dedup)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/link/LinkPreviewProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/link/LinkPreviewProvider.kt
@@ -4,6 +4,8 @@ import co.touchlab.kermit.Logger
 import id.homebase.api.client.OdinApiProviderBase
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.encodeUrl
+import id.homebase.api.util.decodeHtmlEntities
+import id.homebase.api.util.truncateToCodePoints
 import io.ktor.client.HttpClient
 
 class LinkPreviewProvider(
@@ -33,9 +35,19 @@ class LinkPreviewProvider(
 
         throwForFailure(response)
 
-        return deserialize<LinkPreview>(response.body)
-
+        return deserialize<LinkPreview>(response.body)?.sanitize()
     }
 
+    companion object {
+        private const val MAX_FIELD_LENGTH = 300
 
+        private fun LinkPreview.sanitize(): LinkPreview {
+            val cleanTitle = title.decodeHtmlEntities().trim().truncateToCodePoints(MAX_FIELD_LENGTH)
+            val cleanDesc = description.decodeHtmlEntities().trim().truncateToCodePoints(MAX_FIELD_LENGTH)
+            return copy(
+                title = cleanTitle,
+                description = if (cleanDesc.equals(cleanTitle, ignoreCase = true)) "" else cleanDesc,
+            )
+        }
+    }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/link/LinkPreviewProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/link/LinkPreviewProvider.kt
@@ -4,7 +4,7 @@ import co.touchlab.kermit.Logger
 import id.homebase.api.client.OdinApiProviderBase
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.encodeUrl
-import id.homebase.api.util.decodeHtmlEntities
+import id.homebase.api.util.sanitizePreviewText
 import id.homebase.api.util.truncateToCodePoints
 import io.ktor.client.HttpClient
 
@@ -41,16 +41,9 @@ class LinkPreviewProvider(
     companion object {
         private const val MAX_FIELD_LENGTH = 300
 
-        private val whitespaceRun = Regex("\\s+")
-
-        private fun String.collapseWhitespace(): String =
-            whitespaceRun.replace(this, " ")
-
         private fun LinkPreview.sanitize(): LinkPreview {
-            val cleanTitle = title.decodeHtmlEntities().collapseWhitespace().trim()
-                .truncateToCodePoints(MAX_FIELD_LENGTH)
-            val cleanDesc = description.decodeHtmlEntities().collapseWhitespace().trim()
-                .truncateToCodePoints(MAX_FIELD_LENGTH)
+            val cleanTitle = title.sanitizePreviewText().truncateToCodePoints(MAX_FIELD_LENGTH)
+            val cleanDesc = description.sanitizePreviewText().truncateToCodePoints(MAX_FIELD_LENGTH)
             return copy(
                 title = cleanTitle,
                 description = if (cleanDesc.equals(cleanTitle, ignoreCase = true)) "" else cleanDesc,

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/link/LinkPreviewProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/link/LinkPreviewProvider.kt
@@ -41,9 +41,16 @@ class LinkPreviewProvider(
     companion object {
         private const val MAX_FIELD_LENGTH = 300
 
+        private val whitespaceRun = Regex("\\s+")
+
+        private fun String.collapseWhitespace(): String =
+            whitespaceRun.replace(this, " ")
+
         private fun LinkPreview.sanitize(): LinkPreview {
-            val cleanTitle = title.decodeHtmlEntities().trim().truncateToCodePoints(MAX_FIELD_LENGTH)
-            val cleanDesc = description.decodeHtmlEntities().trim().truncateToCodePoints(MAX_FIELD_LENGTH)
+            val cleanTitle = title.decodeHtmlEntities().collapseWhitespace().trim()
+                .truncateToCodePoints(MAX_FIELD_LENGTH)
+            val cleanDesc = description.decodeHtmlEntities().collapseWhitespace().trim()
+                .truncateToCodePoints(MAX_FIELD_LENGTH)
             return copy(
                 title = cleanTitle,
                 description = if (cleanDesc.equals(cleanTitle, ignoreCase = true)) "" else cleanDesc,

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/util/StringExtensions.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/util/StringExtensions.kt
@@ -1,5 +1,48 @@
 package id.homebase.api.util
 
+private val htmlEntityPattern = Regex("&(#(\\d+)|#x([0-9a-fA-F]+)|(\\w+));")
+
+private val namedEntities = mapOf(
+    "amp" to '&', "lt" to '<', "gt" to '>', "quot" to '"', "apos" to '\'',
+    "nbsp" to ' ', "ndash" to '–', "mdash" to '—',
+    "lsquo" to '‘', "rsquo" to '’', "ldquo" to '“', "rdquo" to '”',
+    "bull" to '•', "hellip" to '…', "copy" to '©', "reg" to '®',
+    "trade" to '™', "euro" to '€', "pound" to '£', "yen" to '¥',
+)
+
+private fun codePointToString(cp: Int): String {
+    return if (cp <= 0xFFFF) {
+        Char(cp).toString()
+    } else {
+        val hi = Char(((cp - 0x10000) shr 10) + 0xD800)
+        val lo = Char(((cp - 0x10000) and 0x3FF) + 0xDC00)
+        "$hi$lo"
+    }
+}
+
+fun String.decodeHtmlEntities(): String {
+    if ('&' !in this) return this
+    return htmlEntityPattern.replace(this) { match ->
+        val decimal = match.groupValues[2]
+        val hex = match.groupValues[3]
+        val named = match.groupValues[4]
+        when {
+            decimal.isNotEmpty() -> {
+                val cp = decimal.toIntOrNull()
+                if (cp != null && cp in 1..0x10FFFF) codePointToString(cp)
+                else match.value
+            }
+            hex.isNotEmpty() -> {
+                val cp = hex.toIntOrNull(16)
+                if (cp != null && cp in 1..0x10FFFF) codePointToString(cp)
+                else match.value
+            }
+            named.isNotEmpty() -> namedEntities[named]?.toString() ?: match.value
+            else -> match.value
+        }
+    }
+}
+
 // Truncate a string to maxVisibleCharacters (be sure UTF characters aren't chopped in the middle)
 fun String.truncateToCodePoints(maxVisibleCharacters: Int): String {
     if (maxVisibleCharacters <= 0) return ""

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/util/StringExtensions.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/util/StringExtensions.kt
@@ -4,7 +4,7 @@ private val htmlEntityPattern = Regex("&(#(\\d+)|#x([0-9a-fA-F]+)|(\\w+));")
 
 private val namedEntities = mapOf(
     "amp" to '&', "lt" to '<', "gt" to '>', "quot" to '"', "apos" to '\'',
-    "nbsp" to ' ', "ndash" to '–', "mdash" to '—',
+    "nbsp" to ' ', "ndash" to '–', "mdash" to '—',
     "lsquo" to '‘', "rsquo" to '’', "ldquo" to '“', "rdquo" to '”',
     "bull" to '•', "hellip" to '…', "copy" to '©', "reg" to '®',
     "trade" to '™', "euro" to '€', "pound" to '£', "yen" to '¥',

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/util/StringExtensions.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/util/StringExtensions.kt
@@ -43,6 +43,15 @@ fun String.decodeHtmlEntities(): String {
     }
 }
 
+private val whitespaceRun = Regex("\\s+")
+private val quoteBetweenWords = Regex("(\\w)([\"“”])(\\w)")
+
+fun String.sanitizePreviewText(): String =
+    decodeHtmlEntities()
+        .replace(quoteBetweenWords, "$1 $2$3")
+        .replace(whitespaceRun, " ")
+        .trim()
+
 // Truncate a string to maxVisibleCharacters (be sure UTF characters aren't chopped in the middle)
 fun String.truncateToCodePoints(maxVisibleCharacters: Int): String {
     if (maxVisibleCharacters <= 0) return ""

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/util/DecodeHtmlEntitiesTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/util/DecodeHtmlEntitiesTest.kt
@@ -68,5 +68,16 @@ https://t.co/mS2nxOCFjW https://t.co/RfWM24m8GX&quot; / X"""
         assertTrue(decoded.contains("\"There is no energy transition"))
         assertTrue(decoded.contains("\"Rather than replacing fossil fuels"))
         assertTrue(decoded.endsWith("\" / X"))
+
+        val collapsed = Regex("\\s+").replace(decoded, " ").trim()
+        assertFalse(collapsed.contains('\n'), "Newlines should be collapsed to spaces")
+        assertTrue(
+            collapsed.contains("transition We simply"),
+            "Words across paragraph breaks should be separated by a single space"
+        )
+        assertTrue(
+            collapsed.contains("wind \"Rather"),
+            "Words across paragraph breaks should be separated by a single space"
+        )
     }
 }

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/util/DecodeHtmlEntitiesTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/util/DecodeHtmlEntitiesTest.kt
@@ -1,0 +1,72 @@
+package id.homebase.api.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DecodeHtmlEntitiesTest {
+
+    @Test
+    fun decodes_named_entities() {
+        assertEquals("A & B", "A &amp; B".decodeHtmlEntities())
+        assertEquals("1 < 2 > 0", "1 &lt; 2 &gt; 0".decodeHtmlEntities())
+        assertEquals("He said \"hi\"", "He said &quot;hi&quot;".decodeHtmlEntities())
+    }
+
+    @Test
+    fun decodes_numeric_decimal_entities() {
+        assertEquals("A", "&#65;".decodeHtmlEntities())
+        assertEquals("©", "&#169;".decodeHtmlEntities())
+    }
+
+    @Test
+    fun decodes_numeric_hex_entities() {
+        assertEquals("A", "&#x41;".decodeHtmlEntities())
+        assertEquals("€", "&#x20AC;".decodeHtmlEntities())
+    }
+
+    @Test
+    fun preserves_unknown_named_entities() {
+        assertEquals("&foo;", "&foo;".decodeHtmlEntities())
+    }
+
+    @Test
+    fun returns_input_unchanged_when_no_ampersand() {
+        val input = "Hello world"
+        assertEquals(input, input.decodeHtmlEntities())
+    }
+
+    @Test
+    fun decodes_mixed_entities_in_real_og_title() {
+        assertEquals(
+            "Tom's Diner – A \"Classic\" Bar & Grill",
+            "Tom&apos;s Diner &ndash; A &quot;Classic&quot; Bar &amp; Grill".decodeHtmlEntities()
+        )
+    }
+
+    @Test
+    fun handles_emoji_surrogate_pair_from_numeric_entity() {
+        assertEquals("😀", "&#128512;".decodeHtmlEntities())
+    }
+
+    @Test
+    fun decodes_real_x_twitter_og_description() {
+        val raw = """Bjorn Lomborg on X: &quot;There is no energy transition
+
+We simply use more and more of everything
+
+— fossil fuels, nuclear, renewables, solar and wind
+
+&quot;Rather than replacing fossil fuels, renewables are adding to the overall energy mix&quot;
+Energy Institute Statistical Review 2025
+
+https://t.co/mS2nxOCFjW https://t.co/RfWM24m8GX&quot; / X"""
+
+        val decoded = raw.decodeHtmlEntities()
+        assertFalse(decoded.contains("&quot;"), "All &quot; entities should be decoded")
+        assertTrue(decoded.contains("\"There is no energy transition"))
+        assertTrue(decoded.contains("\"Rather than replacing fossil fuels"))
+        assertTrue(decoded.endsWith("\" / X"))
+    }
+}

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/util/DecodeHtmlEntitiesTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/util/DecodeHtmlEntitiesTest.kt
@@ -49,35 +49,90 @@ class DecodeHtmlEntitiesTest {
     fun handles_emoji_surrogate_pair_from_numeric_entity() {
         assertEquals("😀", "&#128512;".decodeHtmlEntities())
     }
+}
+
+class SanitizePreviewTextTest {
 
     @Test
-    fun decodes_real_x_twitter_og_description() {
-        val raw = """Bjorn Lomborg on X: &quot;There is no energy transition
+    fun collapses_newlines_to_single_space() {
+        assertEquals(
+            "first second third",
+            "first\n\nsecond\n\n\nthird".sanitizePreviewText()
+        )
+    }
 
-We simply use more and more of everything
+    @Test
+    fun collapses_mixed_whitespace() {
+        assertEquals("a b c", "a \t\n b   c".sanitizePreviewText())
+    }
 
-— fossil fuels, nuclear, renewables, solar and wind
+    @Test
+    fun trims_leading_and_trailing_whitespace() {
+        assertEquals("hello", "  hello  ".sanitizePreviewText())
+    }
 
-&quot;Rather than replacing fossil fuels, renewables are adding to the overall energy mix&quot;
-Energy Institute Statistical Review 2025
+    @Test
+    fun inserts_space_before_quote_sandwiched_between_words() {
+        assertEquals(
+            "wind \"Rather than",
+            "wind\"Rather than".sanitizePreviewText()
+        )
+    }
 
-https://t.co/mS2nxOCFjW https://t.co/RfWM24m8GX&quot; / X"""
+    @Test
+    fun decodes_entities_and_spaces_quotes_together() {
+        assertEquals(
+            "wind \"Rather",
+            "wind&quot;Rather".sanitizePreviewText()
+        )
+    }
 
-        val decoded = raw.decodeHtmlEntities()
-        assertFalse(decoded.contains("&quot;"), "All &quot; entities should be decoded")
-        assertTrue(decoded.contains("\"There is no energy transition"))
-        assertTrue(decoded.contains("\"Rather than replacing fossil fuels"))
-        assertTrue(decoded.endsWith("\" / X"))
+    @Test
+    fun full_pipeline_real_x_twitter_og_description() {
+        val raw = "Bjorn Lomborg on X: &quot;There is no energy transition\n\n" +
+            "We simply use more and more of everything\n\n" +
+            "— fossil fuels, nuclear, renewables, solar and wind\n\n" +
+            "&quot;Rather than replacing fossil fuels, renewables are adding to the overall energy mix&quot;\n" +
+            "Energy Institute Statistical Review 2025\n\n" +
+            "https://t.co/mS2nxOCFjW https://t.co/RfWM24m8GX&quot; / X"
 
-        val collapsed = Regex("\\s+").replace(decoded, " ").trim()
-        assertFalse(collapsed.contains('\n'), "Newlines should be collapsed to spaces")
+        val result = raw.sanitizePreviewText()
+
+        assertFalse(result.contains("&quot;"), "HTML entities should be decoded")
+        assertFalse(result.contains('\n'), "Newlines should be collapsed")
         assertTrue(
-            collapsed.contains("transition We simply"),
-            "Words across paragraph breaks should be separated by a single space"
+            result.contains("transition We"),
+            "Words across paragraph breaks should have a space"
         )
         assertTrue(
-            collapsed.contains("wind \"Rather"),
-            "Words across paragraph breaks should be separated by a single space"
+            result.contains("wind \"Rather"),
+            "Quote should be spaced from preceding word"
         )
+    }
+
+    @Test
+    fun full_pipeline_no_newlines_server_stripped() {
+        val raw = "solar and wind" +
+            "&quot;Rather than replacing fossil fuels&quot; / X"
+
+        val result = raw.sanitizePreviewText()
+
+        assertTrue(
+            result.contains("wind \"Rather"),
+            "Quote jammed against word should get a space even without newlines"
+        )
+        assertFalse(result.contains("wind\""), "No quote should be jammed against a word")
+    }
+
+    @Test
+    fun preserves_already_clean_text() {
+        val clean = "Datalogisk Institut – Københavns Universitet"
+        assertEquals(clean, clean.sanitizePreviewText())
+    }
+
+    @Test
+    fun preserves_properly_spaced_quotes() {
+        val text = "He said \"hello\" to everyone"
+        assertEquals(text, text.sanitizePreviewText())
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/LinkPreviewPayloadBuilder.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/LinkPreviewPayloadBuilder.kt
@@ -34,9 +34,9 @@ object LinkPreviewPayloadBuilder {
         val actualHasImage = imageBytes.isNotEmpty()
 
         // 1. Build descriptorContent (stripped JSON, no image base64, ≤1024 bytes)
-        var descriptorContent = buildDescriptorJson(linkPreview, actualHasImage, maxDescLen = null)
+        var descriptorContent = buildDescriptorJson(linkPreview, actualHasImage, maxTextLen = null)
         if (descriptorContent.encodeToByteArray().size > ChatProtocol.MaxDescriptorContentLength) {
-            descriptorContent = buildDescriptorJson(linkPreview, actualHasImage, maxDescLen = 100)
+            descriptorContent = buildDescriptorJson(linkPreview, actualHasImage, maxTextLen = 100)
         }
 
         val mimeType = if (actualHasImage && imageUrl != null) {
@@ -80,19 +80,23 @@ object LinkPreviewPayloadBuilder {
     }
 
     private fun buildDescriptorJson(
-        linkPreview: LinkPreview, hasImage: Boolean, maxDescLen: Int?
+        linkPreview: LinkPreview, hasImage: Boolean, maxTextLen: Int?
     ): String {
         val descriptor = LinkPreviewDescriptor(
             url = linkPreview.url,
             hasImage = hasImage,
             imageWidth = if (hasImage) linkPreview.imageWidth else null,
             imageHeight = if (hasImage) linkPreview.imageHeight else null,
-            description = if (maxDescLen != null) {
-                linkPreview.description.truncateToCodePoints(maxDescLen)
+            description = if (maxTextLen != null) {
+                linkPreview.description.truncateToCodePoints(maxTextLen)
             } else {
                 linkPreview.description
             },
-            title = linkPreview.title
+            title = if (maxTextLen != null) {
+                linkPreview.title.truncateToCodePoints(maxTextLen)
+            } else {
+                linkPreview.title
+            }
         )
         return OdinSystemSerializer.serialize(listOf(descriptor))
     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LinkPreview.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LinkPreview.kt
@@ -57,7 +57,7 @@ private fun LinkPreviewTextContent(
     description: String,
     domain: String,
     maxTitleLines: Int = 2,
-    maxDescriptionLines: Int = 3,
+    maxDescriptionLines: Int = 2,
 ) {
     if (title.isNotEmpty()) {
         Text(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LinkPreview.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LinkPreview.kt
@@ -57,7 +57,7 @@ private fun LinkPreviewTextContent(
     description: String,
     domain: String,
     maxTitleLines: Int = 2,
-    maxDescriptionLines: Int = 2,
+    maxDescriptionLines: Int = 3,
 ) {
     if (title.isNotEmpty()) {
         Text(

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/builder/LinkPreviewPayloadBuilderTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/builder/LinkPreviewPayloadBuilderTest.kt
@@ -71,6 +71,36 @@ class LinkPreviewPayloadBuilderTest {
         assertEquals(null, descriptor.imageWidth)
         assertEquals(null, descriptor.imageHeight)
     }
+
+    @Test
+    fun build_truncatesTitleAndDescription_whenDescriptorExceedsByteLimit() = runTest {
+        val longText = "A".repeat(800)
+        val preview = LinkPreview(
+            title = longText,
+            url = "https://example.com",
+            description = longText,
+            imageUrl = null,
+            imageHeight = null,
+            imageWidth = null,
+        )
+        val fakeFileOps = RecordingFileOperationsProvider()
+
+        val bundle = LinkPreviewPayloadBuilder.build(preview, fakeFileOps)
+        val descriptorJson = bundle.payloads.single().descriptorContent
+        assertNotNull(descriptorJson)
+        val descriptor = OdinSystemSerializer
+            .deserialize<List<LinkPreviewDescriptor>>(descriptorJson)
+            .single()
+
+        assertTrue(
+            descriptor.title.length <= 100,
+            "Title should be truncated when descriptor overflows"
+        )
+        assertTrue(
+            descriptor.description.length <= 100,
+            "Description should be truncated when descriptor overflows"
+        )
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary
- **HTML entity decoding** — `decodeHtmlEntities()` in commonMain handles named (`&quot;`, `&amp;`), decimal (`&#169;`), and hex (`&#x20AC;`) entities with KMP-compatible surrogate pair construction
- **Quote spacing** — inserts space when a quote is jammed between word characters (`wind"Rather` → `wind "Rather`), fixing X/Twitter-style og:descriptions where the server strips paragraph breaks
- **Whitespace collapse** — newlines and whitespace runs in og:description collapsed to single spaces so maxLines budget is not wasted
- **Text truncation** — both title and description capped at 300 code points at fetch time; descriptor overflow path now truncates title too (was description-only)
- **Deduplication** — description suppressed when it equals the title (case-insensitive)
- **KMP regex safety** — uses literal Unicode chars in regex patterns instead of `\uXXXX` escapes for Kotlin/Native compatibility

## Test plan
- [x] `homebase-api:jvmTest` — 7 DecodeHtmlEntitiesTest + 8 SanitizePreviewTextTest cases (real X/Twitter og:description, jammed quotes, whitespace collapse, clean text preservation)
- [x] `homebase-chat:jvmTest` — descriptor overflow truncation test for both title and description
- [x] `homebase-api:compileKotlinIosArm64` — verified KMP-compatible regex and surrogate pairs compile on iOS
- [ ] Manual: send a link with HTML entities in og:title/description, verify decoded text in bubble
- [ ] Manual: send X/Twitter link, verify no jammed words in preview text

🤖 Generated with [Claude Code](https://claude.com/claude-code)