### PR TITLE
fix(chat): stop conversation-file merge from blanking last-message preview

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationFileMerge.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationFileMerge.kt
@@ -1,0 +1,128 @@
+package id.homebase.chat.services.convo
+
+import id.homebase.chat.data.ConversationState
+import id.homebase.chat.data.ConversationUiModel
+import kotlin.time.Instant
+
+/**
+ * Result of merging a conversation-FILE refresh into an in-memory model.
+ *
+ * @property merged          the reconciled conversation model.
+ * @property isNewlyRemoved  true when this merge is the first time we observe
+ *                           the local identity dropping out of a group. The
+ *                           caller owns the side effect (stamp `exitedAt` into
+ *                           localAppData + enqueue the outbox push); the pure
+ *                           merge only reports it.
+ */
+internal data class ConversationFileMergeResult(
+    val merged: ConversationUiModel,
+    val isNewlyRemoved: Boolean,
+)
+
+/**
+ * Pure merge of a conversation-FILE refresh ([incoming]) into the current
+ * in-memory model ([existing]).
+ *
+ * Extracted out of [ConversationStream.updateConversation] for the same reason
+ * [applyIncomingMessageBump] was: so the reconciliation rules can be unit-tested
+ * with no DB, Koin, or coroutines. The caller keeps the side effects (the
+ * newly-removed `exitedAt` stamp + outbox push, and writing the result into the
+ * StateFlow); everything that decides the *values* lives here.
+ *
+ * ## Message-preview ownership
+ *
+ * The message-preview fields (`lastMessage`, `lastMessageDeliveryStatus`,
+ * `lastMessageIsDeleted`, `lastMessageFirstPayload`,
+ * `lastMessageHasMultiplePayloads`, `lastMessageIsFromActiveUser`) and the
+ * `latestMessageTimestamp` sort key are **owned exclusively by the message
+ * pipeline** — [applyIncomingMessageBump] (live arrivals) and
+ * [ConversationMapper.applyLastMessage] (cold-load / WS-batch enrichment). A
+ * conversation FILE never carries real preview data: it is mapped via
+ * `mapToConversationUi(file, lastMsg = null)`, so `ConversationMapper.mapToBasic`
+ * hardcodes `lastMessage = " "`. This merge therefore leaves all of those fields
+ * on their `existing` values and only reconciles structural state (name,
+ * participants, membership, pinned, lastRead/dirty).
+ *
+ * Why this matters: before the persisted-sort-key change (commit 2e0d4e76) this
+ * merge copied the preview fields under an
+ * `incoming.latestMessageTimestamp >= existing.latestMessageTimestamp` guard.
+ * That guard was accidentally safe only because `incoming` carried
+ * `metadata.created` (older than the message-driven `existing`). Once
+ * `mapToBasic` began seeding `latestMessageTimestamp` from the persisted
+ * `localAppData` value — stamped on every send/read — a post-send conv-file echo
+ * arrives with a timestamp *equal to* `existing`, the guard flips true, and the
+ * `" "` placeholder wipes the real preview. See ConversationFileMergeTest.
+ *
+ * @param now used only for the newly-Removed `exitedAt` stamp; passed in so the
+ *            function stays pure (no clock read).
+ */
+internal fun mergeConversationFileUpdate(
+    existing: ConversationUiModel,
+    incoming: ConversationUiModel,
+    now: Instant,
+): ConversationFileMergeResult {
+    // Left is sticky — only cleared by an explicit rejoin action, not by outbox
+    // responses which may not preserve localAppData tags. RejoinPending is the
+    // one exception: it means the server shows us back in participants while we
+    // still have the Left tag locally.
+    val resolvedState = if (existing.conversationState == ConversationState.Left
+        && incoming.conversationState != ConversationState.Left
+        && incoming.conversationState != ConversationState.RejoinPending
+    ) {
+        ConversationState.Left
+    } else {
+        incoming.conversationState
+    }
+
+    // First observed Removed transition — caller stamps lastExitedAt into
+    // localAppData so the mapper reads it back on later loads.
+    val isNewlyRemoved = resolvedState == ConversationState.Removed
+            && existing.conversationState != ConversationState.Removed
+            && existing.conversationState != ConversationState.Left
+
+    // Clear exitedAt when active again; preserve on Left/Removed (first stamp wins).
+    val resolvedExitedAt = when {
+        resolvedState == ConversationState.Active
+                || resolvedState == ConversationState.RejoinPending -> null
+
+        isNewlyRemoved -> now
+        else -> existing.exitedAt ?: incoming.exitedAt
+    }
+
+    // Carries the conversation file's localAppData.lastReadTime forward — a peer
+    // device's mark-as-read (or our own pushed advance echoing back) advances it
+    // and syncs it. lastRead = max keeps it monotonic against a stale echo; dirty
+    // (we still owe a server push) is retired once the remote read reaches our
+    // local value — see reconciledWithRemoteLastRead. Must override dirty
+    // explicitly: the existing.copy base would otherwise preserve a now-stale flag.
+    val reconciled = existing.reconciledWithRemoteLastRead(incoming.lastRead)
+
+    // Structural fields (membership, identity) always come from the conversation
+    // file, regardless of timestamp. The in-memory timestamp is driven by message
+    // arrivals and is almost always newer than metadata.created, so a timestamp
+    // guard would silently drop participant/admin/name changes distributed by
+    // peers (e.g. leave, add member).
+    //
+    // Message-preview fields and latestMessageTimestamp are NOT merged here: a
+    // conversation file never carries real preview data (mapToBasic seeds
+    // lastMessage = " "). They stay on `existing`, owned by the message pipeline.
+    val merged = existing.copy(
+        name = incoming.name,
+        isGroup = incoming.isGroup,
+        isLegacyGroup = incoming.isLegacyGroup,
+        admins = incoming.admins,
+        avatarModel = incoming.avatarModel,
+        avatarTiny = incoming.avatarTiny,
+        avatarUrl = incoming.avatarUrl,
+        avatarInitials = incoming.avatarInitials,
+        participants = incoming.participants,
+        isPinned = incoming.isPinned,
+        conversationState = resolvedState,
+        exitedAt = resolvedExitedAt,
+        fileUpdated = incoming.fileUpdated,
+        lastRead = reconciled.lastRead,
+        dirty = reconciled.dirty,
+    )
+
+    return ConversationFileMergeResult(merged = merged, isNewlyRemoved = isNewlyRemoved)
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -696,79 +696,26 @@ class ConversationStream(
         existing: ConversationUiModel,
         incoming: ConversationUiModel
     ) {
-        // Left is sticky — only cleared by an explicit rejoin action, not by outbox responses
-        // which may not preserve localAppData tags. RejoinPending is the one exception: it means
-        // the server shows us back in participants while we still have the Left tag locally.
-        val resolvedState = if (existing.conversationState == ConversationState.Left
-            && incoming.conversationState != ConversationState.Left
-            && incoming.conversationState != ConversationState.RejoinPending
-        ) {
-            ConversationState.Left
-        } else {
-            incoming.conversationState
-        }
+        // All value reconciliation (state stickiness, exitedAt, lastRead/dirty,
+        // structural-vs-preview field ownership) lives in the pure
+        // [mergeConversationFileUpdate]; this method keeps only the side effects.
+        val result = mergeConversationFileUpdate(
+            existing = existing,
+            incoming = incoming,
+            now = UnixTimeUtc().toInstant(),
+        )
 
-        // Stamp lastExitedAt in localAppData the first time we detect a Removed transition.
-        // The mapper reads it back from localAppData on subsequent loads (cold start, reconnect).
-        val isNewlyRemoved = resolvedState == ConversationState.Removed
-                && existing.conversationState != ConversationState.Removed
-                && existing.conversationState != ConversationState.Left
-        if (isNewlyRemoved) {
+        // Stamp lastExitedAt in localAppData the first time we detect a Removed
+        // transition. The mapper reads it back from localAppData on subsequent
+        // loads (cold start, reconnect).
+        if (result.isNewlyRemoved) {
             optimisticWriter.stampConversationExitedAt(chatDrive, existing.id)
                 ?.let { outboxSync.tryEnqueue(it) }
         }
 
-        // Clear exitedAt when active again; preserve on Left/Removed (first stamp wins).
-        val resolvedExitedAt = when {
-            resolvedState == ConversationState.Active
-                    || resolvedState == ConversationState.RejoinPending -> null
-
-            isNewlyRemoved -> UnixTimeUtc().toInstant()
-            else -> existing.exitedAt ?: incoming.exitedAt
-        }
-
-        // Carries the conversation file's localAppData.lastReadTime forward — a
-        // peer device's mark-as-read (or our own pushed advance echoing back)
-        // advances it and syncs it. lastRead = max keeps it monotonic against a
-        // stale echo; dirty (we still owe a server push) is retired once the
-        // remote read reaches our local value — see reconciledWithRemoteLastRead.
-        // Must override dirty explicitly: the existing.copy base would otherwise
-        // preserve a now-stale flag.
-        val reconciled = existing.reconciledWithRemoteLastRead(incoming.lastRead)
-
-        // Structural fields (membership, identity) always come from the conversation file,
-        // regardless of timestamp. The in-memory timestamp is driven by message arrivals and
-        // is almost always newer than metadata.created, so a timestamp guard would silently
-        // drop participant/admin/name changes distributed by peers (e.g. leave, add member).
-        // Message-preview fields are only applied when the file is genuinely newer.
-        val updatedConvo = existing.copy(
-            name = incoming.name,
-            isGroup = incoming.isGroup,
-            isLegacyGroup = incoming.isLegacyGroup,
-            admins = incoming.admins,
-            avatarModel = incoming.avatarModel,
-            avatarTiny = incoming.avatarTiny,
-            avatarUrl = incoming.avatarUrl,
-            avatarInitials = incoming.avatarInitials,
-            participants = incoming.participants,
-            isPinned = incoming.isPinned,
-            conversationState = resolvedState,
-            exitedAt = resolvedExitedAt,
-            fileUpdated = incoming.fileUpdated,
-            lastRead = reconciled.lastRead,
-            dirty = reconciled.dirty,
-            // Message preview — only overwrite if the file carries a newer last-message snapshot
-            latestMessageTimestamp = if (incoming.latestMessageTimestamp >= existing.latestMessageTimestamp) incoming.latestMessageTimestamp else existing.latestMessageTimestamp,
-            lastMessage = if (incoming.latestMessageTimestamp >= existing.latestMessageTimestamp) incoming.lastMessage else existing.lastMessage,
-            lastMessageDeliveryStatus = if (incoming.latestMessageTimestamp >= existing.latestMessageTimestamp) incoming.lastMessageDeliveryStatus else existing.lastMessageDeliveryStatus,
-            lastMessageIsDeleted = if (incoming.latestMessageTimestamp >= existing.latestMessageTimestamp) incoming.lastMessageIsDeleted else existing.lastMessageIsDeleted,
-            lastMessageFirstPayload = if (incoming.latestMessageTimestamp >= existing.latestMessageTimestamp) incoming.lastMessageFirstPayload else existing.lastMessageFirstPayload,
-            lastMessageHasMultiplePayloads = if (incoming.latestMessageTimestamp >= existing.latestMessageTimestamp) incoming.lastMessageHasMultiplePayloads else existing.lastMessageHasMultiplePayloads,
-            lastMessageIsFromActiveUser = if (incoming.latestMessageTimestamp >= existing.latestMessageTimestamp) incoming.lastMessageIsFromActiveUser else existing.lastMessageIsFromActiveUser,
-        )
         // We should optimize later to not map the full list
         _conversations.value = _conversations.value.copy(
-            items = _conversations.value.items.map { if (it.id == existing.id) updatedConvo else it }
+            items = _conversations.value.items.map { if (it.id == existing.id) result.merged else it }
         )
     }
 

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationFileMergeTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationFileMergeTest.kt
@@ -1,0 +1,221 @@
+package id.homebase.chat.services.convo
+
+import id.homebase.api.common.OdinId
+import id.homebase.chat.data.ConversationState
+import id.homebase.chat.data.ConversationUiModel
+import id.homebase.core.avatars.ConversationAvatarModel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * Locks down [mergeConversationFileUpdate] — the conversation-FILE refresh merge
+ * extracted out of [ConversationStream.updateConversation].
+ *
+ * The regression this exists to guard against: sending a message blanked the
+ * conversation's `lastMessage` preview to a single space.
+ *
+ * A conversation file never carries real preview data — it is mapped via
+ * `mapToConversationUi(file, lastMsg = null)`, so `mapToBasic` hardcodes
+ * `lastMessage = " "`. The pre-fix merge copied the preview fields from `incoming`
+ * under an `incoming.latestMessageTimestamp >= existing.latestMessageTimestamp`
+ * guard. Once `mapToBasic` started seeding `latestMessageTimestamp` from the
+ * persisted localAppData sort key (commit 2e0d4e76, stamped on every send/read),
+ * the post-send conv-file echo arrives with a timestamp EQUAL to `existing`, the
+ * `>=` guard flips true, and the `" "` placeholder overwrites the real preview.
+ *
+ * The most important test here is [postSendEcho_doesNotBlankPreview].
+ */
+class ConversationFileMergeTest {
+
+    private val me = OdinId("owner.test")
+    private val alice = OdinId("alice.test")
+    private val bob = OdinId("bob.test")
+    private val convoId = Uuid.parse("11111111-1111-1111-1111-111111111111")
+
+    private val now = Instant.fromEpochMilliseconds(9_999_999L)
+
+    /** A conversation as it lives in memory (real preview from the message pipeline). */
+    private fun existing(
+        lastMessage: String = "hello there",
+        latestMs: Long = 10_000L,
+        lastRead: Long = 0L,
+        dirty: Boolean = false,
+        name: String = "alice",
+        isPinned: Boolean = false,
+        participants: List<OdinId> = listOf(me, alice),
+        state: ConversationState = ConversationState.Active,
+        isGroup: Boolean = false,
+    ) = ConversationUiModel(
+        id = convoId,
+        name = name,
+        lastMessage = lastMessage,
+        latestMessageTimestamp = Instant.fromEpochMilliseconds(latestMs),
+        unreadCount = 0,
+        avatarInitials = "",
+        avatarUrl = "",
+        avatarTiny = null,
+        participants = participants,
+        isPinned = isPinned,
+        lastRead = Instant.fromEpochMilliseconds(lastRead),
+        dirty = dirty,
+        lastMessageIsFromActiveUser = true,
+        avatarModel = ConversationAvatarModel(
+            type = ConversationAvatarModel.Type.Connection,
+            odinId = alice,
+        ),
+        admins = emptySet(),
+        conversationState = state,
+        isGroup = isGroup,
+    )
+
+    /**
+     * A conversation FILE refresh as produced by `mapToConversationUi(file, null)`:
+     * the preview is always the `" "` placeholder, the sort timestamp comes from
+     * persisted localAppData.
+     */
+    private fun incomingFile(
+        latestMs: Long,
+        lastRead: Long = 0L,
+        name: String = "alice",
+        isPinned: Boolean = false,
+        participants: List<OdinId> = listOf(me, alice),
+        state: ConversationState = ConversationState.Active,
+        isGroup: Boolean = false,
+    ) = ConversationUiModel(
+        id = convoId,
+        name = name,
+        lastMessage = " ",
+        latestMessageTimestamp = Instant.fromEpochMilliseconds(latestMs),
+        unreadCount = 0,
+        avatarInitials = "",
+        avatarUrl = "",
+        avatarTiny = null,
+        participants = participants,
+        isPinned = isPinned,
+        lastRead = Instant.fromEpochMilliseconds(lastRead),
+        dirty = false,
+        lastMessageIsFromActiveUser = false,
+        avatarModel = ConversationAvatarModel(
+            type = ConversationAvatarModel.Type.Connection,
+            odinId = alice,
+        ),
+        admins = emptySet(),
+        conversationState = state,
+        isGroup = isGroup,
+    )
+
+    /**
+     * THE regression guard. After sending a message the in-memory model holds
+     * the real preview ("hello there") at timestamp T; the lastRead writeback
+     * echoes the conversation file back stamped at the SAME T with the `" "`
+     * placeholder preview. The merge must keep the real preview.
+     */
+    @Test
+    fun postSendEcho_doesNotBlankPreview() {
+        val result = mergeConversationFileUpdate(
+            existing = existing(lastMessage = "hello there", latestMs = 10_000L),
+            incoming = incomingFile(latestMs = 10_000L),
+            now = now,
+        )
+
+        assertEquals(
+            "hello there",
+            result.merged.lastMessage,
+            "post-send conv-file echo (same timestamp, placeholder preview) must not blank lastMessage",
+        )
+        assertEquals(10_000L, result.merged.latestMessageTimestamp.toEpochMilliseconds())
+        assertTrue(result.merged.lastMessageIsFromActiveUser)
+    }
+
+    /**
+     * A peer's conversation file can arrive (with its persisted sort key already
+     * advanced) BEFORE the message that advanced it. The placeholder must not
+     * blank the preview, and the sort timestamp must stay on `existing` so the
+     * subsequent [applyIncomingMessageBump] (which requires
+     * `sqlUserDate > existing.latestMessageTimestamp`) can still fire.
+     */
+    @Test
+    fun peerFileBeforeMessage_doesNotBlankPreviewAndDoesNotAdvanceTimestamp() {
+        val result = mergeConversationFileUpdate(
+            existing = existing(lastMessage = "hello there", latestMs = 10_000L),
+            incoming = incomingFile(latestMs = 15_000L),
+            now = now,
+        )
+
+        assertEquals("hello there", result.merged.lastMessage)
+        assertEquals(
+            10_000L,
+            result.merged.latestMessageTimestamp.toEpochMilliseconds(),
+            "a strictly-newer placeholder file must not advance the sort key past the message pipeline",
+        )
+    }
+
+    /** Structural fields still merge from the file; only the preview is frozen. */
+    @Test
+    fun structuralFieldsStillMergeFromFile() {
+        val result = mergeConversationFileUpdate(
+            existing = existing(name = "old name", isPinned = false, participants = listOf(me, alice)),
+            incoming = incomingFile(
+                latestMs = 10_000L,
+                name = "new name",
+                isPinned = true,
+                participants = listOf(me, alice, bob),
+            ),
+            now = now,
+        )
+
+        assertEquals("new name", result.merged.name)
+        assertTrue(result.merged.isPinned)
+        assertEquals(listOf(me, alice, bob), result.merged.participants)
+        // ...while the preview stays from existing.
+        assertEquals("hello there", result.merged.lastMessage)
+    }
+
+    /** lastRead reconciliation is preserved by the extraction. */
+    @Test
+    fun lastReadReconciliation_takesMaxAndClearsDirtyWhenRemoteCatchesUp() {
+        val result = mergeConversationFileUpdate(
+            existing = existing(lastRead = 5_000L, dirty = true),
+            incoming = incomingFile(latestMs = 10_000L, lastRead = 10_000L),
+            now = now,
+        )
+
+        assertEquals(10_000L, result.merged.lastRead.toEpochMilliseconds())
+        assertFalse(result.merged.dirty, "dirty clears once the remote lastRead reaches our local value")
+    }
+
+    /** Left is sticky against an outbox echo that omits the Left tag. */
+    @Test
+    fun leftState_isStickyAgainstActiveEcho() {
+        val result = mergeConversationFileUpdate(
+            existing = existing(state = ConversationState.Left, isGroup = true),
+            incoming = incomingFile(latestMs = 10_000L, state = ConversationState.Active, isGroup = true),
+            now = now,
+        )
+
+        assertEquals(ConversationState.Left, result.merged.conversationState)
+    }
+
+    /** First Removed transition reports isNewlyRemoved and stamps exitedAt = now. */
+    @Test
+    fun newlyRemoved_isReportedAndStampsExitedAt() {
+        val result = mergeConversationFileUpdate(
+            existing = existing(state = ConversationState.Active, isGroup = true),
+            incoming = incomingFile(
+                latestMs = 10_000L,
+                state = ConversationState.Removed,
+                isGroup = true,
+                participants = listOf(alice, bob), // we are no longer a participant
+            ),
+            now = now,
+        )
+
+        assertTrue(result.isNewlyRemoved)
+        assertEquals(ConversationState.Removed, result.merged.conversationState)
+        assertEquals(now, result.merged.exitedAt)
+    }
+}


### PR DESCRIPTION
## Problem

Sending a message often blanks the conversation's **last-message preview** in the conversation list — it shows a single space instead of the message text. Recent regression.

## Root cause

A conversation *file* never carries message-preview text. It's mapped via `mapToConversationUi(file, lastMsg = null)`, so `ConversationMapper.mapToBasic` hardcodes `lastMessage = " "`. The preview fields and the `latestMessageTimestamp` sort key are owned by the **message pipeline** (`applyIncomingMessageBump` + `applyLastMessage` enrichment).

But `ConversationStream.updateConversation` copied the preview fields from the incoming file under an `incoming.latestMessageTimestamp >= existing.latestMessageTimestamp` guard.

That guard was only *accidentally* safe. Before commit `2e0d4e76`, `mapToBasic` seeded the timestamp from `metadata.created` — always older than the message-driven in-memory value — so the guard was false and the real preview survived. Commit `2e0d4e76` ("ride last-message sort key along with lastRead writeback") changed `mapToBasic` to seed the timestamp from the **persisted localAppData sort key**, stamped on every send/read. After a send, the conv-file echo now arrives with a timestamp **equal to** the in-memory one → `>=` flips true → the `" "` placeholder overwrites the real preview.

## Fix

Conversation-file merges no longer touch `lastMessage*` or `latestMessageTimestamp` — those stay on `existing`, owned solely by the message pipeline. Structural fields (name, participants, pinned, membership, lastRead/dirty) still merge from the file as before.

This also fixes a sibling case: a peer's conv-file landing *before* its message would otherwise blank the preview **and** block the subsequent bump (which requires `sqlUserDate > existing.latestMessageTimestamp`).

The merge logic is extracted into a pure `mergeConversationFileUpdate` (`ConversationFileMerge.kt`) — the same testability pattern as `applyIncomingMessageBump` — so `updateConversation` keeps only the side effects (newly-removed `exitedAt` stamp, StateFlow write).

## Proven test-first

With the original `>=` logic reproduced verbatim, the new test failed:

```
postSendEcho_doesNotBlankPreview → expected:<hello there> but was:< >
```

It passes after the fix. `ConversationFileMergeTest` adds 6 tests: the post-send echo regression, peer-file-before-message, structural-merge-still-works, lastRead reconciliation, Left stickiness, and newly-removed flag.

## Verification

```
./gradlew homebase-chat:jvmTest --rerun-tasks   # green
```

## Files

- `ConversationFileMerge.kt` (new) — pure `mergeConversationFileUpdate` + result type
- `ConversationStream.kt` — `updateConversation` delegates to it
- `ConversationFileMergeTest.kt` (new) — regression + reconciliation tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)