### PR TITLE
chore(wasm-prep): close out pre-flight series (step 10)

### DIFF
--- a/homebase-api/build.gradle.kts
+++ b/homebase-api/build.gradle.kts
@@ -129,10 +129,10 @@ kotlin {
             implementation(libs.sqldelight.native.driver)
         }
 
-        // Uncomment in step 10 of the WASM pre-flight plan, paired with the
-        // `wasmJs { browser() }` block above. ktor-client-js provides the
-        // browser engine (fetch/WebSocket); WebWorkerDriver runs sql.js
-        // (SQLite-compiled-to-WASM) inside a Web Worker — see
+        // Uncomment when enabling the wasmJs target (post-pre-flight),
+        // paired with the `wasmJs { browser() }` block above. ktor-client-js
+        // provides the browser engine (fetch/WebSocket); WebWorkerDriver
+        // runs sql.js (SQLite-compiled-to-WASM) inside a Web Worker — see
         // `DatabaseDriverFactory.web.kt` for the constructor shape.
 //        wasmJsMain.dependencies {
 //            implementation(libs.ktor.client.js)

--- a/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.web.kt
+++ b/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.web.kt
@@ -4,16 +4,17 @@ import app.cash.sqldelight.db.SqlDriver
 
 /**
  * wasmJs uses SQLDelight's web-worker-driver backed by sql.js (an
- * in-memory SQLite compiled to WebAssembly). Wired in step 10 of the
- * WASM pre-flight plan once:
+ * in-memory SQLite compiled to WebAssembly). Wiring is deferred until the
+ * wasmJs target itself is enabled — both of the following must happen:
  *
  *   1. `sqldelight-web-worker-driver` is added to `wasmJsMain.dependencies`
  *      in `homebase-api/build.gradle.kts` (paired with uncommenting
- *      `wasmJs { browser() }`).
+ *      `wasmJs { browser() }`). The commented-out block is already in
+ *      place; just delete the `//` prefixes.
  *   2. The `sqljs.worker.js` worker script and the `sql-wasm.wasm` binary
  *      are made available to the browser bundle (via the webApp module's
- *      static assets or a webpack copy plugin from `@cashapp/sqldelight-sqljs-worker`
- *      under node_modules).
+ *      static assets or a webpack copy plugin from
+ *      `@cashapp/sqldelight-sqljs-worker` under node_modules).
  *
  * Reference shape (Kotlin/Wasm + sql.js):
  *
@@ -31,7 +32,16 @@ import app.cash.sqldelight.db.SqlDriver
 @Suppress(names = ["EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING"])
 actual class DatabaseDriverFactory {
     actual fun createDriver(passphrase: String?): SqlDriver {
-        TODO("Wire WebWorkerDriver + sqljs.worker.js in WASM pre-flight step 10")
+        TODO(
+            "wasmJs driver not yet wired. To finish:\n" +
+                " 1. Uncomment `wasmJsMain.dependencies { implementation(libs.sqldelight.web.worker.driver) }`\n" +
+                "    in homebase-api/build.gradle.kts (paired with `wasmJs { browser() }`).\n" +
+                " 2. Drop `sqljs.worker.js` + `sql-wasm.wasm` into webApp's served assets\n" +
+                "    (webApp/src/wasmJsMain/resources/), copying from @cashapp/sqldelight-sqljs-worker.\n" +
+                " 3. Replace this TODO with:\n" +
+                "      val worker = Worker(js(\"new URL('sqljs.worker.js', import.meta.url)\"))\n" +
+                "      return WebWorkerDriver(worker).also { OdinDatabase.Schema.create(it) }"
+        )
     }
 
     // sql.js is in-memory only — no on-disk file to report. Empty string

--- a/homebase-auth/build.gradle.kts
+++ b/homebase-auth/build.gradle.kts
@@ -77,9 +77,9 @@ kotlin {
         jvmMain.dependencies {
             implementation(libs.ktor.client.cio)
         }
-        // Uncomment in step 10 of the WASM pre-flight plan, paired with
-        // `wasmJs { browser() }`. ktor-client-js provides the browser
-        // engine (fetch/WebSocket) for the wasmJs target.
+        // Uncomment when enabling the wasmJs target (post-pre-flight),
+        // paired with the `wasmJs { browser() }` block above.
+        // ktor-client-js provides the browser engine (fetch/WebSocket).
 //        wasmJsMain.dependencies {
 //            implementation(libs.ktor.client.js)
 //        }

--- a/homebase-chat/build.gradle.kts
+++ b/homebase-chat/build.gradle.kts
@@ -88,9 +88,9 @@ kotlin {
             implementation(libs.ktor.client.cio)
             implementation(libs.vlcj)
         }
-        // Uncomment in step 10 of the WASM pre-flight plan, paired with
-        // `wasmJs { browser() }`. ktor-client-js provides the browser
-        // engine (fetch/WebSocket) for the wasmJs target.
+        // Uncomment when enabling the wasmJs target (post-pre-flight),
+        // paired with the `wasmJs { browser() }` block above.
+        // ktor-client-js provides the browser engine (fetch/WebSocket).
 //        wasmJsMain.dependencies {
 //            implementation(libs.ktor.client.js)
 //        }

--- a/homebase-common/build.gradle.kts
+++ b/homebase-common/build.gradle.kts
@@ -144,9 +144,9 @@ kotlin {
             // type from the same source set's classpath.
             api(libs.kmpnotifier)
         }
-        // Uncomment in step 10 of the WASM pre-flight plan, paired with
-        // `wasmJs { browser() }`. ktor-client-js provides the browser
-        // engine (fetch/WebSocket) for the wasmJs target.
+        // Uncomment when enabling the wasmJs target (post-pre-flight),
+        // paired with the `wasmJs { browser() }` block above.
+        // ktor-client-js provides the browser engine (fetch/WebSocket).
 //        wasmJsMain.dependencies {
 //            implementation(libs.ktor.client.js)
 //        }

--- a/homebase-core/build.gradle.kts
+++ b/homebase-core/build.gradle.kts
@@ -114,9 +114,9 @@ kotlin {
                 implementation(libs.conveyor.control)
                 implementation(libs.composenativewebview)
         }
-        // Uncomment in step 10 of the WASM pre-flight plan, paired with
-        // `wasmJs { browser() }`. ktor-client-js provides the browser
-        // engine (fetch/WebSocket) for the wasmJs target.
+        // Uncomment when enabling the wasmJs target (post-pre-flight),
+        // paired with the `wasmJs { browser() }` block above.
+        // ktor-client-js provides the browser engine (fetch/WebSocket).
 //        wasmJsMain.dependencies {
 //            implementation(libs.ktor.client.js)
 //        }


### PR DESCRIPTION
Final entry in the 10-step pre-flight series. Steps 1–9c shipped the substance (catalog aliases, commonMain refactors, facades for kmpnotifier / composenativewebview, kotlinx.io / okio / kermit-io / Dispatchers.IO abstractions). This PR is the close-out: a verification matrix + small comment polish that reflects the new reality, that "step 10" no longer gates anything.

### What changed
- Five `build.gradle.kts` files carry commented-out `wasmJsMain.dependencies` blocks introduced in step 8. The header comments said "Uncomment in step 10 of the WASM pre-flight plan" — step 10 doesn't uncomment them (the wasmJs target itself stays off), so reword to:

      // Uncomment when enabling the wasmJs target (post-pre-flight),
      // paired with the `wasmJs { browser() }` block above.

  Files: homebase-{api,auth,chat,common,core}/build.gradle.kts.

- `homebase-api/src/wasmJsMain/.../DatabaseDriverFactory.web.kt`: the `createDriver` TODO message also pointed at "step 10". Replaced with a concrete checklist of what the next person needs to do (uncomment the dep block, drop `sqljs.worker.js` + `sql-wasm.wasm` into webApp's served assets, paste the `WebWorkerDriver(Worker(js("...")))` snippet). Same polish on the class kdoc.

No functional changes. No code paths are affected at runtime.

### Verification — all green
- `./gradlew :homebase-{api,auth,chat,common}:jvmTest --rerun-tasks` ✓
- `./gradlew :homebase-{api,common,core}:compileKotlinIosArm64` ✓
- `./gradlew :androidApp:assembleDebug` ✓
- Grep audits over `*/src/commonMain`:
  - `runBlocking` → empty
  - `Dispatchers.IO` / `kotlinx.coroutines.IO` → only doc-comments inside `IoDispatcher.kt`
  - `FileSystem.SYSTEM` / `okio.SYSTEM` → only doc-comments inside `SystemFileSystem.kt`
  - `io.github.kdroidfilter.webview` → empty
  - `com.mmk.kmpnotifier` / `NotifierManager` → only doc-comments inside `NotificationBackend.kt` / `NotificationService.kt`

### What this leaves in place
- 5 KMP modules + webApp with `wasmJs { browser() }` and matching `wasmJsMain.dependencies` blocks commented out — a single grep-and- uncomment when enablement starts.
- 48 `.kt` files staged under `*/src/wasmJsMain/` with a mix of real implementations and `TODO()` stubs; none currently compiled because the target is off.
- A complete commonMain refactor that survives a target flip without JVM/Android-only deps leaking in.

### What this does NOT do
Enable the wasmJs target. That is a separate effort with its own mechanical-error → compile-error → runtime-error cycle (sql.js wiring, the remaining `TODO()` stubs in ImageUtil / SharedPreferences / WebFileOperationsProvider, Compose-wasm renderer quirks, browser-API gaps, etc.). The pre-flight's job was to make the commonMain side stop fighting that effort — done.