### PR TITLE
fix(cache): reap resolved_* picker copies on send instead of leaking …

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/FileOperationsProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/FileOperationsProvider.kt
@@ -74,3 +74,52 @@ interface FileOperationsProvider {
         const val DEFAULT_HEADER_BYTES: Int = 64 * 1024
     }
 }
+
+/**
+ * Resolve [path] (which may be an Android `content://` URI) to a real
+ * filesystem path, run [block] with it, and reap the resolved copy afterwards.
+ *
+ * [resolveToFilePath] COPIES a `content://` pick into cacheDir as
+ * `resolved_*.<ext>` — a plaintext copy the full size of the source. Callers
+ * that picked through the gallery (video send, vault upload) must delete that
+ * copy once they've consumed it, or it lingers in cacheDir until the next
+ * cold-start [CacheSweeper] run (observed: a 125 MB send leaving a 125 MB
+ * `resolved_*.mp4`). This is the one shared place that pairs the resolve with
+ * its delete, so no call site can forget — and on platforms where
+ * `resolveToFilePath` is a no-op the path is unchanged and nothing is deleted.
+ *
+ * The reap runs in `finally`, so it also covers the failure path; the startup
+ * sweep stays as the backstop if even that delete fails.
+ */
+suspend fun <T> FileOperationsProvider.withResolvedFile(
+    path: String,
+    block: suspend (resolvedPath: String) -> T,
+): T {
+    val resolved = resolveToFilePath(path)
+    return try {
+        block(resolved)
+    } finally {
+        if (resolved != path) deleteTempFile(resolved)
+    }
+}
+
+/**
+ * List form of [withResolvedFile]: resolve every path in [paths], run [block]
+ * with the resolved paths (positionally aligned with [paths]), and reap each
+ * resolved copy afterwards. Used by callers that pick several files at once
+ * (vault multi-upload). Same reap rule per entry — a path that resolved to
+ * itself (no copy made) is left alone.
+ */
+suspend fun <T> FileOperationsProvider.withResolvedFiles(
+    paths: List<String>,
+    block: suspend (resolvedPaths: List<String>) -> T,
+): T {
+    val resolved = paths.map { resolveToFilePath(it) }
+    return try {
+        block(resolved)
+    } finally {
+        for (i in paths.indices) {
+            if (resolved[i] != paths[i]) deleteTempFile(resolved[i])
+        }
+    }
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPayloadProcessor.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPayloadProcessor.kt
@@ -7,6 +7,7 @@ import id.homebase.api.client.drives.files.ThumbnailFile
 import id.homebase.api.client.drives.upload.EmbeddedThumb
 import id.homebase.api.crypto.AesCbc
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.file.withResolvedFile
 import id.homebase.api.image.createThumbnails
 import id.homebase.api.serialization.OdinSystemSerializer
 import io.ktor.utils.io.core.toByteArray
@@ -26,12 +27,34 @@ class VideoPayloadProcessor(
         trimStartMs: Long? = null,
         trimEndMs: Long? = null,
         videoQuality: VideoQuality = VideoQuality.STANDARD,
-    ): VideoProcessResult {
+    ): VideoProcessResult =
+        // Resolve content URIs (Android copies the gallery pick into cacheDir as
+        // resolved_*; other platforms no-op) and reap that copy when we're done,
+        // so it can't linger at full video size. withResolvedFile is the shared
+        // resolve-then-delete scope — see FileOperationsProvider.withResolvedFile.
+        fileOperationsProvider.withResolvedFile(payload.filePath) { resolvedPath ->
+            processResolved(
+                payload =
+                    if (resolvedPath != payload.filePath) payload.copy(filePath = resolvedPath)
+                    else payload,
+                keyHeader = keyHeader,
+                onProgress = onProgress,
+                descriptorContentPayloadKey = descriptorContentPayloadKey,
+                trimStartMs = trimStartMs,
+                trimEndMs = trimEndMs,
+                videoQuality = videoQuality,
+            )
+        }
 
-        // Resolve content URIs (Android) to real filesystem paths before FFmpeg work
-        val resolvedPath = fileOperationsProvider.resolveToFilePath(payload.filePath)
-        val payload =
-            if (resolvedPath != payload.filePath) payload.copy(filePath = resolvedPath) else payload
+    private suspend fun processResolved(
+        payload: PayloadFile,
+        keyHeader: KeyHeader,
+        onProgress: ((VideoPayloadProgressPhase) -> Unit)?,
+        descriptorContentPayloadKey: String,
+        trimStartMs: Long?,
+        trimEndMs: Long?,
+        videoQuality: VideoQuality,
+    ): VideoProcessResult {
 
         /* ---------- PHASE 1: THUMBNAILS ---------- */
 

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/api/video/ResolvedTempCleanupJvmTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/api/video/ResolvedTempCleanupJvmTest.kt
@@ -1,0 +1,113 @@
+package id.homebase.api.video
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.drives.files.PayloadFile
+import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.file.JvmFileOperationsProvider
+import id.homebase.api.file.safeDeleteRecursively
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.Assume.assumeTrue
+
+/**
+ * Regression test for the `resolved_*` cache leak.
+ *
+ * On Android the video picker hands [VideoPayloadProcessor.process] a
+ * `content://` URI; `resolveToFilePath` copies the entire picked video into
+ * cacheDir as `resolved_*.<ext>` before any FFmpeg work. That copy is the full
+ * size of the source — a 125 MB send was observed leaving a 125 MB
+ * `resolved_*.mp4` in cacheDir until the next cold-start CacheSweeper run
+ * (logcat: `CacheSweeper deleting resolved_… — 125223174 bytes`). `process`
+ * must reap that copy itself, on the same send, not lean on the startup sweep.
+ *
+ * JVM's real `resolveToFilePath` is a no-op (no copy), so this test wraps the
+ * JVM provider with one that copies on resolve — mirroring Android — and
+ * asserts the copy is gone once `process` returns, while the encrypted payload
+ * it produced survives.
+ *
+ * Skips silently when bundled ffmpeg binaries aren't on the classpath. Run with:
+ *   ./gradlew homebase-chat:jvmTest --tests "*ResolvedTempCleanupJvm*"
+ */
+class ResolvedTempCleanupJvmTest {
+
+    private val cacheDir: File = File.createTempFile("resolved_test_cache_", "").let {
+        it.delete(); it.mkdirs(); it
+    }
+
+    @AfterTest
+    fun tearDown() {
+        if (cacheDir.exists()) safeDeleteRecursively(cacheDir.parent, cacheDir.name)
+    }
+
+    /**
+     * Wraps [JvmFileOperationsProvider] but (a) routes scratch into a test-owned
+     * cacheDir and (b) makes `resolveToFilePath` COPY its input, the way the
+     * Android actual does for a `content://` pick. Records the copies it makes
+     * and the paths `process` asks to delete.
+     */
+    private class CopyOnResolveProvider(
+        private val cacheDir: File,
+        private val delegate: JvmFileOperationsProvider = JvmFileOperationsProvider(),
+    ) : FileOperationsProvider by delegate {
+
+        val resolvedCopies = mutableListOf<String>()
+        val deleted = mutableListOf<String>()
+
+        override fun getCacheDirectory(): String = cacheDir.absolutePath
+
+        override suspend fun resolveToFilePath(path: String): String {
+            val copy = File.createTempFile("resolved_", ".mp4", cacheDir)
+            copy.writeBytes(File(path).readBytes())
+            resolvedCopies += copy.absolutePath
+            return copy.absolutePath
+        }
+
+        override fun deleteTempFile(path: String): Boolean {
+            deleted += path
+            return delegate.deleteTempFile(path)
+        }
+    }
+
+    @Test
+    fun process_reapsTheResolvedCopyButKeepsTheEncryptedPayload() = runTest {
+        assumeTrue(
+            "FFmpeg binaries not bundled in this test classpath",
+            FFmpegBinaryManager.isAvailable(),
+        )
+
+        val fixture = VideoTestHelper.copyToTempFile("sample.mp4")
+        val provider = CopyOnResolveProvider(cacheDir)
+        val processor = VideoPayloadProcessor(provider)
+
+        try {
+            val result = processor.process(
+                payload = PayloadFile(key = "vid", filePath = fixture, contentType = "video/mp4"),
+                keyHeader = KeyHeader.newRandom16(),
+                onProgress = null,
+                descriptorContentPayloadKey = "desc",
+            )
+
+            val resolvedCopy = provider.resolvedCopies.single()
+            assertFalse(
+                File(resolvedCopy).exists(),
+                "the resolved_* plaintext copy must be deleted by process(), not left for the startup sweep",
+            )
+            assertTrue(
+                provider.deleted.contains(resolvedCopy),
+                "process() must call deleteTempFile on the resolved copy it created",
+            )
+
+            // We deleted the right file: the encrypted payload process produced
+            // is a different path and still exists for the outbox to upload.
+            val payloadPath = result.payloads.first().filePath
+            assertTrue(payloadPath != resolvedCopy, "payload must not point at the reaped copy")
+            assertTrue(File(payloadPath).exists(), "the encrypted payload must survive for upload")
+        } finally {
+            File(fixture).delete()
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultUploaderService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultUploaderService.kt
@@ -18,6 +18,7 @@ import id.homebase.api.client.drives.upload.UploadFileMetadata
 import id.homebase.api.client.drives.upload.UploadFileRequest
 import id.homebase.api.crypto.ByteArrayUtil
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.file.withResolvedFiles
 import id.homebase.api.image.convertHeicToJpeg
 import id.homebase.api.sync.database.OutboxSync
 import id.homebase.chat.services.LocalAttachmentContextStore
@@ -61,13 +62,42 @@ class VaultUploaderService(
         groupId: Uuid? = null,
         notes: String? = null,
         uniqueId: Uuid = Uuid.random(),
+    ): Uuid? =
+        // Resolve the picked files (Android copies content:// picks into cacheDir
+        // as resolved_*) and reap those copies once the upload is enqueued — the
+        // shared resolve-then-delete scope, so this path can't strand them. See
+        // FileOperationsProvider.withResolvedFiles.
+        fileOperationsProvider.withResolvedFiles(files.map { it.first }) { resolvedPaths ->
+            uploadResolvedFiles(
+                entryName = entryName,
+                files = resolvedPaths.mapIndexed { i, resolved -> resolved to files[i].second },
+                scope = scope,
+                groupId = groupId,
+                notes = notes,
+                uniqueId = uniqueId,
+            )
+        }
+
+    private suspend fun uploadResolvedFiles(
+        entryName: String,
+        files: List<Pair<String, String>>,
+        scope: CoroutineScope,
+        groupId: Uuid?,
+        notes: String?,
+        uniqueId: Uuid,
     ): Uuid? {
+        // heic_converted_*.jpg temps created by convertHeicIfNeeded outlive that
+        // call but are fully consumed once encryptBundle has read them into the
+        // encrypted payloads. Reap them in finally so they don't linger in
+        // cacheDir — same per-send discipline as the resolved copies.
+        val heicTemps = mutableListOf<String>()
         return try {
             val keyHeader = KeyHeader.newRandom16()
 
             val resolvedFiles = files.map { (path, contentType) ->
-                val resolved = fileOperationsProvider.resolveToFilePath(path)
-                convertHeicIfNeeded(resolved, contentType)
+                val converted = convertHeicIfNeeded(path, contentType)
+                if (converted.first != path) heicTemps += converted.first
+                converted
             }
 
             var pdfPageCount: Int? = null
@@ -139,6 +169,8 @@ class VaultUploaderService(
         } catch (e: Exception) {
             Logger.e(e, TAG) { "Failed to enqueue multi-payload upload: $entryName" }
             null
+        } finally {
+            for (temp in heicTemps) fileOperationsProvider.deleteTempFile(temp)
         }
     }
 
@@ -146,7 +178,23 @@ class VaultUploaderService(
         file: VaultEntry,
         newFiles: List<Pair<String, String>>,
         scope: CoroutineScope,
+    ): Boolean =
+        fileOperationsProvider.withResolvedFiles(newFiles.map { it.first }) { resolvedPaths ->
+            appendResolvedPages(
+                file = file,
+                newFiles = resolvedPaths.mapIndexed { i, resolved -> resolved to newFiles[i].second },
+                scope = scope,
+            )
+        }
+
+    private suspend fun appendResolvedPages(
+        file: VaultEntry,
+        newFiles: List<Pair<String, String>>,
+        scope: CoroutineScope,
     ): Boolean {
+        // See uploadResolvedFiles: reap the heic_converted_*.jpg temps once the
+        // bundle has been encrypted, so they don't linger in cacheDir.
+        val heicTemps = mutableListOf<String>()
         return try {
             val existingMaxIndex =
                 file.payloadDescriptors.mapNotNull { it.key.removePrefix("vlt_pg_").toIntOrNull() }
@@ -154,8 +202,9 @@ class VaultUploaderService(
             val startIndex = existingMaxIndex + 1
 
             val resolvedFiles = newFiles.map { (path, contentType) ->
-                val resolved = fileOperationsProvider.resolveToFilePath(path)
-                convertHeicIfNeeded(resolved, contentType)
+                val converted = convertHeicIfNeeded(path, contentType)
+                if (converted.first != path) heicTemps += converted.first
+                converted
             }
 
             val allPayloads = mutableListOf<PayloadFile>()
@@ -212,6 +261,8 @@ class VaultUploaderService(
         } catch (e: Exception) {
             Logger.e(e, TAG) { "Failed to enqueue append pages to ${file.uniqueId}" }
             false
+        } finally {
+            for (temp in heicTemps) fileOperationsProvider.deleteTempFile(temp)
         }
     }
 


### PR DESCRIPTION
…until next launch

Sending a video left ~125 MB of "Other cached files" sitting in the app cache dir until the next cold start. On-device evidence (logcat CacheSweeper at startup):

    deleting resolved_1805536654319821430.mp4 — 125223174 bytes
    deleting resolved_3339334266907072050.mp4 —  11050152 bytes
    reclaimed 129.9MB

Root cause: VideoPayloadProcessor.process() calls resolveToFilePath() to turn the picked content:// URI into a real path, which on Android COPIES the whole video into cacheDir as resolved_*.<ext>. The function reaped its thumbnail and compressed scratch but never the resolved copy, so a full-size plaintext copy lingered until the startup CacheSweeper (the "suspenders") swept it. The per-send "belt" was missing.

Fix: add a shared resolve-then-delete scope so no call site can forget.

- FileOperationsProvider: add withResolvedFile / withResolvedFiles extensions that resolve, run a block, and delete the resolved copy in finally (skipping when resolveToFilePath was a no-op, i.e. the path is unchanged). One commonMain implementation for all platforms; only the resolveToFilePath/deleteTempFile primitives stay expect/actual.
- VideoPayloadProcessor: process() is now a thin wrapper over withResolvedFile; the body moved to private processResolved(). Reap now also covers the failure path.
- VaultUploaderService: route uploadFile and appendPages through withResolvedFiles, closing the same resolved_* leak it had at two spots. Also reap the heic_converted_*.jpg temps that convertHeicIfNeeded creates, once encryptBundle has consumed them.

The startup CacheSweeper remains the backstop if a per-send delete fails.

Test: ResolvedTempCleanupJvmTest drives the real ffmpeg pipeline through process() with a provider that copies on resolve (mirroring Android) and asserts the resolved copy is gone while the encrypted payload survives.