### PR TITLE
fix(dice): stop shake from crashing or corrupting 1d4 rolls

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/dice/BattleRollSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/dice/BattleRollSheet.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.runtime.toMutableStateList
@@ -59,11 +60,9 @@ import id.homebase.resources.chat_dice_roll
 import id.homebase.resources.chat_dice_rolling
 import id.homebase.resources.chat_dice_shake_hint
 import id.homebase.resources.menu_back
-import kotlin.random.Random
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
@@ -152,12 +151,13 @@ private fun BattleRollSheetContent(
             roll(count = initialCount, faces = faces, shakeSamples = seed)
         }
         scope.launch {
-            for (frame in 0 until TUMBLE_FRAMES) {
-                for (i in 0 until initialCount) {
-                    displayValues[i] = Random.nextInt(1, faces + 1)
-                }
-                delay(TUMBLE_FRAME_MS)
-            }
+            runTumble(
+                frames = TUMBLE_FRAMES,
+                count = initialCount,
+                faces = faces,
+                displayValues = displayValues,
+                frameDelayMs = TUMBLE_FRAME_MS,
+            )
             while (displayValues.size < finalResults.size) displayValues.add(null)
             for (i in finalResults.indices) displayValues[i] = finalResults[i]
             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -196,12 +196,17 @@ private fun BattleRollSheetContent(
         }
     }
 
+    // See note in DiceRollComposerSheet — without rememberUpdatedState, the
+    // long-running collect captures the first composition's `doRoll`, whose
+    // `initialCount` snapshot can disagree with `displayValues.size` after a
+    // chainDescriptors update re-keys `displayValues`.
+    val currentDoRoll by rememberUpdatedState(doRoll)
     LaunchedEffect(shakeDetector.isAvailable) {
         if (!shakeDetector.isAvailable) return@LaunchedEffect
         shakeDetector.events().collect { event ->
             shakeSamples = event.accelSamples
             shakeTriggered = true
-            doRoll()
+            currentDoRoll()
         }
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/dice/DiceRollComposerSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/dice/DiceRollComposerSheet.kt
@@ -42,12 +42,14 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
@@ -167,13 +169,13 @@ private fun DiceRollComposerContent(
             // Tumble animation: cycle through random faces, then settle. For
             // OE we tumble the initial 2-die pair only; the trailing chain (if
             // any) pops in when rolling completes.
-            val frames = TUMBLE_FRAMES
-            for (frame in 0 until frames) {
-                for (i in 0 until count) {
-                    displayValues[i] = Random.nextInt(1, faces + 1)
-                }
-                delay(TUMBLE_FRAME_MS)
-            }
+            runTumble(
+                frames = TUMBLE_FRAMES,
+                count = count,
+                faces = faces,
+                displayValues = displayValues,
+                frameDelayMs = TUMBLE_FRAME_MS,
+            )
             // Grow the preview list to fit the full OE chain before stamping
             // in the final faces.
             while (displayValues.size < finalResults.size) displayValues.add(null)
@@ -221,12 +223,18 @@ private fun DiceRollComposerContent(
     }
 
     // Subscribe to shake events while the composer is open (when available).
+    // The collect lambda lives for the lifetime of this composition, so it
+    // would otherwise capture the *first* composition's `doRoll` — whose
+    // `count` snapshot can disagree with `displayValues.size` once the user
+    // toggles OE / changes the count. `rememberUpdatedState` re-binds on
+    // every recomposition so a shake always invokes the current `doRoll`.
+    val currentDoRoll by rememberUpdatedState(doRoll)
     LaunchedEffect(shakeDetector.isAvailable) {
         if (!shakeDetector.isAvailable) return@LaunchedEffect
         shakeDetector.events().collect { event ->
             shakeSamples = event.accelSamples
             shakeTriggered = true
-            doRoll()
+            currentDoRoll()
         }
     }
 
@@ -492,6 +500,7 @@ private fun OpenEndedToggle(
                 checked = checked,
                 onCheckedChange = onCheckedChange,
                 enabled = enabled,
+                modifier = Modifier.testTag(DICE_OE_TOGGLE_TAG),
             )
         }
         if (checked) {
@@ -504,8 +513,34 @@ private fun OpenEndedToggle(
     }
 }
 
+internal const val DICE_OE_TOGGLE_TAG = "dice_oe_toggle"
+
 private const val TUMBLE_FRAMES = 6
 private const val TUMBLE_FRAME_MS = 80L
+
+/**
+ * Tumble animation inner loop, extracted so it can be unit-tested. The upper
+ * bound is clamped against `displayValues.size` because the list can be
+ * resized mid-flight by `LaunchedEffect(count, faces)` if the user toggles
+ * mode while a stale `doRoll` (captured pre-toggle) is still running — see
+ * the `rememberUpdatedState(doRoll)` note above.
+ */
+internal suspend fun runTumble(
+    frames: Int,
+    count: Int,
+    faces: Int,
+    displayValues: SnapshotStateList<Int?>,
+    frameDelayMs: Long,
+    randomFace: (Int) -> Int = { faceCount -> Random.nextInt(1, faceCount + 1) },
+) {
+    for (frame in 0 until frames) {
+        val limit = minOf(count, displayValues.size)
+        for (i in 0 until limit) {
+            displayValues[i] = randomFace(faces)
+        }
+        delay(frameDelayMs)
+    }
+}
 
 private fun coerceFaces(value: Int): Int =
     if (value in DiceRollDescriptor.ALLOWED_FACES) value else DiceRollPreferences.DEFAULT_FACES

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/content/MessageContentParser.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/content/MessageContentParser.kt
@@ -65,7 +65,20 @@ object MessageContentParser {
         if (descriptor.isValid()) {
             MessageContent.DiceRoll(descriptor)
         } else {
-            Logger.w(tag = TAG) { "DiceRoll descriptor failed validation; faces=${descriptor.faces} chainSize=${descriptor.rolls.size}" }
+            // Include mode + first chain entry's results.size + sample so the
+            // log says *why* validation failed, not just "it failed". Without
+            // this the build-1420 mode=OE + faces=4 stale-closure bug was
+            // indistinguishable from any other invalid descriptor.
+            val first = descriptor.rolls.firstOrNull()
+            val sample = first?.results?.take(4)?.joinToString(",") ?: "(none)"
+            Logger.w(tag = TAG) {
+                "DiceRoll descriptor failed validation; " +
+                    "faces=${descriptor.faces} " +
+                    "mode=${descriptor.mode} " +
+                    "chainSize=${descriptor.rolls.size} " +
+                    "firstResultsSize=${first?.results?.size ?: 0} " +
+                    "firstResultsSample=[$sample]"
+            }
             MessageContent.DiceRoll(descriptor = null)
         }
     } catch (e: Exception) {

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/dice/Dice1d4RoundTripTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/dice/Dice1d4RoundTripTest.kt
@@ -1,0 +1,292 @@
+package id.homebase.chat.dice
+
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import id.homebase.api.common.OdinId
+import id.homebase.chat.services.ChatProtocol
+import id.homebase.chat.services.content.MessageContent
+import id.homebase.chat.services.content.MessageContentParser
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * Reproduction tests for the "Ancient roll" bug seen in `homebase2.log`:
+ *
+ *   Warn: (MessageContentParser) DiceRoll descriptor failed validation; faces=4 chainSize=1
+ *
+ * The user sent a 1d4 from the dice composer; their own client logged this
+ * warning seven times (optimistic write, WS push echo, ChatMessageStream
+ * incremental batches) and the bubble rendered as "Ancient roll" (the
+ * `chat_dice_unparseable` string). Existing tests cover faces=6/12/20, never 4.
+ */
+class Dice1d4RoundTripTest {
+
+    @Test
+    fun freshly_built_1d4_standard_is_valid() {
+        val descriptor = build1d4(odinId = "alice.test", result = 3)
+        assertTrue(descriptor.isValid(), "freshly built 1d4 standard must be valid")
+    }
+
+    @Test
+    fun roundtrip_1d4_standard_validates() {
+        val descriptor = build1d4(odinId = "alice.test", result = 3)
+        val json = MessageContentParser.serialize(MessageContent.DiceRoll(descriptor))
+        println("1d4 standard wire JSON: $json")
+
+        val parsed = MessageContentParser.parse(
+            ChatProtocol.ChatDiceRollMessageDataType,
+            json,
+        )
+        val diceRoll = assertIs<MessageContent.DiceRoll>(parsed)
+        val roundTripped = assertNotNull(
+            diceRoll.descriptor,
+            "round-tripped 1d4 descriptor must not be null (would render as Ancient roll)",
+        )
+        assertTrue(
+            roundTripped.isValid(),
+            "round-tripped 1d4 descriptor must validate (mode=${roundTripped.mode} faces=${roundTripped.faces})",
+        )
+        assertEquals(descriptor, roundTripped, "round-trip must preserve all fields")
+    }
+
+    @Test
+    fun roundtrip_each_allowed_face_validates() {
+        for (faces in DiceRollDescriptor.ALLOWED_FACES) {
+            val descriptor = DiceRollDescriptor(
+                faces = faces,
+                mode = DiceRollMode.Standard,
+                rolls = listOf(
+                    ChainRoll(
+                        messageId = Uuid.random(),
+                        odinId = OdinId("alice.test"),
+                        results = listOf(faces),
+                        rolledAtUtcMs = 1_700_000_000_000L,
+                        source = RollSource.LocalRandom,
+                    ),
+                ),
+            )
+            assertTrue(descriptor.isValid(), "freshly built 1d$faces must be valid")
+            val json = MessageContentParser.serialize(MessageContent.DiceRoll(descriptor))
+            val parsed = MessageContentParser.parse(
+                ChatProtocol.ChatDiceRollMessageDataType,
+                json,
+            ) as MessageContent.DiceRoll
+            assertNotNull(parsed.descriptor, "1d$faces round-trip must not produce null descriptor — wire JSON: $json")
+            assertTrue(parsed.descriptor!!.isValid(), "1d$faces round-tripped must validate — wire JSON: $json")
+        }
+    }
+
+    @Test
+    fun roundtrip_1d4_with_user_odin_id_and_shake_seeded_validates() {
+        val descriptor = DiceRollDescriptor(
+            faces = 4,
+            mode = DiceRollMode.Standard,
+            rolls = listOf(
+                ChainRoll(
+                    messageId = Uuid.parse("7a8268c1-79bf-4e04-9158-4804d86335af"),
+                    odinId = OdinId("michael.seifert.page"),
+                    results = listOf(3),
+                    rolledAtUtcMs = 1_778_765_750_409L,
+                    source = RollSource.ShakeSeeded,
+                ),
+            ),
+        )
+        assertTrue(descriptor.isValid())
+
+        val json = MessageContentParser.serialize(MessageContent.DiceRoll(descriptor))
+        println("1d4 (production-shape) wire JSON: $json")
+
+        val parsed = MessageContentParser.parse(
+            ChatProtocol.ChatDiceRollMessageDataType,
+            json,
+        ) as MessageContent.DiceRoll
+        val roundTripped = assertNotNull(parsed.descriptor)
+        assertTrue(
+            roundTripped.isValid(),
+            "production-shape 1d4 must round-trip valid — wire JSON: $json",
+        )
+        assertEquals(RollSource.ShakeSeeded, roundTripped.rolls.first().source)
+    }
+
+    @Test
+    fun roundtrip_oe_then_standard_preserves_mode_field() {
+        val oe = DiceRollDescriptor(
+            faces = 10,
+            mode = DiceRollMode.OpenEndedD100,
+            rolls = listOf(
+                ChainRoll(
+                    messageId = Uuid.random(),
+                    odinId = OdinId("alice.test"),
+                    results = listOf(7, 7),
+                    rolledAtUtcMs = 1_700_000_000_000L,
+                ),
+            ),
+        )
+        val oeJson = MessageContentParser.serialize(MessageContent.DiceRoll(oe))
+        println("OE wire JSON: $oeJson")
+        val oeParsed =
+            (MessageContentParser.parse(ChatProtocol.ChatDiceRollMessageDataType, oeJson) as MessageContent.DiceRoll)
+                .descriptor
+        assertNotNull(oeParsed)
+        assertEquals(DiceRollMode.OpenEndedD100, oeParsed!!.mode, "OE mode must survive round-trip — JSON: $oeJson")
+
+        val standard = build1d4(odinId = "alice.test", result = 3)
+        val stdJson = MessageContentParser.serialize(MessageContent.DiceRoll(standard))
+        println("Standard wire JSON: $stdJson")
+        val stdParsed =
+            (MessageContentParser.parse(ChatProtocol.ChatDiceRollMessageDataType, stdJson) as MessageContent.DiceRoll)
+                .descriptor
+        assertNotNull(stdParsed)
+        assertEquals(DiceRollMode.Standard, stdParsed!!.mode, "Standard mode must survive round-trip — JSON: $stdJson")
+    }
+
+    @Test
+    fun descriptor_with_oe_mode_and_faces_4_is_explicitly_invalid() {
+        val descriptor = DiceRollDescriptor(
+            faces = 4,
+            mode = DiceRollMode.OpenEndedD100,
+            rolls = listOf(
+                ChainRoll(
+                    messageId = Uuid.random(),
+                    odinId = OdinId("alice.test"),
+                    results = listOf(3, 3),
+                    rolledAtUtcMs = 1_700_000_000_000L,
+                ),
+            ),
+        )
+        assertFalse(
+            descriptor.isValid(),
+            "OE mode requires faces=10 — a faces=4 OE descriptor would be the production failure shape",
+        )
+    }
+
+    /**
+     * Root-cause regression for the "Ancient roll" bug seen in `homebase2.log`.
+     *
+     * Build 1.3.1420's composer had:
+     *   var mode by remember { mutableStateOf(initialMode) }          // state
+     *   val faces = if (mode == OE) 10 else standardFaces             // plain val
+     *
+     * `mode` is a state delegate (read inside a lambda re-reads from the
+     * snapshot). `faces` is a plain `val` (captured at the composition
+     * where the lambda was created). A long-running lambda — the shake
+     * handler's `LaunchedEffect(shakeDetector.isAvailable) { collect {
+     * doRoll() } }` — held the FIRST composition's `doRoll`. When the user
+     * toggled OE on, `mode` flipped in state but the captured `doRoll`
+     * still owned `faces = 4`. The next shake invoked that stale `doRoll`,
+     * which read `mode = OE` (fresh) and used `faces = 4` (stale), producing
+     * a `DiceRollDescriptor(faces=4, mode=OpenEndedD100, …)` — invalid by
+     * the OE branch's `if (faces != 10) return false`, rendered as
+     * "Ancient roll".
+     *
+     * The previous-task fix (`rememberUpdatedState(doRoll)` in
+     * `DiceRollComposerSheet.kt` and `BattleRollSheet.kt`) makes the shake
+     * handler always invoke the LATEST `doRoll`, whose `faces` was captured
+     * in the SAME composition as the current `mode` — so they can't
+     * diverge.
+     *
+     * This test exercises both sides of the cure: a stale-captured closure
+     * (the pre-fix shape) produces an invalid descriptor; a fresh-captured
+     * closure (the post-fix shape) produces a valid one.
+     */
+    @Test
+    fun staleClosure_buildsInvalidDescriptor_freshClosure_buildsValid() {
+        val mode = mutableStateOf(DiceRollMode.Standard)
+        val standardFaces = mutableIntStateOf(4)
+        val standardCount = mutableIntStateOf(1)
+
+        // ---- Composition 1: mode = Standard ----
+        // The composer evaluates `faces` and `count` as plain `val`s here.
+        // A lambda captured now closes over these values.
+        val facesAtComposition1 =
+            if (mode.value == DiceRollMode.OpenEndedD100) 10 else standardFaces.intValue
+        val countAtComposition1 =
+            if (mode.value == DiceRollMode.OpenEndedD100) 2 else standardCount.intValue
+        val staleDoRoll: () -> DiceRollDescriptor = {
+            val finalResults = if (mode.value == DiceRollMode.OpenEndedD100) {
+                listOf(5, 7) // stand-in for rollOpenEndedD100
+            } else {
+                List(countAtComposition1) { 3 } // stand-in for roll(count, faces)
+            }
+            DiceRollDescriptor(
+                faces = facesAtComposition1,
+                mode = mode.value,
+                rolls = listOf(
+                    ChainRoll(
+                        messageId = Uuid.random(),
+                        odinId = OdinId("alice.test"),
+                        results = finalResults,
+                        rolledAtUtcMs = 1_700_000_000_000L,
+                    ),
+                ),
+            )
+        }
+
+        // ---- User toggles OE on ----
+        mode.value = DiceRollMode.OpenEndedD100
+
+        // ---- Composition 2: mode = OE ----
+        // The composer re-evaluates `faces`/`count` for the new mode.
+        val facesAtComposition2 =
+            if (mode.value == DiceRollMode.OpenEndedD100) 10 else standardFaces.intValue
+        val countAtComposition2 =
+            if (mode.value == DiceRollMode.OpenEndedD100) 2 else standardCount.intValue
+        val freshDoRoll: () -> DiceRollDescriptor = {
+            val finalResults = if (mode.value == DiceRollMode.OpenEndedD100) {
+                listOf(5, 7)
+            } else {
+                List(countAtComposition2) { 3 }
+            }
+            DiceRollDescriptor(
+                faces = facesAtComposition2,
+                mode = mode.value,
+                rolls = listOf(
+                    ChainRoll(
+                        messageId = Uuid.random(),
+                        odinId = OdinId("alice.test"),
+                        results = finalResults,
+                        rolledAtUtcMs = 1_700_000_000_000L,
+                    ),
+                ),
+            )
+        }
+
+        // ---- Pre-fix: shake's LaunchedEffect held the stale closure ----
+        val stale = staleDoRoll()
+        assertEquals(DiceRollMode.OpenEndedD100, stale.mode, "stale closure reads CURRENT mode")
+        assertEquals(4, stale.faces, "stale closure uses CAPTURED faces (=4)")
+        assertFalse(
+            stale.isValid(),
+            "stale closure builds INVALID descriptor (mode=OE, faces=4) — this is the Ancient roll bug from homebase2.log",
+        )
+
+        // ---- Post-fix: rememberUpdatedState invokes the fresh closure ----
+        val fresh = freshDoRoll()
+        assertEquals(DiceRollMode.OpenEndedD100, fresh.mode)
+        assertEquals(10, fresh.faces, "fresh closure has consistent faces=10 for mode=OE")
+        assertTrue(
+            fresh.isValid(),
+            "fresh closure builds VALID descriptor — what rememberUpdatedState gives us",
+        )
+    }
+
+    private fun build1d4(odinId: String, result: Int): DiceRollDescriptor =
+        DiceRollDescriptor(
+            faces = 4,
+            mode = DiceRollMode.Standard,
+            rolls = listOf(
+                ChainRoll(
+                    messageId = Uuid.random(),
+                    odinId = OdinId(odinId),
+                    results = listOf(result),
+                    rolledAtUtcMs = 1_700_000_000_000L,
+                    source = RollSource.LocalRandom,
+                ),
+            ),
+        )
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/dice/DiceRollComposerShakeRaceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/dice/DiceRollComposerShakeRaceTest.kt
@@ -1,0 +1,156 @@
+package id.homebase.chat.dice
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlin.test.Test
+import kotlin.test.assertNull
+
+/**
+ * Reproduces the 1d4-shake crash from build 1.3.1420.
+ *
+ * The harness composable below mirrors the dice composer's wiring exactly:
+ *  - a `count` state derived from a mode toggle (OE → 2, Standard → 1),
+ *  - a `displayValues` `SnapshotStateList` resized by `LaunchedEffect(count)`,
+ *  - a `doRoll` lambda recreated each composition that loops `0 until count`
+ *    and writes into `displayValues`,
+ *  - a `LaunchedEffect(shakeDetector.isAvailable)` that collects shake events
+ *    forever and invokes `doRoll`.
+ *
+ * Without `rememberUpdatedState(doRoll)`, the long-running collect captures
+ * the first composition's `doRoll` (count = 2). After the user toggles OE
+ * off, `displayValues` shrinks to size 1 but the captured `doRoll` still
+ * thinks count is 2, so the next shake writes `displayValues[1]` and crashes
+ * with `IndexOutOfBoundsException: index 1, size 1`. The test asserts no
+ * such crash propagates.
+ */
+@OptIn(ExperimentalTestApi::class)
+class DiceRollComposerShakeRaceTest {
+
+    @Test
+    fun shakeAfterModeToggle_doesNotCrash() = runComposeUiTest {
+        val fakeShake = FakeShakeDetector()
+        var caught: Throwable? = null
+
+        setContent {
+            MaterialTheme {
+                ComposerShakeHarness(
+                    shakeDetector = fakeShake,
+                    onError = { caught = it },
+                )
+            }
+        }
+
+        // Settle the initial composition (mode = OE → count = 2,
+        // displayValues size 2).
+        waitForIdle()
+
+        // Toggle OE off → mode = Standard, count = 1. The
+        // LaunchedEffect(count) shrinks displayValues to size 1.
+        onNodeWithTag(DICE_OE_TOGGLE_TAG).performClick()
+        waitForIdle()
+
+        // Fire a shake. With the bug, this invokes the stale doRoll (count = 2)
+        // and writes displayValues[1] on a size-1 list → IOOB on the main
+        // coroutine, captured into `caught` by the harness CoroutineExceptionHandler.
+        fakeShake.fire()
+        waitForIdle()
+        // Allow the launched tumble coroutine to schedule and any thrown
+        // exception to propagate.
+        mainClock.advanceTimeBy(500L)
+        waitForIdle()
+
+        assertNull(caught, "shake after toggle must not crash, but got: $caught")
+    }
+}
+
+@Composable
+private fun ComposerShakeHarness(
+    shakeDetector: ShakeDetector,
+    onError: (Throwable) -> Unit,
+) {
+    var mode by remember { mutableStateOf(HarnessMode.OpenEnded) }
+    val count = if (mode == HarnessMode.OpenEnded) 2 else 1
+
+    val displayValues: SnapshotStateList<Int?> = remember {
+        mutableStateListOf<Int?>(null, null)
+    }
+    LaunchedEffect(count) {
+        while (displayValues.size < count) displayValues.add(null)
+        while (displayValues.size > count) displayValues.removeAt(displayValues.lastIndex)
+    }
+
+    val scope = rememberCoroutineScope()
+    // Mirrors the production doRoll: captures `count` per composition and
+    // launches a coroutine that walks `0 until count`. Intentionally does
+    // NOT use the clamped `runTumble` helper here — this test isolates the
+    // `rememberUpdatedState(doRoll)` fix in step 1, separate from the
+    // belt-and-suspenders clamp in step 2 covered by `DiceRollTumbleTest`.
+    val doRoll: () -> Unit = {
+        scope.launch {
+            try {
+                for (frame in 0 until 3) {
+                    for (i in 0 until count) {
+                        displayValues[i] = 2
+                    }
+                    delay(10L)
+                }
+            } catch (t: Throwable) {
+                onError(t)
+            }
+        }
+    }
+
+    // The fix: rememberUpdatedState re-binds the captured callback so the
+    // long-running collect always invokes the current `doRoll` with the
+    // current `count`. Removing this `rememberUpdatedState` and replacing
+    // `currentDoRoll()` with `doRoll()` below reproduces the production
+    // crash.
+    val currentDoRoll by rememberUpdatedState(doRoll)
+    LaunchedEffect(shakeDetector.isAvailable) {
+        if (!shakeDetector.isAvailable) return@LaunchedEffect
+        shakeDetector.events().collect {
+            currentDoRoll()
+        }
+    }
+
+    Switch(
+        checked = mode == HarnessMode.OpenEnded,
+        onCheckedChange = { on ->
+            mode = if (on) HarnessMode.OpenEnded else HarnessMode.Standard
+        },
+        modifier = Modifier.testTag(DICE_OE_TOGGLE_TAG),
+    )
+    Text("count=$count size=${displayValues.size}")
+}
+
+private enum class HarnessMode { OpenEnded, Standard }
+
+private class FakeShakeDetector : ShakeDetector {
+    override val isAvailable: Boolean = true
+    private val flow = MutableSharedFlow<ShakeEvent>(extraBufferCapacity = 16)
+    override fun events(): Flow<ShakeEvent> = flow
+    fun fire() {
+        check(flow.tryEmit(ShakeEvent(intensity = 1.7f, accelSamples = listOf(1L))))
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/dice/DiceRollTumbleTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/dice/DiceRollTumbleTest.kt
@@ -1,0 +1,92 @@
+package id.homebase.chat.dice
+
+import androidx.compose.runtime.mutableStateListOf
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DiceRollTumbleTest {
+
+    /**
+     * Regression for the 1d4 shake crash. A stale `doRoll` closure can hold an
+     * out-of-date `count` while `LaunchedEffect(count, faces)` has already
+     * resized `displayValues` smaller. Without the `minOf` clamp inside
+     * `runTumble`, the next frame writes `displayValues[1]` on a size-1 list
+     * and the main thread crashes with `IndexOutOfBoundsException: index 1,
+     * size 1`. With the clamp, the loop silently writes only the in-range
+     * positions and completes.
+     */
+    @Test
+    fun tumble_survivesMidFlightShrink() = runTest {
+        val displayValues = mutableStateListOf<Int?>(null, null)
+        val frameDelayMs = 10L
+        val totalFrames = 4
+
+        val job = launch {
+            runTumble(
+                frames = totalFrames,
+                count = 2,
+                faces = 4,
+                displayValues = displayValues,
+                frameDelayMs = frameDelayMs,
+                randomFace = { 3 },
+            )
+        }
+
+        advanceTimeBy(frameDelayMs / 2)
+        displayValues.removeAt(displayValues.lastIndex)
+        assertEquals(1, displayValues.size)
+
+        advanceTimeBy(frameDelayMs * totalFrames + frameDelayMs)
+        job.join()
+
+        assertEquals(1, displayValues.size)
+        assertEquals(3, displayValues[0])
+    }
+
+    @Test
+    fun tumble_populatesEveryPositionWhenSizeMatchesCount() = runTest {
+        val displayValues = mutableStateListOf<Int?>(null, null, null)
+
+        val job = launch {
+            runTumble(
+                frames = 2,
+                count = 3,
+                faces = 6,
+                displayValues = displayValues,
+                frameDelayMs = 5L,
+                randomFace = { 5 },
+            )
+        }
+        advanceTimeBy(50L)
+        job.join()
+
+        for (v in displayValues) assertNotNull(v)
+        for (v in displayValues) assertEquals(5, v)
+    }
+
+    @Test
+    fun tumble_doesNothingWhenListIsEmpty() = runTest {
+        val displayValues = mutableStateListOf<Int?>()
+
+        val job = launch {
+            runTumble(
+                frames = 3,
+                count = 5,
+                faces = 6,
+                displayValues = displayValues,
+                frameDelayMs = 5L,
+                randomFace = { 1 },
+            )
+        }
+        advanceTimeBy(50L)
+        job.join()
+
+        assertEquals(0, displayValues.size)
+    }
+}


### PR DESCRIPTION
Two bugs surfaced from build 1.3.1420 logs, both rooted in the same stale-closure pattern in the dice composer.

## 1419 crash — shake-after-mode-toggle IOOB

`homebase.log` (build 1419 watchdog):
    IndexOutOfBoundsException: index: 1, size: 1
    ... SnapshotStateList.set <- invokeSuspend (Main)

`LaunchedEffect(shakeDetector.isAvailable) { collect { doRoll() } }` captured the first composition's `doRoll`. A user with OE persisted as the last mode opened the composer, toggled OE off (count 2 -> 1, displayValues resized to size 1), then shook. The stale `doRoll` launched a tumble loop with the captured `count = 2`, wrote `displayValues[1]` on a size-1 list, and crashed the main thread.

`rememberUpdatedState(doRoll)` rebinds the captured callback every composition so shake invokes the LATEST `doRoll`, whose `count` matches the current `displayValues.size`. Applied to both
`DiceRollComposerSheet.kt` and `BattleRollSheet.kt` (same pattern). The tumble inner loop is extracted into `runTumble(...)` with `minOf(count, displayValues.size)` as belt-and-suspenders against any other path that resizes the list mid-flight.

Tests (`homebase-chat/src/jvmTest/.../dice/`):

  - `DiceRollTumbleTest` (3 tests) drives the extracted helper with a SnapshotStateList shrunk between frames. Without the clamp, frame 1 throws `IndexOutOfBoundsException: index 1, size 1` — verified by reverting the clamp in `runTumble` and watching the test go red.
  - `DiceRollComposerShakeRaceTest` mirrors the composer's shake-wiring in a Compose UI test (`runComposeUiTest`), deliberately NOT using the clamped helper so the test isolates the `rememberUpdatedState` fix. Toggling OE off then firing a shake throws the exact same `index 1, size 1` without `rememberUpdatedState` — also verified by reverting.

## 1420 "Ancient roll" — invalid descriptor on shake

`homebase2.log` shows 7 instances of
    Warn: (MessageContentParser) DiceRoll descriptor failed validation; faces=4 chainSize=1
for a single 1d4 send. The bubble renders the `chat_dice_unparseable` string ("Ancient roll" in en, "Forhistorisk slag" in da).

Same root cause: the composer has `var mode by mutableStateOf(...)` (state delegate, read fresh inside lambdas) but `val faces = if (mode == OE) 10 else standardFaces` as a plain local (captured at composition time). A stale `doRoll` from the shake `LaunchedEffect` read `mode = OE` fresh from state but used the captured `faces = 4`, producing `DiceRollDescriptor(faces=4, mode=OpenEndedD100, ...)`. That fails `isValid()` at the OE branch's `if (faces != 10) return false`, and the malformed descriptor was persisted to local storage, so the bubble renders as "Ancient roll" forever.

The `rememberUpdatedState` fix above already prevents this for new rolls — the shake handler always invokes the latest `doRoll`, whose `mode` and `faces` were captured in the same composition and so can't diverge.

The diagnostic warning in `MessageContentParser.parseDiceRoll` was too thin to identify which `isValid()` predicate failed. It now logs `mode`, `firstResultsSize`, and a `firstResultsSample` of up to 4 values, so a future failure says something like
    faces=4 mode=OpenEndedD100 chainSize=1 firstResultsSize=2 firstResultsSample=[5,7]
which points straight at the OE-vs-Standard mismatch rather than leaving us guessing.

Tests (`homebase-chat/src/commonTest/.../dice/Dice1d4RoundTripTest.kt`):

  - Six in-memory round-trips for 1d4 (standard, every allowed face, user's exact OdinId + ShakeSeeded shape, mode-field preservation, explicit-invalid mode=OE faces=4) rule out a serialization or naming-strategy regression — they all pass.
  - `staleClosure_buildsInvalidDescriptor_freshClosure_buildsValid` documents both sides of the cure: a pre-fix stale closure produces `mode=OE, faces=4` (invalid, `assertFalse(isValid())`); a post-fix fresh closure produces `mode=OE, faces=10` (valid, `assertTrue(isValid())`).

Existing Ancient-roll bubbles already in users' local DBs can't be recovered without a migration; the descriptor JSON on disk is genuinely invalid. New rolls won't reproduce.