### PR TITLE
fix(chat): stop reaction-highlight blink from stale WS pushes

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveWebSocketUpsertWorker.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveWebSocketUpsertWorker.kt
@@ -134,7 +134,7 @@ class DriveWebSocketUpsertWorker(
         }
 
         try {
-            val (_, upsertElapsed) = measureTimedValue {
+            val (written, upsertElapsed) = measureTimedValue {
                 fileHeaderProcessor.baseUpsertEntryZapZap(
                     identityId = identityId,
                     driveId = driveId,
@@ -142,14 +142,33 @@ class DriveWebSocketUpsertWorker(
                     cursor = null,
                 )
             }
+
+            // Emit only the rows that actually changed a DriveMainIndex record
+            // (passed the timestamp guard), not the raw incoming batch. A stale or
+            // duplicate server push — e.g. the half-stale `statisticsChanged`
+            // fan-out copy whose `updated` is older than what we already hold — is
+            // rejected by the guard and so is absent from `written`. Mapping the
+            // raw batch instead would paint that rejected payload into the UI for a
+            // frame (the reaction-highlight blink); honoring the guard here avoids
+            // it and also collapses the fan-out duplicates to the single row that
+            // won.
+            if (written.isEmpty()) {
+                Logger.i(tag = "WSPush") {
+                    "WSPush: drainOnce drive=$driveId rows=${batch.size} took=$upsertElapsed " +
+                        "— no rows changed (timestamp guard); skipping BatchReceived"
+                }
+                return
+            }
+
             Logger.i(tag = "WSPush") {
-                "WSPush: drainOnce drive=$driveId rows=${batch.size} took=$upsertElapsed (emitting BatchReceived)"
+                "WSPush: drainOnce drive=$driveId rows=${batch.size} wrote=${written.size} " +
+                    "took=$upsertElapsed (emitting BatchReceived)"
             }
 
             eventBus.emit(
                 BackendEvent.DataEvent.BatchReceived(
                     driveId = driveId,
-                    batchData = batch,
+                    batchData = written,
                 )
             )
         } catch (e: Exception) {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/MainIndexMeta.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/MainIndexMeta.kt
@@ -168,8 +168,8 @@ object MainIndexMetaHelpers {
             driveId: Uuid,
             fileHeaders: List<HomebaseFile>,
             cursor: QueryBatchCursor?
-        ) {
-            performBaseUpsert(identityId, driveId, fileHeaders, cursor)
+        ): List<HomebaseFile> {
+            return performBaseUpsert(identityId, driveId, fileHeaders, cursor)
         }
 
         /**
@@ -182,7 +182,12 @@ object MainIndexMetaHelpers {
             driveId: Uuid,
             fileHeaders: List<HomebaseFile>,
             cursor: QueryBatchCursor?
-        ) {
+        ): List<HomebaseFile> {
+            // The headers that actually changed a row (passed the DriveMainIndex
+            // timestamp guard, n > 0). Callers — notably DriveWebSocketUpsertWorker
+            // — emit BatchReceived from THIS list, not the raw incoming batch, so a
+            // stale/duplicate server push the guard rejected never reaches the UI.
+            val written = ArrayList<HomebaseFile>(fileHeaders.size)
             databaseManager.withWriteTransaction { db ->
 
                 fileHeaders.forEach { fileHeader ->
@@ -196,6 +201,8 @@ object MainIndexMetaHelpers {
                     // less or equal to the existing modified timestamp), we only want to update the
                     // TAGs if the record is "new"
                     if (n > 0L) {
+                        written.add(fileHeader)
+
                         db.driveTagIndexQueries.deleteByFile(
                             identityId = identityId,
                             driveId = driveId,
@@ -247,6 +254,7 @@ object MainIndexMetaHelpers {
                     }
                 }
             }
+            return written
         }
 
         /**
@@ -263,8 +271,8 @@ object MainIndexMetaHelpers {
             driveId: Uuid,
             fileHeader: HomebaseFile,
             cursor: QueryBatchCursor?
-        ) {
-            baseUpsertEntryZapZap(identityId, driveId, listOf(fileHeader), cursor)
+        ): List<HomebaseFile> {
+            return baseUpsertEntryZapZap(identityId, driveId, listOf(fileHeader), cursor)
         }
     }
 }

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveWebSocketUpsertWorkerTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveWebSocketUpsertWorkerTest.kt
@@ -308,6 +308,52 @@ class DriveWebSocketUpsertWorkerTest {
     }
 
     @Test
+    fun submit_stalePush_doesNotEmitBatchReceived() = runBlocking {
+        // A push the DriveMainIndex timestamp guard rejects (older `updated`
+        // than what we already hold — e.g. the half-stale `statisticsChanged`
+        // fan-out copy) must not produce a BatchReceived: the worker emits only
+        // the rows that actually wrote. Mapping the rejected payload otherwise
+        // paints it into the UI for a frame (the reaction-highlight blink).
+        val identityId = Uuid.random()
+        val driveId = Uuid.random()
+        val eventBus = EventBus()
+
+        val collected = mutableListOf<BackendEvent.DataEvent.BatchReceived>()
+        val collector = launch {
+            eventBus.events.collect { event ->
+                if (event is BackendEvent.DataEvent.BatchReceived) collected.add(event)
+            }
+        }
+        delay(20)
+
+        val worker = DriveWebSocketUpsertWorker(
+            identityId = identityId,
+            driveId = driveId,
+            databaseManager = db,
+            eventBus = eventBus,
+            scope = workerScope,
+        )
+
+        val fileId = Uuid.random()
+        val uniqueId = Uuid.random()
+
+        // Establish the current row (newer timestamp) — emits one batch.
+        worker.submit(makeFile(fileId, driveId, uniqueId, updatedMs = 2_000_000_000_000L))
+        withTimeoutOrNull(5.seconds) { while (collected.isEmpty()) delay(20) }
+
+        // Stale push: same fileId, older `updated` → rejected by the guard.
+        worker.submit(makeFile(fileId, driveId, uniqueId, updatedMs = 1_000_000_000_000L))
+        delay(300) // give any emit a chance to (not) happen
+
+        assertEquals(
+            1, collected.size,
+            "stale push rejected by the guard must not emit a second BatchReceived (got ${collected.size})",
+        )
+
+        collector.cancel()
+    }
+
+    @Test
     fun cancel_doesNotProduceMoreThanOneBatch() = runBlocking {
         val identityId = Uuid.random()
         val driveId = Uuid.random()
@@ -350,6 +396,7 @@ class DriveWebSocketUpsertWorkerTest {
         fileId: Uuid,
         driveId: Uuid,
         uniqueId: Uuid = Uuid.random(),
+        updatedMs: Long = Clock.System.now().epochSeconds * 1000,
     ): HomebaseFile {
         val now = Clock.System.now().epochSeconds
         val json = """{
@@ -365,7 +412,7 @@ class DriveWebSocketUpsertWorkerTest {
             "fileMetadata": {
                 "globalTransitId": "${Uuid.random()}",
                 "created": ${now}000,
-                "updated": ${now}000,
+                "updated": $updatedMs,
                 "transitCreated": 0,
                 "transitUpdated": 0,
                 "serverFileIsEncrypted": true,

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/MainIndexMetaTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/MainIndexMetaTest.kt
@@ -1,6 +1,7 @@
 package id.homebase.api.sync.database
 
 import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.client.drives.files.LocalAppMetadata
 import id.homebase.api.client.drives.query.QueryBatchCursor
 import id.homebase.api.client.drives.query.TimeRowCursor
 import id.homebase.api.common.time.UnixTimeUtc
@@ -905,6 +906,125 @@ class MainIndexMetaTest {
             val totalRecords = dbm.driveMainIndex.countAll()
             assertEquals(
                 1L, totalRecords, "Should still have 1 record after fileId conflict update"
+            )
+        }
+    }
+
+    /**
+     * Blink fix (DB-return half): a stale push — older `updated` than what we
+     * already hold — is rejected by the DriveMainIndex timestamp guard, so it
+     * must NOT appear in the returned written list (callers emit BatchReceived
+     * from that list, so a rejected push never reaches the UI), and it must
+     * leave the existing row untouched.
+     */
+    @Test
+    fun performBaseUpsert_stalePush_returnsEmpty_andLeavesRowIntact() = runTest {
+        DatabaseManager({ createInMemoryDatabase() }).use { dbm ->
+            val identityId = Uuid.random()
+            val driveId = Uuid.random()
+            val fileId = Uuid.random()
+            val uniqueId = Uuid.random()
+            val processor = MainIndexMetaHelpers.HomebaseFileProcessor(dbm)
+
+            val current = makeHeader(
+                fileId, driveId, uniqueId,
+                updatedMs = 2_000L,
+                localReactions = listOf("""{"emoji":"👍"}"""),
+            )
+            assertEquals(1, processor.baseUpsertEntryZapZap(identityId, driveId, current, null).size)
+
+            // Older `updated`, and (like the half-stale statisticsChanged push)
+            // a localReactions that lags the current state.
+            val stale = makeHeader(
+                fileId, driveId, uniqueId,
+                updatedMs = 1_000L,
+                localReactions = emptyList(),
+            )
+            val written = processor.baseUpsertEntryZapZap(identityId, driveId, stale, null)
+
+            assertEquals(0, written.size, "a stale (older-updated) push must not be written")
+            val stored = dbm.driveMainIndex.selectHomebaseFileByUnique(identityId, driveId, uniqueId)
+            assertNotNull(stored)
+            assertEquals(
+                listOf("""{"emoji":"👍"}"""),
+                stored.fileMetadata.localAppData?.localReactions,
+                "the rejected stale push must not alter the stored row",
+            )
+        }
+    }
+
+    /**
+     * Build a minimal [HomebaseFile] with a controllable `updated` timestamp and
+     * an optional `localAppData.localReactions` mirror. localReactions == null
+     * mirrors a server/WS header (which never carries the local-only field).
+     */
+    private fun makeHeader(
+        fileId: Uuid,
+        driveId: Uuid,
+        uniqueId: Uuid,
+        updatedMs: Long,
+        localReactions: List<String>?,
+    ): HomebaseFile {
+        val json = """{
+            "fileId": "${fileId}",
+            "driveId": "${driveId}",
+            "fileState": "active",
+            "fileSystemType": "standard",
+            "serverFileIsEncrypted":"true",
+            "keyHeader" : {
+                "iv" : [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ],
+                "aesKey" : { "bytes" : [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ] }
+            },
+            "fileMetadata": {
+                "globalTransitId": "${Uuid.random()}",
+                "created": $updatedMs,
+                "updated": $updatedMs,
+                "transitCreated": 0,
+                "transitUpdated": 0,
+                "serverFileIsEncrypted": true,
+                "senderOdinId": "test.sender",
+                "originalAuthor": "test.sender",
+                "appData": {
+                    "uniqueId": "${uniqueId}",
+                    "tags": null,
+                    "fileType": 1,
+                    "dataType": 1,
+                    "groupId": null,
+                    "userDate": $updatedMs,
+                    "content": "test content",
+                    "archivalStatus": 1
+                },
+                "localAppData": null,
+                "referencedFile": null,
+                "reactionPreview": null,
+                "versionTag": "1355aa19-2031-d800-403d-e8696a8be494",
+                "payloads": [],
+                "dataSource": null
+            },
+            "serverMetadata": {
+                "accessControlList": {
+                    "requiredSecurityGroup": "owner",
+                    "circleIdList": null,
+                    "odinIdList": null
+                },
+                "doNotIndex": false,
+                "allowDistribution": false,
+                "fileSystemType": "standard",
+                "fileByteCount": 1000,
+                "originalRecipientCount": 0,
+                "transferHistory": null
+            },
+            "priority": 300,
+            "fileByteCount": 1000
+        }"""
+        val base = OdinSystemSerializer.deserialize<HomebaseFile>(json)
+        return if (localReactions == null) {
+            base
+        } else {
+            base.copy(
+                fileMetadata = base.fileMetadata.copy(
+                    localAppData = LocalAppMetadata(localReactions = localReactions),
+                )
             )
         }
     }


### PR DESCRIPTION
Adding or removing a reaction made the own-reaction highlight briefly blink off and back on — a ~1-frame flicker, most visible on Android.

Root cause: for a single reaction the server fans out two WebSocket notifications with the same versionTag — a `statisticsChanged` whose `localReactions`/`updated` are stale (a snapshot from before the reaction committed) and a correct `fileModified`. The DriveMainIndex timestamp guard correctly REJECTS the stale `statisticsChanged` (older `updated`), so it never persists. But DriveWebSocketUpsertWorker emitted BatchReceived from the raw incoming batch regardless, and ChatMessageStream.processIncrementalBatch maps that wire payload straight into the message list — so the rejected push (carrying a stale own-reaction set) painted for one frame before the correct push landed.

Fix: make the upsert report what it actually wrote, and surface only that to the UI.
- MainIndexMeta.performBaseUpsert / baseUpsertEntryZapZap now return the headers that passed the timestamp guard (n > 0).
- DriveWebSocketUpsertWorker emits BatchReceived from that written list and skips the emit entirely when nothing changed. The UI now reflects only authoritative DB writes; guard-rejected stale/duplicate pushes are dropped, which also collapses the server's per-write fan-out duplicates.

No special-casing of reaction fields and no extra DB reads on the sync hot path. Verified on the Android emulator (no blink; log showed the stale statisticsChanged being skipped).

Tests:
- MainIndexMetaTest: a stale (older-updated) push returns an empty written list and leaves the stored row intact.
- DriveWebSocketUpsertWorkerTest: a stale push emits no second BatchReceived.

Server-side follow-ups (tracked separately): the stale statisticsChanged payload, the localReactions ownership/wiring inconsistency, the two-events-per-reaction (statisticsChanged + fileModified) behaviour, and the existing per-write fan-out duplication.