### PR TITLE
chore(wasm-prep): abstract okio FileSystem.SYSTEM behind systemFileSy…

### DIFF
--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/file/SystemFileSystem.android.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/file/SystemFileSystem.android.kt
@@ -1,0 +1,6 @@
+package id.homebase.api.file
+
+import okio.FileSystem
+import okio.SYSTEM
+
+actual val systemFileSystem: FileSystem = FileSystem.SYSTEM

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
@@ -13,6 +13,7 @@ import id.homebase.api.client.drives.files.DriveFileHttpProvider
 import id.homebase.api.client.drives.files.PayloadOperationOptions
 import id.homebase.api.crypto.AesCbc
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.file.systemFileSystem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -28,9 +29,7 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.sync.withPermit
 import okio.ByteString.Companion.encodeUtf8
-import okio.FileSystem
 import okio.Path.Companion.toPath
-import okio.SYSTEM
 
 /**
  * Disk-backed, encrypted cache for authenticated drive file bytes. Wraps
@@ -78,7 +77,7 @@ class DriveFileProviderCached(
     private val delegate: DriveFileHttpProvider =
             DriveFileHttpProvider(httpClient, credentialsManager)
 
-    private val fileSystem = FileSystem.SYSTEM
+    private val fileSystem = systemFileSystem
     private val directory = fileOperationsProvider.getCacheDirectory()
 
     private val payloadSemaphore = Semaphore(1)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveFileHttpProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveFileHttpProvider.kt
@@ -25,8 +25,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.client.statement.bodyAsChannel
-import okio.Path.Companion.toPath
-import okio.FileSystem
 import io.ktor.utils.io.readAvailable
 
 private fun ByteReadChannel.asFlow(chunkSize: Int = 64 * 1024): Flow<ByteArray> = flow {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
@@ -6,6 +6,7 @@ import id.homebase.api.client.cache.CacheStats
 import id.homebase.api.common.OdinId
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.file.systemFileSystem
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.HttpResponse
@@ -20,10 +21,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import okio.ByteString.Companion.encodeUtf8
-import okio.FileSystem
 import okio.Path
 import okio.Path.Companion.toPath
-import okio.SYSTEM
 import kotlin.time.Clock
 
 /**
@@ -68,7 +67,7 @@ class PublicProfileProviderCached(
     private val serializer = OdinSystemSerializer
     private val clock = Clock.System
 
-    private val fileSystem = FileSystem.SYSTEM
+    private val fileSystem = systemFileSystem
     private val directory = fileOperationsProvider.getCacheDirectory()
 
     private val lock = Mutex()

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/SystemFileSystem.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/SystemFileSystem.kt
@@ -1,0 +1,21 @@
+package id.homebase.api.file
+
+import okio.FileSystem
+
+/**
+ * Multiplatform handle to the OS filesystem via okio. Use this from
+ * commonMain instead of `okio.FileSystem.SYSTEM`, which is JVM/Android/Native
+ * only — wasmJs doesn't ship a real filesystem.
+ *
+ * - jvm / android / native: backed by `okio.FileSystem.SYSTEM`.
+ * - wasmJs: an in-memory `okio.fakefilesystem.FakeFileSystem`. Persistence
+ *   in the browser (IndexedDB / OPFS / Cache API) is intentionally deferred
+ *   — first-pass wasm support keeps Coil's `DiskCache`,
+ *   `DriveFileProviderCached`, and friends functional without disk.
+ *
+ * For ordinary whole-file or streaming I/O, prefer
+ * [FileOperationsProvider] — this val is the escape hatch for code that
+ * needs okio's atomic `writeInt`/`readUtf8` binary serialization or
+ * recursive directory deletion.
+ */
+expect val systemFileSystem: FileSystem

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPreloader.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPreloader.kt
@@ -2,21 +2,20 @@ package id.homebase.api.video
 
 import co.touchlab.kermit.Logger
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.file.systemFileSystem
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import okio.FileSystem
 import okio.Path.Companion.toPath
-import okio.SYSTEM
 import kotlin.uuid.Uuid
 
 class VideoPreloader(
     private val driveFileProvider: VideoPrefetchDriveAccess,
     private val fileOperationsProvider: FileOperationsProvider,
 ) {
-    private val fileSystem = FileSystem.SYSTEM
+    private val fileSystem = systemFileSystem
     private val mutexMap = mutableMapOf<String, Mutex>()
     private val progressMap = mutableMapOf<String, MutableStateFlow<Float>>()
     private val mapLock = Mutex()

--- a/homebase-api/src/jvmMain/kotlin/id/homebase/api/file/SystemFileSystem.jvm.kt
+++ b/homebase-api/src/jvmMain/kotlin/id/homebase/api/file/SystemFileSystem.jvm.kt
@@ -1,0 +1,6 @@
+package id.homebase.api.file
+
+import okio.FileSystem
+import okio.SYSTEM
+
+actual val systemFileSystem: FileSystem = FileSystem.SYSTEM

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/SystemFileSystem.native.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/SystemFileSystem.native.kt
@@ -1,0 +1,6 @@
+package id.homebase.api.file
+
+import okio.FileSystem
+import okio.SYSTEM
+
+actual val systemFileSystem: FileSystem = FileSystem.SYSTEM

--- a/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/file/SystemFileSystem.web.kt
+++ b/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/file/SystemFileSystem.web.kt
@@ -1,0 +1,10 @@
+package id.homebase.api.file
+
+import okio.FileSystem
+import okio.fakefilesystem.FakeFileSystem
+
+// In-memory placeholder. Cleared on page refresh; do not rely on it for
+// persistence. Step 10 of the WASM pre-flight plan will wire the
+// `com.squareup.okio:okio-fakefilesystem` dependency; a future browser
+// backing (IndexedDB / OPFS) is out of scope for the pre-flight pass.
+actual val systemFileSystem: FileSystem = FakeFileSystem()

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -4,13 +4,12 @@ import co.touchlab.kermit.Logger
 import coil3.ImageLoader
 import id.homebase.api.di.apiModule
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.file.systemFileSystem
 import id.homebase.api.client.upgrade.IdentityUpgradeProvider
 
 import id.homebase.api.sync.DriveSyncManager
 import id.homebase.api.youauth.YouAuthFlowManager
-import okio.FileSystem
 import okio.Path.Companion.toPath
-import okio.SYSTEM
 import id.homebase.auth.login.LoginViewModel
 import id.homebase.chat.addgroupmembers.AddGroupMembersViewModel
 import id.homebase.chat.archivedconversations.ArchivedConversationsViewModel
@@ -158,7 +157,7 @@ val appModule = module {
     single {
         val imageLoader: ImageLoader = get()
         val fileOps: FileOperationsProvider = get()
-        val fileSystem = FileSystem.SYSTEM
+        val fileSystem = systemFileSystem
         val pendingUpgradeManager: PendingUpgradeManager = get()
         YouAuthFlowManager(
             driveSyncManager = get(),

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsViewModel.kt
@@ -9,6 +9,7 @@ import id.homebase.api.client.cache.CacheStats
 import id.homebase.api.client.drives.cache.DriveFileProviderCached
 import id.homebase.api.client.profile.PublicProfileProviderCached
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.file.systemFileSystem
 import id.homebase.api.sync.DriveSyncManager
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.core.sync.DriveRegistry
@@ -20,10 +21,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import okio.FileSystem
 import okio.Path
 import okio.Path.Companion.toPath
-import okio.SYSTEM
 import kotlin.uuid.Uuid
 
 class StorageSettingsViewModel(
@@ -38,7 +37,7 @@ class StorageSettingsViewModel(
     private val driveRegistry: DriveRegistry,
 ) : ViewModel() {
 
-    private val fileSystem = FileSystem.SYSTEM
+    private val fileSystem = systemFileSystem
 
     private val _uiState = MutableStateFlow(StorageSettingsUiState())
     val uiState: StateFlow<StorageSettingsUiState> = _uiState.asStateFlow()


### PR DESCRIPTION
…stem (step 5)

`okio.FileSystem.SYSTEM` is JVM/Android/Native only — wasmJs has no real disk. Introduce `expect val systemFileSystem: FileSystem` in homebase-api so commonMain code stops referencing the platform-specific singleton directly. Pattern mirrors step 4's `ioDispatcher`.

Why a top-level val rather than extending FileOperationsProvider: FileOperationsProvider's existing API is whole-file or stream-based. The call sites being migrated do okio-DSL binary serialization (writeInt/writeLong/writeUtf8/write(bytes)) and recursive directory deletion — both well below FileOperationsProvider's abstraction layer and tied to okio's BufferedSink/Source DSL. Keeping a parallel single-value handle stays close to those existing call shapes and matches the ioDispatcher precedent.

Actuals:
- jvm / android / native: `FileSystem.SYSTEM`
- wasmJs: `FakeFileSystem()` — in-memory placeholder. Cleared on page refresh; persistence in the browser (IndexedDB / OPFS) is out of scope for the pre-flight pass. The `okio-fakefilesystem` dependency will be wired in step 10.

Call sites migrated (5 in commonMain):
- homebase-api/.../client/drives/cache/DriveFileProviderCached.kt
- homebase-api/.../client/profile/PublicProfileProviderCached.kt
- homebase-api/.../video/VideoPreloader.kt
- homebase-core/.../ui/screens/storage/StorageSettingsViewModel.kt
- homebase-core/.../di/AppModule.kt (logout cache cleanup hook)

Plus dead-import cleanup in
homebase-api/.../client/drives/files/DriveFileHttpProvider.kt — the `okio.FileSystem` and `okio.Path.Companion.toPath` imports there were unused.

Verification:
- `grep -rn "FileSystem\.SYSTEM\|okio\.SYSTEM" */src/commonMain` returns only doc-comment hits inside SystemFileSystem.kt itself.
- JVM tests pass: homebase-api, homebase-auth, homebase-chat, homebase-common.
- iOS arm64 compiles cleanly: :homebase-api:compileKotlinIosArm64 + :homebase-core:compileKotlinIosArm64.

Out of scope (deferred to later steps per the pre-flight plan):
- `kotlinx.io.files.SystemFileSystem` usage in DatabaseDriverFactory, LoggerConfig, LogFileExporter — those will be addressed by step 6 (logging) and step 7 (DB driver).