### PR TITLE
chore(wasm-prep): drop dead kache deps + verify BuildConfig (step 9a)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,6 @@ ffmpegKit = "1.0"
 vlcj = "4.8.2"
 jetbrains-compose-material3 = "1.9.0"
 jetbrains-compose-material3-adaptive = "1.2.0"
-kache = "2.1.1"
 kotlinxHtmlJvm = "0.12.0"
 kotlinxSerializationJson = "1.11.0"
 materialIconsExtended = "1.7.3"
@@ -177,8 +176,6 @@ accompanist-systemuicontroller = { module = "com.google.accompanist:accompanist-
 kmpnotifier = { module = "io.github.mirzemehdi:kmpnotifier", version.ref = "kmpnotifier" }
 firebase-messaging = { module = "com.google.firebase:firebase-messaging", version.ref = "firebase-messaging" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics", version.ref = "firebase-crashlytics" }
-kache-file = { module = "com.mayakapps.kache:file-kache", version.ref = "kache" }
-kache = { module = "com.mayakapps.kache:kache", version.ref = "kache" }
 composenativetray = { module = "io.github.kdroidfilter:composenativetray", version.ref = "composenativetray" }
 composenativewebview = { module = "io.github.kdroidfilter:composewebview", version.ref = "composenativewebview" }
 conveyor-control = { module = "dev.hydraulic.conveyor:conveyor-control", version.ref = "conveyorControl" }

--- a/homebase-api/build.gradle.kts
+++ b/homebase-api/build.gradle.kts
@@ -40,7 +40,6 @@ kotlin {
         }
     }
 
-    // REMOVED so we could support FileKache
 //    @OptIn(ExperimentalWasmDsl::class)
 //    wasmJs {
 //        browser()
@@ -91,8 +90,6 @@ kotlin {
             implementation(libs.filekit.dialogs.compose)
             implementation(libs.kotlinx.io.core)
             implementation(libs.kotlinx.immutableCollections)
-            implementation(libs.kache)
-            implementation(libs.kache.file)
             implementation(libs.coil3)
             implementation(libs.okio)
         }


### PR DESCRIPTION

Step 9 of the WASM pre-flight plan has four sub-items of very
uneven size:
  9a (this PR): remove dead `kache`/`kache-file` deps + verify
               BuildConfig wasm support.
  9b (next):   decouple `composenativewebview` from homebase-core
               commonMain (FeedScreen + PlatformWebView refactor).
  9c (next):   decouple `kmpnotifier` from homebase-common commonMain
               (NotificationService refactor).

Each gets its own PR so the bigger refactors are easy to review.

---

### kache: turns out it was already dead

`com.mayakapps.kache:kache` and `com.mayakapps.kache:file-kache` are
declared in homebase-api/build.gradle.kts commonMain but no production
code imports them — `grep -rn "^import com\.mayakapps" --include=*.kt
homebase-{api,common,chat,auth,core}` returns zero matches. The only
references are migration-cleanup *comments* in
DriveFileProviderCached.init / PublicProfileProviderCached.init that
delete the pre-Coil mayakapps cache directories
(`homebase-payloads`, `homebase-thumbs`, `homebase-public-profiles`,
`homebase-public-images`). Those comments stay; they're correct that
the directories existed once, but the *dependency* hasn't been needed
since the Coil DiskCache migration.

The plan's worry that kache 2.1.1 might not ship wasmJs is moot — the
dep is unused, removing it sidesteps the question entirely.

Also dropped the stale "REMOVED so we could support FileKache" comment
above the commented-out `wasmJs { browser() }` block in
homebase-api/build.gradle.kts. The block stays commented out for step
10, but the reasoning for the original removal no longer applies.

### BuildConfig: no change needed

`gmazzo.buildconfig` 6.0.9 (used in homebase-common to generate
`APP_BUILD_TIME`) has supported `wasmJs` source sets since the 5.x
series; the generated source is attached via Kotlin's standard
KotlinCompile task graph, which works for every active KMP target.
The `LocalDateTime.now().format(...)` call inside `buildConfig { ... }`
runs at Gradle configuration time, producing a String literal that's
embedded into the generated `BuildConfig.kt` — no runtime
`java.time.*` references reach the wasmJs output. No code change
required; final on-target verification will fall out of step 10 when
`wasmJs { browser() }` is uncommented.

Verification:
- `./gradlew :homebase-{api,auth,chat,common}:jvmTest --rerun-tasks` passes
- `:homebase-api:compileKotlinIosArm64 + :homebase-core:compileKotlinIosArm64`
  passes — no transitive kache reference broke any platform.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>