### PR TITLE
chore(wasm-prep): guard file logging behind platform shims (step 6)

### DIFF
--- a/homebase-common/build.gradle.kts
+++ b/homebase-common/build.gradle.kts
@@ -94,7 +94,6 @@ kotlin {
             api(libs.coil3.network)
             api(libs.coil3.svg)
             implementation(libs.kermit)
-            implementation(libs.kermit.io)
             api(libs.filekit.core)
             api(libs.koin.core)
             api(libs.koin.compose)
@@ -119,9 +118,11 @@ kotlin {
             implementation(libs.accompanist.permissions)
             implementation(libs.firebase.crashlytics)
             api(libs.coil3.video)
+            implementation(libs.kermit.io)
         }
         appleMain.dependencies {
             implementation(libs.ktor.client.darwin)
+            implementation(libs.kermit.io)
         }
         jvmMain.dependencies {
             implementation(libs.ktor.client.cio)
@@ -130,6 +131,7 @@ kotlin {
             implementation(libs.nucleus.notification.windows)
             implementation(libs.nucleus.notification.macos)
             implementation(libs.nucleus.notification.linux)
+            implementation(libs.kermit.io)
         }
     }
 

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/logging/LoggerPlatform.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/logging/LoggerPlatform.android.kt
@@ -1,0 +1,35 @@
+package id.homebase.core.logging
+
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.io.RollingFileLogWriter
+import co.touchlab.kermit.io.RollingFileLogWriterConfig
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+
+internal actual fun createFileLogWriter(
+    logDirectory: Path,
+    fileName: String,
+    rollOnSize: Long,
+    maxFiles: Int,
+): LogWriter? = RollingFileLogWriter(
+    config = RollingFileLogWriterConfig(
+        logFilePath = logDirectory,
+        logFileName = fileName,
+        rollOnSize = rollOnSize,
+        maxLogFiles = maxFiles,
+    ),
+)
+
+internal actual fun listHomebaseLogFiles(logDirectory: Path): List<Path> =
+    SystemFileSystem.list(logDirectory)
+        .filter { it.name.startsWith("homebase") && it.name.endsWith(".log") }
+
+internal actual fun deleteHomebaseLogFiles(logDirectory: Path): Boolean =
+    try {
+        listHomebaseLogFiles(logDirectory).forEach {
+            SystemFileSystem.delete(it, mustExist = false)
+        }
+        true
+    } catch (e: Exception) {
+        false
+    }

--- a/homebase-common/src/appleMain/kotlin/id/homebase/core/logging/LoggerPlatform.apple.kt
+++ b/homebase-common/src/appleMain/kotlin/id/homebase/core/logging/LoggerPlatform.apple.kt
@@ -1,0 +1,35 @@
+package id.homebase.core.logging
+
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.io.RollingFileLogWriter
+import co.touchlab.kermit.io.RollingFileLogWriterConfig
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+
+internal actual fun createFileLogWriter(
+    logDirectory: Path,
+    fileName: String,
+    rollOnSize: Long,
+    maxFiles: Int,
+): LogWriter? = RollingFileLogWriter(
+    config = RollingFileLogWriterConfig(
+        logFilePath = logDirectory,
+        logFileName = fileName,
+        rollOnSize = rollOnSize,
+        maxLogFiles = maxFiles,
+    ),
+)
+
+internal actual fun listHomebaseLogFiles(logDirectory: Path): List<Path> =
+    SystemFileSystem.list(logDirectory)
+        .filter { it.name.startsWith("homebase") && it.name.endsWith(".log") }
+
+internal actual fun deleteHomebaseLogFiles(logDirectory: Path): Boolean =
+    try {
+        listHomebaseLogFiles(logDirectory).forEach {
+            SystemFileSystem.delete(it, mustExist = false)
+        }
+        true
+    } catch (e: Exception) {
+        false
+    }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/logging/LogFileExporter.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/logging/LogFileExporter.kt
@@ -2,47 +2,31 @@ package id.homebase.core.logging
 
 import co.touchlab.kermit.Logger
 import kotlinx.io.files.Path
-import kotlinx.io.files.SystemFileSystem
 
 /**
  * Utility to export/access log files for sharing or viewing
  */
 object LogFileExporter {
     private const val TAG = "LogFileExporter"
-    
+
     /**
      * Get the most recent log file path
      * Returns null if no log files exist
      */
     fun getMostRecentLogFile(logDirectory: Path): Path? {
-        return try {
-            val files = SystemFileSystem.list(logDirectory)
-                .filter { it.name.startsWith("homebase") && it.name.endsWith(".log") }
-                .sortedByDescending { it.name }
-            
-            if (files.isEmpty()) {
-                Logger.w(tag = TAG) { "No log files found in $logDirectory" }
-                null
-            } else {
-                files.first()
-            }
-        } catch (e: Exception) {
-            Logger.e(throwable = e, tag = TAG) { "Failed to get log files from $logDirectory" }
+        val files = listHomebaseLogFiles(logDirectory).sortedByDescending { it.name }
+        return if (files.isEmpty()) {
+            Logger.w(tag = TAG) { "No log files found in $logDirectory" }
             null
+        } else {
+            files.first()
         }
     }
-    
+
     /**
      * Get all log files in the directory
      */
     fun getAllLogFiles(logDirectory: Path): List<Path> {
-        return try {
-            SystemFileSystem.list(logDirectory)
-                .filter { it.name.startsWith("homebase") && it.name.endsWith(".log") }
-                .sortedByDescending { it.name }
-        } catch (e: Exception) {
-            Logger.e(throwable = e, tag = TAG) { "Failed to get log files from $logDirectory" }
-            emptyList()
-        }
+        return listHomebaseLogFiles(logDirectory).sortedByDescending { it.name }
     }
 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/logging/LoggerConfig.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/logging/LoggerConfig.kt
@@ -3,11 +3,8 @@ package id.homebase.core.logging
 import co.touchlab.kermit.LogWriter
 import co.touchlab.kermit.Logger
 import co.touchlab.kermit.Severity
-import co.touchlab.kermit.io.RollingFileLogWriter
-import co.touchlab.kermit.io.RollingFileLogWriterConfig
 import co.touchlab.kermit.platformLogWriter
 import kotlinx.io.files.Path
-import kotlinx.io.files.SystemFileSystem
 
 object LoggerConfig {
     private const val TAG = "LoggerConfig"
@@ -45,16 +42,18 @@ object LoggerConfig {
 
         // Add rolling file logger
         try {
-            val fileLogWriter = RollingFileLogWriter(
-                config =  RollingFileLogWriterConfig(
-                    logFilePath = logDirectory,
-                    logFileName = "homebase",
-                    rollOnSize = maxFileSize,
-                    maxLogFiles = maxFiles,
-                ),
+            val fileLogWriter = createFileLogWriter(
+                logDirectory = logDirectory,
+                fileName = "homebase",
+                rollOnSize = maxFileSize,
+                maxFiles = maxFiles,
             )
-            logWriters.add(fileLogWriter)
-            Logger.i(tag = TAG) { "File logging initialized at: $logDirectory" }
+            if (fileLogWriter != null) {
+                logWriters.add(fileLogWriter)
+                Logger.i(tag = TAG) { "File logging initialized at: $logDirectory" }
+            } else {
+                Logger.i(tag = TAG) { "File logging unavailable on this platform — console only" }
+            }
         } catch (e: Exception) {
             Logger.e(TAG, e, "Failed to initialize file logging")
         }
@@ -72,7 +71,7 @@ object LoggerConfig {
      * Returns true if every matching file was deleted, false otherwise.
      *
      * On Windows the active log file is held open with an exclusive lock by
-     * [RollingFileLogWriter], so we drop it from the Logger's writer list before
+     * the file log writer, so we drop it from the Logger's writer list before
      * attempting to delete; the file handle is released when the writer is GC'd.
      * Callers that care about the user-visible outcome (e.g. a "Clear log" button)
      * should use the return value rather than assume success.
@@ -84,14 +83,9 @@ object LoggerConfig {
         Logger.setLogWriters(listOf(platformLogWriter()))
         isInitialized = false
 
-        val deleted = try {
-            val files = SystemFileSystem.list(path)
-                .filter { it.name.startsWith("homebase") && it.name.endsWith(".log") }
-            files.forEach { SystemFileSystem.delete(it, mustExist = false) }
-            true
-        } catch (e: Exception) {
-            Logger.e(throwable = e, tag = TAG) { "Failed to delete log files in $path" }
-            false
+        val deleted = deleteHomebaseLogFiles(path)
+        if (!deleted) {
+            Logger.e(tag = TAG) { "Failed to delete log files in $path" }
         }
 
         // Restore file logging regardless of outcome — we don't want the rest of the

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/logging/LoggerPlatform.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/logging/LoggerPlatform.kt
@@ -1,0 +1,30 @@
+package id.homebase.core.logging
+
+import co.touchlab.kermit.LogWriter
+import kotlinx.io.files.Path
+
+/**
+ * Platform shims for file-backed logging. Kept narrow on purpose: every
+ * other piece of `LoggerConfig` / `LogFileExporter` is plain Kermit + Path
+ * and stays in commonMain.
+ *
+ * - `RollingFileLogWriter` (kermit-io) has no wasmJs artifact, so the file
+ *   writer is built per-platform behind [createFileLogWriter].
+ * - `kotlinx.io.files.SystemFileSystem` is also platform-specific, so log-
+ *   directory listing and deletion go behind [listHomebaseLogFiles] /
+ *   [deleteHomebaseLogFiles].
+ *
+ * On wasmJs all three become safe no-ops: there is no real disk, so the
+ * console-only `platformLogWriter()` Kermit installs by default carries the
+ * whole logging surface.
+ */
+internal expect fun createFileLogWriter(
+    logDirectory: Path,
+    fileName: String,
+    rollOnSize: Long,
+    maxFiles: Int,
+): LogWriter?
+
+internal expect fun listHomebaseLogFiles(logDirectory: Path): List<Path>
+
+internal expect fun deleteHomebaseLogFiles(logDirectory: Path): Boolean

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/logging/LoggerPlatform.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/logging/LoggerPlatform.jvm.kt
@@ -1,0 +1,35 @@
+package id.homebase.core.logging
+
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.io.RollingFileLogWriter
+import co.touchlab.kermit.io.RollingFileLogWriterConfig
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+
+internal actual fun createFileLogWriter(
+    logDirectory: Path,
+    fileName: String,
+    rollOnSize: Long,
+    maxFiles: Int,
+): LogWriter? = RollingFileLogWriter(
+    config = RollingFileLogWriterConfig(
+        logFilePath = logDirectory,
+        logFileName = fileName,
+        rollOnSize = rollOnSize,
+        maxLogFiles = maxFiles,
+    ),
+)
+
+internal actual fun listHomebaseLogFiles(logDirectory: Path): List<Path> =
+    SystemFileSystem.list(logDirectory)
+        .filter { it.name.startsWith("homebase") && it.name.endsWith(".log") }
+
+internal actual fun deleteHomebaseLogFiles(logDirectory: Path): Boolean =
+    try {
+        listHomebaseLogFiles(logDirectory).forEach {
+            SystemFileSystem.delete(it, mustExist = false)
+        }
+        true
+    } catch (e: Exception) {
+        false
+    }

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/logging/LoggerPlatform.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/logging/LoggerPlatform.web.kt
@@ -1,0 +1,20 @@
+package id.homebase.core.logging
+
+import co.touchlab.kermit.LogWriter
+import kotlinx.io.files.Path
+
+// No real filesystem on wasmJs — the console-only `platformLogWriter()`
+// that Kermit installs by default carries the whole logging surface.
+// Step 6 of the WASM pre-flight plan; an in-browser sink (e.g. accumulating
+// to a Blob for user download) can come later.
+
+internal actual fun createFileLogWriter(
+    logDirectory: Path,
+    fileName: String,
+    rollOnSize: Long,
+    maxFiles: Int,
+): LogWriter? = null
+
+internal actual fun listHomebaseLogFiles(logDirectory: Path): List<Path> = emptyList()
+
+internal actual fun deleteHomebaseLogFiles(logDirectory: Path): Boolean = true


### PR DESCRIPTION
`kermit-io`'s `RollingFileLogWriter` and `kotlinx.io.files.SystemFileSystem` are both unavailable on wasmJs. Refactor `LoggerConfig` / `LogFileExporter` so commonMain stops referencing those types directly; each piece routes through three new internal expect funs in `LoggerPlatform.kt`:

  - createFileLogWriter(...) -> LogWriter?
  - listHomebaseLogFiles(path) -> List<Path>
  - deleteHomebaseLogFiles(path) -> Boolean

Actuals:
- jvm / android / apple: build a RollingFileLogWriter and use SystemFileSystem.list/delete (behavior identical to today).
- wasmJs: createFileLogWriter returns null, list returns empty, deleteHomebaseLogFiles is a no-op (true). LoggerConfig handles the null writer by installing only Kermit's `platformLogWriter()` (console), and logs "File logging unavailable on this platform — console only" at init so it's obvious in dev tools.

Build:
- Moved `libs.kermit.io` out of commonMain.dependencies and into jvmMain/androidMain/appleMain. Required because the kermit-io artifact has no wasmJs variant; leaving it on commonMain would fail dependency resolution the moment wasmJs is enabled (step 10).
- The apple actual lives in `appleMain/` (not `nativeMain/`) because the kermit-io dep is declared on appleMain.dependencies; nativeMain is the *parent* source set and would not see the dep. This project's only native targets are iOS, so appleMain covers them.

Verification:
- `grep -rn "co\.touchlab\.kermit\.io\|RollingFileLogWriter\|SystemFileSystem" homebase-common/src/commonMain` returns only doc-comment references inside LoggerPlatform.kt and a stale comment in CrashLogger.kt — no live code references.
- JVM tests pass across homebase-api/auth/chat/common, including the Windows-lock regression test in `LoggerConfigTest.purgeLogs_*`.
- iOS arm64 compiles cleanly: :homebase-common:compileKotlinIosArm64 + :homebase-core:compileKotlinIosArm64.

Out of scope: the `kotlinx.io.files.SystemFileSystem.delete` call in `DatabaseDriverFactory.deleteDatabaseFiles` remains — that's step 7's natural home (DB driver work; wasmJs uses sql.js in-memory so the WAL/SHM delete becomes a no-op there).