### PR TITLE
chore(wasm-prep): abstract Dispatchers.IO behind ioDispatcher (step 4)

### DIFF
--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/coroutines/IoDispatcher.android.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/coroutines/IoDispatcher.android.kt
@@ -1,0 +1,6 @@
+package id.homebase.api.coroutines
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+actual val ioDispatcher: CoroutineDispatcher = Dispatchers.IO

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/coroutines/IoDispatcher.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/coroutines/IoDispatcher.kt
@@ -1,0 +1,17 @@
+package id.homebase.api.coroutines
+
+import kotlinx.coroutines.CoroutineDispatcher
+
+/**
+ * Multiplatform IO dispatcher. Use this from commonMain instead of
+ * `kotlinx.coroutines.Dispatchers.IO`, which is JVM/Native-only — wasmJs and
+ * legacy JS don't ship an `IO` dispatcher because the browser event loop is
+ * single-threaded.
+ *
+ * - jvm / android / native: backed by `Dispatchers.IO`.
+ * - wasmJs: falls back to `Dispatchers.Default`. The browser has no separate
+ *   IO pool, so callers are effectively running on the main worker. Real
+ *   off-main work in the browser belongs in a Web Worker (e.g. the
+ *   SQLDelight web-worker-driver) rather than on a dispatcher.
+ */
+expect val ioDispatcher: CoroutineDispatcher

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
@@ -16,13 +16,12 @@ import id.homebase.api.client.drives.upload.UploadFileRequest
 import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.coroutines.ioDispatcher
 import id.homebase.api.crypto.toUtf8ByteArray
 import id.homebase.api.serialization.OdinSystemSerializer
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.sync.*
@@ -53,7 +52,7 @@ class OutboxSync(
     scope: CoroutineScope? = null
 ) {
     // The threads use the DB & Network, so we use the IO dispatcher
-    private val scope = scope ?: CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val scope = scope ?: CoroutineScope(SupervisorJob() + ioDispatcher)
     @kotlin.concurrent.Volatile
     private var isOnline = false
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthFlowManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthFlowManager.kt
@@ -10,6 +10,7 @@ import id.homebase.api.client.profile.PublicProfileProviderCached
 import id.homebase.api.client.http.UriBuilder
 import id.homebase.api.common.OdinId
 import id.homebase.api.common.SecureByteArray
+import id.homebase.api.coroutines.ioDispatcher
 import id.homebase.api.crypto.EccKeyPair
 import id.homebase.api.crypto.EccKeySize
 import id.homebase.api.crypto.generateEccKeyPair
@@ -23,8 +24,6 @@ import id.homebase.api.sync.DriveSyncManager
 import id.homebase.api.share.ShareAuthBridge
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -86,7 +85,7 @@ class YouAuthFlowManager(
     private val _authState = MutableStateFlow<YouAuthState>(YouAuthState.Initializing)
     val authState: StateFlow<YouAuthState> = _authState.asStateFlow()
 
-    private val scope = CoroutineScope(Job() + Dispatchers.IO)
+    private val scope = CoroutineScope(Job() + ioDispatcher)
 
     // Registry for callback routing
     private val callbackRegistry = mutableMapOf<String, AuthCodeFlowState>()

--- a/homebase-api/src/jvmMain/kotlin/id/homebase/api/coroutines/IoDispatcher.jvm.kt
+++ b/homebase-api/src/jvmMain/kotlin/id/homebase/api/coroutines/IoDispatcher.jvm.kt
@@ -1,0 +1,6 @@
+package id.homebase.api.coroutines
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+actual val ioDispatcher: CoroutineDispatcher = Dispatchers.IO

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/coroutines/IoDispatcher.native.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/coroutines/IoDispatcher.native.kt
@@ -2,5 +2,12 @@ package id.homebase.api.coroutines
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+// `Dispatchers.IO` is an `internal val` member on Native — referencing it
+// directly fails with "Cannot access 'val IO: CoroutineDispatcher': it is
+// internal in 'kotlinx.coroutines.Dispatchers'". The public way in is the
+// top-level extension property `kotlinx.coroutines.IO`, which this import
+// brings into scope so `Dispatchers.IO` resolves to it instead of the
+// internal member.
+import kotlinx.coroutines.IO
 
 actual val ioDispatcher: CoroutineDispatcher = Dispatchers.IO

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/coroutines/IoDispatcher.native.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/coroutines/IoDispatcher.native.kt
@@ -1,0 +1,6 @@
+package id.homebase.api.coroutines
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+actual val ioDispatcher: CoroutineDispatcher = Dispatchers.IO

--- a/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/coroutines/IoDispatcher.web.kt
+++ b/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/coroutines/IoDispatcher.web.kt
@@ -1,0 +1,9 @@
+package id.homebase.api.coroutines
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+// wasmJs has no Dispatchers.IO — the browser is single-threaded and there is
+// no separate IO thread pool. Fall back to Dispatchers.Default; real off-main
+// work belongs in a Web Worker, not on a dispatcher.
+actual val ioDispatcher: CoroutineDispatcher = Dispatchers.Default

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -15,6 +15,7 @@ import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.coroutines.ioDispatcher
 import id.homebase.core.emoji.EmojiNormalization.distinctByEmoji
 import id.homebase.api.file.FileOperationsProvider
 import id.homebase.chat.conversationlist.ConversationListUiEvent.NavigateBack
@@ -59,7 +60,6 @@ import kotlinx.collections.immutable.toPersistentMap
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -553,7 +553,7 @@ class ConversationListViewModel(
         // full ConversationStream.start() enrichment pipeline (or, on a
         // warm VM, for the next sync batch) — which is what made
         // notification taps feel like they were gated on the drive-sync
-        // spinner. Dispatchers.IO so the kick can't be queued behind
+        // spinner. ioDispatcher so the kick can't be queued behind
         // enrichAllConversationsWithUnreadCounts on Main.
         viewModelScope.launch {
             pendingNotificationTap.state.collect { tap ->
@@ -562,7 +562,7 @@ class ConversationListViewModel(
                 val alreadyLoaded = conversationStream.conversations.value.items
                     .any { it.id == convoId }
                 if (alreadyLoaded) return@collect
-                launch(Dispatchers.IO) {
+                launch(ioDispatcher) {
                     conversationStream.loadConversation(convoId)
                 }
             }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MediaDownloadHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MediaDownloadHandler.kt
@@ -3,6 +3,7 @@ package id.homebase.chat.conversationlist
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.drives.files.DriveFileProvider
+import id.homebase.api.coroutines.ioDispatcher
 import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.video.FFmpegUtils
@@ -21,8 +22,6 @@ import io.github.vinceglb.filekit.name
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -148,7 +147,7 @@ internal class MediaDownloadHandler(
                 val filePath =
                     "${fileOperationsProvider.getCacheDirectory()}/$fullName"
 
-                val success = withContext(Dispatchers.IO) {
+                val success = withContext(ioDispatcher) {
                     driveFileProvider.streamPayloadDecryptedToPath(
                         driveId = chatTargetDrive.alias,
                         fileId = message.fileId,
@@ -191,7 +190,7 @@ internal class MediaDownloadHandler(
                 )
 
                 if (hlsMetadata != null) {
-                    val (mp4Path, mp4Name) = withContext(Dispatchers.IO) {
+                    val (mp4Path, mp4Name) = withContext(ioDispatcher) {
                         downloadAndRemuxHlsToMp4(
                             fileId = action.fileId,
                             payloadKey = action.payloadKey,
@@ -211,7 +210,7 @@ internal class MediaDownloadHandler(
                     val filePath =
                         "${fileOperationsProvider.getCacheDirectory()}/$fullName"
 
-                    val success = withContext(Dispatchers.IO) {
+                    val success = withContext(ioDispatcher) {
                         driveFileProvider.streamPayloadDecryptedToPath(
                             driveId = chatTargetDrive.alias,
                             fileId = action.fileId,


### PR DESCRIPTION
wasmJs has no Dispatchers.IO — the browser is single-threaded and ships no separate IO thread pool. Introduce an expect/actual `ioDispatcher` in homebase-api so commonMain code stops referencing the JVM-only extension property.

- commonMain: `expect val ioDispatcher: CoroutineDispatcher`
- jvm / android / native: `Dispatchers.IO`
- wasmJs: `Dispatchers.Default` (real off-main work in the browser belongs in a Web Worker, not on a dispatcher)

Updated 4 commonMain call sites:
  - homebase-api/.../sync/database/OutboxSync.kt
  - homebase-api/.../youauth/YouAuthFlowManager.kt
  - homebase-chat/.../conversationlist/MediaDownloadHandler.kt (3 withContext blocks)
  - homebase-chat/.../conversationlist/ConversationListViewModel.kt

Verified: `grep -rn "Dispatchers\.IO\|kotlinx\.coroutines\.IO" */src/commonMain` returns only the doc-comment references inside IoDispatcher.kt itself.

JVM tests pass across homebase-api, homebase-auth, homebase-chat, homebase-common.