### PR TITLE
Fix scroll-to-bottom FAB stalling when paged deep into history

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -155,6 +155,12 @@ class ConversationListViewModel(
     val messageInputTextState = RichTextState().applyDefaultStyling()
     private var currentConversationJob: Job? = null
 
+    // Conversations whose next message emission should land the user at the
+    // newest message (set by the ScrollToLatest action, consumed once in the
+    // message-emission collect block below). Per-conversation so rapid
+    // conversation switches can't cross-fire a scroll.
+    private val pendingScrollToLatest = mutableSetOf<Uuid>()
+
     private val mediaDownloadHandler = MediaDownloadHandler(
         scope = viewModelScope,
         uiState = _uiState,
@@ -781,6 +787,14 @@ class ConversationListViewModel(
             }
 
             is ConversationListUiAction.ScrollToLatest -> {
+                // Mark the reload as scroll-to-latest BEFORE loading: when the
+                // user is paged deep into history (hasNewerMessages == true) the
+                // loaded window's bottom isn't the real latest message, so we
+                // reload the newest page. The next observeMessages emission for
+                // this conversation then resolves a triggerScroll bottom anchor
+                // (see resolveScrollToLatestPosition) instead of leaving the
+                // listState parked at its stale history index.
+                pendingScrollToLatest.add(action.conversationId)
                 viewModelScope.launch { chatMessageStream.loadConversation(action.conversationId) }
             }
 
@@ -1232,20 +1246,33 @@ class ConversationListViewModel(
                                 null
                             }
 
-                            val newScroll = if (indexOfMessageForScroll == null) {
-                                if (setInitialScroll && !scrollToBottom) {
+                            val newScroll = when {
+                                // ScrollToLatest reload: the user tapped the
+                                // scroll-to-bottom FAB while paged into history.
+                                // .remove() consumes the flag once and reports
+                                // whether it was set. Land on the newest message.
+                                pendingScrollToLatest.remove(conversationId) -> {
+                                    Logger.i("Scroll-to-latest: landing at newest message")
+                                    resolveScrollToLatestPosition(messagesModels)
+                                }
+
+                                indexOfMessageForScroll != null -> {
+                                    Logger.i("Setting scroll position: $indexOfMessageForScroll")
+                                    ScrollPosition(
+                                        firstVisibleItemIndex = indexOfMessageForScroll,
+                                        triggerScroll = true
+                                    )
+                                }
+
+                                setInitialScroll && !scrollToBottom -> {
                                     Logger.i("Getting saved scroll position")
                                     getScrollPosition(conversationId, messagesModels)
-                                } else {
+                                }
+
+                                else -> {
                                     Logger.i("No saved scroll position")
                                     null
                                 }
-                            } else {
-                                Logger.i("Setting scroll position: $indexOfMessageForScroll")
-                                ScrollPosition(
-                                    firstVisibleItemIndex = indexOfMessageForScroll,
-                                    triggerScroll = true
-                                )
                             }
 
                             // Persist the anchor only when we just landed on a freshly

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ScrollAnchorResolver.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ScrollAnchorResolver.kt
@@ -1,5 +1,6 @@
 package id.homebase.chat.conversationlist
 
+import id.homebase.core.util.ScrollPosition
 import kotlin.uuid.Uuid
 
 /**
@@ -56,4 +57,26 @@ internal fun resolveAnchorIndex(
         i++
     }
     return null
+}
+
+/**
+ * After a "scroll to latest" reload swaps the in-memory window to the newest
+ * page, the Pane's [androidx.compose.foundation.lazy.LazyListState] still
+ * points at the stale history index it had while the user was paged backwards.
+ * Produce an explicit bottom anchor (`triggerScroll = true`) at the last
+ * message so [id.homebase.chat.widget.ConversationMessagesPane]'s
+ * scroll-trigger effect jumps to the newest message instead of leaving the
+ * user mid-window. Returns `null` when there are no message rows to land on.
+ *
+ * Walks back from the end to the last [MessageListContentModel.Message] rather
+ * than using `lastIndex`: after the reload `hasNewerMessages` is false so there
+ * is no trailing `LoadingNewer` row, but this stays correct even if the model
+ * list ever ends in a separator or other non-message row.
+ */
+internal fun resolveScrollToLatestPosition(
+    messages: List<MessageListContentModel>,
+): ScrollPosition? {
+    val lastMessageIndex = messages.indexOfLast { it is MessageListContentModel.Message }
+    if (lastMessageIndex < 0) return null
+    return ScrollPosition(firstVisibleItemIndex = lastMessageIndex, triggerScroll = true)
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -1133,8 +1133,15 @@ fun ConversationContent(
                                     // Deep in history: the bottom of the loaded
                                     // window isn't the latest message, so a plain
                                     // animateScrollToItem(last) would land mid-history.
-                                    // Reload the latest page instead — the existing
-                                    // auto-follow then snaps the user to the bottom.
+                                    // Reload the latest page instead — the VM marks
+                                    // the reload pending-scroll-to-latest and the
+                                    // resulting emission carries a triggerScroll
+                                    // bottom anchor (resolveScrollToLatestPosition)
+                                    // that ConversationMessagesPane scrolls to.
+                                    // (Auto-follow can't do this: it only fires on
+                                    // list growth while already at the bottom, but
+                                    // this reload shrinks the window from up in
+                                    // history.)
                                     onUiAction(ConversationListUiAction.ScrollToLatest(conversation.conversation.id))
                                 } else {
                                     coroutineScope.launch {

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/ScrollToLatestResolverTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/ScrollToLatestResolverTest.kt
@@ -1,0 +1,117 @@
+package id.homebase.chat.conversationlist
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.common.OdinId
+import id.homebase.chat.data.MessageUiModel
+import id.homebase.chat.services.MessageAppData
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * Covers [resolveScrollToLatestPosition], the bottom-anchor producer behind the
+ * scroll-to-bottom FAB's "deep in history" branch.
+ *
+ * Bug: when the user was paged backwards far enough that the window trimmed
+ * (`hasNewerMessages == true`), tapping the FAB reloaded the latest page but
+ * never scrolled — the listState stayed parked at its stale history index and
+ * the user landed mid-window. The fix has the VM mark the reload and resolve a
+ * `triggerScroll` bottom anchor on the next emission; these tests lock that the
+ * anchor points at the newest message (and that it degrades to null when there
+ * is nothing to land on).
+ */
+class ScrollToLatestResolverTest {
+
+    private val alice = OdinId("alice.test")
+    private val baseTime = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+
+    private fun message(id: Uuid = Uuid.random()): MessageListContentModel.Message =
+        MessageListContentModel.Message(
+            message = MessageUiModel(
+                id = id,
+                globalTransitId = null,
+                fileId = Uuid.random(),
+                conversationId = Uuid.random(),
+                content = "test",
+                userDate = baseTime,
+                modified = null,
+                created = baseTime,
+                originalAuthor = alice,
+                sender = alice,
+                displayName = alice.domainName,
+                localReadTimestamp = null,
+                isDeleted = false,
+                isPendingSend = false,
+                versionTag = Uuid.NIL,
+                messageAppData = MessageAppData(),
+                reactionPreview = null,
+                previewThumbnail = null,
+                payloads = null,
+                keyHeader = KeyHeader.empty(),
+                hasMore = false,
+            ),
+        )
+
+    @Test
+    fun deepHistoryReload_landsOnNewestMessage() {
+        // The realistic model list the VM produces right after a ScrollToLatest
+        // reload: a LoadingOlder spinner (older pages still exist), a date
+        // Section, then the freshly loaded newest messages. Crucially there is
+        // NO trailing LoadingNewer row, because the reload set
+        // hasNewerMessages = false — so the last row IS the latest message.
+        val newest = message()
+        val models = listOf<MessageListContentModel>(
+            MessageListContentModel.LoadingOlder,
+            MessageListContentModel.Section(date = kotlinx.datetime.LocalDate(2026, 1, 1)),
+            message(),
+            message(),
+            newest,
+        )
+
+        val pos = resolveScrollToLatestPosition(models)
+
+        // Pre-fix the ScrollToLatest path produced no scroll position at all
+        // (null), so the user stayed mid-window. It must now point at the bottom.
+        assertNotNull(pos)
+        assertEquals(models.lastIndex, pos.firstVisibleItemIndex)
+        assertEquals(newest.message.id, (models[pos.firstVisibleItemIndex] as MessageListContentModel.Message).message.id)
+        assertTrue(pos.triggerScroll)
+    }
+
+    @Test
+    fun trailingNonMessageRow_resolvesToLastMessageNotTheTrailingRow() {
+        // Defensive: even if a non-message row ever sits after the last message,
+        // the anchor must be the last MESSAGE, never the trailing row.
+        val newest = message()
+        val models = listOf<MessageListContentModel>(
+            MessageListContentModel.Header,
+            newest,
+            MessageListContentModel.LoadingNewer,
+        )
+
+        val pos = resolveScrollToLatestPosition(models)
+
+        assertNotNull(pos)
+        assertEquals(1, pos.firstVisibleItemIndex)
+        assertEquals(newest.message.id, (models[pos.firstVisibleItemIndex] as MessageListContentModel.Message).message.id)
+        assertTrue(pos.triggerScroll)
+    }
+
+    @Test
+    fun noMessageRows_returnsNull() {
+        val models = listOf<MessageListContentModel>(
+            MessageListContentModel.Header,
+            MessageListContentModel.UnreadSeparator,
+        )
+        assertNull(resolveScrollToLatestPosition(models))
+    }
+
+    @Test
+    fun emptyList_returnsNull() {
+        assertNull(resolveScrollToLatestPosition(emptyList()))
+    }
+}


### PR DESCRIPTION
When the user scrolled far enough up that the in-memory window trimmed (MAX_WINDOW_SIZE = 300, hasNewerMessages = true) or reopened a conversation at a deep saved anchor, tapping the scroll-to-bottom FAB landed them mid-conversation instead of at the newest message. A second tap "worked".

Root cause: the FAB's hasNewerMessages branch dispatches ScrollToLatest, whose handler only called chatMessageStream.loadConversation() to swap the in-memory window to the newest page. Nothing then scrolled the LazyColumn:

  - loadConversation does not toggle isLoadingMessages, so the Pane's listState = remember(conversationId, isLoadingMessages) is not recreated with the Int.MAX_VALUE bottom sentinel.
  - The resulting emission has setInitialScroll already false (the conversation is open), so newScroll resolved to null.
  - The auto-follow effect only fires on list GROWTH while the user was at the bottom; here the list shrinks (<=300 -> ~75) while the user is up in history, so it never fires.

The listState therefore kept its stale firstVisibleItemIndex and the user landed mid-window. The second tap succeeded only because hasNewerMessages was false by then, taking the working animateScrollToItem(last) path.

Fix: route ScrollToLatest through the existing scrollPosition.triggerScroll mechanism that ConversationMessagesPane already honors.

  - ScrollAnchorResolver: new pure resolveScrollToLatestPosition(models) returning a triggerScroll anchor at the last message row (walks back to the last Message, defensive against a trailing non-message row).
  - ConversationListViewModel: pendingScrollToLatest set, marked by the ScrollToLatest handler before reloading and consumed once in the message-emission newScroll resolution. While hasNewerMessages is true the stream gates upserts and refreshCachedWindows skips the window, so the next emission is guaranteed to be the freshly loaded latest page.
  - ConversationContent: corrected the misleading auto-follow comment.

Test: ScrollToLatestResolverTest (pure JVM) locks that a realistic post-reload model list resolves to the newest message with triggerScroll = true (previously the path produced null), skips a trailing non-message row, and returns null when there are no message rows.