### PR TITLE
fix(chat): ride last-message sort key along with lastRead writeback

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/common/time/UnixTimeUtc.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/common/time/UnixTimeUtc.kt
@@ -47,6 +47,13 @@ data class UnixTimeUtc(val milliseconds: Long) : Comparable<UnixTimeUtc> {
         fun fromInstant(instant: Instant): UnixTimeUtc {
             return UnixTimeUtc(instant)
         }
+
+        /** The larger of two nullable timestamps; null only when both are null. */
+        fun later(a: UnixTimeUtc?, b: UnixTimeUtc?): UnixTimeUtc? {
+            if (a == null) return b
+            if (b == null) return a
+            return if (a >= b) a else b
+        }
     }
 
     val seconds: Long

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/common/time/UnixTimeUtcLaterTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/common/time/UnixTimeUtcLaterTest.kt
@@ -1,0 +1,34 @@
+package id.homebase.api.common.time
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Covers [UnixTimeUtc.later] — the nullable monotonic-max used by the lastRead
+ * writeback to ride the conversation-list sort key along without ever regressing
+ * it (a device behind on sync must not stamp an older time over a newer one).
+ */
+class UnixTimeUtcLaterTest {
+
+    @Test
+    fun bothNullReturnsNull() {
+        assertNull(UnixTimeUtc.later(null, null))
+    }
+
+    @Test
+    fun oneNullReturnsTheOther() {
+        val t = UnixTimeUtc(100)
+        assertEquals(t, UnixTimeUtc.later(t, null))
+        assertEquals(t, UnixTimeUtc.later(null, t))
+    }
+
+    @Test
+    fun bothNonNullReturnsTheLarger() {
+        val lo = UnixTimeUtc(100)
+        val hi = UnixTimeUtc(200)
+        assertEquals(hi, UnixTimeUtc.later(lo, hi))
+        assertEquals(hi, UnixTimeUtc.later(hi, lo))
+        assertEquals(hi, UnixTimeUtc.later(hi, hi))
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationLocalAppDataJson.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationLocalAppDataJson.kt
@@ -16,4 +16,17 @@ data class ConversationLocalAppDataJson(
         Uuid.Companion.NIL, // TODO: Obsolete, ignore. Same as uniqueId for conversation
     val lastReadTime: UnixTimeUtc? = null,
     val lastExitedAt: UnixTimeUtc? = null,
+    /**
+     * Sort key for the conversation list: the userDate of the most recent
+     * message known the last time this conversation was stamped. It rides
+     * along with the [lastReadTime] writeback (no separate push), so it is
+     * refreshed whenever the conversation is read or sent to.
+     *
+     * [ConversationMapper.mapToBasic] reads it so the cold-load / post-sync
+     * basic list lands in last-message order without waiting for the enrich
+     * JOIN. Null for never-stamped or message-less threads, which fall back to
+     * `fileMetadata.created`. May lag for a thread that received an unread
+     * message since its last stamp — the enrich pass corrects that.
+     */
+    val latestMessageTimestamp: UnixTimeUtc? = null,
 )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMapper.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMapper.kt
@@ -50,9 +50,10 @@ class ConversationMapper(
      * MANDATORY — basic conversation row required to render the list.
      *
      * Populates identity, title, participants, avatar model, membership
-     * state (Active/Left/Archived/Removed/…), and seeds
-     * `latestMessageTimestamp = metadata.created` so freshly-created
-     * threads (no messages yet) still sort by recency.
+     * state (Active/Left/Archived/Removed/…), and resolves
+     * `latestMessageTimestamp` from the persisted localAppData sort key
+     * (written by the lastRead writeback), falling back to `metadata.created`
+     * so freshly-created or never-stamped threads still sort by recency.
      *
      * Explicitly does NOT populate:
      *   - `lastMessage*` fields (defaults: " ", null, false)
@@ -210,11 +211,16 @@ class ConversationMapper(
                     id = conversationId,
                     name = title,
                     lastMessage = " ",
-                    // Seed sort timestamp with file creation so a freshly-created thread
-                    // (e.g. one started alongside a connection request, before any messages
-                    // have flowed) sorts to the top of the list instead of the bottom.
-                    // applyLastMessage overwrites this once a real message exists.
-                    latestMessageTimestamp = metadata.created.toInstant(),
+                    // Sort key for the list. Prefer the persisted last-message time
+                    // (rides along with the lastRead writeback in localAppData) so the
+                    // basic / post-sync list lands in last-message order without waiting
+                    // for the enrich JOIN. Fall back to file creation for never-stamped
+                    // or message-less threads so a freshly-created thread (e.g. one
+                    // started alongside a connection request, before any messages have
+                    // flowed) still sorts by recency. applyLastMessage overwrites this
+                    // once the real last message is loaded.
+                    latestMessageTimestamp = localAppData?.latestMessageTimestamp?.toInstant()
+                        ?: metadata.created.toInstant(),
                     unreadCount = 0,
                     avatarTiny = appData.previewThumbnail,
                     avatarInitials = "",

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -2439,6 +2439,10 @@ class ConversationService(
                     driveId = chatDrive,
                     conversationId = id,
                     newLastReadTime = target,
+                    // Ride the list sort key along with the lastRead push so the
+                    // post-sync basic list lands in last-message order. mapToBasic
+                    // reads it back from localAppData.
+                    latestMessageTimestamp = UnixTimeUtc(convo.latestMessageTimestamp.toEpochMilliseconds()),
                 )
                 if (request == null) {
                     Logger.w(tag = "MarkAsRead") {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
@@ -634,9 +634,16 @@ class OptimisticWriter(
         driveId: Uuid,
         conversationId: Uuid,
         newLastReadTime: UnixTimeUtc,
+        latestMessageTimestamp: UnixTimeUtc? = null,
     ): UpdateLocalAppdataContentOutboxRequest? =
         stampConversationLocalAppData(driveId, conversationId, "stampConversationLastReadTime") {
-            it.copy(lastReadTime = newLastReadTime)
+            it.copy(
+                lastReadTime = newLastReadTime,
+                // Ride the list sort key along with the lastRead push — no separate
+                // write. Monotonic so a device behind on sync can't stamp an older
+                // last-message time over a newer one another device already pushed.
+                latestMessageTimestamp = UnixTimeUtc.later(it.latestMessageTimestamp, latestMessageTimestamp),
+            )
         }
 
     @OptIn(ExperimentalEncodingApi::class)

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceLastReadDebounceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceLastReadDebounceTest.kt
@@ -86,6 +86,49 @@ class ConversationServiceLastReadDebounceTest {
                         .fileMetadata.localAppData?.content?.contains("\"lastReadTime\":5000") == true,
                     "stamped conv-file must carry the model's lastRead (5000)",
                 )
+                assertTrue(
+                    fixture.getConversationFile(convoId)!!
+                        .fileMetadata.localAppData?.content?.contains("\"latestMessageTimestamp\":10000") == true,
+                    "stamped conv-file must carry the model's latestMessageTimestamp (10000) — the list sort key ride-along",
+                )
+            }
+        } finally { serviceScope.cancel() }
+    }
+
+    @Test
+    fun basicMapPrefersPersistedLatestMessageTimestampElseFallsBackToCreated() = runBlocking {
+        val serviceScope = newServiceScope()
+        try {
+            ConversationServiceTestFixture().use { fixture ->
+                val service = fixture.build(scope = serviceScope)
+                val mapper = ConversationMapper(fixture.credentialsManager, fixture.dbm)
+                val convoId = fixture.seedOneOnOne(other = "dave.test")
+
+                // Fallback: a never-stamped conversation has no persisted sort key,
+                // so mapToBasic seeds latestMessageTimestamp from fileMetadata.created.
+                val freshFile = fixture.getConversationFile(convoId)!!
+                assertEquals(
+                    freshFile.fileMetadata.created.toInstant(),
+                    mapper.mapToBasic(freshFile).latestMessageTimestamp,
+                    "never-stamped conversation falls back to fileMetadata.created",
+                )
+
+                // Round-trip: a lastRead flush stamps the sort key into localAppData;
+                // mapToBasic then reads it back instead of using created.
+                fixture.participantLookup.setLastRead(
+                    convoId,
+                    Instant.fromEpochMilliseconds(5_000L),
+                    latestMessageTimestamp = Instant.fromEpochMilliseconds(10_000L),
+                    dirty = true,
+                )
+                service.flushLastReadNow()
+
+                assertEquals(
+                    10_000L,
+                    mapper.mapToBasic(fixture.getConversationFile(convoId)!!)
+                        .latestMessageTimestamp.toEpochMilliseconds(),
+                    "mapToBasic must prefer the persisted localAppData sort key over created",
+                )
             }
         } finally { serviceScope.cancel() }
     }


### PR DESCRIPTION
The conversation list re-ordered itself for a sub-second window after every reconnect: DriveEvent.Stopped triggers loadBasicConversations(), and ConversationMapper.mapToBasic seeded latestMessageTimestamp (the list's sort key) from fileMetadata.created. The list therefore rendered in *creation* order until enrichWithLastMessages() ran the message JOIN and re-sorted by the real last-message time -- the visible "old order -> new order" jump.

Fix: persist the last-message time on the conversation so the basic load already has it. A new nullable field ConversationLocalAppDataJson .latestMessageTimestamp rides along with the existing lastRead writeback: stampConversationLastReadTime now writes it into the same localAppData blob (monotonic via UnixTimeUtc.later so a device behind on sync can't stamp an older value over a newer one), and mapToBasic reads it back, falling back to fileMetadata.created only for never-stamped / message-less threads. No new push or DB path -- it reuses the local-upsert + outbox flush already in place.

Trade-off: the persisted key only refreshes when a conversation is read or sent to, so a thread that received an unread message since its last stamp can still move once when enrich runs. That's bounded to genuinely-changed threads (not the whole list) and self-heals on next read; deferred until we see how it plays out in practice.

Compatibility: localAppData round-trips through the server across the user's devices; OdinSystemSerializer has ignoreUnknownKeys=true, so older app versions safely ignore the new key.

Tests:
- UnixTimeUtcLaterTest: nullable monotonic-max (both-null, one-null, larger).
- ConversationServiceLastReadDebounceTest: the flush stamps latestMessageTimestamp into localAppData, and mapToBasic prefers the persisted value, falling back to created when unstamped.