### PR TITLE
fix(chat): group heal preserves the group picture; cleanup status is local-only

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveFileProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveFileProvider.kt
@@ -63,7 +63,7 @@ public class DriveFileProvider(
     httpClient: HttpClient,
     credentialsManager: CredentialsManager,
     private val driveCache: DriveFileProviderCached
-) : OdinApiProviderBase(httpClient, credentialsManager), VideoPrefetchDriveAccess {
+) : OdinApiProviderBase(httpClient, credentialsManager), VideoPrefetchDriveAccess, ResendPayloadByteSource {
 
     companion object {
         private const val TAG = "DriveFileProvider"
@@ -205,12 +205,32 @@ public class DriveFileProvider(
      * receiving the heal'd file also receive the payload bytes (the manifest would
      * otherwise be empty and the payload wouldn't ship).
      */
-    suspend fun getPayloadBytesEncrypted(
+    override suspend fun getPayloadBytesEncrypted(
         driveId: Uuid,
         fileId: Uuid,
         key: String,
     ): ByteArray? {
         val response = driveCache.getPayloadBytesRaw(driveId, fileId, key)
+        if (response.status == 404) return null
+        return response.bytes
+    }
+
+    /**
+     * Fetch the FULL still-encrypted bytes of one of a payload's thumbnails, going
+     * through the disk cache. Returns null on 404. Counterpart to
+     * [getPayloadBytesEncrypted] for the heal-redistribute path: the thumbnails
+     * must be re-attached alongside the payload or the `updateFileByUniqueId`
+     * AppendOrOverwrite wipes them server-side (see [ResendPayloadByteSource]).
+     */
+    override suspend fun getThumbBytesEncrypted(
+        driveId: Uuid,
+        fileId: Uuid,
+        payloadKey: String,
+        width: Int,
+        height: Int,
+        lastModified: Long?,
+    ): ByteArray? {
+        val response = driveCache.getThumbBytesRaw(driveId, fileId, payloadKey, width, height, lastModified)
         if (response.status == 404) return null
         return response.bytes
     }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/ResendPayloadByteSource.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/ResendPayloadByteSource.kt
@@ -1,0 +1,35 @@
+package id.homebase.api.client.drives.files
+
+import kotlin.uuid.Uuid
+
+/**
+ * Narrow read-only seam over [DriveFileProvider] for the chat group-heal
+ * "resend" path. That path pulls an existing file's ALREADY-encrypted payload
+ * **and** thumbnail bytes off our own drive and re-attaches them to an
+ * `updateFileByUniqueId` request (as pre-encrypted [PayloadFile] / [ThumbnailFile]
+ * entries) so a peer receiving the heal'd file gets the complete image — and so
+ * the `AppendOrOverwrite` doesn't degrade our own copy.
+ *
+ * Re-attaching the payload bytes WITHOUT its thumbnails is the
+ * group-image-destroyed-on-heal bug: the overwrite wipes the server-side
+ * thumbnails, leaving the avatar loader to 404 on every size (warning triangle
+ * over the surviving embedded preview).
+ *
+ * Exposed as an interface so `ConversationService` can be unit-tested with a fake
+ * instead of a real [DriveFileProvider] (which needs an HTTP client + disk cache).
+ * Implemented by [DriveFileProvider].
+ */
+interface ResendPayloadByteSource {
+    /** Raw, still-encrypted bytes of a payload; null on 404. */
+    suspend fun getPayloadBytesEncrypted(driveId: Uuid, fileId: Uuid, key: String): ByteArray?
+
+    /** Raw, still-encrypted bytes of one of a payload's thumbnails; null on 404. */
+    suspend fun getThumbBytesEncrypted(
+        driveId: Uuid,
+        fileId: Uuid,
+        payloadKey: String,
+        width: Int,
+        height: Int,
+        lastModified: Long? = null,
+    ): ByteArray?
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/upload/DriveUploadProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/upload/DriveUploadProvider.kt
@@ -220,6 +220,35 @@ class DriveUploadProvider(
 
         val creds = requireCreds()
         val sharedSecret = creds.secret.unsafeBytes
+
+        // DRAIN-TIME payload integrity check (HealAudit). Payload bytes (e.g. the
+        // reused `convo_img` group image on a group heal) are staged to a temp
+        // file at ENQUEUE time but read lazily HERE, at outbox-drain time. On
+        // Android that staging dir is cacheDir, which the OS can reclaim while the
+        // row waits in the outbox: getFileSize() returns 0 for a missing file and
+        // openFileInput() then streams 0 bytes, so an AppendOrOverwrite can
+        // silently replace a good payload with an EMPTY one — the file header (and
+        // its previewThumbnail) survive while the full payload becomes unreadable
+        // (warning triangle over the tiny thumb). The upload still reports
+        // "success", so without this log the corruption is invisible. Logged WARN
+        // when a payload is missing/zero so a heal repro shows exactly which
+        // payload shipped empty.
+        request.payloads?.forEach { p ->
+            val size = runCatching { fileOperationsProvider.getFileSize(p.filePath) }.getOrDefault(-1L)
+            if (size <= 0L) {
+                Logger.w(tag = "HealAudit") {
+                    "$TAG.updateFileByUniqueId: payload key=${p.key} size=$size at drain " +
+                        "(uniqueId=${request.uniqueId} path=${p.filePath} preEncrypted=${p.isPreEncrypted}) — " +
+                        "AppendOrOverwrite may ship an EMPTY payload and clobber the existing one"
+                }
+            } else {
+                Logger.d(tag = "HealAudit") {
+                    "$TAG.updateFileByUniqueId: payload key=${p.key} size=$size at drain " +
+                        "(uniqueId=${request.uniqueId} preEncrypted=${p.isPreEncrypted})"
+                }
+            }
+        }
+
         // Build encrypted descriptor
         val sharedSecretEncryptedDescriptor =
             buildSharedSecretEncryptedUpdateDescriptor(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/MessageMapper.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/MessageMapper.kt
@@ -171,6 +171,16 @@ suspend fun mapToMessageData(
         when {
             isStatusMessage -> {
                 val status = OdinSystemSerializer.deserialize<StatusMessageData>(content)
+                // GroupHealLocalCleanup is a private "I cleaned up MY broken copy"
+                // marker — only meaningful to the receiver that did the cleanup. A
+                // fixed sender writes it local-only, but a peer still on an older
+                // build fans it out over the wire. Drop any peer-authored copy so it
+                // never lands in our chat as if our own copy had auto-healed.
+                if (status.statusMessage == StatusMessage.GroupHealLocalCleanup &&
+                    metadata.originalAuthor != domain
+                ) {
+                    return null
+                }
                 val rendered = renderStatusMessage(
                     author = metadata.originalAuthor,
                     status = status,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/StatusMessage.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/StatusMessage.kt
@@ -27,6 +27,8 @@ enum class StatusMessage() {
 
     /** Local-only marker written by the receive-side heal handler when it actually
      *  hard-deleted broken local copies. Surfaces the cleanup to the user instead of
-     *  letting it happen silently. Never sent over peer. */
+     *  letting it happen silently. Never sent over peer — the sender enforces this by
+     *  passing `recipientOverride = emptyList()` (see GroupHealService.handleIncomingHealRequest);
+     *  a peer-authored copy of this status must NOT be rendered (see MessageMapper). */
     GroupHealLocalCleanup,
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -93,11 +93,12 @@ class ConversationService(
      * still at t1) and stamp the conversation file backwards.
      */
     private val participantLookup: ConversationParticipantLookup,
-    /** Used by the heal redistribute path to pull existing payload bytes off our
-     *  drive and re-attach them to the update request. Nullable so tests can
-     *  pass null without standing up the full network stack — the
-     *  payload-reuse helper short-circuits to an empty manifest in that case. */
-    private val driveFileProvider: id.homebase.api.client.drives.files.DriveFileProvider? = null,
+    /** Used by the heal redistribute path to pull existing payload AND thumbnail
+     *  bytes off our drive and re-attach them to the update request. Narrowed to
+     *  [ResendPayloadByteSource] (implemented by DriveFileProvider) so tests can
+     *  pass a fake without standing up the full network stack — the payload-reuse
+     *  helper short-circuits to an empty manifest when null. */
+    private val driveFileProvider: id.homebase.api.client.drives.files.ResendPayloadByteSource? = null,
     /** Used by the heal redistribute path to spill the encrypted payload bytes
      *  to a temp file for upload. Same nullable-for-tests rationale as above. */
     private val fileOperationsProvider: id.homebase.api.file.FileOperationsProvider? = null,
@@ -1294,22 +1295,23 @@ class ConversationService(
         Logger.d { "updateConversationInternal PRE-REQUEST: conversationId=$conversationId aesKey=${keyHeader.aesKey.unsafeBytes.toBase64()} versionTag=${conversationFile.fileMetadata.versionTag}" }
 
         // Full-shape log of what we're about to enqueue. Lets us read the
-        // log and see exactly which recipients are on this push, whether
-        // any payloads are being shipped (heal carries none today — see
-        // [healGroupDistribution] image gap), and what versionTag the
-        // server-side per-peer apply will check against. Tagged so it
-        // stands out in a sea of debug noise.
+        // log and see exactly which recipients are on this push, whether the
+        // payloads (and their thumbnails) are being shipped, and what
+        // versionTag the server-side per-peer apply will check against. With
+        // preserveExistingPayloads=true (heal) the existing payloads + thumbs
+        // are re-attached into the manifest below; payloadsCount/thumbsCount
+        // should be non-zero. Tagged so it stands out in a sea of debug noise.
         Logger.i(tag = "HealAudit") {
             val existingPayloadKeys = conversationFile.fileMetadata.payloads?.joinToString(",") { it.key } ?: "<none>"
             val manifestKeys = manifest.payloadDescriptors?.joinToString(",") { "${it.payloadKey}:${it.operationType}" } ?: "<empty>"
             "updateConversationInternal ENQUEUE conversationId=$conversationId " +
                 "versionTagIn=${conversationFile.fileMetadata.versionTag} " +
                 "distribute=$distribute distributeOnlyTo=${distributeOnlyTo?.map { it.domainName }} " +
+                "preserveExistingPayloads=$preserveExistingPayloads " +
                 "instructions.recipients=${instructions.recipients.map { it.domainName }} " +
                 "manifest.payloadDescriptors=[$manifestKeys] " +
                 "request.payloadsCount=${payloads.size} request.thumbsCount=${thumbs.size} " +
-                "existingFilePayloads=[$existingPayloadKeys] (these stay on OUR server but are " +
-                "NOT in the manifest, so peer transit may not ship them — see image-on-heal bug)"
+                "existingFilePayloads=[$existingPayloadKeys]"
         }
 
         val request =
@@ -2052,6 +2054,7 @@ class ConversationService(
         }
 
         val payloads = mutableListOf<PayloadFile>()
+        val thumbnails = mutableListOf<ThumbnailFile>()
         for (descriptor in existing) {
             try {
                 val bytes = dfp.getPayloadBytesEncrypted(chatDrive, file.fileId, descriptor.key)
@@ -2079,13 +2082,58 @@ class ConversationService(
                 payloads += PayloadFile(
                     key = descriptor.key,
                     filePath = tempPath,
+                    // Keep the payload's embedded preview thumbnail on the descriptor too.
+                    previewThumbnail = descriptor.previewThumbnail?.toEmbeddedThumb(),
                     contentType = descriptor.contentType ?: "",
                     isPreEncrypted = true,
                     iv = ivBytes,
                     descriptorContent = descriptor.descriptorContent,
                 )
+
+                // Re-attach the payload's thumbnails. The update ships an
+                // AppendOrOverwrite for this payload key, which REPLACES the
+                // payload AND its thumbnail set on the server. Re-attaching only
+                // the payload bytes (the previous behavior) wiped every
+                // server-side thumbnail, so the avatar loader 404'd on each size
+                // — the warning-triangle-over-tiny-thumb group-image bug. The
+                // thumbnails are encrypted with the SAME payload key + iv, so we
+                // ship the pre-encrypted bytes as-is (no re-encryption needed).
+                var reattachedThumbs = 0
+                for (thumb in descriptor.thumbnails.orEmpty()) {
+                    val w = thumb.pixelWidth
+                    val h = thumb.pixelHeight
+                    if (w == null || h == null) {
+                        Logger.w(tag = "HealAudit") {
+                            "reuseExistingPayloadsForResend: skipping thumbnail for key=${descriptor.key} — missing pixel dims (w=$w h=$h fileId=${file.fileId})"
+                        }
+                        continue
+                    }
+                    val thumbBytes = dfp.getThumbBytesEncrypted(
+                        driveId = chatDrive,
+                        fileId = file.fileId,
+                        payloadKey = descriptor.key,
+                        width = w,
+                        height = h,
+                        lastModified = descriptor.lastModified,
+                    )
+                    if (thumbBytes == null || thumbBytes.isEmpty()) {
+                        Logger.w(tag = "HealAudit") {
+                            "reuseExistingPayloadsForResend: skipping thumbnail key=${descriptor.key} ${w}x$h — getThumbBytesEncrypted returned ${if (thumbBytes == null) "null" else "empty"} (fileId=${file.fileId})"
+                        }
+                        continue
+                    }
+                    thumbnails += ThumbnailFile(
+                        pixelWidth = w,
+                        pixelHeight = h,
+                        thumbnailBytes = thumbBytes,
+                        key = descriptor.key,
+                        contentType = thumb.contentType ?: "image/webp",
+                    )
+                    reattachedThumbs++
+                }
+
                 Logger.i(tag = "HealAudit") {
-                    "reuseExistingPayloadsForResend: re-attached payload key=${descriptor.key} bytes=${bytes.size} tempPath=$tempPath fileId=${file.fileId}"
+                    "reuseExistingPayloadsForResend: re-attached payload key=${descriptor.key} bytes=${bytes.size} thumbs=$reattachedThumbs/${descriptor.thumbnails?.size ?: 0} tempPath=$tempPath fileId=${file.fileId}"
                 }
             } catch (e: Exception) {
                 Logger.w(throwable = e, tag = "HealAudit") {
@@ -2093,7 +2141,7 @@ class ConversationService(
                 }
             }
         }
-        return payloads to emptyList()
+        return payloads to thumbnails
     }
 
     override suspend fun getConversationHomebaseFile(conversationId: Uuid): HomebaseFile? {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/GroupHealService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/GroupHealService.kt
@@ -654,11 +654,17 @@ class GroupHealService(
             }
         }
 
-        // Surface the cleanup to the user. Local-only status message — never
-        // sent to peers (additionalRecipients stays empty; the conversation
-        // recipients list is irrelevant because sendStatusMessage routes the
-        // optimistic write through the same path regardless of fan-out).
-        audit.step(3, "sendStatusMessage(GroupHealLocalCleanup mainNeedsHeal=$mainNeedsHeal adminNeedsHeal=$adminNeedsHeal)")
+        // Surface the cleanup to the user. This MUST be local-only: it's our
+        // private record that *we* cleaned up *our* broken copy, meaningless to
+        // peers. `recipientOverride = emptyList()` forces an empty recipient set
+        // (sendMessageInternal → getRecipients → isLocalOnly=true,
+        // allowDistribution=false, no transit), while the optimistic local write
+        // still surfaces the message in our own chat. Without the override,
+        // getRecipients falls back to ALL conversation participants and fans the
+        // cleanup status out over the wire — including back to the heal sender,
+        // who then renders "Removed broken local copy…" in *their* chat as if
+        // their own copy had auto-healed. (That was the bug.)
+        audit.step(3, "sendStatusMessage(GroupHealLocalCleanup mainNeedsHeal=$mainNeedsHeal adminNeedsHeal=$adminNeedsHeal recipientOverride=[] local-only)")
         runCatching {
             chatMessageSenderService.sendStatusMessage(
                 messageUniqueId = Uuid.random(),
@@ -670,6 +676,7 @@ class GroupHealService(
                         cleanedUpAdmin = adminNeedsHeal,
                     ),
                 ),
+                recipientOverride = emptyList(),
             )
             audit.checkPass("cleanupStatusSent")
         }.onFailure { e ->

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceHealTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceHealTest.kt
@@ -238,6 +238,55 @@ class ConversationServiceHealTest {
     }
 
     @Test
+    fun cleanupStatus_isSentLocalOnly_notFannedOutToPeers() = runTest {
+        // Regression: GroupHealLocalCleanup is a private "I cleaned up MY broken
+        // copy" marker. It must be written local-only (recipientOverride=emptyList).
+        // Previously it was sent with no override, so getRecipients fell back to
+        // ALL participants and fanned it out over the wire — landing back in the
+        // heal sender's chat as "Removed broken local copy…", as if the sender's
+        // own copy had auto-healed.
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val healService = fixture.buildHealService(service)
+            val convoId = Uuid.random()
+            val canonicalParticipants = listOf(
+                OdinId(canonicalAuthorDomain),
+                OdinId(fixture.testDomain),
+                OdinId("bob.test"),
+            )
+            // Both main and admin missing ⇒ cleanup path fires and posts the status.
+            val healMsg = stubStatusMessageFile(fixture.chatDriveId)
+
+            healService.handleIncomingHealRequest(
+                status = healStatus(
+                    conversationId = convoId,
+                    canonicalAuthor = canonicalAuthorDomain,
+                    canonicalParticipants = canonicalParticipants,
+                    canonicalAdmins = listOf(OdinId(canonicalAuthorDomain)),
+                ),
+                sender = OdinId(canonicalAuthorDomain),
+                messageFile = healMsg,
+            )
+
+            val cleanupCalls = fixture.statusMessageSender.calls.filter {
+                it.statusMessage.statusMessage == StatusMessage.GroupHealLocalCleanup
+            }
+            assertEquals(
+                1,
+                cleanupCalls.size,
+                "exactly one GroupHealLocalCleanup status should be posted on a cleanup; " +
+                    "got ${fixture.statusMessageSender.calls.map { it.statusMessage.statusMessage }}",
+            )
+            assertEquals(
+                emptyList(),
+                cleanupCalls.single().recipientOverride,
+                "GroupHealLocalCleanup must be local-only (recipientOverride=emptyList) so it is " +
+                    "never fanned out to peers — including back to the heal sender",
+            )
+        }
+    }
+
+    @Test
     fun adminMissing_withCanonicalAdmins_writesAdminPlaceholder() = runTest {
         ConversationServiceTestFixture().use { fixture ->
             val service = fixture.build(scope = this)

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceResendImageTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceResendImageTest.kt
@@ -1,0 +1,108 @@
+package id.homebase.chat.services.convo
+
+import id.homebase.api.client.drives.files.DriveOutboxUploader
+import id.homebase.api.client.drives.upload.UpdateFileByUniqueIdRequest
+import id.homebase.api.common.OdinId
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.sync.database.Outbox
+import id.homebase.chat.services.ChatProtocol
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Regression coverage for the group-image-destroyed-on-heal bug.
+ *
+ * `GroupHealService.healGroupDistribution` resends the main conversation file to
+ * Missing peers via `updateConversationInternal(preserveExistingPayloads = true)`.
+ * That path re-attaches the existing `convo_img` payload as a pre-encrypted
+ * `AppendOrOverwrite`. The bug: it re-attached the payload BYTES but NOT the
+ * payload's thumbnails, so the overwrite wiped every server-side thumbnail —
+ * the embedded tiny preview in the header survived, but the avatar loader 404'd
+ * on each requested size (warning triangle over the tiny thumb), on the sender's
+ * own drive and every recipient the author pushed to.
+ *
+ * Diagnosed from a live desktop repro (homebase.log): `convo_img` shipped with
+ * `request.thumbsCount=0`, followed by repeated
+ * `HomebaseImageLoader … thumb load failed … key=convo_img … NotFoundException`.
+ */
+class ConversationServiceResendImageTest {
+
+    @Test
+    fun preserveExistingPayloads_reattachesPayloadThumbnails_soOverwriteDoesNotWipeThem() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val byteSource = FakeResendPayloadByteSource()
+            val fileOps = FakeFileOperationsProvider()
+            val service = fixture.build(
+                scope = this,
+                driveFileProvider = byteSource,
+                fileOperationsProvider = fileOps,
+            )
+
+            val peer = "frodo.baggins.demo.rocks"
+            val convoId = fixture.seedGroupWithImagePayload(
+                others = listOf(peer),
+                thumbnailSizes = listOf(72, 320),
+                title = "Sammys Ground",
+            )
+
+            // Exactly what heal does for the main file: resend to the Missing peer,
+            // preserving the existing image payload.
+            service.updateConversationInternal(
+                conversationId = convoId,
+                title = "Sammys Ground",
+                participants = listOf(OdinId(fixture.testDomain), OdinId(peer)),
+                distribute = true,
+                distributeOnlyTo = listOf(OdinId(peer)),
+                preserveExistingPayloads = true,
+            )
+
+            val updateReq = fixture.drainOutbox()
+                .mapNotNull { it.asUpdateFileRequestOrNull() }
+                .firstOrNull { it.uniqueId == convoId }
+            assertNotNull(updateReq, "an UpdateFileByUniqueIdRequest for the conversation must be enqueued")
+
+            // The payload itself ships — this part already worked before the fix.
+            val convoImgPayloads = updateReq.payloads.orEmpty()
+                .filter { it.key == ChatProtocol.ConversationImageKey }
+            assertEquals(1, convoImgPayloads.size, "convo_img payload must be re-attached")
+            assertTrue(
+                byteSource.payloadRequests.contains(ChatProtocol.ConversationImageKey),
+                "resend must read the existing convo_img payload bytes",
+            )
+
+            // REGRESSION ASSERTION: the payload's thumbnails must ship too, or the
+            // AppendOrOverwrite wipes them server-side. Empty here == the bug.
+            val convoImgThumbs = updateReq.thumbnails.orEmpty()
+                .filter { it.key == ChatProtocol.ConversationImageKey }
+            assertEquals(
+                setOf(72 to 72, 320 to 320),
+                convoImgThumbs.map { it.pixelWidth to it.pixelHeight }.toSet(),
+                "resend must re-attach ALL of the convo_img payload's thumbnails; got $convoImgThumbs",
+            )
+            assertTrue(
+                convoImgThumbs.all { it.thumbnailBytes.isNotEmpty() },
+                "re-attached thumbnails must carry their (pre-encrypted) bytes",
+            )
+            assertEquals(
+                setOf(
+                    Triple(ChatProtocol.ConversationImageKey, 72, 72),
+                    Triple(ChatProtocol.ConversationImageKey, 320, 320),
+                ),
+                byteSource.thumbRequests.toSet(),
+                "resend must fetch each thumbnail's encrypted bytes from the drive",
+            )
+        }
+    }
+
+    private fun Outbox.asUpdateFileRequestOrNull(): UpdateFileByUniqueIdRequest? {
+        if (this.uploadType != DriveOutboxUploader.UpdateFile) return null
+        return try {
+            OdinSystemSerializer.deserialize<UpdateFileByUniqueIdRequest>(this.json.decodeToString())
+        } catch (_: Throwable) {
+            null
+        }
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceTestFixture.kt
@@ -94,6 +94,8 @@ class ConversationServiceTestFixture : AutoCloseable {
     suspend fun build(
         scope: CoroutineScope = TestScope(),
         lastReadDebounceMs: Long = Long.MAX_VALUE / 2,
+        driveFileProvider: id.homebase.api.client.drives.files.ResendPayloadByteSource? = null,
+        fileOperationsProvider: id.homebase.api.file.FileOperationsProvider? = null,
     ): ConversationService {
         dbm = createInMemoryDbm()
         credentialsManager = createCredentialsManager(testDomain)
@@ -127,12 +129,12 @@ class ConversationServiceTestFixture : AutoCloseable {
             optimisticWriter = optimisticWriter,
             conversationStream = conversationLoader,
             participantLookup = participantLookup,
-            // Heal-payload-reuse helpers — null in tests, real instances in prod.
-            // The fixture doesn't exercise the heal redistribute path, so a null
-            // here just short-circuits reuseExistingPayloadsForResend to an
-            // empty manifest (matches pre-image-fix behavior for tests).
-            driveFileProvider = null,
-            fileOperationsProvider = null,
+            // Heal-payload-reuse helpers — null by default, but tests exercising
+            // the heal redistribute path (image preservation) pass fakes. A null
+            // here short-circuits reuseExistingPayloadsForResend to an empty
+            // manifest.
+            driveFileProvider = driveFileProvider,
+            fileOperationsProvider = fileOperationsProvider,
             lastReadDebounceMs = lastReadDebounceMs,
         )
     }
@@ -340,6 +342,7 @@ class ConversationServiceTestFixture : AutoCloseable {
         title: String = "",
         archivalStatus: Int = 0,
         localTags: List<Uuid> = emptyList(),
+        payloadsJson: String = "[]",
     ) {
         val now = Clock.System.now().epochSeconds
         val recipientsJson = participants.joinToString(",") { "\"$it\"" }
@@ -390,7 +393,7 @@ class ConversationServiceTestFixture : AutoCloseable {
                 "referencedFile": null,
                 "reactionPreview": null,
                 "versionTag": "${Uuid.random()}",
-                "payloads": [],
+                "payloads": $payloadsJson,
                 "dataSource": null
               },
               "serverMetadata": {
@@ -410,6 +413,45 @@ class ConversationServiceTestFixture : AutoCloseable {
               "fileByteCount": 100
             }"""
         )
+    }
+
+    /**
+     * Seed a group conversation whose conversation file carries a `convo_img`
+     * payload descriptor WITH a set of thumbnails — the shape the group-heal
+     * redistribute path reuses. Used to assert that the resend re-attaches those
+     * thumbnails (otherwise the AppendOrOverwrite wipes them and the avatar 404s).
+     */
+    suspend fun seedGroupWithImagePayload(
+        conversationId: Uuid = Uuid.random(),
+        others: List<String>,
+        thumbnailSizes: List<Int> = listOf(72, 320),
+        imagePayloadIvBase64: String = "AAAAAAAAAAAAAAAAAAAAAA==", // 16 zero bytes
+        title: String = "",
+    ): Uuid {
+        val participants = listOf(testDomain) + others
+        val thumbsJson = thumbnailSizes.joinToString(",") { s ->
+            """{"pixelWidth":$s,"pixelHeight":$s,"contentType":"image/webp"}"""
+        }
+        val payloadsJson = """[
+            {
+              "key": "${ChatProtocol.ConversationImageKey}",
+              "contentType": "image/jpeg",
+              "iv": "$imagePayloadIvBase64",
+              "lastModified": 1779276955816,
+              "thumbnails": [$thumbsJson]
+            }
+        ]"""
+        insertConversationFile(
+            fileId = Uuid.random(),
+            uniqueId = conversationId,
+            participants = participants,
+            originalAuthor = testDomain,
+            isGroup = true,
+            adminDataJson = """{"admins":["$testDomain"]}""",
+            title = title,
+            payloadsJson = payloadsJson,
+        )
+        return conversationId
     }
 
     private suspend fun insertAdminFile(
@@ -560,6 +602,64 @@ class FakeStatusMessageSender : StatusMessageSender {
         )
         return SendMessageResult(messageUniqueId)
     }
+}
+
+/**
+ * Fake [id.homebase.api.client.drives.files.ResendPayloadByteSource] for the heal
+ * redistribute path. Returns fixed non-empty encrypted bytes for any payload /
+ * thumbnail request and records what was asked for so tests can assert the
+ * resend pulled the payload's thumbnails (not just the payload bytes).
+ */
+class FakeResendPayloadByteSource(
+    private val payloadBytes: ByteArray = ByteArray(2048) { 1 },
+    private val thumbBytes: ByteArray = ByteArray(256) { 2 },
+) : id.homebase.api.client.drives.files.ResendPayloadByteSource {
+    val payloadRequests = mutableListOf<String>()
+    val thumbRequests = mutableListOf<Triple<String, Int, Int>>()
+
+    override suspend fun getPayloadBytesEncrypted(driveId: Uuid, fileId: Uuid, key: String): ByteArray {
+        payloadRequests += key
+        return payloadBytes
+    }
+
+    override suspend fun getThumbBytesEncrypted(
+        driveId: Uuid,
+        fileId: Uuid,
+        payloadKey: String,
+        width: Int,
+        height: Int,
+        lastModified: Long?,
+    ): ByteArray {
+        thumbRequests += Triple(payloadKey, width, height)
+        return thumbBytes
+    }
+}
+
+/**
+ * Minimal [id.homebase.api.file.FileOperationsProvider]. Only [writeBytesToTempFile]
+ * is exercised by the heal resend path (it spills encrypted payload bytes to a
+ * temp file); everything else errors so an unexpected call is caught.
+ */
+class FakeFileOperationsProvider : id.homebase.api.file.FileOperationsProvider {
+    private var counter = 0
+    val writtenPaths = mutableListOf<String>()
+
+    override fun openFileInput(path: String): io.ktor.client.request.forms.InputProvider =
+        error("FakeFileOperationsProvider.openFileInput should not be called in tests")
+    override suspend fun readFileBytes(path: String): ByteArray =
+        error("FakeFileOperationsProvider.readFileBytes should not be called in tests")
+    override fun deleteTempFile(path: String): Boolean = true
+    override fun getCacheDirectory(): String = "/tmp"
+    override fun getFileSize(path: String): Long = 0L
+    override suspend fun writeBytesToTempFile(bytes: ByteArray, prefix: String, suffix: String): String {
+        val path = "/tmp/${prefix}${counter++}$suffix"
+        writtenPaths += path
+        return path
+    }
+    override suspend fun writeBytesToShareOutboundFile(bytes: ByteArray, suffix: String): String =
+        error("FakeFileOperationsProvider.writeBytesToShareOutboundFile should not be called in tests")
+    override suspend fun writeStream(path: String, data: kotlinx.coroutines.flow.Flow<ByteArray>) =
+        error("FakeFileOperationsProvider.writeStream should not be called in tests")
 }
 
 class FakeConversationLoader : ConversationLoader {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -270,7 +270,7 @@ val appModule = module {
             conversationStream = get(),
             participantLookup = get(),
             driveSyncManager = get(),
-            driveFileProvider = get(),
+            driveFileProvider = get<id.homebase.api.client.drives.files.DriveFileProvider>(),
             fileOperationsProvider = get(),
         )
     }
@@ -368,7 +368,7 @@ val appModule = module {
             driveSyncManager = get(),
             credentialsManager = get(),
             databaseManager = get(),
-            driveFileProvider = get(),
+            driveFileProvider = get<id.homebase.api.client.drives.files.DriveFileProvider>(),
             conversationService = get(),
             mapToBasicProbe = mapToBasicProbe,
             decodeMessageContentProbe = decodeMessageContentProbe,
@@ -401,7 +401,7 @@ val appModule = module {
             contactService = get(),
             connectionService = get(),
             connectionRequestService = get(),
-            driveFileProvider = get(),
+            driveFileProvider = get<id.homebase.api.client.drives.files.DriveFileProvider>(),
             shareContentProcessor = get(),
             localVideoContextStore = get(),
             pendingNotificationTap = get(),


### PR DESCRIPTION


Fixes two independent group-heal bugs.

1) Group picture destroyed on heal (warning triangle over the tiny thumb)

   When the canonical author resends the main conversation file to a Missing
   peer, updateConversationInternal(preserveExistingPayloads=true) re-attaches
   the existing convo_img payload as a pre-encrypted AppendOrOverwrite.
   reuseExistingPayloadsForResend re-attached the payload BYTES but returned
   emptyList() for thumbnails, so the overwrite wiped every server-side
   thumbnail. The embedded tiny preview in the header survived, but the avatar
   loader 404'd on each requested size — on the sender's own drive and every
   recipient the author pushed to. Deterministic; only fires when the main file
   is actually resent (a peer is Missing), which is why it was "often".

   Root cause confirmed from a live desktop homebase.log: convo_img shipped with
   request.thumbsCount=0, followed by repeated
   "HomebaseImageLoader ... thumb load failed ... key=convo_img ...
   NotFoundException".

   Fix: reuseExistingPayloadsForResend now re-attaches each payload's thumbnails
   (and the payload's embedded preview thumbnail). Added
   DriveFileProvider.getThumbBytesEncrypted (mirrors getPayloadBytesEncrypted)
   and a narrow ResendPayloadByteSource seam so the resend path is unit-testable
   without the network stack. Added a drain-time payload-size WARN in
   DriveUploadProvider.updateFileByUniqueId that surfaces the otherwise-silent
   "shipped an empty payload" case (it ruled out the temp-file theory and guards
   against a future empty-payload regression).

2) "Removed broken local copy" leaking into the heal sender's chat

   The receive-side cleanup posts a GroupHealLocalCleanup status. Its comment and
   enum docstring claimed "local-only, never sent to peers", but it was sent with
   no recipientOverride, so getRecipients fanned it out to ALL participants —
   including back to the heal sender, who then rendered it as if their own copy
   had auto-healed. The self-loopback guard was correct; the status routing was
   not.

   Fix: send GroupHealLocalCleanup with recipientOverride=emptyList() (truly
   local-only; the optimistic local write still shows it to the receiver).
   Defense-in-depth: MessageMapper now drops a peer-authored GroupHealLocalCleanup
   so a teammate still on an old build can't pollute a fixed sender's chat.

Tests
- ConversationServiceResendImageTest: seeds a convo_img payload with thumbnails, runs the resend, asserts the thumbnails are re-attached. Verified RED with the fix reverted, GREEN with it.
- ConversationServiceHealTest: asserts GroupHealLocalCleanup is sent with recipientOverride=emptyList().
- Test fixture gains injectable ResendPayloadByteSource / FileOperationsProvider fakes and a seedGroupWithImagePayload helper.

Green: homebase-chat:jvmTest, homebase-api:jvmTest, androidApp:assembleDebug.