### PR TITLE
feat(chat): orange status icon for stale-pending and failed messages

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Reply
 import androidx.compose.material.icons.filled.AddReaction
 import androidx.compose.material.icons.filled.Alarm
+import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
@@ -39,6 +40,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -111,18 +113,23 @@ import id.homebase.resources.media
 import id.homebase.resources.cd_reply_thumbnail
 import id.homebase.resources.message_delivered
 import id.homebase.resources.message_read
+import id.homebase.resources.message_send_failed
 import id.homebase.resources.message_sending
 import id.homebase.resources.message_sent
 import id.homebase.resources.you
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.decodeToImageBitmap
 import org.jetbrains.compose.resources.stringResource
 import kotlin.io.encoding.Base64
 import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
 import kotlin.uuid.Uuid
 
 private val GroupMessageAvatarOptions = AvatarOptions(size = Dimens.Conversation.itemAvatarSize)
@@ -812,16 +819,28 @@ fun DeliveryStatus(
     isPendingSend: Boolean,
     deliveryStatus: Int,
     contentColor: Color,
+    pendingSince: Instant? = null,
 ) {
+    val warning = HomebaseTheme.extendedColors.warning
     if (isPendingSend) {
+        val stale = pendingSince != null && rememberPendingStale(pendingSince)
         Icon(
             Icons.Default.Alarm,
             contentDescription = stringResource(MR.string.message_sending),
             modifier = Modifier.size(16.dp),
-            tint = contentColor,
+            tint = if (stale) warning else contentColor,
         )
     } else {
         when (deliveryStatus) {
+            ChatDeliveryStatus.Failed.value -> {
+                Icon(
+                    Icons.Default.ErrorOutline,
+                    contentDescription = stringResource(MR.string.message_send_failed),
+                    modifier = Modifier.height(DELIVERY_ICON_SIZE),
+                    tint = warning,
+                )
+            }
+
             ChatDeliveryStatus.Read.value -> {
                 Icon(
                     HomebaseIcons.MessageSentAndRead,
@@ -849,6 +868,24 @@ fun DeliveryStatus(
             }
         }
     }
+}
+
+/**
+ * True once the message has been pending (un-sent) for at least [threshold]. Computes the
+ * answer once for the current [since] value, then schedules a single delay to flip at the
+ * threshold — no polling ticker, so it leaves the Compose dispatcher idle while waiting.
+ */
+@Composable
+private fun rememberPendingStale(since: Instant, threshold: Duration = 1.minutes): Boolean {
+    var stale by remember(since) { mutableStateOf(Clock.System.now() - since >= threshold) }
+    LaunchedEffect(since) {
+        if (!stale) {
+            val remaining = threshold - (Clock.System.now() - since)
+            if (remaining > Duration.ZERO) delay(remaining)
+            stale = true
+        }
+    }
+    return stale
 }
 
 fun String.hasContent(): Boolean {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -82,6 +82,7 @@ import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
+import kotlin.time.Instant
 import kotlin.uuid.Uuid
 
 /**
@@ -335,6 +336,7 @@ fun MessageBubbleRaw(
                         isPendingSend = isPendingSend,
                         deliveryStatus = message.messageAppData.deliveryStatus,
                         contentColor = contentColor,
+                        pendingSince = message.userDate,
                     )
                 }
             } else if (replyMediaOnly && !message.isDeleted) {
@@ -372,6 +374,7 @@ fun MessageBubbleRaw(
                                 isPendingSend = isPendingSend,
                                 deliveryStatus = message.messageAppData.deliveryStatus,
                                 contentColor = contentColor,
+                                pendingSince = message.userDate,
                             )
                         }
                     },
@@ -513,6 +516,7 @@ fun MessageBubbleRaw(
                                         isPendingSend = isPendingSend,
                                         deliveryStatus = message.messageAppData.deliveryStatus,
                                         contentColor = contentColor.copy(alpha = 0.7f),
+                                        pendingSince = message.userDate,
                                     )
                                 }
                             }
@@ -729,6 +733,7 @@ private fun BoxScope.MediaTimestampOverlay(
     isPendingSend: Boolean,
     deliveryStatus: Int,
     contentColor: Color,
+    pendingSince: Instant?,
 ) {
     Box(modifier = Modifier.matchParentSize().align(Alignment.BottomStart)) {
         Box(
@@ -757,6 +762,7 @@ private fun BoxScope.MediaTimestampOverlay(
                         isPendingSend = isPendingSend,
                         deliveryStatus = deliveryStatus,
                         contentColor = contentColor.copy(alpha = 0.7f),
+                        pendingSince = pendingSince,
                     )
                 }
             }

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/DeliveryStatusTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/DeliveryStatusTest.kt
@@ -6,6 +6,8 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest
 import id.homebase.chat.services.ChatDeliveryStatus
 import kotlin.test.Test
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
 
 @OptIn(ExperimentalTestApi::class)
 class DeliveryStatusTest {
@@ -60,6 +62,35 @@ class DeliveryStatusTest {
                     isPendingSend = false,
                     deliveryStatus = ChatDeliveryStatus.Read.value,
                     contentColor = Color.White,
+                )
+            }
+        }
+        waitForIdle()
+    }
+
+    @Test
+    fun rendersForFailedStatus() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                DeliveryStatus(
+                    isPendingSend = false,
+                    deliveryStatus = ChatDeliveryStatus.Failed.value,
+                    contentColor = Color.White,
+                )
+            }
+        }
+        waitForIdle()
+    }
+
+    @Test
+    fun rendersForStalePendingSend() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                DeliveryStatus(
+                    isPendingSend = true,
+                    deliveryStatus = 0,
+                    contentColor = Color.White,
+                    pendingSince = Clock.System.now() - 2.minutes,
                 )
             }
         }

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -912,6 +912,7 @@
     <string name="message_read">Read</string>
     <string name="message_delivered">Delivered</string>
     <string name="message_sent">Sent</string>
+    <string name="message_send_failed">Failed to send</string>
 
     <!-- Accessibility: content descriptions -->
     <string name="cd_play_video">Play video</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/theme/Theme.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/theme/Theme.kt
@@ -86,6 +86,7 @@ data class HomebaseExtendedColors(
         val onSurfaceVariant1: androidx.compose.ui.graphics.Color,
         val bubbleSentSurface: androidx.compose.ui.graphics.Color,
         val bubbleSentOnSurface: androidx.compose.ui.graphics.Color,
+        val warning: androidx.compose.ui.graphics.Color,
 )
 
 private val LightExtendedColors =
@@ -108,6 +109,7 @@ private val LightExtendedColors =
                 onSurfaceVariant1 = LightColors.OnSurfaceVariant1,
                 bubbleSentSurface = LightColors.Primary,
                 bubbleSentOnSurface = LightColors.OnPrimary,
+                warning = ExtendedColors.Warning,
         )
 
 private val DarkExtendedColors =
@@ -130,6 +132,7 @@ private val DarkExtendedColors =
                 onSurfaceVariant1 = DarkColors.OnSurfaceVariant1,
                 bubbleSentSurface = LightColors.Primary,
                 bubbleSentOnSurface = LightColors.OnPrimary,
+                warning = ExtendedColors.Warning,
         )
 
 val LocalHomebaseExtendedColors = staticCompositionLocalOf { LightExtendedColors }


### PR DESCRIPTION
The pending "watch" (alarm) icon previously looked identical whether a
  message had just been sent or had been stuck in the outbox for minutes,
  and the Failed delivery status had no `when` branch at all so failed
  messages rendered no icon.

  - DeliveryStatus(): tint the pending alarm icon deep orange once the
    message has been pending for >= 1 minute, and add the missing Failed
    branch (Icons.Default.ErrorOutline) in the same orange.
  - rememberPendingStale(): compute staleness once and schedule a single
    delay to flip at the threshold (no polling ticker).
  - Thread pendingSince = message.userDate through both bubble paths.
  - Expose ExtendedColors.Warning (#FF9800) via HomebaseExtendedColors.
  - Add message_send_failed string + DeliveryStatusTest cases.

  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>