### PR TITLE
feat(privacy): stop cloud-backing-up auth credentials and the encrypt…

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
 
     <application
         android:name=".MainApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:fullBackupContent="@xml/full_backup_content"
         android:dataExtractionRules="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
@@ -268,6 +268,16 @@ class DatabaseManager(
     suspend fun wipeAndRecreate() = withContext(dispatcher) {
         val log = Logger.withTag("DatabaseManager")
 
+        // Pre-wipe snapshot of the SQLite-internal page state. Captured *before* the
+        // DROPs so we have a baseline to compare against after the VACUUM + checkpoint.
+        // See [readPragmaLong] / [readPragmaCheckpoint] for what each pragma reports.
+        val journalMode = readPragmaString("PRAGMA journal_mode") ?: "?"
+        val pagesBefore = readPragmaLong("PRAGMA page_count") ?: -1L
+        val freelistBefore = readPragmaLong("PRAGMA freelist_count") ?: -1L
+        log.i {
+            "wipeAndRecreate: pre-wipe journal_mode=$journalMode page_count=$pagesBefore freelist_count=$freelistBefore"
+        }
+
         TABLE_NAMES.forEach { table ->
             driver.execute(null, "DROP TABLE IF EXISTS $table;", 0)
         }
@@ -317,8 +327,100 @@ class DatabaseManager(
         // dbDispatcher has the single-writer slot so we're safe here.
         driver.execute(identifier = null, sql = "VACUUM", parameters = 0)
 
+        // Force the WAL file to truncate to zero, so an on-disk `-wal` left over
+        // from before the wipe cannot carry pages forward into the next session.
+        // No-op when journal_mode != WAL (returns busy=0,log=0,ckpt=0 cleanly).
+        // The motivating bug: a user reported chat rows with corrupt timestamps
+        // surviving logout. wipeAndRecreate's tables were dropped, but if WAL
+        // mode was active and the WAL sidecar wasn't truncated, the next open
+        // could still see those pages. This is the cheapest probe that proves
+        // it didn't.
+        val checkpoint = readPragmaCheckpoint("PRAGMA wal_checkpoint(TRUNCATE)")
+        val pagesAfter = readPragmaLong("PRAGMA page_count") ?: -1L
+        val freelistAfter = readPragmaLong("PRAGMA freelist_count") ?: -1L
+        if (checkpoint != null) {
+            val (busy, logPages, ckptPages) = checkpoint
+            // busy=1 means another connection held the WAL — should never happen here
+            // because we're on the single-writer dbDispatcher with no other clients.
+            // logPages > 0 after wipe + VACUUM is the red flag: it means we VACUUMed
+            // into a fresh main DB but the WAL still holds pages that a future open
+            // would replay on top.
+            if (busy != 0L || logPages > 0L) {
+                log.e {
+                    "wipeAndRecreate: WAL checkpoint reports busy=$busy log_pages=$logPages " +
+                        "ckpt_pages=$ckptPages — WAL was non-empty after wipe, potential leak"
+                }
+            } else {
+                log.i {
+                    "wipeAndRecreate: WAL checkpoint clean (busy=0 log=0 ckpt=$ckptPages)"
+                }
+            }
+        }
+        log.i {
+            "wipeAndRecreate: post-wipe page_count=$pagesAfter freelist_count=$freelistAfter " +
+                "(was page_count=$pagesBefore freelist_count=$freelistBefore)"
+        }
+
         log.i { "wipeAndRecreate: completed (${TABLE_NAMES.size} tables)" }
     }
+
+    /**
+     * Read a single string from a PRAGMA that returns one row, one column
+     * (e.g. `PRAGMA journal_mode`). Returns `null` if the pragma fails or the
+     * cursor is empty — we never want a probe call to abort wipeAndRecreate.
+     */
+    private fun readPragmaString(sql: String): String? = runCatching {
+        driver.executeQuery(
+            identifier = null,
+            sql = sql,
+            mapper = { cursor ->
+                val value = if (cursor.next().value) cursor.getString(0) else null
+                QueryResult.Value(value)
+            },
+            parameters = 0,
+        ).value
+    }.getOrNull()
+
+    /**
+     * Read a single integer from a PRAGMA that returns one row, one column
+     * (e.g. `PRAGMA page_count`, `PRAGMA freelist_count`). Returns `null` on
+     * failure — probes must never throw.
+     */
+    private fun readPragmaLong(sql: String): Long? = runCatching {
+        driver.executeQuery(
+            identifier = null,
+            sql = sql,
+            mapper = { cursor ->
+                val value = if (cursor.next().value) cursor.getLong(0) else null
+                QueryResult.Value(value)
+            },
+            parameters = 0,
+        ).value
+    }.getOrNull()
+
+    /**
+     * Read the result of `PRAGMA wal_checkpoint(...)`, which returns a single
+     * row of three integers: (busy, log_frames, checkpoint_frames). Returns
+     * `null` if the pragma is unsupported (e.g. wasmJs's sql.js doesn't
+     * implement the WAL checkpoint pragma) or the call throws.
+     */
+    private fun readPragmaCheckpoint(sql: String): Triple<Long, Long, Long>? = runCatching {
+        driver.executeQuery(
+            identifier = null,
+            sql = sql,
+            mapper = { cursor ->
+                val value = if (cursor.next().value) {
+                    Triple(
+                        cursor.getLong(0) ?: 0L,
+                        cursor.getLong(1) ?: 0L,
+                        cursor.getLong(2) ?: 0L,
+                    )
+                } else null
+                QueryResult.Value(value)
+            },
+            parameters = 0,
+        ).value
+    }.getOrNull()
 
     // Reclaim space released by DELETE/DROP without nuking schema. Runs on the
     // single-writer [dispatcher] so it cannot race with other queries. Used by

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/LogoutLoginRoundTripTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/LogoutLoginRoundTripTest.kt
@@ -1,0 +1,200 @@
+package id.homebase.api.sync
+
+import id.homebase.api.client.auth.ApiCredentials
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.query.DriveQueryProvider
+import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.SecureByteArray
+import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.sync.database.createInMemoryDatabase
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.client.engine.mock.respond
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+
+/**
+ * End-to-end coverage for the bug the user reported in May 2026: chat rows with
+ * corrupt server-side timestamps survived `logout()` and reappeared on next
+ * login. We can't drive YouAuthFlowManager from a common test (it depends on
+ * platform credential storage), but its load-bearing storage steps are
+ * [DriveSyncManager.clearStorage] and the post-login [DriveSyncManager.start] /
+ * [DriveSyncManager.mountDrive] dance. This test freezes the contract:
+ *
+ *  - Given a row in DriveMainIndex with a marker timestamp.
+ *  - When clearStorage runs (the storage half of logout).
+ *  - And the user "logs back in" (a fresh mountDrive + start cycle with a
+ *    clean server returning no rows).
+ *  - Then the marker timestamp does not exist anywhere in DriveMainIndex.
+ *
+ * A regression where, e.g., wipeAndRecreate gains a code path that resurrects
+ * data (a future "smart wipe" that preserves "recently used" rows, an
+ * in-memory cache that flushes back after the drop, a missing
+ * `expectFreshCursors=true` after clearStorage) would fail this test.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class LogoutLoginRoundTripTest {
+
+    private val badUserDate = 9_999_999_999_999L // sentinel — far in the future
+
+    @Test
+    fun rowsPresentBeforeLogout_areGoneAfterLogoutAndCleanRelogin() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+
+        runTest {
+            val credentials = buildCredentials()
+            val eventBus = EventBus()
+            // Mock engine that pretends the server is reachable but returns no
+            // data — the post-login sync must produce a clean local state, not
+            // re-deliver pre-wipe rows.
+            val cleanServerEngine = MockEngine {
+                respond(
+                    content = ByteReadChannel("""{ "results": [], "cursor": null }"""),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf("Content-Type", "application/json"),
+                )
+            }
+            val manager = buildManagerWith(db, credentials, eventBus, backgroundScope, cleanServerEngine)
+
+            val driveId = Uuid.random()
+            val identityId = credentials.requireActiveCredentials().getIdentityId()
+
+            // Seed: a single corrupt row representing the buggy server's delivery.
+            seedBadRow(db, identityId, driveId)
+            assertEquals(
+                1L,
+                countRowsWithUserDate(db, badUserDate),
+                "precondition: seeded bad row must be present before logout",
+            )
+
+            // Storage half of logout. After this, the DB must be empty and the
+            // expectFreshCursors flag should be set so a stale cursor cannot
+            // silently resume a partial sync.
+            manager.clearStorage()
+            assertEquals(
+                0L,
+                countRowsWithUserDate(db, badUserDate),
+                "logout's clearStorage must remove every DriveMainIndex row",
+            )
+
+            // "Login" half: a fresh mount + start with a clean server. If
+            // anything in DriveSyncManager held the pre-wipe rows in memory and
+            // wrote them back here, this assertion would fail.
+            manager.mountDrive(driveId, "Chat")
+            manager.start()
+            runCurrent()
+            advanceUntilIdle()
+
+            assertEquals(
+                0L,
+                countRowsWithUserDate(db, badUserDate),
+                "after a clean re-login, the pre-wipe bad row must not reappear",
+            )
+            // Belt-and-suspenders: the whole table must be empty.
+            assertEquals(
+                0L,
+                countAllRows(db),
+                "after a clean re-login with an empty server response, " +
+                    "DriveMainIndex must remain empty",
+            )
+        }
+
+        db.close()
+    }
+
+    private suspend fun seedBadRow(db: DatabaseManager, identityId: Uuid, driveId: Uuid) {
+        db.withWrite { odin ->
+            odin.driveMainIndexQueries.upsertDriveMainIndex(
+                identityId = identityId,
+                driveId = driveId,
+                fileId = Uuid.random(),
+                uniqueId = null,
+                globalTransitId = null,
+                groupId = null,
+                senderId = null,
+                originalAuthor = null,
+                fileType = 7878L,
+                dataType = 0L,
+                archivalStatus = 0L,
+                fileState = 1L,
+                historyStatus = 0L,
+                userDate = badUserDate,
+                created = badUserDate,
+                modified = badUserDate,
+                fileSystemType = 0L,
+                jsonHeader = "{}",
+            )
+        }
+    }
+
+    private suspend fun countRowsWithUserDate(db: DatabaseManager, userDate: Long): Long {
+        // Use the DatabaseManager's read path so we go through the same
+        // dispatcher as the production code — no risk of a race against the
+        // background sync job. Raw SQL keeps the test independent of which
+        // generated .sq query happens to match this shape.
+        return db.executeReadQuery(
+            identifier = null,
+            sql = "SELECT COUNT(*) FROM DriveMainIndex WHERE userDate = ?",
+            mapper = { cursor ->
+                cursor.next()
+                app.cash.sqldelight.db.QueryResult.Value(cursor.getLong(0) ?: 0L)
+            },
+            parameters = 1,
+            binders = { bindLong(0, userDate) },
+        ).value
+    }
+
+    private suspend fun countAllRows(db: DatabaseManager): Long {
+        return db.executeReadQuery(
+            identifier = null,
+            sql = "SELECT COUNT(*) FROM DriveMainIndex",
+            mapper = { cursor ->
+                cursor.next()
+                app.cash.sqldelight.db.QueryResult.Value(cursor.getLong(0) ?: 0L)
+            },
+            parameters = 0,
+        ).value
+    }
+
+    private fun buildManagerWith(
+        db: DatabaseManager,
+        credentialsManager: CredentialsManager,
+        eventBus: EventBus,
+        scope: CoroutineScope,
+        engine: MockEngine,
+        mandatoryDrives: Map<Uuid, String> = emptyMap(),
+    ): DriveSyncManager {
+        val httpClient = HttpClient(engine)
+        val driveQueryProvider = DriveQueryProvider(httpClient, credentialsManager)
+        return DriveSyncManager(
+            driveQueryProvider = driveQueryProvider,
+            credentialsManager = credentialsManager,
+            eventBus = eventBus,
+            scope = scope,
+            databaseManager = db,
+            mandatoryDrives = mandatoryDrives,
+        )
+    }
+
+    private suspend fun buildCredentials(): CredentialsManager {
+        val credentialsManager = CredentialsManager()
+        credentialsManager.setActiveCredentials(
+            ApiCredentials.create(
+                domain = OdinId("test.homebase.id"),
+                clientAccessToken = "fake-token",
+                sharedSecret = SecureByteArray(ByteArray(16))
+            )
+        )
+        return credentialsManager
+    }
+}

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/WipeAndRecreateSidecarTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/WipeAndRecreateSidecarTest.kt
@@ -1,0 +1,197 @@
+package id.homebase.api.sync.database
+
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import kotlinx.coroutines.test.runTest
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Properties
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.exists
+import kotlin.io.path.fileSize
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * Coverage for the "data survives logout" bug. Plain-SQLite (no SQLCipher)
+ * against a temp-dir on-disk file: WAL mode is enabled, a row is inserted
+ * into [DriveMainIndex], then [DatabaseManager.wipeAndRecreate] is called.
+ *
+ * Two assertions, both of which would catch the reported leak:
+ *
+ *  1. After the wipe, `SELECT COUNT(*) FROM DriveMainIndex` is zero — both
+ *     on the still-open driver AND on a freshly opened driver. A non-zero
+ *     count on reopen specifically means a WAL frame replayed the dropped
+ *     row, which is the precise failure mode we're guarding against.
+ *  2. If a `-wal` sidecar exists on disk after the wipe, it is zero bytes
+ *     — proving `wal_checkpoint(TRUNCATE)` ran. We don't require the WAL
+ *     to materialise (xerial sqlite-jdbc, in single-connection auto-commit
+ *     mode, frequently keeps WAL pages off disk until checkpoint), so this
+ *     assertion is a "if it's there, it must be empty" guard rather than
+ *     a precondition.
+ *
+ * Vanilla SQLite is sufficient even though production uses SQLCipher — the
+ * wipe path is at the SQL layer (DROP / CREATE / VACUUM / PRAGMA) and the
+ * cipher doesn't change how the WAL sidecar behaves.
+ */
+class WipeAndRecreateSidecarTest {
+
+    private lateinit var tempDir: Path
+    private lateinit var dbPath: Path
+    private lateinit var walPath: Path
+    private lateinit var shmPath: Path
+
+    @BeforeTest
+    fun setUp() {
+        tempDir = Files.createTempDirectory("wipeAndRecreateTest")
+        dbPath = tempDir.resolve("odin-2.db")
+        walPath = tempDir.resolve("odin-2.db-wal")
+        shmPath = tempDir.resolve("odin-2.db-shm")
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Files.walk(tempDir)
+            .sorted(Comparator.reverseOrder())
+            .forEach { Files.deleteIfExists(it) }
+    }
+
+    @Test
+    fun wipeAndRecreate_emptiesDriveMainIndex_andTruncatesWalSidecar() = runTest {
+        val driver = openWalDriver(dbPath.absolutePathString())
+        val dbm = DatabaseManager({ driver })
+
+        // Insert a row with a deliberately-bad userDate so we can grep for the
+        // exact value in the post-wipe assertion. Going via raw SQL rather than
+        // through the SQLDelight-generated upsert keeps this test independent
+        // of the schema's column count drift over time — wipeAndRecreate
+        // protects every row in DriveMainIndex equally.
+        val badUserDate = 9_999_999_999_999L
+        val identityId = Uuid.random()
+        val driveId = Uuid.random()
+        val fileId = Uuid.random()
+        dbm.withWrite { db ->
+            db.driveMainIndexQueries.upsertDriveMainIndex(
+                identityId = identityId,
+                driveId = driveId,
+                fileId = fileId,
+                uniqueId = null,
+                globalTransitId = null,
+                groupId = null,
+                senderId = null,
+                originalAuthor = null,
+                fileType = 7878L,
+                dataType = 0L,
+                archivalStatus = 0L,
+                fileState = 1L,
+                historyStatus = 0L,
+                userDate = badUserDate,
+                created = badUserDate,
+                modified = badUserDate,
+                fileSystemType = 0L,
+                jsonHeader = "{}",
+            )
+        }
+
+        // Sanity: row visible before wipe.
+        assertEquals(1L, countDriveMainIndex(driver), "row should exist pre-wipe")
+
+        // The whole point.
+        dbm.wipeAndRecreate()
+
+        // Assertion 1: on the still-open driver, the table is empty.
+        assertEquals(
+            0L,
+            countDriveMainIndex(driver),
+            "DriveMainIndex must be empty on the still-open driver after wipeAndRecreate",
+        )
+
+        // Assertion 2: if the WAL sidecar exists on disk, it must be empty
+        // (proving wal_checkpoint(TRUNCATE) ran). The xerial sqlite-jdbc driver
+        // running single-connection often keeps WAL frames off disk entirely,
+        // so we tolerate "not present" — but a non-empty WAL would mean the
+        // checkpoint failed to run.
+        if (walPath.exists()) {
+            assertEquals(
+                0L,
+                walPath.fileSize(),
+                "WAL sidecar exists but is non-empty after wipeAndRecreate " +
+                    "(size=${walPath.fileSize()} at $walPath) — wipeAndRecreate's " +
+                    "checkpoint(TRUNCATE) did not take effect, and a stale page " +
+                    "can survive logout.",
+            )
+        }
+
+        // Belt-and-suspenders: close, reopen against the same file, confirm zero.
+        // If a future change re-introduces the leak (WAL frames replay on the
+        // new connection), this is the assertion that catches it.
+        dbm.close()
+
+        val reopenedDriver = openWalDriver(dbPath.absolutePathString())
+        val reopened = DatabaseManager({ reopenedDriver })
+        try {
+            assertEquals(
+                0L,
+                countDriveMainIndex(reopenedDriver),
+                "DriveMainIndex must be empty after closing and reopening the DB " +
+                    "(a non-zero count here means the WAL replayed an old page)",
+            )
+        } finally {
+            reopened.close()
+        }
+    }
+
+    /**
+     * Open a JDBC SQLite driver and force the database into WAL journal mode
+     * so the test exercises the same on-disk layout that production
+     * (`SupportOpenHelperFactory` on Android, JDBC + WAL on JVM) uses. Without
+     * this step the test runs in DELETE journal mode and would never produce
+     * the `-wal` sidecar we're trying to verify.
+     *
+     * Per xerial sqlite-jdbc: a bare `PRAGMA journal_mode=WAL` issued through
+     * `driver.execute(..., parameters=0)` is a no-op because that path runs as
+     * a *statement* (executeUpdate) rather than a *query* — the driver discards
+     * any result rows the pragma emits, but more importantly some pragmas only
+     * take effect when consumed as a query. We issue it via `executeQuery` and
+     * actually read the returned mode string so we can `require(...)` that WAL
+     * is on before the rest of the test runs.
+     */
+    private fun openWalDriver(path: String): JdbcSqliteDriver {
+        val driver = JdbcSqliteDriver("jdbc:sqlite:$path", Properties())
+        val resultingMode = driver.executeQuery(
+            identifier = null,
+            sql = "PRAGMA journal_mode=WAL;",
+            mapper = { cursor ->
+                cursor.next()
+                QueryResult.Value(cursor.getString(0) ?: "")
+            },
+            parameters = 0,
+        ).value
+        require(resultingMode.equals("wal", ignoreCase = true)) {
+            "Could not switch driver to WAL journal mode (got '$resultingMode'). " +
+                "The sidecar test is meaningless in non-WAL modes."
+        }
+        return driver
+    }
+
+    /**
+     * Count rows in DriveMainIndex via raw SQL. Avoids depending on the
+     * generated SQLDelight query API so the test stays focused on the wipe
+     * behaviour even if column count drifts.
+     */
+    private fun countDriveMainIndex(driver: JdbcSqliteDriver): Long {
+        return driver.executeQuery(
+            identifier = null,
+            sql = "SELECT COUNT(*) FROM DriveMainIndex",
+            mapper = { cursor ->
+                cursor.next()
+                QueryResult.Value(cursor.getLong(0) ?: 0L)
+            },
+            parameters = 0,
+        ).value
+    }
+}

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/share/ShareAuthBridge.native.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/share/ShareAuthBridge.native.kt
@@ -23,7 +23,7 @@ import platform.Security.SecItemDelete
 import platform.Security.SecItemUpdate
 import platform.Security.errSecItemNotFound
 import platform.Security.kSecAttrAccessible
-import platform.Security.kSecAttrAccessibleAfterFirstUnlock
+import platform.Security.kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
 import platform.Security.kSecAttrAccount
 import platform.Security.kSecAttrService
 import platform.Security.kSecClass
@@ -72,7 +72,7 @@ actual object ShareAuthBridge {
         )
         val valueCf = CFBridgingRetain(valueData)
         CFDictionarySetValue(attrs, kSecValueData, valueCf)
-        CFDictionarySetValue(attrs, kSecAttrAccessible, kSecAttrAccessibleAfterFirstUnlock)
+        CFDictionarySetValue(attrs, kSecAttrAccessible, kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly)
         CFRelease(valueCf)
 
         val status = SecItemUpdate(query, attrs)
@@ -84,7 +84,7 @@ actual object ShareAuthBridge {
             val addValueCf = CFBridgingRetain(valueData)
             CFDictionarySetValue(addDict, kSecValueData, addValueCf)
             CFRelease(addValueCf)
-            CFDictionarySetValue(addDict, kSecAttrAccessible, kSecAttrAccessibleAfterFirstUnlock)
+            CFDictionarySetValue(addDict, kSecAttrAccessible, kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly)
             SecItemAdd(addDict, null)
             CFRelease(addDict)
         }

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/storage/SecureStorage.native.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/storage/SecureStorage.native.kt
@@ -30,7 +30,7 @@ import platform.Security.SecItemUpdate
 import platform.Security.errSecItemNotFound
 import platform.Security.errSecSuccess
 import platform.Security.kSecAttrAccessible
-import platform.Security.kSecAttrAccessibleAfterFirstUnlock
+import platform.Security.kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
 import platform.Security.kSecAttrAccount
 import platform.Security.kSecAttrService
 import platform.Security.kSecClass
@@ -86,7 +86,7 @@ actual object SecureStorage {
         CFDictionarySetValue(attributesToUpdate, kSecValueData, valueDataCf)
 
         CFDictionarySetValue(
-            attributesToUpdate, kSecAttrAccessible, kSecAttrAccessibleAfterFirstUnlock
+            attributesToUpdate, kSecAttrAccessible, kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
         )
         CFRelease(valueDataCf)
 
@@ -104,7 +104,7 @@ actual object SecureStorage {
             CFDictionarySetValue(addDict, kSecValueData, valueDataCfForAdd)
             CFRelease(valueDataCfForAdd)
 
-            CFDictionarySetValue(addDict, kSecAttrAccessible, kSecAttrAccessibleAfterFirstUnlock)
+            CFDictionarySetValue(addDict, kSecAttrAccessible, kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly)
 
             SecItemAdd(addDict, null)
             CFRelease(addDict)

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.native.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.native.kt
@@ -1,13 +1,26 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class, kotlinx.cinterop.BetaInteropApi::class)
+
 package id.homebase.api.sync.database
 
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
+import co.touchlab.kermit.Logger
 import co.touchlab.sqliter.DatabaseConfiguration
+import kotlinx.cinterop.ObjCObjectVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.value
+import platform.Foundation.NSError
+import platform.Foundation.NSFileManager
 import platform.Foundation.NSHomeDirectory
+import platform.Foundation.NSNumber
+import platform.Foundation.NSURL
+import platform.Foundation.NSURLIsExcludedFromBackupKey
 
 actual class DatabaseDriverFactory {
     actual fun createDriver(passphrase: String?): SqlDriver {
-        return NativeSqliteDriver(
+        val driver = NativeSqliteDriver(
             schema = OdinDatabase.Schema, name = DB_FILE_NAME, onConfiguration = { config ->
                 config.copy(
                     encryptionConfig = DatabaseConfiguration.Encryption(
@@ -15,10 +28,74 @@ actual class DatabaseDriverFactory {
                     )
                 )
             })
+
+        // Mark the SQLite files as ineligible for iCloud / Finder backup. Same
+        // motivation as Android's allowBackup=false (AndroidManifest.xml): the
+        // DB is content-encrypted by SQLCipher, but the keychain holding its
+        // passphrase rides backup unless the keychain items use
+        // *ThisDeviceOnly* — so a restored device could decrypt a restored DB.
+        // Marking the files excluded breaks that cross-device chain at the
+        // file-system layer.
+        //
+        // The directory exclusion handles WAL/SHM sidecars that SQLite creates
+        // lazily after this call. The per-file calls are belt-and-suspenders
+        // for the primary .db so the attribute is set even if a future iOS
+        // build refuses to honour directory-level exclusion.
+        excludeFromBackup("${NSHomeDirectory()}/databases")
+        for (suffix in DB_SUFFIXES) {
+            val path = "${NSHomeDirectory()}/databases/$DB_FILE_NAME$suffix"
+            if (NSFileManager.defaultManager.fileExistsAtPath(path)) {
+                excludeFromBackup(path)
+            }
+        }
+
+        return driver
     }
 
     // NativeSqliteDriver resolves `name` to "${NSHomeDirectory()}/databases/<name>"
     // under the hood; report the same path here so the shared recovery deletes
     // the file the driver was looking at.
     actual fun dbFilePath(): String = "${NSHomeDirectory()}/databases/$DB_FILE_NAME"
+
+    private companion object {
+        val DB_SUFFIXES = arrayOf("", "-wal", "-shm", "-journal")
+    }
+}
+
+/**
+ * Set `NSURLIsExcludedFromBackupKey = true` on [path] so iCloud / Finder /
+ * encrypted backups skip it. Stored as the extended attribute
+ * `com.apple.metadata:com_apple_backup_excludeItem` on the inode — survives
+ * the lifetime of the file but is lost if the file is deleted and recreated
+ * (relevant for WAL/SHM, which is why we also flag the parent directory).
+ *
+ * Errors are logged at warn — refusing to start the database because backup
+ * exclusion failed would be a worse failure mode than carrying a backup
+ * surface we'd rather not have. A persistent failure here would show up in
+ * `homebase.log` as a recurring `excludeFromBackup` warning, which is what we
+ * want for diagnosability.
+ */
+private fun excludeFromBackup(path: String) {
+    runCatching {
+        val url = NSURL.fileURLWithPath(path)
+        memScoped {
+            // alloc() zero-initialises, so errorVar.value is already null.
+            val errorVar = alloc<ObjCObjectVar<NSError?>>()
+            val ok = url.setResourceValue(
+                value = NSNumber(bool = true),
+                forKey = NSURLIsExcludedFromBackupKey,
+                error = errorVar.ptr,
+            )
+            if (!ok) {
+                Logger.withTag("DatabaseDriverFactory").w {
+                    "excludeFromBackup($path): setResourceValue returned false: " +
+                        (errorVar.value?.localizedDescription ?: "no NSError")
+                }
+            }
+        }
+    }.onFailure { e ->
+        Logger.withTag("DatabaseDriverFactory").w(throwable = e) {
+            "excludeFromBackup($path): unexpected throw"
+        }
+    }
 }

--- a/iosApp/ShareExtension/SharedKeychainHelper.swift
+++ b/iosApp/ShareExtension/SharedKeychainHelper.swift
@@ -41,7 +41,7 @@ struct SharedKeychainHelper {
 
         let attributes: [String: Any] = [
             kSecValueData as String: data,
-            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
         ]
 
         let status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
@@ -49,7 +49,7 @@ struct SharedKeychainHelper {
         if status == errSecItemNotFound {
             var newItem = query
             newItem[kSecValueData as String] = data
-            newItem[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+            newItem[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
             SecItemAdd(newItem as CFDictionary, nil)
         }
     }


### PR DESCRIPTION
…ed DB

Android: set android:allowBackup=false. The DB files were already excluded via backup_rules.xml, but shared_prefs/secure_storage_prefs.xml (holding IDENTITY, CLIENT_AUTH_TOKEN, SHARED_SECRET) and filesDir/ (encrypted drive-file + profile caches) were riding Google's auto-backup channel and auto-restoring after a "Clear Data" — meaning credentials and cached content survived a wipe.

iOS: flip the keychain accessibility from kSecAttrAccessibleAfterFirstUnlock to *ThisDeviceOnly in SecureStorage.native.kt, ShareAuthBridge.native.kt, and the share-extension's SharedKeychainHelper.swift. Without *ThisDeviceOnly the keychain items rode encrypted iCloud / Finder backups and migrated to a new device on Quick Start — equivalent of the Android issue. Also mark the databases/ directory and odin-2.db (+ -wal/-shm/-journal) with NSURLIsExcludedFromBackupKey so SQLCipher's encrypted file no longer rides iCloud Backup, closing the SQLCipher-passphrase-restored-with-DB chain.

Net effect: a phone restore or new-device migration on either platform now presents the login screen — no silent re-auth.

Side-loaded with two regression tests that lock in the behaviour the user's "data survives logout" report exposed:

- WipeAndRecreateSidecarTest (jvmTest): after wipeAndRecreate, both the still-open driver and a fresh reopen see zero rows in DriveMainIndex, and if a `-wal` sidecar exists on disk it is zero bytes — proving the PRAGMA wal_checkpoint(TRUNCATE) ran.
- LogoutLoginRoundTripTest (commonTest): seeds a corrupt row, calls clearStorage, then mounts+starts against a MockEngine returning empty results; asserts the bad row never reappears.

And cheap permanent instrumentation in DatabaseManager.wipeAndRecreate: PRAGMA journal_mode/page_count/freelist_count before+after, plus wal_checkpoint(TRUNCATE) with a loud log if the WAL was non-empty after the wipe. Catches the bug class on real devices via homebase.log.

Caveats for release notes:
- Existing iCloud / Google backups remain in the user's cloud account until normal expiry; users wanting to scrub proactively must do it from Google One / iCloud settings.
- New-device migration now requires re-login (intentional).