### PR TITLE
refactor(cache): drop dead hbvid_preload mop-up sites

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
@@ -514,8 +514,6 @@ class DriveFileProviderCached(
             Logger.w(tag = "DriveFileProviderCached", throwable = e) { "thumb cache clear failed" }
         }
 
-        safeDeleteRecursively(directory, "hbvid_preload")
-
         notFoundCache = emptySet()
     }
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPreloader.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPreloader.kt
@@ -2,7 +2,6 @@ package id.homebase.api.video
 
 import co.touchlab.kermit.Logger
 import id.homebase.api.file.FileOperationsProvider
-import id.homebase.api.file.safeDeleteRecursively
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -132,10 +131,5 @@ class VideoPreloader(
         val mutex = mapLock.withLock { mutexMap.getOrPut(key) { Mutex() } }
         mutex.withLock {}  // wait for any in-progress download to finish
         return null
-    }
-
-    /** Deletes any legacy pre-decrypted files written by older builds. */
-    fun clearCache() {
-        safeDeleteRecursively(fileOperationsProvider.getCacheDirectory(), "hbvid_preload")
     }
 }


### PR DESCRIPTION
Both call sites that purge <cacheDir>/hbvid_preload/ are now redundant with the startup CacheSweeper that landed in #cache-diagnostics-hls-key-cleanup, and one of them was already orphaned. The directory is a legacy artifact of older VideoPreloader builds that wrote pre-decrypted video bytes to disk; the current implementation does not write there at all (awaitPreloadedFile always returns null and decryption happens at playback time).

Removed:

1. VideoPreloader.clearCache() — zero callers anywhere in the repo. Pure dead code. Drops the unused safeDeleteRecursively import too.

2. The inline `safeDeleteRecursively(directory, "hbvid_preload")` line in DriveFileProviderCached.clearCaches() — ran on every "Clear caches" tap in Storage Settings and on every logout, for no live effect. The DriveFileProviderCached import of safeDeleteRecursively stays: it is still used by the init-time pre-v2 Coil migration deletes (homebase-payloads, homebase-thumbs) which are out of scope here.

Why this is safe:

- hbvid_preload is not in CacheAudit.KNOWN_CACHE_DIRS and not in ANDROID_SYSTEM_DIRS (the sacred set), so CacheSweeper.decide returns DELETE for it on every cold start. The on-device boot logs already show this working.
- CacheSweeperTest pins the contract: decide(entry("hbvid_preload"), UNTRACKED) == DELETE so a future refactor that breaks the sweep's reach would fail the unit test before it could leave hbvid_preload undeleted.
- If we are wrong about either premise, the worst case is one cold-start sweep tick of disk that the next sweep tick reclaims.

Verified: homebase-api:jvmTest --rerun-tasks green.