### PR TITLE
Cache diagnostics hls key cleanup

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -156,6 +156,7 @@ dependencies {
     implementation(libs.kermit)
     implementation(libs.androidx.work.runtime)
     implementation(libs.androidx.sharetarget)
+    implementation(libs.androidx.lifecycle.process)
     implementation(libs.firebase.messaging)
     implementation(libs.firebase.crashlytics)
 

--- a/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
@@ -5,11 +5,16 @@ import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.os.Build
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import co.touchlab.kermit.Logger
 import com.google.firebase.Firebase
 import com.google.firebase.crashlytics.crashlytics
 import com.mmk.kmpnotifier.notification.NotifierManager
 import com.mmk.kmpnotifier.notification.configuration.NotificationPlatformConfiguration
+import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.file.sweepShareOutbound
 import id.homebase.api.storage.SecureStorage
 import id.homebase.api.storage.SharedPreferences
 import id.homebase.api.sync.database.DatabaseDriverFactory
@@ -30,6 +35,7 @@ import id.homebase.feed.share.ShareShortcutPublisher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.io.files.Path
 import org.koin.android.ext.koin.androidContext
@@ -111,6 +117,29 @@ class MainApplication : Application(), KoinComponent {
 
         // Publish share shortcuts when conversations change
         initShareShortcuts()
+
+        // Reap cleartext share-OUT temps every time the app reaches the
+        // foreground. The chat "Share to other app" flow writes decrypted
+        // copies of E2EE Homebase payloads into <cacheDir>/share_outbound/
+        // and hands the URI to Intent.ACTION_SEND via FileProvider; the
+        // receiving app reads it through the URI grant. Once we're back in
+        // foreground, the receiving app has had its read window — we delete
+        // the cleartext so it doesn't sit on disk indefinitely.
+        // Cold-start is covered by StartupCacheAudit; this is the bound on
+        // a same-process share's on-disk lifetime.
+        registerShareOutboundForegroundSweep()
+    }
+
+    private fun registerShareOutboundForegroundSweep() {
+        val fileOps = get<FileOperationsProvider>()
+        ProcessLifecycleOwner.get().lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onStart(owner: LifecycleOwner) {
+                appScope.launch {
+                    runCatching { sweepShareOutbound(fileOps.getCacheDirectory()) }
+                        .onFailure { Logger.w("share_outbound foreground sweep failed", it) }
+                }
+            }
+        })
     }
 
     private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)

--- a/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
@@ -27,6 +27,7 @@ import co.touchlab.kermit.Logger
 import com.mohamedrejeb.richeditor.model.RichTextState
 import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.file.safeDeleteRecursively
 import id.homebase.api.youauth.YouAuthFlowManager
 import id.homebase.api.youauth.YouAuthState
 import id.homebase.chat.conversationlist.AttachmentPendingFile
@@ -436,11 +437,7 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
     }
 
     private fun cleanupTempFiles() {
-        try {
-            File(cacheDir, "share_temp").deleteRecursively()
-        } catch (_: Exception) {
-            // Ignore cleanup errors
-        }
+        safeDeleteRecursively(cacheDir.absolutePath, "share_temp")
     }
 
     private fun extractDirectShareConversationId(): String? {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -104,6 +104,10 @@ androidx-work-runtime = { module = "androidx.work:work-runtime-ktx", version.ref
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-lifecycle-viewmodelCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
+# Google AndroidX (NOT the JetBrains KMP one above) — needed for ProcessLifecycleOwner,
+# which lets us hook app foreground transitions on Android. Used by MainApplication's
+# share-outbound foreground sweep.
+androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version = "2.10.0" }
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "androidx-media3" }
 androidx-media3-exoplayer-hls = { module = "androidx.media3:media3-exoplayer-hls", version.ref = "androidx-media3" }
 androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "androidx-media3" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -126,6 +126,7 @@ atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu"
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 kermit-io = { module = "co.touchlab:kermit-io", version.ref = "kermit" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
+okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesystem", version.ref = "okio" }
 richeditor-compose = { module = "com.mohamedrejeb.richeditor:richeditor-compose", version.ref = "richeditorCompose" }
 sqldelight-runtime = { module = "app.cash.sqldelight:runtime", version.ref = "sqldelight" }
 sqldelight-coroutines-extensions = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqldelight" }

--- a/homebase-api/build.gradle.kts
+++ b/homebase-api/build.gradle.kts
@@ -97,6 +97,7 @@ kotlin {
             implementation(libs.kotlin.test)
             implementation(libs.kotlinx.coroutines.test)
             implementation(libs.ktor.client.mock)
+            implementation(libs.okio.fakefilesystem)
         }
         androidMain.dependencies {
             implementation(libs.androidx.appcompat)

--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/file/AndroidFileOperationsProvider.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/file/AndroidFileOperationsProvider.kt
@@ -122,6 +122,15 @@ class AndroidFileOperationsProvider(
         file.path
     }
 
+    override suspend fun writeBytesToShareOutboundFile(
+        bytes: ByteArray, suffix: String
+    ): String = withContext(Dispatchers.IO) {
+        val dir = File(context.cacheDir, SHARE_OUTBOUND_DIR_NAME).apply { mkdirs() }
+        val file = File.createTempFile("share_", suffix, dir)
+        file.writeBytes(bytes)
+        file.path
+    }
+
     override suspend fun resolveToFilePath(path: String): String {
         if (!path.startsWith("content://") && !path.startsWith("content:")) return path
         return withContext(Dispatchers.IO) {

--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/video/FFmpegUtils.android.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/video/FFmpegUtils.android.kt
@@ -382,6 +382,9 @@ actual object FFmpegUtils {
 
             val session = FFmpegKit.executeWithArguments(args.toTypedArray())
             if (ReturnCode.isSuccess(session.returnCode)) {
+                // Segmentation done — FFmpeg has consumed the key material. Delete it now
+                // so the plaintext AES key doesn't linger in the cache dir (see #7).
+                deleteHlsKeyMaterial(outputDir.absolutePath)
                 Pair(playlistPath, segmentPath)
             } else {
                 Log.e(TAG, "Segment+Encrypt failed: ${session.failStackTrace}")

--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/video/FFmpegUtils.android.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/video/FFmpegUtils.android.kt
@@ -205,6 +205,8 @@ actual object FFmpegUtils {
                 return@withContext outputPath
             } else {
                 Log.e(TAG, "Compression failed: ${swSession.failStackTrace}")
+                // Both encoders failed — delete the partial/empty output (see #5).
+                deleteFailedFfmpegOutput(outputPath)
                 return@withContext null
             }
         }
@@ -305,6 +307,9 @@ actual object FFmpegUtils {
                 return@withContext Pair(playlistPath, segmentPath)
             } else {
                 Log.e(TAG, "Segmentation failed: ${session.failStackTrace}")
+                // Delete the partial playlist + segment left behind (see #5).
+                deleteFailedFfmpegOutput(playlistPath)
+                deleteFailedFfmpegOutput(playlistPath.replace(".m3u8", ".ts"))
                 return@withContext null
             }
         }
@@ -388,6 +393,8 @@ actual object FFmpegUtils {
                 Pair(playlistPath, segmentPath)
             } else {
                 Log.e(TAG, "Segment+Encrypt failed: ${session.failStackTrace}")
+                // Delete the whole hls_<uuid>/ dir — partial segments + key material (see #5).
+                deleteFailedFfmpegOutput(outputDir.absolutePath)
                 null
             }
         }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
@@ -13,6 +13,7 @@ import id.homebase.api.client.drives.files.DriveFileHttpProvider
 import id.homebase.api.client.drives.files.PayloadOperationOptions
 import id.homebase.api.crypto.AesCbc
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.file.safeDeleteRecursively
 import id.homebase.api.file.systemFileSystem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -120,8 +121,8 @@ class DriveFileProviderCached(
         // the construction thread so an upgrade-day delete of a populated
         // 500 MB dir cannot block whatever path instantiates this class.
         CoroutineScope(SupervisorJob() + Dispatchers.Default).launch {
-            runCatching { fileSystem.deleteRecursively("$directory/homebase-payloads".toPath()) }
-            runCatching { fileSystem.deleteRecursively("$directory/homebase-thumbs".toPath()) }
+            safeDeleteRecursively(directory, "homebase-payloads")
+            safeDeleteRecursively(directory, "homebase-thumbs")
         }
     }
 
@@ -500,8 +501,6 @@ class DriveFileProviderCached(
                     .joinToString(":")
 
     suspend fun clearCaches() {
-        val preloadDir = "$directory/hbvid_preload".toPath()
-
         // Coil's DiskCache.clear() is documented as thread-safe; it serialises
         // internally against in-flight readers/writers.
         try {
@@ -515,11 +514,7 @@ class DriveFileProviderCached(
             Logger.w(tag = "DriveFileProviderCached", throwable = e) { "thumb cache clear failed" }
         }
 
-        try {
-            fileSystem.deleteRecursively(preloadDir)
-        } catch (e: Exception) {
-            Logger.w(tag = "DriveFileProviderCached", throwable = e) { "hbvid_preload dir delete failed" }
-        }
+        safeDeleteRecursively(directory, "hbvid_preload")
 
         notFoundCache = emptySet()
     }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/upload/DriveUploadProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/upload/DriveUploadProvider.kt
@@ -559,5 +559,12 @@ class DriveUploadProvider(
                 Logger.w(tag = TAG) { "Temp file could not be deleted (best-effort): $path" }
             }
         }
+
+        // The per-file loop above only kills the single payload file (e.g. the
+        // HLS `index.ts`). For HLS sends we also want the parent `hls_<uuid>/`
+        // dir gone — otherwise `index.m3u8` and any FFmpeg `.tmp` leftovers
+        // accumulate (the cache leak chased in #6). cleanupHlsScratch is a
+        // no-op for non-HLS payloads.
+        cleanupHlsScratch(payloads)
     }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/upload/HlsScratchCleanup.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/upload/HlsScratchCleanup.kt
@@ -1,0 +1,54 @@
+package id.homebase.api.client.drives.upload
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.client.drives.files.PayloadFile
+import id.homebase.api.file.safeDeleteRecursively
+import id.homebase.api.file.systemFileSystem
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+/**
+ * For each payload whose `filePath` sits inside an `hls_<uuid>/` directory,
+ * recursive-delete that directory via [safeDeleteRecursively]. Best-effort,
+ * never throws.
+ *
+ * Called from:
+ *  - the upload SUCCESS path (`DriveUploadProvider.cleanupPayloadTempFiles`),
+ *    where the per-file deletion of `index.ts` would otherwise leave the
+ *    parent dir + sibling `index.m3u8` (and any `.ts.tmp` FFmpeg leftovers)
+ *    behind;
+ *  - the Outbox PERMANENT-FAILURE / drop path (`OutboxSync.outboxSend`), so a
+ *    message that exhausted retries or hit a terminal error doesn't leak its
+ *    HLS scratch dir.
+ *
+ * Non-HLS payloads (image / audio / non-HLS MP4) have a `filePath` whose parent
+ * is *not* `hls_*`; they are silently skipped, leaving the existing per-file
+ * cleanup path responsible for them.
+ *
+ * Multiple payloads may share the same `hls_<uuid>/` parent. The first call
+ * removes the dir; subsequent calls fall through `safeDeleteRecursively`'s
+ * "missing target → quiet false" path. A small in-call dedup avoids logging
+ * the same path more than once per invocation.
+ */
+internal fun cleanupHlsScratch(
+    payloads: List<PayloadFile>?,
+    fileSystem: FileSystem = systemFileSystem,
+) {
+    if (payloads.isNullOrEmpty()) return
+    val seen = HashSet<String>()
+    for (p in payloads) {
+        val parent = runCatching { p.filePath.toPath().parent }.getOrNull() ?: continue
+        if (!parent.name.startsWith(HLS_DIR_PREFIX)) continue
+        val parentBase = parent.parent?.toString() ?: continue
+        val key = "$parentBase|${parent.name}"
+        if (!seen.add(key)) continue
+        runCatching {
+            safeDeleteRecursively(parentBase, parent.name, fileSystem)
+        }.onFailure {
+            Logger.w(tag = TAG, throwable = it) { "hls scratch cleanup failed for ${parent}" }
+        }
+    }
+}
+
+private const val HLS_DIR_PREFIX = "hls_"
+private const val TAG = "HlsScratchCleanup"

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
@@ -6,6 +6,7 @@ import id.homebase.api.client.cache.CacheStats
 import id.homebase.api.common.OdinId
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.file.safeDeleteRecursively
 import id.homebase.api.file.systemFileSystem
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
@@ -100,8 +101,8 @@ class PublicProfileProviderCached(
         // Fire-and-forget reclaim of the pre-migration mayakapps/kache cache
         // directories — see DriveFileProviderCached.init for rationale.
         CoroutineScope(SupervisorJob() + Dispatchers.Default).launch {
-            runCatching { fileSystem.deleteRecursively("$directory/homebase-public-profiles".toPath()) }
-            runCatching { fileSystem.deleteRecursively("$directory/homebase-public-images".toPath()) }
+            safeDeleteRecursively(directory, "homebase-public-profiles")
+            safeDeleteRecursively(directory, "homebase-public-images")
         }
     }
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
@@ -25,6 +25,7 @@ import id.homebase.api.client.peer.PeerDriveQueryProvider
 import id.homebase.api.client.profile.PublicProfileProvider
 import id.homebase.api.client.profile.PublicProfileProviderCached
 import id.homebase.api.client.upgrade.IdentityUpgradeProvider
+import id.homebase.api.file.StartupCacheAudit
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.OutboxSync
 import id.homebase.api.sync.database.OutboxUploader
@@ -95,4 +96,9 @@ val apiModule = module {
     singleOf(::LocationPreviewProvider)
 
     single { EventBus() }
+
+    // Eager startup task: logs a one-shot breakdown of the cache directory so an
+    // `adb logcat -s CacheAudit:*` capture shows where disk usage is going. The
+    // audit work runs off the main thread (see StartupCacheAudit). Diagnostics only.
+    single(createdAtStart = true) { StartupCacheAudit(get()) }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheAudit.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheAudit.kt
@@ -1,0 +1,160 @@
+package id.homebase.api.file
+
+import co.touchlab.kermit.Logger
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+/**
+ * Read-only inventory of the app cache directory
+ * ([FileOperationsProvider.getCacheDirectory]).
+ *
+ * Motivation: Android's system "Cache" figure — which is exactly
+ * `context.cacheDir` — was observed at ~4 GB while the app's Storage Settings
+ * screen accounted for only ~710 MB. The gap is scratch files written straight
+ * into the cache directory that the app neither tracks, caps, nor evicts:
+ * FFmpeg segment/compress output, `hls_*` dirs created on every video send,
+ * decrypted downloads, share temp files, the legacy `hbvid_preload` dir, and so
+ * on. [CacheAudit] enumerates the *top-level* entries of the cache directory and
+ * classifies each as "known" (one of the four capped Coil `DiskCache`
+ * directories) or "untracked", so the breakdown is visible both in logs and in
+ * the Storage Settings UI.
+ *
+ * This is diagnostics only — it never deletes anything.
+ */
+object CacheAudit {
+
+    /**
+     * The cache-directory entries the app tracks and caps via Coil's `DiskCache`
+     * (LRU-evicted). Everything else under the cache directory is untracked
+     * scratch. Keep in sync with the directory names in `DriveFileProviderCached`
+     * and `PublicProfileProviderCached`.
+     */
+    val KNOWN_CACHE_DIRS: Set<String> = setOf(
+        "homebase-payloads-v2",
+        "homebase-thumbs-v2",
+        "homebase-public-profiles-v2",
+        "homebase-public-images-v2",
+    )
+
+    /** A single top-level entry of the cache directory. */
+    data class Entry(
+        val name: String,
+        val isDirectory: Boolean,
+        val sizeBytes: Long,
+        /** True when [name] is one of [KNOWN_CACHE_DIRS]. */
+        val known: Boolean,
+        /** Best-guess human-readable origin, for the log line. Diagnostic only. */
+        val label: String,
+    )
+
+    data class Report(
+        val cacheDirPath: String,
+        /** All top-level entries, sorted largest-first. */
+        val entries: List<Entry>,
+        val knownBytes: Long,
+        val untrackedBytes: Long,
+        val totalBytes: Long,
+    )
+
+    /**
+     * Enumerate the immediate children of [cacheDirPath], recursively sizing
+     * each. Never throws — a missing cache directory yields an empty report, and
+     * a per-entry failure is logged and skipped.
+     */
+    fun audit(cacheDirPath: String, fileSystem: FileSystem = systemFileSystem): Report {
+        val dir = cacheDirPath.toPath()
+        if (!fileSystem.exists(dir)) {
+            return Report(cacheDirPath, emptyList(), 0L, 0L, 0L)
+        }
+
+        val children = try {
+            fileSystem.list(dir)
+        } catch (e: Exception) {
+            Logger.w(tag = TAG, throwable = e) { "cannot list cache dir $cacheDirPath" }
+            return Report(cacheDirPath, emptyList(), 0L, 0L, 0L)
+        }
+
+        val entries = ArrayList<Entry>(children.size)
+        for (child in children) {
+            try {
+                val meta = fileSystem.metadata(child)
+                val isDir = meta.isDirectory
+                val size = if (isDir) fileSystem.directorySizeBytes(child) else (meta.size ?: 0L)
+                val name = child.name
+                entries.add(
+                    Entry(
+                        name = name,
+                        isDirectory = isDir,
+                        sizeBytes = size,
+                        known = name in KNOWN_CACHE_DIRS,
+                        label = classify(name),
+                    )
+                )
+            } catch (e: Exception) {
+                Logger.w(tag = TAG, throwable = e) { "cannot size cache entry ${child.name}" }
+            }
+        }
+        entries.sortByDescending { it.sizeBytes }
+
+        var known = 0L
+        var untracked = 0L
+        for (e in entries) {
+            if (e.known) known += e.sizeBytes else untracked += e.sizeBytes
+        }
+        return Report(
+            cacheDirPath = cacheDirPath,
+            entries = entries,
+            knownBytes = known,
+            untrackedBytes = untracked,
+            totalBytes = known + untracked,
+        )
+    }
+
+    /** Emit [report] to the log under tag [TAG]. */
+    fun logReport(report: Report) {
+        Logger.i(tag = TAG) {
+            "cacheDir=${report.cacheDirPath} total=${report.totalBytes} " +
+                "known=${report.knownBytes} untracked=${report.untrackedBytes} " +
+                "entries=${report.entries.size}"
+        }
+        for (e in report.entries) {
+            val line = "  ${e.name}${if (e.isDirectory) "/" else ""} — ${e.sizeBytes} bytes " +
+                "[${if (e.known) "tracked" else "untracked"}: ${e.label}]"
+            // Untracked entries over the threshold are the ones worth chasing —
+            // log them at WARN so they stand out in an `adb logcat` capture.
+            if (!e.known && e.sizeBytes >= LOUD_THRESHOLD_BYTES) {
+                Logger.w(tag = TAG) { line }
+            } else {
+                Logger.i(tag = TAG) { line }
+            }
+        }
+    }
+
+    /**
+     * Best-guess origin of a cache entry from its name, for the log line only.
+     * This is a *labelling* table, never a deletion list — anything not matched
+     * is reported as "unknown" and still counted as untracked.
+     */
+    private fun classify(name: String): String = when {
+        name in KNOWN_CACHE_DIRS -> "tracked Coil disk cache"
+        name == "hbvid_preload" -> "legacy video preload dir"
+        name == "coil3_disk_cache" -> "orphan Coil disk cache"
+        name == "homebase-payloads" || name == "homebase-thumbs" ||
+            name == "homebase-public-profiles" || name == "homebase-public-images" ->
+            "legacy kache dir (pre-v2)"
+        name.startsWith("hls_") -> "FFmpeg HLS segment dir (video send)"
+        name.startsWith("compressed_") -> "FFmpeg compressed video"
+        name.startsWith("ffmpeg-segmented-") -> "FFmpeg segment output"
+        name.startsWith("input_hlsdl_") -> "HLS download intermediate"
+        name.startsWith("hlsdl_") -> "HLS download output"
+        name.startsWith("input_") -> "FFmpeg input cache"
+        name.startsWith("thumb0001-") -> "FFmpeg thumbnail"
+        name.startsWith("share_") || name.startsWith("resolved_") -> "share temp file"
+        else -> "unknown"
+    }
+
+    private const val TAG = "CacheAudit"
+
+    /** Untracked entries at or above this size are logged at WARN. */
+    private const val LOUD_THRESHOLD_BYTES = 50L * 1024L * 1024L
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheAudit.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheAudit.kt
@@ -36,6 +36,22 @@ object CacheAudit {
         "homebase-public-images-v2",
     )
 
+    /**
+     * Top-level entries Android places inside our `cacheDir` that are owned by
+     * the platform / WebView / a crash reporter — not by us. Wiping any of
+     * these is destructive: nukes in-app browser cookies + storage, forces a
+     * slow ART recompile of WebView native libs, or loses pending crash
+     * reports. The CacheSweeper KEEPS these regardless of mode (even on
+     * logout / "Clear caches"). The user-facing way to clear browser state is
+     * `WebView.clearCache()`, not deleting files under it.
+     */
+    val ANDROID_SYSTEM_DIRS: Set<String> = setOf(
+        "WebView",
+        "oat_primary",
+        "data",
+        "Crash Reports",
+    )
+
     /** A single top-level entry of the cache directory. */
     data class Entry(
         val name: String,
@@ -43,6 +59,8 @@ object CacheAudit {
         val sizeBytes: Long,
         /** True when [name] is one of [KNOWN_CACHE_DIRS]. */
         val known: Boolean,
+        /** True when [name] is one of [ANDROID_SYSTEM_DIRS] — the sacred set. */
+        val androidSystem: Boolean = false,
         /** Best-guess human-readable origin, for the log line. Diagnostic only. */
         val label: String,
     )
@@ -87,6 +105,7 @@ object CacheAudit {
                         isDirectory = isDir,
                         sizeBytes = size,
                         known = name in KNOWN_CACHE_DIRS,
+                        androidSystem = name in ANDROID_SYSTEM_DIRS,
                         label = classify(name),
                     )
                 )
@@ -118,11 +137,18 @@ object CacheAudit {
                 "entries=${report.entries.size}"
         }
         for (e in report.entries) {
+            val origin = when {
+                e.androidSystem -> "android system"
+                e.known -> "tracked"
+                else -> "untracked"
+            }
             val line = "  ${e.name}${if (e.isDirectory) "/" else ""} — ${e.sizeBytes} bytes " +
-                "[${if (e.known) "tracked" else "untracked"}: ${e.label}]"
+                "[$origin: ${e.label}]"
             // Untracked entries over the threshold are the ones worth chasing —
             // log them at WARN so they stand out in an `adb logcat` capture.
-            if (!e.known && e.sizeBytes >= LOUD_THRESHOLD_BYTES) {
+            // Tracked Coil caches and Android system dirs are never WARN-worthy
+            // here: we don't (and won't) sweep them.
+            if (!e.known && !e.androidSystem && e.sizeBytes >= LOUD_THRESHOLD_BYTES) {
                 Logger.w(tag = TAG) { line }
             } else {
                 Logger.i(tag = TAG) { line }
@@ -137,6 +163,10 @@ object CacheAudit {
      */
     private fun classify(name: String): String = when {
         name in KNOWN_CACHE_DIRS -> "tracked Coil disk cache"
+        name == "WebView" -> "Android system: WebView (cookies/storage) — sacred"
+        name == "oat_primary" -> "Android system: WebView ART/OAT cache — sacred"
+        name == "data" -> "Android system: WebView data — sacred"
+        name == "Crash Reports" -> "Android system: crash reporter — sacred"
         name == "hbvid_preload" -> "legacy video preload dir"
         name == "coil3_disk_cache" -> "orphan Coil disk cache"
         name == "homebase-payloads" || name == "homebase-thumbs" ||

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheAudit.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheAudit.kt
@@ -179,7 +179,12 @@ object CacheAudit {
         name.startsWith("hlsdl_") -> "HLS download output"
         name.startsWith("input_") -> "FFmpeg input cache"
         name.startsWith("thumb0001-") -> "FFmpeg thumbnail"
-        name.startsWith("share_") || name.startsWith("resolved_") -> "share temp file"
+        name == SHARE_OUTBOUND_DIR_NAME ->
+            "share-OUT decrypted Homebase payload (security: sequestered + reaped)"
+        name.startsWith("share_") ->
+            "share-OUT decrypted Homebase payload (security: legacy, top-level)"
+        name.startsWith("resolved_") ->
+            "share-IN / picker temp (plaintext input from gallery or sharing app)"
         else -> "unknown"
     }
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheAudit.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheAudit.kt
@@ -69,8 +69,16 @@ object CacheAudit {
         val cacheDirPath: String,
         /** All top-level entries, sorted largest-first. */
         val entries: List<Entry>,
+        /** Bytes in tracked Coil `-v2` caches ([KNOWN_CACHE_DIRS]). */
         val knownBytes: Long,
+        /**
+         * Bytes in entries that are neither tracked Coil caches nor
+         * [ANDROID_SYSTEM_DIRS]. Sweeper-eligible — this is what
+         * `sweepUntracked` actually deletes.
+         */
         val untrackedBytes: Long,
+        /** Bytes in [ANDROID_SYSTEM_DIRS] (sacred — never swept). */
+        val androidSystemBytes: Long,
         val totalBytes: Long,
     )
 
@@ -82,14 +90,14 @@ object CacheAudit {
     fun audit(cacheDirPath: String, fileSystem: FileSystem = systemFileSystem): Report {
         val dir = cacheDirPath.toPath()
         if (!fileSystem.exists(dir)) {
-            return Report(cacheDirPath, emptyList(), 0L, 0L, 0L)
+            return Report(cacheDirPath, emptyList(), 0L, 0L, 0L, 0L)
         }
 
         val children = try {
             fileSystem.list(dir)
         } catch (e: Exception) {
             Logger.w(tag = TAG, throwable = e) { "cannot list cache dir $cacheDirPath" }
-            return Report(cacheDirPath, emptyList(), 0L, 0L, 0L)
+            return Report(cacheDirPath, emptyList(), 0L, 0L, 0L, 0L)
         }
 
         val entries = ArrayList<Entry>(children.size)
@@ -117,15 +125,25 @@ object CacheAudit {
 
         var known = 0L
         var untracked = 0L
+        var androidSystem = 0L
         for (e in entries) {
-            if (e.known) known += e.sizeBytes else untracked += e.sizeBytes
+            // Three disjoint buckets — androidSystem entries must NOT spill into
+            // `untracked`, otherwise the sweeper logs "deleting=N (untracked)"
+            // for bytes it will actually KEEP and the post-sweep "freed=0" line
+            // looks like a delete failure.
+            when {
+                e.androidSystem -> androidSystem += e.sizeBytes
+                e.known -> known += e.sizeBytes
+                else -> untracked += e.sizeBytes
+            }
         }
         return Report(
             cacheDirPath = cacheDirPath,
             entries = entries,
             knownBytes = known,
             untrackedBytes = untracked,
-            totalBytes = known + untracked,
+            androidSystemBytes = androidSystem,
+            totalBytes = known + untracked + androidSystem,
         )
     }
 
@@ -134,6 +152,7 @@ object CacheAudit {
         Logger.i(tag = TAG) {
             "cacheDir=${report.cacheDirPath} total=${report.totalBytes} " +
                 "known=${report.knownBytes} untracked=${report.untrackedBytes} " +
+                "androidSystem=${report.androidSystemBytes} " +
                 "entries=${report.entries.size}"
         }
         for (e in report.entries) {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheSweeper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheSweeper.kt
@@ -2,6 +2,7 @@ package id.homebase.api.file
 
 import co.touchlab.kermit.Logger
 import okio.FileSystem
+import okio.Path.Companion.toPath
 
 /**
  * Decides what to delete from the app cache directory.
@@ -40,7 +41,9 @@ object CacheSweeper {
                 "deleting=${report.untrackedBytes} bytes (untracked) " +
                 "keeping=${report.knownBytes} bytes (tracked Coil caches + android system)"
         }
+        val before = report.totalBytes
         for (e in report.entries) act(e, decide(e, SweepMode.UNTRACKED), report.cacheDirPath, fileSystem)
+        logCompletion("sweepUntracked", report.cacheDirPath, before, fileSystem)
     }
 
     /**
@@ -54,7 +57,37 @@ object CacheSweeper {
                 "totalEntries=${report.entries.size} " +
                 "deleting=${report.totalBytes} bytes (incl. tracked Coil caches)"
         }
+        val before = report.totalBytes
         for (e in report.entries) act(e, decide(e, SweepMode.ALL), report.cacheDirPath, fileSystem)
+        logCompletion("sweepAll", report.cacheDirPath, before, fileSystem)
+    }
+
+    /**
+     * Re-measure cacheDir and log a before/after/reclaimed line. Without this
+     * the sweep is opaque on real devices: the up-front "deleting=N bytes"
+     * is intent, not outcome — a delete failure (permissions, race with another
+     * writer) leaves a silent gap. The after-measurement also picks up bytes
+     * freed inside KEPT entries (e.g. Coil DiskCache LRU eviction triggered
+     * during the same sweep window).
+     */
+    private fun logCompletion(label: String, cacheDirPath: String, before: Long, fileSystem: FileSystem) {
+        val after = runCatching { fileSystem.directorySizeBytes(cacheDirPath.toPath()) }
+            .getOrElse {
+                Logger.w(tag = TAG, throwable = it) { "$label: post-measure failed" }
+                return
+            }
+        val reclaimed = before - after
+        Logger.i(tag = TAG) {
+            "$label: complete — before=$before after=$after reclaimed=$reclaimed bytes " +
+                "(${humanMB(before)} → ${humanMB(after)}, freed ${humanMB(reclaimed)})"
+        }
+    }
+
+    private fun humanMB(bytes: Long): String {
+        val mb = bytes.toDouble() / (1024.0 * 1024.0)
+        // One decimal is plenty — log scanners want approximate magnitude, not precision.
+        val rounded = (mb * 10).toLong() / 10.0
+        return "${rounded}MB"
     }
 
     private fun act(e: CacheAudit.Entry, action: SweepAction, baseDir: String, fileSystem: FileSystem) {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheSweeper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheSweeper.kt
@@ -6,71 +6,71 @@ import okio.FileSystem
 /**
  * Decides what to delete from the app cache directory.
  *
- * **Currently DRY-RUN ONLY** — every "delete" is replaced with a `WOULD DELETE`
- * log line; nothing is actually removed. The intent is to ship this, capture
- * real-device adb logs (`adb logcat -s CacheSweeper:*`), confirm the sweeper
- * targets the right entries — *then* flip the WOULD-DELETE lines to real
- * [safeDeleteRecursively] calls.
+ * Two entry points:
+ * - [sweepUntracked] — startup reclaim: deletes every entry that isn't one of
+ *   the four `-v2` Coil DiskCache directories nor an Android system dir. Eats
+ *   the cache backlog (FFmpeg scratch, share temps, leftover pickers, ...).
+ * - [sweepAll] — logout reclaim: also deletes the `-v2` caches.
  *
- * Two entry points mirror the future real sweep:
- * - [sweepUntracked] — startup reclaim: would delete every entry that isn't one
- *   of the four `-v2` Coil DiskCache directories. Eats the ~4 GB backlog.
- * - [sweepAll] — logout reclaim: would *also* delete the `-v2` caches (the live
- *   DiskCache journal interaction is the nuance to resolve before going live).
+ * Sacred set ([CacheAudit.ANDROID_SYSTEM_DIRS]: `WebView/`, `oat_primary/`,
+ * `data/`, `Crash Reports/`) is always kept — see [decide]. Wiping them would
+ * nuke browser cookies, force a slow ART recompile of WebView native libs, or
+ * lose pending crash reports.
  *
- * Special case: if `coil3_disk_cache` is found, it is logged at **ERROR** — its
- * mere existence means something bypassed our configured ImageLoader. This
- * absorbs the role currently scattered across `AppModule`'s logout lambda, the
- * Storage screen's "Clear caches" button, and `probeOrphanCoilDiskCache`.
+ * Special case: if `coil3_disk_cache` is found it is logged at **ERROR** and
+ * deleted — its mere existence means something bypassed our configured
+ * ImageLoader. This absorbs the role previously scattered across `AppModule`'s
+ * logout lambda, the Storage screen's "Clear caches" button, and
+ * `probeOrphanCoilDiskCache`.
+ *
+ * The shape of the sweep was validated in dry-run mode against an on-device
+ * cache audit before this real-delete flip; see commit history.
  */
 object CacheSweeper {
 
     /**
-     * Startup-reclaim sweep — would delete everything in [report] that isn't one
-     * of [CacheAudit.KNOWN_CACHE_DIRS]. Log-only for now, with one exception:
-     * an orphan `coil3_disk_cache` is *actually* deleted (see [act]).
+     * Startup-reclaim sweep — deletes everything in [report] that isn't a
+     * tracked Coil cache or an Android system dir. Best-effort; per-entry
+     * failures are logged by [safeDeleteRecursively] and don't stop the sweep.
      */
     fun sweepUntracked(report: CacheAudit.Report, fileSystem: FileSystem = systemFileSystem) {
         Logger.i(tag = TAG) {
-            "DRY-RUN sweepUntracked: cacheDir=${report.cacheDirPath} " +
+            "sweepUntracked: cacheDir=${report.cacheDirPath} " +
                 "totalEntries=${report.entries.size} " +
-                "wouldDelete=${report.untrackedBytes} bytes (untracked) " +
-                "wouldKeep=${report.knownBytes} bytes (tracked Coil caches)"
+                "deleting=${report.untrackedBytes} bytes (untracked) " +
+                "keeping=${report.knownBytes} bytes (tracked Coil caches + android system)"
         }
         for (e in report.entries) act(e, decide(e, SweepMode.UNTRACKED), report.cacheDirPath, fileSystem)
     }
 
     /**
-     * Full sweep (e.g. logout) — would delete everything in [report], including
-     * the tracked `-v2` Coil DiskCache directories. Log-only for now, with one
-     * exception: an orphan `coil3_disk_cache` is *actually* deleted (see [act]).
+     * Full sweep (e.g. logout) — deletes everything in [report], including the
+     * tracked `-v2` Coil DiskCache directories. Android system dirs are still
+     * kept (see [CacheAudit.ANDROID_SYSTEM_DIRS]).
      */
     fun sweepAll(report: CacheAudit.Report, fileSystem: FileSystem = systemFileSystem) {
         Logger.i(tag = TAG) {
-            "DRY-RUN sweepAll: cacheDir=${report.cacheDirPath} " +
+            "sweepAll: cacheDir=${report.cacheDirPath} " +
                 "totalEntries=${report.entries.size} " +
-                "wouldDelete=${report.totalBytes} bytes (incl. tracked Coil caches)"
+                "deleting=${report.totalBytes} bytes (incl. tracked Coil caches)"
         }
         for (e in report.entries) act(e, decide(e, SweepMode.ALL), report.cacheDirPath, fileSystem)
     }
 
     private fun act(e: CacheAudit.Entry, action: SweepAction, baseDir: String, fileSystem: FileSystem) {
-        val verb = when (action) {
-            SweepAction.KEEP -> "WOULD KEEP  "
-            SweepAction.DELETE, SweepAction.ORPHAN_COIL_DELETE -> "WOULD DELETE"
-        }
-        val line = "$verb ${e.name}${if (e.isDirectory) "/" else ""} — ${e.sizeBytes} bytes [${e.label}]"
+        val line = "${e.name}${if (e.isDirectory) "/" else ""} — ${e.sizeBytes} bytes [${e.label}]"
         when (action) {
             SweepAction.ORPHAN_COIL_DELETE -> {
-                // The one case we actually delete during the dry-run period: orphan-coil is
-                // safe (no live DiskCache state behind it), expected to be absent, and
-                // "always delete on sight" is the existing scattered behavior we're absorbing.
-                // This lets the rogue safeDeleteRecursively("coil3_disk_cache") lines retire.
-                Logger.e(tag = TAG) { "ORPHAN COIL DISK CACHE DETECTED — $line (deleting now)" }
+                // Orphan coil dir means something bypassed our configured ImageLoader
+                // (we set .diskCache(null)). Logged loudly so the regression is visible.
+                Logger.e(tag = TAG) { "ORPHAN COIL DISK CACHE DETECTED — deleting $line" }
                 safeDeleteRecursively(baseDir, e.name, fileSystem)
             }
-            SweepAction.DELETE -> Logger.w(tag = TAG) { line }
-            SweepAction.KEEP -> Logger.i(tag = TAG) { line }
+            SweepAction.DELETE -> {
+                Logger.i(tag = TAG) { "deleting $line" }
+                safeDeleteRecursively(baseDir, e.name, fileSystem)
+            }
+            SweepAction.KEEP -> Logger.i(tag = TAG) { "keeping  $line" }
         }
     }
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheSweeper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheSweeper.kt
@@ -1,0 +1,95 @@
+package id.homebase.api.file
+
+import co.touchlab.kermit.Logger
+import okio.FileSystem
+
+/**
+ * Decides what to delete from the app cache directory.
+ *
+ * **Currently DRY-RUN ONLY** — every "delete" is replaced with a `WOULD DELETE`
+ * log line; nothing is actually removed. The intent is to ship this, capture
+ * real-device adb logs (`adb logcat -s CacheSweeper:*`), confirm the sweeper
+ * targets the right entries — *then* flip the WOULD-DELETE lines to real
+ * [safeDeleteRecursively] calls.
+ *
+ * Two entry points mirror the future real sweep:
+ * - [sweepUntracked] — startup reclaim: would delete every entry that isn't one
+ *   of the four `-v2` Coil DiskCache directories. Eats the ~4 GB backlog.
+ * - [sweepAll] — logout reclaim: would *also* delete the `-v2` caches (the live
+ *   DiskCache journal interaction is the nuance to resolve before going live).
+ *
+ * Special case: if `coil3_disk_cache` is found, it is logged at **ERROR** — its
+ * mere existence means something bypassed our configured ImageLoader. This
+ * absorbs the role currently scattered across `AppModule`'s logout lambda, the
+ * Storage screen's "Clear caches" button, and `probeOrphanCoilDiskCache`.
+ */
+object CacheSweeper {
+
+    /**
+     * Startup-reclaim sweep — would delete everything in [report] that isn't one
+     * of [CacheAudit.KNOWN_CACHE_DIRS]. Log-only for now, with one exception:
+     * an orphan `coil3_disk_cache` is *actually* deleted (see [act]).
+     */
+    fun sweepUntracked(report: CacheAudit.Report, fileSystem: FileSystem = systemFileSystem) {
+        Logger.i(tag = TAG) {
+            "DRY-RUN sweepUntracked: cacheDir=${report.cacheDirPath} " +
+                "totalEntries=${report.entries.size} " +
+                "wouldDelete=${report.untrackedBytes} bytes (untracked) " +
+                "wouldKeep=${report.knownBytes} bytes (tracked Coil caches)"
+        }
+        for (e in report.entries) act(e, decide(e, SweepMode.UNTRACKED), report.cacheDirPath, fileSystem)
+    }
+
+    /**
+     * Full sweep (e.g. logout) — would delete everything in [report], including
+     * the tracked `-v2` Coil DiskCache directories. Log-only for now, with one
+     * exception: an orphan `coil3_disk_cache` is *actually* deleted (see [act]).
+     */
+    fun sweepAll(report: CacheAudit.Report, fileSystem: FileSystem = systemFileSystem) {
+        Logger.i(tag = TAG) {
+            "DRY-RUN sweepAll: cacheDir=${report.cacheDirPath} " +
+                "totalEntries=${report.entries.size} " +
+                "wouldDelete=${report.totalBytes} bytes (incl. tracked Coil caches)"
+        }
+        for (e in report.entries) act(e, decide(e, SweepMode.ALL), report.cacheDirPath, fileSystem)
+    }
+
+    private fun act(e: CacheAudit.Entry, action: SweepAction, baseDir: String, fileSystem: FileSystem) {
+        val verb = when (action) {
+            SweepAction.KEEP -> "WOULD KEEP  "
+            SweepAction.DELETE, SweepAction.ORPHAN_COIL_DELETE -> "WOULD DELETE"
+        }
+        val line = "$verb ${e.name}${if (e.isDirectory) "/" else ""} — ${e.sizeBytes} bytes [${e.label}]"
+        when (action) {
+            SweepAction.ORPHAN_COIL_DELETE -> {
+                // The one case we actually delete during the dry-run period: orphan-coil is
+                // safe (no live DiskCache state behind it), expected to be absent, and
+                // "always delete on sight" is the existing scattered behavior we're absorbing.
+                // This lets the rogue safeDeleteRecursively("coil3_disk_cache") lines retire.
+                Logger.e(tag = TAG) { "ORPHAN COIL DISK CACHE DETECTED — $line (deleting now)" }
+                safeDeleteRecursively(baseDir, e.name, fileSystem)
+            }
+            SweepAction.DELETE -> Logger.w(tag = TAG) { line }
+            SweepAction.KEEP -> Logger.i(tag = TAG) { line }
+        }
+    }
+
+    private const val TAG = "CacheSweeper"
+}
+
+internal enum class SweepMode { UNTRACKED, ALL }
+
+internal enum class SweepAction { KEEP, DELETE, ORPHAN_COIL_DELETE }
+
+/**
+ * Per-entry decision the sweeper would take. Pure function so it can be
+ * unit-tested without log-capturing.
+ */
+internal fun decide(entry: CacheAudit.Entry, mode: SweepMode): SweepAction = when {
+    entry.name == ORPHAN_COIL_DIR_NAME -> SweepAction.ORPHAN_COIL_DELETE
+    !entry.known -> SweepAction.DELETE
+    mode == SweepMode.ALL -> SweepAction.DELETE
+    else -> SweepAction.KEEP
+}
+
+internal const val ORPHAN_COIL_DIR_NAME = "coil3_disk_cache"

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheSweeper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheSweeper.kt
@@ -86,6 +86,11 @@ internal enum class SweepAction { KEEP, DELETE, ORPHAN_COIL_DELETE }
  * unit-tested without log-capturing.
  */
 internal fun decide(entry: CacheAudit.Entry, mode: SweepMode): SweepAction = when {
+    // Sacred set: WebView/, oat_primary/, data/, Crash Reports/. Owned by the
+    // Android platform / WebView / Crashlytics — wiping them nukes browser
+    // cookies, forces a slow ART recompile, or loses pending crash reports.
+    // Wins over every other rule — including the full "logout" sweep.
+    entry.androidSystem -> SweepAction.KEEP
     entry.name == ORPHAN_COIL_DIR_NAME -> SweepAction.ORPHAN_COIL_DELETE
     !entry.known -> SweepAction.DELETE
     mode == SweepMode.ALL -> SweepAction.DELETE

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheSweeper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheSweeper.kt
@@ -39,7 +39,8 @@ object CacheSweeper {
             "sweepUntracked: cacheDir=${report.cacheDirPath} " +
                 "totalEntries=${report.entries.size} " +
                 "deleting=${report.untrackedBytes} bytes (untracked) " +
-                "keeping=${report.knownBytes} bytes (tracked Coil caches + android system)"
+                "keepingTracked=${report.knownBytes} bytes (Coil caches) " +
+                "keepingAndroidSystem=${report.androidSystemBytes} bytes (sacred)"
         }
         val before = report.totalBytes
         for (e in report.entries) act(e, decide(e, SweepMode.UNTRACKED), report.cacheDirPath, fileSystem)
@@ -52,10 +53,14 @@ object CacheSweeper {
      * kept (see [CacheAudit.ANDROID_SYSTEM_DIRS]).
      */
     fun sweepAll(report: CacheAudit.Report, fileSystem: FileSystem = systemFileSystem) {
+        // sweepAll deletes tracked too, but Android system dirs stay sacred —
+        // so the truthful "deleting" total is everything except androidSystem.
+        val deleting = report.untrackedBytes + report.knownBytes
         Logger.i(tag = TAG) {
             "sweepAll: cacheDir=${report.cacheDirPath} " +
                 "totalEntries=${report.entries.size} " +
-                "deleting=${report.totalBytes} bytes (incl. tracked Coil caches)"
+                "deleting=$deleting bytes (untracked + tracked Coil caches) " +
+                "keepingAndroidSystem=${report.androidSystemBytes} bytes (sacred)"
         }
         val before = report.totalBytes
         for (e in report.entries) act(e, decide(e, SweepMode.ALL), report.cacheDirPath, fileSystem)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/FileOperationsProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/FileOperationsProvider.kt
@@ -43,6 +43,22 @@ interface FileOperationsProvider {
         suffix: String
     ): String
 
+    /**
+     * Write [bytes] to a sequestered subdirectory `<cacheDir>/share_outbound/`
+     * (see [SHARE_OUTBOUND_DIR_NAME]) using a `share_<random>$suffix` filename
+     * and return the absolute path. Used **only** by the chat "Share to other
+     * app" flow, which decrypts a Homebase payload and hands the resulting
+     * cleartext file to `Intent.ACTION_SEND` via Android `FileProvider`.
+     *
+     * The subdir lets [sweepShareOutbound] reap every cleartext share temp
+     * as a single unit on cold start and on app foreground — bounding the
+     * on-disk lifetime of decrypted Homebase content.
+     */
+    suspend fun writeBytesToShareOutboundFile(
+        bytes: ByteArray,
+        suffix: String,
+    ): String
+
     suspend fun writeStream(
         path: String,
         data: Flow<ByteArray>

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/FileSystemExtensions.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/FileSystemExtensions.kt
@@ -1,0 +1,23 @@
+package id.homebase.api.file
+
+import okio.FileSystem
+import okio.Path
+
+/**
+ * Recursively sum the byte size of every regular file under [dir].
+ *
+ * Returns 0 when [dir] does not exist. Intended to be called on directories —
+ * okio's [FileSystem.list] throws when given a regular file, so callers that
+ * may hold either should branch on [okio.FileMetadata.isDirectory] first.
+ *
+ * Single implementation shared by [CacheAudit] and the Storage Settings screen.
+ */
+fun FileSystem.directorySizeBytes(dir: Path): Long {
+    if (!exists(dir)) return 0L
+    var total = 0L
+    for (child in list(dir)) {
+        val meta = metadata(child)
+        total += if (meta.isDirectory) directorySizeBytes(child) else (meta.size ?: 0L)
+    }
+    return total
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/SafeDelete.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/SafeDelete.kt
@@ -1,0 +1,107 @@
+package id.homebase.api.file
+
+import co.touchlab.kermit.Logger
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+/**
+ * Belt-and-suspenders recursive folder delete — THE single entry point for
+ * "delete a folder" anywhere in the codebase. Never call
+ * [FileSystem.deleteRecursively] directly.
+ *
+ * The delete target is [relativeSubPath] resolved under [baseDir] (the trusted
+ * root the caller operates within — the app cache / data / install directory).
+ * The call is refused — logged at ERROR, **nothing deleted**, returns false —
+ * unless every one of these holds:
+ *  - [baseDir] is non-blank and at least [MIN_BASE_DIR_LENGTH] characters (a
+ *    cheap floor against `""`, `"/"`, `"."` being passed as the trusted root);
+ *  - [baseDir] is an absolute path with a parent (never a filesystem root);
+ *  - [relativeSubPath] is non-blank and NOT absolute;
+ *  - [relativeSubPath] contains no `..` segment;
+ *  - the resolved target stays strictly *under* [baseDir] — deeper than it and
+ *    sharing its full prefix — never equal to [baseDir] itself, never outside.
+ *
+ * A missing target is not an error: nothing to delete, returns false quietly.
+ *
+ * @return true only when a real directory existed under [baseDir] and was deleted.
+ */
+fun safeDeleteRecursively(
+    baseDir: String,
+    relativeSubPath: String,
+    fileSystem: FileSystem = systemFileSystem,
+): Boolean {
+    // 1. Base dir: non-blank and not trivially short. The length floor is a
+    //    cheap extra guard; the real protection is the structural checks below.
+    //    Kept low so legitimate short system roots (e.g. "/tmp") still pass.
+    if (baseDir.isBlank() || baseDir.length < MIN_BASE_DIR_LENGTH) {
+        Logger.e(tag = TAG) {
+            "refusing recursive delete: base dir is blank or too short ('$baseDir')"
+        }
+        return false
+    }
+    // 2. Relative sub-path: non-blank.
+    if (relativeSubPath.isBlank()) {
+        Logger.e(tag = TAG) {
+            "refusing recursive delete: relative sub-path is blank (base='$baseDir')"
+        }
+        return false
+    }
+
+    val base = runCatching { baseDir.toPath() }.getOrNull()
+    // 3. Base dir must be an absolute path with a parent — never a filesystem root.
+    if (base == null || !base.isAbsolute || base.parent == null) {
+        Logger.e(tag = TAG) {
+            "refusing recursive delete: base dir is not an absolute path with a parent ('$baseDir')"
+        }
+        return false
+    }
+
+    val rel = runCatching { relativeSubPath.toPath() }.getOrNull()
+    // 4. Relative sub-path must actually be relative.
+    if (rel == null || rel.isAbsolute) {
+        Logger.e(tag = TAG) {
+            "refusing recursive delete: sub-path must be relative, not absolute ('$relativeSubPath', base='$baseDir')"
+        }
+        return false
+    }
+    // 5. No '..' segment — reject any traversal outright, even one that would
+    //    happen to resolve back under the base.
+    if (rel.segments.any { it == ".." }) {
+        Logger.e(tag = TAG) {
+            "refusing recursive delete: sub-path contains a '..' segment ('$relativeSubPath', base='$baseDir')"
+        }
+        return false
+    }
+
+    // 6. Resolve, and require the target to be STRICTLY under the base: deeper
+    //    than it, and sharing its full prefix of segments.
+    val normBase = base.normalized()
+    val target = (normBase / relativeSubPath).normalized()
+    val baseSegs = normBase.segments
+    val targetSegs = target.segments
+    if (targetSegs.size <= baseSegs.size || targetSegs.subList(0, baseSegs.size) != baseSegs) {
+        Logger.e(tag = TAG) {
+            "refusing recursive delete: target '$target' is not strictly under base '$normBase'"
+        }
+        return false
+    }
+
+    // All guards passed — delete. A missing target is a quiet no-op.
+    return try {
+        if (!fileSystem.exists(target)) return false
+        fileSystem.deleteRecursively(target)
+        true
+    } catch (e: Exception) {
+        Logger.e(tag = TAG, throwable = e) { "recursive delete failed for '$target'" }
+        false
+    }
+}
+
+/**
+ * Floor on [safeDeleteRecursively]'s `baseDir` length. Deliberately low — the
+ * real safety comes from the absolute/parent/escape checks — but enough to
+ * reject `""`, `"/"`, `"."` outright.
+ */
+private const val MIN_BASE_DIR_LENGTH = 4
+
+private const val TAG = "SafeDelete"

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/ShareOutboundCleanup.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/ShareOutboundCleanup.kt
@@ -1,0 +1,45 @@
+package id.homebase.api.file
+
+import co.touchlab.kermit.Logger
+import okio.FileSystem
+
+/**
+ * Subdirectory of the app cache where the chat "Share to other app" flow
+ * writes its plaintext-decrypted Homebase payloads. Sequestered so the
+ * security-relevant temp files (Category 2: cleartext copies of
+ * end-to-end-encrypted chat content) never mingle with general cache
+ * scratch and can be reaped as a single unit.
+ *
+ * The flow itself: `MediaDownloadHandler.handleShareMedia` decrypts a
+ * payload, writes the bytes here under a `share_<random>.<ext>` name, and
+ * hands the path to `Intent.ACTION_SEND` via Android `FileProvider`. The
+ * receiving app reads the file via the URI grant; nothing in the standard
+ * Android flow deletes it afterwards. [sweepShareOutbound] is what does.
+ */
+const val SHARE_OUTBOUND_DIR_NAME: String = "share_outbound"
+
+/**
+ * Recursively delete the share-outbound subdirectory under [cacheDirPath].
+ * Best-effort: a missing dir is a quiet no-op, a delete failure is logged.
+ *
+ * Called from:
+ *  - cold startup, alongside [CacheAudit] / [CacheSweeper], so a cleartext
+ *    file that survived a process death gets reaped on next launch;
+ *  - app foreground (Android `ProcessLifecycleOwner.ON_START`), so the
+ *    moment the user returns to the chat app after a share, the cleartext
+ *    is gone — bounding the on-disk lifetime to "user's time in another
+ *    app";
+ *  - logout (full sweep), so the cleartext doesn't outlive the session.
+ */
+fun sweepShareOutbound(
+    cacheDirPath: String,
+    fileSystem: FileSystem = systemFileSystem,
+): Boolean {
+    val deleted = safeDeleteRecursively(cacheDirPath, SHARE_OUTBOUND_DIR_NAME, fileSystem)
+    if (deleted) {
+        Logger.i(tag = "ShareOutbound") {
+            "swept $cacheDirPath/$SHARE_OUTBOUND_DIR_NAME (cleartext share temps)"
+        }
+    }
+    return deleted
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/StartupCacheAudit.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/StartupCacheAudit.kt
@@ -23,7 +23,12 @@ class StartupCacheAudit(fileOperationsProvider: FileOperationsProvider) {
         val cacheDir = fileOperationsProvider.getCacheDirectory()
         CoroutineScope(SupervisorJob() + Dispatchers.Default).launch {
             runCatching {
-                CacheAudit.logReport(CacheAudit.audit(cacheDir))
+                val report = CacheAudit.audit(cacheDir)
+                CacheAudit.logReport(report)
+                // Dry-run sweep: logs what the future startup sweep WOULD delete.
+                // Once on-device logs confirm the targets, this flips from log to
+                // real safeDeleteRecursively. See CacheSweeper.
+                CacheSweeper.sweepUntracked(report)
             }.onFailure {
                 Logger.w(tag = "CacheAudit", throwable = it) { "startup cache audit failed" }
             }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/StartupCacheAudit.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/StartupCacheAudit.kt
@@ -1,0 +1,32 @@
+package id.homebase.api.file
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+/**
+ * Logs a [CacheAudit] report once at app startup, so an
+ * `adb logcat -s CacheAudit:*` capture shows the cache-directory breakdown
+ * without needing the Storage Settings screen open.
+ *
+ * Wired as a `createdAtStart` Koin singleton (see `apiModule`) so it runs on
+ * every platform with no per-platform code. The audit itself is dispatched onto
+ * [Dispatchers.Default] — mirroring the fire-and-forget cleanup pattern in
+ * `DriveFileProviderCached.init` — so it never blocks cold start or risks an ANR.
+ *
+ * Diagnostics only — see [CacheAudit].
+ */
+class StartupCacheAudit(fileOperationsProvider: FileOperationsProvider) {
+    init {
+        val cacheDir = fileOperationsProvider.getCacheDirectory()
+        CoroutineScope(SupervisorJob() + Dispatchers.Default).launch {
+            runCatching {
+                CacheAudit.logReport(CacheAudit.audit(cacheDir))
+            }.onFailure {
+                Logger.w(tag = "CacheAudit", throwable = it) { "startup cache audit failed" }
+            }
+        }
+    }
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/StartupCacheAudit.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/StartupCacheAudit.kt
@@ -29,6 +29,12 @@ class StartupCacheAudit(fileOperationsProvider: FileOperationsProvider) {
                 // Once on-device logs confirm the targets, this flips from log to
                 // real safeDeleteRecursively. See CacheSweeper.
                 CacheSweeper.sweepUntracked(report)
+                // Real (not dry-run) sweep: cleartext copies of E2EE Homebase
+                // payloads written by the chat "Share to other app" flow live
+                // in a dedicated subdir and are reaped on every cold start so
+                // a process death between share + foreground doesn't strand
+                // them on disk. See ShareOutboundCleanup.
+                sweepShareOutbound(cacheDir)
             }.onFailure {
                 Logger.w(tag = "CacheAudit", throwable = it) { "startup cache audit failed" }
             }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
@@ -13,6 +13,7 @@ import id.homebase.api.client.drives.upload.UpdateFileByUniqueIdRequest
 import id.homebase.api.client.drives.upload.UpdateLocalAppdataContentOutboxRequest
 import id.homebase.api.client.drives.upload.UpdateLocalMetadataTagsOutboxRequest
 import id.homebase.api.client.drives.upload.UploadFileRequest
+import id.homebase.api.client.drives.upload.cleanupHlsScratch
 import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
@@ -210,6 +211,19 @@ class OutboxSync(
                         e
                     )
                     databaseManager.outbox.deleteByRowId(outboxRecord.rowId)
+
+                    // Drop branch: the upload exhausted retries or hit a permanent
+                    // error, so the row is gone with nothing else to clean up its
+                    // HLS scratch dir. Reach into the serialized request, pull out
+                    // the payloads, and let cleanupHlsScratch reclaim any
+                    // hls_<uuid>/ parent. Wrapped in runCatching — cleanup failure
+                    // must never affect the drop semantics.
+                    runCatching {
+                        cleanupHlsScratchForDroppedRow(outboxRecord)
+                    }.onFailure {
+                        Logger.w("OutboxSync: hls scratch cleanup failed for dropped uniqueId=${outboxRecord.uniqueId}", it)
+                    }
+
                     eventBus.emit(
                         BackendEvent.OutboxEvent.OutboxItemDropped(
                             outboxRecord.driveId,
@@ -551,6 +565,25 @@ class OutboxSync(
 
         return false
 
+    }
+
+    /**
+     * Decode the dropped row's serialized request just enough to find the
+     * payload list, then sweep any `hls_<uuid>/` scratch dir each payload
+     * sits in. Only `UploadNewFile` and `UpdateFile` carry payloads — the
+     * other upload types return null/empty payload lists and the helper
+     * silently no-ops.
+     */
+    private fun cleanupHlsScratchForDroppedRow(outboxRecord: Outbox) {
+        val json = outboxRecord.json.decodeToString()
+        val payloads = when (outboxRecord.uploadType) {
+            DriveOutboxUploader.UploadNewFile ->
+                OdinSystemSerializer.deserialize<UploadFileRequest>(json).payloads
+            DriveOutboxUploader.UpdateFile ->
+                OdinSystemSerializer.deserialize<UpdateFileByUniqueIdRequest>(json).payloads
+            else -> null
+        }
+        cleanupHlsScratch(payloads)
     }
 
     suspend fun clearCheckout(timeoutMs: Long = 10_000) {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
@@ -14,6 +14,8 @@ import id.homebase.api.client.drives.upload.UpdateLocalAppdataContentOutboxReque
 import id.homebase.api.client.drives.upload.UpdateLocalMetadataTagsOutboxRequest
 import id.homebase.api.client.drives.upload.UploadFileRequest
 import id.homebase.api.client.drives.upload.cleanupHlsScratch
+import id.homebase.api.file.systemFileSystem
+import okio.Path.Companion.toPath
 import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
@@ -213,15 +215,16 @@ class OutboxSync(
                     databaseManager.outbox.deleteByRowId(outboxRecord.rowId)
 
                     // Drop branch: the upload exhausted retries or hit a permanent
-                    // error, so the row is gone with nothing else to clean up its
-                    // HLS scratch dir. Reach into the serialized request, pull out
-                    // the payloads, and let cleanupHlsScratch reclaim any
-                    // hls_<uuid>/ parent. Wrapped in runCatching — cleanup failure
-                    // must never affect the drop semantics.
+                    // error, so nothing else will clean up the request's payload
+                    // temps. Reach into the serialized request, pull out the
+                    // payloads, and reap both the per-file temps (resolved_*.mp4
+                    // etc.) AND any hls_<uuid>/ parent dir. Wrapped in
+                    // runCatching — cleanup failure must never affect drop
+                    // semantics.
                     runCatching {
-                        cleanupHlsScratchForDroppedRow(outboxRecord)
+                        cleanupPayloadsForDroppedRow(outboxRecord)
                     }.onFailure {
-                        Logger.w("OutboxSync: hls scratch cleanup failed for dropped uniqueId=${outboxRecord.uniqueId}", it)
+                        Logger.w("OutboxSync: payload cleanup failed for dropped uniqueId=${outboxRecord.uniqueId}", it)
                     }
 
                     eventBus.emit(
@@ -569,12 +572,18 @@ class OutboxSync(
 
     /**
      * Decode the dropped row's serialized request just enough to find the
-     * payload list, then sweep any `hls_<uuid>/` scratch dir each payload
-     * sits in. Only `UploadNewFile` and `UpdateFile` carry payloads — the
-     * other upload types return null/empty payload lists and the helper
-     * silently no-ops.
+     * payload list, then reap both the per-file temps (resolved_*.mp4 etc.)
+     * AND any `hls_<uuid>/` parent dir. Only `UploadNewFile` and `UpdateFile`
+     * carry payloads — the other upload types return null/empty and the
+     * helpers silently no-op.
+     *
+     * The success path (DriveUploadProvider.cleanupPayloadTempFiles) does the
+     * same per-file delete after a successful upload. This mirror is what
+     * keeps a permanently-failed upload (20 retries / terminal error) from
+     * leaking its picker-resolved input file. The leak was the largest single
+     * contributor to the cacheDir backlog seen on a real device.
      */
-    private fun cleanupHlsScratchForDroppedRow(outboxRecord: Outbox) {
+    private fun cleanupPayloadsForDroppedRow(outboxRecord: Outbox) {
         val json = outboxRecord.json.decodeToString()
         val payloads = when (outboxRecord.uploadType) {
             DriveOutboxUploader.UploadNewFile ->
@@ -582,7 +591,23 @@ class OutboxSync(
             DriveOutboxUploader.UpdateFile ->
                 OdinSystemSerializer.deserialize<UpdateFileByUniqueIdRequest>(json).payloads
             else -> null
+        } ?: return
+
+        // Per-file delete. Skip content:// SAF URIs (Android share-in / picker
+        // sometimes leaves payload.filePath as a content URI we don't own and
+        // must not touch).
+        for (p in payloads) {
+            val path = p.filePath
+            if (path.startsWith("content://") || path.startsWith("content:")) continue
+            runCatching {
+                val okio = path.toPath()
+                if (systemFileSystem.exists(okio)) systemFileSystem.delete(okio)
+            }.onFailure {
+                Logger.w("OutboxSync: drop-cleanup file delete failed for $path", it)
+            }
         }
+
+        // Plus the parent hls_<uuid>/ dir if any.
         cleanupHlsScratch(payloads)
     }
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/FfmpegOutputCleanup.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/FfmpegOutputCleanup.kt
@@ -1,0 +1,65 @@
+package id.homebase.api.video
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.file.safeDeleteRecursively
+import id.homebase.api.file.systemFileSystem
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+/**
+ * Best-effort delete of FFmpeg output left behind by a *failed* compress or
+ * segment operation.
+ *
+ * `compressVideo` / `segmentVideo` / `segmentAndEncryptVideo` each write their
+ * output into the cache directory and, on FFmpeg failure, used to just return
+ * null (or throw) — leaving a partial or empty file (`compressed_*.mp4`,
+ * `ffmpeg-segmented-*.{m3u8,ts}`) or a whole `hls_<uuid>/` directory behind,
+ * uncapped and never evicted. Each failure path now calls this to delete what
+ * it created.
+ *
+ * [path] may be a single file or a directory; directories are removed
+ * recursively. Never throws — a cleanup failure must not mask the original
+ * FFmpeg failure the caller is already handling.
+ *
+ * @return true if something was deleted; false if [path] did not exist or
+ *   could not be removed.
+ */
+fun deleteFailedFfmpegOutput(
+    path: String,
+    fileSystem: FileSystem = systemFileSystem,
+): Boolean {
+    // Guard against a catastrophic delete. This only ever runs on a leftover
+    // FFmpeg output path — a `compressed_*.mp4` file or an `hls_<uuid>/` dir
+    // under the cache directory — so real callers always pass a deep absolute
+    // path. A blank, relative, or filesystem-root path here means an upstream
+    // bug; refuse it rather than risk deleteRecursively on the wrong tree.
+    if (path.isBlank()) {
+        Logger.w(tag = "FFmpegUtils") { "refusing to clean up a blank FFmpeg output path" }
+        return false
+    }
+    val p = path.toPath()
+    if (!p.isAbsolute || p.parent == null) {
+        Logger.w(tag = "FFmpegUtils") {
+            "refusing to delete unsafe FFmpeg output path '$path' — " +
+                "expected an absolute path with a parent"
+        }
+        return false
+    }
+    return try {
+        if (!fileSystem.exists(p)) return false
+        if (fileSystem.metadata(p).isDirectory) {
+            // Route folder deletes through the centralized safety check; the
+            // guard above already ensured p is absolute with a parent.
+            val parent = p.parent ?: return false
+            safeDeleteRecursively(parent.toString(), p.name, fileSystem)
+        } else {
+            fileSystem.delete(p)
+            true
+        }
+    } catch (e: Exception) {
+        Logger.w(tag = "FFmpegUtils", throwable = e) {
+            "failed to clean up FFmpeg output at $path"
+        }
+        false
+    }
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/HlsKeyMaterial.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/HlsKeyMaterial.kt
@@ -1,0 +1,53 @@
+package id.homebase.api.video
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.file.systemFileSystem
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+/**
+ * File names FFmpeg's HLS encryption needs on disk during segmentation: the raw
+ * AES key and the keyinfo file that points FFmpeg at it. Each platform's
+ * `FFmpegUtils.generateHlsKeyInfoFile` writes exactly these names — keep this the
+ * single source of truth so [deleteHlsKeyMaterial] removes exactly what was written.
+ */
+const val HLS_KEY_FILE_NAME: String = "enc.key"
+const val HLS_KEY_INFO_FILE_NAME: String = "keyinfo.txt"
+
+/**
+ * Deletes the HLS key material ([HLS_KEY_FILE_NAME] and [HLS_KEY_INFO_FILE_NAME])
+ * from [outputDirPath].
+ *
+ * FFmpeg needs the raw AES key on disk *during* segmentation — it reads the
+ * keyinfo file to encrypt each segment — but the moment segmentation finishes the
+ * key is dead weight: it is not needed for transmission (the key travels in the
+ * message [id.homebase.api.client.KeyHeader], not the file), and leaving a
+ * plaintext AES key sitting in the cache directory is a needless exposure. Call
+ * this as soon as `segmentAndEncryptVideo` finishes, before returning.
+ *
+ * Best-effort: a missing file or a delete failure is logged and skipped, never
+ * thrown — tidy-up must not fail an otherwise-successful segmentation.
+ *
+ * @return how many key-material files were actually deleted (0..2).
+ */
+fun deleteHlsKeyMaterial(
+    outputDirPath: String,
+    fileSystem: FileSystem = systemFileSystem,
+): Int {
+    val dir = outputDirPath.toPath()
+    var deleted = 0
+    for (name in arrayOf(HLS_KEY_FILE_NAME, HLS_KEY_INFO_FILE_NAME)) {
+        val path = dir / name
+        try {
+            if (fileSystem.exists(path)) {
+                fileSystem.delete(path)
+                deleted++
+            }
+        } catch (e: Exception) {
+            Logger.w(tag = "FFmpegUtils", throwable = e) {
+                "failed to delete HLS key material $name in $outputDirPath"
+            }
+        }
+    }
+    return deleted
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPayloadProcessor.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPayloadProcessor.kt
@@ -147,6 +147,15 @@ class VideoPayloadProcessor(
         val durationMs = FFmpegUtils.getDurationMs(compressedPath)
         val codec = detectVideoCodec(finalVideoPath)
 
+        // Reap the FFmpeg compressed_*.mp4 scratch — its bytes have already
+        // been re-encoded into either the HLS segment (segmented path) or the
+        // encrypted payload (non-segmented path), and metadata has been read.
+        // Skip when compressVideo fell back to the input path (no compression
+        // happened — compressedPath IS payload.filePath, owned by the caller).
+        if (compressedPath != payload.filePath) {
+            fileOperationsProvider.deleteTempFile(compressedPath)
+        }
+
         val playlistContent =
             if (isSegmented && playlistPath != null) {
                 fileOperationsProvider.readFileBytes(playlistPath).decodeToString()

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPreloader.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPreloader.kt
@@ -2,25 +2,22 @@ package id.homebase.api.video
 
 import co.touchlab.kermit.Logger
 import id.homebase.api.file.FileOperationsProvider
-import id.homebase.api.file.systemFileSystem
+import id.homebase.api.file.safeDeleteRecursively
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import okio.Path.Companion.toPath
 import kotlin.uuid.Uuid
 
 class VideoPreloader(
     private val driveFileProvider: VideoPrefetchDriveAccess,
     private val fileOperationsProvider: FileOperationsProvider,
 ) {
-    private val fileSystem = systemFileSystem
     private val mutexMap = mutableMapOf<String, Mutex>()
     private val progressMap = mutableMapOf<String, MutableStateFlow<Float>>()
     private val mapLock = Mutex()
 
-    private val preloadDir get() = "${fileOperationsProvider.getCacheDirectory()}/hbvid_preload"
     private fun cacheKey(fileId: Uuid, payloadKey: String) = "$fileId/$payloadKey"
 
     /**
@@ -139,10 +136,6 @@ class VideoPreloader(
 
     /** Deletes any legacy pre-decrypted files written by older builds. */
     fun clearCache() {
-        try {
-            fileSystem.deleteRecursively(preloadDir.toPath())
-        } catch (e: Exception) {
-            Logger.w(tag = "VideoIO") { "VideoPreloader.clearCache failed: ${e.message}" }
-        }
+        safeDeleteRecursively(fileOperationsProvider.getCacheDirectory(), "hbvid_preload")
     }
 }

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/client/drives/upload/HlsScratchCleanupTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/client/drives/upload/HlsScratchCleanupTest.kt
@@ -1,0 +1,116 @@
+package id.homebase.api.client.drives.upload
+
+import id.homebase.api.client.drives.files.PayloadFile
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Cross-platform red-green test for [cleanupHlsScratch]. Uses an okio
+ * [FakeFileSystem] so the shared cleanup logic is exercised on every target
+ * (JVM / Android / iOS native).
+ */
+class HlsScratchCleanupTest {
+
+    private val cacheDir = "/data/data/id.homebase.test/cache"
+
+    private fun payload(filePath: String, key: String = "vid"): PayloadFile =
+        PayloadFile(key = key, filePath = filePath)
+
+    private fun FakeFileSystem.seedHlsDir(parent: String) {
+        createDirectories(parent.toPath())
+        write("$parent/index.ts".toPath()) { write(ByteArray(8)) }
+        write("$parent/index.m3u8".toPath()) { write(ByteArray(8)) }
+    }
+
+    @Test
+    fun hlsParent_recursivelyDeleted() {
+        val fs = FakeFileSystem()
+        fs.createDirectories(cacheDir.toPath())
+        val hlsDir = "$cacheDir/hls_abc"
+        fs.seedHlsDir(hlsDir)
+
+        cleanupHlsScratch(listOf(payload("$hlsDir/index.ts")), fs)
+
+        assertFalse(fs.exists(hlsDir.toPath()), "hls_<uuid>/ dir must be gone")
+        assertTrue(fs.exists(cacheDir.toPath()), "cacheDir itself must survive")
+    }
+
+    @Test
+    fun nonHlsParent_leftAlone() {
+        val fs = FakeFileSystem()
+        fs.createDirectories(cacheDir.toPath())
+        val nonHls = "$cacheDir/some.bin"
+        fs.write(nonHls.toPath()) { write(ByteArray(8)) }
+
+        cleanupHlsScratch(listOf(payload(nonHls)), fs)
+
+        assertTrue(fs.exists(nonHls.toPath()), "non-hls payload file must survive")
+        assertTrue(fs.exists(cacheDir.toPath()), "cacheDir must survive")
+    }
+
+    @Test
+    fun mixedPayloads_onlyHlsDirRemoved() {
+        val fs = FakeFileSystem()
+        fs.createDirectories(cacheDir.toPath())
+        val hlsDir = "$cacheDir/hls_xyz"
+        fs.seedHlsDir(hlsDir)
+        val nonHls = "$cacheDir/photo.jpg"
+        fs.write(nonHls.toPath()) { write(ByteArray(8)) }
+
+        cleanupHlsScratch(
+            listOf(
+                payload("$hlsDir/index.ts", key = "vid"),
+                payload(nonHls, key = "img"),
+            ),
+            fs,
+        )
+
+        assertFalse(fs.exists(hlsDir.toPath()), "hls dir must be gone")
+        assertTrue(fs.exists(nonHls.toPath()), "non-hls payload must survive")
+    }
+
+    @Test
+    fun nullPayloads_noOp() {
+        val fs = FakeFileSystem()
+        fs.createDirectories(cacheDir.toPath())
+
+        cleanupHlsScratch(null, fs)
+
+        assertTrue(fs.exists(cacheDir.toPath()))
+    }
+
+    @Test
+    fun emptyPayloads_noOp() {
+        val fs = FakeFileSystem()
+        fs.createDirectories(cacheDir.toPath())
+
+        cleanupHlsScratch(emptyList(), fs)
+
+        assertTrue(fs.exists(cacheDir.toPath()))
+    }
+
+    @Test
+    fun multiplePayloadsInSameHlsDir_idempotent() {
+        // Two payloads pointing into the same hls_<uuid>/ dir — first
+        // call deletes the dir, the second call's safeDeleteRecursively
+        // returns false silently (target gone is a no-op). No throw.
+        val fs = FakeFileSystem()
+        fs.createDirectories(cacheDir.toPath())
+        val hlsDir = "$cacheDir/hls_dup"
+        fs.seedHlsDir(hlsDir)
+
+        cleanupHlsScratch(
+            listOf(
+                payload("$hlsDir/index.ts", key = "vid1"),
+                payload("$hlsDir/index.m3u8", key = "vid2"),
+            ),
+            fs,
+        )
+
+        assertFalse(fs.exists(hlsDir.toPath()))
+        assertTrue(fs.exists(cacheDir.toPath()))
+    }
+}

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/client/profile/FakeFileOperationsProvider.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/client/profile/FakeFileOperationsProvider.kt
@@ -11,5 +11,6 @@ class FakeFileOperationsProvider : FileOperationsProvider {
     override fun deleteTempFile(path: String): Boolean = false
     override fun getFileSize(path: String): Long = 0L
     override suspend fun writeBytesToTempFile(bytes: ByteArray, prefix: String, suffix: String): String = throw UnsupportedOperationException()
+    override suspend fun writeBytesToShareOutboundFile(bytes: ByteArray, suffix: String): String = throw UnsupportedOperationException()
     override suspend fun writeStream(path: String, data: Flow<ByteArray>) = throw UnsupportedOperationException()
 }

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/file/CacheAuditTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/file/CacheAuditTest.kt
@@ -89,4 +89,30 @@ class CacheAuditTest {
         val fs = FakeFileSystem()
         assertEquals(0L, fs.directorySizeBytes("/cache/does-not-exist".toPath()))
     }
+
+    @Test
+    fun audit_flagsAndroidSystemDirs_andLabelsThem() {
+        // These four directories live under the app's cacheDir on Android but
+        // are managed by the Android platform / WebView / Crashlytics — never
+        // by us. The audit must mark them so the CacheSweeper can KEEP them
+        // regardless of sweep mode (even on logout / "Clear caches"). Wiping
+        // them would, in order: nuke in-app browser cookies + storage (WebView,
+        // data), force a slow ART re-compile of WebView native libs
+        // (oat_primary), and lose pending crash reports (Crash Reports).
+        val fs = FakeFileSystem()
+        fs.createDirectories(cacheDir)
+        fs.writeFile("/cache/WebView/cookies.bin", 100)
+        fs.writeFile("/cache/oat_primary/some.oat", 100)
+        fs.writeFile("/cache/data/x.bin", 100)
+        fs.writeFile("/cache/Crash Reports/report.json", 100)
+
+        val report = CacheAudit.audit(cacheDir.toString(), fs)
+
+        for (name in listOf("WebView", "oat_primary", "data", "Crash Reports")) {
+            val entry = report.entries.single { it.name == name }
+            assertTrue(entry.androidSystem, "$name must be flagged as Android system")
+            assertFalse(entry.known, "$name must not be classified as a tracked Coil cache")
+            assertTrue(entry.label.isNotBlank(), "$name needs a descriptive label")
+        }
+    }
 }

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/file/CacheAuditTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/file/CacheAuditTest.kt
@@ -33,6 +33,7 @@ class CacheAuditTest {
 
         assertEquals(300L, report.knownBytes)
         assertEquals(550L, report.untrackedBytes)
+        assertEquals(0L, report.androidSystemBytes)
         assertEquals(850L, report.totalBytes)
         assertEquals(3, report.entries.size)
         // sorted largest-first
@@ -114,5 +115,28 @@ class CacheAuditTest {
             assertFalse(entry.known, "$name must not be classified as a tracked Coil cache")
             assertTrue(entry.label.isNotBlank(), "$name needs a descriptive label")
         }
+    }
+
+    @Test
+    fun audit_androidSystemBytes_areBucketedSeparately_notLumpedIntoUntracked() {
+        // Real-device regression: when only sacred dirs lived alongside the
+        // tracked Coil caches, the audit lumped WebView/Crash Reports/etc. into
+        // `untrackedBytes`. The sweeper then logged "deleting=N bytes (untracked)"
+        // for entries it would actually KEEP, and the post-sweep "freed=0 bytes"
+        // line looked like a delete failure. Three disjoint buckets — each entry
+        // counted in exactly one — keep the headline numbers honest.
+        val fs = FakeFileSystem()
+        fs.createDirectories(cacheDir)
+        fs.writeFile("/cache/homebase-payloads-v2/x", 100)         // tracked Coil
+        fs.writeFile("/cache/WebView/cookies.bin", 200)            // android system
+        fs.writeFile("/cache/Crash Reports/r.json", 50)            // android system
+        fs.writeFile("/cache/hls_orphan/index.ts", 400)            // untracked
+
+        val report = CacheAudit.audit(cacheDir.toString(), fs)
+
+        assertEquals(100L, report.knownBytes, "tracked Coil bucket")
+        assertEquals(400L, report.untrackedBytes, "untracked bucket — must NOT include WebView/Crash Reports")
+        assertEquals(250L, report.androidSystemBytes, "android system bucket")
+        assertEquals(750L, report.totalBytes, "total = known + untracked + androidSystem")
     }
 }

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/file/CacheAuditTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/file/CacheAuditTest.kt
@@ -1,0 +1,92 @@
+package id.homebase.api.file
+
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CacheAuditTest {
+
+    private val cacheDir = "/cache".toPath()
+
+    private fun FakeFileSystem.writeFile(path: String, sizeBytes: Int) {
+        val p = path.toPath()
+        p.parent?.let { createDirectories(it) }
+        write(p) { write(ByteArray(sizeBytes)) }
+    }
+
+    @Test
+    fun audit_classifiesKnownVsUntracked_andSumsSizes() {
+        val fs = FakeFileSystem()
+        fs.createDirectories(cacheDir)
+        // tracked Coil disk cache: 300 bytes across two files
+        fs.writeFile("/cache/homebase-payloads-v2/a", 100)
+        fs.writeFile("/cache/homebase-payloads-v2/b", 200)
+        // untracked FFmpeg HLS dir: 500 bytes
+        fs.writeFile("/cache/hls_abc/index.ts", 500)
+        // untracked loose decrypted download: 50 bytes
+        fs.writeFile("/cache/myphoto.jpg", 50)
+
+        val report = CacheAudit.audit(cacheDir.toString(), fs)
+
+        assertEquals(300L, report.knownBytes)
+        assertEquals(550L, report.untrackedBytes)
+        assertEquals(850L, report.totalBytes)
+        assertEquals(3, report.entries.size)
+        // sorted largest-first
+        assertEquals(
+            listOf("hls_abc", "homebase-payloads-v2", "myphoto.jpg"),
+            report.entries.map { it.name },
+        )
+
+        val tracked = report.entries.single { it.name == "homebase-payloads-v2" }
+        assertTrue(tracked.known)
+        assertTrue(tracked.isDirectory)
+        assertEquals(300L, tracked.sizeBytes)
+
+        val hls = report.entries.single { it.name == "hls_abc" }
+        assertFalse(hls.known)
+        assertTrue(hls.isDirectory)
+        assertEquals("FFmpeg HLS segment dir (video send)", hls.label)
+
+        val loose = report.entries.single { it.name == "myphoto.jpg" }
+        assertFalse(loose.known)
+        assertFalse(loose.isDirectory)
+        assertEquals("unknown", loose.label)
+    }
+
+    @Test
+    fun audit_missingCacheDir_returnsEmptyReport() {
+        val fs = FakeFileSystem()
+        val report = CacheAudit.audit("/nonexistent".toPath().toString(), fs)
+        assertEquals(0L, report.totalBytes)
+        assertTrue(report.entries.isEmpty())
+    }
+
+    @Test
+    fun audit_emptyCacheDir_returnsEmptyReport() {
+        val fs = FakeFileSystem()
+        fs.createDirectories(cacheDir)
+        val report = CacheAudit.audit(cacheDir.toString(), fs)
+        assertEquals(0L, report.totalBytes)
+        assertTrue(report.entries.isEmpty())
+    }
+
+    @Test
+    fun directorySizeBytes_emptyAndNested() {
+        val fs = FakeFileSystem()
+        fs.createDirectories("/cache/empty".toPath())
+        assertEquals(0L, fs.directorySizeBytes("/cache/empty".toPath()))
+
+        fs.writeFile("/cache/nest/x/y.bin", 42)
+        assertEquals(42L, fs.directorySizeBytes("/cache/nest".toPath()))
+    }
+
+    @Test
+    fun directorySizeBytes_missingDir_returnsZero() {
+        val fs = FakeFileSystem()
+        assertEquals(0L, fs.directorySizeBytes("/cache/does-not-exist".toPath()))
+    }
+}

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/file/CacheSweeperTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/file/CacheSweeperTest.kt
@@ -9,12 +9,17 @@ import kotlin.test.assertTrue
 
 class CacheSweeperTest {
 
-    private fun entry(name: String, known: Boolean = false): CacheAudit.Entry =
+    private fun entry(
+        name: String,
+        known: Boolean = false,
+        androidSystem: Boolean = false,
+    ): CacheAudit.Entry =
         CacheAudit.Entry(
             name = name,
             isDirectory = true,
             sizeBytes = 100L,
             known = known,
+            androidSystem = androidSystem,
             label = "test",
         )
 
@@ -52,6 +57,25 @@ class CacheSweeperTest {
             SweepAction.ORPHAN_COIL_DELETE,
             decide(entry(ORPHAN_COIL_DIR_NAME), SweepMode.ALL),
         )
+    }
+
+    @Test
+    fun androidSystemDirs_areAlwaysKept_regardlessOfMode() {
+        // Sacred set: WebView/, oat_primary/, data/, Crash Reports/. Even on
+        // logout (full sweep), we don't touch them — they're owned by the
+        // Android platform / WebView / Crashlytics, not the chat app.
+        for (name in listOf("WebView", "oat_primary", "data", "Crash Reports")) {
+            assertEquals(
+                SweepAction.KEEP,
+                decide(entry(name, androidSystem = true), SweepMode.UNTRACKED),
+                "$name must be KEPT in untracked sweep",
+            )
+            assertEquals(
+                SweepAction.KEEP,
+                decide(entry(name, androidSystem = true), SweepMode.ALL),
+                "$name must be KEPT in full sweep too",
+            )
+        }
     }
 
     @Test

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/file/CacheSweeperTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/file/CacheSweeperTest.kt
@@ -79,34 +79,64 @@ class CacheSweeperTest {
     }
 
     @Test
-    fun sweep_actuallyDeletes_coil3DiskCache_evenInDryRunMode() {
-        // Pinned exception to dry-run: the orphan-coil dir is the one case the sweeper
-        // actually deletes now (it absorbs the role of the retired rogue
-        // safeDeleteRecursively("coil3_disk_cache") lines). Everything else stays log-only
-        // until on-device adb confirms the targets are right.
+    fun sweepUntracked_deletes_untrackedEntries_keeps_trackedAndAndroidSystem() {
         val fs = FakeFileSystem()
         val cacheDir = "/data/data/id.homebase.test/cache"
         fs.createDirectories(cacheDir.toPath())
+        // Untracked: should be reaped.
         fs.createDirectories("$cacheDir/coil3_disk_cache".toPath())
         fs.write("$cacheDir/coil3_disk_cache/some.bin".toPath()) { write(ByteArray(8)) }
-        fs.createDirectories("$cacheDir/homebase-payloads-v2".toPath())
         fs.createDirectories("$cacheDir/hls_abc".toPath())
         fs.write("$cacheDir/hls_abc/index.ts".toPath()) { write(ByteArray(8)) }
+        fs.write("$cacheDir/resolved_99.jpeg".toPath()) { write(ByteArray(8)) }
+        // Tracked Coil cache: kept in untracked sweep.
+        fs.createDirectories("$cacheDir/homebase-payloads-v2".toPath())
+        fs.write("$cacheDir/homebase-payloads-v2/x.bin".toPath()) { write(ByteArray(8)) }
+        // Android system dir: sacred — kept regardless of sweep mode.
+        fs.createDirectories("$cacheDir/WebView".toPath())
+        fs.write("$cacheDir/WebView/cookies.bin".toPath()) { write(ByteArray(8)) }
 
         val report = CacheAudit.audit(cacheDir, fs)
         CacheSweeper.sweepUntracked(report, fs)
 
         assertFalse(
             fs.exists("$cacheDir/coil3_disk_cache".toPath()),
-            "orphan coil3_disk_cache must be actually deleted, not just logged",
+            "orphan coil3_disk_cache must be deleted",
         )
-        assertTrue(
+        assertFalse(
             fs.exists("$cacheDir/hls_abc".toPath()),
-            "non-orphan untracked entries stay on disk during dry-run (log only)",
+            "untracked dir must be deleted",
+        )
+        assertFalse(
+            fs.exists("$cacheDir/resolved_99.jpeg".toPath()),
+            "untracked file must be deleted",
         )
         assertTrue(
             fs.exists("$cacheDir/homebase-payloads-v2".toPath()),
-            "tracked Coil cache dirs are kept",
+            "tracked Coil cache dir kept in untracked sweep",
         )
+        assertTrue(
+            fs.exists("$cacheDir/WebView".toPath()),
+            "Android system dir is sacred, must survive any sweep",
+        )
+    }
+
+    @Test
+    fun sweepAll_deletesEverythingExceptAndroidSystem() {
+        val fs = FakeFileSystem()
+        val cacheDir = "/data/data/id.homebase.test/cache"
+        fs.createDirectories(cacheDir.toPath())
+        fs.createDirectories("$cacheDir/homebase-payloads-v2".toPath())
+        fs.write("$cacheDir/homebase-payloads-v2/x.bin".toPath()) { write(ByteArray(8)) }
+        fs.write("$cacheDir/resolved_99.jpeg".toPath()) { write(ByteArray(8)) }
+        fs.createDirectories("$cacheDir/WebView".toPath())
+        fs.write("$cacheDir/WebView/cookies.bin".toPath()) { write(ByteArray(8)) }
+
+        val report = CacheAudit.audit(cacheDir, fs)
+        CacheSweeper.sweepAll(report, fs)
+
+        assertFalse(fs.exists("$cacheDir/homebase-payloads-v2".toPath()), "logout sweep deletes tracked too")
+        assertFalse(fs.exists("$cacheDir/resolved_99.jpeg".toPath()), "logout sweep deletes untracked too")
+        assertTrue(fs.exists("$cacheDir/WebView".toPath()), "logout sweep still keeps Android system dirs")
     }
 }

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/file/CacheSweeperTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/file/CacheSweeperTest.kt
@@ -122,6 +122,30 @@ class CacheSweeperTest {
     }
 
     @Test
+    fun sweep_actuallyReclaimsBytes_measuredAfterDelete() {
+        // Smoke test for the post-sweep re-measurement: the sweep must
+        // actually shrink the cache directory's footprint, not just
+        // declare what it intended to delete.
+        val fs = FakeFileSystem()
+        val cacheDir = "/data/data/id.homebase.test/cache"
+        fs.createDirectories(cacheDir.toPath())
+        fs.createDirectories("$cacheDir/hls_orphan".toPath())
+        fs.write("$cacheDir/hls_orphan/big.ts".toPath()) { write(ByteArray(10_000)) }
+        fs.write("$cacheDir/resolved_x.mp4".toPath()) { write(ByteArray(20_000)) }
+        fs.createDirectories("$cacheDir/homebase-payloads-v2".toPath())
+        fs.write("$cacheDir/homebase-payloads-v2/keep.bin".toPath()) { write(ByteArray(1_000)) }
+
+        val before = fs.directorySizeBytes(cacheDir.toPath())
+        assertEquals(31_000L, before)
+
+        val report = CacheAudit.audit(cacheDir, fs)
+        CacheSweeper.sweepUntracked(report, fs)
+
+        val after = fs.directorySizeBytes(cacheDir.toPath())
+        assertEquals(1_000L, after, "only the tracked Coil cache (1KB) should remain")
+    }
+
+    @Test
     fun sweepAll_deletesEverythingExceptAndroidSystem() {
         val fs = FakeFileSystem()
         val cacheDir = "/data/data/id.homebase.test/cache"

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/file/CacheSweeperTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/file/CacheSweeperTest.kt
@@ -1,0 +1,88 @@
+package id.homebase.api.file
+
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CacheSweeperTest {
+
+    private fun entry(name: String, known: Boolean = false): CacheAudit.Entry =
+        CacheAudit.Entry(
+            name = name,
+            isDirectory = true,
+            sizeBytes = 100L,
+            known = known,
+            label = "test",
+        )
+
+    @Test
+    fun untrackedMode_keepsKnownCacheDirs() {
+        assertEquals(
+            SweepAction.KEEP,
+            decide(entry("homebase-payloads-v2", known = true), SweepMode.UNTRACKED),
+        )
+    }
+
+    @Test
+    fun untrackedMode_deletesUnknownEntries() {
+        assertEquals(SweepAction.DELETE, decide(entry("hls_abc"), SweepMode.UNTRACKED))
+        assertEquals(SweepAction.DELETE, decide(entry("compressed_clip.mp4"), SweepMode.UNTRACKED))
+        assertEquals(SweepAction.DELETE, decide(entry("hbvid_preload"), SweepMode.UNTRACKED))
+    }
+
+    @Test
+    fun allMode_deletesEverythingIncludingTrackedCaches() {
+        assertEquals(
+            SweepAction.DELETE,
+            decide(entry("homebase-payloads-v2", known = true), SweepMode.ALL),
+        )
+        assertEquals(SweepAction.DELETE, decide(entry("hls_abc"), SweepMode.ALL))
+    }
+
+    @Test
+    fun coil3DiskCache_isAlwaysOrphanCoilDelete_regardlessOfMode() {
+        assertEquals(
+            SweepAction.ORPHAN_COIL_DELETE,
+            decide(entry(ORPHAN_COIL_DIR_NAME), SweepMode.UNTRACKED),
+        )
+        assertEquals(
+            SweepAction.ORPHAN_COIL_DELETE,
+            decide(entry(ORPHAN_COIL_DIR_NAME), SweepMode.ALL),
+        )
+    }
+
+    @Test
+    fun sweep_actuallyDeletes_coil3DiskCache_evenInDryRunMode() {
+        // Pinned exception to dry-run: the orphan-coil dir is the one case the sweeper
+        // actually deletes now (it absorbs the role of the retired rogue
+        // safeDeleteRecursively("coil3_disk_cache") lines). Everything else stays log-only
+        // until on-device adb confirms the targets are right.
+        val fs = FakeFileSystem()
+        val cacheDir = "/data/data/id.homebase.test/cache"
+        fs.createDirectories(cacheDir.toPath())
+        fs.createDirectories("$cacheDir/coil3_disk_cache".toPath())
+        fs.write("$cacheDir/coil3_disk_cache/some.bin".toPath()) { write(ByteArray(8)) }
+        fs.createDirectories("$cacheDir/homebase-payloads-v2".toPath())
+        fs.createDirectories("$cacheDir/hls_abc".toPath())
+        fs.write("$cacheDir/hls_abc/index.ts".toPath()) { write(ByteArray(8)) }
+
+        val report = CacheAudit.audit(cacheDir, fs)
+        CacheSweeper.sweepUntracked(report, fs)
+
+        assertFalse(
+            fs.exists("$cacheDir/coil3_disk_cache".toPath()),
+            "orphan coil3_disk_cache must be actually deleted, not just logged",
+        )
+        assertTrue(
+            fs.exists("$cacheDir/hls_abc".toPath()),
+            "non-orphan untracked entries stay on disk during dry-run (log only)",
+        )
+        assertTrue(
+            fs.exists("$cacheDir/homebase-payloads-v2".toPath()),
+            "tracked Coil cache dirs are kept",
+        )
+    }
+}

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/file/SafeDeleteTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/file/SafeDeleteTest.kt
@@ -1,0 +1,126 @@
+package id.homebase.api.file
+
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Cross-platform red-green test for [safeDeleteRecursively]. Uses an okio
+ * [FakeFileSystem], so the shared safety logic is exercised on every target.
+ */
+class SafeDeleteTest {
+
+    // A realistic, comfortably-long trusted base directory.
+    private val base = "/data/data/id.homebase.test/cache"
+
+    private fun FakeFileSystem.seedDir(path: String, vararg files: String) {
+        createDirectories(path.toPath())
+        for (f in files) {
+            val fp = path.toPath() / f
+            fp.parent?.let { createDirectories(it) }
+            write(fp) { write(ByteArray(8)) }
+        }
+    }
+
+    @Test
+    fun deletesDirectoryStrictlyUnderBase() {
+        val fs = FakeFileSystem()
+        fs.seedDir(base)
+        fs.seedDir("$base/homebase-payloads", "a.bin", "nested/b.bin")
+
+        val deleted = safeDeleteRecursively(base, "homebase-payloads", fs)
+
+        assertTrue(deleted, "must delete a real directory under the base")
+        assertFalse(fs.exists("$base/homebase-payloads".toPath()), "target dir must be gone")
+        assertTrue(fs.exists(base.toPath()), "the base dir itself must survive")
+    }
+
+    @Test
+    fun deletesNestedRelativeSubPath() {
+        val fs = FakeFileSystem()
+        fs.seedDir(base)
+        fs.seedDir("$base/a/b/c", "x.bin")
+
+        val deleted = safeDeleteRecursively(base, "a/b/c", fs)
+
+        assertTrue(deleted)
+        assertFalse(fs.exists("$base/a/b/c".toPath()))
+        assertTrue(fs.exists("$base/a/b".toPath()), "only the named sub-path is removed")
+    }
+
+    @Test
+    fun missingTarget_returnsFalse_doesNotThrow() {
+        val fs = FakeFileSystem()
+        fs.seedDir(base)
+        assertFalse(safeDeleteRecursively(base, "does-not-exist", fs))
+    }
+
+    // --- belt & suspenders: every one of these must delete NOTHING ---
+
+    @Test
+    fun refusesBlankBase() {
+        val fs = FakeFileSystem()
+        assertFalse(safeDeleteRecursively("", "cache", fs))
+        assertFalse(safeDeleteRecursively("   ", "cache", fs))
+    }
+
+    @Test
+    fun refusesTooShortOrRootBase() {
+        val fs = FakeFileSystem()
+        assertFalse(safeDeleteRecursively("/", "cache", fs))
+    }
+
+    @Test
+    fun refusesBlankRelativeSubPath() {
+        val fs = FakeFileSystem()
+        fs.seedDir(base, "keep.bin")
+        assertFalse(safeDeleteRecursively(base, "", fs))
+        assertFalse(safeDeleteRecursively(base, "   ", fs))
+        assertTrue(fs.exists("$base/keep.bin".toPath()), "a blank relative path must delete nothing")
+    }
+
+    @Test
+    fun refusesAbsoluteRelativeSubPath() {
+        val fs = FakeFileSystem()
+        fs.seedDir(base)
+        fs.seedDir("/etc", "passwd")
+        assertFalse(safeDeleteRecursively(base, "/etc", fs))
+        assertTrue(fs.exists("/etc".toPath()), "an absolute 'relative' path must be refused")
+    }
+
+    @Test
+    fun refusesDotDotEscape() {
+        val fs = FakeFileSystem()
+        fs.seedDir(base)
+        fs.seedDir("/data/data/id.homebase.test/databases", "odin.db")
+
+        val deleted = safeDeleteRecursively(base, "../databases", fs)
+
+        assertFalse(deleted, "must refuse a '..' that escapes the base")
+        assertTrue(
+            fs.exists("/data/data/id.homebase.test/databases".toPath()),
+            "the escaped sibling directory must be untouched",
+        )
+    }
+
+    @Test
+    fun refusesAnyDotDotSegment_evenWhenItStaysUnderBase() {
+        val fs = FakeFileSystem()
+        fs.seedDir(base)
+        fs.seedDir("$base/real", "x.bin")
+        // "decoy/../real" resolves back under the base, but we reject any ".." outright.
+        assertFalse(safeDeleteRecursively(base, "decoy/../real", fs))
+        assertTrue(fs.exists("$base/real".toPath()))
+    }
+
+    @Test
+    fun refusesRelativeResolvingToBaseItself() {
+        val fs = FakeFileSystem()
+        fs.seedDir(base, "keep.bin")
+        assertFalse(safeDeleteRecursively(base, ".", fs), "must refuse a path that resolves to the base itself")
+        assertTrue(fs.exists(base.toPath()))
+        assertTrue(fs.exists("$base/keep.bin".toPath()))
+    }
+}

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/file/ShareOutboundCleanupTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/file/ShareOutboundCleanupTest.kt
@@ -1,0 +1,73 @@
+package id.homebase.api.file
+
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ShareOutboundCleanupTest {
+
+    private val cacheDir = "/data/data/id.homebase.test/cache"
+
+    @Test
+    fun sweep_removesEntireSubdir_butLeavesOtherCacheEntries() {
+        val fs = FakeFileSystem()
+        fs.createDirectories(cacheDir.toPath())
+        // Two cleartext share temps in the dedicated subdir.
+        fs.createDirectories("$cacheDir/$SHARE_OUTBOUND_DIR_NAME".toPath())
+        fs.write("$cacheDir/$SHARE_OUTBOUND_DIR_NAME/share_abc.jpg".toPath()) { write(ByteArray(64)) }
+        fs.write("$cacheDir/$SHARE_OUTBOUND_DIR_NAME/share_def.mp4".toPath()) { write(ByteArray(128)) }
+        // Bystander entries that must survive.
+        fs.createDirectories("$cacheDir/homebase-payloads-v2".toPath())
+        fs.write("$cacheDir/some_other.bin".toPath()) { write(ByteArray(8)) }
+
+        val result = sweepShareOutbound(cacheDir, fs)
+
+        assertTrue(result, "must report a real delete")
+        assertFalse(
+            fs.exists("$cacheDir/$SHARE_OUTBOUND_DIR_NAME".toPath()),
+            "share_outbound subdir must be gone",
+        )
+        assertTrue(
+            fs.exists("$cacheDir/homebase-payloads-v2".toPath()),
+            "tracked Coil cache must survive",
+        )
+        assertTrue(
+            fs.exists("$cacheDir/some_other.bin".toPath()),
+            "unrelated cache entries must survive",
+        )
+        assertTrue(fs.exists(cacheDir.toPath()), "cacheDir itself must survive")
+    }
+
+    @Test
+    fun sweep_missingSubdir_quietNoOp() {
+        val fs = FakeFileSystem()
+        fs.createDirectories(cacheDir.toPath())
+
+        val result = sweepShareOutbound(cacheDir, fs)
+
+        assertFalse(result, "no real delete happened, must report false")
+        assertTrue(fs.exists(cacheDir.toPath()))
+    }
+
+    @Test
+    fun sweep_isIdempotent() {
+        val fs = FakeFileSystem()
+        fs.createDirectories(cacheDir.toPath())
+        fs.createDirectories("$cacheDir/$SHARE_OUTBOUND_DIR_NAME".toPath())
+        fs.write("$cacheDir/$SHARE_OUTBOUND_DIR_NAME/share_xyz.png".toPath()) { write(ByteArray(8)) }
+
+        assertTrue(sweepShareOutbound(cacheDir, fs))
+        assertFalse(sweepShareOutbound(cacheDir, fs), "second call has nothing to delete")
+        assertFalse(fs.exists("$cacheDir/$SHARE_OUTBOUND_DIR_NAME".toPath()))
+    }
+
+    @Test
+    fun sweep_blankCacheDir_refusedByGuards_noThrow() {
+        val fs = FakeFileSystem()
+        // safeDeleteRecursively's guards refuse blank/short base dirs — we
+        // must not blow up, must not delete anything.
+        assertFalse(sweepShareOutbound("", fs))
+    }
+}

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/video/FfmpegOutputCleanupTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/video/FfmpegOutputCleanupTest.kt
@@ -1,0 +1,79 @@
+package id.homebase.api.video
+
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Cross-platform red-green test for [deleteFailedFfmpegOutput]. Uses an okio
+ * [FakeFileSystem], so the shared cleanup logic is exercised on every target —
+ * no real FFmpeg, no device needed.
+ */
+class FfmpegOutputCleanupTest {
+
+    @Test
+    fun deletesLeftoverFile() {
+        val fs = FakeFileSystem()
+        val file = "/cache/compressed_clip.mp4".toPath()
+        fs.createDirectories("/cache".toPath())
+        fs.write(file) { write(ByteArray(16)) }
+
+        val deleted = deleteFailedFfmpegOutput(file.toString(), fs)
+
+        assertTrue(deleted, "deleteFailedFfmpegOutput must report it deleted the file")
+        assertFalse(fs.exists(file), "partial output file must be deleted")
+    }
+
+    @Test
+    fun deletesLeftoverDirectoryRecursively() {
+        val fs = FakeFileSystem()
+        val dir = "/cache/hls_abc".toPath()
+        fs.createDirectories(dir)
+        fs.write(dir / "index.ts") { write(ByteArray(32)) }
+        fs.write(dir / "index.m3u8") { write(ByteArray(8)) }
+        fs.write(dir / "enc.key") { write(ByteArray(16)) }
+
+        val deleted = deleteFailedFfmpegOutput(dir.toString(), fs)
+
+        assertTrue(deleted, "deleteFailedFfmpegOutput must report it deleted the directory")
+        assertFalse(fs.exists(dir), "leftover hls_<uuid>/ dir must be deleted recursively")
+    }
+
+    @Test
+    fun missingPath_returnsFalse_doesNotThrow() {
+        val fs = FakeFileSystem()
+        val deleted = deleteFailedFfmpegOutput("/cache/does_not_exist.mp4", fs)
+        assertFalse(deleted, "a missing path is not an error — just nothing to delete")
+    }
+
+    // --- safety guards: a blank / relative / root path here means an upstream
+    //     bug; deleteRecursively must never run on it. ---
+
+    @Test
+    fun refusesRootPath_doesNotRecurseIntoFilesystemRoot() {
+        val fs = FakeFileSystem()
+        val sentinel = "/keep_me.txt".toPath()
+        fs.write(sentinel) { write(ByteArray(4)) }
+
+        val deleted = deleteFailedFfmpegOutput("/", fs)
+
+        assertFalse(deleted, "must refuse to delete the filesystem root")
+        assertTrue(fs.exists(sentinel), "refusing the root must not touch anything under it")
+    }
+
+    @Test
+    fun refusesRelativePath() {
+        val fs = FakeFileSystem()
+        val deleted = deleteFailedFfmpegOutput("hls_relative", fs)
+        assertFalse(deleted, "must refuse a non-absolute path")
+    }
+
+    @Test
+    fun refusesBlankPath() {
+        val fs = FakeFileSystem()
+        val deleted = deleteFailedFfmpegOutput("   ", fs)
+        assertFalse(deleted, "must refuse a blank path")
+    }
+}

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/video/HlsKeyMaterialTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/video/HlsKeyMaterialTest.kt
@@ -1,0 +1,71 @@
+package id.homebase.api.video
+
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Cross-platform red-green test for [deleteHlsKeyMaterial]. Uses an okio
+ * [FakeFileSystem], so it exercises the shared cleanup logic on every target —
+ * no real FFmpeg, no real video, no device needed. The key files are written
+ * by our own `generateHlsKeyInfoFile` with fixed names, so the leak reproduces
+ * deterministically just by seeding a directory.
+ */
+class HlsKeyMaterialTest {
+
+    private val hlsDir = "/cache/hls_abc".toPath()
+
+    private fun FakeFileSystem.seed(vararg names: String) {
+        createDirectories(hlsDir)
+        for (name in names) {
+            write(hlsDir / name) { write(ByteArray(8)) }
+        }
+    }
+
+    @Test
+    fun deletesKeyMaterial_keepsSegments() {
+        val fs = FakeFileSystem()
+        fs.seed(HLS_KEY_FILE_NAME, HLS_KEY_INFO_FILE_NAME, "index.ts", "index.m3u8")
+
+        val deleted = deleteHlsKeyMaterial(hlsDir.toString(), fs)
+
+        assertEquals(2, deleted)
+        assertFalse(fs.exists(hlsDir / HLS_KEY_FILE_NAME), "enc.key must be deleted")
+        assertFalse(fs.exists(hlsDir / HLS_KEY_INFO_FILE_NAME), "keyinfo.txt must be deleted")
+        assertTrue(fs.exists(hlsDir / "index.ts"), "encrypted segment must be kept")
+        assertTrue(fs.exists(hlsDir / "index.m3u8"), "playlist must be kept")
+    }
+
+    @Test
+    fun missingKeyMaterial_returnsZero_doesNotThrow() {
+        val fs = FakeFileSystem()
+        fs.seed("index.ts", "index.m3u8")
+
+        val deleted = deleteHlsKeyMaterial(hlsDir.toString(), fs)
+
+        assertEquals(0, deleted)
+        assertTrue(fs.exists(hlsDir / "index.ts"))
+    }
+
+    @Test
+    fun partialKeyMaterial_deletesOnlyWhatExists() {
+        val fs = FakeFileSystem()
+        fs.seed(HLS_KEY_FILE_NAME, "index.ts")
+
+        val deleted = deleteHlsKeyMaterial(hlsDir.toString(), fs)
+
+        assertEquals(1, deleted)
+        assertFalse(fs.exists(hlsDir / HLS_KEY_FILE_NAME))
+        assertTrue(fs.exists(hlsDir / "index.ts"))
+    }
+
+    @Test
+    fun missingDir_returnsZero_doesNotThrow() {
+        val fs = FakeFileSystem()
+        val deleted = deleteHlsKeyMaterial("/cache/hls_does_not_exist", fs)
+        assertEquals(0, deleted)
+    }
+}

--- a/homebase-api/src/jvmMain/java/id/homebase/api/video/FFmpegUtils.jvm.kt
+++ b/homebase-api/src/jvmMain/java/id/homebase/api/video/FFmpegUtils.jvm.kt
@@ -245,12 +245,17 @@ actual object FFmpegUtils {
                 iv = keyHeader.iv
             )
 
-            segmentInternal(
+            val result = segmentInternal(
                 inputPath = inputPath,
                 outputDir = outputDir,
                 keyInfoFile = keyInfoFile,
                 onProgress = onProgress
             )
+            // Segmentation done — FFmpeg has consumed the key material. Delete it now
+            // so the plaintext AES key doesn't linger in the temp dir (see #7).
+            // segmentInternal throws on failure, so reaching here means success.
+            deleteHlsKeyMaterial(outputDir.absolutePath)
+            result
         }
 
     private suspend fun segmentInternal(

--- a/homebase-api/src/jvmMain/java/id/homebase/api/video/FFmpegUtils.jvm.kt
+++ b/homebase-api/src/jvmMain/java/id/homebase/api/video/FFmpegUtils.jvm.kt
@@ -149,6 +149,8 @@ actual object FFmpegUtils {
             if (result.exitCode == 0 && File(outputPath).exists()) {
                 outputPath
             } else {
+                // FFmpeg failed — delete the partial/empty output (see #5).
+                deleteFailedFfmpegOutput(outputPath)
                 null
             }
         }
@@ -211,11 +213,18 @@ actual object FFmpegUtils {
                 "hls_${UUID.randomUUID()}"
             ).apply { mkdirs() }
 
-            segmentInternal(
-                inputPath = inputPath,
-                outputDir = outputDir,
-                onProgress = onProgress
-            )
+            try {
+                segmentInternal(
+                    inputPath = inputPath,
+                    outputDir = outputDir,
+                    onProgress = onProgress
+                )
+            } catch (e: Throwable) {
+                // segmentInternal throws on FFmpeg failure — delete the leftover
+                // hls_<uuid>/ dir before the exception propagates (see #5).
+                deleteFailedFfmpegOutput(outputDir.absolutePath)
+                throw e
+            }
         }
 
     actual suspend fun segmentAndEncryptVideo(
@@ -239,23 +248,30 @@ actual object FFmpegUtils {
                 "hls_${UUID.randomUUID()}"
             ).apply { mkdirs() }
 
-            val keyInfoFile = generateHlsKeyInfoFile(
-                outputDir = outputDir,
-                aesKey = keyHeader.aesKey.unsafeBytes,
-                iv = keyHeader.iv
-            )
+            try {
+                val keyInfoFile = generateHlsKeyInfoFile(
+                    outputDir = outputDir,
+                    aesKey = keyHeader.aesKey.unsafeBytes,
+                    iv = keyHeader.iv
+                )
 
-            val result = segmentInternal(
-                inputPath = inputPath,
-                outputDir = outputDir,
-                keyInfoFile = keyInfoFile,
-                onProgress = onProgress
-            )
-            // Segmentation done — FFmpeg has consumed the key material. Delete it now
-            // so the plaintext AES key doesn't linger in the temp dir (see #7).
-            // segmentInternal throws on failure, so reaching here means success.
-            deleteHlsKeyMaterial(outputDir.absolutePath)
-            result
+                val result = segmentInternal(
+                    inputPath = inputPath,
+                    outputDir = outputDir,
+                    keyInfoFile = keyInfoFile,
+                    onProgress = onProgress
+                )
+                // Segmentation done — FFmpeg has consumed the key material. Delete it now
+                // so the plaintext AES key doesn't linger in the temp dir (see #7).
+                // segmentInternal throws on failure, so reaching here means success.
+                deleteHlsKeyMaterial(outputDir.absolutePath)
+                result
+            } catch (e: Throwable) {
+                // segmentInternal throws on FFmpeg failure — delete the leftover
+                // hls_<uuid>/ dir (key material included) before rethrowing (see #5).
+                deleteFailedFfmpegOutput(outputDir.absolutePath)
+                throw e
+            }
         }
 
     private suspend fun segmentInternal(

--- a/homebase-api/src/jvmMain/kotlin/id/homebase/api/file/JvmFileOperationsProvider.kt
+++ b/homebase-api/src/jvmMain/kotlin/id/homebase/api/file/JvmFileOperationsProvider.kt
@@ -78,6 +78,16 @@ class JvmFileOperationsProvider : FileOperationsProvider {
             file.absolutePath
         }
 
+    override suspend fun writeBytesToShareOutboundFile(
+        bytes: ByteArray,
+        suffix: String,
+    ): String = withContext(Dispatchers.IO) {
+        val dir = File(getCacheDirectory(), SHARE_OUTBOUND_DIR_NAME).apply { mkdirs() }
+        val file = File.createTempFile("share_", suffix, dir)
+        file.writeBytes(bytes)
+        file.absolutePath
+    }
+
     override suspend fun writeStream(
         path: String,
         data: Flow<ByteArray>

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
@@ -85,6 +85,7 @@ class DriveFileProviderCachedTest {
                 override fun deleteTempFile(path: String) = false
                 override fun getFileSize(path: String) = 0L
                 override suspend fun writeBytesToTempFile(bytes: ByteArray, prefix: String, suffix: String): String = error("not used in tests")
+                override suspend fun writeBytesToShareOutboundFile(bytes: ByteArray, suffix: String): String = error("not used in tests")
                 override suspend fun writeStream(path: String, data: Flow<ByteArray>) = error("not used in tests")
             }
         )

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/profile/PublicProfileProviderCachedTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/profile/PublicProfileProviderCachedTest.kt
@@ -73,6 +73,7 @@ class PublicProfileProviderCachedTest {
                 override fun deleteTempFile(path: String) = false
                 override fun getFileSize(path: String) = 0L
                 override suspend fun writeBytesToTempFile(bytes: ByteArray, prefix: String, suffix: String): String = error("not used in tests")
+                override suspend fun writeBytesToShareOutboundFile(bytes: ByteArray, suffix: String): String = error("not used in tests")
                 override suspend fun writeStream(path: String, data: Flow<ByteArray>) = error("not used in tests")
             }
         )

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/IOSFileOperationsProvider.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/IOSFileOperationsProvider.kt
@@ -120,6 +120,25 @@ class IOSFileOperationsProvider : FileOperationsProvider {
     }
 
     @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+    override suspend fun writeBytesToShareOutboundFile(
+        bytes: ByteArray,
+        suffix: String,
+    ): String {
+        val cacheDir = getCacheDirectory().trimEnd('/')
+        val dir = "$cacheDir/$SHARE_OUTBOUND_DIR_NAME"
+        val fm = NSFileManager.defaultManager
+        if (!fm.fileExistsAtPath(dir)) {
+            fm.createDirectoryAtPath(dir, true, null, null)
+        }
+        val filePath = "$dir/share_${NSUUID().UUIDString}$suffix"
+        val data = bytes.usePinned { pinned ->
+            NSData.create(bytes = pinned.addressOf(0), length = bytes.size.toULong())
+        }
+        data.writeToFile(filePath, atomically = true)
+        return filePath
+    }
+
+    @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
     override suspend fun writeStream(
         path: String,
         data: Flow<ByteArray>

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/video/FFmpegUtils.native.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/video/FFmpegUtils.native.kt
@@ -157,7 +157,13 @@ actual object FFmpegUtils {
                     val fallbackCommand =
                             "-y ${trimPre}-i \"$inputPath\" ${trimMid}-c:v libx264 -b:v 3000k -vf scale=min(1280\\,iw):-2 -preset fast \"$outputPath\""
                     val fallbackResult = bridge.executeFFmpeg(fallbackCommand)
-                    if (fallbackResult.isSuccess) outputPath else null
+                    if (fallbackResult.isSuccess) {
+                        outputPath
+                    } else {
+                        // Both encoders failed — delete the partial/empty output (see #5).
+                        deleteFailedFfmpegOutput(outputPath)
+                        null
+                    }
                 }
             }
 
@@ -225,6 +231,8 @@ actual object FFmpegUtils {
                     Pair(indexPath, segmentPath)
                 } else {
                     println("Docs: Error segmenting video: ${result.failStackTrace}")
+                    // Delete the leftover hls_<uuid>/ dir (see #5).
+                    deleteFailedFfmpegOutput(outputDir)
                     null
                 }
             }
@@ -303,6 +311,8 @@ actual object FFmpegUtils {
                     Pair(indexPath, segmentPath)
                 } else {
                     println("Docs: Error segment+encrypt video: ${result.failStackTrace}")
+                    // Delete the whole hls_<uuid>/ dir — partial segments + key material (see #5).
+                    deleteFailedFfmpegOutput(outputDir)
                     null
                 }
             }

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/video/FFmpegUtils.native.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/video/FFmpegUtils.native.kt
@@ -297,6 +297,9 @@ actual object FFmpegUtils {
                 val result = bridge.executeFFmpeg(command)
 
                 if (result.isSuccess) {
+                    // Segmentation done — FFmpeg has consumed the key material. Delete it now
+                    // so the plaintext AES key doesn't linger in the cache dir (see #7).
+                    deleteHlsKeyMaterial(outputDir)
                     Pair(indexPath, segmentPath)
                 } else {
                     println("Docs: Error segment+encrypt video: ${result.failStackTrace}")

--- a/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/video/FFmpegUtils.web.kt
+++ b/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/video/FFmpegUtils.web.kt
@@ -21,6 +21,28 @@ actual object FFmpegUtils {
 
     actual suspend fun getDurationMs(inputPath: String): Long = 0L
 
+    // ┌─────────────────────────────────────────────────────────────────────────┐
+    // │ ⚠️  WASM TODO — DO NOT FORGET WHEN IMPLEMENTING VIDEO SEGMENTATION       │
+    // │                                                                         │
+    // │ When this stub becomes a real implementation, it MUST delete the HLS    │
+    // │ key material the moment segmentation finishes — exactly as the Android, │
+    // │ JVM and native actuals now do (see #7).                                 │
+    // │                                                                         │
+    // │ HLS encryption writes the raw AES key (`enc.key`) + `keyinfo.txt` into  │
+    // │ the output dir because FFmpeg needs them ON DISK while it encrypts each │
+    // │ segment. Once segmentation is done they are dead weight — the key is    │
+    // │ NOT needed for transmission (it travels in the message KeyHeader), and  │
+    // │ leaving a plaintext AES key in the cache directory is a security leak.  │
+    // │                                                                         │
+    // │ On a successful segmentation, call:                                     │
+    // │     deleteHlsKeyMaterial(outputDir)                                     │
+    // │ from id.homebase.api.video.HlsKeyMaterial (commonMain) — it removes      │
+    // │ HLS_KEY_FILE_NAME + HLS_KEY_INFO_FILE_NAME and is already cross-platform.│
+    // │ Note it relies on okio's systemFileSystem; the wasmJs systemFileSystem  │
+    // │ is currently an in-memory FakeFileSystem, so confirm the segmentation   │
+    // │ strategy (ffmpeg.wasm / MediaRecorder / server-side) writes through the │
+    // │ same filesystem the deletion reads, or the call will be a silent no-op. │
+    // └─────────────────────────────────────────────────────────────────────────┘
     actual suspend fun segmentAndEncryptVideo(
         inputPath: String,
         keyHeader: KeyHeader,

--- a/homebase-chat/src/androidMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.android.kt
+++ b/homebase-chat/src/androidMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.android.kt
@@ -34,6 +34,7 @@ import androidx.media3.exoplayer.hls.HlsMediaSource
 import androidx.media3.ui.PlayerView
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.drives.files.DriveFileProvider
+import id.homebase.api.file.safeDeleteRecursively
 import id.homebase.api.video.VideoContent
 import id.homebase.api.video.VideoPlayerData
 import id.homebase.api.video.VideoPreloader
@@ -74,7 +75,9 @@ actual fun VideoPlayerSurface(
     DisposableEffect(data) {
         onDispose {
             exoPlayer?.release()
-            tempDir?.deleteRecursively()
+            tempDir?.let { dir ->
+                dir.parent?.let { parent -> safeDeleteRecursively(parent, dir.name) }
+            }
         }
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MediaDownloadHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MediaDownloadHandler.kt
@@ -74,8 +74,12 @@ internal class MediaDownloadHandler(
                         "jpeg" -> "jpg"
                         else -> extension
                     }
-                    val tempPath = fileOperationsProvider.writeBytesToTempFile(
-                        bytes, "share_", ".$extension"
+                    // Cleartext copy of an end-to-end-encrypted Homebase
+                    // payload — sequestered into the share_outbound subdir so
+                    // the cold-start + foreground sweepers can reap it as a
+                    // single unit, bounding its on-disk lifetime.
+                    val tempPath = fileOperationsProvider.writeBytesToShareOutboundFile(
+                        bytes, ".$extension"
                     )
                     sendEvent(ShareFile(tempPath))
                 } else {

--- a/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.jvm.kt
+++ b/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.jvm.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.unit.sp
 import co.touchlab.kermit.Logger
 import com.sun.net.httpserver.HttpServer
 import id.homebase.api.client.drives.files.DriveFileProvider
+import id.homebase.api.file.safeDeleteRecursively
 import id.homebase.api.video.VideoContent
 import id.homebase.api.video.VideoPlayerData
 import id.homebase.api.video.VideoPreloader
@@ -97,7 +98,9 @@ actual fun VideoPlayerSurface(
     DisposableEffect(data) {
         onDispose {
             httpServer?.stop(0)
-            tempDir?.deleteRecursively()
+            tempDir?.let { dir ->
+                dir.parent?.let { parent -> safeDeleteRecursively(parent, dir.name) }
+            }
         }
     }
 

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/api/video/FFmpegUtilsCompressTrimIntegrationTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/api/video/FFmpegUtilsCompressTrimIntegrationTest.kt
@@ -1,7 +1,12 @@
 package id.homebase.api.video
 
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.file.safeDeleteRecursively
 import java.io.File
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -103,6 +108,96 @@ class FFmpegUtilsCompressTrimIntegrationTest {
             }
         } finally {
             File(fixturePath).delete()
+        }
+    }
+
+    /**
+     * End-to-end check of HLS segment-and-encrypt: the output is genuinely
+     * AES-128 encrypted, and the plaintext key material FFmpeg needed on disk
+     * during segmentation is deleted afterwards (issue #7).
+     */
+    @Test
+    fun segmentAndEncrypt_producesEncryptedHls_andDeletesKeyMaterial() = runTest {
+        assumeTrue(
+            "FFmpeg binaries not bundled in this test classpath",
+            FFmpegBinaryManager.isAvailable(),
+        )
+
+        val fixturePath = VideoTestHelper.copyToTempFile("sample.mp4")
+        try {
+            val result = FFmpegUtils.segmentAndEncryptVideo(
+                inputPath = fixturePath,
+                keyHeader = KeyHeader.newRandom16(),
+                onProgress = null,
+            )
+            assertNotNull(result, "segmentAndEncryptVideo must produce an HLS playlist + segment")
+            val (playlistPath, segmentPath) = result
+            val outputDir = File(playlistPath).parentFile!!
+
+            try {
+                // The encrypted segment + playlist exist...
+                assertTrue(File(playlistPath).exists(), "index.m3u8 must exist")
+                assertTrue(File(segmentPath).exists(), "index.ts must exist")
+
+                // ...the playlist proves the segment really was AES-128 encrypted, so the
+                // key-cleanup assertion below can't "pass" by silently skipping encryption...
+                val playlist = File(playlistPath).readText()
+                assertTrue(
+                    playlist.contains("#EXT-X-KEY") && playlist.contains("METHOD=AES-128"),
+                    "playlist must declare AES-128 encryption, was:\n$playlist",
+                )
+
+                // ...and the plaintext key material FFmpeg needed during segmentation is
+                // gone — it must not linger in the cache dir (issue #7).
+                assertFalse(File(outputDir, "enc.key").exists(), "enc.key must be deleted after segmentation")
+                assertFalse(File(outputDir, "keyinfo.txt").exists(), "keyinfo.txt must be deleted after segmentation")
+            } finally {
+                safeDeleteRecursively(outputDir.parent, outputDir.name)
+            }
+        } finally {
+            File(fixturePath).delete()
+        }
+    }
+
+    /**
+     * A failed segmentation must not leak its `hls_<uuid>/` working directory
+     * into the cache dir (issue #5).
+     */
+    @Test
+    fun segmentAndEncrypt_failedInput_leavesNoOutputDirBehind() = runTest {
+        assumeTrue(
+            "FFmpeg binaries not bundled in this test classpath",
+            FFmpegBinaryManager.isAvailable(),
+        )
+
+        // Garbage bytes with a video extension — FFmpeg cannot possibly segment this.
+        val corrupt = File.createTempFile("corrupt_", ".mp4")
+        corrupt.writeBytes(ByteArray(2048) { it.toByte() })
+
+        val tmpDir = File(System.getProperty("java.io.tmpdir"))
+        fun hlsDirNames(): Set<String> =
+            (tmpDir.listFiles { f -> f.isDirectory && f.name.startsWith("hls_") } ?: emptyArray())
+                .map { it.name }
+                .toSet()
+        val before = hlsDirNames()
+
+        try {
+            assertFailsWith<VideoSegmentException> {
+                FFmpegUtils.segmentAndEncryptVideo(
+                    inputPath = corrupt.absolutePath,
+                    keyHeader = KeyHeader.newRandom16(),
+                    onProgress = null,
+                )
+            }
+            // The hls_<uuid>/ dir created for the failed run must be cleaned up,
+            // not leaked into the cache dir (issue #5).
+            assertEquals(
+                before,
+                hlsDirNames(),
+                "a failed segmentation must not leave an hls_<uuid>/ directory behind",
+            )
+        } finally {
+            corrupt.delete()
         }
     }
 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
@@ -547,6 +547,7 @@ private class NoopFileOperationsProvider : FileOperationsProvider {
     override fun getCacheDirectory(): String = uniqueCacheDir
     override fun getFileSize(path: String) = nope()
     override suspend fun writeBytesToTempFile(bytes: ByteArray, prefix: String, suffix: String) = nope()
+    override suspend fun writeBytesToShareOutboundFile(bytes: ByteArray, suffix: String) = nope()
     override suspend fun writeStream(path: String, data: Flow<ByteArray>) = nope()
 }
 

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceTestFixture.kt
@@ -272,6 +272,7 @@ private class SenderNoopFileOperationsProvider : FileOperationsProvider {
     override fun getCacheDirectory(): String = uniqueCacheDir
     override fun getFileSize(path: String) = nope()
     override suspend fun writeBytesToTempFile(bytes: ByteArray, prefix: String, suffix: String) = nope()
+    override suspend fun writeBytesToShareOutboundFile(bytes: ByteArray, suffix: String) = nope()
     override suspend fun writeStream(path: String, data: Flow<ByteArray>) = nope()
 }
 

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/builder/LinkPreviewPayloadBuilderTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/builder/LinkPreviewPayloadBuilderTest.kt
@@ -124,6 +124,9 @@ private class RecordingFileOperationsProvider : FileOperationsProvider {
         return path
     }
 
+    override suspend fun writeBytesToShareOutboundFile(bytes: ByteArray, suffix: String): String =
+        error("not used in this test — share-outbound is for chat ShareMedia only")
+
     // Unused by LinkPreviewPayloadBuilder; throw so any future drift is loud.
     override fun openFileInput(path: String): InputProvider = error("not used in this test")
     override suspend fun readFileBytes(path: String): ByteArray = error("not used in this test")

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilderTrimTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilderTrimTest.kt
@@ -29,6 +29,9 @@ class MessageAttachmentBuilderTrimTest {
         override suspend fun writeBytesToTempFile(
             bytes: ByteArray, prefix: String, suffix: String,
         ): String = fail("writeBytesToTempFile")
+        override suspend fun writeBytesToShareOutboundFile(
+            bytes: ByteArray, suffix: String,
+        ): String = fail("writeBytesToShareOutboundFile")
         override suspend fun writeStream(path: String, data: Flow<ByteArray>) =
             fail<Unit>("writeStream")
         private fun <T> fail(name: String): T =

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/share/ShareCacheStorage.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/share/ShareCacheStorage.android.kt
@@ -1,6 +1,7 @@
 package id.homebase.core.share
 
 import android.content.Context
+import id.homebase.api.file.safeDeleteRecursively
 import java.io.File
 
 /**
@@ -38,9 +39,7 @@ actual class ShareCacheStorage(private val context: Context) {
     actual fun clearSharedContent() {
         File(cacheDir, SHARED_CONTENT_FILE).delete()
         // Clean up any shared media files
-        File(cacheDir, SHARED_FILES_SUBDIR).let { dir ->
-            if (dir.exists()) dir.deleteRecursively()
-        }
+        safeDeleteRecursively(cacheDir.absolutePath, SHARED_FILES_SUBDIR)
     }
 
     actual fun getSharedFilesDirectory(): String {

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -215,6 +215,7 @@
     <string name="storage_cache_unhealthy_body">One or more on-disk caches failed to initialise. Tap \"Clear caches\" to reset them — cached bytes will be lost but no primary data is affected.</string>
     <string name="storage_other_header">Other</string>
     <string name="storage_database">Database</string>
+    <string name="storage_other_cache_files">Other cached files</string>
 
     <!-- Defragmenter -->
     <string name="storage_defragment_button">Defragment</string>

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/share/ShareCacheStorage.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/share/ShareCacheStorage.jvm.kt
@@ -1,5 +1,6 @@
 package id.homebase.core.share
 
+import id.homebase.api.file.safeDeleteRecursively
 import java.io.File
 
 /**
@@ -39,7 +40,7 @@ actual class ShareCacheStorage {
 
     actual fun clearSharedContent() {
         File(cacheDir, "shared_content.json").delete()
-        File(cacheDir, "shared_files").let { if (it.exists()) it.deleteRecursively() }
+        safeDeleteRecursively(cacheDir.absolutePath, "shared_files")
     }
 
     actual fun getSharedFilesDirectory(): String {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -3,8 +3,9 @@ package id.homebase.core.di
 import co.touchlab.kermit.Logger
 import coil3.ImageLoader
 import id.homebase.api.di.apiModule
+import id.homebase.api.file.CacheAudit
+import id.homebase.api.file.CacheSweeper
 import id.homebase.api.file.FileOperationsProvider
-import id.homebase.api.file.safeDeleteRecursively
 import id.homebase.api.file.systemFileSystem
 import id.homebase.api.client.upgrade.IdentityUpgradeProvider
 
@@ -166,13 +167,23 @@ val appModule = module {
             driveFileProviderCached = get(),
             publicProfileProviderCached = get(),
             clearPlatformCaches = {
+                // Logout sweep. In dry-run for the broader cleanup; the orphan
+                // coil3_disk_cache is actually deleted by CacheSweeper now — that absorbs
+                // the role the standalone safeDeleteRecursively("coil3_disk_cache") line
+                // used to play here.
+                runCatching {
+                    CacheSweeper.sweepAll(CacheAudit.audit(fileOps.getCacheDirectory()))
+                }.onFailure {
+                    Logger.w(tag = "YouAuthFlowManager", throwable = it) {
+                        "logout cache sweep failed"
+                    }
+                }
                 runCatching { imageLoader.memoryCache?.clear() }
                     .onFailure {
                         Logger.w(tag = "YouAuthFlowManager", throwable = it) {
                             "coil memory cache clear failed on logout"
                         }
                     }
-                safeDeleteRecursively(fileOps.getCacheDirectory(), "coil3_disk_cache")
                 pendingUpgradeManager.reset()
             },
         )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -4,6 +4,7 @@ import co.touchlab.kermit.Logger
 import coil3.ImageLoader
 import id.homebase.api.di.apiModule
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.file.safeDeleteRecursively
 import id.homebase.api.file.systemFileSystem
 import id.homebase.api.client.upgrade.IdentityUpgradeProvider
 
@@ -157,7 +158,6 @@ val appModule = module {
     single {
         val imageLoader: ImageLoader = get()
         val fileOps: FileOperationsProvider = get()
-        val fileSystem = systemFileSystem
         val pendingUpgradeManager: PendingUpgradeManager = get()
         YouAuthFlowManager(
             driveSyncManager = get(),
@@ -172,14 +172,7 @@ val appModule = module {
                             "coil memory cache clear failed on logout"
                         }
                     }
-                runCatching {
-                    val orphan = "${fileOps.getCacheDirectory()}/coil3_disk_cache".toPath()
-                    if (fileSystem.exists(orphan)) fileSystem.deleteRecursively(orphan)
-                }.onFailure {
-                    Logger.w(tag = "YouAuthFlowManager", throwable = it) {
-                        "orphan coil disk cache delete failed on logout"
-                    }
-                }
+                safeDeleteRecursively(fileOps.getCacheDirectory(), "coil3_disk_cache")
                 pendingUpgradeManager.reset()
             },
         )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsScreen.kt
@@ -68,6 +68,7 @@ import id.homebase.resources.storage_defragment_button
 import id.homebase.resources.storage_drive_count_format
 import id.homebase.resources.storage_drives_header
 import id.homebase.resources.storage_drives_none
+import id.homebase.resources.storage_other_cache_files
 import id.homebase.resources.storage_other_header
 import id.homebase.resources.storage_total_cache_format
 import org.jetbrains.compose.resources.StringResource
@@ -224,10 +225,17 @@ fun StorageSettingsUi(
             SectionHeader(title = stringResource(MR.string.storage_other_header))
 
             Card(modifier = Modifier.fillMaxWidth()) {
-                SimpleSizeRow(
-                    label = stringResource(MR.string.storage_database),
-                    sizeBytes = uiState.databaseSizeBytes,
-                )
+                Column {
+                    SimpleSizeRow(
+                        label = stringResource(MR.string.storage_database),
+                        sizeBytes = uiState.databaseSizeBytes,
+                    )
+                    HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    SimpleSizeRow(
+                        label = stringResource(MR.string.storage_other_cache_files),
+                        sizeBytes = uiState.otherCacheBytes,
+                    )
+                }
             }
 
             Spacer(modifier = Modifier.height(24.dp))

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsUiState.kt
@@ -16,6 +16,12 @@ data class StorageSettingsUiState(
     // caches" to delete it) or a regression that reintroduced Coil's default
     // disk cache somewhere. Rendered as a red warning row.
     val orphanCoilDiskBytes: Long = 0L,
+    // Aggregate size of every top-level cache-directory entry the app does not
+    // track or cap — FFmpeg scratch (hls_*, compressed_*, ffmpeg-segmented-*),
+    // decrypted downloads, share temp files, the legacy hbvid_preload dir, etc.
+    // See CacheAudit. Surfaced so the gap between this and the tracked caches is
+    // visible without adb. Excludes the separately-shown orphanCoilDiskBytes.
+    val otherCacheBytes: Long = 0L,
     val isLoading: Boolean = true,
     val isClearing: Boolean = false,
     val uiEvent: StorageSettingsUiEvent? = null,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsViewModel.kt
@@ -8,7 +8,9 @@ import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.cache.CacheStats
 import id.homebase.api.client.drives.cache.DriveFileProviderCached
 import id.homebase.api.client.profile.PublicProfileProviderCached
+import id.homebase.api.file.CacheAudit
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.file.directorySizeBytes
 import id.homebase.api.file.systemFileSystem
 import id.homebase.api.sync.DriveSyncManager
 import id.homebase.api.sync.database.DatabaseManager
@@ -21,7 +23,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import okio.Path
 import okio.Path.Companion.toPath
 import kotlin.uuid.Uuid
 
@@ -101,6 +102,18 @@ class StorageSettingsViewModel(
                 probeOrphanCoilDiskCache()
             }
 
+            // Everything in the cache directory the app neither tracks nor caps.
+            // The orphan Coil dir is part of that untracked total but gets its
+            // own red warning row, so subtract it here to avoid double-counting.
+            val otherCacheBytes = withContext(Dispatchers.Default) {
+                runCatching {
+                    CacheAudit.audit(fileOperationsProvider.getCacheDirectory()).untrackedBytes
+                }.getOrElse {
+                    Logger.w(tag = "StorageSettings", throwable = it) { "cache audit failed" }
+                    0L
+                }
+            }
+
             _uiState.update {
                 it.copy(
                     caches = caches,
@@ -109,6 +122,7 @@ class StorageSettingsViewModel(
                     totalCacheBytes = total,
                     databaseSizeBytes = dbSize,
                     orphanCoilDiskBytes = orphanCoilBytes,
+                    otherCacheBytes = (otherCacheBytes - orphanCoilBytes).coerceAtLeast(0L),
                     isLoading = false,
                 )
             }
@@ -128,7 +142,7 @@ class StorageSettingsViewModel(
         return runCatching {
             val path = "${fileOperationsProvider.getCacheDirectory()}/coil3_disk_cache".toPath()
             if (!fileSystem.exists(path)) return@runCatching 0L
-            val total = directorySizeBytes(path)
+            val total = fileSystem.directorySizeBytes(path)
             if (total > 0L) {
                 Logger.e(tag = "StorageSettings") {
                     "orphan coil3_disk_cache detected: $total bytes at $path — " +
@@ -140,15 +154,6 @@ class StorageSettingsViewModel(
             Logger.w(tag = "StorageSettings", throwable = it) { "orphan coil disk probe failed" }
             0L
         }
-    }
-
-    private fun directorySizeBytes(dir: Path): Long {
-        var total = 0L
-        for (child in fileSystem.list(dir)) {
-            val meta = fileSystem.metadata(child)
-            total += if (meta.isDirectory) directorySizeBytes(child) else (meta.size ?: 0L)
-        }
-        return total
     }
 
     private suspend fun loadDriveRows(): List<DriveRowState> {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsViewModel.kt
@@ -9,9 +9,9 @@ import id.homebase.api.client.cache.CacheStats
 import id.homebase.api.client.drives.cache.DriveFileProviderCached
 import id.homebase.api.client.profile.PublicProfileProviderCached
 import id.homebase.api.file.CacheAudit
+import id.homebase.api.file.CacheSweeper
 import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.file.directorySizeBytes
-import id.homebase.api.file.safeDeleteRecursively
 import id.homebase.api.file.systemFileSystem
 import id.homebase.api.sync.DriveSyncManager
 import id.homebase.api.sync.database.DatabaseManager
@@ -200,7 +200,15 @@ class StorageSettingsViewModel(
                 .onFailure { Logger.w(tag = "StorageSettings", throwable = it) { "drive clearCaches failed" } }
             runCatching { imageLoader.memoryCache?.clear() }
                 .onFailure { Logger.w(tag = "StorageSettings", throwable = it) { "coil memory clear failed" } }
-            safeDeleteRecursively(fileOperationsProvider.getCacheDirectory(), "coil3_disk_cache")
+            // CacheSweeper absorbs the role of "delete orphan coil3_disk_cache" + adds
+            // diagnostic logging for any other untracked entries — replaces the
+            // standalone safeDeleteRecursively("coil3_disk_cache") line that used to
+            // live here.
+            runCatching {
+                CacheSweeper.sweepUntracked(CacheAudit.audit(fileOperationsProvider.getCacheDirectory()))
+            }.onFailure {
+                Logger.w(tag = "StorageSettings", throwable = it) { "post-clear cache sweep failed" }
+            }
             _uiState.update { it.copy(isClearing = false, uiEvent = StorageSettingsUiEvent.CachesCleared) }
             load()
         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsViewModel.kt
@@ -11,6 +11,7 @@ import id.homebase.api.client.profile.PublicProfileProviderCached
 import id.homebase.api.file.CacheAudit
 import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.file.directorySizeBytes
+import id.homebase.api.file.safeDeleteRecursively
 import id.homebase.api.file.systemFileSystem
 import id.homebase.api.sync.DriveSyncManager
 import id.homebase.api.sync.database.DatabaseManager
@@ -199,10 +200,7 @@ class StorageSettingsViewModel(
                 .onFailure { Logger.w(tag = "StorageSettings", throwable = it) { "drive clearCaches failed" } }
             runCatching { imageLoader.memoryCache?.clear() }
                 .onFailure { Logger.w(tag = "StorageSettings", throwable = it) { "coil memory clear failed" } }
-            runCatching {
-                val orphan = "${fileOperationsProvider.getCacheDirectory()}/coil3_disk_cache".toPath()
-                if (fileSystem.exists(orphan)) fileSystem.deleteRecursively(orphan)
-            }.onFailure { Logger.w(tag = "StorageSettings", throwable = it) { "orphan coil disk clear failed" } }
+            safeDeleteRecursively(fileOperationsProvider.getCacheDirectory(), "coil3_disk_cache")
             _uiState.update { it.copy(isClearing = false, uiEvent = StorageSettingsUiEvent.CachesCleared) }
             load()
         }


### PR DESCRIPTION
  Summary

  Investigation into Android reporting ~4 GB of app "Cache" while the in-app Storage screen accounted for only ~710 MB. Root cause: scratch files written
  straight into context.cacheDir that nothing tracked, capped, or evicted — FFmpeg compress/segment output, leaked HLS scratch dirs, decrypted share-out
  cleartext, share-in / picker temps, plus a plaintext AES key sitting next to the encrypted segments.

  This branch ships:
  1. A startup audit + diagnostics so the breakdown is visible in adb logcat and the in-app Storage screen.
  2. A guarded recursive-delete utility that every cleanup site now goes through.
  3. Per-leak fixes at every terminal state (success, retry-exhaustion, FFmpeg failure, kill-mid-flow).
  4. A cold-start sweeper as the safety net for kills, crashes, and any future leak we miss.
  5. A foreground-event re-sweep specifically for the security-relevant share-out cleartext.

  Validated on a real Android device (Frodo): five boots captured in homebase.log. The first cold start after install reclaimed 405 MB. A deliberate
  kill-mid-compression test confirmed the orphaned compressed_*.mp4 was caught by the next cold start (138 MB freed). Steady-state cacheDir is now ~24 MB —
  homebase-payloads-v2 (Coil, capped) + WebView/ (Android system, sacred).

  Commits (12)

  #: 1
  Commit: e995c264
  What it does: Diagnostics: CacheAudit + StartupCacheAudit + Storage Settings "Other cached files" row. #7 fix: deleteHlsKeyMaterial reaps the plaintext
  AES
    enc.key + keyinfo.txt that FFmpeg requires on disk during HLS segmentation.
  ────────────────────────────────────────
  #: 2
  Commit: 3f3bf54a
  What it does: #5: deleteFailedFfmpegOutput wired into all 9 FFmpeg failure paths (compress / segment / segmentAndEncrypt across Android, JVM, native). #9:

    safeDeleteRecursively — every recursive-delete call site now goes through one guarded helper (refuses unless baseDir is non-blank/absolute, sub-path is
    non-blank/relative/no-../strictly-under-base).
  ────────────────────────────────────────
  #: 3
  Commit: 3c018beb
  What it does: Real-FFmpeg integration test coverage for #5 + #7 (uses bundled FFmpeg + sample.mp4 fixture).
  ────────────────────────────────────────
  #: 4
  Commit: 76e87246
  What it does: CacheSweeper introduced as the single decision point for cleanup, initially dry-run (log-only). One exception: coil3_disk_cache is deleted
  on
    sight (consolidates the rogue cleanup lines that used to live in AppModule logout + StorageSettingsViewModel.clearCaches). Pure decide() function for
    unit testing.
  ────────────────────────────────────────
  #: 5
  Commit: 767cb703
  What it does: #6: cleanupHlsScratch — recursive-deletes hls_<uuid>/ after Outbox delivery. Wired at both terminal states: DriveUploadProvider success path

    AND OutboxSync.outboxSend drop branch (20-retry exhaustion / terminal error code). Derives the parent dir from PayloadFile.filePath — no schema change,
    no signature plumbing.
  ────────────────────────────────────────
  #: 6
  Commit: ed42f145
  What it does: Sacred set: WebView/, oat_primary/, data/, Crash Reports/ are owned by the Android platform / WebView / Crashlytics. androidSystem=true flag

    on Entry; decide() returns KEEP regardless of mode (even on logout / "Clear caches"). Wiping any of these would nuke browser cookies, force a slow ART
    recompile, or lose pending crash reports.
  ────────────────────────────────────────
  #: 7
  Commit: 38cd64dc
  What it does: Security: MediaDownloadHandler.handleShareMedia decrypts an end-to-end-encrypted Homebase payload to cleartext for Intent.ACTION_SEND. Was
    named share_<5-6 chars>.<ext> at the cacheDir top level and never deleted. Sequestered into <cacheDir>/share_outbound/ via new
    FileOperationsProvider.writeBytesToShareOutboundFile (Android/JVM/iOS); reaped via (a) cold-start sweep and (b) ProcessLifecycleOwner ON_START observer
    in MainApplication — bounds on-disk lifetime to "user's time in another app". CacheAudit.classify now distinguishes share-OUT (security-relevant) from
    resolved_* share-IN / picker temps (not security-relevant; gallery already had the bytes).
  ────────────────────────────────────────
  #: 8
  Commit: 17e70f75
  What it does: Flip CacheSweeper from dry-run to real delete. Validated against the real-device cold-boot audit before flipping.
  ────────────────────────────────────────
  #: 9
  Commit: 3d4fe23f
  What it does: OutboxSync drop branch now also reaps the per-file payload temps (most importantly the resolved_*.mp4/.jpeg files that
    AndroidFileOperationsProvider's SAF adapter writes when materializing a content:// URI for upload — measured at ~338 MB on one real device from two
    unsent share-target MP4s). Skips content:// URIs we don't own.
  ────────────────────────────────────────
  #: 10
  Commit: 830426b9
  What it does: compressed_*.mp4 reaped after Phase 5 metadata read in VideoPayloadProcessor — its bytes have already been re-encoded into the HLS segment
  or
    the encrypted payload. Skipped when compressVideo fell back to the input path (no compression actually happened).
  ────────────────────────────────────────
  #: 11
  Commit: 293beaa9
  What it does: Sweep diagnostics: post-sweep re-measurement so the log reads before=N after=M reclaimed=K bytes (X MB → Y MB, freed Z MB). Without this the

    sweep is opaque on real devices — the up-front "deleting=N" line is intent, not outcome.
  ────────────────────────────────────────
  #: 12
  Commit: 87ba754a
  What it does: Cosmetic fix caught by the diagnostics in commit 11: CacheAudit was lumping androidSystem dirs into untrackedBytes, so the sweeper logged
    "deleting 11.9 MB (untracked)" for entries it would actually KEEP, and "freed=0 MB" looked like a delete failure. Three disjoint buckets — known /
    untracked / androidSystem — and the sweep headers report each separately.

  Architecture

  Diagnostics (homebase-api/.../file/)
  - CacheAudit — read-only inventory of cacheDir's top-level entries; classifies each as tracked Coil (4 -v2 dirs), Android-system (sacred), or untracked.
  Three disjoint byte buckets.
  - StartupCacheAudit — runs once at startup via Koin createdAtStart (off-main); logs the report and triggers sweepUntracked + sweepShareOutbound.
  - Storage Settings screen — new "Other cached files" row surfaces the untracked total without adb.

  Cleanup helpers (homebase-api/.../file/, homebase-api/.../client/drives/upload/)
  - safeDeleteRecursively(baseDir, relativeSubPath) — every recursive-delete in the repo now goes through this one guarded helper. Refuses unless baseDir is
   non-blank/absolute (≥4 chars + parent), relativeSubPath is non-blank/non-absolute/no-../strictly-under-base. Logs ERROR on refusal, returns false,
  deletes nothing.
  - deleteHlsKeyMaterial — removes the plaintext AES key + keyinfo.txt the FFmpeg HLS encrypter requires on disk.
  - deleteFailedFfmpegOutput — handles a file or a directory; wired into all 9 FFmpeg failure paths.
  - cleanupHlsScratch — derives hls_<uuid>/ from PayloadFile.filePath.parent; called from upload success AND outbox drop.
  - sweepShareOutbound — recursive-deletes <cacheDir>/share_outbound/.

  Decision point (homebase-api/.../file/CacheSweeper.kt)
  - sweepUntracked(report) — startup reclaim. Deletes everything that isn't a tracked Coil cache or an Android system dir.
  - sweepAll(report) — logout reclaim. Also deletes the -v2 Coil caches. Android system dirs still kept.
  - Pure decide(entry, mode) -> SweepAction so the rules unit-test without log capture.
  - Special case: coil3_disk_cache is logged at ERROR and deleted on sight regardless of mode (its existence means something bypassed our configured
  ImageLoader).

  Defense in depth for share-out cleartext
  - Sequestered into a dedicated subdir (not the cacheDir top level).
  - Cold-start sweep on every launch (StartupCacheAudit).
  - Foreground-event sweep on every ProcessLifecycleOwner ON_START (MainApplication.registerShareOutboundForegroundSweep) — bounds on-disk lifetime to the
  user's time in another app.
  - Logout sweep (the sweepAll already covers it).

  Tests (~530 new lines of test code)

  All test-first (red stub → failing test → impl → green), all using okio FakeFileSystem so they run cross-platform from commonTest:

  ┌─────────────────────────────────────────────────────┬───────────────────────────────────────────────────────────────────────────────────────────────┐
  │                      Test file                      │                                         What it pins                                          │
  ├─────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
  │ CacheAuditTest                                      │ Three-bucket classification (known / untracked / androidSystem), labels, missing/empty        │
  │                                                     │ cacheDir handling                                                                             │
  ├─────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
  │ CacheSweeperTest                                    │ Sweep modes, sacred-set kept regardless of mode, real bytes reclaimed (not just intent),      │
  │                                                     │ orphan-coil always deleted                                                                    │
  ├─────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
  │ SafeDeleteTest                                      │ All 9 guard rejections (blank, root, .., absolute sub-path, etc.) + happy paths               │
  ├─────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
  │ HlsKeyMaterialTest                                  │ Both files removed; idempotent on partial state                                               │
  ├─────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
  │ FfmpegOutputCleanupTest                             │ File + directory branches                                                                     │
  ├─────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ShareOutboundCleanupTest                            │ Success / no-op / idempotent / guard-refusal                                                  │
  ├─────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
  │ HlsScratchCleanupTest                               │ hls dir reaped, non-hls left alone, mixed payloads, null/empty input, idempotent              │
  ├─────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
  │ FFmpegUtilsCompressTrimIntegrationTest              │ Real FFmpeg + sample.mp4 fixture: AES-128 declared in playlist, key material gone afterwards, │
  │                                                     │  no leaked dir on failed input                                                                │
  ├─────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
  │ MessageAttachmentBuilderTrimTest (+ 6 other test    │ Updated for the new writeBytesToShareOutboundFile contract                                    │
  │ fixtures)                                           │                                                                                               │
  └─────────────────────────────────────────────────────┴───────────────────────────────────────────────────────────────────────────────────────────────┘

  On-device validation (Android, Frodo)

  Five boots captured in homebase.log:

  ┌─────┬──────────┬─────────────────┬─────────┬────────────────────────────────────────────────────────────────────────────────────────────────────────┐
  │  #  │   Time   │  Total → After  │  Freed  │                                                  Note                                                  │
  ├─────┼──────────┼─────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ 1   │ 08:48:54 │ 443 MB → 443 MB │ 0       │ Last DRY-RUN boot before the flip                                                                      │
  ├─────┼──────────┼─────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ 2   │ 08:49:10 │ 422.8 MB → 17.7 │ 405.1   │ First real-delete boot — full backlog gone                                                             │
  │     │          │  MB             │ MB      │                                                                                                        │
  ├─────┼──────────┼─────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ 3   │ 08:51:32 │ 151.6 MB → 21.1 │ 130.4   │ After clean video send. No compressed_* and no hls_* survived — in-flow cleanup worked end-to-end      │
  │     │          │  MB             │ MB      │                                                                                                        │
  ├─────┼──────────┼─────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ 4   │ 08:51:59 │ 161.9 MB → 23.7 │ 138.1   │ Kill-mid-compression test. Found the orphaned compressed_*.mp4 (10.7 MB) + the 134 MB resolved_* input │
  │     │          │  MB             │ MB      │  — sweep caught both                                                                                   │
  ├─────┼──────────┼─────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ 5   │ 08:53:39 │ 23.7 MB → 23.7  │ 0       │ Steady state. Nothing left to delete                                                                   │
  │     │          │ MB              │         │                                                                                                        │
  └─────┴──────────┴─────────────────┴─────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────┘

  Steady-state 23.7 MB breakdown: 11.4 MB homebase-payloads-v2/ (Coil, LRU-capped) + 11.4 MB WebView/ (Android system, sacred) + ~1 MB other tracked Coil
  caches + 5 KB Crash Reports/.

  Out of scope (deferred)

  - WebView in-app browser cache cap (the sacred 11.4 MB WebView/ dir on the test device — bounded but uncapped). Separate branch when prioritized.
  - Desktop-only index.ts.tmp FFmpeg leftover (minor; Desktop-only, doesn't appear on Android).