### PR TITLE
Fix flaky nav teardown test and close CI test-coverage gaps

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -35,7 +35,9 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Run JVM unit tests
-        run: ./gradlew homebase-chat:jvmTest homebase-auth:jvmTest homebase-common:jvmTest homebase-api:jvmTest homebase-core:jvmTest
+        # Unqualified `jvmTest` fans out to every subproject's jvmTest, so newly
+        # added modules are covered automatically (no per-module allow-list to drift).
+        run: ./gradlew jvmTest
         env:
           JDK_21: ${{ env.JAVA_HOME }}
           CI: true
@@ -45,10 +47,7 @@ jobs:
         if: always()  # Run even if tests fail
         with:
           files: |
-            homebase-api/build/test-results/jvmTest/TEST-*.xml
-            homebase-chat/build/test-results/jvmTest/TEST-*.xml
-            homebase-auth/build/test-results/jvmTest/TEST-*.xml
-            homebase-common/build/test-results/jvmTest/TEST-*.xml
+            **/build/test-results/jvmTest/TEST-*.xml
           check_name: JVM Test Results
 
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,12 @@ jobs:
         include:
           - os: ubuntu-latest
             name: Android & Desktop
-            # Run Android Unit Tests and Desktop Tests
+            # `jvmTest` fans out to every subproject (covers desktop logic too);
+            # `testDebugUnitTest` runs the Android app unit tests. The old
+            # `./gradlew desktopTest` referenced a task that does not exist.
             test-command: |
               set -o pipefail
-              ./gradlew testDebugUnitTest --info | tee test-output.log
-              ./gradlew homebase-common:jvmTest homebase-chat:jvmTest
-              ./gradlew desktopTest
+              ./gradlew jvmTest testDebugUnitTest --info | tee test-output.log
           - os: macos-latest
             name: iOS
             # Run iOS Simulator Tests

--- a/homebase-core/build.gradle.kts
+++ b/homebase-core/build.gradle.kts
@@ -151,19 +151,6 @@ kotlin {
     }
 }
 
-// Skip flaky navigation lifecycle tests in CI (headless environment has stricter lifecycle management)
-tasks.withType<Test>().configureEach {
-    val isCI = System.getenv("CI")?.toBoolean() ?: false
-    if (isCI) {
-        filter {
-            // These tests access NavController back stack entries outside composition,
-            // which triggers IllegalStateException in headless test environments
-            excludeTestsMatching("id.homebase.core.ui.navigation.NotificationTapColdStartTest.warm_start_notification_tap_from_detail_navigates_via_chatlist")
-            excludeTestsMatching("id.homebase.core.ui.navigation.NotificationTapColdStartTest.broken_top_only_gate_hangs_when_on_detail")
-        }
-    }
-}
-
 // `withHostTest {}` is enabled above so AGP 9.2 stops warning about commonTest
 // with no Android host-test runner. However, most commonTest files here use
 // `runComposeUiTest {}` (compose-ui-test), which resolves to a Skiko-backed

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -128,7 +128,6 @@ import id.homebase.imageeditor.ui.CropScreen
 import id.homebase.imageeditor.ui.DrawScreen
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.first
 import androidx.navigation.toRoute
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
@@ -313,10 +312,8 @@ fun AppNavHost(
                     // ConversationListViewModel via the PendingNotificationTap
                     // singleton (TTL-retried until drive sync lands the
                     // conversation) — here we only manage the back stack.
-                    val stack = navController.currentBackStack.first { stack ->
-                        stack.any {
-                            it.destination.hasRoute(Route.ChatList::class)
-                        }
+                    val stack = navController.currentBackStack.firstContaining {
+                        it.destination.hasRoute(Route.ChatList::class)
                     }
                     Logger.i(tag = "AppNavHost") {
                         "ChatList present in stack (size=${stack.size}), popping to it"

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/BackStackGate.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/BackStackGate.kt
@@ -1,0 +1,21 @@
+package id.homebase.core.ui.navigation
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+
+/**
+ * Suspends until this flow emits a list containing at least one element matching
+ * [predicate], then returns that list.
+ *
+ * Used to gate notification-tap navigation on [Route.ChatList] being *anywhere* in the
+ * NavController back stack, not just on top. A top-of-stack gate hangs forever when the
+ * user is warm on a Detail/Settings screen, silently dropping the tap (PR #322 warm-path
+ * regression). Membership gating resolves as soon as ChatList sits anywhere in the stack.
+ *
+ * Extracted as a pure Flow helper so the regression is covered by a deterministic coroutine
+ * test ([id.homebase.core.ui.navigation.BackStackGateTest]) instead of a live NavController
+ * under runComposeUiTest, whose Skiko desktop scene teardown crashes when destroying a
+ * still-INITIALIZED NavBackStackEntry.
+ */
+suspend fun <T> Flow<List<T>>.firstContaining(predicate: (T) -> Boolean): List<T> =
+    first { list -> list.any(predicate) }

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/navigation/BackStackGateTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/navigation/BackStackGateTest.kt
@@ -1,0 +1,65 @@
+package id.homebase.core.ui.navigation
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Deterministic coverage for the notification-tap back-stack gate (PR #322), replacing the
+ * two runComposeUiTest cases that crash on Compose-Multiplatform's desktop (Skiko) scene
+ * teardown — see the @Ignore'd warm_start_… / broken_top_only_… tests in
+ * [NotificationTapColdStartTest].
+ *
+ * The production gate ([firstContaining], used by AppNavHost) must resolve when
+ * Route.ChatList is *anywhere* in the back stack, not only when it is on top. The old
+ * top-only gate (`currentBackStackEntryFlow.first { it == ChatList }`) hangs forever when
+ * the user is warm on a Detail screen, silently dropping the tap.
+ *
+ * The back stack is modeled as a [MutableStateFlow] — faithful because
+ * `navController.currentBackStack` is itself a StateFlow that never completes, so a
+ * never-matching top-only gate genuinely suspends and `withTimeoutOrNull` (auto-advanced by
+ * `runTest` virtual time) returns null instantly.
+ */
+class BackStackGateTest {
+
+    @Test
+    fun membership_gate_resolves_when_chatlist_is_below_top() = runTest {
+        // Warm on Detail: ChatList sits *below* the top entry.
+        val backStack = MutableStateFlow(listOf("ChatList", "Detail"))
+
+        val result = backStack.firstContaining { it == "ChatList" }
+
+        assertEquals(listOf("ChatList", "Detail"), result)
+    }
+
+    @Test
+    fun membership_gate_suspends_until_chatlist_pushed() = runTest {
+        // Cold start: gate fires while ChatList is not yet in the stack, then resolves
+        // once it is pushed.
+        val backStack = MutableStateFlow(listOf("AppLoading"))
+
+        val gated = async { backStack.firstContaining { it == "ChatList" } }
+        backStack.value = listOf("ChatList")
+
+        assertEquals(listOf("ChatList"), gated.await())
+    }
+
+    @Test
+    fun top_only_gate_hangs_when_chatlist_is_below_top() = runTest {
+        // Negative control: the pre-fix top-only gate over the same warm-on-Detail stack
+        // never matches (top is Detail) and suspends forever.
+        val backStack = MutableStateFlow(listOf("ChatList", "Detail"))
+
+        val resolved = withTimeoutOrNull(5.seconds) {
+            backStack.first { stack -> stack.last() == "ChatList" }
+        }
+
+        assertNull(resolved, "top-only gate must hang while ChatList is below the top")
+    }
+}

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/navigation/NotificationTapColdStartTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/navigation/NotificationTapColdStartTest.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.serialization.Serializable
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.uuid.Uuid
 
@@ -184,6 +185,14 @@ class NotificationTapColdStartTest {
      * subsequent popBackStack(ChatList, inclusive=false) then brings ChatList
      * back to the top, which reads pendingConversationId and routes.
      */
+    @Ignore(
+        "CMP SkikoComposeUiTest.closeScene moves a still-INITIALIZED NavBackStackEntry " +
+            "(destination=TestDetail) to DESTROYED during desktop scene teardown, throwing " +
+            "IllegalStateException AFTER the test body passes. Harness bug, not product. The " +
+            "back-stack gate regression is covered meanwhile by BackStackGateTest. Remove " +
+            "@Ignore when CMP fixes desktop nav teardown — natural trigger is the " +
+            "composeMultiplatform 1.10.3 -> 1.11.0 bump."
+    )
     @Test
     fun warm_start_notification_tap_from_detail_navigates_via_chatlist() = runComposeUiTest {
         val events = Channel<NotificationNavigationEvent>(Channel.BUFFERED)
@@ -260,6 +269,14 @@ class NotificationTapColdStartTest {
         kotlin.test.assertNotNull(navControllerRef)
     }
 
+    @Ignore(
+        "CMP SkikoComposeUiTest.closeScene moves a still-INITIALIZED NavBackStackEntry " +
+            "(destination=TestDetail) to DESTROYED during desktop scene teardown, throwing " +
+            "IllegalStateException AFTER the test body passes. Harness bug, not product. The " +
+            "back-stack gate regression is covered meanwhile by BackStackGateTest. Remove " +
+            "@Ignore when CMP fixes desktop nav teardown — natural trigger is the " +
+            "composeMultiplatform 1.10.3 -> 1.11.0 bump."
+    )
     @Test
     fun broken_top_only_gate_hangs_when_on_detail() = runComposeUiTest {
         // Negative control: same warm-on-Detail scenario as the test above,


### PR DESCRIPTION
## Summary

Two related fixes: resolve the flaky `NotificationTapColdStartTest`, and harden which tests actually run in CI (a few modules were silently never tested).

## Flaky test

Two `NotificationTapColdStartTest` cases (`warm_start_…`, `broken_top_only_…`) **pass their assertions** but crash *after* the test body during Compose-Multiplatform's desktop (Skiko) scene teardown:

```
IllegalStateException: State must be at least 'CREATED' to be moved to 'DESTROYED'
  NavBackStackEntry(... destination=TestDetail)
  at androidx.compose.ui.test.SkikoComposeUiTest.closeScene
```

It only hits the two tests that `navigate()` to a second destination. This is a **test-harness bug, not a product bug**, and it was masked by a `CI`-only `excludeTestsMatching` in `homebase-core/build.gradle.kts` — green in CI, red locally.

Fix (hybrid — keep coverage, leave an unwind breadcrumb):
- Extract the back-stack gate into a pure helper `Flow<List<T>>.firstContaining(predicate)` (`BackStackGate.kt`) and use it in `AppNavHost`.
- Cover the PR #322 regression (route via ChatList when it is *anywhere* in the stack, not just on top) deterministically with **`BackStackGateTest`** (plain `runTest`, no `runComposeUiTest`).
- Keep the two live `runComposeUiTest` cases but `@Ignore` them with a reason + unwind trigger (drop `@Ignore` on the `composeMultiplatform 1.10.3 → 1.11.0` bump and re-check). They still compile, so they can't rot silently.
- Delete the CI-only exclusion — `@Ignore` skips identically in CI and locally.

Library upgrade was investigated and set aside as the gating fix: `navigation-compose` stable is `2.9.2` (= current); the crash lives in CMP's `ui-test` (`SkikoComposeUiTest.closeScene`), and CMP 1.11.0 is now stable but no changelog confirms it fixes this exact teardown symptom.

## CI coverage

Both test workflows used hand-maintained per-module allow-lists that had drifted:

- **`homebase-notifshared:jvmTest` (13 tests)** and **`image-editor-core:jvmTest` (58 tests)** ran in **no** workflow.
- `test.yml` invoked `./gradlew desktopTest` — a task that **does not exist** (and `desktopApp:jvmTest` is `NO-SOURCE`).

Changes:
- `build-check.yml`: run unqualified `./gradlew jvmTest` (fans out to every subproject, so new modules are covered automatically); widen the published results glob to `**/build/test-results/jvmTest/TEST-*.xml`.
- `test.yml`: run `./gradlew jvmTest testDebugUnitTest`; drop the dead `desktopTest` line.

## Verification

`./gradlew jvmTest androidApp:testDebugUnitTest --rerun-tasks` → **1699 tests, 0 failures, 0 errors, 7 intentional `@Ignore` skips** (2 from this change, 5 pre-existing). Identical results with and without `CI=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)