### PR TITLE
refactor(chat): drop by-fileId WS fan-out de-dupe and its warnings

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveWebSocketUpsertWorker.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveWebSocketUpsertWorker.kt
@@ -109,30 +109,6 @@ class DriveWebSocketUpsertWorker(
             snapshot
         }
 
-        // ╔════════════════════════════════════════════════════════════════╗
-        // ║  HACK detection — REMOVE ONCE THE SERVER STOPS FAN-OUT-PER-   ║
-        // ║  WRITE                                                         ║
-        // ║                                                                ║
-        // ║  TODO(server): the chat-drive WS currently emits N             ║
-        // ║  notifications (typically 3) per logical file write — same     ║
-        // ║  fileId, same versionTag, same content, just delivered         ║
-        // ║  multiple times. The DB upsert is idempotent so correctness    ║
-        // ║  isn't affected, but we redundantly decrypt + upsert. This     ║
-        // ║  warning is the canary so we don't forget to fix it on the    ║
-        // ║  backend.                                                      ║
-        // ║                                                                ║
-        // ║  When the server-side fix lands: delete this block.            ║
-        // ╚════════════════════════════════════════════════════════════════╝
-        val uniqueFileIds = batch.mapTo(HashSet()) { it.fileId }
-        if (uniqueFileIds.size != batch.size) {
-            Logger.w {
-                "WSPush: HACK detected ${batch.size - uniqueFileIds.size} duplicate file(s) " +
-                    "in batch drive=$driveId rows=${batch.size} unique=${uniqueFileIds.size} " +
-                    "(server fan-out workaround — same fileId delivered multiple times). " +
-                    "TODO(server): stop fan-out-per-write."
-            }
-        }
-
         try {
             val (written, upsertElapsed) = measureTimedValue {
                 fileHeaderProcessor.baseUpsertEntryZapZap(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -349,44 +349,17 @@ class ConversationStream(
         if (messageFiles.size != incoming.size)
             Logger.w("ConversationStream: ${messageFiles.size - incoming.size} of ${messageFiles.size} messages failed to convert")
 
-        // ╔══════════════════════════════════════════════════════════════╗
-        // ║  HACK ── REMOVE ONCE THE SERVER STOPS FAN-OUT-PER-WRITE      ║
-        // ║                                                              ║
-        // ║  TODO(server): the chat-drive WS currently emits N           ║
-        // ║  notifications (typically 3) per logical file write — same   ║
-        // ║  uniqueId, same versionTag, same content, just delivered     ║
-        // ║  multiple times. Suspected cause: multi-stage server-side    ║
-        // ║  processing or duplicated subscription registration.         ║
-        // ║                                                              ║
-        // ║  Downstream caches dedupe naturally:                         ║
-        // ║    • [DriveMainIndex] upsert is idempotent on uniqueId.      ║
-        // ║    • [PaginatedConversationState.upsert] collapses by        ║
-        // ║      `m.id`.                                                 ║
-        // ║                                                              ║
-        // ║  But the per-message side effects in this loop (unread bump  ║
-        // ║  via [applyIncomingMessageBump], orphan placeholder, deleted-║
-        // ║  conversation revive, auto-unarchive) would otherwise fire   ║
-        // ║  N times per logical message — N-x over-counting unread      ║
-        // ║  observable in homebase.log as repeated `unread++` lines all ║
-        // ║  carrying the same convo id within a millisecond.            ║
-        // ║                                                              ║
-        // ║  Until the server is fixed, we collapse the batch by         ║
-        // ║  message id here. `associateBy` keeps the LAST occurrence on ║
-        // ║  key collision, which gives us the latest wire state.        ║
-        // ║                                                              ║
-        // ║  When the server-side fix lands: delete this block and the   ║
-        // ║  loop should iterate `incoming` directly.                    ║
-        // ╚══════════════════════════════════════════════════════════════╝
-        val deduped = incoming.associateBy { (_, m) -> m.id }.values.toList()
-        if (deduped.size != incoming.size) {
-            Logger.w(
-                "ConversationStream: HACK dedupe — dropped ${incoming.size - deduped.size} " +
-                    "duplicate message file(s) from batch (server fan-out workaround; " +
-                    "kept ${deduped.size} unique by id)"
-            )
-        }
-
-        for ((file, m) in deduped) {
+        // Process every incoming event — no by-id de-dupe. The chat-drive WS can
+        // legitimately deliver two *distinct* events for one logical write (e.g. a
+        // reaction emits fileModified + statisticsChanged with the same uniqueId);
+        // collapsing by id would silently drop a real event. Re-processing a
+        // same-id event is safe here: each branch below re-reads
+        // `matchingConversation` from live `_conversations.value`, so unarchive /
+        // revive / orphan-placeholder no-op on the second pass, and the unread bump
+        // is guarded by `sqlUserDate <= latestMessageTimestamp` in
+        // [applyIncomingMessageBump], so re-emits carrying the original message's
+        // userDate never double-count.
+        for ((file, m) in incoming) {
             val matchingConversation = _conversations.value.items.find { it.id == m.conversationId }
 
             // Drop messages for conversations the user has left or been removed from


### PR DESCRIPTION
The chat-drive WS used to fan out 5–6 byte-identical copies per write, so the client collapsed incoming batches by fileId/message-id as a workaround (with "HACK detected duplicate" / "HACK dedupe" warnings as canaries). The server no longer does that.

What remains is legitimate: one logical write can produce two *distinct* events with the same uniqueId — a reaction emits `fileModified` (header / localReactions change) plus `statisticsChanged` (reactionPreview aggregate change), each a full header snapshot with its own `updated`. Collapsing those by id is now a guess that "same fileId can be ignored," which would silently drop a real event — exactly the disaster the canary was meant to catch.

Remove the by-id collapse so every incoming event is processed:
- DriveWebSocketUpsertWorker: delete the `uniqueFileIds` "HACK detected duplicate" warning block (it was logging-only).
- ConversationStream: delete the `associateBy { m.id }` collapse and its "HACK dedupe" warning; the loop now iterates `incoming` directly.

Re-processing a same-id event is safe, so this needs no extra guard:
- each branch re-reads `matchingConversation` from live `_conversations.value`, so auto-unarchive / deleted-conversation revive / orphan-placeholder no-op on the second pass; and
- the unread bump is already guarded by `sqlUserDate <= latestMessageTimestamp` in applyIncomingMessageBump, so re-emits carrying the original message's userDate never double-count.

Left intact: `PaginatedConversationState.upsert`'s `byId[msg.id] = msg` merge — that's the in-place window update (newest snapshot wins), not a fan-out guess. The DriveMainIndex timestamp guard remains the authority on which snapshot persists.

Only cost: a little redundant work on the conversation-list path while the server still sends two events per reaction; harmless, and it disappears if the server collapses to one event. homebase-api + homebase-chat JVM suites pass.