### PR TITLE
chore(wasm-prep): prepare DB driver for sql.js on wasmJs (step 7)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -132,6 +132,7 @@ sqldelight-coroutines-extensions = { module = "app.cash.sqldelight:coroutines-ex
 sqldelight-android-driver = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }
 sqldelight-native-driver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
 sqldelight-sqlite-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
+sqldelight-web-worker-driver = { module = "app.cash.sqldelight:web-worker-driver", version.ref = "sqldelight" }
 sqlite-jdbc-crypt = { module = "io.github.willena:sqlite-jdbc", version.ref = "sqlite-jdbc-crypt" }
 sqldelight-sqlite338-dialect = { module = "app.cash.sqldelight:sqlite-3-38-dialect", version.ref = "sqldelight" }
 android-database-sqlcipher = { module = "net.zetetic:sqlcipher-android", version.ref = "sqlcipher" }

--- a/homebase-api/build.gradle.kts
+++ b/homebase-api/build.gradle.kts
@@ -120,6 +120,14 @@ kotlin {
             implementation(libs.sqldelight.native.driver)
         }
 
+        // Uncomment in step 10 of the WASM pre-flight plan, paired with the
+        // `wasmJs { browser() }` block above. WebWorkerDriver runs sql.js
+        // (SQLite-compiled-to-WASM) inside a Web Worker; see
+        // `DatabaseDriverFactory.web.kt` for the constructor shape.
+//        wasmJsMain.dependencies {
+//            implementation(libs.sqldelight.web.worker.driver)
+//        }
+
         jvmMain.dependencies {
             implementation(libs.ktor.client.cio)
             implementation(libs.sqldelight.sqlite.driver.get().toString()) {

--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/sync/database/DatabaseFileOps.android.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/sync/database/DatabaseFileOps.android.kt
@@ -1,0 +1,8 @@
+package id.homebase.api.sync.database
+
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+
+internal actual fun deleteSqliteFileIfExists(path: String) {
+    SystemFileSystem.delete(Path(path), mustExist = false)
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.kt
@@ -1,8 +1,6 @@
 package id.homebase.api.sync.database
 
 import app.cash.sqldelight.db.SqlDriver
-import kotlinx.io.files.Path
-import kotlinx.io.files.SystemFileSystem
 
 /** The on-disk database file name used by every platform's [DatabaseDriverFactory]. */
 internal const val DB_FILE_NAME = "odin-2.db"
@@ -17,15 +15,29 @@ expect class DatabaseDriverFactory {
      * [DatabaseManager.initializeWithRecovery]. Each platform reports the
      * exact path its `createDriver` opens (or would open) so the recovery
      * deletes the file the driver was looking at.
+     *
+     * Platforms without an on-disk database (e.g. wasmJs's in-memory sql.js)
+     * return an empty string — [deleteOnDiskFiles] becomes a no-op.
      */
     fun dbFilePath(): String
 }
 
 /**
+ * Delete a single SQLite side file at [path] if it exists. Per-platform so
+ * commonMain doesn't have to reference `kotlinx.io.files.SystemFileSystem`,
+ * which is unavailable on wasmJs. Missing files are treated as a no-op
+ * (matches `SystemFileSystem.delete(..., mustExist = false)`).
+ *
+ * On wasmJs this is a no-op because sql.js is in-memory and has no on-disk
+ * file to delete.
+ */
+internal expect fun deleteSqliteFileIfExists(path: String)
+
+/**
  * Delete the on-disk database file plus its WAL/SHM/journal siblings. The
  * loop and suffix list live in commonMain because they aren't
  * platform-specific — only [DatabaseDriverFactory.dbFilePath] is. Missing
- * files are treated as a no-op (`mustExist = false`).
+ * files are treated as a no-op.
  */
 internal fun DatabaseDriverFactory.deleteOnDiskFiles() {
     deleteDatabaseFiles(dbFilePath())
@@ -47,7 +59,8 @@ internal fun DatabaseDriverFactory.deleteOnDiskFiles() {
  * zombies.
  */
 internal fun deleteDatabaseFiles(dbFilePath: String) {
+    if (dbFilePath.isEmpty()) return
     for (suffix in listOf("", "-journal", "-wal", "-shm")) {
-        SystemFileSystem.delete(Path(dbFilePath + suffix), mustExist = false)
+        deleteSqliteFileIfExists(dbFilePath + suffix)
     }
 }

--- a/homebase-api/src/jvmMain/kotlin/id/homebase/api/sync/database/DatabaseFileOps.jvm.kt
+++ b/homebase-api/src/jvmMain/kotlin/id/homebase/api/sync/database/DatabaseFileOps.jvm.kt
@@ -1,0 +1,8 @@
+package id.homebase.api.sync.database
+
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+
+internal actual fun deleteSqliteFileIfExists(path: String) {
+    SystemFileSystem.delete(Path(path), mustExist = false)
+}

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/sync/database/DatabaseFileOps.native.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/sync/database/DatabaseFileOps.native.kt
@@ -1,0 +1,8 @@
+package id.homebase.api.sync.database
+
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+
+internal actual fun deleteSqliteFileIfExists(path: String) {
+    SystemFileSystem.delete(Path(path), mustExist = false)
+}

--- a/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.web.kt
+++ b/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.web.kt
@@ -2,13 +2,40 @@ package id.homebase.api.sync.database
 
 import app.cash.sqldelight.db.SqlDriver
 
+/**
+ * wasmJs uses SQLDelight's web-worker-driver backed by sql.js (an
+ * in-memory SQLite compiled to WebAssembly). Wired in step 10 of the
+ * WASM pre-flight plan once:
+ *
+ *   1. `sqldelight-web-worker-driver` is added to `wasmJsMain.dependencies`
+ *      in `homebase-api/build.gradle.kts` (paired with uncommenting
+ *      `wasmJs { browser() }`).
+ *   2. The `sqljs.worker.js` worker script and the `sql-wasm.wasm` binary
+ *      are made available to the browser bundle (via the webApp module's
+ *      static assets or a webpack copy plugin from `@cashapp/sqldelight-sqljs-worker`
+ *      under node_modules).
+ *
+ * Reference shape (Kotlin/Wasm + sql.js):
+ *
+ * ```
+ * val worker = Worker(js("new URL('sqljs.worker.js', import.meta.url)"))
+ * return WebWorkerDriver(worker).also { OdinDatabase.Schema.create(it) }
+ * ```
+ *
+ * sql.js has no SQLCipher equivalent — the `passphrase` argument is
+ * intentionally ignored on wasmJs. CLAUDE.md acknowledges this constraint
+ * ("SQLite will be in-memory, no SQLCipher"). On the browser, transport
+ * security is the responsibility of the HTTPS connection and IndexedDB/
+ * OPFS-level encryption when persistence is added later.
+ */
 @Suppress(names = ["EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING"])
 actual class DatabaseDriverFactory {
     actual fun createDriver(passphrase: String?): SqlDriver {
-        TODO("Not yet implemented")
+        TODO("Wire WebWorkerDriver + sqljs.worker.js in WASM pre-flight step 10")
     }
 
-    actual fun dbFilePath(): String {
-        TODO("Not yet implemented")
-    }
+    // sql.js is in-memory only — no on-disk file to report. Empty string
+    // causes `deleteDatabaseFiles` to short-circuit, which is correct: there
+    // is no SQLite file (or WAL/SHM siblings) to delete on the web.
+    actual fun dbFilePath(): String = ""
 }

--- a/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/sync/database/DatabaseFileOps.web.kt
+++ b/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/sync/database/DatabaseFileOps.web.kt
@@ -1,0 +1,8 @@
+package id.homebase.api.sync.database
+
+// sql.js is in-memory only — there is no on-disk SQLite file to delete on
+// wasmJs. The recovery path in `DatabaseManager.initializeWithRecovery`
+// becomes a no-op; restarting the worker effectively wipes the database.
+internal actual fun deleteSqliteFileIfExists(path: String) {
+    // intentionally empty
+}


### PR DESCRIPTION
Three pieces in one commit, all scoped to the database layer:

1. `deleteDatabaseFiles` no longer reaches into commonMain's `kotlinx.io.files.SystemFileSystem` — that singleton has no wasmJs variant. The suffix loop stays in commonMain (the bit `DeleteDatabaseFilesTest` exercises), but the per-file delete moves to a new `internal expect fun deleteSqliteFileIfExists(path: String)`. Actuals:
   - jvm / android / native: SystemFileSystem.delete(Path, mustExist = false)
   - wasmJs: no-op (sql.js is in-memory; nothing to delete)

   Also short-circuit `deleteDatabaseFiles` when dbFilePath is empty so
   the wasmJs path is a clean no-op without a wasted suffix loop.

2. `DatabaseDriverFactory.web.kt` is no longer a bare `TODO("Not yet implemented")`. The class doc now records:
   - the reference-shape implementation (`WebWorkerDriver(Worker(js("new URL('sqljs.worker.js', import.meta.url)")))`)
   - that `passphrase` is intentionally ignored (sql.js has no SQLCipher equivalent — CLAUDE.md flags this constraint as accepted)
   - that `dbFilePath()` returns "" so the recovery path no-ops. The actual driver wiring + worker-asset plumbing happens in step 10 alongside `wasmJs { browser() }` being uncommented.

3. Build setup:
   - Added `sqldelight-web-worker-driver` to libs.versions.toml.
   - Added a commented-out `wasmJsMain.dependencies` block in homebase-api/build.gradle.kts, paired with the existing commented-out `wasmJs { browser() }` declaration. Uncommenting is a single mechanical step in step 10.

Verification:
- `grep -rn "SystemFileSystem" homebase-api/src/commonMain` returns only doc-comment hits inside DatabaseDriverFactory.kt itself.
- All JVM tests pass across api/auth/chat/common — including `DeleteDatabaseFilesTest` (4 cases) which still exercises the loop through the new expect/actual indirection on JVM.
- :homebase-api:compileKotlinIosArm64 + :homebase-core:compileKotlinIosArm64 pass.