### PR TITLE
Clear compiler warnings in crypto and UI

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/link/LinkPreviewProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/link/LinkPreviewProvider.kt
@@ -35,7 +35,7 @@ class LinkPreviewProvider(
 
         throwForFailure(response)
 
-        return deserialize<LinkPreview>(response.body)?.sanitize()
+        return deserialize<LinkPreview>(response.body).sanitize()
     }
 
     companion object {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/crypto/PureKotlinSha256.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/crypto/PureKotlinSha256.kt
@@ -15,21 +15,21 @@ package id.homebase.api.crypto
 internal object PureKotlinSha256 {
 
     private val K = intArrayOf(
-        0x428a2f98.toInt(), 0x71374491.toInt(), -0x4a3f0431, -0x164a245b,
-        0x3956c25b.toInt(), 0x59f111f1.toInt(), -0x6dc07d5c, -0x54e3a12b,
-        -0x27f85568, 0x12835b01.toInt(), 0x243185be.toInt(), 0x550c7dc3.toInt(),
-        0x72be5d74.toInt(), -0x7f214e02, -0x6423f959, -0x3e640e8c,
-        -0x1b64963f, -0x1041b87a, 0x0fc19dc6.toInt(), 0x240ca1cc.toInt(),
-        0x2de92c6f.toInt(), 0x4a7484aa.toInt(), 0x5cb0a9dc.toInt(), 0x76f988da.toInt(),
+        0x428a2f98, 0x71374491, -0x4a3f0431, -0x164a245b,
+        0x3956c25b, 0x59f111f1, -0x6dc07d5c, -0x54e3a12b,
+        -0x27f85568, 0x12835b01, 0x243185be, 0x550c7dc3,
+        0x72be5d74, -0x7f214e02, -0x6423f959, -0x3e640e8c,
+        -0x1b64963f, -0x1041b87a, 0x0fc19dc6, 0x240ca1cc,
+        0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
         -0x67c1aeae, -0x57ce3993, -0x4ffcd838, -0x40a68039,
-        -0x391ff40d, -0x2a586eb9, 0x06ca6351.toInt(), 0x14292967.toInt(),
-        0x27b70a85.toInt(), 0x2e1b2138.toInt(), 0x4d2c6dfc.toInt(), 0x53380d13.toInt(),
-        0x650a7354.toInt(), 0x766a0abb.toInt(), -0x7e3d36d2, -0x6d8dd37b,
+        -0x391ff40d, -0x2a586eb9, 0x06ca6351, 0x14292967,
+        0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+        0x650a7354, 0x766a0abb, -0x7e3d36d2, -0x6d8dd37b,
         -0x5d40175f, -0x57e599b5, -0x3db47490, -0x3893ae5d,
-        -0x2e6d17e7, -0x2966f9dc, -0xbf1ca7b, 0x106aa070.toInt(),
-        0x19a4c116.toInt(), 0x1e376c08.toInt(), 0x2748774c.toInt(), 0x34b0bcb5.toInt(),
-        0x391c0cb3.toInt(), 0x4ed8aa4a.toInt(), 0x5b9cca4f.toInt(), 0x682e6ff3.toInt(),
-        0x748f82ee.toInt(), 0x78a5636f.toInt(), -0x7b3787ec, -0x7338fdf8,
+        -0x2e6d17e7, -0x2966f9dc, -0xbf1ca7b, 0x106aa070,
+        0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+        0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, -0x7b3787ec, -0x7338fdf8,
         -0x6f410006, -0x5baf9315, -0x41065c09, -0x398e870e,
     )
 
@@ -45,10 +45,10 @@ internal object PureKotlinSha256 {
             padded[padded.size - 1 - i] = (bitLen ushr (i * 8)).toByte()
         }
 
-        var h0 = 0x6a09e667.toInt(); var h1 = -0x4498517b
-        var h2 = 0x3c6ef372.toInt(); var h3 = -0x5ab00ac6
-        var h4 = 0x510e527f.toInt(); var h5 = -0x64fa9774
-        var h6 = 0x1f83d9ab.toInt(); var h7 = 0x5be0cd19.toInt()
+        var h0 = 0x6a09e667; var h1 = -0x4498517b
+        var h2 = 0x3c6ef372; var h3 = -0x5ab00ac6
+        var h4 = 0x510e527f; var h5 = -0x64fa9774
+        var h6 = 0x1f83d9ab; var h7 = 0x5be0cd19
 
         val w = IntArray(64)
         var chunk = 0

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultScreen.kt
@@ -146,6 +146,7 @@ fun VaultScreen(
         onDispose { viewModel.onAction(VaultUiAction.CloseOverlay) }
     }
 
+    @Suppress("DEPRECATION")
     BackHandler(enabled = uiState.fullScreenOverlay != null) {
         viewModel.onAction(VaultUiAction.CloseOverlay)
     }


### PR DESCRIPTION
Cleans up the warnings surfaced by a forced recompile of the Android and Desktop code paths. No behavior changes.

- PureKotlinSha256: drop the redundant `.toInt()` on the SHA-256 K-table and h0..h7 init constants. Those hex literals (top digit 0-7) already fit in a positive Int, so the conversion was a no-op — the high-bit constants were already written as negative hex without it. Resulting bytecode is identical; the FIPS 180-4 vector and sync==async parity tests in PureKotlinSha256Test still pass.

- LinkPreviewProvider: remove the unnecessary safe call in `deserialize<LinkPreview>(response.body)?.sanitize()`. The generic `deserialize<T>` returns a non-null T, so `?.` was dead.

- VaultScreen: add `@Suppress("DEPRECATION")` to the lone BackHandler call site that was missing it. Every other site (SettingsScreen, DefragmenterScreen, ConversationContent, ConversationListScreen, ...) already carries it; the androidx.compose.ui.backhandler.BackHandler -> NavigationEventHandler migration is intentionally deferred, so this just restores consistency.