### PR TITLE
feat(vault): document support — PDF preview, file upload, text viewer, file-type icons

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -22,6 +22,7 @@ android {
     compileSdk {
         version = release(libs.versions.android.targetSdk.get().toInt())
     }
+    compileSdkExtension = 19
 
     defaultConfig {
         applicationId = "id.homebase.feed"

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -42,7 +42,7 @@
         android:roundIcon="@mipmap/ic_launcher"
         android:supportsRtl="true"
         android:largeHeap="true"
-        android:theme="@style/Theme.AppCompat.DayNight.NoActionBar"
+        android:theme="@style/Theme.Material3.DayNight.NoActionBar"
         android:enableOnBackInvokedCallback="true"
         android:usesCleartextTraffic="true"
         tools:targetApi="33">
@@ -83,7 +83,7 @@
             android:name=".share.ShareReceiverActivity"
             android:exported="true"
             android:launchMode="singleTop"
-            android:theme="@style/Theme.AppCompat.DayNight.NoActionBar"
+            android:theme="@style/Theme.Material3.DayNight.NoActionBar"
             android:label="Homebase Chat">
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />

--- a/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
@@ -49,7 +49,7 @@ class MainApplication : Application(), KoinComponent {
     override fun onCreate() {
         super.onCreate()
 
-        if (!isMainProcess()) return
+        if (getProcessName() != packageName) return
 
         // Register the application Context up-front so components that only
         // need Context (cacheDir, ContentResolver — e.g. FFmpegUtils Android
@@ -195,14 +195,6 @@ class MainApplication : Application(), KoinComponent {
                 }
             )
         }
-    }
-
-    private fun isMainProcess(): Boolean {
-        val pid = android.os.Process.myPid()
-        val am = getSystemService(ACTIVITY_SERVICE) as android.app.ActivityManager
-        return am.runningAppProcesses?.any {
-            it.pid == pid && it.processName == packageName
-        } ?: true
     }
 
     private fun setupCrashHandler() {

--- a/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
@@ -49,6 +49,8 @@ class MainApplication : Application(), KoinComponent {
     override fun onCreate() {
         super.onCreate()
 
+        if (!isMainProcess()) return
+
         // Register the application Context up-front so components that only
         // need Context (cacheDir, ContentResolver — e.g. FFmpegUtils Android
         // actuals, VideoThumbnailExtractor) can resolve it before MainActivity
@@ -193,6 +195,14 @@ class MainApplication : Application(), KoinComponent {
                 }
             )
         }
+    }
+
+    private fun isMainProcess(): Boolean {
+        val pid = android.os.Process.myPid()
+        val am = getSystemService(ACTIVITY_SERVICE) as android.app.ActivityManager
+        return am.runningAppProcesses?.any {
+            it.pid == pid && it.processName == packageName
+        } ?: true
     }
 
     private fun setupCrashHandler() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ conveyor = "2.0"
 conveyorControl = "1.1"
 ffmpegKit = "1.0"
 mp4parser = "1.9.39"
+androidx-pdf-viewer = "1.0.0-alpha18"
 pdfbox = "3.0.5"
 vlcj = "4.8.2"
 jetbrains-compose-material3 = "1.9.0"
@@ -74,6 +75,7 @@ play-services-location = "21.3.0"
 [libraries]
 ffmpeg-kit = { module = "id.homebase.libs:ffmpeg-kit", version.ref = "ffmpegKit" }
 mp4parser-isoparser = { module = "org.mp4parser:isoparser", version.ref = "mp4parser" }
+androidx-pdf-viewer = { module = "androidx.pdf:pdf-viewer-fragment", version.ref = "androidx-pdf-viewer" }
 pdfbox = { module = "org.apache.pdfbox:pdfbox", version.ref = "pdfbox" }
 konsist = { module = "com.lemonappdev:konsist", version.ref = "konsist" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "9.2.0"
 android-compileSdk = "36"
-android-minSdk = "27"
+android-minSdk = "28"
 android-targetSdk = "36"
 androidx-activity = "1.13.0"
 androidx-appcompat = "1.7.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ conveyor = "2.0"
 conveyorControl = "1.1"
 ffmpegKit = "1.0"
 mp4parser = "1.9.39"
+pdfbox = "3.0.5"
 vlcj = "4.8.2"
 jetbrains-compose-material3 = "1.9.0"
 jetbrains-compose-material3-adaptive = "1.2.0"
@@ -73,6 +74,7 @@ play-services-location = "21.3.0"
 [libraries]
 ffmpeg-kit = { module = "id.homebase.libs:ffmpeg-kit", version.ref = "ffmpegKit" }
 mp4parser-isoparser = { module = "org.mp4parser:isoparser", version.ref = "mp4parser" }
+pdfbox = { module = "org.apache.pdfbox:pdfbox", version.ref = "pdfbox" }
 konsist = { module = "com.lemonappdev:konsist", version.ref = "konsist" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-testJunit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/FileOperationsProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/FileOperationsProvider.kt
@@ -70,6 +70,14 @@ interface FileOperationsProvider {
      */
     suspend fun resolveToFilePath(path: String): String = path
 
+    /**
+     * Synchronous copy of a security-scoped or externally-provided file into the app
+     * sandbox. Must be called while the file picker's implicit access grant is active
+     * (i.e., on the same call stack as the picker callback, before any suspension).
+     * Returns the sandbox path on success, or the original [path] if no copy is needed.
+     */
+    fun copyToSandboxIfNeeded(path: String): String = path
+
     companion object {
         const val DEFAULT_HEADER_BYTES: Int = 64 * 1024
     }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/FileOperationsProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/FileOperationsProvider.kt
@@ -70,14 +70,6 @@ interface FileOperationsProvider {
      */
     suspend fun resolveToFilePath(path: String): String = path
 
-    /**
-     * Synchronous copy of a security-scoped or externally-provided file into the app
-     * sandbox. Must be called while the file picker's implicit access grant is active
-     * (i.e., on the same call stack as the picker callback, before any suspension).
-     * Returns the sandbox path on success, or the original [path] if no copy is needed.
-     */
-    fun copyToSandboxIfNeeded(path: String): String = path
-
     companion object {
         const val DEFAULT_HEADER_BYTES: Int = 64 * 1024
     }

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/IOSFileOperationsProvider.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/IOSFileOperationsProvider.kt
@@ -67,26 +67,6 @@ class IOSFileOperationsProvider : FileOperationsProvider {
     }
 
     @OptIn(ExperimentalForeignApi::class)
-    override fun copyToSandboxIfNeeded(path: String): String {
-        if (path.startsWith("ph://") || path.contains("/L0/")) return path
-        val fm = NSFileManager.defaultManager
-        if (fm.isReadableFileAtPath(path)) return path
-
-        val url = NSURL.fileURLWithPath(path)
-        val accessed = url.startAccessingSecurityScopedResource()
-        try {
-            val ext = url.pathExtension ?: "tmp"
-            val tempPath = "${NSTemporaryDirectory()}sandbox_${NSUUID().UUIDString}.$ext"
-            if (fm.copyItemAtPath(path, tempPath, null)) {
-                return tempPath
-            }
-        } finally {
-            if (accessed) url.stopAccessingSecurityScopedResource()
-        }
-        return path
-    }
-
-    @OptIn(ExperimentalForeignApi::class)
     override fun deleteTempFile(path: String): Boolean {
         return runCatching {
             val fileManager = NSFileManager.defaultManager
@@ -209,22 +189,6 @@ class IOSFileOperationsProvider : FileOperationsProvider {
             }
             data.writeToFile(tmpPath, atomically = true)
             return tmpPath
-        }
-
-        if (path.contains("File Provider Storage") || path.contains("/Shared/AppGroup/")) {
-            val url = NSURL.fileURLWithPath(path)
-            val accessed = url.startAccessingSecurityScopedResource()
-            try {
-                val fm = NSFileManager.defaultManager
-                val ext = url.pathExtension ?: "tmp"
-                val tempPath = "${NSTemporaryDirectory()}resolved_${NSUUID().UUIDString}.$ext"
-                val tempUrl = NSURL.fileURLWithPath(tempPath)
-                if (fm.copyItemAtURL(url, tempUrl, null)) {
-                    return tempPath
-                }
-            } finally {
-                if (accessed) url.stopAccessingSecurityScopedResource()
-            }
         }
 
         return path

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/IOSFileOperationsProvider.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/IOSFileOperationsProvider.kt
@@ -15,6 +15,7 @@ import platform.Foundation.NSFileHandle
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSNumber
 import platform.Foundation.NSTemporaryDirectory
+import platform.Foundation.NSURL
 import platform.Foundation.NSUUID
 import platform.Foundation.NSUserDomainMask
 import platform.Foundation.closeFile
@@ -32,18 +33,29 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 class IOSFileOperationsProvider : FileOperationsProvider {
+
+    @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+    private fun readFileData(path: String): ByteArray {
+        val url = NSURL.fileURLWithPath(path)
+        val accessed = url.startAccessingSecurityScopedResource()
+        try {
+            val data = NSData.dataWithContentsOfFile(path)
+                ?: error("Unable to read file at $path")
+            val bytes = ByteArray(data.length.toInt())
+            bytes.usePinned { pinned -> memcpy(pinned.addressOf(0), data.bytes, data.length) }
+            return bytes
+        } finally {
+            if (accessed) url.stopAccessingSecurityScopedResource()
+        }
+    }
+
     @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
     override fun openFileInput(path: String): InputProvider = InputProvider {
         if (path.startsWith("ph://") || path.contains("/L0/")) {
             val bytes = runBlocking { readPhotoLibraryAsset(path) }
             return@InputProvider Buffer().apply { write(bytes) }
         }
-        val data = NSData.dataWithContentsOfFile(path) ?: error("Unable to read file at $path")
-
-        val bytes = ByteArray(data.length.toInt())
-        bytes.usePinned { pinned -> memcpy(pinned.addressOf(0), data.bytes, data.length) }
-
-        Buffer().apply { write(bytes) }
+        Buffer().apply { write(readFileData(path)) }
     }
 
     @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
@@ -51,11 +63,27 @@ class IOSFileOperationsProvider : FileOperationsProvider {
         if (path.startsWith("ph://") || path.contains("/L0/")) {
             return readPhotoLibraryAsset(path)
         }
-        val data = NSData.dataWithContentsOfFile(path) ?: error("Unable to read file at $path")
+        return readFileData(path)
+    }
 
-        val bytes = ByteArray(data.length.toInt())
-        bytes.usePinned { pinned -> memcpy(pinned.addressOf(0), data.bytes, data.length) }
-        return bytes
+    @OptIn(ExperimentalForeignApi::class)
+    override fun copyToSandboxIfNeeded(path: String): String {
+        if (path.startsWith("ph://") || path.contains("/L0/")) return path
+        val fm = NSFileManager.defaultManager
+        if (fm.isReadableFileAtPath(path)) return path
+
+        val url = NSURL.fileURLWithPath(path)
+        val accessed = url.startAccessingSecurityScopedResource()
+        try {
+            val ext = url.pathExtension ?: "tmp"
+            val tempPath = "${NSTemporaryDirectory()}sandbox_${NSUUID().UUIDString}.$ext"
+            if (fm.copyItemAtPath(path, tempPath, null)) {
+                return tempPath
+            }
+        } finally {
+            if (accessed) url.stopAccessingSecurityScopedResource()
+        }
+        return path
     }
 
     @OptIn(ExperimentalForeignApi::class)
@@ -173,14 +201,33 @@ class IOSFileOperationsProvider : FileOperationsProvider {
 
     @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
     override suspend fun resolveToFilePath(path: String): String {
-        if (!path.startsWith("ph://") && !path.contains("/L0/")) return path
-        val bytes = readPhotoLibraryAsset(path)
-        val tmpPath = "${NSTemporaryDirectory()}resolved_${NSUUID().UUIDString}.mov"
-        val data = bytes.usePinned { pinned ->
-            NSData.create(bytes = pinned.addressOf(0), length = bytes.size.toULong())
+        if (path.startsWith("ph://") || path.contains("/L0/")) {
+            val bytes = readPhotoLibraryAsset(path)
+            val tmpPath = "${NSTemporaryDirectory()}resolved_${NSUUID().UUIDString}.mov"
+            val data = bytes.usePinned { pinned ->
+                NSData.create(bytes = pinned.addressOf(0), length = bytes.size.toULong())
+            }
+            data.writeToFile(tmpPath, atomically = true)
+            return tmpPath
         }
-        data.writeToFile(tmpPath, atomically = true)
-        return tmpPath
+
+        if (path.contains("File Provider Storage") || path.contains("/Shared/AppGroup/")) {
+            val url = NSURL.fileURLWithPath(path)
+            val accessed = url.startAccessingSecurityScopedResource()
+            try {
+                val fm = NSFileManager.defaultManager
+                val ext = url.pathExtension ?: "tmp"
+                val tempPath = "${NSTemporaryDirectory()}resolved_${NSUUID().UUIDString}.$ext"
+                val tempUrl = NSURL.fileURLWithPath(tempPath)
+                if (fm.copyItemAtURL(url, tempUrl, null)) {
+                    return tempPath
+                }
+            } finally {
+                if (accessed) url.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        return path
     }
 
     @OptIn(ExperimentalForeignApi::class, kotlinx.cinterop.BetaInteropApi::class)

--- a/homebase-auth/build.gradle.kts
+++ b/homebase-auth/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
     android {
         namespace = "id.homebase.auth"
         compileSdk = libs.versions.android.targetSdk.get().toInt()
+        compileSdkExtension = 19
         minSdk = libs.versions.android.minSdk.get().toInt()
         withHostTest {}
     }

--- a/homebase-chat/build.gradle.kts
+++ b/homebase-chat/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
     android {
         namespace = "id.homebase.chat"
         compileSdk = libs.versions.android.targetSdk.get().toInt()
+        compileSdkExtension = 19
         minSdk = libs.versions.android.minSdk.get().toInt()
         withHostTest {}
     }

--- a/homebase-common/build.gradle.kts
+++ b/homebase-common/build.gradle.kts
@@ -113,6 +113,7 @@ kotlin {
             implementation(libs.androidx.appcompat)
             implementation(libs.androidx.biometric)
             implementation(libs.androidx.browser)
+            implementation(libs.androidx.pdf.viewer)
             implementation(libs.ktor.client.okhttp)
             implementation(libs.accompanist.permissions)
             implementation(libs.firebase.crashlytics)

--- a/homebase-common/build.gradle.kts
+++ b/homebase-common/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
     android {
         namespace = "id.homebase.common"
         compileSdk = libs.versions.android.targetSdk.get().toInt()
+        compileSdkExtension = 19
         minSdk = libs.versions.android.minSdk.get().toInt()
         androidResources.enable = true
         withHostTest {}

--- a/homebase-common/build.gradle.kts
+++ b/homebase-common/build.gradle.kts
@@ -132,6 +132,7 @@ kotlin {
             implementation(libs.nucleus.notification.macos)
             implementation(libs.nucleus.notification.linux)
             implementation(libs.kermit.io)
+            implementation(libs.pdfbox)
         }
         // Uncomment in step 10 of the WASM pre-flight plan, paired with
         // `wasmJs { browser() }`. ktor-client-js provides the browser

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfPageViewer.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfPageViewer.android.kt
@@ -1,0 +1,60 @@
+package id.homebase.core.pdf
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@Composable
+actual fun PdfPageViewer(
+    filePath: String,
+    onTap: (() -> Unit)?,
+    modifier: Modifier,
+) {
+    var renderer by remember { mutableStateOf<PdfRenderer?>(null) }
+
+    LaunchedEffect(filePath) {
+        renderer?.close()
+        renderer = null
+        val r = PdfRenderer()
+        try {
+            withContext(Dispatchers.Default) { r.open(filePath) }
+            renderer = r
+        } catch (e: CancellationException) {
+            r.close()
+            throw e
+        } catch (_: Exception) {
+            r.close()
+        }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose { renderer?.close() }
+    }
+
+    val r = renderer
+    if (r != null) {
+        BitmapPdfPageViewer(renderer = r, onTap = onTap, modifier = modifier)
+    } else {
+        Box(modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(32.dp),
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+    }
+}

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfPageViewer.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfPageViewer.android.kt
@@ -1,5 +1,8 @@
 package id.homebase.core.pdf
 
+import android.net.Uri
+import android.os.Build
+import android.os.ext.SdkExtensions
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
@@ -14,13 +17,77 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentContainerView
+import androidx.pdf.viewer.fragment.PdfViewerFragment
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.io.File
+
+private fun isPdfViewerAvailable(): Boolean =
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+        SdkExtensions.getExtensionVersion(Build.VERSION_CODES.S) >= 13
 
 @Composable
 actual fun PdfPageViewer(
+    filePath: String,
+    onTap: (() -> Unit)?,
+    modifier: Modifier,
+) {
+    if (isPdfViewerAvailable()) {
+        NativePdfViewer(filePath = filePath, modifier = modifier)
+    } else {
+        BitmapPdfViewerFallback(filePath = filePath, onTap = onTap, modifier = modifier)
+    }
+}
+
+@Composable
+private fun NativePdfViewer(filePath: String, modifier: Modifier) {
+    val context = LocalContext.current
+    val uri = remember(filePath) { Uri.fromFile(File(filePath)) }
+    val fragmentTag = remember(filePath) { "pdf_viewer_${filePath.hashCode()}" }
+
+    AndroidView(
+        factory = { ctx ->
+            FragmentContainerView(ctx).apply {
+                id = android.view.View.generateViewId()
+            }
+        },
+        update = { containerView ->
+            val activity = context as? FragmentActivity ?: return@AndroidView
+            val fm = activity.supportFragmentManager
+            val existing = fm.findFragmentByTag(fragmentTag) as? PdfViewerFragment
+            if (existing == null) {
+                val fragment = PdfViewerFragment()
+                fm.beginTransaction()
+                    .replace(containerView.id, fragment, fragmentTag)
+                    .commitAllowingStateLoss()
+                fm.executePendingTransactions()
+                fragment.documentUri = uri
+            } else if (existing.documentUri != uri) {
+                existing.documentUri = uri
+            }
+        },
+        onReset = { containerView ->
+            val activity = context as? FragmentActivity
+            if (activity != null) {
+                val fm = activity.supportFragmentManager
+                val fragment = fm.findFragmentByTag(fragmentTag)
+                if (fragment != null) {
+                    fm.beginTransaction().remove(fragment).commitAllowingStateLoss()
+                }
+            }
+        },
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun BitmapPdfViewerFallback(
     filePath: String,
     onTap: (() -> Unit)?,
     modifier: Modifier,

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfPageViewer.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfPageViewer.android.kt
@@ -1,36 +1,15 @@
 package id.homebase.core.pdf
 
 import android.net.Uri
-import android.os.Build
-import android.os.ext.SdkExtensions
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.size
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentContainerView
 import androidx.pdf.viewer.fragment.PdfViewerFragment
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import java.io.File
-
-private fun isPdfViewerAvailable(): Boolean =
-    Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
-        SdkExtensions.getExtensionVersion(Build.VERSION_CODES.S) >= 13
 
 @Composable
 actual fun PdfPageViewer(
@@ -38,18 +17,9 @@ actual fun PdfPageViewer(
     onTap: (() -> Unit)?,
     modifier: Modifier,
 ) {
-    if (isPdfViewerAvailable()) {
-        NativePdfViewer(filePath = filePath, modifier = modifier)
-    } else {
-        BitmapPdfViewerFallback(filePath = filePath, onTap = onTap, modifier = modifier)
-    }
-}
-
-@Composable
-private fun NativePdfViewer(filePath: String, modifier: Modifier) {
     val context = LocalContext.current
     val uri = remember(filePath) { Uri.fromFile(File(filePath)) }
-    val fragmentTag = remember(filePath) { "pdf_viewer_${filePath.hashCode()}" }
+    val fragmentTag = remember(filePath) { "pdf_viewer_${filePath.hashCode()}_${filePath.length}" }
 
     AndroidView(
         factory = { ctx ->
@@ -84,44 +54,4 @@ private fun NativePdfViewer(filePath: String, modifier: Modifier) {
         },
         modifier = modifier,
     )
-}
-
-@Composable
-private fun BitmapPdfViewerFallback(
-    filePath: String,
-    onTap: (() -> Unit)?,
-    modifier: Modifier,
-) {
-    var renderer by remember { mutableStateOf<PdfRenderer?>(null) }
-
-    LaunchedEffect(filePath) {
-        renderer?.close()
-        renderer = null
-        val r = PdfRenderer()
-        try {
-            withContext(Dispatchers.Default) { r.open(filePath) }
-            renderer = r
-        } catch (e: CancellationException) {
-            r.close()
-            throw e
-        } catch (_: Exception) {
-            r.close()
-        }
-    }
-
-    DisposableEffect(Unit) {
-        onDispose { renderer?.close() }
-    }
-
-    val r = renderer
-    if (r != null) {
-        BitmapPdfPageViewer(renderer = r, onTap = onTap, modifier = modifier)
-    } else {
-        Box(modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            CircularProgressIndicator(
-                modifier = Modifier.size(32.dp),
-                color = MaterialTheme.colorScheme.primary,
-            )
-        }
-    }
 }

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfPageViewer.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfPageViewer.android.kt
@@ -1,6 +1,11 @@
 package id.homebase.core.pdf
 
+import android.content.Context
 import android.net.Uri
+import android.view.GestureDetector
+import android.view.MotionEvent
+import android.view.View
+import android.widget.FrameLayout
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -10,6 +15,29 @@ import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentContainerView
 import androidx.pdf.viewer.fragment.PdfViewerFragment
 import java.io.File
+
+private class TapDetectingFrameLayout(
+    ctx: Context,
+    private val onSingleTap: (() -> Unit)?,
+) : FrameLayout(ctx) {
+
+    private val detector = onSingleTap?.let {
+        GestureDetector(
+            ctx,
+            object : GestureDetector.SimpleOnGestureListener() {
+                override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
+                    it()
+                    return true
+                }
+            },
+        )
+    }
+
+    override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+        if (ev.pointerCount == 1) detector?.onTouchEvent(ev)
+        return super.dispatchTouchEvent(ev)
+    }
+}
 
 @Composable
 actual fun PdfPageViewer(
@@ -23,18 +51,28 @@ actual fun PdfPageViewer(
 
     AndroidView(
         factory = { ctx ->
-            FragmentContainerView(ctx).apply {
-                id = android.view.View.generateViewId()
+            TapDetectingFrameLayout(ctx, onTap).apply {
+                val container = FragmentContainerView(ctx).apply {
+                    id = View.generateViewId()
+                }
+                addView(
+                    container,
+                    FrameLayout.LayoutParams(
+                        FrameLayout.LayoutParams.MATCH_PARENT,
+                        FrameLayout.LayoutParams.MATCH_PARENT,
+                    ),
+                )
             }
         },
-        update = { containerView ->
+        update = { frameLayout ->
             val activity = context as? FragmentActivity ?: return@AndroidView
             val fm = activity.supportFragmentManager
+            val container = frameLayout.getChildAt(0) as? FragmentContainerView ?: return@AndroidView
             val existing = fm.findFragmentByTag(fragmentTag) as? PdfViewerFragment
             if (existing == null) {
                 val fragment = PdfViewerFragment()
                 fm.beginTransaction()
-                    .replace(containerView.id, fragment, fragmentTag)
+                    .replace(container.id, fragment, fragmentTag)
                     .commitAllowingStateLoss()
                 fm.executePendingTransactions()
                 fragment.documentUri = uri
@@ -42,7 +80,7 @@ actual fun PdfPageViewer(
                 existing.documentUri = uri
             }
         },
-        onReset = { containerView ->
+        onReset = { frameLayout ->
             val activity = context as? FragmentActivity
             if (activity != null) {
                 val fm = activity.supportFragmentManager

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfRenderer.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfRenderer.android.kt
@@ -1,0 +1,44 @@
+package id.homebase.core.pdf
+
+import android.graphics.Bitmap
+import android.os.ParcelFileDescriptor
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import java.io.File
+import android.graphics.pdf.PdfRenderer as AndroidPdfRenderer
+
+actual class PdfRenderer actual constructor() {
+
+    private var fileDescriptor: ParcelFileDescriptor? = null
+    private var nativeRenderer: AndroidPdfRenderer? = null
+
+    actual fun open(filePath: String) {
+        val fd = ParcelFileDescriptor.open(File(filePath), ParcelFileDescriptor.MODE_READ_ONLY)
+        fileDescriptor = fd
+        nativeRenderer = AndroidPdfRenderer(fd)
+    }
+
+    actual val pageCount: Int
+        get() = nativeRenderer?.pageCount ?: 0
+
+    actual fun renderPage(index: Int, width: Int, height: Int): ImageBitmap {
+        val renderer = requireNotNull(nativeRenderer) { "PdfRenderer not opened. Call open() first." }
+        val page = renderer.openPage(index)
+        val scaleX = width.toFloat() / page.width
+        val scaleY = height.toFloat() / page.height
+        val scale = minOf(scaleX, scaleY)
+        val bitmapWidth = (page.width * scale).toInt()
+        val bitmapHeight = (page.height * scale).toInt()
+        val bitmap = Bitmap.createBitmap(bitmapWidth, bitmapHeight, Bitmap.Config.ARGB_8888)
+        page.render(bitmap, null, null, AndroidPdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+        page.close()
+        return bitmap.asImageBitmap()
+    }
+
+    actual fun close() {
+        try { nativeRenderer?.close() } catch (_: Exception) { }
+        try { fileDescriptor?.close() } catch (_: Exception) { }
+        nativeRenderer = null
+        fileDescriptor = null
+    }
+}

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfRenderer.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfRenderer.android.kt
@@ -13,6 +13,7 @@ actual class PdfRenderer actual constructor() {
     private var nativeRenderer: AndroidPdfRenderer? = null
 
     actual fun open(filePath: String) {
+        close()
         val fd = ParcelFileDescriptor.open(File(filePath), ParcelFileDescriptor.MODE_READ_ONLY)
         fileDescriptor = fd
         nativeRenderer = AndroidPdfRenderer(fd)

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfRenderer.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfRenderer.android.kt
@@ -31,6 +31,7 @@ actual class PdfRenderer actual constructor() {
         val bitmapWidth = (page.width * scale).toInt()
         val bitmapHeight = (page.height * scale).toInt()
         val bitmap = Bitmap.createBitmap(bitmapWidth, bitmapHeight, Bitmap.Config.ARGB_8888)
+        bitmap.eraseColor(android.graphics.Color.WHITE)
         page.render(bitmap, null, null, AndroidPdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
         page.close()
         return bitmap.asImageBitmap()

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.android.kt
@@ -6,6 +6,40 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import android.graphics.pdf.PdfRenderer as AndroidPdfRenderer
 
+actual fun generatePdfThumbnailFromFile(filePath: String, maxWidth: Int): PdfThumbnailResult? {
+    return try {
+        val fd = ParcelFileDescriptor.open(File(filePath), ParcelFileDescriptor.MODE_READ_ONLY)
+        try {
+            val renderer = AndroidPdfRenderer(fd)
+            try {
+                val page = renderer.openPage(0)
+                val scale = maxWidth.toFloat() / page.width
+                val bitmapWidth = (page.width * scale).toInt()
+                val bitmapHeight = (page.height * scale).toInt()
+                val bitmap = Bitmap.createBitmap(bitmapWidth, bitmapHeight, Bitmap.Config.ARGB_8888)
+                try {
+                    page.render(bitmap, null, null, AndroidPdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+                } finally {
+                    page.close()
+                }
+                val pageCount = renderer.pageCount
+                val output = ByteArrayOutputStream()
+                bitmap.compress(Bitmap.CompressFormat.JPEG, 80, output)
+                PdfThumbnailResult(
+                    thumbnailBytes = output.toByteArray(),
+                    pageCount = pageCount,
+                )
+            } finally {
+                renderer.close()
+            }
+        } finally {
+            fd.close()
+        }
+    } catch (_: Exception) {
+        null
+    }
+}
+
 actual fun generatePdfThumbnail(bytes: ByteArray, maxWidth: Int): PdfThumbnailResult? {
     return try {
         val tempFile = File.createTempFile("pdf_thumb_", ".pdf")

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.android.kt
@@ -17,6 +17,7 @@ actual fun generatePdfThumbnailFromFile(filePath: String, maxWidth: Int): PdfThu
                 val bitmapWidth = (page.width * scale).toInt()
                 val bitmapHeight = (page.height * scale).toInt()
                 val bitmap = Bitmap.createBitmap(bitmapWidth, bitmapHeight, Bitmap.Config.ARGB_8888)
+                bitmap.eraseColor(android.graphics.Color.WHITE)
                 try {
                     page.render(bitmap, null, null, AndroidPdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
                 } finally {
@@ -54,6 +55,7 @@ actual fun generatePdfThumbnail(bytes: ByteArray, maxWidth: Int): PdfThumbnailRe
                     val bitmapWidth = (page.width * scale).toInt()
                     val bitmapHeight = (page.height * scale).toInt()
                     val bitmap = Bitmap.createBitmap(bitmapWidth, bitmapHeight, Bitmap.Config.ARGB_8888)
+                    bitmap.eraseColor(android.graphics.Color.WHITE)
                     try {
                         page.render(bitmap, null, null, AndroidPdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
                     } finally {

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.android.kt
@@ -1,0 +1,47 @@
+package id.homebase.core.pdf
+
+import android.graphics.Bitmap
+import android.os.ParcelFileDescriptor
+import java.io.ByteArrayOutputStream
+import java.io.File
+import android.graphics.pdf.PdfRenderer as AndroidPdfRenderer
+
+actual fun generatePdfThumbnail(bytes: ByteArray, maxWidth: Int): PdfThumbnailResult? {
+    return try {
+        val tempFile = File.createTempFile("pdf_thumb_", ".pdf")
+        try {
+            tempFile.writeBytes(bytes)
+            val fd = ParcelFileDescriptor.open(tempFile, ParcelFileDescriptor.MODE_READ_ONLY)
+            try {
+                val renderer = AndroidPdfRenderer(fd)
+                try {
+                    val page = renderer.openPage(0)
+                    val scale = maxWidth.toFloat() / page.width
+                    val bitmapWidth = (page.width * scale).toInt()
+                    val bitmapHeight = (page.height * scale).toInt()
+                    val bitmap = Bitmap.createBitmap(bitmapWidth, bitmapHeight, Bitmap.Config.ARGB_8888)
+                    try {
+                        page.render(bitmap, null, null, AndroidPdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+                    } finally {
+                        page.close()
+                    }
+                    val pageCount = renderer.pageCount
+                    val output = ByteArrayOutputStream()
+                    bitmap.compress(Bitmap.CompressFormat.JPEG, 80, output)
+                    PdfThumbnailResult(
+                        thumbnailBytes = output.toByteArray(),
+                        pageCount = pageCount,
+                    )
+                } finally {
+                    renderer.close()
+                }
+            } finally {
+                fd.close()
+            }
+        } finally {
+            tempFile.delete()
+        }
+    } catch (_: Exception) {
+        null
+    }
+}

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.android.kt
@@ -6,30 +6,34 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import android.graphics.pdf.PdfRenderer as AndroidPdfRenderer
 
+private fun generatePdfThumbnail(renderer: AndroidPdfRenderer, maxWidth: Int): PdfThumbnailResult {
+    val page = renderer.openPage(0)
+    val scale = maxWidth.toFloat() / page.width
+    val bitmapWidth = (page.width * scale).toInt()
+    val bitmapHeight = (page.height * scale).toInt()
+    val bitmap = Bitmap.createBitmap(bitmapWidth, bitmapHeight, Bitmap.Config.ARGB_8888)
+    bitmap.eraseColor(android.graphics.Color.WHITE)
+    try {
+        page.render(bitmap, null, null, AndroidPdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+    } finally {
+        page.close()
+    }
+    val pageCount = renderer.pageCount
+    val output = ByteArrayOutputStream()
+    bitmap.compress(Bitmap.CompressFormat.JPEG, 80, output)
+    return PdfThumbnailResult(
+        thumbnailBytes = output.toByteArray(),
+        pageCount = pageCount,
+    )
+}
+
 actual fun generatePdfThumbnailFromFile(filePath: String, maxWidth: Int): PdfThumbnailResult? {
     return try {
         val fd = ParcelFileDescriptor.open(File(filePath), ParcelFileDescriptor.MODE_READ_ONLY)
         try {
             val renderer = AndroidPdfRenderer(fd)
             try {
-                val page = renderer.openPage(0)
-                val scale = maxWidth.toFloat() / page.width
-                val bitmapWidth = (page.width * scale).toInt()
-                val bitmapHeight = (page.height * scale).toInt()
-                val bitmap = Bitmap.createBitmap(bitmapWidth, bitmapHeight, Bitmap.Config.ARGB_8888)
-                bitmap.eraseColor(android.graphics.Color.WHITE)
-                try {
-                    page.render(bitmap, null, null, AndroidPdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
-                } finally {
-                    page.close()
-                }
-                val pageCount = renderer.pageCount
-                val output = ByteArrayOutputStream()
-                bitmap.compress(Bitmap.CompressFormat.JPEG, 80, output)
-                PdfThumbnailResult(
-                    thumbnailBytes = output.toByteArray(),
-                    pageCount = pageCount,
-                )
+                generatePdfThumbnail(renderer, maxWidth)
             } finally {
                 renderer.close()
             }
@@ -50,24 +54,7 @@ actual fun generatePdfThumbnail(bytes: ByteArray, maxWidth: Int): PdfThumbnailRe
             try {
                 val renderer = AndroidPdfRenderer(fd)
                 try {
-                    val page = renderer.openPage(0)
-                    val scale = maxWidth.toFloat() / page.width
-                    val bitmapWidth = (page.width * scale).toInt()
-                    val bitmapHeight = (page.height * scale).toInt()
-                    val bitmap = Bitmap.createBitmap(bitmapWidth, bitmapHeight, Bitmap.Config.ARGB_8888)
-                    bitmap.eraseColor(android.graphics.Color.WHITE)
-                    try {
-                        page.render(bitmap, null, null, AndroidPdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
-                    } finally {
-                        page.close()
-                    }
-                    val pageCount = renderer.pageCount
-                    val output = ByteArrayOutputStream()
-                    bitmap.compress(Bitmap.CompressFormat.JPEG, 80, output)
-                    PdfThumbnailResult(
-                        thumbnailBytes = output.toByteArray(),
-                        pageCount = pageCount,
-                    )
+                    generatePdfThumbnail(renderer, maxWidth)
                 } finally {
                     renderer.close()
                 }

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -807,6 +807,7 @@
     <string name="vault_pdf_preview_error">Unable to preview PDF</string>
     <string name="vault_pdf_page_content_description">PDF page %1$d of %2$d</string>
     <string name="vault_text_preview_error">Unable to preview file</string>
+    <string name="vault_text_truncated">File is large — showing first 1 MB</string>
 
     <string name="feed_error_title">Failed to load feed</string>
     <string name="feed_error_retry">Retry</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -805,6 +805,7 @@
     <string name="vault_error_image_unavailable">Image could not be loaded</string>
     <string name="vault_pdf_badge">PDF</string>
     <string name="vault_pdf_preview_error">Unable to preview PDF</string>
+    <string name="vault_pdf_not_supported">PDF preview is not supported on web</string>
     <string name="vault_pdf_page_content_description">PDF page %1$d of %2$d</string>
     <string name="vault_text_preview_error">Unable to preview file</string>
     <string name="vault_text_truncated">File is large — showing first 1 MB</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -746,8 +746,10 @@
     <string name="vault_entry_delete_confirm">Delete %1$s? This entry and all its images will be permanently deleted.</string>
 
     <string name="vault_image_add">Add Image</string>
+    <string name="vault_add_entry">Add Entry</string>
     <string name="vault_image_take_photo">Take Photo</string>
     <string name="vault_image_choose_gallery">Choose from Gallery</string>
+    <string name="vault_choose_file">Choose File</string>
     <string name="vault_image_replace">Replace</string>
     <string name="vault_image_delete">Delete Image</string>
 
@@ -801,6 +803,9 @@
     <string name="vault_error_download_page">Failed to download page for sharing</string>
     <string name="vault_error_outbox_upload">Upload failed</string>
     <string name="vault_error_image_unavailable">Image could not be loaded</string>
+    <string name="vault_pdf_badge">PDF</string>
+    <string name="vault_pdf_preview_error">Unable to preview PDF</string>
+    <string name="vault_pdf_page_content_description">PDF page %1$d of %2$d</string>
 
     <string name="feed_error_title">Failed to load feed</string>
     <string name="feed_error_retry">Retry</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -806,6 +806,7 @@
     <string name="vault_pdf_badge">PDF</string>
     <string name="vault_pdf_preview_error">Unable to preview PDF</string>
     <string name="vault_pdf_page_content_description">PDF page %1$d of %2$d</string>
+    <string name="vault_text_preview_error">Unable to preview file</string>
 
     <string name="feed_error_title">Failed to load feed</string>
     <string name="feed_error_retry">Retry</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/EmbeddedThumbExt.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/EmbeddedThumbExt.kt
@@ -10,10 +10,7 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 fun EmbeddedThumb.decodeBitmap(): ImageBitmap? {
     val raw = content ?: return null
     return try {
-        val cleaned = raw
-            .removePrefix("data:image/png;base64,")
-            .removePrefix("data:image/jpeg;base64,")
-            .removePrefix("data:image/jpg;base64,")
+        val cleaned = raw.replace(Regex("^data:image/[^;]+;base64,"), "")
         Base64.decode(cleaned).decodeToImageBitmap()
     } catch (_: Exception) {
         null

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/EmbeddedThumbExt.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/EmbeddedThumbExt.kt
@@ -1,0 +1,21 @@
+package id.homebase.core.image
+
+import androidx.compose.ui.graphics.ImageBitmap
+import id.homebase.api.client.drives.upload.EmbeddedThumb
+import org.jetbrains.compose.resources.decodeToImageBitmap
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+@OptIn(ExperimentalEncodingApi::class)
+fun EmbeddedThumb.decodeBitmap(): ImageBitmap? {
+    val raw = content ?: return null
+    return try {
+        val cleaned = raw
+            .removePrefix("data:image/png;base64,")
+            .removePrefix("data:image/jpeg;base64,")
+            .removePrefix("data:image/jpg;base64,")
+        Base64.decode(cleaned).decodeToImageBitmap()
+    } catch (_: Exception) {
+        null
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/pdf/PdfPageViewer.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/pdf/PdfPageViewer.kt
@@ -34,6 +34,8 @@ import id.homebase.resources.MR
 import id.homebase.resources.vault_gallery_page_counter
 import id.homebase.resources.vault_pdf_page_content_description
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
 
@@ -56,6 +58,7 @@ internal fun BitmapPdfPageViewer(
     val listState = rememberLazyListState()
     val pageCount = renderer.pageCount
     val renderedPages = remember { mutableStateMapOf<Int, ImageBitmap>() }
+    val renderMutex = remember { Mutex() }
 
     val currentPage by remember {
         derivedStateOf {
@@ -88,6 +91,7 @@ internal fun BitmapPdfPageViewer(
             items(pageCount) { index ->
                 BitmapPdfPage(
                     renderer = renderer,
+                    renderMutex = renderMutex,
                     pageIndex = index,
                     pageCount = pageCount,
                     cachedBitmap = renderedPages[index],
@@ -121,6 +125,7 @@ internal fun BitmapPdfPageViewer(
 @Composable
 private fun BitmapPdfPage(
     renderer: PdfRenderer,
+    renderMutex: Mutex,
     pageIndex: Int,
     pageCount: Int,
     cachedBitmap: ImageBitmap?,
@@ -139,8 +144,10 @@ private fun BitmapPdfPage(
 
         LaunchedEffect(pageIndex, pixelWidth, pixelHeight) {
             if (cachedBitmap == null && pixelWidth > 0 && pixelHeight > 0) {
-                val bitmap = withContext(Dispatchers.Default) {
-                    renderer.renderPage(pageIndex, pixelWidth, pixelHeight)
+                val bitmap = renderMutex.withLock {
+                    withContext(Dispatchers.Default) {
+                        renderer.renderPage(pageIndex, pixelWidth, pixelHeight)
+                    }
                 }
                 onRendered(bitmap)
             }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/pdf/PdfPageViewer.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/pdf/PdfPageViewer.kt
@@ -2,10 +2,7 @@ package id.homebase.core.pdf
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -25,8 +22,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import id.homebase.core.util.boundedFirstVisibleItemIndex
@@ -42,6 +40,7 @@ private const val PAGE_CACHE_WINDOW = 5
 @Composable
 fun PdfPageViewer(
     renderer: PdfRenderer,
+    onTap: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val listState = rememberLazyListState()
@@ -66,11 +65,15 @@ fun PdfPageViewer(
             }
     }
 
-    Box(modifier = modifier.fillMaxSize()) {
+    val tapModifier = if (onTap != null) {
+        Modifier.pointerInput(Unit) { detectTapGestures(onTap = { onTap() }) }
+    } else {
+        Modifier
+    }
+
+    Box(modifier = modifier.fillMaxSize().then(tapModifier)) {
         LazyColumn(
             state = listState,
-            contentPadding = PaddingValues(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier.fillMaxSize(),
         ) {
             items(pageCount) { index ->
@@ -80,6 +83,7 @@ fun PdfPageViewer(
                     pageCount = pageCount,
                     cachedBitmap = renderedPages[index],
                     onRendered = { renderedPages[index] = it },
+                    modifier = Modifier.fillParentMaxHeight(),
                 )
             }
         }
@@ -112,6 +116,7 @@ private fun PdfPage(
     pageCount: Int,
     cachedBitmap: ImageBitmap?,
     onRendered: (ImageBitmap) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     LaunchedEffect(pageIndex) {
         if (cachedBitmap == null) {
@@ -123,10 +128,8 @@ private fun PdfPage(
     }
 
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
-            .aspectRatio(0.75f)
-            .clip(RoundedCornerShape(4.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerLowest),
         contentAlignment = Alignment.Center,
     ) {

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/pdf/PdfPageViewer.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/pdf/PdfPageViewer.kt
@@ -2,6 +2,7 @@ package id.homebase.core.pdf
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -22,7 +23,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
@@ -35,10 +35,18 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
 
+@Composable
+expect fun PdfPageViewer(
+    filePath: String,
+    onTap: (() -> Unit)? = null,
+    modifier: Modifier = Modifier,
+)
+
+// Bitmap-based viewer used by Android, JVM, and Web actuals
 private const val PAGE_CACHE_WINDOW = 5
 
 @Composable
-fun PdfPageViewer(
+internal fun BitmapPdfPageViewer(
     renderer: PdfRenderer,
     onTap: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
@@ -54,7 +62,6 @@ fun PdfPageViewer(
         }
     }
 
-    // Evict pages outside the visible window to bound memory usage
     LaunchedEffect(Unit) {
         snapshotFlow { listState.boundedFirstVisibleItemIndex(pageCount) }
             .collect { visibleIndex ->
@@ -77,7 +84,7 @@ fun PdfPageViewer(
             modifier = Modifier.fillMaxSize(),
         ) {
             items(pageCount) { index ->
-                PdfPage(
+                BitmapPdfPage(
                     renderer = renderer,
                     pageIndex = index,
                     pageCount = pageCount,
@@ -110,7 +117,7 @@ fun PdfPageViewer(
 }
 
 @Composable
-private fun PdfPage(
+private fun BitmapPdfPage(
     renderer: PdfRenderer,
     pageIndex: Int,
     pageCount: Int,

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/pdf/PdfPageViewer.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/pdf/PdfPageViewer.kt
@@ -1,0 +1,152 @@
+package id.homebase.core.pdf
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import id.homebase.core.util.boundedFirstVisibleItemIndex
+import id.homebase.resources.MR
+import id.homebase.resources.vault_gallery_page_counter
+import id.homebase.resources.vault_pdf_page_content_description
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.stringResource
+
+private const val PAGE_CACHE_WINDOW = 5
+
+@Composable
+fun PdfPageViewer(
+    renderer: PdfRenderer,
+    modifier: Modifier = Modifier,
+) {
+    val listState = rememberLazyListState()
+    val pageCount = renderer.pageCount
+    val renderedPages = remember { mutableStateMapOf<Int, ImageBitmap>() }
+
+    val currentPage by remember {
+        derivedStateOf {
+            val bounded = listState.boundedFirstVisibleItemIndex(pageCount)
+            (bounded ?: 0) + 1
+        }
+    }
+
+    // Evict pages outside the visible window to bound memory usage
+    LaunchedEffect(Unit) {
+        snapshotFlow { listState.boundedFirstVisibleItemIndex(pageCount) }
+            .collect { visibleIndex ->
+                val center = visibleIndex ?: return@collect
+                val keep = (center - PAGE_CACHE_WINDOW)..(center + PAGE_CACHE_WINDOW)
+                val toEvict = renderedPages.keys.filter { it !in keep }
+                toEvict.forEach { renderedPages.remove(it) }
+            }
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        LazyColumn(
+            state = listState,
+            contentPadding = PaddingValues(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            items(pageCount) { index ->
+                PdfPage(
+                    renderer = renderer,
+                    pageIndex = index,
+                    pageCount = pageCount,
+                    cachedBitmap = renderedPages[index],
+                    onRendered = { renderedPages[index] = it },
+                )
+            }
+        }
+
+        if (pageCount > 1) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 16.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.inverseSurface.copy(alpha = 0.8f),
+                        shape = RoundedCornerShape(16.dp),
+                    )
+                    .padding(horizontal = 14.dp, vertical = 6.dp),
+            ) {
+                Text(
+                    text = stringResource(MR.string.vault_gallery_page_counter, currentPage, pageCount),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.inverseOnSurface,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PdfPage(
+    renderer: PdfRenderer,
+    pageIndex: Int,
+    pageCount: Int,
+    cachedBitmap: ImageBitmap?,
+    onRendered: (ImageBitmap) -> Unit,
+) {
+    LaunchedEffect(pageIndex) {
+        if (cachedBitmap == null) {
+            val bitmap = withContext(Dispatchers.Default) {
+                renderer.renderPage(pageIndex, 1200, 1600)
+            }
+            onRendered(bitmap)
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .aspectRatio(0.75f)
+            .clip(RoundedCornerShape(4.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerLowest),
+        contentAlignment = Alignment.Center,
+    ) {
+        val bitmap = cachedBitmap
+        if (bitmap != null) {
+            Image(
+                bitmap = bitmap,
+                contentDescription = stringResource(
+                    MR.string.vault_pdf_page_content_description,
+                    pageIndex + 1,
+                    pageCount,
+                ),
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Fit,
+            )
+        } else {
+            CircularProgressIndicator(
+                modifier = Modifier.size(32.dp),
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/pdf/PdfPageViewer.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/pdf/PdfPageViewer.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -26,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import id.homebase.core.util.boundedFirstVisibleItemIndex
 import id.homebase.resources.MR
@@ -125,21 +127,25 @@ private fun BitmapPdfPage(
     onRendered: (ImageBitmap) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LaunchedEffect(pageIndex) {
-        if (cachedBitmap == null) {
-            val bitmap = withContext(Dispatchers.Default) {
-                renderer.renderPage(pageIndex, 1200, 1600)
-            }
-            onRendered(bitmap)
-        }
-    }
-
-    Box(
+    BoxWithConstraints(
         modifier = modifier
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.surfaceContainerLowest),
         contentAlignment = Alignment.Center,
     ) {
+        val density = LocalDensity.current
+        val pixelWidth = with(density) { maxWidth.roundToPx() }
+        val pixelHeight = with(density) { maxHeight.roundToPx() }
+
+        LaunchedEffect(pageIndex, pixelWidth, pixelHeight) {
+            if (cachedBitmap == null && pixelWidth > 0 && pixelHeight > 0) {
+                val bitmap = withContext(Dispatchers.Default) {
+                    renderer.renderPage(pageIndex, pixelWidth, pixelHeight)
+                }
+                onRendered(bitmap)
+            }
+        }
+
         val bitmap = cachedBitmap
         if (bitmap != null) {
             Image(

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/pdf/PdfRenderer.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/pdf/PdfRenderer.kt
@@ -1,0 +1,10 @@
+package id.homebase.core.pdf
+
+import androidx.compose.ui.graphics.ImageBitmap
+
+expect class PdfRenderer() {
+    fun open(filePath: String)
+    val pageCount: Int
+    fun renderPage(index: Int, width: Int, height: Int): ImageBitmap
+    fun close()
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.kt
@@ -23,3 +23,5 @@ data class PdfThumbnailResult(
 }
 
 expect fun generatePdfThumbnail(bytes: ByteArray, maxWidth: Int): PdfThumbnailResult?
+
+expect fun generatePdfThumbnailFromFile(filePath: String, maxWidth: Int): PdfThumbnailResult?

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.kt
@@ -1,0 +1,25 @@
+package id.homebase.core.pdf
+
+data class PdfThumbnailResult(
+    val thumbnailBytes: ByteArray?,
+    val pageCount: Int,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        other as PdfThumbnailResult
+        if (thumbnailBytes != null) {
+            if (other.thumbnailBytes == null) return false
+            if (!thumbnailBytes.contentEquals(other.thumbnailBytes)) return false
+        } else if (other.thumbnailBytes != null) return false
+        return pageCount == other.pageCount
+    }
+
+    override fun hashCode(): Int {
+        var result = thumbnailBytes?.contentHashCode() ?: 0
+        result = 31 * result + pageCount
+        return result
+    }
+}
+
+expect fun generatePdfThumbnail(bytes: ByteArray, maxWidth: Int): PdfThumbnailResult?

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/util/ByteArrayExtensions.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/util/ByteArrayExtensions.kt
@@ -1,0 +1,21 @@
+package id.homebase.core.util
+
+fun ByteArray.trimToUtf8Boundary(): ByteArray {
+    if (isEmpty()) return this
+    val last = this[size - 1].toInt() and 0xFF
+    if (last and 0x80 == 0) return this // ends with ASCII
+
+    var startBytePos = size - 1
+    while (startBytePos > 0 && (this[startBytePos].toInt() and 0xC0) == 0x80) {
+        startBytePos--
+    }
+    val b = this[startBytePos].toInt() and 0xFF
+    val expectedLen = when {
+        b and 0xE0 == 0xC0 -> 2
+        b and 0xF0 == 0xE0 -> 3
+        b and 0xF8 == 0xF0 -> 4
+        else -> 1
+    }
+    val actual = size - startBytePos
+    return if (actual >= expectedLen) this else copyOf(startBytePos)
+}

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/pdf/PdfPageViewer.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/pdf/PdfPageViewer.jvm.kt
@@ -1,0 +1,60 @@
+package id.homebase.core.pdf
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@Composable
+actual fun PdfPageViewer(
+    filePath: String,
+    onTap: (() -> Unit)?,
+    modifier: Modifier,
+) {
+    var renderer by remember { mutableStateOf<PdfRenderer?>(null) }
+
+    LaunchedEffect(filePath) {
+        renderer?.close()
+        renderer = null
+        val r = PdfRenderer()
+        try {
+            withContext(Dispatchers.Default) { r.open(filePath) }
+            renderer = r
+        } catch (e: CancellationException) {
+            r.close()
+            throw e
+        } catch (_: Exception) {
+            r.close()
+        }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose { renderer?.close() }
+    }
+
+    val r = renderer
+    if (r != null) {
+        BitmapPdfPageViewer(renderer = r, onTap = onTap, modifier = modifier)
+    } else {
+        Box(modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(32.dp),
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+    }
+}

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/pdf/PdfRenderer.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/pdf/PdfRenderer.jvm.kt
@@ -14,6 +14,7 @@ actual class PdfRenderer actual constructor() {
     private var boxRenderer: PdfBoxRenderer? = null
 
     actual fun open(filePath: String) {
+        close()
         val doc = Loader.loadPDF(File(filePath))
         document = doc
         boxRenderer = PdfBoxRenderer(doc)

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/pdf/PdfRenderer.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/pdf/PdfRenderer.jvm.kt
@@ -1,0 +1,44 @@
+package id.homebase.core.pdf
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import org.apache.pdfbox.Loader
+import org.apache.pdfbox.pdmodel.PDDocument
+import org.apache.pdfbox.rendering.ImageType
+import java.io.File
+import org.apache.pdfbox.rendering.PDFRenderer as PdfBoxRenderer
+
+actual class PdfRenderer actual constructor() {
+
+    private var document: PDDocument? = null
+    private var boxRenderer: PdfBoxRenderer? = null
+
+    actual fun open(filePath: String) {
+        val doc = Loader.loadPDF(File(filePath))
+        document = doc
+        boxRenderer = PdfBoxRenderer(doc)
+    }
+
+    actual val pageCount: Int
+        get() = document?.numberOfPages ?: 0
+
+    actual fun renderPage(index: Int, width: Int, height: Int): ImageBitmap {
+        val renderer = requireNotNull(boxRenderer) { "PdfRenderer not opened. Call open() first." }
+        val page = requireNotNull(document).getPage(index)
+        val mediaBox = page.mediaBox
+        val scaleX = width.toFloat() / mediaBox.width
+        val scaleY = height.toFloat() / mediaBox.height
+        val scale = minOf(scaleX, scaleY)
+        val dpi = scale * 72f
+        val bufferedImage = renderer.renderImageWithDPI(index, dpi, ImageType.RGB)
+        return bufferedImage.toComposeImageBitmap()
+    }
+
+    actual fun close() {
+        try {
+            document?.close()
+        } catch (_: Exception) { }
+        document = null
+        boxRenderer = null
+    }
+}

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.jvm.kt
@@ -6,6 +6,27 @@ import org.apache.pdfbox.rendering.PDFRenderer
 import java.io.ByteArrayOutputStream
 import javax.imageio.ImageIO
 
+actual fun generatePdfThumbnailFromFile(filePath: String, maxWidth: Int): PdfThumbnailResult? {
+    return try {
+        Loader.loadPDF(java.io.File(filePath)).use { document ->
+            val pageCount = document.numberOfPages
+            val renderer = PDFRenderer(document)
+            val page = document.getPage(0)
+            val scale = maxWidth.toFloat() / page.mediaBox.width
+            val dpi = scale * 72f
+            val image = renderer.renderImageWithDPI(0, dpi, ImageType.RGB)
+            val output = ByteArrayOutputStream()
+            ImageIO.write(image, "JPEG", output)
+            PdfThumbnailResult(
+                thumbnailBytes = output.toByteArray(),
+                pageCount = pageCount,
+            )
+        }
+    } catch (_: Exception) {
+        null
+    }
+}
+
 actual fun generatePdfThumbnail(bytes: ByteArray, maxWidth: Int): PdfThumbnailResult? {
     return try {
         Loader.loadPDF(bytes).use { document ->

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.jvm.kt
@@ -1,0 +1,28 @@
+package id.homebase.core.pdf
+
+import org.apache.pdfbox.Loader
+import org.apache.pdfbox.rendering.ImageType
+import org.apache.pdfbox.rendering.PDFRenderer
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+
+actual fun generatePdfThumbnail(bytes: ByteArray, maxWidth: Int): PdfThumbnailResult? {
+    return try {
+        Loader.loadPDF(bytes).use { document ->
+            val pageCount = document.numberOfPages
+            val renderer = PDFRenderer(document)
+            val page = document.getPage(0)
+            val scale = maxWidth.toFloat() / page.mediaBox.width
+            val dpi = scale * 72f
+            val image = renderer.renderImageWithDPI(0, dpi, ImageType.RGB)
+            val output = ByteArrayOutputStream()
+            ImageIO.write(image, "JPEG", output)
+            PdfThumbnailResult(
+                thumbnailBytes = output.toByteArray(),
+                pageCount = pageCount,
+            )
+        }
+    } catch (_: Exception) {
+        null
+    }
+}

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/pdf/PdfRendererJvmTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/pdf/PdfRendererJvmTest.kt
@@ -1,0 +1,191 @@
+package id.homebase.core.pdf
+
+import id.homebase.api.HomebaseProtocol
+import id.homebase.api.image.createImageThumbnail
+import id.homebase.api.image.tinyThumbSize
+import kotlinx.coroutines.test.runTest
+import org.apache.pdfbox.pdmodel.PDDocument
+import org.apache.pdfbox.pdmodel.PDPage
+import org.apache.pdfbox.pdmodel.PDPageContentStream
+import org.apache.pdfbox.pdmodel.font.PDType1Font
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PdfRendererJvmTest {
+
+    private fun createTestPdf(pageCount: Int): File {
+        val file = File.createTempFile("test_pdf_", ".pdf")
+        PDDocument().use { doc ->
+            repeat(pageCount) { i ->
+                val page = PDPage()
+                doc.addPage(page)
+                PDPageContentStream(doc, page).use { cs ->
+                    cs.beginText()
+                    cs.setFont(PDType1Font(Standard14Fonts.FontName.HELVETICA), 24f)
+                    cs.newLineAtOffset(100f, 700f)
+                    cs.showText("Page ${i + 1}")
+                    cs.endText()
+                }
+            }
+            doc.save(file)
+        }
+        return file
+    }
+
+    @Test
+    fun open_validPdf_reportsCorrectPageCount() {
+        val file = createTestPdf(5)
+        try {
+            val renderer = PdfRenderer()
+            renderer.open(file.absolutePath)
+            assertEquals(5, renderer.pageCount)
+            renderer.close()
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun renderPage_returnsImageBitmapWithPositiveDimensions() {
+        val file = createTestPdf(1)
+        try {
+            val renderer = PdfRenderer()
+            renderer.open(file.absolutePath)
+            val bitmap = renderer.renderPage(0, 640, 480)
+            assertTrue(bitmap.width > 0)
+            assertTrue(bitmap.height > 0)
+            renderer.close()
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun close_doubleCloseDoesNotThrow() {
+        val file = createTestPdf(1)
+        try {
+            val renderer = PdfRenderer()
+            renderer.open(file.absolutePath)
+            renderer.close()
+            renderer.close()
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun renderPage_withoutOpen_throws() {
+        val renderer = PdfRenderer()
+        try {
+            renderer.renderPage(0, 640, 480)
+            assertTrue(false, "Expected exception")
+        } catch (_: IllegalArgumentException) { }
+        catch (_: IllegalStateException) { }
+    }
+
+    @Test
+    fun open_invalidPath_throws() {
+        val renderer = PdfRenderer()
+        try {
+            renderer.open("/nonexistent/path/fake.pdf")
+            assertTrue(false, "Expected exception")
+        } catch (_: Exception) { }
+    }
+
+    @Test
+    fun renderPage_multiplePages_eachRendersIndependently() {
+        val file = createTestPdf(3)
+        try {
+            val renderer = PdfRenderer()
+            renderer.open(file.absolutePath)
+            val bitmaps = (0 until 3).map { renderer.renderPage(it, 300, 400) }
+            bitmaps.forEach { assertTrue(it.width > 0) }
+            assertEquals(3, bitmaps.size)
+            renderer.close()
+        } finally {
+            file.delete()
+        }
+    }
+}
+
+class PdfThumbnailGeneratorJvmTest {
+
+    private fun createTestPdfBytes(pageCount: Int): ByteArray {
+        val baos = java.io.ByteArrayOutputStream()
+        PDDocument().use { doc ->
+            repeat(pageCount) { i ->
+                val page = PDPage()
+                doc.addPage(page)
+                PDPageContentStream(doc, page).use { cs ->
+                    cs.beginText()
+                    cs.setFont(PDType1Font(Standard14Fonts.FontName.HELVETICA), 24f)
+                    cs.newLineAtOffset(100f, 700f)
+                    cs.showText("Page ${i + 1}")
+                    cs.endText()
+                }
+            }
+            doc.save(baos)
+        }
+        return baos.toByteArray()
+    }
+
+    @Test
+    fun generatePdfThumbnail_validPdf_returnsJpegBytesAndPageCount() {
+        val pdfBytes = createTestPdfBytes(3)
+        val result = generatePdfThumbnail(pdfBytes, 320)
+        assertNotNull(result)
+        assertEquals(3, result.pageCount)
+        val thumb = result.thumbnailBytes
+        assertNotNull(thumb)
+        assertTrue(thumb.size > 100)
+        assertEquals(0xFF.toByte(), thumb[0])
+        assertEquals(0xD8.toByte(), thumb[1])
+        assertEquals(0xFF.toByte(), thumb[2])
+    }
+
+    @Test
+    fun generatePdfThumbnail_invalidBytes_returnsNull() {
+        val garbage = "this is not a pdf".toByteArray()
+        val result = generatePdfThumbnail(garbage, 320)
+        assertNull(result)
+    }
+
+    @Test
+    fun generatePdfThumbnail_singlePage_returnsPageCountOne() {
+        val pdfBytes = createTestPdfBytes(1)
+        val result = generatePdfThumbnail(pdfBytes, 320)
+        assertNotNull(result)
+        assertEquals(1, result.pageCount)
+    }
+
+    @Test
+    fun generatePdfThumbnail_tinyThumb_fitsUnderMaxEmbeddedThumbBytes() = runTest {
+        val pdfBytes = createTestPdfBytes(3)
+        val pdfResult = generatePdfThumbnail(pdfBytes, 320)
+        assertNotNull(pdfResult)
+        val thumbBytes = pdfResult.thumbnailBytes
+        assertNotNull(thumbBytes)
+
+        val tinyThumb = createImageThumbnail(
+            thumbBytes, "test_key", tinyThumbSize, isTinyThumb = true,
+        )
+        assertTrue(
+            tinyThumb.thumbnailBytes.size <= HomebaseProtocol.MaxEmbeddedThumbBytes,
+            "Tiny thumb ${tinyThumb.thumbnailBytes.size} bytes exceeds " +
+                "${HomebaseProtocol.MaxEmbeddedThumbBytes} byte server limit",
+        )
+        assertTrue(tinyThumb.pixelWidth in 1..30)
+        assertTrue(tinyThumb.pixelHeight in 1..30)
+    }
+
+    @Test
+    fun generatePdfThumbnail_emptyByteArray_returnsNull() {
+        val result = generatePdfThumbnail(ByteArray(0), 320)
+        assertNull(result)
+    }
+}

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/pdf/PdfRendererJvmTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/pdf/PdfRendererJvmTest.kt
@@ -111,6 +111,40 @@ class PdfRendererJvmTest {
             file.delete()
         }
     }
+    @Test
+    fun close_thenPageCount_returnsZero() {
+        val file = createTestPdf(3)
+        try {
+            val renderer = PdfRenderer()
+            renderer.open(file.absolutePath)
+            assertEquals(3, renderer.pageCount)
+            renderer.close()
+            assertEquals(0, renderer.pageCount)
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun reopen_afterClose_works() {
+        val file1 = createTestPdf(2)
+        val file2 = createTestPdf(4)
+        try {
+            val renderer = PdfRenderer()
+            renderer.open(file1.absolutePath)
+            assertEquals(2, renderer.pageCount)
+            renderer.close()
+
+            renderer.open(file2.absolutePath)
+            assertEquals(4, renderer.pageCount)
+            val bitmap = renderer.renderPage(0, 300, 400)
+            assertTrue(bitmap.width > 0)
+            renderer.close()
+        } finally {
+            file1.delete()
+            file2.delete()
+        }
+    }
 }
 
 class PdfThumbnailGeneratorJvmTest {

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/util/ByteArrayExtensionsTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/util/ByteArrayExtensionsTest.kt
@@ -1,0 +1,93 @@
+package id.homebase.core.util
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class TrimToUtf8BoundaryTest {
+
+    @Test
+    fun ascii_only_unchanged() {
+        val input = "Hello".encodeToByteArray()
+        assertContentEquals(input, input.trimToUtf8Boundary())
+    }
+
+    @Test
+    fun empty_array() {
+        val input = ByteArray(0)
+        assertContentEquals(input, input.trimToUtf8Boundary())
+    }
+
+    @Test
+    fun complete_two_byte_char_preserved() {
+        // é = C3 A9 (2-byte UTF-8)
+        val input = "café".encodeToByteArray()
+        assertContentEquals(input, input.trimToUtf8Boundary())
+    }
+
+    @Test
+    fun split_two_byte_char_trimmed() {
+        // "é" = [0xC3, 0xA9]; drop the continuation byte to simulate truncation
+        val full = "café".encodeToByteArray()
+        val truncated = full.copyOf(full.size - 1) // cuts off A9, leaves dangling C3
+        val result = truncated.trimToUtf8Boundary()
+        assertEquals("caf", result.decodeToString())
+    }
+
+    @Test
+    fun complete_three_byte_char_preserved() {
+        // € = E2 82 AC (3-byte UTF-8)
+        val input = "a€b".encodeToByteArray()
+        assertContentEquals(input, input.trimToUtf8Boundary())
+    }
+
+    @Test
+    fun split_three_byte_missing_one_continuation() {
+        // "€" = [0xE2, 0x82, 0xAC]; truncate after 2 bytes of the 3-byte sequence
+        val full = "a€".encodeToByteArray() // [0x61, 0xE2, 0x82, 0xAC]
+        val truncated = full.copyOf(full.size - 1) // [0x61, 0xE2, 0x82]
+        val result = truncated.trimToUtf8Boundary()
+        assertEquals("a", result.decodeToString())
+    }
+
+    @Test
+    fun split_three_byte_missing_two_continuations() {
+        // truncate after only the start byte of the 3-byte sequence
+        val full = "a€".encodeToByteArray() // [0x61, 0xE2, 0x82, 0xAC]
+        val truncated = full.copyOf(2) // [0x61, 0xE2]
+        val result = truncated.trimToUtf8Boundary()
+        assertEquals("a", result.decodeToString())
+    }
+
+    @Test
+    fun complete_four_byte_emoji_preserved() {
+        // 😀 = F0 9F 98 80 (4-byte UTF-8)
+        val input = "hi😀".encodeToByteArray()
+        assertContentEquals(input, input.trimToUtf8Boundary())
+    }
+
+    @Test
+    fun split_four_byte_emoji_trimmed() {
+        val full = "hi😀".encodeToByteArray() // [0x68, 0x69, 0xF0, 0x9F, 0x98, 0x80]
+        val truncated = full.copyOf(full.size - 2) // cuts 2 continuation bytes
+        val result = truncated.trimToUtf8Boundary()
+        assertEquals("hi", result.decodeToString())
+    }
+
+    @Test
+    fun multiple_multibyte_chars_only_last_split() {
+        // "café😀" — split only the emoji
+        val full = "café😀".encodeToByteArray()
+        val cafeLen = "café".encodeToByteArray().size
+        val truncated = full.copyOf(cafeLen + 1) // just the first byte of the emoji
+        val result = truncated.trimToUtf8Boundary()
+        assertEquals("café", result.decodeToString())
+    }
+
+    @Test
+    fun ends_with_complete_multibyte_no_change() {
+        val input = "test€".encodeToByteArray()
+        val result = input.trimToUtf8Boundary()
+        assertContentEquals(input, result)
+    }
+}

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfConstants.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfConstants.kt
@@ -1,0 +1,4 @@
+package id.homebase.core.pdf
+
+// kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little → BGRA in memory
+internal val PDF_BITMAP_INFO: UInt = 2u or 8192u

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfPageViewer.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfPageViewer.native.kt
@@ -1,4 +1,4 @@
-@file:OptIn(ExperimentalForeignApi::class)
+@file:OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
 
 package id.homebase.core.pdf
 
@@ -6,11 +6,23 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.UIKitView
+import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.Foundation.NSURL
 import platform.PDFKit.PDFDocument
 import platform.PDFKit.PDFView
+import platform.UIKit.UITapGestureRecognizer
 import platform.UIKit.UIView
+import platform.darwin.NSObject
+import platform.objc.sel_registerName
+
+private class TapHandler(private val onTap: () -> Unit) : NSObject() {
+    @Suppress("unused")
+    @kotlinx.cinterop.ObjCAction
+    fun handleTap() {
+        onTap()
+    }
+}
 
 @Composable
 actual fun PdfPageViewer(
@@ -21,12 +33,23 @@ actual fun PdfPageViewer(
     val document = remember(filePath) {
         PDFDocument(NSURL.fileURLWithPath(filePath))
     }
+    val tapHandler = remember {
+        if (onTap != null) TapHandler(onTap) else null
+    }
 
     UIKitView<UIView>(
         factory = {
             PDFView().apply {
                 setAutoScales(true)
                 setDocument(document)
+                if (tapHandler != null) {
+                    addGestureRecognizer(
+                        UITapGestureRecognizer(
+                            target = tapHandler,
+                            action = sel_registerName("handleTap"),
+                        ),
+                    )
+                }
             }
         },
         update = { view ->

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfPageViewer.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfPageViewer.native.kt
@@ -1,0 +1,40 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package id.homebase.core.pdf
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.UIKitView
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSURL
+import platform.PDFKit.PDFDocument
+import platform.PDFKit.PDFView
+import platform.UIKit.UIView
+
+@Composable
+actual fun PdfPageViewer(
+    filePath: String,
+    onTap: (() -> Unit)?,
+    modifier: Modifier,
+) {
+    val document = remember(filePath) {
+        PDFDocument(NSURL.fileURLWithPath(filePath))
+    }
+
+    UIKitView<UIView>(
+        factory = {
+            PDFView().apply {
+                setAutoScales(true)
+                setDocument(document)
+            }
+        },
+        update = { view ->
+            val pdfView = view as PDFView
+            if (pdfView.document() !== document) {
+                pdfView.setDocument(document)
+            }
+        },
+        modifier = modifier,
+    )
+}

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfRenderer.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfRenderer.native.kt
@@ -13,6 +13,7 @@ import org.jetbrains.skia.ColorType
 import org.jetbrains.skia.ImageInfo
 import platform.CoreGraphics.CGBitmapContextCreate
 import platform.CoreGraphics.CGColorSpaceCreateDeviceRGB
+import platform.CoreGraphics.CGColorSpaceRelease
 import platform.CoreGraphics.CGContextDrawPDFPage
 import platform.CoreGraphics.CGContextRelease
 import platform.CoreGraphics.CGContextScaleCTM
@@ -61,20 +62,24 @@ actual class PdfRenderer actual constructor() {
         val bytesPerRow = bitmapWidth * 4
         val bitmapData = ByteArray(bytesPerRow * bitmapHeight)
 
-        bitmapData.usePinned { pinned ->
-            val context = CGBitmapContextCreate(
-                data = pinned.addressOf(0),
-                width = bitmapWidth.toULong(),
-                height = bitmapHeight.toULong(),
-                bitsPerComponent = 8u,
-                bytesPerRow = bytesPerRow.toULong(),
-                space = colorSpace,
-                bitmapInfo = BITMAP_INFO,
-            ) ?: throw RuntimeException("Cannot create CGContext")
+        try {
+            bitmapData.usePinned { pinned ->
+                val context = CGBitmapContextCreate(
+                    data = pinned.addressOf(0),
+                    width = bitmapWidth.toULong(),
+                    height = bitmapHeight.toULong(),
+                    bitsPerComponent = 8u,
+                    bytesPerRow = bytesPerRow.toULong(),
+                    space = colorSpace,
+                    bitmapInfo = BITMAP_INFO,
+                ) ?: throw RuntimeException("Cannot create CGContext")
 
-            CGContextScaleCTM(context, scale, scale)
-            CGContextDrawPDFPage(context, page)
-            CGContextRelease(context)
+                CGContextScaleCTM(context, scale, scale)
+                CGContextDrawPDFPage(context, page)
+                CGContextRelease(context)
+            }
+        } finally {
+            CGColorSpaceRelease(colorSpace)
         }
 
         val skiaImage = org.jetbrains.skia.Image.makeRaster(

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfRenderer.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfRenderer.native.kt
@@ -34,6 +34,7 @@ actual class PdfRenderer actual constructor() {
     private var document: CGPDFDocumentRef? = null
 
     actual fun open(filePath: String) {
+        close()
         val url = platform.Foundation.CFBridgingRetain(NSURL.fileURLWithPath(filePath))
         try {
             document = CGPDFDocumentCreateWithURL(url as platform.CoreFoundation.CFURLRef)

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfRenderer.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfRenderer.native.kt
@@ -39,12 +39,15 @@ actual class PdfRenderer actual constructor() {
         close()
         val nsUrl = NSURL.fileURLWithPath(filePath)
         val accessed = nsUrl.startAccessingSecurityScopedResource()
-        if (accessed) accessedUrl = nsUrl
 
         val cfUrl = platform.Foundation.CFBridgingRetain(nsUrl)
         try {
             document = CGPDFDocumentCreateWithURL(cfUrl as platform.CoreFoundation.CFURLRef)
                 ?: throw IllegalArgumentException("Cannot open PDF: $filePath")
+            if (accessed) accessedUrl = nsUrl
+        } catch (e: Throwable) {
+            if (accessed) nsUrl.stopAccessingSecurityScopedResource()
+            throw e
         } finally {
             platform.CoreFoundation.CFRelease(cfUrl)
         }

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfRenderer.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfRenderer.native.kt
@@ -1,0 +1,92 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package id.homebase.core.pdf
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.useContents
+import kotlinx.cinterop.usePinned
+import org.jetbrains.skia.ColorAlphaType
+import org.jetbrains.skia.ColorType
+import org.jetbrains.skia.ImageInfo
+import platform.CoreGraphics.CGBitmapContextCreate
+import platform.CoreGraphics.CGColorSpaceCreateDeviceRGB
+import platform.CoreGraphics.CGContextDrawPDFPage
+import platform.CoreGraphics.CGContextRelease
+import platform.CoreGraphics.CGContextScaleCTM
+import platform.CoreGraphics.CGPDFDocumentCreateWithURL
+import platform.CoreGraphics.CGPDFDocumentGetNumberOfPages
+import platform.CoreGraphics.CGPDFDocumentGetPage
+import platform.CoreGraphics.CGPDFDocumentRelease
+import platform.CoreGraphics.CGPDFDocumentRef
+import platform.CoreGraphics.CGPDFPageGetBoxRect
+import platform.CoreGraphics.kCGPDFMediaBox
+import platform.Foundation.NSURL
+
+private val BITMAP_INFO: UInt = 1u or 8192u
+
+actual class PdfRenderer actual constructor() {
+
+    private var document: CGPDFDocumentRef? = null
+
+    actual fun open(filePath: String) {
+        val url = platform.Foundation.CFBridgingRetain(NSURL.fileURLWithPath(filePath))
+        try {
+            document = CGPDFDocumentCreateWithURL(url as platform.CoreFoundation.CFURLRef)
+                ?: throw IllegalArgumentException("Cannot open PDF: $filePath")
+        } finally {
+            platform.CoreFoundation.CFRelease(url)
+        }
+    }
+
+    actual val pageCount: Int
+        get() = document?.let { CGPDFDocumentGetNumberOfPages(it).toInt() } ?: 0
+
+    actual fun renderPage(index: Int, width: Int, height: Int): ImageBitmap {
+        val doc = requireNotNull(document) { "PdfRenderer not opened. Call open() first." }
+        val page = CGPDFDocumentGetPage(doc, (index + 1).toULong())
+            ?: throw IllegalArgumentException("Page $index not found")
+
+        val mediaBox = CGPDFPageGetBoxRect(page, kCGPDFMediaBox)
+        val (pageWidth, pageHeight) = mediaBox.useContents { size.width to size.height }
+        val scaleX = width.toDouble() / pageWidth
+        val scaleY = height.toDouble() / pageHeight
+        val scale = minOf(scaleX, scaleY)
+        val bitmapWidth = (pageWidth * scale).toInt()
+        val bitmapHeight = (pageHeight * scale).toInt()
+
+        val colorSpace = CGColorSpaceCreateDeviceRGB()
+        val bytesPerRow = bitmapWidth * 4
+        val bitmapData = ByteArray(bytesPerRow * bitmapHeight)
+
+        bitmapData.usePinned { pinned ->
+            val context = CGBitmapContextCreate(
+                data = pinned.addressOf(0),
+                width = bitmapWidth.toULong(),
+                height = bitmapHeight.toULong(),
+                bitsPerComponent = 8u,
+                bytesPerRow = bytesPerRow.toULong(),
+                space = colorSpace,
+                bitmapInfo = BITMAP_INFO,
+            ) ?: throw RuntimeException("Cannot create CGContext")
+
+            CGContextScaleCTM(context, scale, scale)
+            CGContextDrawPDFPage(context, page)
+            CGContextRelease(context)
+        }
+
+        val skiaImage = org.jetbrains.skia.Image.makeRaster(
+            imageInfo = ImageInfo(bitmapWidth, bitmapHeight, ColorType.RGBA_8888, ColorAlphaType.PREMUL),
+            bytes = bitmapData,
+            rowBytes = bytesPerRow,
+        )
+        return skiaImage.toComposeImageBitmap()
+    }
+
+    actual fun close() {
+        document?.let { CGPDFDocumentRelease(it) }
+        document = null
+    }
+}

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfRenderer.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfRenderer.native.kt
@@ -26,7 +26,8 @@ import platform.CoreGraphics.CGPDFPageGetBoxRect
 import platform.CoreGraphics.kCGPDFMediaBox
 import platform.Foundation.NSURL
 
-private val BITMAP_INFO: UInt = 1u or 8192u
+// kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little → BGRA in memory
+private val BITMAP_INFO: UInt = 2u or 8192u
 
 actual class PdfRenderer actual constructor() {
 
@@ -83,7 +84,7 @@ actual class PdfRenderer actual constructor() {
         }
 
         val skiaImage = org.jetbrains.skia.Image.makeRaster(
-            imageInfo = ImageInfo(bitmapWidth, bitmapHeight, ColorType.RGBA_8888, ColorAlphaType.PREMUL),
+            imageInfo = ImageInfo(bitmapWidth, bitmapHeight, ColorType.BGRA_8888, ColorAlphaType.PREMUL),
             bytes = bitmapData,
             rowBytes = bytesPerRow,
         )

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfRenderer.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfRenderer.native.kt
@@ -15,8 +15,11 @@ import platform.CoreGraphics.CGBitmapContextCreate
 import platform.CoreGraphics.CGColorSpaceCreateDeviceRGB
 import platform.CoreGraphics.CGColorSpaceRelease
 import platform.CoreGraphics.CGContextDrawPDFPage
+import platform.CoreGraphics.CGContextFillRect
 import platform.CoreGraphics.CGContextRelease
 import platform.CoreGraphics.CGContextScaleCTM
+import platform.CoreGraphics.CGContextSetRGBFillColor
+import platform.CoreGraphics.CGRectMake
 import platform.CoreGraphics.CGPDFDocumentCreateWithURL
 import platform.CoreGraphics.CGPDFDocumentGetNumberOfPages
 import platform.CoreGraphics.CGPDFDocumentGetPage
@@ -33,14 +36,20 @@ actual class PdfRenderer actual constructor() {
 
     private var document: CGPDFDocumentRef? = null
 
+    private var accessedUrl: NSURL? = null
+
     actual fun open(filePath: String) {
         close()
-        val url = platform.Foundation.CFBridgingRetain(NSURL.fileURLWithPath(filePath))
+        val nsUrl = NSURL.fileURLWithPath(filePath)
+        val accessed = nsUrl.startAccessingSecurityScopedResource()
+        if (accessed) accessedUrl = nsUrl
+
+        val cfUrl = platform.Foundation.CFBridgingRetain(nsUrl)
         try {
-            document = CGPDFDocumentCreateWithURL(url as platform.CoreFoundation.CFURLRef)
+            document = CGPDFDocumentCreateWithURL(cfUrl as platform.CoreFoundation.CFURLRef)
                 ?: throw IllegalArgumentException("Cannot open PDF: $filePath")
         } finally {
-            platform.CoreFoundation.CFRelease(url)
+            platform.CoreFoundation.CFRelease(cfUrl)
         }
     }
 
@@ -76,6 +85,8 @@ actual class PdfRenderer actual constructor() {
                     bitmapInfo = BITMAP_INFO,
                 ) ?: throw RuntimeException("Cannot create CGContext")
 
+                CGContextSetRGBFillColor(context, 1.0, 1.0, 1.0, 1.0)
+                CGContextFillRect(context, CGRectMake(0.0, 0.0, bitmapWidth.toDouble(), bitmapHeight.toDouble()))
                 CGContextScaleCTM(context, scale, scale)
                 CGContextDrawPDFPage(context, page)
                 CGContextRelease(context)
@@ -95,5 +106,7 @@ actual class PdfRenderer actual constructor() {
     actual fun close() {
         document?.let { CGPDFDocumentRelease(it) }
         document = null
+        accessedUrl?.stopAccessingSecurityScopedResource()
+        accessedUrl = null
     }
 }

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfRenderer.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfRenderer.native.kt
@@ -29,9 +29,6 @@ import platform.CoreGraphics.CGPDFPageGetBoxRect
 import platform.CoreGraphics.kCGPDFMediaBox
 import platform.Foundation.NSURL
 
-// kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little → BGRA in memory
-private val BITMAP_INFO: UInt = 2u or 8192u
-
 actual class PdfRenderer actual constructor() {
 
     private var document: CGPDFDocumentRef? = null
@@ -82,7 +79,7 @@ actual class PdfRenderer actual constructor() {
                     bitsPerComponent = 8u,
                     bytesPerRow = bytesPerRow.toULong(),
                     space = colorSpace,
-                    bitmapInfo = BITMAP_INFO,
+                    bitmapInfo = PDF_BITMAP_INFO,
                 ) ?: throw RuntimeException("Cannot create CGContext")
 
                 CGContextSetRGBFillColor(context, 1.0, 1.0, 1.0, 1.0)

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.native.kt
@@ -10,6 +10,7 @@ import kotlinx.cinterop.usePinned
 import platform.CoreGraphics.CGBitmapContextCreate
 import platform.CoreGraphics.CGBitmapContextCreateImage
 import platform.CoreGraphics.CGColorSpaceCreateDeviceRGB
+import platform.CoreGraphics.CGColorSpaceRelease
 import platform.CoreGraphics.CGContextDrawPDFPage
 import platform.CoreGraphics.CGContextRelease
 import platform.CoreGraphics.CGContextScaleCTM
@@ -52,39 +53,43 @@ actual fun generatePdfThumbnail(bytes: ByteArray, maxWidth: Int): PdfThumbnailRe
                 val bitmapHeight = (mediaBox.useContents { size.height } * scale).toInt()
 
                 val colorSpace = CGColorSpaceCreateDeviceRGB()
-                val bytesPerRow = bitmapWidth * 4
-                val bitmapData = ByteArray(bytesPerRow * bitmapHeight)
+                try {
+                    val bytesPerRow = bitmapWidth * 4
+                    val bitmapData = ByteArray(bytesPerRow * bitmapHeight)
 
-                val result = bitmapData.usePinned { bmpPinned ->
-                    val context = CGBitmapContextCreate(
-                        data = bmpPinned.addressOf(0),
-                        width = bitmapWidth.toULong(),
-                        height = bitmapHeight.toULong(),
-                        bitsPerComponent = 8u,
-                        bytesPerRow = bytesPerRow.toULong(),
-                        space = colorSpace,
-                        bitmapInfo = BITMAP_INFO,
-                    ) ?: return null
+                    val result = bitmapData.usePinned { bmpPinned ->
+                        val context = CGBitmapContextCreate(
+                            data = bmpPinned.addressOf(0),
+                            width = bitmapWidth.toULong(),
+                            height = bitmapHeight.toULong(),
+                            bitsPerComponent = 8u,
+                            bytesPerRow = bytesPerRow.toULong(),
+                            space = colorSpace,
+                            bitmapInfo = BITMAP_INFO,
+                        ) ?: return null
 
-                    CGContextScaleCTM(context, scale, scale)
-                    CGContextDrawPDFPage(context, page)
+                        CGContextScaleCTM(context, scale, scale)
+                        CGContextDrawPDFPage(context, page)
 
-                    val cgImage = CGBitmapContextCreateImage(context)
-                    CGContextRelease(context)
-                    cgImage ?: return null
+                        val cgImage = CGBitmapContextCreateImage(context)
+                        CGContextRelease(context)
+                        cgImage ?: return null
 
-                    val uiImage = UIImage(cGImage = cgImage)
-                    CGImageRelease(cgImage)
+                        val uiImage = UIImage(cGImage = cgImage)
+                        CGImageRelease(cgImage)
 
-                    val jpegData = UIImageJPEGRepresentation(uiImage, 0.8)
-                        ?: return null
+                        val jpegData = UIImageJPEGRepresentation(uiImage, 0.8)
+                            ?: return null
 
-                    PdfThumbnailResult(
-                        thumbnailBytes = jpegData.toKotlinByteArray(),
-                        pageCount = pageCount,
-                    )
+                        PdfThumbnailResult(
+                            thumbnailBytes = jpegData.toKotlinByteArray(),
+                            pageCount = pageCount,
+                        )
+                    }
+                    result
+                } finally {
+                    CGColorSpaceRelease(colorSpace)
                 }
-                result
             } finally {
                 CGPDFDocumentRelease(document)
             }

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.native.kt
@@ -18,17 +18,40 @@ import platform.CoreGraphics.CGDataProviderCreateWithData
 import platform.CoreGraphics.CGDataProviderRelease
 import platform.CoreGraphics.CGImageRelease
 import platform.CoreGraphics.CGPDFDocumentCreateWithProvider
+import platform.CoreGraphics.CGPDFDocumentCreateWithURL
 import platform.CoreGraphics.CGPDFDocumentGetNumberOfPages
 import platform.CoreGraphics.CGPDFDocumentGetPage
+import platform.CoreGraphics.CGPDFDocumentRef
 import platform.CoreGraphics.CGPDFDocumentRelease
 import platform.CoreGraphics.CGPDFPageGetBoxRect
 import platform.CoreGraphics.kCGPDFMediaBox
 import platform.Foundation.NSData
+import platform.Foundation.NSURL
 import platform.UIKit.UIImage
 import platform.UIKit.UIImageJPEGRepresentation
 
 // kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little → BGRA in memory
 private val BITMAP_INFO: UInt = 2u or 8192u
+
+actual fun generatePdfThumbnailFromFile(filePath: String, maxWidth: Int): PdfThumbnailResult? {
+    return try {
+        val url = platform.Foundation.CFBridgingRetain(NSURL.fileURLWithPath(filePath))
+        try {
+            val document = CGPDFDocumentCreateWithURL(
+                url as platform.CoreFoundation.CFURLRef,
+            ) ?: return null
+            try {
+                renderFirstPageThumbnail(document, maxWidth)
+            } finally {
+                CGPDFDocumentRelease(document)
+            }
+        } finally {
+            platform.CoreFoundation.CFRelease(url)
+        }
+    } catch (_: Exception) {
+        null
+    }
+}
 
 actual fun generatePdfThumbnail(bytes: ByteArray, maxWidth: Int): PdfThumbnailResult? {
     return try {
@@ -45,58 +68,64 @@ actual fun generatePdfThumbnail(bytes: ByteArray, maxWidth: Int): PdfThumbnailRe
             document ?: return null
 
             try {
-                val pageCount = CGPDFDocumentGetNumberOfPages(document).toInt()
-                val page = CGPDFDocumentGetPage(document, 1u) ?: return null
-                val mediaBox = CGPDFPageGetBoxRect(page, kCGPDFMediaBox)
-                val pageWidth = mediaBox.useContents { size.width }
-                val scale = maxWidth.toDouble() / pageWidth
-                val bitmapWidth = (pageWidth * scale).toInt()
-                val bitmapHeight = (mediaBox.useContents { size.height } * scale).toInt()
-
-                val colorSpace = CGColorSpaceCreateDeviceRGB()
-                try {
-                    val bytesPerRow = bitmapWidth * 4
-                    val bitmapData = ByteArray(bytesPerRow * bitmapHeight)
-
-                    val result = bitmapData.usePinned { bmpPinned ->
-                        val context = CGBitmapContextCreate(
-                            data = bmpPinned.addressOf(0),
-                            width = bitmapWidth.toULong(),
-                            height = bitmapHeight.toULong(),
-                            bitsPerComponent = 8u,
-                            bytesPerRow = bytesPerRow.toULong(),
-                            space = colorSpace,
-                            bitmapInfo = BITMAP_INFO,
-                        ) ?: return null
-
-                        CGContextScaleCTM(context, scale, scale)
-                        CGContextDrawPDFPage(context, page)
-
-                        val cgImage = CGBitmapContextCreateImage(context)
-                        CGContextRelease(context)
-                        cgImage ?: return null
-
-                        val uiImage = UIImage(cGImage = cgImage)
-                        CGImageRelease(cgImage)
-
-                        val jpegData = UIImageJPEGRepresentation(uiImage, 0.8)
-                            ?: return null
-
-                        PdfThumbnailResult(
-                            thumbnailBytes = jpegData.toKotlinByteArray(),
-                            pageCount = pageCount,
-                        )
-                    }
-                    result
-                } finally {
-                    CGColorSpaceRelease(colorSpace)
-                }
+                renderFirstPageThumbnail(document, maxWidth)
             } finally {
                 CGPDFDocumentRelease(document)
             }
         }
     } catch (_: Exception) {
         null
+    }
+}
+
+private fun renderFirstPageThumbnail(
+    document: CGPDFDocumentRef,
+    maxWidth: Int,
+): PdfThumbnailResult? {
+    val pageCount = CGPDFDocumentGetNumberOfPages(document).toInt()
+    val page = CGPDFDocumentGetPage(document, 1u) ?: return null
+    val mediaBox = CGPDFPageGetBoxRect(page, kCGPDFMediaBox)
+    val pageWidth = mediaBox.useContents { size.width }
+    val scale = maxWidth.toDouble() / pageWidth
+    val bitmapWidth = (pageWidth * scale).toInt()
+    val bitmapHeight = (mediaBox.useContents { size.height } * scale).toInt()
+
+    val colorSpace = CGColorSpaceCreateDeviceRGB()
+    try {
+        val bytesPerRow = bitmapWidth * 4
+        val bitmapData = ByteArray(bytesPerRow * bitmapHeight)
+
+        return bitmapData.usePinned { bmpPinned ->
+            val context = CGBitmapContextCreate(
+                data = bmpPinned.addressOf(0),
+                width = bitmapWidth.toULong(),
+                height = bitmapHeight.toULong(),
+                bitsPerComponent = 8u,
+                bytesPerRow = bytesPerRow.toULong(),
+                space = colorSpace,
+                bitmapInfo = BITMAP_INFO,
+            ) ?: return null
+
+            CGContextScaleCTM(context, scale, scale)
+            CGContextDrawPDFPage(context, page)
+
+            val cgImage = CGBitmapContextCreateImage(context)
+            CGContextRelease(context)
+            cgImage ?: return null
+
+            val uiImage = UIImage(cGImage = cgImage)
+            CGImageRelease(cgImage)
+
+            val jpegData = UIImageJPEGRepresentation(uiImage, 0.8)
+                ?: return null
+
+            PdfThumbnailResult(
+                thumbnailBytes = jpegData.toKotlinByteArray(),
+                pageCount = pageCount,
+            )
+        }
+    } finally {
+        CGColorSpaceRelease(colorSpace)
     }
 }
 

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.native.kt
@@ -27,7 +27,8 @@ import platform.Foundation.NSData
 import platform.UIKit.UIImage
 import platform.UIKit.UIImageJPEGRepresentation
 
-private val BITMAP_INFO: UInt = 1u or 8192u
+// kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little → BGRA in memory
+private val BITMAP_INFO: UInt = 2u or 8192u
 
 actual fun generatePdfThumbnail(bytes: ByteArray, maxWidth: Int): PdfThumbnailResult? {
     return try {

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.native.kt
@@ -12,8 +12,11 @@ import platform.CoreGraphics.CGBitmapContextCreateImage
 import platform.CoreGraphics.CGColorSpaceCreateDeviceRGB
 import platform.CoreGraphics.CGColorSpaceRelease
 import platform.CoreGraphics.CGContextDrawPDFPage
+import platform.CoreGraphics.CGContextFillRect
 import platform.CoreGraphics.CGContextRelease
 import platform.CoreGraphics.CGContextScaleCTM
+import platform.CoreGraphics.CGContextSetRGBFillColor
+import platform.CoreGraphics.CGRectMake
 import platform.CoreGraphics.CGDataProviderCreateWithData
 import platform.CoreGraphics.CGDataProviderRelease
 import platform.CoreGraphics.CGImageRelease
@@ -35,18 +38,24 @@ private val BITMAP_INFO: UInt = 2u or 8192u
 
 actual fun generatePdfThumbnailFromFile(filePath: String, maxWidth: Int): PdfThumbnailResult? {
     return try {
-        val url = platform.Foundation.CFBridgingRetain(NSURL.fileURLWithPath(filePath))
+        val nsUrl = NSURL.fileURLWithPath(filePath)
+        val accessed = nsUrl.startAccessingSecurityScopedResource()
         try {
-            val document = CGPDFDocumentCreateWithURL(
-                url as platform.CoreFoundation.CFURLRef,
-            ) ?: return null
+            val cfUrl = platform.Foundation.CFBridgingRetain(nsUrl)
             try {
-                renderFirstPageThumbnail(document, maxWidth)
+                val document = CGPDFDocumentCreateWithURL(
+                    cfUrl as platform.CoreFoundation.CFURLRef,
+                ) ?: return null
+                try {
+                    renderFirstPageThumbnail(document, maxWidth)
+                } finally {
+                    CGPDFDocumentRelease(document)
+                }
             } finally {
-                CGPDFDocumentRelease(document)
+                platform.CoreFoundation.CFRelease(cfUrl)
             }
         } finally {
-            platform.CoreFoundation.CFRelease(url)
+            if (accessed) nsUrl.stopAccessingSecurityScopedResource()
         }
     } catch (_: Exception) {
         null
@@ -106,6 +115,8 @@ private fun renderFirstPageThumbnail(
                 bitmapInfo = BITMAP_INFO,
             ) ?: return null
 
+            CGContextSetRGBFillColor(context, 1.0, 1.0, 1.0, 1.0)
+            CGContextFillRect(context, CGRectMake(0.0, 0.0, bitmapWidth.toDouble(), bitmapHeight.toDouble()))
             CGContextScaleCTM(context, scale, scale)
             CGContextDrawPDFPage(context, page)
 

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.native.kt
@@ -33,9 +33,6 @@ import platform.Foundation.NSURL
 import platform.UIKit.UIImage
 import platform.UIKit.UIImageJPEGRepresentation
 
-// kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little → BGRA in memory
-private val BITMAP_INFO: UInt = 2u or 8192u
-
 actual fun generatePdfThumbnailFromFile(filePath: String, maxWidth: Int): PdfThumbnailResult? {
     return try {
         val nsUrl = NSURL.fileURLWithPath(filePath)
@@ -112,7 +109,7 @@ private fun renderFirstPageThumbnail(
                 bitsPerComponent = 8u,
                 bytesPerRow = bytesPerRow.toULong(),
                 space = colorSpace,
-                bitmapInfo = BITMAP_INFO,
+                bitmapInfo = PDF_BITMAP_INFO,
             ) ?: return null
 
             CGContextSetRGBFillColor(context, 1.0, 1.0, 1.0, 1.0)

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.native.kt
@@ -1,0 +1,107 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package id.homebase.core.pdf
+
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.useContents
+import kotlinx.cinterop.usePinned
+import platform.CoreGraphics.CGBitmapContextCreate
+import platform.CoreGraphics.CGBitmapContextCreateImage
+import platform.CoreGraphics.CGColorSpaceCreateDeviceRGB
+import platform.CoreGraphics.CGContextDrawPDFPage
+import platform.CoreGraphics.CGContextRelease
+import platform.CoreGraphics.CGContextScaleCTM
+import platform.CoreGraphics.CGDataProviderCreateWithData
+import platform.CoreGraphics.CGDataProviderRelease
+import platform.CoreGraphics.CGImageRelease
+import platform.CoreGraphics.CGPDFDocumentCreateWithProvider
+import platform.CoreGraphics.CGPDFDocumentGetNumberOfPages
+import platform.CoreGraphics.CGPDFDocumentGetPage
+import platform.CoreGraphics.CGPDFDocumentRelease
+import platform.CoreGraphics.CGPDFPageGetBoxRect
+import platform.CoreGraphics.kCGPDFMediaBox
+import platform.Foundation.NSData
+import platform.UIKit.UIImage
+import platform.UIKit.UIImageJPEGRepresentation
+
+private val BITMAP_INFO: UInt = 1u or 8192u
+
+actual fun generatePdfThumbnail(bytes: ByteArray, maxWidth: Int): PdfThumbnailResult? {
+    return try {
+        bytes.usePinned { pinned ->
+            val provider = CGDataProviderCreateWithData(
+                info = null,
+                data = pinned.addressOf(0),
+                size = bytes.size.toULong(),
+                releaseData = null,
+            ) ?: return null
+
+            val document = CGPDFDocumentCreateWithProvider(provider)
+            CGDataProviderRelease(provider)
+            document ?: return null
+
+            try {
+                val pageCount = CGPDFDocumentGetNumberOfPages(document).toInt()
+                val page = CGPDFDocumentGetPage(document, 1u) ?: return null
+                val mediaBox = CGPDFPageGetBoxRect(page, kCGPDFMediaBox)
+                val pageWidth = mediaBox.useContents { size.width }
+                val scale = maxWidth.toDouble() / pageWidth
+                val bitmapWidth = (pageWidth * scale).toInt()
+                val bitmapHeight = (mediaBox.useContents { size.height } * scale).toInt()
+
+                val colorSpace = CGColorSpaceCreateDeviceRGB()
+                val bytesPerRow = bitmapWidth * 4
+                val bitmapData = ByteArray(bytesPerRow * bitmapHeight)
+
+                val result = bitmapData.usePinned { bmpPinned ->
+                    val context = CGBitmapContextCreate(
+                        data = bmpPinned.addressOf(0),
+                        width = bitmapWidth.toULong(),
+                        height = bitmapHeight.toULong(),
+                        bitsPerComponent = 8u,
+                        bytesPerRow = bytesPerRow.toULong(),
+                        space = colorSpace,
+                        bitmapInfo = BITMAP_INFO,
+                    ) ?: return null
+
+                    CGContextScaleCTM(context, scale, scale)
+                    CGContextDrawPDFPage(context, page)
+
+                    val cgImage = CGBitmapContextCreateImage(context)
+                    CGContextRelease(context)
+                    cgImage ?: return null
+
+                    val uiImage = UIImage(cGImage = cgImage)
+                    CGImageRelease(cgImage)
+
+                    val jpegData = UIImageJPEGRepresentation(uiImage, 0.8)
+                        ?: return null
+
+                    PdfThumbnailResult(
+                        thumbnailBytes = jpegData.toKotlinByteArray(),
+                        pageCount = pageCount,
+                    )
+                }
+                result
+            } finally {
+                CGPDFDocumentRelease(document)
+            }
+        }
+    } catch (_: Exception) {
+        null
+    }
+}
+
+@OptIn(BetaInteropApi::class)
+private fun NSData.toKotlinByteArray(): ByteArray {
+    val length = this.length.toInt()
+    if (length == 0) return ByteArray(0)
+    val result = ByteArray(length)
+    result.usePinned { pinned ->
+        @Suppress("UNCHECKED_CAST")
+        platform.posix.memcpy(pinned.addressOf(0), this.bytes, this.length)
+    }
+    return result
+}

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/pdf/PdfPageViewer.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/pdf/PdfPageViewer.web.kt
@@ -1,0 +1,27 @@
+package id.homebase.core.pdf
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import id.homebase.resources.MR
+import id.homebase.resources.vault_pdf_not_supported
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+actual fun PdfPageViewer(
+    filePath: String,
+    onTap: (() -> Unit)?,
+    modifier: Modifier,
+) {
+    Box(modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(
+            text = stringResource(MR.string.vault_pdf_not_supported),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/pdf/PdfRenderer.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/pdf/PdfRenderer.web.kt
@@ -1,0 +1,18 @@
+package id.homebase.core.pdf
+
+import androidx.compose.ui.graphics.ImageBitmap
+
+actual class PdfRenderer actual constructor() {
+
+    actual fun open(filePath: String) {
+        throw UnsupportedOperationException("PDF rendering not supported on web")
+    }
+
+    actual val pageCount: Int get() = 0
+
+    actual fun renderPage(index: Int, width: Int, height: Int): ImageBitmap {
+        throw UnsupportedOperationException("PDF rendering not supported on web")
+    }
+
+    actual fun close() { }
+}

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.web.kt
@@ -1,0 +1,3 @@
+package id.homebase.core.pdf
+
+actual fun generatePdfThumbnail(bytes: ByteArray, maxWidth: Int): PdfThumbnailResult? = null

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/pdf/PdfThumbnailGenerator.web.kt
@@ -1,3 +1,5 @@
 package id.homebase.core.pdf
 
 actual fun generatePdfThumbnail(bytes: ByteArray, maxWidth: Int): PdfThumbnailResult? = null
+
+actual fun generatePdfThumbnailFromFile(filePath: String, maxWidth: Int): PdfThumbnailResult? = null

--- a/homebase-core/build.gradle.kts
+++ b/homebase-core/build.gradle.kts
@@ -22,6 +22,7 @@ kotlin {
     android {
         namespace = "id.homebase.core"
         compileSdk = libs.versions.android.targetSdk.get().toInt()
+        compileSdkExtension = 19
         minSdk = libs.versions.android.minSdk.get().toInt()
         withHostTest {}
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -441,6 +441,7 @@ val appModule = module {
             authConnectionCoordinator = get(),
             driveRegistry = get(),
             localAttachmentStore = get(),
+            fileOperationsProvider = get(),
             driveSyncManager = get(),
         )
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultEntryCard.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultEntryCard.kt
@@ -1,5 +1,6 @@
 package id.homebase.core.ui.screens.vault
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -26,6 +27,8 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import id.homebase.core.image.decodeBitmap
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.runtime.remember
@@ -37,6 +40,7 @@ import id.homebase.chat.services.LocalAttachmentContextStore
 import id.homebase.core.ui.screens.vault.components.fileTypeIcon
 import id.homebase.core.ui.screens.vault.model.VaultEntry
 import id.homebase.core.image.HomebaseImage
+import id.homebase.resources.vault_pdf_badge
 import id.homebase.resources.vault_upload_failed
 import id.homebase.core.image.HomebaseImageData
 import id.homebase.core.image.ImageSize
@@ -118,7 +122,7 @@ fun VaultEntryCard(
                     ).value
                 val localImage = localCtx as? LocalAttachmentContext.Image
 
-                if (file.isImage && localImage != null) {
+                if ((file.isImage || file.isPdf) && localImage != null) {
                     var imageModifier: Modifier = Modifier.fillMaxSize()
                     if (sharedTransitionScope != null && animatedVisibilityScope != null) {
                         with(sharedTransitionScope) {
@@ -175,6 +179,60 @@ fun VaultEntryCard(
                             modifier = Modifier.size(32.dp),
                         )
                     }
+                } else if (file.isPdf) {
+                    @OptIn(ExperimentalEncodingApi::class)
+                    val descriptor = file.payloadDescriptors.firstOrNull()
+                    val payloadIv = remember(descriptor?.iv) {
+                        descriptor?.iv?.let {
+                            try { Base64.decode(it) } catch (_: Exception) { null }
+                        }
+                    }
+                    if (descriptor != null && payloadIv != null) {
+                        HomebaseImage(
+                            imageData = HomebaseImageData(
+                                driveId = file.driveId,
+                                fileId = file.fileId,
+                                payloadKey = descriptor.key,
+                                previewThumbnail = file.previewThumbnail,
+                                requestedSize = ImageSize.THUMB_MEDIUM,
+                                isEncrypted = file.isEncrypted,
+                                keyHeader = KeyHeader(
+                                    iv = payloadIv,
+                                    aesKey = file.keyHeader.aesKey,
+                                ),
+                                lastModified = descriptor.lastModified,
+                            ),
+                            modifier = Modifier.fillMaxSize(),
+                            contentScale = ContentScale.Crop,
+                            contentDescription = description,
+                        )
+                    } else if (file.previewThumbnail != null) {
+                        val thumbBitmap = remember(file.previewThumbnail) {
+                            file.previewThumbnail.decodeBitmap()
+                        }
+                        if (thumbBitmap != null) {
+                            Image(
+                                bitmap = thumbBitmap,
+                                contentDescription = description,
+                                modifier = Modifier.fillMaxSize(),
+                                contentScale = ContentScale.Crop,
+                            )
+                        } else {
+                            Icon(
+                                imageVector = fileTypeIcon(file.contentType),
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(32.dp),
+                            )
+                        }
+                    } else {
+                        Icon(
+                            imageVector = fileTypeIcon(file.contentType),
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(32.dp),
+                        )
+                    }
                 } else {
                     Icon(
                         imageVector = fileTypeIcon(file.contentType),
@@ -218,6 +276,27 @@ fun VaultEntryCard(
                     }
 
                     else -> Unit
+                }
+
+                // PDF type badge
+                if (file.isPdf && file.previewThumbnail?.content != null) {
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(4.dp)
+                            .background(
+                                color = MaterialTheme.colorScheme.error.copy(alpha = 0.85f),
+                                shape = RoundedCornerShape(4.dp),
+                            )
+                            .padding(horizontal = 4.dp, vertical = 1.dp),
+                    ) {
+                        Text(
+                            text = stringResource(MR.string.vault_pdf_badge),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onError,
+                            fontSize = 8.sp,
+                        )
+                    }
                 }
 
                 // Page count badge (only for multi-page)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultEntryCard.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultEntryCard.kt
@@ -86,8 +86,8 @@ fun VaultEntryCard(
                 .height(THUMBNAIL_HEIGHT),
             contentAlignment = Alignment.Center,
         ) {
-            // Stacked shadow layers (only for multi-page)
-            if (file.hasMultiplePages) {
+            // Stacked shadow layers (multi-payload entries like scans, not PDFs)
+            if (file.hasMultiplePages && !file.isPdf) {
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
@@ -299,8 +299,8 @@ fun VaultEntryCard(
                     }
                 }
 
-                // Page count badge (only for multi-page)
-                if (file.hasMultiplePages) {
+                // Page count badge (multi-payload entries like scans, not PDFs)
+                if (file.hasMultiplePages && !file.isPdf) {
                     Box(
                         modifier = Modifier
                             .align(Alignment.BottomEnd)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultEntryCard.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultEntryCard.kt
@@ -20,20 +20,30 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import id.homebase.core.image.decodeBitmap
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.runtime.remember
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
+import id.homebase.core.pdf.PdfRenderer
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import id.homebase.api.client.KeyHeader
 import id.homebase.chat.services.LocalAttachmentContext
 import id.homebase.chat.services.LocalAttachmentContextStore
@@ -132,12 +142,20 @@ fun VaultEntryCard(
                             )
                         }
                     }
-                    AsyncImage(
-                        model = localImage.localFilePath,
-                        contentDescription = description,
-                        modifier = imageModifier,
-                        contentScale = ContentScale.Crop,
-                    )
+                    if (file.isPdf) {
+                        LocalPdfThumbnail(
+                            filePath = localImage.localFilePath,
+                            contentDescription = description,
+                            modifier = imageModifier,
+                        )
+                    } else {
+                        AsyncImage(
+                            model = localImage.localFilePath,
+                            contentDescription = description,
+                            modifier = imageModifier,
+                            contentScale = ContentScale.Crop,
+                        )
+                    }
                 } else if (file.isImage) {
                     @OptIn(ExperimentalEncodingApi::class)
                     val descriptor = file.payloadDescriptors.firstOrNull()
@@ -343,3 +361,44 @@ fun VaultEntryCard(
     }
 }
 
+@Composable
+private fun LocalPdfThumbnail(
+    filePath: String,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+) {
+    BoxWithConstraints(
+        modifier = modifier,
+        contentAlignment = Alignment.Center,
+    ) {
+        val density = LocalDensity.current
+        val pixelWidth = with(density) { maxWidth.roundToPx() }
+        val pixelHeight = with(density) { maxHeight.roundToPx() }
+
+        var bitmap by remember { mutableStateOf<ImageBitmap?>(null) }
+
+        LaunchedEffect(filePath, pixelWidth, pixelHeight) {
+            if (pixelWidth > 0 && pixelHeight > 0) {
+                bitmap = withContext(Dispatchers.Default) {
+                    val renderer = PdfRenderer()
+                    try {
+                        renderer.open(filePath)
+                        renderer.renderPage(0, pixelWidth, pixelHeight)
+                    } finally {
+                        renderer.close()
+                    }
+                }
+            }
+        }
+
+        val bmp = bitmap
+        if (bmp != null) {
+            Image(
+                bitmap = bmp,
+                contentDescription = contentDescription,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop,
+            )
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultEntryCard.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultEntryCard.kt
@@ -205,6 +205,8 @@ fun VaultEntryCard(
                             modifier = Modifier.fillMaxSize(),
                             contentScale = ContentScale.Crop,
                             contentDescription = description,
+                            sharedTransitionScope = sharedTransitionScope,
+                            animatedVisibilityScope = animatedVisibilityScope,
                         )
                     } else if (file.previewThumbnail != null) {
                         val thumbBitmap = remember(file.previewThumbnail) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultEntryCard.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultEntryCard.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import id.homebase.core.image.decodeBitmap
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.SharedTransitionScope
@@ -122,127 +121,14 @@ fun VaultEntryCard(
                     ).value
                 val localImage = localCtx as? LocalAttachmentContext.Image
 
-                if ((file.isImage || file.isPdf) && localImage != null) {
-                    var imageModifier: Modifier = Modifier.fillMaxSize()
-                    if (sharedTransitionScope != null && animatedVisibilityScope != null) {
-                        with(sharedTransitionScope) {
-                            imageModifier = imageModifier.sharedBounds(
-                                rememberSharedContentState(key = "image-${file.fileId}-${firstPayloadKey}"),
-                                animatedVisibilityScope = animatedVisibilityScope,
-                            )
-                        }
-                    }
-                    AsyncImage(
-                        model = localImage.localFilePath,
-                        contentDescription = description,
-                        modifier = imageModifier,
-                        contentScale = ContentScale.Crop,
-                    )
-                } else if (file.isImage) {
-                    @OptIn(ExperimentalEncodingApi::class)
-                    val descriptor = file.payloadDescriptors.firstOrNull()
-                    val payloadIv = remember(descriptor?.iv) {
-                        descriptor?.iv?.let {
-                            try {
-                                Base64.decode(it)
-                            } catch (_: Exception) {
-                                null
-                            }
-                        }
-                    }
-                    if (descriptor != null && payloadIv != null) {
-                        HomebaseImage(
-                            imageData = HomebaseImageData(
-                                driveId = file.driveId,
-                                fileId = file.fileId,
-                                payloadKey = descriptor.key,
-                                previewThumbnail = file.previewThumbnail,
-                                requestedSize = ImageSize.THUMB_MEDIUM,
-                                isEncrypted = file.isEncrypted,
-                                keyHeader = KeyHeader(
-                                    iv = payloadIv,
-                                    aesKey = file.keyHeader.aesKey
-                                ),
-                                lastModified = descriptor.lastModified,
-                            ),
-                            modifier = Modifier.fillMaxSize(),
-                            contentScale = ContentScale.Crop,
-                            contentDescription = description,
-                            sharedTransitionScope = sharedTransitionScope,
-                            animatedVisibilityScope = animatedVisibilityScope,
-                        )
-                    } else {
-                        Icon(
-                            imageVector = Icons.Outlined.Image,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.size(32.dp),
-                        )
-                    }
-                } else if (file.isPdf) {
-                    @OptIn(ExperimentalEncodingApi::class)
-                    val descriptor = file.payloadDescriptors.firstOrNull()
-                    val payloadIv = remember(descriptor?.iv) {
-                        descriptor?.iv?.let {
-                            try { Base64.decode(it) } catch (_: Exception) { null }
-                        }
-                    }
-                    if (descriptor != null && payloadIv != null) {
-                        HomebaseImage(
-                            imageData = HomebaseImageData(
-                                driveId = file.driveId,
-                                fileId = file.fileId,
-                                payloadKey = descriptor.key,
-                                previewThumbnail = file.previewThumbnail,
-                                requestedSize = ImageSize.THUMB_MEDIUM,
-                                isEncrypted = file.isEncrypted,
-                                keyHeader = KeyHeader(
-                                    iv = payloadIv,
-                                    aesKey = file.keyHeader.aesKey,
-                                ),
-                                lastModified = descriptor.lastModified,
-                            ),
-                            modifier = Modifier.fillMaxSize(),
-                            contentScale = ContentScale.Crop,
-                            contentDescription = description,
-                            sharedTransitionScope = sharedTransitionScope,
-                            animatedVisibilityScope = animatedVisibilityScope,
-                        )
-                    } else if (file.previewThumbnail != null) {
-                        val thumbBitmap = remember(file.previewThumbnail) {
-                            file.previewThumbnail.decodeBitmap()
-                        }
-                        if (thumbBitmap != null) {
-                            Image(
-                                bitmap = thumbBitmap,
-                                contentDescription = description,
-                                modifier = Modifier.fillMaxSize(),
-                                contentScale = ContentScale.Crop,
-                            )
-                        } else {
-                            Icon(
-                                imageVector = fileTypeIcon(file.contentType),
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.size(32.dp),
-                            )
-                        }
-                    } else {
-                        Icon(
-                            imageVector = fileTypeIcon(file.contentType),
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.size(32.dp),
-                        )
-                    }
-                } else {
-                    Icon(
-                        imageVector = fileTypeIcon(file.contentType),
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(32.dp),
-                    )
-                }
+                VaultCardThumbnail(
+                    file = file,
+                    localImage = localImage,
+                    firstPayloadKey = firstPayloadKey,
+                    description = description,
+                    sharedTransitionScope = sharedTransitionScope,
+                    animatedVisibilityScope = animatedVisibilityScope,
+                )
 
                 // Upload status overlay
                 when (val status = file.uploadStatus) {
@@ -296,7 +182,6 @@ fun VaultEntryCard(
                             text = stringResource(MR.string.vault_pdf_badge),
                             style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.onError,
-                            fontSize = 8.sp,
                         )
                     }
                 }
@@ -341,4 +226,90 @@ fun VaultEntryCard(
             }
         }
     }
+}
+
+@OptIn(ExperimentalEncodingApi::class)
+@Composable
+private fun VaultCardThumbnail(
+    file: VaultEntry,
+    localImage: LocalAttachmentContext.Image?,
+    firstPayloadKey: String,
+    description: String,
+    sharedTransitionScope: SharedTransitionScope?,
+    animatedVisibilityScope: AnimatedVisibilityScope?,
+) {
+    // 1. Local file available (pending upload or cached thumbnail)
+    if ((file.isImage || file.isPdf) && localImage != null) {
+        var imageModifier: Modifier = Modifier.fillMaxSize()
+        if (sharedTransitionScope != null && animatedVisibilityScope != null) {
+            with(sharedTransitionScope) {
+                imageModifier = imageModifier.sharedBounds(
+                    rememberSharedContentState(key = "image-${file.fileId}-${firstPayloadKey}"),
+                    animatedVisibilityScope = animatedVisibilityScope,
+                )
+            }
+        }
+        AsyncImage(
+            model = localImage.localFilePath,
+            contentDescription = description,
+            modifier = imageModifier,
+            contentScale = ContentScale.Crop,
+        )
+        return
+    }
+
+    // 2. Encrypted server thumbnail (image or PDF — same HomebaseImage path)
+    val descriptor = file.payloadDescriptors.firstOrNull()
+    val payloadIv = remember(descriptor?.iv) {
+        descriptor?.iv?.let {
+            try { Base64.decode(it) } catch (_: Exception) { null }
+        }
+    }
+    if ((file.isImage || file.isPdf) && descriptor != null && payloadIv != null) {
+        HomebaseImage(
+            imageData = HomebaseImageData(
+                driveId = file.driveId,
+                fileId = file.fileId,
+                payloadKey = descriptor.key,
+                previewThumbnail = file.previewThumbnail,
+                requestedSize = ImageSize.THUMB_MEDIUM,
+                isEncrypted = file.isEncrypted,
+                keyHeader = KeyHeader(
+                    iv = payloadIv,
+                    aesKey = file.keyHeader.aesKey,
+                ),
+                lastModified = descriptor.lastModified,
+            ),
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Crop,
+            contentDescription = description,
+            sharedTransitionScope = sharedTransitionScope,
+            animatedVisibilityScope = animatedVisibilityScope,
+        )
+        return
+    }
+
+    // 3. PDF embedded preview thumbnail (no encryption key available yet)
+    if (file.isPdf && file.previewThumbnail != null) {
+        val thumbBitmap = remember(file.previewThumbnail) {
+            file.previewThumbnail.decodeBitmap()
+        }
+        if (thumbBitmap != null) {
+            Image(
+                bitmap = thumbBitmap,
+                contentDescription = description,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop,
+            )
+            return
+        }
+    }
+
+    // 4. Fallback icon
+    Icon(
+        imageVector = if (file.isImage) Icons.Outlined.Image else fileTypeIcon(file.contentType),
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.size(32.dp),
+    )
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultEntryCard.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultEntryCard.kt
@@ -20,30 +20,20 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import id.homebase.core.image.decodeBitmap
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.SharedTransitionScope
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.runtime.remember
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
-import id.homebase.core.pdf.PdfRenderer
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import id.homebase.api.client.KeyHeader
 import id.homebase.chat.services.LocalAttachmentContext
 import id.homebase.chat.services.LocalAttachmentContextStore
@@ -142,20 +132,12 @@ fun VaultEntryCard(
                             )
                         }
                     }
-                    if (file.isPdf) {
-                        LocalPdfThumbnail(
-                            filePath = localImage.localFilePath,
-                            contentDescription = description,
-                            modifier = imageModifier,
-                        )
-                    } else {
-                        AsyncImage(
-                            model = localImage.localFilePath,
-                            contentDescription = description,
-                            modifier = imageModifier,
-                            contentScale = ContentScale.Crop,
-                        )
-                    }
+                    AsyncImage(
+                        model = localImage.localFilePath,
+                        contentDescription = description,
+                        modifier = imageModifier,
+                        contentScale = ContentScale.Crop,
+                    )
                 } else if (file.isImage) {
                     @OptIn(ExperimentalEncodingApi::class)
                     val descriptor = file.payloadDescriptors.firstOrNull()
@@ -299,7 +281,7 @@ fun VaultEntryCard(
                 }
 
                 // PDF type badge
-                if (file.isPdf && file.previewThumbnail?.content != null) {
+                if (file.isPdf && (file.previewThumbnail?.content != null || localImage != null)) {
                     Box(
                         modifier = Modifier
                             .align(Alignment.TopEnd)
@@ -357,48 +339,6 @@ fun VaultEntryCard(
                     color = MaterialTheme.colorScheme.onSurface,
                 )
             }
-        }
-    }
-}
-
-@Composable
-private fun LocalPdfThumbnail(
-    filePath: String,
-    modifier: Modifier = Modifier,
-    contentDescription: String? = null,
-) {
-    BoxWithConstraints(
-        modifier = modifier,
-        contentAlignment = Alignment.Center,
-    ) {
-        val density = LocalDensity.current
-        val pixelWidth = with(density) { maxWidth.roundToPx() }
-        val pixelHeight = with(density) { maxHeight.roundToPx() }
-
-        var bitmap by remember { mutableStateOf<ImageBitmap?>(null) }
-
-        LaunchedEffect(filePath, pixelWidth, pixelHeight) {
-            if (pixelWidth > 0 && pixelHeight > 0) {
-                bitmap = withContext(Dispatchers.Default) {
-                    val renderer = PdfRenderer()
-                    try {
-                        renderer.open(filePath)
-                        renderer.renderPage(0, pixelWidth, pixelHeight)
-                    } finally {
-                        renderer.close()
-                    }
-                }
-            }
-        }
-
-        val bmp = bitmap
-        if (bmp != null) {
-            Image(
-                bitmap = bmp,
-                contentDescription = contentDescription,
-                modifier = Modifier.fillMaxSize(),
-                contentScale = ContentScale.Crop,
-            )
         }
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultScreen.kt
@@ -46,7 +46,7 @@ import id.homebase.chat.conversationlist.ExtendPermissionViewModel
 import id.homebase.chat.services.LocalAttachmentContextStore
 import id.homebase.core.ui.screens.vault.auth.VaultBiometricGate
 import id.homebase.core.ui.screens.vault.components.VaultAddSectionControl
-import id.homebase.core.ui.screens.vault.components.VaultImageAddSheet
+import id.homebase.core.ui.screens.vault.components.VaultAddEntrySheet
 import id.homebase.core.ui.screens.vault.components.VaultNewSectionSheet
 import id.homebase.core.ui.screens.vault.gallery.VaultGalleryScreen
 import id.homebase.core.ui.screens.vault.model.VaultEntry
@@ -177,9 +177,27 @@ fun VaultScreen(
         }
     }
 
-    // File picker — dispatches to append or add based on fileForAppend
-    val filePicker = rememberFilePickerLauncher(
+    // Image picker — dispatches to append or add based on fileForAppend
+    val imagePicker = rememberFilePickerLauncher(
         type = FileKitType.Image,
+        mode = FileKitMode.Multiple(),
+    ) { files ->
+        if (!files.isNullOrEmpty()) {
+            val appendFile = fileForAppend
+            if (appendFile != null) {
+                viewModel.onAction(VaultUiAction.AppendPages(appendFile, files))
+                fileForAppend = null
+            } else {
+                activeSectionForEntry?.let { section ->
+                    viewModel.onAction(VaultUiAction.AddEntryToSection(section.sectionId, files))
+                }
+            }
+        }
+    }
+
+    // File picker — all file types (PDFs get thumbnail + preview automatically)
+    val documentPicker = rememberFilePickerLauncher(
+        type = FileKitType.File(),
         mode = FileKitMode.Multiple(),
     ) { files ->
         if (!files.isNullOrEmpty()) {
@@ -328,17 +346,21 @@ fun VaultScreen(
             }
             VaultPickerAction.Gallery -> {
                 isPickerActive = true
-                filePicker.launch()
+                imagePicker.launch()
+            }
+            VaultPickerAction.File -> {
+                isPickerActive = true
+                documentPicker.launch()
             }
             null -> {}
         }
         pendingPickerAction = null
     }
 
-    // Image add bottom sheet
+    // Entry add bottom sheet
     if (showImageAddSheet) {
         val sheetState = rememberModalBottomSheetState()
-        VaultImageAddSheet(
+        VaultAddEntrySheet(
             sheetState = sheetState,
             onTakePhoto = {
                 showImageAddSheet = false
@@ -347,6 +369,10 @@ fun VaultScreen(
             onChooseGallery = {
                 showImageAddSheet = false
                 pendingPickerAction = VaultPickerAction.Gallery
+            },
+            onChooseFile = {
+                showImageAddSheet = false
+                pendingPickerAction = VaultPickerAction.File
             },
             onDismiss = {
                 showImageAddSheet = false
@@ -427,7 +453,7 @@ fun VaultScreen(
 
 }
 
-private enum class VaultPickerAction { Camera, Gallery }
+private enum class VaultPickerAction { Camera, Gallery, File }
 
 @Composable
 private fun resolveVaultError(error: VaultError): String = when (error) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultUploaderService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultUploaderService.kt
@@ -33,7 +33,7 @@ import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.image.ImageUtils
 import id.homebase.api.image.createImageThumbnail
 import id.homebase.api.image.tinyThumbSize
-import id.homebase.core.pdf.generatePdfThumbnail
+import id.homebase.core.pdf.generatePdfThumbnailFromFile
 import kotlinx.coroutines.CoroutineScope
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
@@ -298,8 +298,7 @@ class VaultUploaderService(
                 }
             } else if (contentType == "application/pdf") {
                 try {
-                    val pdfBytes = fileOperationsProvider.readFileBytes(filePath)
-                    val pdfResult = generatePdfThumbnail(pdfBytes, 320)
+                    val pdfResult = generatePdfThumbnailFromFile(filePath, 320)
                     val thumbBytes = pdfResult?.thumbnailBytes
                     if (thumbBytes != null) {
                         // Tiny embedded preview for appData (must fit under MaxEmbeddedThumbBytes)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultUploaderService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultUploaderService.kt
@@ -30,6 +30,10 @@ import id.homebase.core.ui.screens.vault.model.VaultEntry
 import id.homebase.core.ui.screens.vault.model.VaultFileContent
 import id.homebase.core.ui.screens.vault.model.VAULT_FILE_TYPE
 import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.image.ImageUtils
+import id.homebase.api.image.createImageThumbnail
+import id.homebase.api.image.tinyThumbSize
+import id.homebase.core.pdf.generatePdfThumbnail
 import kotlinx.coroutines.CoroutineScope
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
@@ -66,14 +70,15 @@ class VaultUploaderService(
                 convertHeicIfNeeded(resolved, contentType)
             }
 
-            val bundle = buildMultiPayloadBundle(resolvedFiles)
+            var pdfPageCount: Int? = null
+            val bundle = buildMultiPayloadBundle(resolvedFiles) { pdfPageCount = it }
 
             val encryptedBundle = payloadEncryptionService.encryptBundle(
                 uniqueId, bundle, keyHeader.aesKey, scope
             )
 
             val content = OdinSystemSerializer.serialize(
-                VaultFileContent(name = entryName, notes = notes)
+                VaultFileContent(name = entryName, notes = notes, pdfPageCount = pdfPageCount)
             )
             val unencryptedMetadata = UploadFileMetadata(
                 allowDistribution = false,
@@ -270,6 +275,7 @@ class VaultUploaderService(
 
     private suspend fun buildMultiPayloadBundle(
         files: List<Pair<String, String>>,
+        onPdfPageCount: ((Int) -> Unit)? = null,
     ): PayloadBundle {
         val allPayloads = mutableListOf<PayloadFile>()
         val allThumbnails = mutableListOf<ThumbnailFile>()
@@ -289,6 +295,39 @@ class VaultUploaderService(
                     thumbnails = result.thumbnails
                 } catch (e: Exception) {
                     Logger.w(e, TAG) { "Thumbnail generation failed for payload $key" }
+                }
+            } else if (contentType == "application/pdf") {
+                try {
+                    val pdfBytes = fileOperationsProvider.readFileBytes(filePath)
+                    val pdfResult = generatePdfThumbnail(pdfBytes, 320)
+                    val thumbBytes = pdfResult?.thumbnailBytes
+                    if (thumbBytes != null) {
+                        // Tiny embedded preview for appData (must fit under MaxEmbeddedThumbBytes)
+                        val tinyThumb = createImageThumbnail(
+                            thumbBytes, key, tinyThumbSize, isTinyThumb = true,
+                        )
+                        previewThumbnail = EmbeddedThumb(
+                            pixelWidth = tinyThumb.pixelWidth,
+                            pixelHeight = tinyThumb.pixelHeight,
+                            contentType = tinyThumb.contentType,
+                            content = Base64.encode(tinyThumb.thumbnailBytes),
+                        )
+                        // Larger thumbnail for crisp card display
+                        val naturalSize = ImageUtils.getNaturalSize(thumbBytes)
+                        thumbnails = listOf(
+                            ThumbnailFile(
+                                pixelWidth = naturalSize.pixelWidth,
+                                pixelHeight = naturalSize.pixelHeight,
+                                thumbnailBytes = thumbBytes,
+                                key = key,
+                                contentType = "image/jpeg",
+                                quality = 80,
+                            ),
+                        )
+                    }
+                    if (pdfResult != null) onPdfPageCount?.invoke(pdfResult.pageCount)
+                } catch (e: Exception) {
+                    Logger.w(e, TAG) { "PDF thumbnail generation failed for payload $key" }
                 }
             }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultUploaderService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultUploaderService.kt
@@ -325,7 +325,7 @@ class VaultUploaderService(
                             ),
                         )
                     }
-                    if (pdfResult != null) onPdfPageCount?.invoke(pdfResult.pageCount)
+                    if (pdfResult != null && index == 0) onPdfPageCount?.invoke(pdfResult.pageCount)
                 } catch (e: Exception) {
                     Logger.w(e, TAG) { "PDF thumbnail generation failed for payload $key" }
                 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
@@ -420,6 +420,8 @@ class VaultViewModel(
                             LocalAttachmentContext.Image(localFilePath = thumbPath, aspectRatio = null),
                         )
                     }
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    throw e
                 } catch (_: Exception) { }
             }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
@@ -13,7 +13,7 @@ import id.homebase.chat.conversationlist.ExtendPermissionViewModel
 import id.homebase.chat.services.LocalAttachmentContext
 import id.homebase.chat.services.LocalAttachmentContextStore
 import id.homebase.core.auth.AuthConnectionCoordinator
-import id.homebase.core.pdf.generatePdfThumbnail
+import id.homebase.core.pdf.generatePdfThumbnailFromFile
 import id.homebase.core.config.vaultDefaultSections
 import id.homebase.core.config.vaultLabeledDrive
 import id.homebase.core.sync.DriveRegistry
@@ -407,8 +407,7 @@ class VaultViewModel(
             // Generate local JPEG thumbnail for PDFs so the card can show a preview via AsyncImage
             if (firstContentType == "application/pdf") {
                 try {
-                    val pdfBytes = fileOperationsProvider.readFileBytes(fileData.first().first)
-                    val pdfResult = generatePdfThumbnail(pdfBytes, 320)
+                    val pdfResult = generatePdfThumbnailFromFile(fileData.first().first, 320)
                     val thumbBytes = pdfResult?.thumbnailBytes
                     if (thumbBytes != null) {
                         val thumbPath = fileOperationsProvider.writeBytesToTempFile(

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
@@ -13,7 +13,7 @@ import id.homebase.chat.conversationlist.ExtendPermissionViewModel
 import id.homebase.chat.services.LocalAttachmentContext
 import id.homebase.chat.services.LocalAttachmentContextStore
 import id.homebase.core.auth.AuthConnectionCoordinator
-import id.homebase.core.pdf.generatePdfThumbnailFromFile
+
 import id.homebase.core.config.vaultDefaultSections
 import id.homebase.core.config.vaultLabeledDrive
 import id.homebase.core.sync.DriveRegistry
@@ -372,15 +372,13 @@ class VaultViewModel(
             )
         }
 
-        fileData.forEachIndexed { index, (path, contentType) ->
+        fileData.forEachIndexed { index, (path, _) ->
             val payloadKey = "vlt_pg_${index.toString().padStart(2, '0')}"
-            if (contentType != "application/pdf") {
-                localAttachmentStore.put(
-                    pendingId,
-                    payloadKey,
-                    LocalAttachmentContext.Image(localFilePath = path, aspectRatio = null),
-                )
-            }
+            localAttachmentStore.put(
+                pendingId,
+                payloadKey,
+                LocalAttachmentContext.Image(localFilePath = path, aspectRatio = null),
+            )
         }
 
         val pendingItem = VaultEntry(
@@ -401,28 +399,8 @@ class VaultViewModel(
             payloadDescriptors = placeholderDescriptors,
         )
 
-        vaultStream.insertOptimisticEntry(pendingItem, action.sectionId)
-
         viewModelScope.launch {
-            // Generate local JPEG thumbnail for PDFs so the card can show a preview via AsyncImage
-            if (firstContentType == "application/pdf") {
-                try {
-                    val pdfResult = generatePdfThumbnailFromFile(fileData.first().first, 320)
-                    val thumbBytes = pdfResult?.thumbnailBytes
-                    if (thumbBytes != null) {
-                        val thumbPath = fileOperationsProvider.writeBytesToTempFile(
-                            thumbBytes, "pdf_card_", ".jpg",
-                        )
-                        localAttachmentStore.put(
-                            pendingId,
-                            "vlt_pg_00",
-                            LocalAttachmentContext.Image(localFilePath = thumbPath, aspectRatio = null),
-                        )
-                    }
-                } catch (e: kotlinx.coroutines.CancellationException) {
-                    throw e
-                } catch (_: Exception) { }
-            }
+            vaultStream.insertOptimisticEntry(pendingItem, action.sectionId)
 
             val uniqueId = vaultUploaderService.uploadFile(
                 entryName = firstName,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
@@ -13,7 +13,7 @@ import id.homebase.chat.conversationlist.ExtendPermissionViewModel
 import id.homebase.chat.services.LocalAttachmentContext
 import id.homebase.chat.services.LocalAttachmentContextStore
 import id.homebase.core.auth.AuthConnectionCoordinator
-
+import id.homebase.core.pdf.generatePdfThumbnailFromFile
 import id.homebase.core.config.vaultDefaultSections
 import id.homebase.core.config.vaultLabeledDrive
 import id.homebase.core.sync.DriveRegistry
@@ -28,6 +28,8 @@ import id.homebase.api.sync.DriveState
 import io.github.vinceglb.filekit.mimeType
 import io.github.vinceglb.filekit.name
 import io.github.vinceglb.filekit.path
+import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.copyTo
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -40,7 +42,9 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -360,25 +364,26 @@ class VaultViewModel(
         val firstContentType = resolveContentType(firstName, files.first().mimeType()?.toString())
         val pendingId = Uuid.random()
 
-        val fileData = files.map { file ->
-            val ct = resolveContentType(file.name, file.mimeType()?.toString())
-            file.path to ct
+        val fileContentTypes = files.map { file ->
+            resolveContentType(file.name, file.mimeType()?.toString())
         }
 
-        val placeholderDescriptors = fileData.mapIndexed { index, (_, contentType) ->
+        val placeholderDescriptors = fileContentTypes.mapIndexed { index, contentType ->
             PayloadDescriptor(
                 key = "vlt_pg_${index.toString().padStart(2, '0')}",
                 contentType = contentType,
             )
         }
 
-        fileData.forEachIndexed { index, (path, _) ->
+        files.forEachIndexed { index, file ->
             val payloadKey = "vlt_pg_${index.toString().padStart(2, '0')}"
-            localAttachmentStore.put(
-                pendingId,
-                payloadKey,
-                LocalAttachmentContext.Image(localFilePath = path, aspectRatio = null),
-            )
+            if (fileContentTypes[index] != "application/pdf") {
+                localAttachmentStore.put(
+                    pendingId,
+                    payloadKey,
+                    LocalAttachmentContext.Image(localFilePath = file.path, aspectRatio = null),
+                )
+            }
         }
 
         val pendingItem = VaultEntry(
@@ -400,6 +405,37 @@ class VaultViewModel(
         )
 
         viewModelScope.launch {
+            val fileData = files.mapIndexed { index, file ->
+                val ext = file.name.substringAfterLast('.', "tmp")
+                val cacheDir = fileOperationsProvider.getCacheDirectory()
+                val tempPath = "$cacheDir/vault_upload_${Uuid.random()}.$ext"
+                file.copyTo(PlatformFile(tempPath))
+                tempPath to fileContentTypes[index]
+            }
+
+            if (firstContentType == "application/pdf") {
+                try {
+                    val pdfResult = withContext(Dispatchers.Default) {
+                        generatePdfThumbnailFromFile(fileData.first().first, 320)
+                    }
+                    val thumbBytes = pdfResult?.thumbnailBytes
+                    if (thumbBytes != null) {
+                        val thumbPath = fileOperationsProvider.writeBytesToTempFile(
+                            thumbBytes, "pdf_card_", ".jpg",
+                        )
+                        localAttachmentStore.put(
+                            pendingId,
+                            "vlt_pg_00",
+                            LocalAttachmentContext.Image(localFilePath = thumbPath, aspectRatio = null),
+                        )
+                    }
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Logger.w(e, TAG) { "PDF card thumbnail generation failed" }
+                }
+            }
+
             vaultStream.insertOptimisticEntry(pendingItem, action.sectionId)
 
             val uniqueId = vaultUploaderService.uploadFile(

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
@@ -13,6 +13,7 @@ import id.homebase.chat.conversationlist.ExtendPermissionViewModel
 import id.homebase.chat.services.LocalAttachmentContext
 import id.homebase.chat.services.LocalAttachmentContextStore
 import id.homebase.core.auth.AuthConnectionCoordinator
+import id.homebase.core.pdf.generatePdfThumbnail
 import id.homebase.core.config.vaultDefaultSections
 import id.homebase.core.config.vaultLabeledDrive
 import id.homebase.core.sync.DriveRegistry
@@ -22,6 +23,7 @@ import id.homebase.core.ui.screens.vault.model.VaultSectionContent
 import id.homebase.core.util.resolveContentType
 import id.homebase.core.vault.VaultPreferences
 import id.homebase.api.client.KeyHeader
+import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.sync.DriveState
 import io.github.vinceglb.filekit.mimeType
 import io.github.vinceglb.filekit.name
@@ -54,6 +56,7 @@ class VaultViewModel(
     private val authConnectionCoordinator: AuthConnectionCoordinator,
     private val driveRegistry: DriveRegistry,
     private val localAttachmentStore: LocalAttachmentContextStore,
+    private val fileOperationsProvider: FileOperationsProvider,
     private val driveSyncManager: DriveSyncManager,
 ) : ViewModel() {
 
@@ -369,13 +372,15 @@ class VaultViewModel(
             )
         }
 
-        fileData.forEachIndexed { index, (path, _) ->
+        fileData.forEachIndexed { index, (path, contentType) ->
             val payloadKey = "vlt_pg_${index.toString().padStart(2, '0')}"
-            localAttachmentStore.put(
-                pendingId,
-                payloadKey,
-                LocalAttachmentContext.Image(localFilePath = path, aspectRatio = null),
-            )
+            if (contentType != "application/pdf") {
+                localAttachmentStore.put(
+                    pendingId,
+                    payloadKey,
+                    LocalAttachmentContext.Image(localFilePath = path, aspectRatio = null),
+                )
+            }
         }
 
         val pendingItem = VaultEntry(
@@ -399,6 +404,25 @@ class VaultViewModel(
         vaultStream.insertOptimisticEntry(pendingItem, action.sectionId)
 
         viewModelScope.launch {
+            // Generate local JPEG thumbnail for PDFs so the card can show a preview via AsyncImage
+            if (firstContentType == "application/pdf") {
+                try {
+                    val pdfBytes = fileOperationsProvider.readFileBytes(fileData.first().first)
+                    val pdfResult = generatePdfThumbnail(pdfBytes, 320)
+                    val thumbBytes = pdfResult?.thumbnailBytes
+                    if (thumbBytes != null) {
+                        val thumbPath = fileOperationsProvider.writeBytesToTempFile(
+                            thumbBytes, "pdf_card_", ".jpg",
+                        )
+                        localAttachmentStore.put(
+                            pendingId,
+                            "vlt_pg_00",
+                            LocalAttachmentContext.Image(localFilePath = thumbPath, aspectRatio = null),
+                        )
+                    }
+                } catch (_: Exception) { }
+            }
+
             val uniqueId = vaultUploaderService.uploadFile(
                 entryName = firstName,
                 files = fileData,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
@@ -404,48 +404,64 @@ class VaultViewModel(
             payloadDescriptors = placeholderDescriptors,
         )
 
+        vaultStream.insertOptimisticEntry(pendingItem, action.sectionId)
+
         viewModelScope.launch {
-            val fileData = files.mapIndexed { index, file ->
-                val ext = file.name.substringAfterLast('.', "tmp")
-                val cacheDir = fileOperationsProvider.getCacheDirectory()
-                val tempPath = "$cacheDir/vault_upload_${Uuid.random()}.$ext"
-                file.copyTo(PlatformFile(tempPath))
-                tempPath to fileContentTypes[index]
-            }
-
-            if (firstContentType == "application/pdf") {
-                try {
-                    val pdfResult = withContext(Dispatchers.Default) {
-                        generatePdfThumbnailFromFile(fileData.first().first, 320)
-                    }
-                    val thumbBytes = pdfResult?.thumbnailBytes
-                    if (thumbBytes != null) {
-                        val thumbPath = fileOperationsProvider.writeBytesToTempFile(
-                            thumbBytes, "pdf_card_", ".jpg",
-                        )
-                        localAttachmentStore.put(
-                            pendingId,
-                            "vlt_pg_00",
-                            LocalAttachmentContext.Image(localFilePath = thumbPath, aspectRatio = null),
-                        )
-                    }
-                } catch (e: kotlinx.coroutines.CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    Logger.w(e, TAG) { "PDF card thumbnail generation failed" }
+            var fileData: List<Pair<String, String>> = emptyList()
+            try {
+                fileData = files.mapIndexed { index, file ->
+                    val ext = file.name.substringAfterLast('.', "tmp")
+                    val cacheDir = fileOperationsProvider.getCacheDirectory()
+                    val tempPath = "$cacheDir/vault_upload_${Uuid.random()}.$ext"
+                    file.copyTo(PlatformFile(tempPath))
+                    tempPath to fileContentTypes[index]
                 }
-            }
 
-            vaultStream.insertOptimisticEntry(pendingItem, action.sectionId)
+                if (firstContentType == "application/pdf") {
+                    try {
+                        val pdfResult = withContext(Dispatchers.Default) {
+                            generatePdfThumbnailFromFile(fileData.first().first, 320)
+                        }
+                        val thumbBytes = pdfResult?.thumbnailBytes
+                        if (thumbBytes != null) {
+                            val thumbPath = fileOperationsProvider.writeBytesToTempFile(
+                                thumbBytes, "pdf_card_", ".jpg",
+                            )
+                            localAttachmentStore.put(
+                                pendingId,
+                                "vlt_pg_00",
+                                LocalAttachmentContext.Image(localFilePath = thumbPath, aspectRatio = null),
+                            )
+                        }
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        Logger.w(e, TAG) { "PDF card thumbnail generation failed" }
+                    }
+                }
 
-            val uniqueId = vaultUploaderService.uploadFile(
-                entryName = firstName,
-                files = fileData,
-                scope = viewModelScope,
-                groupId = action.sectionId,
-                uniqueId = pendingId,
-            )
-            if (uniqueId == null) {
+                val uniqueId = vaultUploaderService.uploadFile(
+                    entryName = firstName,
+                    files = fileData,
+                    scope = viewModelScope,
+                    groupId = action.sectionId,
+                    uniqueId = pendingId,
+                )
+                if (uniqueId == null) {
+                    vaultStream.updateOptimisticEntry(
+                        pendingItem.copy(uploadStatus = VaultUploadStatus.Failed("Upload failed"))
+                    )
+                    _events.tryEmit(VaultUiEvent.Error(VaultError.UploadFailed(firstName)))
+                }
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                fileData.forEach { (path, _) ->
+                    try { fileOperationsProvider.deleteTempFile(path) } catch (_: Exception) { }
+                }
+                throw e
+            } catch (e: Exception) {
+                fileData.forEach { (path, _) ->
+                    try { fileOperationsProvider.deleteTempFile(path) } catch (_: Exception) { }
+                }
                 vaultStream.updateOptimisticEntry(
                     pendingItem.copy(uploadStatus = VaultUploadStatus.Failed("Upload failed"))
                 )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/components/VaultFileIcon.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/components/VaultFileIcon.kt
@@ -4,9 +4,15 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.InsertDriveFile
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.outlined.Article
 import androidx.compose.material.icons.outlined.AudioFile
+import androidx.compose.material.icons.outlined.Code
+import androidx.compose.material.icons.outlined.Description
+import androidx.compose.material.icons.outlined.FolderZip
 import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material.icons.outlined.PictureAsPdf
+import androidx.compose.material.icons.outlined.Slideshow
+import androidx.compose.material.icons.outlined.TableChart
 import androidx.compose.material.icons.outlined.VideoFile
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -42,6 +48,34 @@ fun fileTypeIcon(contentType: String): ImageVector = when {
     contentType.startsWith("video/") -> Icons.Outlined.VideoFile
     contentType.startsWith("audio/") -> Icons.Outlined.AudioFile
     contentType == "application/pdf" -> Icons.Outlined.PictureAsPdf
+
+    contentType == "application/json" ||
+        contentType == "application/xml" ||
+        contentType == "application/javascript" ||
+        contentType == "application/x-sh" ||
+        contentType == "application/x-yaml" ||
+        contentType.startsWith("text/x-") -> Icons.Outlined.Code
+
+    contentType == "text/csv" ||
+        contentType == "application/vnd.ms-excel" ||
+        contentType.contains("spreadsheetml") -> Icons.Outlined.TableChart
+
+    contentType == "application/vnd.ms-powerpoint" ||
+        contentType.contains("presentationml") -> Icons.Outlined.Slideshow
+
+    contentType == "application/msword" ||
+        contentType.contains("wordprocessingml") ||
+        contentType == "application/vnd.oasis.opendocument.text" ||
+        contentType == "application/rtf" -> Icons.Outlined.Article
+
+    contentType == "application/zip" ||
+        contentType == "application/x-tar" ||
+        contentType == "application/gzip" ||
+        contentType == "application/x-rar-compressed" ||
+        contentType == "application/x-7z-compressed" -> Icons.Outlined.FolderZip
+
+    contentType.startsWith("text/") -> Icons.Outlined.Description
+
     else -> Icons.AutoMirrored.Outlined.InsertDriveFile
 }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/components/VaultFileIcon.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/components/VaultFileIcon.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.InsertDriveFile
 import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material.icons.outlined.Article
+import androidx.compose.material.icons.automirrored.outlined.Article
 import androidx.compose.material.icons.outlined.AudioFile
 import androidx.compose.material.icons.outlined.Code
 import androidx.compose.material.icons.outlined.Description
@@ -66,7 +66,7 @@ fun fileTypeIcon(contentType: String): ImageVector = when {
     contentType == "application/msword" ||
         contentType.contains("wordprocessingml") ||
         contentType == "application/vnd.oasis.opendocument.text" ||
-        contentType == "application/rtf" -> Icons.Outlined.Article
+        contentType == "application/rtf" -> Icons.AutoMirrored.Outlined.Article
 
     contentType == "application/zip" ||
         contentType == "application/x-tar" ||

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/components/VaultImageAddSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/components/VaultImageAddSheet.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.CameraAlt
+import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -23,17 +24,19 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import id.homebase.resources.MR
-import id.homebase.resources.vault_image_add
+import id.homebase.resources.vault_add_entry
+import id.homebase.resources.vault_choose_file
 import id.homebase.resources.vault_image_choose_gallery
 import id.homebase.resources.vault_image_take_photo
 import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun VaultImageAddSheet(
+fun VaultAddEntrySheet(
     sheetState: SheetState,
     onTakePhoto: () -> Unit,
     onChooseGallery: () -> Unit,
+    onChooseFile: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     ModalBottomSheet(
@@ -47,7 +50,7 @@ fun VaultImageAddSheet(
                 .padding(bottom = 16.dp),
         ) {
             Text(
-                text = stringResource(MR.string.vault_image_add),
+                text = stringResource(MR.string.vault_add_entry),
                 style = MaterialTheme.typography.titleLarge,
             )
 
@@ -74,8 +77,6 @@ fun VaultImageAddSheet(
                 )
             }
 
-            Spacer(modifier = Modifier.height(16.dp))
-
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -92,6 +93,27 @@ fun VaultImageAddSheet(
                 Spacer(modifier = Modifier.width(16.dp))
                 Text(
                     text = stringResource(MR.string.vault_image_choose_gallery),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .clickable(onClick = onChooseFile),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Description,
+                    contentDescription = stringResource(MR.string.vault_choose_file),
+                    modifier = Modifier.size(24.dp),
+                    tint = MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+                Text(
+                    text = stringResource(MR.string.vault_choose_file),
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurface,
                 )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/PdfViewerPage.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/PdfViewerPage.kt
@@ -78,7 +78,7 @@ fun PdfViewerPage(
                 state = PdfViewerState.Error
             } else {
                 renderer = PdfRenderer()
-                renderer.open(tempPath)
+                withContext(Dispatchers.Default) { renderer.open(tempPath) }
                 state = PdfViewerState.Ready(renderer, tempPath)
             }
         } catch (e: CancellationException) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/PdfViewerPage.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/PdfViewerPage.kt
@@ -1,0 +1,132 @@
+package id.homebase.core.ui.screens.vault.gallery
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import id.homebase.api.file.FileOperationsProvider
+import id.homebase.core.pdf.PdfPageViewer
+import id.homebase.core.pdf.PdfRenderer
+import id.homebase.core.ui.screens.vault.VaultUploaderService
+import id.homebase.core.ui.screens.vault.model.VaultEntry
+import id.homebase.resources.MR
+import id.homebase.resources.vault_pdf_preview_error
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.stringResource
+
+private sealed interface PdfViewerState {
+    data object Loading : PdfViewerState
+    data class Ready(val renderer: PdfRenderer, val tempFilePath: String) : PdfViewerState
+    data object Error : PdfViewerState
+}
+
+private fun cleanupPdfResources(
+    renderer: PdfRenderer?,
+    tempPath: String?,
+    fileOps: FileOperationsProvider,
+) {
+    renderer?.close()
+    tempPath?.let { try { fileOps.deleteTempFile(it) } catch (_: Exception) { } }
+}
+
+@Composable
+fun PdfViewerPage(
+    file: VaultEntry,
+    uploaderService: VaultUploaderService,
+    fileOperationsProvider: FileOperationsProvider,
+    modifier: Modifier = Modifier,
+) {
+    var state by remember { mutableStateOf<PdfViewerState>(PdfViewerState.Loading) }
+
+    LaunchedEffect(file.fileId) {
+        // Clean up previous Ready state when fileId changes
+        val prev = state
+        if (prev is PdfViewerState.Ready) {
+            cleanupPdfResources(prev.renderer, prev.tempFilePath, fileOperationsProvider)
+        }
+        state = PdfViewerState.Loading
+
+        var tempPath: String? = null
+        var renderer: PdfRenderer? = null
+        try {
+            val payloadKey = file.payloadDescriptors.firstOrNull()?.key ?: "vlt_pg_00"
+            tempPath = withContext(Dispatchers.Default) {
+                uploaderService.downloadPayload(file, payloadKey)
+            }
+            if (tempPath == null) {
+                state = PdfViewerState.Error
+            } else {
+                renderer = PdfRenderer()
+                renderer.open(tempPath)
+                state = PdfViewerState.Ready(renderer, tempPath)
+            }
+        } catch (e: CancellationException) {
+            cleanupPdfResources(renderer, tempPath, fileOperationsProvider)
+            throw e
+        } catch (_: Exception) {
+            cleanupPdfResources(renderer, tempPath, fileOperationsProvider)
+            state = PdfViewerState.Error
+        }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            val current = state
+            if (current is PdfViewerState.Ready) {
+                cleanupPdfResources(current.renderer, current.tempFilePath, fileOperationsProvider)
+            }
+        }
+    }
+
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        when (val s = state) {
+            is PdfViewerState.Loading -> {
+                CircularProgressIndicator()
+            }
+
+            is PdfViewerState.Ready -> {
+                PdfPageViewer(
+                    renderer = s.renderer,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+
+            is PdfViewerState.Error -> {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Icon(
+                        imageVector = Icons.Outlined.ErrorOutline,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.size(48.dp),
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    Text(
+                        text = stringResource(MR.string.vault_pdf_preview_error),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/PdfViewerPage.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/PdfViewerPage.kt
@@ -1,8 +1,5 @@
 package id.homebase.core.ui.screens.vault.gallery
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -24,13 +21,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil3.compose.AsyncImage
 import id.homebase.api.file.FileOperationsProvider
-import id.homebase.chat.services.LocalAttachmentContext
-import id.homebase.chat.services.LocalAttachmentContextStore
 import id.homebase.core.pdf.PdfPageViewer
 import id.homebase.core.ui.screens.vault.VaultUploaderService
 import id.homebase.core.ui.screens.vault.model.VaultEntry
@@ -40,7 +32,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
-import org.koin.compose.koinInject
 
 private sealed interface PdfViewerState {
     data object Loading : PdfViewerState
@@ -87,21 +78,13 @@ fun PdfViewerPage(
         }
     }
 
-    var revealViewer by remember { mutableStateOf(false) }
-
-    LaunchedEffect(state) {
-        if (state is PdfViewerState.Ready) {
-            kotlinx.coroutines.delay(600)
-            revealViewer = true
-        } else {
-            revealViewer = false
-        }
-    }
-
     Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         when (val s = state) {
             is PdfViewerState.Loading -> {
-                PdfLoadingPreview(file = file)
+                CircularProgressIndicator(
+                    modifier = Modifier.size(48.dp),
+                    color = MaterialTheme.colorScheme.inversePrimary,
+                )
             }
 
             is PdfViewerState.Ready -> {
@@ -110,13 +93,6 @@ fun PdfViewerPage(
                     onTap = onToggleUI,
                     modifier = Modifier.fillMaxSize(),
                 )
-                AnimatedVisibility(
-                    visible = !revealViewer,
-                    enter = fadeIn(),
-                    exit = fadeOut(),
-                ) {
-                    PdfLoadingPreview(file = file)
-                }
             }
 
             is PdfViewerState.Error -> {
@@ -136,29 +112,5 @@ fun PdfViewerPage(
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun PdfLoadingPreview(file: VaultEntry) {
-    val store = koinInject<LocalAttachmentContextStore>()
-    val payloadKey = file.payloadDescriptors.firstOrNull()?.key ?: "vlt_pg_00"
-    val localCtx by store.observe(file.uniqueId, payloadKey)
-        .collectAsStateWithLifecycle(initialValue = store.get(file.uniqueId, payloadKey))
-    val thumbPath = (localCtx as? LocalAttachmentContext.Image)?.localFilePath
-
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        if (thumbPath != null) {
-            AsyncImage(
-                model = thumbPath,
-                contentDescription = null,
-                modifier = Modifier.fillMaxSize(),
-                contentScale = ContentScale.Fit,
-            )
-        }
-        CircularProgressIndicator(
-            modifier = Modifier.size(48.dp),
-            color = MaterialTheme.colorScheme.inversePrimary,
-        )
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/PdfViewerPage.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/PdfViewerPage.kt
@@ -1,5 +1,8 @@
 package id.homebase.core.ui.screens.vault.gallery
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -21,8 +24,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil3.compose.AsyncImage
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.chat.services.LocalAttachmentContext
+import id.homebase.chat.services.LocalAttachmentContextStore
 import id.homebase.core.pdf.PdfPageViewer
 import id.homebase.core.ui.screens.vault.VaultUploaderService
 import id.homebase.core.ui.screens.vault.model.VaultEntry
@@ -32,6 +40,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 
 private sealed interface PdfViewerState {
     data object Loading : PdfViewerState
@@ -78,10 +87,21 @@ fun PdfViewerPage(
         }
     }
 
+    var revealViewer by remember { mutableStateOf(false) }
+
+    LaunchedEffect(state) {
+        if (state is PdfViewerState.Ready) {
+            kotlinx.coroutines.delay(600)
+            revealViewer = true
+        } else {
+            revealViewer = false
+        }
+    }
+
     Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         when (val s = state) {
             is PdfViewerState.Loading -> {
-                CircularProgressIndicator()
+                PdfLoadingPreview(file = file)
             }
 
             is PdfViewerState.Ready -> {
@@ -90,6 +110,13 @@ fun PdfViewerPage(
                     onTap = onToggleUI,
                     modifier = Modifier.fillMaxSize(),
                 )
+                AnimatedVisibility(
+                    visible = !revealViewer,
+                    enter = fadeIn(),
+                    exit = fadeOut(),
+                ) {
+                    PdfLoadingPreview(file = file)
+                }
             }
 
             is PdfViewerState.Error -> {
@@ -109,5 +136,29 @@ fun PdfViewerPage(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun PdfLoadingPreview(file: VaultEntry) {
+    val store = koinInject<LocalAttachmentContextStore>()
+    val payloadKey = file.payloadDescriptors.firstOrNull()?.key ?: "vlt_pg_00"
+    val localCtx by store.observe(file.uniqueId, payloadKey)
+        .collectAsStateWithLifecycle(initialValue = store.get(file.uniqueId, payloadKey))
+    val thumbPath = (localCtx as? LocalAttachmentContext.Image)?.localFilePath
+
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        if (thumbPath != null) {
+            AsyncImage(
+                model = thumbPath,
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Fit,
+            )
+        }
+        CircularProgressIndicator(
+            modifier = Modifier.size(48.dp),
+            color = MaterialTheme.colorScheme.inversePrimary,
+        )
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/PdfViewerPage.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/PdfViewerPage.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import id.homebase.api.file.FileOperationsProvider
 import id.homebase.core.pdf.PdfPageViewer
-import id.homebase.core.pdf.PdfRenderer
 import id.homebase.core.ui.screens.vault.VaultUploaderService
 import id.homebase.core.ui.screens.vault.model.VaultEntry
 import id.homebase.resources.MR
@@ -36,17 +35,8 @@ import org.jetbrains.compose.resources.stringResource
 
 private sealed interface PdfViewerState {
     data object Loading : PdfViewerState
-    data class Ready(val renderer: PdfRenderer, val tempFilePath: String) : PdfViewerState
+    data class Ready(val tempFilePath: String) : PdfViewerState
     data object Error : PdfViewerState
-}
-
-private fun cleanupPdfResources(
-    renderer: PdfRenderer?,
-    tempPath: String?,
-    fileOps: FileOperationsProvider,
-) {
-    renderer?.close()
-    tempPath?.let { try { fileOps.deleteTempFile(it) } catch (_: Exception) { } }
 }
 
 @Composable
@@ -60,32 +50,21 @@ fun PdfViewerPage(
     var state by remember { mutableStateOf<PdfViewerState>(PdfViewerState.Loading) }
 
     LaunchedEffect(file.fileId) {
-        // Clean up previous Ready state when fileId changes
         val prev = state
         if (prev is PdfViewerState.Ready) {
-            cleanupPdfResources(prev.renderer, prev.tempFilePath, fileOperationsProvider)
+            try { fileOperationsProvider.deleteTempFile(prev.tempFilePath) } catch (_: Exception) { }
         }
         state = PdfViewerState.Loading
 
-        var tempPath: String? = null
-        var renderer: PdfRenderer? = null
         try {
             val payloadKey = file.payloadDescriptors.firstOrNull()?.key ?: "vlt_pg_00"
-            tempPath = withContext(Dispatchers.Default) {
+            val tempPath = withContext(Dispatchers.Default) {
                 uploaderService.downloadPayload(file, payloadKey)
             }
-            if (tempPath == null) {
-                state = PdfViewerState.Error
-            } else {
-                renderer = PdfRenderer()
-                withContext(Dispatchers.Default) { renderer.open(tempPath) }
-                state = PdfViewerState.Ready(renderer, tempPath)
-            }
+            state = if (tempPath != null) PdfViewerState.Ready(tempPath) else PdfViewerState.Error
         } catch (e: CancellationException) {
-            cleanupPdfResources(renderer, tempPath, fileOperationsProvider)
             throw e
         } catch (_: Exception) {
-            cleanupPdfResources(renderer, tempPath, fileOperationsProvider)
             state = PdfViewerState.Error
         }
     }
@@ -94,7 +73,7 @@ fun PdfViewerPage(
         onDispose {
             val current = state
             if (current is PdfViewerState.Ready) {
-                cleanupPdfResources(current.renderer, current.tempFilePath, fileOperationsProvider)
+                try { fileOperationsProvider.deleteTempFile(current.tempFilePath) } catch (_: Exception) { }
             }
         }
     }
@@ -107,7 +86,7 @@ fun PdfViewerPage(
 
             is PdfViewerState.Ready -> {
                 PdfPageViewer(
-                    renderer = s.renderer,
+                    filePath = s.tempFilePath,
                     onTap = onToggleUI,
                     modifier = Modifier.fillMaxSize(),
                 )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/TextViewerPage.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/TextViewerPage.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.core.util.trimToUtf8Boundary
 import id.homebase.core.ui.screens.vault.VaultUploaderService
 import id.homebase.core.ui.screens.vault.model.VaultEntry
 import id.homebase.resources.MR
@@ -75,7 +76,7 @@ fun TextViewerPage(
                 val truncated = fileSize > MAX_TEXT_BYTES
                 val bytes = withContext(Dispatchers.Default) {
                     val raw = fileOperationsProvider.readFileHeaderBytes(tempPath, MAX_TEXT_BYTES)
-                    if (truncated) trimToUtf8Boundary(raw) else raw
+                    if (truncated) raw.trimToUtf8Boundary() else raw
                 }
                 state = TextViewerState.Ready(bytes.decodeToString(), truncated)
                 try { fileOperationsProvider.deleteTempFile(tempPath) } catch (_: Exception) { }
@@ -144,26 +145,4 @@ fun TextViewerPage(
             }
         }
     }
-}
-
-private fun trimToUtf8Boundary(bytes: ByteArray): ByteArray {
-    var end = bytes.size
-    while (end > 0) {
-        val b = bytes[end - 1].toInt() and 0xFF
-        if (b and 0x80 == 0) break            // ASCII — clean boundary
-        if (b and 0xC0 == 0xC0) {             // start of a multi-byte sequence
-            val expectedLen = when {
-                b and 0xE0 == 0xC0 -> 2
-                b and 0xF0 == 0xE0 -> 3
-                b and 0xF8 == 0xF0 -> 4
-                else -> 1
-            }
-            val available = bytes.size - (end - 1)
-            if (available >= expectedLen) break // sequence is complete
-            end--                              // incomplete — drop this start byte too
-            break
-        }
-        end--                                  // continuation byte (10xxxxxx) — keep scanning
-    }
-    return if (end == bytes.size) bytes else bytes.copyOf(end)
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/TextViewerPage.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/TextViewerPage.kt
@@ -35,13 +35,16 @@ import id.homebase.core.ui.screens.vault.VaultUploaderService
 import id.homebase.core.ui.screens.vault.model.VaultEntry
 import id.homebase.resources.MR
 import id.homebase.resources.vault_text_preview_error
+import id.homebase.resources.vault_text_truncated
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
 
+private const val MAX_TEXT_BYTES = 1_048_576
+
 private sealed interface TextViewerState {
     data object Loading : TextViewerState
-    data class Ready(val content: String) : TextViewerState
+    data class Ready(val content: String, val truncated: Boolean) : TextViewerState
     data object Error : TextViewerState
 }
 
@@ -68,7 +71,9 @@ fun TextViewerPage(
                 val bytes = withContext(Dispatchers.Default) {
                     fileOperationsProvider.readFileBytes(tempPath)
                 }
-                state = TextViewerState.Ready(bytes.decodeToString())
+                val truncated = bytes.size > MAX_TEXT_BYTES
+                val displayBytes = if (truncated) bytes.copyOf(MAX_TEXT_BYTES) else bytes
+                state = TextViewerState.Ready(displayBytes.decodeToString(), truncated)
                 try { fileOperationsProvider.deleteTempFile(tempPath) } catch (_: Exception) { }
             }
         } catch (_: Exception) {
@@ -88,20 +93,30 @@ fun TextViewerPage(
             }
 
             is TextViewerState.Ready -> {
-                SelectionContainer {
-                    Text(
-                        text = s.content,
-                        style = MaterialTheme.typography.bodySmall.copy(
-                            fontFamily = FontFamily.Monospace,
-                        ),
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(MaterialTheme.colorScheme.surface)
-                            .verticalScroll(rememberScrollState())
-                            .horizontalScroll(rememberScrollState())
-                            .padding(16.dp),
-                    )
+                Column(modifier = Modifier.fillMaxSize()) {
+                    if (s.truncated) {
+                        Text(
+                            text = stringResource(MR.string.vault_text_truncated),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                        )
+                    }
+                    SelectionContainer(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = s.content,
+                            style = MaterialTheme.typography.bodySmall.copy(
+                                fontFamily = FontFamily.Monospace,
+                            ),
+                            color = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(MaterialTheme.colorScheme.surface)
+                                .verticalScroll(rememberScrollState())
+                                .horizontalScroll(rememberScrollState())
+                                .padding(16.dp),
+                        )
+                    }
                 }
             }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/TextViewerPage.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/TextViewerPage.kt
@@ -74,7 +74,8 @@ fun TextViewerPage(
                 }
                 val truncated = fileSize > MAX_TEXT_BYTES
                 val bytes = withContext(Dispatchers.Default) {
-                    fileOperationsProvider.readFileHeaderBytes(tempPath, MAX_TEXT_BYTES)
+                    val raw = fileOperationsProvider.readFileHeaderBytes(tempPath, MAX_TEXT_BYTES)
+                    if (truncated) trimToUtf8Boundary(raw) else raw
                 }
                 state = TextViewerState.Ready(bytes.decodeToString(), truncated)
                 try { fileOperationsProvider.deleteTempFile(tempPath) } catch (_: Exception) { }
@@ -143,4 +144,26 @@ fun TextViewerPage(
             }
         }
     }
+}
+
+private fun trimToUtf8Boundary(bytes: ByteArray): ByteArray {
+    var end = bytes.size
+    while (end > 0) {
+        val b = bytes[end - 1].toInt() and 0xFF
+        if (b and 0x80 == 0) break            // ASCII — clean boundary
+        if (b and 0xC0 == 0xC0) {             // start of a multi-byte sequence
+            val expectedLen = when {
+                b and 0xE0 == 0xC0 -> 2
+                b and 0xF0 == 0xE0 -> 3
+                b and 0xF8 == 0xF0 -> 4
+                else -> 1
+            }
+            val available = bytes.size - (end - 1)
+            if (available >= expectedLen) break // sequence is complete
+            end--                              // incomplete — drop this start byte too
+            break
+        }
+        end--                                  // continuation byte (10xxxxxx) — keep scanning
+    }
+    return if (end == bytes.size) bytes else bytes.copyOf(end)
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/TextViewerPage.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/TextViewerPage.kt
@@ -36,6 +36,7 @@ import id.homebase.core.ui.screens.vault.model.VaultEntry
 import id.homebase.resources.MR
 import id.homebase.resources.vault_text_preview_error
 import id.homebase.resources.vault_text_truncated
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
@@ -76,6 +77,8 @@ fun TextViewerPage(
                 state = TextViewerState.Ready(displayBytes.decodeToString(), truncated)
                 try { fileOperationsProvider.deleteTempFile(tempPath) } catch (_: Exception) { }
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (_: Exception) {
             state = TextViewerState.Error
         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/TextViewerPage.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/TextViewerPage.kt
@@ -1,11 +1,18 @@
 package id.homebase.core.ui.screens.vault.gallery
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ErrorOutline
 import androidx.compose.material3.CircularProgressIndicator
@@ -13,7 +20,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -21,99 +27,85 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import id.homebase.api.file.FileOperationsProvider
-import id.homebase.core.pdf.PdfPageViewer
-import id.homebase.core.pdf.PdfRenderer
 import id.homebase.core.ui.screens.vault.VaultUploaderService
 import id.homebase.core.ui.screens.vault.model.VaultEntry
 import id.homebase.resources.MR
-import id.homebase.resources.vault_pdf_preview_error
-import kotlinx.coroutines.CancellationException
+import id.homebase.resources.vault_text_preview_error
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
 
-private sealed interface PdfViewerState {
-    data object Loading : PdfViewerState
-    data class Ready(val renderer: PdfRenderer, val tempFilePath: String) : PdfViewerState
-    data object Error : PdfViewerState
-}
-
-private fun cleanupPdfResources(
-    renderer: PdfRenderer?,
-    tempPath: String?,
-    fileOps: FileOperationsProvider,
-) {
-    renderer?.close()
-    tempPath?.let { try { fileOps.deleteTempFile(it) } catch (_: Exception) { } }
+private sealed interface TextViewerState {
+    data object Loading : TextViewerState
+    data class Ready(val content: String) : TextViewerState
+    data object Error : TextViewerState
 }
 
 @Composable
-fun PdfViewerPage(
+fun TextViewerPage(
     file: VaultEntry,
     uploaderService: VaultUploaderService,
     fileOperationsProvider: FileOperationsProvider,
     onToggleUI: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
-    var state by remember { mutableStateOf<PdfViewerState>(PdfViewerState.Loading) }
+    var state by remember { mutableStateOf<TextViewerState>(TextViewerState.Loading) }
 
     LaunchedEffect(file.fileId) {
-        // Clean up previous Ready state when fileId changes
-        val prev = state
-        if (prev is PdfViewerState.Ready) {
-            cleanupPdfResources(prev.renderer, prev.tempFilePath, fileOperationsProvider)
-        }
-        state = PdfViewerState.Loading
-
-        var tempPath: String? = null
-        var renderer: PdfRenderer? = null
+        state = TextViewerState.Loading
         try {
             val payloadKey = file.payloadDescriptors.firstOrNull()?.key ?: "vlt_pg_00"
-            tempPath = withContext(Dispatchers.Default) {
+            val tempPath = withContext(Dispatchers.Default) {
                 uploaderService.downloadPayload(file, payloadKey)
             }
             if (tempPath == null) {
-                state = PdfViewerState.Error
+                state = TextViewerState.Error
             } else {
-                renderer = PdfRenderer()
-                renderer.open(tempPath)
-                state = PdfViewerState.Ready(renderer, tempPath)
+                val bytes = withContext(Dispatchers.Default) {
+                    fileOperationsProvider.readFileBytes(tempPath)
+                }
+                state = TextViewerState.Ready(bytes.decodeToString())
+                try { fileOperationsProvider.deleteTempFile(tempPath) } catch (_: Exception) { }
             }
-        } catch (e: CancellationException) {
-            cleanupPdfResources(renderer, tempPath, fileOperationsProvider)
-            throw e
         } catch (_: Exception) {
-            cleanupPdfResources(renderer, tempPath, fileOperationsProvider)
-            state = PdfViewerState.Error
+            state = TextViewerState.Error
         }
     }
 
-    DisposableEffect(Unit) {
-        onDispose {
-            val current = state
-            if (current is PdfViewerState.Ready) {
-                cleanupPdfResources(current.renderer, current.tempFilePath, fileOperationsProvider)
-            }
-        }
-    }
-
-    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .pointerInput(Unit) { detectTapGestures(onTap = { onToggleUI() }) },
+        contentAlignment = Alignment.Center,
+    ) {
         when (val s = state) {
-            is PdfViewerState.Loading -> {
+            is TextViewerState.Loading -> {
                 CircularProgressIndicator()
             }
 
-            is PdfViewerState.Ready -> {
-                PdfPageViewer(
-                    renderer = s.renderer,
-                    onTap = onToggleUI,
-                    modifier = Modifier.fillMaxSize(),
-                )
+            is TextViewerState.Ready -> {
+                SelectionContainer {
+                    Text(
+                        text = s.content,
+                        style = MaterialTheme.typography.bodySmall.copy(
+                            fontFamily = FontFamily.Monospace,
+                        ),
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(MaterialTheme.colorScheme.surface)
+                            .verticalScroll(rememberScrollState())
+                            .horizontalScroll(rememberScrollState())
+                            .padding(16.dp),
+                    )
+                }
             }
 
-            is PdfViewerState.Error -> {
+            is TextViewerState.Error -> {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     Icon(
                         imageVector = Icons.Outlined.ErrorOutline,
@@ -123,7 +115,7 @@ fun PdfViewerPage(
                     )
                     Spacer(Modifier.height(12.dp))
                     Text(
-                        text = stringResource(MR.string.vault_pdf_preview_error),
+                        text = stringResource(MR.string.vault_text_preview_error),
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.onSurface,
                     )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/TextViewerPage.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/TextViewerPage.kt
@@ -69,12 +69,14 @@ fun TextViewerPage(
             if (tempPath == null) {
                 state = TextViewerState.Error
             } else {
-                val bytes = withContext(Dispatchers.Default) {
-                    fileOperationsProvider.readFileBytes(tempPath)
+                val fileSize = withContext(Dispatchers.Default) {
+                    fileOperationsProvider.getFileSize(tempPath)
                 }
-                val truncated = bytes.size > MAX_TEXT_BYTES
-                val displayBytes = if (truncated) bytes.copyOf(MAX_TEXT_BYTES) else bytes
-                state = TextViewerState.Ready(displayBytes.decodeToString(), truncated)
+                val truncated = fileSize > MAX_TEXT_BYTES
+                val bytes = withContext(Dispatchers.Default) {
+                    fileOperationsProvider.readFileHeaderBytes(tempPath, MAX_TEXT_BYTES)
+                }
+                state = TextViewerState.Ready(bytes.decodeToString(), truncated)
                 try { fileOperationsProvider.deleteTempFile(tempPath) } catch (_: Exception) { }
             }
         } catch (e: CancellationException) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultGalleryDetailSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultGalleryDetailSheet.kt
@@ -132,7 +132,8 @@ fun VaultGalleryDetailSheet(
                     },
                     contentAlignment = Alignment.Center,
                 ) {
-                    if (isImage) {
+                    val isPdf = descriptor.contentType == "application/pdf"
+                    if (isImage || isPdf) {
                         val localImage by localAttachmentStore.observe(file.uniqueId, descriptor.key)
                             .collectAsStateWithLifecycle(
                                 initialValue = localAttachmentStore.get(file.uniqueId, descriptor.key),

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultGalleryScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultGalleryScreen.kt
@@ -64,6 +64,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import id.homebase.api.client.drives.files.PayloadDescriptor
+import id.homebase.api.file.FileOperationsProvider
+import id.homebase.core.ui.screens.vault.VaultUploaderService
 import id.homebase.core.ui.screens.vault.components.VaultFileDropdownMenu
 import id.homebase.core.ui.screens.vault.components.fileTypeIcon
 import id.homebase.core.ui.screens.vault.model.VaultEntry
@@ -103,6 +105,8 @@ fun VaultGalleryScreen(
     animatedVisibilityScope: AnimatedVisibilityScope? = null,
 ) {
     val localAttachmentStore = koinInject<LocalAttachmentContextStore>()
+    val uploaderService = koinInject<VaultUploaderService>()
+    val fileOperationsProvider = koinInject<FileOperationsProvider>()
     val pages = file.payloadDescriptors
     if (pages.isEmpty()) return
 
@@ -232,6 +236,12 @@ fun VaultGalleryScreen(
                             onToggleUI = onTapImage,
                             sharedTransitionScope = sharedTransitionScope,
                             animatedVisibilityScope = animatedVisibilityScope,
+                        )
+                    } else if (file.isPdf) {
+                        PdfViewerPage(
+                            file = file,
+                            uploaderService = uploaderService,
+                            fileOperationsProvider = fileOperationsProvider,
                         )
                     } else {
                         GalleryPageNonImage(

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultGalleryScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultGalleryScreen.kt
@@ -242,6 +242,14 @@ fun VaultGalleryScreen(
                             file = file,
                             uploaderService = uploaderService,
                             fileOperationsProvider = fileOperationsProvider,
+                            onToggleUI = onTapImage,
+                        )
+                    } else if (file.isText) {
+                        TextViewerPage(
+                            file = file,
+                            uploaderService = uploaderService,
+                            fileOperationsProvider = fileOperationsProvider,
+                            onToggleUI = onTapImage,
                         )
                     } else {
                         GalleryPageNonImage(

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/model/VaultEntry.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/model/VaultEntry.kt
@@ -35,10 +35,11 @@ data class VaultEntry(
     val groupId: Uuid? = null,
     val payloadDescriptors: List<PayloadDescriptor> = emptyList(),
     val notes: String? = null,
+    val pdfPageCount: Int? = null,
 ) {
     val isPending: Boolean get() = pendingFileUri != null
 
-    val pageCount: Int get() = payloadDescriptors.size.coerceAtLeast(1)
+    val pageCount: Int get() = pdfPageCount ?: payloadDescriptors.size.coerceAtLeast(1)
     val hasMultiplePages: Boolean get() = pageCount > 1
 
     val isImage: Boolean get() = contentType.startsWith("image/")
@@ -87,5 +88,6 @@ fun HomebaseFile.toVaultEntry(): VaultEntry? {
         groupId = fileMetadata.appData.groupId,
         payloadDescriptors = payloads,
         notes = vaultFileContent.notes,
+        pdfPageCount = vaultFileContent.pdfPageCount,
     )
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/model/VaultEntry.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/model/VaultEntry.kt
@@ -49,6 +49,13 @@ data class VaultEntry(
     val isAudio: Boolean get() = contentType.startsWith("audio/")
 
     val isPdf: Boolean get() = contentType == "application/pdf"
+
+    val isText: Boolean get() = contentType.startsWith("text/") ||
+        contentType == "application/json" ||
+        contentType == "application/xml" ||
+        contentType == "application/x-yaml" ||
+        contentType == "application/javascript" ||
+        contentType == "application/x-sh"
 }
 
 /**

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/model/VaultFileContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/model/VaultFileContent.kt
@@ -10,6 +10,7 @@ data class VaultFileContent(
     val name: String,
     val label: String? = null,
     val notes: String? = null,
+    val pdfPageCount: Int? = null,
 )
 
 @Serializable

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/vault/VaultEntryTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/vault/VaultEntryTest.kt
@@ -523,6 +523,125 @@ class VaultEntryTest {
     }
 
     // ---------------------------------------------------------------
+    // VaultEntry — isText property
+    // ---------------------------------------------------------------
+
+    @Test
+    fun isText_textPlain() {
+        val item = buildHomebaseFile(
+            payloads = listOf(PayloadDescriptor(key = "k", contentType = "text/plain", bytesWritten = 10L)),
+        ).toVaultEntry()
+        assertNotNull(item)
+        assertTrue(item.isText)
+    }
+
+    @Test
+    fun isText_applicationJson() {
+        val item = buildHomebaseFile(
+            payloads = listOf(PayloadDescriptor(key = "k", contentType = "application/json", bytesWritten = 10L)),
+        ).toVaultEntry()
+        assertNotNull(item)
+        assertTrue(item.isText)
+    }
+
+    @Test
+    fun isText_applicationXml() {
+        val item = buildHomebaseFile(
+            payloads = listOf(PayloadDescriptor(key = "k", contentType = "application/xml", bytesWritten = 10L)),
+        ).toVaultEntry()
+        assertNotNull(item)
+        assertTrue(item.isText)
+    }
+
+    @Test
+    fun isText_applicationYaml() {
+        val item = buildHomebaseFile(
+            payloads = listOf(PayloadDescriptor(key = "k", contentType = "application/x-yaml", bytesWritten = 10L)),
+        ).toVaultEntry()
+        assertNotNull(item)
+        assertTrue(item.isText)
+    }
+
+    @Test
+    fun isText_applicationJavascript() {
+        val item = buildHomebaseFile(
+            payloads = listOf(PayloadDescriptor(key = "k", contentType = "application/javascript", bytesWritten = 10L)),
+        ).toVaultEntry()
+        assertNotNull(item)
+        assertTrue(item.isText)
+    }
+
+    @Test
+    fun isText_applicationSh() {
+        val item = buildHomebaseFile(
+            payloads = listOf(PayloadDescriptor(key = "k", contentType = "application/x-sh", bytesWritten = 10L)),
+        ).toVaultEntry()
+        assertNotNull(item)
+        assertTrue(item.isText)
+    }
+
+    @Test
+    fun isText_falseForImage() {
+        val item = buildHomebaseFile(
+            payloads = listOf(PayloadDescriptor(key = "k", contentType = "image/jpeg", bytesWritten = 10L)),
+        ).toVaultEntry()
+        assertNotNull(item)
+        assertFalse(item.isText)
+    }
+
+    @Test
+    fun isText_falseForPdf() {
+        val item = buildHomebaseFile(
+            payloads = listOf(PayloadDescriptor(key = "k", contentType = "application/pdf", bytesWritten = 10L)),
+        ).toVaultEntry()
+        assertNotNull(item)
+        assertFalse(item.isText)
+    }
+
+    // ---------------------------------------------------------------
+    // VaultEntry — pdfPageCount
+    // ---------------------------------------------------------------
+
+    @Test
+    fun pdfPageCount_usedWhenPresent() {
+        val file = buildHomebaseFile(
+            payloads = listOf(PayloadDescriptor(key = "k", contentType = "application/pdf", bytesWritten = 100L)),
+            contentJson = OdinSystemSerializer.serialize(VaultFileContent(name = "doc.pdf", pdfPageCount = 7)),
+        )
+        val item = file.toVaultEntry()
+        assertNotNull(item)
+        assertEquals(7, item.pageCount)
+        assertTrue(item.hasMultiplePages)
+    }
+
+    @Test
+    fun pdfPageCount_fallsBackToPayloadCount() {
+        val file = buildHomebaseFile(
+            payloads = listOf(
+                PayloadDescriptor(key = "a", contentType = "image/jpeg", bytesWritten = 100L),
+                PayloadDescriptor(key = "b", contentType = "image/jpeg", bytesWritten = 100L),
+            ),
+            contentJson = OdinSystemSerializer.serialize(VaultFileContent(name = "img.jpg")),
+        )
+        val item = file.toVaultEntry()
+        assertNotNull(item)
+        assertNull(item.pdfPageCount)
+        assertEquals(2, item.pageCount)
+    }
+
+    @Test
+    fun pdfPageCount_singlePage_hasMultiplePagesFalse() {
+        val file = buildHomebaseFile(
+            payloads = listOf(PayloadDescriptor(key = "k", contentType = "application/pdf", bytesWritten = 100L)),
+            contentJson = OdinSystemSerializer.serialize(VaultFileContent(name = "one.pdf", pdfPageCount = 1)),
+        )
+        val item = file.toVaultEntry()
+        assertNotNull(item)
+        assertEquals(1, item.pageCount)
+        assertFalse(item.hasMultiplePages)
+    }
+
+    // ---------------------------------------------------------------
     // detectContentTypeFromExtensionOrHint() — common extensions
     // ---------------------------------------------------------------
 

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/vault/VaultFileIconTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/vault/VaultFileIconTest.kt
@@ -1,0 +1,116 @@
+package id.homebase.core.ui.screens.vault
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Article
+import androidx.compose.material.icons.automirrored.outlined.InsertDriveFile
+import androidx.compose.material.icons.outlined.AudioFile
+import androidx.compose.material.icons.outlined.Code
+import androidx.compose.material.icons.outlined.Description
+import androidx.compose.material.icons.outlined.FolderZip
+import androidx.compose.material.icons.outlined.Image
+import androidx.compose.material.icons.outlined.PictureAsPdf
+import androidx.compose.material.icons.outlined.Slideshow
+import androidx.compose.material.icons.outlined.TableChart
+import androidx.compose.material.icons.outlined.VideoFile
+import id.homebase.core.ui.screens.vault.components.fileTypeIcon
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class VaultFileIconTest {
+
+    @Test
+    fun image_mimeTypes() {
+        assertEquals(Icons.Outlined.Image, fileTypeIcon("image/jpeg"))
+        assertEquals(Icons.Outlined.Image, fileTypeIcon("image/png"))
+        assertEquals(Icons.Outlined.Image, fileTypeIcon("image/webp"))
+        assertEquals(Icons.Outlined.Image, fileTypeIcon("image/svg+xml"))
+    }
+
+    @Test
+    fun video_mimeTypes() {
+        assertEquals(Icons.Outlined.VideoFile, fileTypeIcon("video/mp4"))
+        assertEquals(Icons.Outlined.VideoFile, fileTypeIcon("video/quicktime"))
+    }
+
+    @Test
+    fun audio_mimeTypes() {
+        assertEquals(Icons.Outlined.AudioFile, fileTypeIcon("audio/mpeg"))
+        assertEquals(Icons.Outlined.AudioFile, fileTypeIcon("audio/wav"))
+    }
+
+    @Test
+    fun pdf() {
+        assertEquals(Icons.Outlined.PictureAsPdf, fileTypeIcon("application/pdf"))
+    }
+
+    @Test
+    fun code_mimeTypes() {
+        assertEquals(Icons.Outlined.Code, fileTypeIcon("application/json"))
+        assertEquals(Icons.Outlined.Code, fileTypeIcon("application/xml"))
+        assertEquals(Icons.Outlined.Code, fileTypeIcon("application/javascript"))
+        assertEquals(Icons.Outlined.Code, fileTypeIcon("application/x-sh"))
+        assertEquals(Icons.Outlined.Code, fileTypeIcon("application/x-yaml"))
+        assertEquals(Icons.Outlined.Code, fileTypeIcon("text/x-python"))
+        assertEquals(Icons.Outlined.Code, fileTypeIcon("text/x-kotlin"))
+    }
+
+    @Test
+    fun spreadsheet_mimeTypes() {
+        assertEquals(Icons.Outlined.TableChart, fileTypeIcon("text/csv"))
+        assertEquals(Icons.Outlined.TableChart, fileTypeIcon("application/vnd.ms-excel"))
+        assertEquals(
+            Icons.Outlined.TableChart,
+            fileTypeIcon("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+        )
+    }
+
+    @Test
+    fun presentation_mimeTypes() {
+        assertEquals(Icons.Outlined.Slideshow, fileTypeIcon("application/vnd.ms-powerpoint"))
+        assertEquals(
+            Icons.Outlined.Slideshow,
+            fileTypeIcon("application/vnd.openxmlformats-officedocument.presentationml.presentation"),
+        )
+    }
+
+    @Test
+    fun document_mimeTypes() {
+        assertEquals(Icons.AutoMirrored.Outlined.Article, fileTypeIcon("application/msword"))
+        assertEquals(
+            Icons.AutoMirrored.Outlined.Article,
+            fileTypeIcon("application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+        )
+        assertEquals(Icons.AutoMirrored.Outlined.Article, fileTypeIcon("application/vnd.oasis.opendocument.text"))
+        assertEquals(Icons.AutoMirrored.Outlined.Article, fileTypeIcon("application/rtf"))
+    }
+
+    @Test
+    fun archive_mimeTypes() {
+        assertEquals(Icons.Outlined.FolderZip, fileTypeIcon("application/zip"))
+        assertEquals(Icons.Outlined.FolderZip, fileTypeIcon("application/x-tar"))
+        assertEquals(Icons.Outlined.FolderZip, fileTypeIcon("application/gzip"))
+        assertEquals(Icons.Outlined.FolderZip, fileTypeIcon("application/x-rar-compressed"))
+        assertEquals(Icons.Outlined.FolderZip, fileTypeIcon("application/x-7z-compressed"))
+    }
+
+    @Test
+    fun plainText_mimeTypes() {
+        assertEquals(Icons.Outlined.Description, fileTypeIcon("text/plain"))
+        assertEquals(Icons.Outlined.Description, fileTypeIcon("text/markdown"))
+        assertEquals(Icons.Outlined.Description, fileTypeIcon("text/html"))
+    }
+
+    @Test
+    fun fallback_unknownMimeType() {
+        assertEquals(Icons.AutoMirrored.Outlined.InsertDriveFile, fileTypeIcon("application/octet-stream"))
+        assertEquals(Icons.AutoMirrored.Outlined.InsertDriveFile, fileTypeIcon(""))
+        assertEquals(Icons.AutoMirrored.Outlined.InsertDriveFile, fileTypeIcon("application/x-unknown"))
+    }
+
+    @Test
+    fun code_takePrecedenceOverPlainText() {
+        // text/x-* should match code, not fall through to text/*
+        assertEquals(Icons.Outlined.Code, fileTypeIcon("text/x-java"))
+        assertEquals(Icons.Outlined.Code, fileTypeIcon("text/x-c"))
+    }
+}

--- a/image-editor-ui/build.gradle.kts
+++ b/image-editor-ui/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
     android {
         namespace = "id.homebase.imageeditor.ui"
         compileSdk = libs.versions.android.targetSdk.get().toInt()
+        compileSdkExtension = 19
         minSdk = libs.versions.android.minSdk.get().toInt()
         androidResources.enable = true
         withHostTest {}


### PR DESCRIPTION
## Summary

Adds full document support to the Vault feature — PDF preview, text file viewer, file upload with thumbnails, and file-type-specific icons across all KMP platforms.

### PDF Rendering (native per platform)
- **Android**: Native `PdfViewerFragment` from `androidx.pdf:pdf-viewer-fragment:1.0.0-alpha18` — pinch-to-zoom, search, scroll built-in
- **iOS**: Native `PDFKit.PDFView` via `UIKitView` — auto-scales, smooth scrolling
- **Desktop (JVM)**: Bitmap-based renderer via Apache PDFBox with adaptive density rendering (`BoxWithConstraints` + `LocalDensity`)
- **Web**: Stub with "not supported" message

### File Upload and Thumbnails
- PDF upload generates JPEG thumbnail of first page for card preview
- `generatePdfThumbnailFromFile()` — file-path-based API avoids loading entire PDF into memory
- Tiny embedded thumbnail fits under `MaxEmbeddedThumbBytes` server limit
- PDF page count stored in `VaultFileContent` for badge display

### Text Viewer
- Renders text/code files with monospace font, selectable text, horizontal scroll
- 1 MB truncation guard with "showing first 1 MB" hint to prevent OOM

### File-Type Icons
- 10+ MIME categories: image, video, audio, PDF, code, spreadsheet, presentation, document, archive, plain text
- Uses Material Icons Extended (`Icons.AutoMirrored.Outlined.*` for RTL)
- PDF badge overlay on cards with thumbnail

### Architecture
- `expect fun PdfPageViewer()` with 4 platform actuals (Android, iOS, JVM, Web)
- `expect class PdfRenderer` with 4 platform actuals for bitmap rendering
- `expect fun generatePdfThumbnail()` + `generatePdfThumbnailFromFile()` with 4 actuals
- Shared `BitmapPdfPageViewer` in commonMain for JVM fallback with sliding-window page cache
- `VaultEntry.isText` property for text-viewable MIME detection

### Build Changes
- `android-minSdk` bumped from 27 to 28 (required by `androidx.pdf`)
- `compileSdkExtension = 19` added to all Android modules
- New deps: `androidx.pdf:pdf-viewer-fragment:1.0.0-alpha18`, `org.apache.pdfbox:pdfbox:3.0.5`

### Code Quality
- All `CancellationException` properly re-thrown (structured concurrency)
- `CGColorSpace`/`CGPDFDocument` released in `try/finally` (no CoreFoundation leaks)
- Defensive `close()` in `PdfRenderer.open()` on all platforms
- `boundedFirstVisibleItemIndex` for safe LazyList index access
- All strings via `stringResource()`, Material 3 colors/typography, RTL-safe padding
- Shared transition scope wired for PDF card to gallery animation

## Test Plan

- [x] JVM unit tests: PdfRendererJvmTest (8 tests), PdfThumbnailGeneratorJvmTest (5 tests)
- [x] JVM unit tests: VaultFileIconTest (12 tests), VaultEntryTest (11 tests)
- [x] Android compile verified
- [x] iOS compile verified
- [x] Lint passes across all modules
- [ ] Manual: upload PDF on Android, verify native viewer with pinch-to-zoom
- [ ] Manual: upload PDF on iOS, verify native PDFKit rendering
- [ ] Manual: upload text file, verify monospace viewer with truncation hint on large files
- [ ] Manual: verify file-type icons for various MIME types
- [ ] Manual: verify PDF card to gallery shared transition animation