### PR TITLE
Clear all in-memory caches on logout

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/eventbus/BackendEvent.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/eventbus/BackendEvent.kt
@@ -212,6 +212,17 @@ sealed interface BackendEvent {
     data object ConnectionOnline : BackendEvent
     data object ConnectionOffline : BackendEvent
 
+    /**
+     * Emitted once when the user logs out (authState → Unauthenticated), AFTER the
+     * WebSocket and DriveSync have been torn down so no producer can re-populate
+     * afterwards. Stateful singletons (ConversationStream, ChatMessageStream, the
+     * contact/connection/moments/vault services, …) listen for this and clear their
+     * own in-memory per-identity caches, mirroring the SQL DB wipe in
+     * [id.homebase.api.youauth.YouAuthFlowManager.logout]. Decentralised by design:
+     * each service owns its teardown instead of logout() reaching into all of them.
+     */
+    data object SessionEnded : BackendEvent
+
     // A drive subscription was rejected by the server (non-fatal — other drives still sync)
     data class DriveAuthorizationFailed(val message: String) : BackendEvent
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -62,6 +62,8 @@ class ChatMessageStream(
         scope.launch {
             eventBus.events.collect { event ->
                 when (event) {
+                    // Logout: drop cached message windows for the previous identity.
+                    is BackendEvent.SessionEnded -> paginatedState.reset()
                     is BackendEvent.OutboxEvent.OptimisticRollback -> {
                         if (event.driveId == chatDrive) {
                             paginatedState.removeMessage(event.uniqueId)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/LocalVideoContextStore.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/LocalVideoContextStore.kt
@@ -1,10 +1,14 @@
 package id.homebase.chat.services
 
+import id.homebase.api.client.eventbus.BackendEvent
+import id.homebase.api.client.eventbus.EventBus
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import kotlin.uuid.Uuid
 
 /**
@@ -60,9 +64,28 @@ sealed interface LocalAttachmentContext {
     ) : LocalAttachmentContext
 }
 
-class LocalAttachmentContextStore {
+class LocalAttachmentContextStore(
+    eventBus: EventBus,
+    scope: CoroutineScope,
+) {
     private val _contexts =
         MutableStateFlow<Map<Uuid, Map<String, LocalAttachmentContext>>>(emptyMap())
+
+    init {
+        // Logout: drop the previous identity's outgoing-attachment previews
+        // (local file paths + thumbnail bytes) so they don't survive into the
+        // next session.
+        scope.launch {
+            eventBus.events.collect { event ->
+                if (event is BackendEvent.SessionEnded) reset()
+            }
+        }
+    }
+
+    /** Logout: clear all cached attachment previews. */
+    fun reset() {
+        _contexts.value = emptyMap()
+    }
 
     fun put(messageId: Uuid, payloadKey: String, context: LocalAttachmentContext) {
         _contexts.update { current ->

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/PaginatedConversationState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/PaginatedConversationState.kt
@@ -57,6 +57,16 @@ class PaginatedConversationState(
     private val _windows = MutableStateFlow<Map<Uuid, MessageWindow>>(emptyMap())
     val windows: StateFlow<Map<Uuid, MessageWindow>> = _windows.asStateFlow()
 
+    /**
+     * Drop every cached message window. Called on logout so the previous
+     * identity's open-conversation messages don't survive in memory into the
+     * next session; windows reload lazily via [setInitialWindow] when the user
+     * reopens a conversation.
+     */
+    fun reset() {
+        _windows.value = emptyMap()
+    }
+
     fun hasCachedMessages(conversationId: Uuid): Boolean =
         _windows.value.containsKey(conversationId)
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -197,6 +197,11 @@ class ConversationStream(
         scope.launch {
             eventBus.events.collect { event ->
                 when (event) {
+                    // Logout: drop the previous identity's conversation list so it
+                    // doesn't linger on the login screen or bleed into the next
+                    // session. The DB is wiped concurrently by logout(); this clears
+                    // the in-memory mirror. start() reloads cold on the next login.
+                    is BackendEvent.SessionEnded -> reset()
                     is BackendEvent.DriveEvent.Stopped -> {
                         if (event.driveId != chatDrive) return@collect
                         Logger.d("ConversationStream: Stopped(totalCount=${event.totalCount})")

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ConnectionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ConnectionService.kt
@@ -78,6 +78,8 @@ class ConnectionService(
                     // When the websocket comes back after an offline window, reconcile
                     // against the server — covers the airplane-mode-off case.
                     is BackendEvent.ConnectionOnline -> launchRefresh()
+                    // Logout: drop the previous identity's connection map.
+                    is BackendEvent.SessionEnded -> reset()
                     else -> {}
                 }
             }
@@ -91,6 +93,19 @@ class ConnectionService(
             hydrateFromCache()
             launchRefresh()
         }
+    }
+
+    /**
+     * Logout: cancel any in-flight refresh and drop the connection map back to
+     * the not-loaded state. Clearing `started` lets the next login's [start]
+     * re-hydrate from cache and re-fetch. The init eventBus collector is left
+     * running (it's app-scoped, single, and gates on the new session's events).
+     */
+    fun reset() {
+        refreshJob?.cancel()
+        refreshJob = null
+        started = false
+        _connections.value = ConnectionState(isLoaded = false, map = emptyMap())
     }
 
     private suspend fun hydrateFromCache() {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/DriveContactService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/DriveContactService.kt
@@ -89,7 +89,9 @@ class DriveContactService(
                 // Both branches scope.launch { refresh() } — never call refresh() inline:
                 // QueryBatch hangs on partial connectivity, which would park the EventBus
                 // buffer and cascade into stalling the chat Send path.
-                if (event is BackendEvent.DriveEvent.Stopped &&
+                if (event is BackendEvent.SessionEnded) {
+                    reset()
+                } else if (event is BackendEvent.DriveEvent.Stopped &&
                     event.driveId == contactDrive &&
                     event.totalCount > 0
                 ) {
@@ -105,6 +107,18 @@ class DriveContactService(
     }
 
     private var startJob: Job? = null
+
+    /**
+     * Logout: cancel any in-flight refresh and drop the previous identity's
+     * contacts. ContactService (which combines this flow) re-emits empty
+     * automatically. The next session repopulates via the contact-drive sync.
+     */
+    fun reset() {
+        startJob?.cancel()
+        startJob = null
+        _contacts.value = emptyList()
+        contactByOdinId.value = emptyMap()
+    }
 
     fun start() {
         if (startJob?.isActive == true) return

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/LocalAttachmentContextStoreFileExistenceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/LocalAttachmentContextStoreFileExistenceTest.kt
@@ -1,5 +1,8 @@
 package id.homebase.chat.services
 
+import id.homebase.api.client.eventbus.EventBus
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import java.io.File
@@ -15,7 +18,7 @@ import kotlin.uuid.Uuid
 @OptIn(ExperimentalUuidApi::class)
 class LocalAttachmentContextStoreFileExistenceTest {
 
-    private val store = LocalAttachmentContextStore()
+    private val store = LocalAttachmentContextStore(EventBus(), CoroutineScope(SupervisorJob()))
     private val messageId = Uuid.random()
     private val payloadKey = "vlt_pg_00"
 

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/LocalAttachmentContextStoreFileExistenceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/LocalAttachmentContextStoreFileExistenceTest.kt
@@ -1,9 +1,12 @@
 package id.homebase.chat.services
 
+import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import java.io.File
 import kotlin.test.Test
@@ -215,6 +218,32 @@ class LocalAttachmentContextStoreFileExistenceTest {
 
         assertNull(store.get(messageId, payloadKey))
         assertNotNull(store.get(otherMessageId, payloadKey))
+    }
+
+    // endregion
+
+    // region Logout (BackendEvent.SessionEnded) clears all cached previews
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun sessionEnded_clearsAllContexts() = runTest(UnconfinedTestDispatcher()) {
+        val eventBus = EventBus()
+        // Unconfined dispatcher so the store's init eventBus collector subscribes
+        // eagerly before we emit — exercising the real logout wiring, not just reset().
+        val store = LocalAttachmentContextStore(eventBus, backgroundScope)
+
+        val otherMessageId = Uuid.random()
+        store.put(messageId, "pg_00", image(createTempFile().absolutePath))
+        store.put(messageId, "pg_01", image(createTempFile().absolutePath))
+        store.put(otherMessageId, "pg_00", image(createTempFile().absolutePath))
+        assertTrue(store.hasAny(messageId))
+        assertTrue(store.hasAny(otherMessageId))
+
+        eventBus.emit(BackendEvent.SessionEnded)
+
+        assertFalse(store.hasAny(messageId), "logout must drop the previous identity's previews")
+        assertFalse(store.hasAny(otherMessageId))
+        assertTrue(store.getAll(messageId).isEmpty())
     }
 
     // endregion

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/PaginatedConversationStateTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/PaginatedConversationStateTest.kt
@@ -81,6 +81,24 @@ class PaginatedConversationStateTest {
     }
 
     @Test
+    fun reset_dropsAllCachedWindows() {
+        val state = PaginatedConversationState()
+        val otherConvoId = Uuid.parse("22222222-2222-2222-2222-222222222222")
+        state.setInitialWindow(convoId, listOf(message(userDateMs = 10, conversationId = convoId)))
+        state.setInitialWindow(otherConvoId, listOf(message(userDateMs = 20, conversationId = otherConvoId)))
+        assertTrue(state.hasCachedMessages(convoId))
+        assertTrue(state.hasCachedMessages(otherConvoId))
+
+        // Logout: every previous-identity window must be gone.
+        state.reset()
+
+        assertFalse(state.hasCachedMessages(convoId))
+        assertFalse(state.hasCachedMessages(otherConvoId))
+        assertNull(state.getWindow(convoId))
+        assertTrue(state.windows.value.isEmpty())
+    }
+
+    @Test
     fun prependOlderMessages_keepsAscendingOrder_andDedupesByMessageId() {
         val state = PaginatedConversationState()
         val mid = message(userDateMs = 50, conversationId = convoId)

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -147,6 +147,20 @@ class AuthConnectionCoordinator(
             is YouAuthState.Initializing -> {
                 // ignore
             }
+            is YouAuthState.Unauthenticated -> {
+                disconnect()
+                // The profile is loaded here on auth (loadProfile); clear it on the
+                // way out so the owner avatar/name doesn't bleed into the login screen
+                // or the next identity. AuthCC owns the profile lifecycle, so it clears
+                // it directly rather than over the bus.
+                ownerSessionRepository.clear()
+                // Broadcast session end so every stateful singleton clears its own
+                // in-memory caches (conversations, messages, contacts, moments,
+                // vault, …). Emitted AFTER disconnect() — WS is closed and DriveSync
+                // stopped — so nothing can re-populate after the services reset.
+                Logger.i(tag = "AuthLifecycle") { "AuthCC: emitting SessionEnded (logout)" }
+                eventBus.tryEmit(BackendEvent.SessionEnded)
+            }
             else -> {
                 disconnect()
             }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
@@ -2,6 +2,8 @@ package id.homebase.core.notifications
 
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.eventbus.BackendEvent
+import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.client.notifications.PushNotificationApi
 import id.homebase.api.client.notifications.PushSubscriptionResponse
 import id.homebase.api.client.profile.PublicProfileProviderCached
@@ -52,6 +54,7 @@ class NotificationService(
     private val credentialsManager: CredentialsManager,
     private val pendingNotificationTap: PendingNotificationTap,
     private val notificationBackend: NotificationBackend,
+    private val eventBus: EventBus,
 ) {
 
     private var isListening = false
@@ -94,6 +97,13 @@ class NotificationService(
                 if (id != null) conversationMessageCounts.remove(id.toString())
             }
         }
+        // Logout: drop per-conversation unread counts and the chime cooldown so the
+        // previous identity's notification summary state doesn't carry into the next.
+        scope.launch {
+            eventBus.events.collect { event ->
+                if (event is BackendEvent.SessionEnded) reset()
+            }
+        }
         // Route clicks from platform backends (Nucleus on JVM) through the shared
         // NotificationEntry so every platform's tap path lands in the same place,
         // with the same defensive-sync semantics. Lazy Koin lookup avoids a
@@ -107,6 +117,12 @@ class NotificationService(
     /** Clears the accumulated message count for a conversation (e.g. on mark-as-read). */
     fun clearNotificationCount(conversationId: String) {
         conversationMessageCounts.remove(conversationId)
+    }
+
+    /** Logout: clear all accumulated per-conversation counts and reset the chime cooldown. */
+    fun reset() {
+        conversationMessageCounts.clear()
+        lastAlertMark = TimeSource.Monotonic.markNow() - ALERT_COOLDOWN
     }
 
     /**

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentGroupService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentGroupService.kt
@@ -74,9 +74,15 @@ class MomentGroupService(
 
         scope.launch {
             eventBus.events.collect { event ->
-                if (event !is BackendEvent.DataEvent || event.driveId != drive) return@collect
-                if (event !is BackendEvent.DataEvent.BatchReceived) return@collect
-                processIncrementalBatch(event.batchData)
+                when (event) {
+                    // Logout: drop the previous identity's moment groups.
+                    is BackendEvent.SessionEnded -> reset()
+                    is BackendEvent.DataEvent.BatchReceived -> {
+                        if (event.driveId != drive) return@collect
+                        processIncrementalBatch(event.batchData)
+                    }
+                    else -> {}
+                }
             }
         }
     }
@@ -354,6 +360,16 @@ class MomentGroupService(
 
     private fun emitSorted() {
         _groups.value = byId.values.sortedBy { it.title.lowercase() }
+    }
+
+    /**
+     * Logout: drop the previous identity's moment groups. `started` is left set
+     * — the app-scoped eventBus collector stays alive and repopulates from the
+     * next session's moments-drive sync.
+     */
+    fun reset() {
+        byId.clear()
+        _groups.value = emptyList()
     }
 }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentsFeedService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentsFeedService.kt
@@ -78,6 +78,8 @@ class MomentsFeedService(
         scope.launch {
             eventBus.events.collect { event ->
                 when (event) {
+                    // Logout: drop the previous identity's moments feed.
+                    is BackendEvent.SessionEnded -> reset()
                     is BackendEvent.DataEvent.BatchReceived -> {
                         if (event.driveId != drive) return@collect
                         processIncrementalBatch(event.batchData)
@@ -228,6 +230,16 @@ class MomentsFeedService(
 
     private fun emitSorted() {
         _feed.value = byId.values.sortedByDescending { it.userDateMs }
+    }
+
+    /**
+     * Logout: drop the previous identity's moments. `started` is intentionally
+     * left set — the app-scoped eventBus collector stays alive and repopulates
+     * from the next session's moments-drive sync (DriveEvent.Stopped).
+     */
+    fun reset() {
+        byId.clear()
+        _feed.value = emptyList()
     }
 }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentsRecipientMruStore.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentsRecipientMruStore.kt
@@ -96,14 +96,25 @@ class MomentsRecipientMruStore(
         scope.launch {
             reloadFromLocal()
             eventBus.events.collect { event ->
-                if (event !is BackendEvent.DataEvent.BatchReceived) return@collect
-                if (event.driveId != drive) return@collect
-                val touches = event.batchData.any {
-                    it.fileMetadata.appData.uniqueId == MomentsProtocol.MomentsRecipientMruUniqueId
+                when (event) {
+                    // Logout: drop the previous identity's recent-recipients list.
+                    is BackendEvent.SessionEnded -> reset()
+                    is BackendEvent.DataEvent.BatchReceived -> {
+                        if (event.driveId != drive) return@collect
+                        val touches = event.batchData.any {
+                            it.fileMetadata.appData.uniqueId == MomentsProtocol.MomentsRecipientMruUniqueId
+                        }
+                        if (touches) reloadFromLocal()
+                    }
+                    else -> {}
                 }
-                if (touches) reloadFromLocal()
             }
         }
+    }
+
+    /** Logout: clear the in-memory MRU list for the previous identity. */
+    fun reset() {
+        _stableKeys.value = emptyList()
     }
 
     /**

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultStream.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultStream.kt
@@ -169,6 +169,8 @@ class VaultStream(
     private suspend fun observeEvents() {
         eventBus.events.collect { event ->
             when (event) {
+                // Logout: drop the previous identity's vault sections/entries.
+                is BackendEvent.SessionEnded -> reset()
                 is BackendEvent.DataEvent.BatchReceived -> {
                     if (event.driveId != driveId) return@collect
                     // Every BatchReceived is a live WS-push event (DriveSync is


### PR DESCRIPTION
## Problem

Logout wiped the encrypted SQL DB but left every per-identity **in-memory** cache intact in long-lived Koin singletons. The previous account's data therefore lingered after logout (e.g. the conversation list kept showing the prior user's conversations) and only cleared on a full app kill. As a side effect, the cold-start "initial sync / progress" login UI only appeared after a kill — never on a normal logout → login.

**Evidence:** after logout the DB wipe ran correctly (`wipeAndRecreate … page_count=32`, i.e. an empty schema), yet `ConversationListViewModel` kept emitting `enrichedCount=59` from the in-memory `ConversationStream` cache, and a fresh re-login found the local DB empty (note-to-self recreated → server "already exists") while the UI still showed stale data.

## Approach

A single logout signal that each stateful service reacts to **itself**, rather than `logout()` reaching into every service:

- New `BackendEvent.SessionEnded`, emitted once from `AuthConnectionCoordinator` on the `Unauthenticated` transition — **after** the WebSocket and DriveSync are torn down, so no producer can re-populate after services reset.
- Each stateful singleton clears its own in-memory state on that event, co-located with its load logic.
- `OwnerSessionRepository` is cleared directly by the coordinator (it owns profile load/unload).
- Derived services (`ContactService`, `MomentsRecipientLookupService`) need no changes — they re-emit empty automatically when their `combine` sources clear.

The WebSocket itself was already torn down correctly on logout (verified), so it isn't a re-population source.

## Services cleared

| Service | In-memory state cleared |
|---|---|
| `ConversationStream` | conversations, shareable list, deletedIds |
| `ChatMessageStream` | paginated message windows |
| `DriveContactService` | contacts, contactByOdinId |
| `ConnectionService` | connection map |
| `MomentsFeedService` / `MomentGroupService` | feed items / groups |
| `MomentsRecipientMruStore` | recent-recipient MRU |
| `VaultStream` | sections / entries |
| `NotificationService` | per-conversation unread counts, chime cooldown |
| `LocalAttachmentContextStore` | outgoing-attachment previews |
| `OwnerSessionRepository` | owner profile (name/avatar) |

## Result

- After logout, in-memory caches are empty → no stale data on the login screen or the next login.
- The cold-start login/progress UI now shows on a normal logout → login (no app kill needed).

## Verification

`./gradlew homebase-api:jvmTest homebase-common:jvmTest homebase-chat:jvmTest homebase-core:jvmTest --rerun-tasks` — all pass except 2 pre-existing `NotificationTapColdStartTest` cases that crash in Compose-Multiplatform's **desktop test-harness teardown** (`SkikoComposeUiTest.closeScene`). They fail identically on `main` and are unrelated to this change (CI-only excluded today); a proper fix is tracked separately.

## Notes

- The eventBus has `replay = 1`, so `SessionEnded` lingers as the last event until the next emit. In practice harmless (singleton collectors consume it once; login immediately emits more events; resets are idempotent) — flagged for awareness rather than hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
