### PR TITLE
docs(wasm): explain why web omits PublicImageFetcher.Factory

### DIFF
--- a/homebase-core/src/wasmJsMain/kotlin/id/homebase/core/di/AppModule.web.kt
+++ b/homebase-core/src/wasmJsMain/kotlin/id/homebase/core/di/AppModule.web.kt
@@ -42,6 +42,14 @@ actual fun platformModule(): Module = module {
     single<ShakeDetector> { WebShakeDetector() }
 
     single {
+        // Web intentionally does NOT register PublicImageFetcher.Factory here, even though
+        // android/desktop/native do. On web that fetcher routes public avatars (/pub/image)
+        // through getPublicImage() (app httpClient + cache), which fails on this target and
+        // drops EVERY avatar to its initials fallback. Coil's default network fetcher is what
+        // makes web avatars load, so leave them on it. Do not add the Factory as a
+        // "parity"/consistency fix — it's a regression here (verified). (Unrelated, separate
+        // low-frequency cosmetic issue: a host-less "https:///pub/image" can resolve to the
+        // app's own origin and fail; adding the Factory does not fix that either.)
         ImageLoader.Builder(PlatformContext.INSTANCE)
                 .components {
                     add(HomebaseImageKeyer())


### PR DESCRIPTION
## What

Adds an explanatory comment in the web `ImageLoader` setup (`AppModule.web.kt`) documenting why `PublicImageFetcher.Factory` is **deliberately not registered** on web, even though android/desktop/native register it.

## Why

It looks like an inconsistency that "should" be fixed for parity — but registering it on web is a **regression**: that fetcher routes public avatars (`/pub/image`) through `getPublicImage()` (app `HttpClient` + cache), which fails on the wasm target and drops **every** avatar to its initials fallback. Coil's default network fetcher is what makes web avatars load, so web must stay on it.

This was verified empirically (registered it → all web avatars became initials → reverted). The comment lives at the exact spot someone would be tempted to "fix the inconsistency," to stop the regression being reintroduced.

## Scope

Comment only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
