### PR TITLE
feat(video): wire ffmpeg compress + HLS segment progress on Android +iOS

### DIFF
--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/video/FFmpegUtils.android.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/video/FFmpegUtils.android.kt
@@ -5,7 +5,10 @@ import android.util.Log
 import androidx.core.net.toUri
 import com.arthenica.ffmpegkit.FFmpegKit
 import com.arthenica.ffmpegkit.FFmpegSession
+import com.arthenica.ffmpegkit.FFmpegSessionCompleteCallback
 import com.arthenica.ffmpegkit.ReturnCode
+import com.arthenica.ffmpegkit.Statistics
+import com.arthenica.ffmpegkit.StatisticsCallback
 import id.homebase.api.ActivityProvider
 import id.homebase.api.client.KeyHeader
 import java.io.File
@@ -202,7 +205,9 @@ actual object FFmpegUtils {
         // thread, avoiding the issue. Verified empirically on the API 36
         // emulator running compressVideo 4× sequentially.
         val session = try {
-            executeFfmpegAsync(args)
+            executeFfmpegAsync(args) { stats ->
+                onProgress?.invoke(progressFraction(stats.time.toLong(), trimDurationMs))
+            }
         } catch (e: Throwable) {
             val elapsedMs = System.currentTimeMillis() - t0
             Log.e(TAG, "compressVideo crashed after ${elapsedMs}ms", e)
@@ -302,16 +307,35 @@ actual object FFmpegUtils {
      * [FFmpegSession] so the caller can inspect `returnCode` and friends.
      * Uses the async API to avoid sync `executeWithArguments`'s
      * re-entry-in-same-process crashes (see [compressVideo] for details).
+     *
+     * When [onStatistics] is non-null, the 4-arg overload is used so ffmpeg-kit
+     * fires progress callbacks (~1-2 Hz) on its internal worker thread.
      */
-    private suspend fun executeFfmpegAsync(args: Array<String>): FFmpegSession =
+    private suspend fun executeFfmpegAsync(
+        args: Array<String>,
+        onStatistics: ((Statistics) -> Unit)? = null,
+    ): FFmpegSession =
         suspendCancellableCoroutine { cont ->
-            val session = FFmpegKit.executeWithArgumentsAsync(args) { sess ->
+            val onComplete = FFmpegSessionCompleteCallback { sess ->
                 if (cont.isActive) cont.resume(sess)
+            }
+            val session = if (onStatistics != null) {
+                FFmpegKit.executeWithArgumentsAsync(
+                    args,
+                    onComplete,
+                    null,
+                    StatisticsCallback { stats -> stats?.let(onStatistics) },
+                )
+            } else {
+                FFmpegKit.executeWithArgumentsAsync(args, onComplete)
             }
             cont.invokeOnCancellation {
                 try { session.cancel() } catch (_: Exception) {}
             }
         }
+
+    private fun progressFraction(timeMs: Long, durationMs: Long): Float =
+        if (durationMs <= 0L) 0f else (timeMs.toFloat() / durationMs).coerceIn(0f, 1f)
 
     actual suspend fun segmentVideo(inputPath: String,
                                     onProgress: ((Float) -> Unit)?): Pair<String, String>? =
@@ -452,7 +476,20 @@ actual object FFmpegUtils {
 
             Log.d(TAG, "Segment+Encrypt args: $args")
 
-            val session = FFmpegKit.executeWithArguments(args.toTypedArray())
+            // Re-probe on the segmentation input — the upstream compressor may
+            // have trimmed, so the original input's duration is no longer the
+            // denominator for progress scaling.
+            val durationMs = getDurationMs(inputPath)
+
+            val session = try {
+                executeFfmpegAsync(args.toTypedArray()) { stats ->
+                    onProgress?.invoke(progressFraction(stats.time.toLong(), durationMs))
+                }
+            } catch (e: Throwable) {
+                Log.e(TAG, "segmentAndEncryptVideo crashed", e)
+                deleteFailedFfmpegOutput(outputDir.absolutePath)
+                return@withContext null
+            }
             if (ReturnCode.isSuccess(session.returnCode)) {
                 // Segmentation done — FFmpeg has consumed the key material. Delete it now
                 // so the plaintext AES key doesn't linger in the cache dir (see #7).

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/video/FFmpegKitBridge.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/video/FFmpegKitBridge.kt
@@ -13,6 +13,29 @@ interface FFmpegKitBridge {
     fun executeFFmpeg(command: String): FFmpegResult
 
     /**
+     * Asynchronous execution with progress reporting. [onProgress] fires
+     * whenever ffmpeg-kit emits a statistics callback (~1-2 Hz) with the
+     * elapsed output media time in milliseconds. [onComplete] fires exactly
+     * once when ffmpeg exits. Both callbacks may be invoked on ffmpeg-kit's
+     * internal worker thread — implementations downstream must be
+     * thread-safe (EventBus.tryEmit on MutableSharedFlow is).
+     */
+    fun executeFFmpegAsync(
+        command: String,
+        onProgress: (timeMs: Long) -> Unit,
+        onComplete: (FFmpegResult) -> Unit,
+    )
+
+    /**
+     * Cancel all in-flight ffmpeg sessions. Invoked from coroutine
+     * cancellation to kill the work when the caller navigates away mid-job.
+     * Bridge-wide cancel — fine for the current single-job flow, but if
+     * concurrent attachments land, swap to per-session cancellation by
+     * returning a session id from [executeFFmpegAsync].
+     */
+    fun cancelAllFFmpegSessions()
+
+    /**
      * Get media information for a file.
      * @param filePath Path to the media file
      * @return MediaInfo or null if failed

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/video/FFmpegUtils.native.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/video/FFmpegUtils.native.kt
@@ -1,10 +1,12 @@
 package id.homebase.api.video
 
 import id.homebase.api.client.KeyHeader
+import kotlin.coroutines.resume
 import kotlin.math.roundToLong
 import kotlinx.cinterop.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import platform.AVFoundation.*
 import platform.CoreMedia.CMTimeGetSeconds
@@ -176,7 +178,7 @@ actual object FFmpegUtils {
             // (which app cacheDir-rooted), so this naive quoting is sufficient.
             val command = plan.args.joinToString(" ") { if (' ' in it) "\"$it\"" else it }
 
-            val result = bridge.executeFFmpeg(command)
+            val result = executeFfmpegWithProgress(command, durationMs, onProgress)
             if (result.isSuccess) {
                 return@withContext outputPath
             }
@@ -233,6 +235,35 @@ actual object FFmpegUtils {
                     null
                 }
             }
+
+    private fun progressFraction(timeMs: Long, durationMs: Long): Float =
+        if (durationMs <= 0L) 0f else (timeMs.toFloat() / durationMs).coerceIn(0f, 1f)
+
+    /**
+     * Bridges the Swift async ffmpeg API to a suspending coroutine and converts
+     * ffmpeg-kit's elapsed media time (ms) into a 0..1 progress fraction via
+     * [progressFraction]. Cancellation calls the bridge-wide cancel — fine for
+     * the current single-job flow (see [FFmpegKitBridge.cancelAllFFmpegSessions]
+     * docs for the per-session follow-up).
+     */
+    private suspend fun executeFfmpegWithProgress(
+        command: String,
+        durationMs: Long,
+        onProgress: ((Float) -> Unit)?,
+    ): FFmpegResult = suspendCancellableCoroutine { cont ->
+        bridge.executeFFmpegAsync(
+            command = command,
+            onProgress = { timeMs ->
+                onProgress?.invoke(progressFraction(timeMs, durationMs))
+            },
+            onComplete = { result ->
+                if (cont.isActive) cont.resume(result)
+            },
+        )
+        cont.invokeOnCancellation {
+            try { bridge.cancelAllFFmpegSessions() } catch (_: Exception) {}
+        }
+    }
 
     private fun getCacheDirectory(): String {
         val paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, true)
@@ -299,7 +330,12 @@ actual object FFmpegUtils {
                 val command =
                         "$baseCommand -hls_time 6 -hls_list_size 0 -hls_flags single_file -hls_key_info_file \"$keyInfoFilePath\" -f hls -hls_segment_filename \"$segmentPath\" \"$indexPath\""
 
-                val result = bridge.executeFFmpeg(command)
+                // Re-probe on the segmentation input — the upstream compressor
+                // may have trimmed, so the original input's duration is no
+                // longer the denominator for progress scaling.
+                val durationMs = getDurationMs(inputPath)
+
+                val result = executeFfmpegWithProgress(command, durationMs, onProgress)
 
                 if (result.isSuccess) {
                     // Segmentation done — FFmpeg has consumed the key material. Delete it now

--- a/iosApp/iosApp/FFmpegKitBridgeImpl.swift
+++ b/iosApp/iosApp/FFmpegKitBridgeImpl.swift
@@ -13,6 +13,30 @@ class FFmpegKitBridgeImpl: FFmpegKitBridge {
         return FFmpegResult(isSuccess: isSuccess, failStackTrace: failStackTrace)
     }
 
+    func executeFFmpegAsync(
+        command: String,
+        onProgress: @escaping (KotlinLong) -> Void,
+        onComplete: @escaping (FFmpegResult) -> Void
+    ) {
+        FFmpegKit.executeAsync(
+            command,
+            withCompleteCallback: { session in
+                let isSuccess = ReturnCode.isSuccess(session?.getReturnCode())
+                let failStackTrace = session?.getFailStackTrace()
+                onComplete(FFmpegResult(isSuccess: isSuccess, failStackTrace: failStackTrace))
+            },
+            withLogCallback: nil,
+            withStatisticsCallback: { stats in
+                let timeMs = Int64(stats?.getTime() ?? 0)
+                onProgress(KotlinLong(value: timeMs))
+            }
+        )
+    }
+
+    func cancelAllFFmpegSessions() {
+        FFmpegKit.cancel()
+    }
+
     func getFfmpegVersionBanner() -> String? {
         guard let session = FFmpegKit.execute("-version") else { return nil }
         guard ReturnCode.isSuccess(session.getReturnCode()) else { return nil }


### PR DESCRIPTION
The video-attachment progress UI (CircularProgressIndicator + phase label in MediaMessage) was already built end-to-end: VideoPayloadProcessor emits a PhaseProgress event, the chat ViewModel maps it to UploadStatus.Processing, and the bubble renders a determinate ring. JVM populated real progress by parsing `-progress pipe:1`. Android and iOS accepted the `onProgress` callback in their actuals and silently dropped it, so the ring stayed at 0 on those platforms for the full duration of compression and HLS segmentation.

This wires real progress on both platforms.

Android (FFmpegUtils.android.kt):
- Extend the private executeFfmpegAsync helper with an optional onStatistics parameter; routes to ffmpeg-kit's 4-arg executeWithArgumentsAsync overload (executeCallback, logCallback, statisticsCallback) when supplied. Statistics fire on ffmpeg-kit's internal worker at ~1-2 Hz.
- Add a private progressFraction(timeMs, durationMs) helper that returns 0 when duration is unknown and clamps to 0..1 otherwise.
- compressVideo now passes a statistics callback that scales stats.time by trimDurationMs (the actual output media duration — using inputDurationMs would never reach 100% on a trimmed video).
- segmentAndEncryptVideo switched from synchronous FFmpegKit.executeWithArguments to the async helper with progress. Probes its own duration on inputPath because the upstream compressor may have trimmed.

iOS Kotlin (FFmpegKitBridge.kt, FFmpegUtils.native.kt):
- Add executeFFmpegAsync(command, onProgress, onComplete) and cancelAllFFmpegSessions() to the bridge interface. The two callbacks arrive on ffmpeg-kit's internal thread; downstream EventBus.tryEmit on MutableSharedFlow is thread-safe so no dispatcher hop is needed.
- Add a private progressFraction helper (same shape as Android — deliberately duplicated rather than lifted to commonMain since the trigger Statistics.getTime() is platform-specific).
- Add a private suspending executeFfmpegWithProgress wrapper that bridges the bridge's two callbacks to a single suspending call via suspendCancellableCoroutine, scales timeMs → 0..1 via progressFraction, and honors coroutine cancellation by calling the bridge-wide cancel.
- Swap call sites in compressVideo and segmentAndEncryptVideo to the new wrapper. The other three callers (grabThumbnail, segmentVideo, remuxHlsToMp4) keep using the existing synchronous bridge.executeFFmpeg since they don't surface progress and don't justify the API change.

iOS Swift (FFmpegKitBridgeImpl.swift):
- Implement executeFFmpegAsync using FFmpegKit.executeAsync with all three callbacks. Statistics callback wraps stats?.getTime() in KotlinLong for the Kotlin closure.
- Implement cancelAllFFmpegSessions → FFmpegKit.cancel().

Caveats called out for review:
- iOS cancellation is bridge-wide (FFmpegKit.cancel cancels all in-flight sessions). Fine for the current single-attachment flow. If concurrent uploads land later, switch to per-session cancellation by returning a session id from executeFFmpegAsync.
- No throttling on emissions; ffmpeg-kit's ~1-2 Hz cadence is well below Compose recomposition thresholds and matches what JVM already does.
- The "independent spinner for segmentation" is already provided by the existing VideoProcessingPhase machine: SEGMENTING is a distinct phase with its own string resource (upload_segmenting), and the ring resets 0→100 % when the phase transitions from COMPRESSING. No UI change here.

Verified:
- ./gradlew :androidApp:assembleDebug — green.
- ./gradlew :homebase-api:compileKotlinIosSimulatorArm64 — green.
- iOS Xcode build of iosApp/ and end-to-end manual flow on both platforms still needed; can only be run on a Mac with simulator + an Android device/emulator.