### PR TITLE
chore(startup): add boot checkpoints to bracket desktop cold-start ph…

### DIFF
--- a/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
+++ b/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
@@ -72,9 +72,11 @@ fun main() {
 
     // Set up crash handler
     setupCrashHandler()
+    StartupLogger.checkpoint("main() entered, file logger online")
 
     // Initialize Koin first
     startKoin { modules(allModules) }
+    StartupLogger.checkpoint("Koin DI graph built")
 
     val platformInfo = GlobalContext.get().get<PlatformInfo>()
     StartupLogger.logAppStartupInfo(platformInfo.versionName, platformInfo.versionCode, BuildConfig.APP_BUILD_TIME)
@@ -110,6 +112,7 @@ fun main() {
     val userPreferences = koin.get<UserPreferences>()
 
     runBlocking { applyStoredLocale(userPreferences) }
+    StartupLogger.checkpoint("locale applied")
 
     val minWidth = 480
     val minHeight = 400
@@ -120,7 +123,9 @@ fun main() {
     }
 
     application {
+        remember { StartupLogger.checkpoint("Compose application{} entered") }
         val viewModel = koin.get<DesktopViewModel>()
+        remember { StartupLogger.checkpoint("DesktopViewModel resolved") }
         val uiState by viewModel.uiState.collectAsState()
         val icon = painterResource(MR.drawable.homebase_icon_round)
         var isWindowVisible by remember { mutableStateOf(true) }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/logging/StartupLogger.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/logging/StartupLogger.kt
@@ -11,4 +11,15 @@ object StartupLogger {
         Logger.i(tag = TAG) { "Build date: $buildDate" }
         Logger.i(tag = TAG) { "=================================" }
     }
+
+    /**
+     * One-shot timing marker. The log timestamp is the data; diff two checkpoints
+     * to size a phase. Cheap — fire-and-forget Logger.i, no allocation beyond the
+     * literal. Add at hand-picked boundaries (Koin built, DB open, Compose entered,
+     * top-level VM resolved). Don't call from a Composable body — wrap in
+     * LaunchedEffect(Unit) so it fires once, not per recomposition.
+     */
+    fun checkpoint(name: String) {
+        Logger.i(tag = TAG) { "checkpoint: $name" }
+    }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/App.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/App.kt
@@ -8,7 +8,9 @@ import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import androidx.compose.runtime.remember
 import id.homebase.api.youauth.YouAuthFlowManager
+import id.homebase.core.logging.StartupLogger
 import id.homebase.core.settings.ThemeState
 import id.homebase.core.settings.UserPreferences
 import id.homebase.core.ui.navigation.AppNavHost
@@ -21,9 +23,11 @@ import org.koin.compose.koinInject
 fun App(
     onNavHostReady: suspend (NavController) -> Unit = {},
 ) {
+    remember { StartupLogger.checkpoint("App() first composition") }
     val navController = rememberNavController()
     val youAuthFlowManager: YouAuthFlowManager = koinInject()
     val userPreferences: UserPreferences = koinInject()
+    remember { StartupLogger.checkpoint("App() Koin injections done") }
 
     val prefState by userPreferences.preferenceState.collectAsStateWithLifecycle()
     val isDarkTheme = if (prefState.theme == ThemeState.System) isSystemInDarkTheme() else if (prefState.theme == ThemeState.Dark) true else false


### PR DESCRIPTION
…ases

Cold-start logs leave a ~2.4s gap between `(DatabaseManager) Database initialized` and `(AuthLifecycle) AuthCC: collector started` with no instrumentation in between, so we can't tell whether the cost is in Compose `application{}` entry, the top-level `DesktopViewModel` resolve, the first `App()` composition, or something downstream of Koin injecting `AuthConnectionCoordinator`. There's also no log before `startKoin`, which hides whatever the Koin DI graph build itself takes.

Adds `StartupLogger.checkpoint(name)` (one-line tagged `Logger.i`, timestamps do the timing) and six call sites:

- Main.kt: `main() entered, file logger online`, `Koin DI graph built`, `locale applied`, `Compose application{} entered`, `DesktopViewModel resolved`
- App.kt: `App() first composition`, `App() Koin injections done`

The two calls inside `application { }` and the two inside the `App()` composable are wrapped in `remember { ... }` so they fire once instead of on every recomposition (the application body recomposes on uiState).

No behavior change — six extra Info log lines per cold start.