### PR TITLE
Send v2 ws-token bearer as base64url (fixes browser/wasm SyntaxError)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
@@ -265,7 +265,15 @@ class OdinWebSocketClient(
         // two subprotocol values: the application protocol (which the server must
         // echo back in the 101) and a bearer credential of the form
         // odin.bearer.<base64url(33-byte App ClientAuthToken)>.
-        val bearer = "odin.bearer.${creds.clientAccessToken}"
+        //
+        // clientAccessToken is STANDARD base64 (see YouAuthProvider). A Sec-WebSocket-Protocol
+        // value must be an RFC 7230 token, and '/' — which standard base64 emits for ~50% of
+        // 33-byte tokens — is not a legal token char, so the browser's WebSocket constructor
+        // throws SyntaxError before connecting (proven against Chromium). Convert to base64url
+        // (no padding); the server reverses it via Base64UrlToBase64. Native engines happened to
+        // tolerate standard base64, but the wire value must be base64url for the browser/wasm path.
+        val bearerToken = creds.clientAccessToken.replace('+', '-').replace('/', '_').trimEnd('=')
+        val bearer = "odin.bearer.$bearerToken"
 
         client.webSocket(
             urlString = wsUrl,

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/websockets/BearerSubprotocolGrammarTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/websockets/BearerSubprotocolGrammarTest.kt
@@ -1,0 +1,56 @@
+package id.homebase.api.client.websockets
+
+import java.util.Base64
+import java.util.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression guard for the v2 ws-token bearer encoding.
+ *
+ * The bearer is sent as a `Sec-WebSocket-Protocol` value (`odin.bearer.<token>`). Per RFC 6455
+ * §4.1 each subprotocol must be an RFC 7230 `token` (1*tchar); browsers enforce this in the
+ * `new WebSocket(url, protocols)` constructor and throw SyntaxError BEFORE connecting (verified
+ * against Chromium). The App ClientAuthenticationToken is 33 bytes → 44-char base64 with no
+ * padding; the only base64 char that is not a legal token char is '/'. Standard base64 emits '/'
+ * (~50% of tokens), so OdinWebSocketClient must send base64url ('-'/'_'), which is always a valid
+ * token. This test pins that: the base64url transform the client applies must produce a valid
+ * subprotocol for every token, while raw standard base64 frequently does not.
+ */
+class BearerSubprotocolGrammarTest {
+
+    // RFC 7230 token chars (== what RFC 6455 requires for each Sec-WebSocket-Protocol value).
+    private val tchar: Set<Char> =
+        (('A'..'Z') + ('a'..'z') + ('0'..'9') + "!#$%&'*+-.^_`|~".toList()).toSet()
+
+    private fun isValidWsSubprotocol(value: String): Boolean =
+        value.isNotEmpty() && value.all { it in tchar }
+
+    private fun standardBase64(bytes: ByteArray) = Base64.getEncoder().encodeToString(bytes)
+
+    // The exact transform OdinWebSocketClient applies to creds.clientAccessToken.
+    private fun toBase64Url(standardB64: String) =
+        standardB64.replace('+', '-').replace('/', '_').trimEnd('=')
+
+    @Test
+    fun base64urlBearerIsAlwaysAValidSubprotocol_andStandardBase64FrequentlyIsNot() {
+        val rng = Random(7)
+        val n = 20000
+        var stdRejected = 0
+        var urlRejected = 0
+
+        repeat(n) {
+            val cat = ByteArray(33).also { rng.nextBytes(it) } // App CAT shape: Id16+halfKey16+type1
+            val std = standardBase64(cat)
+            if (!isValidWsSubprotocol("odin.bearer.$std")) stdRejected++
+            if (!isValidWsSubprotocol("odin.bearer.${toBase64Url(std)}")) urlRejected++
+        }
+
+        // The fix: base64url bearers are ALWAYS valid subprotocols (browser never rejects them).
+        assertEquals(0, urlRejected, "base64url bearers must always be valid WebSocket subprotocols")
+        // Why the fix is needed: raw standard base64 is browser-invalid for a large share of tokens.
+        assertTrue(stdRejected > n / 4,
+            "Expected many standard-base64 bearers to be browser-invalid; got $stdRejected/$n")
+    }
+}


### PR DESCRIPTION
## Problem

The v2 WebSocket auth bearer is sent as a `Sec-WebSocket-Protocol` value
(`odin.bearer.<token>`). Per RFC 6455 §4.1 each subprotocol must be an RFC 7230 `token`
(`1*tchar`), and **browsers enforce this in the `new WebSocket(url, protocols)` constructor — they throw `SyntaxError` before any network/auth.**

`OdinWebSocketClient` built the bearer from `creds.clientAccessToken`, which is **standard**
base64 (`YouAuthProvider` encodes the 33-byte App ClientAuthToken with `kotlin.io.encoding.Base64`).
Standard base64 emits `/`, which is **not** a legal token char, for ~50% of 33-byte tokens. So on
**web/wasm** the WebSocket constructor throws `SyntaxError` roughly half the time and the socket
never connects (an intermittent red dot that depends on the token bytes).

Native engines (CIO/OkHttp/Darwin) don't validate the subprotocol grammar and the server tolerates
standard base64, so native was unaffected — but the contract is **base64url** (the controller
reverses it via `Base64UrlToBase64`), and the surrounding comment already documented
`odin.bearer.<base64url(...)>`.

## Fix

Convert the token to base64url (no padding) before building the bearer — same bytes, URL-safe
alphabet, always a valid subprotocol token:

```kotlin
val bearerToken = creds.clientAccessToken.replace('+', '-').replace('/', '_').trimEnd('=')
val bearer = "odin.bearer.$bearerToken"
```

## Proof (before the fix)

- **Live, real browser:** `new WebSocket("wss://samwise.../api/v2/notify/ws-token", ["odin.notify.v1", "odin.bearer.<standard-base64>"])` in Chromium → `throw:SyntaxError`; the base64url form → `ok`.
- **`BearerSubprotocolGrammarTest`** (added): base64url bearers are valid subprotocols for every token; raw standard base64 is browser-invalid for **10028/20000 (50.1%)**.

## Compatibility

Server-side, standard base64 and base64url resolve to the **same** token (the controller normalizes
with `Base64UrlToBase64`), so native is unchanged and this is safe. That equivalence is covered by
`V2NotificationBearerEncodingTests` in the corresponding odin-core PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
