### PR TITLE
chore(wasm-prep): decouple kmpnotifier from commonMain (step 9c)

### DIFF
--- a/homebase-common/build.gradle.kts
+++ b/homebase-common/build.gradle.kts
@@ -97,7 +97,6 @@ kotlin {
             api(libs.filekit.core)
             api(libs.koin.core)
             api(libs.koin.compose)
-            api(libs.kmpnotifier)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
@@ -119,10 +118,18 @@ kotlin {
             implementation(libs.firebase.crashlytics)
             api(libs.coil3.video)
             implementation(libs.kermit.io)
+            // kmpnotifier has no wasmJs artifact — must stay off commonMain.
+            // `api` so the dep cascades transitively to androidApp (which
+            // imports NotifierManager in MainApplication/MainActivity).
+            api(libs.kmpnotifier)
         }
         appleMain.dependencies {
             implementation(libs.ktor.client.darwin)
             implementation(libs.kermit.io)
+            // `api` so the iOS framework `export(libs.kmpnotifier)` block above
+            // resolves the symbols for Swift consumption (iOSApp.swift calls
+            // `NotifierManager.shared.initialize(...)`).
+            api(libs.kmpnotifier)
         }
         jvmMain.dependencies {
             implementation(libs.ktor.client.cio)
@@ -132,6 +139,10 @@ kotlin {
             implementation(libs.nucleus.notification.macos)
             implementation(libs.nucleus.notification.linux)
             implementation(libs.kermit.io)
+            // `api` so desktopApp's existing direct kmpnotifier dep stays
+            // consistent and `RichNotificationDisplayer.jvm.kt` can reach the
+            // type from the same source set's classpath.
+            api(libs.kmpnotifier)
         }
         // Uncomment in step 10 of the WASM pre-flight plan, paired with
         // `wasmJs { browser() }`. ktor-client-js provides the browser

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/notifications/KMPNotifierBackend.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/notifications/KMPNotifierBackend.android.kt
@@ -1,0 +1,46 @@
+package id.homebase.core.notifications
+
+import com.mmk.kmpnotifier.notification.NotifierManager
+
+/**
+ * Android implementation of [NotificationBackend] that delegates to
+ * `com.mmk.kmpnotifier.notification.NotifierManager`. Assumes
+ * `NotifierManager.initialize(...)` has already been called by the entry
+ * point (`androidApp/MainApplication.kt`). Same shape duplicated across the
+ * three real-platform actuals — see step 9c of the WASM pre-flight plan; no
+ * common ancestor source set covers Android/JVM/Apple.
+ */
+class KMPNotifierBackend : NotificationBackend {
+    override fun addListener(listener: NotificationListener) {
+        NotifierManager.addListener(object : NotifierManager.Listener {
+            override fun onNewToken(token: String) =
+                listener.onNewToken(token)
+            override fun onPushNotificationWithPayloadData(
+                title: String?, body: String?, data: com.mmk.kmpnotifier.notification.PayloadData,
+            ) = listener.onPushNotificationWithPayloadData(title, body, data)
+            override fun onNotificationClicked(data: com.mmk.kmpnotifier.notification.PayloadData) =
+                listener.onNotificationClicked(data)
+            override fun onPushNotification(title: String?, body: String?) =
+                listener.onPushNotification(title, body)
+            override fun onPayloadData(data: com.mmk.kmpnotifier.notification.PayloadData) =
+                listener.onPayloadData(data)
+        })
+    }
+
+    override fun setLogger(log: (String) -> Unit) {
+        NotifierManager.setLogger { log(it) }
+    }
+
+    override fun showLocalNotification(id: Int, title: String, body: String, payloadData: Map<String, String>) {
+        NotifierManager.getLocalNotifier().notify(
+            id = id, title = title, body = body, payloadData = payloadData,
+        )
+    }
+
+    override suspend fun getPushToken(): String? =
+        NotifierManager.getPushNotifier().getToken()
+
+    override suspend fun deletePushToken() {
+        NotifierManager.getPushNotifier().deleteMyToken()
+    }
+}

--- a/homebase-common/src/appleMain/kotlin/id/homebase/core/notifications/KMPNotifierBackend.apple.kt
+++ b/homebase-common/src/appleMain/kotlin/id/homebase/core/notifications/KMPNotifierBackend.apple.kt
@@ -1,0 +1,45 @@
+package id.homebase.core.notifications
+
+import com.mmk.kmpnotifier.notification.NotifierManager
+
+/**
+ * Apple (iOS) implementation of [NotificationBackend]. Assumes
+ * `NotifierManager.shared.initialize(...)` has already been called by
+ * `iosApp/iOSApp.swift`. Same shape duplicated across the three
+ * real-platform actuals — see step 9c of the WASM pre-flight plan; no common
+ * ancestor source set covers Android/JVM/Apple.
+ */
+class KMPNotifierBackend : NotificationBackend {
+    override fun addListener(listener: NotificationListener) {
+        NotifierManager.addListener(object : NotifierManager.Listener {
+            override fun onNewToken(token: String) =
+                listener.onNewToken(token)
+            override fun onPushNotificationWithPayloadData(
+                title: String?, body: String?, data: com.mmk.kmpnotifier.notification.PayloadData,
+            ) = listener.onPushNotificationWithPayloadData(title, body, data)
+            override fun onNotificationClicked(data: com.mmk.kmpnotifier.notification.PayloadData) =
+                listener.onNotificationClicked(data)
+            override fun onPushNotification(title: String?, body: String?) =
+                listener.onPushNotification(title, body)
+            override fun onPayloadData(data: com.mmk.kmpnotifier.notification.PayloadData) =
+                listener.onPayloadData(data)
+        })
+    }
+
+    override fun setLogger(log: (String) -> Unit) {
+        NotifierManager.setLogger { log(it) }
+    }
+
+    override fun showLocalNotification(id: Int, title: String, body: String, payloadData: Map<String, String>) {
+        NotifierManager.getLocalNotifier().notify(
+            id = id, title = title, body = body, payloadData = payloadData,
+        )
+    }
+
+    override suspend fun getPushToken(): String? =
+        NotifierManager.getPushNotifier().getToken()
+
+    override suspend fun deletePushToken() {
+        NotifierManager.getPushNotifier().deleteMyToken()
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationBackend.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationBackend.kt
@@ -1,0 +1,51 @@
+package id.homebase.core.notifications
+
+/**
+ * Drop-in alias for kmpnotifier's `PayloadData`. Matches the upstream
+ * `typealias PayloadData = Map<String, Any?>` exactly so commonMain call
+ * sites that handled `PayloadData` previously stay byte-equivalent — the only
+ * change is the import.
+ *
+ * Step 9c of the WASM pre-flight plan moves the kmpnotifier types off
+ * commonMain so the wasmJs target can stop pulling a JVM/Android/iOS-only
+ * artifact.
+ */
+typealias PayloadData = Map<String, Any?>
+
+/**
+ * Listener interface that mirrors `NotifierManager.Listener` but lives in
+ * commonMain so [NotificationService] can subscribe without importing
+ * kmpnotifier. All callbacks default to no-ops — implementations only need to
+ * override what they care about.
+ */
+interface NotificationListener {
+    fun onNewToken(token: String) {}
+    fun onPushNotificationWithPayloadData(title: String?, body: String?, data: PayloadData) {}
+    fun onNotificationClicked(data: PayloadData) {}
+    fun onPushNotification(title: String?, body: String?) {}
+    fun onPayloadData(data: PayloadData) {}
+}
+
+/**
+ * Platform-agnostic facade over the push / local-notification machinery.
+ * Bound through Koin in each platform's `platformModule()`. On Android / JVM /
+ * iOS the implementation delegates to `com.mmk.kmpnotifier.notification.NotifierManager`;
+ * on wasmJs the implementation is a no-op.
+ */
+interface NotificationBackend {
+    fun addListener(listener: NotificationListener)
+    fun setLogger(log: (String) -> Unit)
+    /**
+     * [payloadData] is `Map<String, String>` (not [PayloadData]) because the
+     * underlying `LocalNotifier.notify` signature constrains values to
+     * strings — only the listener side widens to `Any?`.
+     */
+    fun showLocalNotification(
+        id: Int,
+        title: String,
+        body: String,
+        payloadData: Map<String, String>,
+    )
+    suspend fun getPushToken(): String?
+    suspend fun deletePushToken()
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationClickRouter.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationClickRouter.kt
@@ -1,6 +1,5 @@
 package id.homebase.core.notifications
 
-import com.mmk.kmpnotifier.notification.PayloadData
 import kotlin.concurrent.Volatile
 
 /**

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationEntry.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationEntry.kt
@@ -1,7 +1,6 @@
 package id.homebase.core.notifications
 
 import co.touchlab.kermit.Logger
-import com.mmk.kmpnotifier.notification.PayloadData
 import id.homebase.core.auth.AuthConnectionCoordinator
 import id.homebase.core.sync.BackgroundSyncOrchestrator
 import id.homebase.core.sync.SyncOutcome

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
@@ -1,8 +1,6 @@
 package id.homebase.core.notifications
 
 import co.touchlab.kermit.Logger
-import com.mmk.kmpnotifier.notification.NotifierManager
-import com.mmk.kmpnotifier.notification.PayloadData
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.notifications.PushNotificationApi
 import id.homebase.api.client.notifications.PushSubscriptionResponse
@@ -53,6 +51,7 @@ class NotificationService(
     private val userPreferences: UserPreferences,
     private val credentialsManager: CredentialsManager,
     private val pendingNotificationTap: PendingNotificationTap,
+    private val notificationBackend: NotificationBackend,
 ) {
 
     private var isListening = false
@@ -111,16 +110,16 @@ class NotificationService(
     }
 
     /**
-     * Initializes notification listeners. Call after NotifierManager.initialize() has been called
-     * on the platform side.
+     * Initializes notification listeners. Call after the platform backend has
+     * been initialized at the entry point (e.g. NotifierManager.initialize()
+     * on Android/JVM/iOS).
      */
     fun startListening() {
         if (isListening) return
         isListening = true
 
-        NotifierManager.addListener(object : NotifierManager.Listener {
+        notificationBackend.addListener(object : NotificationListener {
             override fun onNewToken(token: String) {
-                super.onNewToken(token)
                 Logger.i(tag = "NotificationService") { "New push token: $token" }
                 registerToken(token)
             }
@@ -128,7 +127,6 @@ class NotificationService(
             override fun onPushNotificationWithPayloadData(
                 title: String?, body: String?, data: PayloadData
             ) {
-                super.onPushNotificationWithPayloadData(title, body, data)
                 Logger.i(tag = "NotificationService") {
                     "Push received — title=$title body=$body data=$data"
                 }
@@ -144,20 +142,18 @@ class NotificationService(
             }
 
             override fun onPushNotification(title: String?, body: String?) {
-                super.onPushNotification(title, body)
                 Logger.i(tag = "NotificationService") {
                     "Push received — title=$title body=$body"
                 }
             }
 
             override fun onPayloadData(data: PayloadData) {
-                super.onPayloadData(data)
                 Logger.i(tag = "NotificationService") { "Payload received: $data" }
                 handleIncomingPayload(data)
             }
         })
 
-        NotifierManager.setLogger { message -> Logger.d(tag = "KMPNotifier") { message } }
+        notificationBackend.setLogger { message -> Logger.d(tag = "KMPNotifier") { message } }
     }
 
     /**
@@ -510,18 +506,17 @@ class NotificationService(
         }
     }
 
-    /** Displays a local notification using KMPNotifier (fallback). */
+    /** Displays a local notification using the platform backend (fallback). */
     fun showLocalNotification(
         title: String,
         body: String,
         payloadData: Map<String, String> = emptyMap(),
     ) {
-        val notifier = NotifierManager.getLocalNotifier()
-        notifier.notify(
+        notificationBackend.showLocalNotification(
             id = Random.nextInt(0, Int.MAX_VALUE),
             title = title,
             body = body,
-            payloadData = payloadData
+            payloadData = payloadData,
         )
     }
 
@@ -582,7 +577,7 @@ class NotificationService(
     /** Gets the current push notification token, or null if not available. */
     suspend fun getToken(): String? {
         return try {
-            NotifierManager.getPushNotifier().getToken()
+            notificationBackend.getPushToken()
         } catch (e: Exception) {
             Logger.w(tag = "NotificationService") { "Failed to get push token: ${e.message}" }
             null
@@ -594,7 +589,7 @@ class NotificationService(
         try {
             Logger.i(tag = "NotificationService") { "Unsubscribing token..." }
             api.unsubscribe()
-            NotifierManager.getPushNotifier().deleteMyToken()
+            notificationBackend.deletePushToken()
             Logger.i(tag = "NotificationService") { "Token deleted and unsubscribed" }
         } catch (e: Exception) {
             Logger.w(tag = "NotificationService") { "Failed to delete token/unsubscribe: ${e.message}" }
@@ -609,10 +604,10 @@ class NotificationService(
         return try {
             Logger.i(tag = "NotificationService") { "Re-registering: unsubscribing old token..." }
             api.unsubscribe()
-            NotifierManager.getPushNotifier().deleteMyToken()
+            notificationBackend.deletePushToken()
 
             Logger.i(tag = "NotificationService") { "Re-registering: fetching new token..." }
-            val newToken = NotifierManager.getPushNotifier().getToken()
+            val newToken = notificationBackend.getPushToken()
             if (newToken != null) {
                 registerTokenSuspend(newToken)
             }

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/notifications/KMPNotifierBackend.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/notifications/KMPNotifierBackend.jvm.kt
@@ -1,0 +1,45 @@
+package id.homebase.core.notifications
+
+import com.mmk.kmpnotifier.notification.NotifierManager
+
+/**
+ * JVM (Desktop) implementation of [NotificationBackend]. Assumes
+ * `NotifierManager.initialize(...)` has already been called by
+ * `desktopApp/Main.kt`. Same shape duplicated across the three real-platform
+ * actuals — see step 9c of the WASM pre-flight plan; no common ancestor
+ * source set covers Android/JVM/Apple.
+ */
+class KMPNotifierBackend : NotificationBackend {
+    override fun addListener(listener: NotificationListener) {
+        NotifierManager.addListener(object : NotifierManager.Listener {
+            override fun onNewToken(token: String) =
+                listener.onNewToken(token)
+            override fun onPushNotificationWithPayloadData(
+                title: String?, body: String?, data: com.mmk.kmpnotifier.notification.PayloadData,
+            ) = listener.onPushNotificationWithPayloadData(title, body, data)
+            override fun onNotificationClicked(data: com.mmk.kmpnotifier.notification.PayloadData) =
+                listener.onNotificationClicked(data)
+            override fun onPushNotification(title: String?, body: String?) =
+                listener.onPushNotification(title, body)
+            override fun onPayloadData(data: com.mmk.kmpnotifier.notification.PayloadData) =
+                listener.onPayloadData(data)
+        })
+    }
+
+    override fun setLogger(log: (String) -> Unit) {
+        NotifierManager.setLogger { log(it) }
+    }
+
+    override fun showLocalNotification(id: Int, title: String, body: String, payloadData: Map<String, String>) {
+        NotifierManager.getLocalNotifier().notify(
+            id = id, title = title, body = body, payloadData = payloadData,
+        )
+    }
+
+    override suspend fun getPushToken(): String? =
+        NotifierManager.getPushNotifier().getToken()
+
+    override suspend fun deletePushToken() {
+        NotifierManager.getPushNotifier().deleteMyToken()
+    }
+}

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/notifications/NoopNotificationBackend.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/notifications/NoopNotificationBackend.web.kt
@@ -1,0 +1,13 @@
+package id.homebase.core.notifications
+
+// No push / local notifications on wasmJs yet — kmpnotifier has no wasmJs
+// artifact. Returning a no-op backend lets NotificationService construct
+// without throwing; the browser Notification API or a service-worker shim
+// can come later if/when web push matters.
+class NoopNotificationBackend : NotificationBackend {
+    override fun addListener(listener: NotificationListener) {}
+    override fun setLogger(log: (String) -> Unit) {}
+    override fun showLocalNotification(id: Int, title: String, body: String, payloadData: Map<String, String>) {}
+    override suspend fun getPushToken(): String? = null
+    override suspend fun deletePushToken() {}
+}

--- a/homebase-core/src/androidMain/kotlin/id/homebase/core/di/AppModule.android.kt
+++ b/homebase-core/src/androidMain/kotlin/id/homebase/core/di/AppModule.android.kt
@@ -23,6 +23,8 @@ import id.homebase.core.gallery.PlatformGalleryManager
 import id.homebase.core.image.HomebaseImageFetcher
 import id.homebase.core.image.HomebaseImageKeyer
 import id.homebase.core.image.PublicImageFetcher
+import id.homebase.core.notifications.KMPNotifierBackend
+import id.homebase.core.notifications.NotificationBackend
 import id.homebase.core.settings.createSettings
 import id.homebase.core.share.ShareCacheStorage
 import id.homebase.core.updater.AndroidUpdateAppManager
@@ -65,6 +67,7 @@ actual fun platformModule(): Module = module {
     single<DatabaseSizeProbe> { AndroidDatabaseSizeProbe(androidContext()) }
     single<UpdateAppManager> { AndroidUpdateAppManager(androidContext()) }
     single<ShakeDetector> { AndroidShakeDetector(androidContext()) }
+    single<NotificationBackend> { KMPNotifierBackend() }
     single(createdAtStart = true) {
         ImageLoader.Builder(androidContext())
                 .components {

--- a/homebase-core/src/jvmMain/kotlin/id/homebase/core/di/AppModule.desktop.kt
+++ b/homebase-core/src/jvmMain/kotlin/id/homebase/core/di/AppModule.desktop.kt
@@ -23,6 +23,8 @@ import id.homebase.core.image.HomebaseImageFetcher
 import id.homebase.core.image.HomebaseImageKeyer
 import id.homebase.core.image.PublicImageFetcher
 import id.homebase.core.notifications.DesktopChatNotificationBridge
+import id.homebase.core.notifications.KMPNotifierBackend
+import id.homebase.core.notifications.NotificationBackend
 import id.homebase.core.settings.createSettings
 import id.homebase.core.share.ShareCacheStorage
 import id.homebase.core.updater.JvmUpdateAppManager
@@ -48,6 +50,7 @@ actual fun platformModule(): Module = module {
         platformInfo = get(),
     ) }
     single<ShakeDetector> { JvmShakeDetector() }
+    single<NotificationBackend> { KMPNotifierBackend() }
     single(createdAtStart = true) {
         DesktopChatNotificationBridge(
             eventBus = get(),

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/di/AppModule.native.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/di/AppModule.native.kt
@@ -24,6 +24,8 @@ import id.homebase.core.image.HomebaseImageFetcher
 import id.homebase.core.image.HomebaseImageKeyer
 import id.homebase.core.image.PHAssetFetcher
 import id.homebase.core.image.PublicImageFetcher
+import id.homebase.core.notifications.KMPNotifierBackend
+import id.homebase.core.notifications.NotificationBackend
 import id.homebase.core.settings.createSettings
 import id.homebase.core.share.ShareCacheStorage
 import id.homebase.core.updater.IOSUpdateAppManager
@@ -50,6 +52,7 @@ actual fun platformModule(): Module = module {
     single<DatabaseSizeProbe> { NativeDatabaseSizeProbe() }
     single<UpdateAppManager> { IOSUpdateAppManager(get()) }
     single<ShakeDetector> { IosShakeDetector() }
+    single<NotificationBackend> { KMPNotifierBackend() }
     single(createdAtStart = true) {
         ImageLoader.Builder(PlatformContext.INSTANCE)
                 .components {

--- a/homebase-core/src/wasmJsMain/kotlin/id/homebase/core/di/AppModule.web.kt
+++ b/homebase-core/src/wasmJsMain/kotlin/id/homebase/core/di/AppModule.web.kt
@@ -6,6 +6,8 @@ import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.file.WebFileOperationsProvider
 import id.homebase.core.image.HomebaseImageFetcher
 import id.homebase.core.image.HomebaseImageKeyer
+import id.homebase.core.notifications.NoopNotificationBackend
+import id.homebase.core.notifications.NotificationBackend
 import id.homebase.core.settings.createSettings
 import org.koin.core.module.Module
 import org.koin.dsl.module
@@ -14,6 +16,7 @@ actual fun platformModule(): Module = module {
     single { createSettings() }
     single<FileOperationsProvider> { WebFileOperationsProvider() }
     single { id.homebase.core.share.ShareCacheStorage() }
+    single<NotificationBackend> { NoopNotificationBackend() }
     single {
         ImageLoader.Builder(PlatformContext.INSTANCE)
                 .components {


### PR DESCRIPTION
`kmpnotifier` (`com.mmk.kmpnotifier` 1.6.1) has no wasmJs artifact, so it can't stay on `homebase-common`'s commonMain dependency graph once `wasmJs { browser() }` is uncommented. This PR introduces a small `NotificationBackend` interface in commonMain, moves the kmpnotifier dep to per-platform source sets, and binds the backend through Koin.

### Facade (new commonMain file)
`homebase-common/src/commonMain/.../notifications/NotificationBackend.kt`:
  - `typealias PayloadData = Map<String, Any?>` — drop-in alias for kmpnotifier's PayloadData (also `Map<String, Any?>`); call sites stay byte-equivalent, only the import changes.
  - `interface NotificationListener` — mirrors `NotifierManager.Listener` with empty default impls.
  - `interface NotificationBackend` — addListener / setLogger / showLocalNotification / getPushToken / deletePushToken.

`showLocalNotification.payloadData` is typed `Map<String, String>` (not PayloadData) because the underlying `LocalNotifier.notify` constrains values to strings — only the listener side widens to `Any?`. Caught by a first compile-error pass.

### NotificationService.kt refactor
- Drop kmpnotifier imports.
- New ctor param `private val notificationBackend: NotificationBackend` (Koin's `singleOf(::NotificationService)` picks it up reflectively from the graph — no change to AppModule.kt commonMain).
- Replace all `NotifierManager.*` calls with `notificationBackend.*`.
- `object : NotifierManager.Listener` → `object : NotificationListener`. Drop the vestigial `super.onFoo()` calls inside overrides (the facade interface's empty default impls preserve identical behavior).

### NotificationClickRouter + NotificationEntry
Drop `import com.mmk.kmpnotifier.notification.PayloadData`. The local `PayloadData` typealias in the same package resolves automatically. No signature changes.

### Platform actuals
`homebase-common/src/{android,jvm,apple}Main/.../notifications/KMPNotifierBackend.*.kt` each ship a `class KMPNotifierBackend : NotificationBackend` that delegates to `NotifierManager`. Same shape duplicated across three real-platform actuals — no common ancestor source set covers Android/JVM/Apple. Matches the duplication strategy already used in step 6 (`LoggerPlatform.*.kt`) and step 9b (`FeedWebView.*.kt`).

`homebase-common/src/wasmJsMain/.../notifications/NoopNotificationBackend.web.kt` returns `null` from `getPushToken` and no-ops everywhere else. Web push via the browser Notification API is a separate feature, out of scope.

Classes are `public` (not `internal`) so the Koin module declarations in homebase-core can reference them across module boundaries.

### Koin DI
Bound in each per-platform `platformModule()`:
- `homebase-core/src/{android,jvm,native}Main/.../di/AppModule.{android,desktop,native}.kt`: `single<NotificationBackend> { KMPNotifierBackend() }`
- `homebase-core/src/wasmJsMain/.../di/AppModule.web.kt`: `single<NotificationBackend> { NoopNotificationBackend() }`

`NotificationService`'s Koin definition at
`homebase-core/src/commonMain/.../di/AppModule.kt:277` is unchanged — `singleOf(::NotificationService)` resolves the new ctor param reflectively.

### Build
`homebase-common/build.gradle.kts`:
- Remove `api(libs.kmpnotifier)` from `commonMain.dependencies`.
- Add `api(libs.kmpnotifier)` to `androidMain`, `appleMain`, `jvmMain`. `api` (not `implementation`) because:
  - androidApp's `MainApplication` / `MainActivity` import kmpnotifier transitively through homebase-common.
  - The iOS framework `export(libs.kmpnotifier)` declaration above needs `api` somewhere on the chain — iOSApp.swift directly calls `NotifierManager.shared.initialize(...)`.
  - desktopApp uses `RichNotificationDisplayer.jvm.kt` as a fallback path that needs kmpnotifier on the jvmMain classpath.
- The commented-out `wasmJsMain.dependencies` block from step 8 stays empty for kmpnotifier — wasmJs uses the NoopNotificationBackend.

### Verification
- `grep -rn "com\.mmk\.kmpnotifier\|NotifierManager" homebase-common/src/commonMain homebase-core/src/commonMain` returns only doc-comment references inside NotificationBackend.kt / NotificationService.kt.
- `./gradlew :homebase-{api,auth,chat,common}:jvmTest --rerun-tasks` passes.
- `:homebase-common:compileKotlinIosArm64 + :homebase-core:compileKotlinIosArm64` passes — confirms apple actual + iOS framework export still resolve.

### Out of scope
- Web push via the browser `Notification` API / service-worker shim.
- Touching the Android `MainActivity`/`MainApplication`, desktop `Main.kt`, or `iosApp/iOSApp.swift` kmpnotifier-initialize calls — those are platform glue, not commonMain.

This completes step 9 (after 9a + 9b). Step 10 — actually uncommenting `wasmJs { browser() }` and wiring the sql.js worker assets — is next.