### PR TITLE
Hard-delete unrecoverable own-drive corrupt conversation headers

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -1600,6 +1600,13 @@ class ConversationService(
         // "Heal Group" button); pushing a placeholder pre-emptively to the
         // server has been observed to make the recipient's local state
         // overwrite later heals, defeating the heal flow.
+        //
+        // The one exception is the own-drive corrupt-header cleanup below
+        // ([tryHardDeleteUnrecoverableOwnHeader]): it hard-deletes a dead file we
+        // authored from our OWN drive (recipients=null ⇒ no peer fan-out), which is
+        // file removal, not distribution — the same primitive GroupHealService STEP 1
+        // uses. Without it, a self-only corrupt header re-syncs from our own server
+        // drive every launch and loops forever.
         val existingFile = getConversationHomebaseFile(conversationId)
 
         // Three pieces of state we resolve from the (optional) existing file:
@@ -1608,9 +1615,11 @@ class ConversationService(
         //   - early return if the file is already healthy
         val brokenFileIdToDelete: Uuid?
         val participants: List<OdinId>
+        // Hoisted so the corrupt-header cleanup below can see the mapped state.
+        var existingState: ConversationState? = null
 
         if (existingFile != null) {
-            val existingState: ConversationState? = try {
+            existingState = try {
                 mapper.mapToConversationUi(existingFile, null).conversationState
             } catch (e: Exception) {
                 Logger.w(e) { "ConversationService: recoverConversation($conversationId) — existing file failed to map, will overwrite" }
@@ -1650,6 +1659,23 @@ class ConversationService(
         // branch — yielding a healthy Active state instead of another
         // unmappable_conversation flag.
         val hasNonSelfParticipant = participants.any { it != domain }
+
+        // Before writing yet another local placeholder, check whether this is a dead
+        // own-drive corrupt header that local-only recovery can never fix (it would
+        // just re-sync and loop). If so, hard-delete it server-side and bail.
+        if (existingFile != null &&
+            tryHardDeleteUnrecoverableOwnHeader(
+                conversationId = conversationId,
+                existingFile = existingFile,
+                existingState = existingState,
+                domain = domain,
+                hasNonSelfParticipant = hasNonSelfParticipant,
+                audit = audit,
+            )
+        ) {
+            return
+        }
+
         val forcedGroupForUnmappable1to1 = isOneToOne && !hasNonSelfParticipant
         val placeholderIsGroup = !isOneToOne || forcedGroupForUnmappable1to1
         // Give forced-group recoveries a recognisable label so the user can
@@ -1669,6 +1695,85 @@ class ConversationService(
             audit = audit,
         )
         audit.finish("local-only recovery complete")
+    }
+
+    /**
+     * Breaks the re-sync loop for a corrupt header on our OWN drive. A header we
+     * authored that is genuinely [ConversationState.Invalid], lists only ourselves,
+     * and has no peer message in its group is a dead file that local-only recovery
+     * can never fix — deleting just the local row lets the next sync re-download it,
+     * so it loops forever (FAILED map → recover → deleteBy(local) → "1:1 repair" →
+     * re-sync → repeat).
+     *
+     * When all gates pass it hard-deletes the file from our own server drive
+     * (recipients=null ⇒ no peer fan-out, the same primitive GroupHealService STEP 1
+     * uses), drops the local row, refreshes the model, and returns `true` (the caller
+     * then returns — there is nothing to place). Returns `false` otherwise, leaving
+     * the existing local-placeholder path untouched.
+     *
+     * Conservatively gated: never a file we didn't author, and never one with any
+     * peer-message trace ([FileStateFilter.All] counts soft-deleted tombstones too —
+     * if a peer ever wrote here we keep the placeholder rather than destroy context).
+     */
+    private suspend fun tryHardDeleteUnrecoverableOwnHeader(
+        conversationId: Uuid,
+        existingFile: HomebaseFile,
+        existingState: ConversationState?,
+        domain: OdinId,
+        hasNonSelfParticipant: Boolean,
+        audit: MethodAudit,
+    ): Boolean {
+        val authoredBySelf =
+            (existingFile.fileMetadata.originalAuthor
+                ?: existingFile.fileMetadata.senderOdinId ?: domain) == domain
+        if (existingState != ConversationState.Invalid || !authoredBySelf || hasNonSelfParticipant) {
+            return false
+        }
+
+        val identityId = credentialsManager.requireActiveCredentials().getIdentityId()
+        val hasPeerMessage = QueryBatch(identityId).queryBatchAsync(
+            dbm = dbm,
+            driveId = chatDrive,
+            noOfItems = 10_000,
+            fileSystemType = FileSystemType.Standard.value,
+            fileState = FileStateFilter.All, // conservative: tombstones count as a peer trace
+            filetypesAnyOf = listOf(ChatProtocol.MessageFileType),
+            groupIdAnyOf = listOf(conversationId),
+        ).records.any { m ->
+            val author = m.fileMetadata.originalAuthor ?: m.fileMetadata.senderOdinId
+            author != null && author != domain
+        }
+        if (hasPeerMessage) {
+            audit.info("corrupt own header has a peer message — leaving for local-placeholder path")
+            return false // recoverable ⇒ keep the placeholder behaviour
+        }
+
+        Logger.w("ConversationService: recoverConversation($conversationId) — own-drive corrupt header with no recoverable counterparty; hard-deleting fileId=${existingFile.fileId} from own drive")
+        audit.step(1, "outboxSync.tryEnqueue(DeleteLocalFilesByFileIdRequest hardDelete=true recipients=null fileId=${existingFile.fileId})")
+        runCatching {
+            outboxSync.tryEnqueue(
+                DeleteLocalFilesByFileIdRequest(
+                    driveId = chatDrive,
+                    fileIds = listOf(existingFile.fileId),
+                    recipients = null,
+                    hardDelete = true,
+                )
+            )
+        }.onSuccess { enqueued -> audit.info("hardDelete enqueued=$enqueued") }
+            .onFailure { e -> audit.threw("hardDeleteEnqueue", e) }
+
+        audit.step(2, "deleteBy(local corrupt row fileId=${existingFile.fileId})")
+        runCatching {
+            dbm.driveMainIndex.deleteBy(
+                identityId = identityId,
+                driveId = chatDrive,
+                fileId = existingFile.fileId,
+            )
+        }.onFailure { e -> audit.threw("deleteLocalRow", e) }
+
+        conversationStream.removeConversation(conversationId)
+        audit.finish("own-drive corrupt header hard-deleted")
+        return true
     }
 
     /**

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceHealTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceHealTest.kt
@@ -9,8 +9,6 @@ import id.homebase.api.client.drives.ServerMetadata
 import id.homebase.api.client.drives.files.AppFileMetaData
 import id.homebase.api.client.drives.files.FileMetadata
 import id.homebase.api.client.drives.files.LocalAppMetadata
-import id.homebase.api.client.drives.files.DeleteLocalFilesByFileIdRequest
-import id.homebase.api.client.drives.files.DriveOutboxUploader
 import id.homebase.api.common.OdinId
 import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.api.serialization.OdinSystemSerializer
@@ -545,17 +543,6 @@ class ConversationServiceHealTest {
         priority = 100,
         fileByteCount = 100,
     )
-
-    private fun Outbox.isHardDeleteRequest(): Boolean = asHardDeleteRequestOrNull() != null
-
-    private fun Outbox.asHardDeleteRequestOrNull(): DeleteLocalFilesByFileIdRequest? {
-        if (this.uploadType != DriveOutboxUploader.DeleteFile) return null
-        return try {
-            OdinSystemSerializer.deserialize<DeleteLocalFilesByFileIdRequest>(this.json.decodeToString())
-        } catch (_: Throwable) {
-            null
-        }
-    }
 
     private fun readPlaceholderRecipients(file: HomebaseFile): List<String> {
         val raw = file.fileMetadata.appData.content ?: return emptyList()

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceRecoveryTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceRecoveryTest.kt
@@ -175,57 +175,93 @@ class ConversationServiceRecoveryTest {
     }
 
     /**
-     * Regression: an orphaned 1:1 with `recipients=[self]` crashes the
-     * mapper at line 151 (`participants.first { it != domain }`). The
-     * recovery path (ConversationService.kt:1583–1597) is explicitly designed
-     * to handle this — it forces the placeholder to the group branch so the
-     * mapper takes the safe path instead of crashing. Without an active caller
-     * invoking `recoverConversation` this row stays broken on every list load,
-     * which is what `ConversationStream.loadBasicConversations` now wires up.
+     * An own-authored, unmappable (self-only `recipients=[self]`), message-less
+     * header is a dead file on our OWN drive that local-only recovery can never fix:
+     * deleting just the local row lets the next sync re-download it, looping forever
+     * (FAILED map → recover → deleteBy(local) → "1:1 repair" → re-sync → repeat).
      *
-     * Pins the local-only recovery contract: after recovery the placeholder
-     * file carries the group tag (so the mapper's group branch fires) and
-     * no outbox work was enqueued.
+     * Pins the loop-breaker: recovery hard-deletes the file from our own server drive
+     * (`recipients=null` ⇒ no peer fan-out), drops the local row, and writes NO
+     * placeholder so the dead thread disappears.
      */
     @Test
-    fun recoverConversation_oneOnOne_existingInvalidSelfOnly_revivesAsGroupPlaceholder() = runTest {
+    fun recoverConversation_ownAuthoredSelfOnlyInvalid_noMessages_hardDeletesServerHeader() = runTest {
         ConversationServiceTestFixture().use { fixture ->
             val service = fixture.build(scope = this)
-            // The orphan shape: recipients=[testDomain only]. The conversationId
-            // doesn't matter for the crash — what matters is that the stored
-            // recipients list contains only the current user.
+            // The orphan shape: recipients=[testDomain only], authored by us, no messages.
             val convoId = fixture.seedOrphanedOneOnOneSelfOnly()
-            val rowsBefore = fixture.outboxRowCount()
+            val brokenFileId = fixture.getConversationFile(convoId)!!.fileId
 
             service.recoverConversation(
                 conversationId = convoId,
                 originalAuthor = OdinId(fixture.testDomain),
             )
 
+            val deletes = fixture.drainOutbox().mapNotNull { it.asHardDeleteRequestOrNull() }
+            assertEquals(1, deletes.size, "exactly one own-drive hard-delete should be enqueued; got $deletes")
+            val del = deletes.single()
             assertEquals(
-                rowsBefore,
-                fixture.outboxRowCount(),
-                "recovery is local-only ⇒ no outbox enqueue",
+                listOf(brokenFileId),
+                del.fileIds,
+                "hard-delete must target the broken header's fileId",
             )
+            assertNull(del.recipients, "own-drive delete must have no recipients (no peer fan-out)")
+            assertTrue(del.hardDelete, "must be a hard delete so the next peer push lands as a fresh create")
 
-            val file = fixture.getConversationFile(convoId)
-            assertNotNull(file, "post-recovery placeholder file must exist")
-            assertNull(file.fileMetadata.versionTag, "placeholder marker (versionTag=null)")
-
-            // The placeholder MUST carry the group tag so the mapper takes the
-            // group branch — the whole point of the forced-group recovery is to
-            // avoid the `participants.first { it != domain }` deref.
-            val tags = file.fileMetadata.appData.tags ?: emptyList()
+            assertNull(
+                fixture.getConversationFile(convoId),
+                "local row must be gone so the dead thread disappears (no placeholder written)",
+            )
             assertTrue(
-                tags.contains(ChatProtocol.ConversationGroupTag),
-                "self-only 1:1 must be revived with the group tag so the mapper " +
-                        "takes the safe (group) branch; got tags=$tags",
+                fixture.conversationLoader.removed.contains(convoId),
+                "recoverConversation should drop the in-memory model via removeConversation",
+            )
+        }
+    }
+
+    /**
+     * Guard: a self-only Invalid header that we authored but which DOES have a peer
+     * message in its group is recoverable — we must NOT hard-delete it (that would
+     * strand the peer's messages). Falls back to the existing local-placeholder path.
+     */
+    @Test
+    fun recoverConversation_ownAuthoredSelfOnlyInvalid_withPeerMessage_doesNotDelete() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = fixture.seedOrphanedOneOnOneSelfOnly()
+            fixture.seedMessage(groupId = convoId, author = "alice.test")
+
+            service.recoverConversation(
+                conversationId = convoId,
+                originalAuthor = OdinId(fixture.testDomain),
             )
 
-            assertTrue(
-                fixture.conversationLoader.loaded.contains(convoId),
-                "recoverConversation should refresh the in-memory model via loadConversation",
+            val deletes = fixture.drainOutbox().mapNotNull { it.asHardDeleteRequestOrNull() }
+            assertTrue(deletes.isEmpty(), "recoverable header (has a peer message) must NOT be hard-deleted; got $deletes")
+            assertNotNull(
+                fixture.getConversationFile(convoId),
+                "recoverable header keeps a local placeholder",
             )
+        }
+    }
+
+    /**
+     * Ownership gate: a self-only Invalid header authored by a PEER (not us) must
+     * never be hard-deleted from our drive — we only ever remove files we authored.
+     */
+    @Test
+    fun recoverConversation_peerAuthoredSelfOnlyInvalid_doesNotDelete() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = fixture.seedOrphanedOneOnOneSelfOnly(originalAuthor = "alice.test")
+
+            service.recoverConversation(
+                conversationId = convoId,
+                originalAuthor = OdinId("alice.test"),
+            )
+
+            val deletes = fixture.drainOutbox().mapNotNull { it.asHardDeleteRequestOrNull() }
+            assertTrue(deletes.isEmpty(), "peer-authored header must NOT be hard-deleted from our drive; got $deletes")
         }
     }
 

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceTestFixture.kt
@@ -7,6 +7,8 @@ import id.homebase.api.client.connections.IntroductionGroup
 import id.homebase.api.client.connections.IntroductionResult
 import id.homebase.api.client.connections.IntroductionSender
 import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.client.drives.files.DeleteLocalFilesByFileIdRequest
+import id.homebase.api.client.drives.files.DriveOutboxUploader
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.common.OdinId
 import id.homebase.api.common.SecureByteArray
@@ -231,16 +233,86 @@ class ConversationServiceTestFixture : AutoCloseable {
      */
     suspend fun seedOrphanedOneOnOneSelfOnly(
         conversationId: Uuid = Uuid.random(),
+        originalAuthor: String = testDomain,
     ): Uuid {
         insertConversationFile(
             fileId = Uuid.random(),
             uniqueId = conversationId,
             participants = listOf(testDomain),
-            originalAuthor = testDomain,
+            originalAuthor = originalAuthor,
             isGroup = false,
             title = "",
         )
         return conversationId
+    }
+
+    /**
+     * Seed a chat message (fileType=MessageFileType, dataType=0) in [groupId] authored
+     * by [author]. Used to exercise recoverConversation's peer-message guard — only
+     * groupId / fileType / originalAuthor are read there, so the content is a stub.
+     */
+    suspend fun seedMessage(
+        groupId: Uuid,
+        author: String,
+        fileId: Uuid = Uuid.random(),
+        archivalStatus: Int = 0,
+    ) {
+        val now = Clock.System.now().epochSeconds
+        insertFile(
+            """{
+              "fileId": "$fileId",
+              "driveId": "$chatDriveId",
+              "fileState": "active",
+              "fileSystemType": "standard",
+              "serverFileIsEncrypted": "false",
+              "keyHeader": {
+                "iv": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+                "aesKey": {"bytes": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}
+              },
+              "fileMetadata": {
+                "globalTransitId": "${Uuid.random()}",
+                "created": ${now}000,
+                "updated": ${now}000,
+                "transitCreated": ${now}000,
+                "transitUpdated": 0,
+                "isEncrypted": false,
+                "senderOdinId": "$author",
+                "originalAuthor": "$author",
+                "appData": {
+                  "uniqueId": "${Uuid.random()}",
+                  "tags": null,
+                  "fileType": ${ChatProtocol.MessageFileType},
+                  "dataType": 0,
+                  "groupId": "$groupId",
+                  "userDate": ${now}000,
+                  "content": null,
+                  "previewThumbnail": null,
+                  "archivalStatus": $archivalStatus
+                },
+                "localAppData": null,
+                "referencedFile": null,
+                "reactionPreview": null,
+                "versionTag": "${Uuid.random()}",
+                "payloads": [],
+                "dataSource": null
+              },
+              "serverMetadata": {
+                "accessControlList": {
+                  "requiredSecurityGroup": "owner",
+                  "circleIdList": null,
+                  "odinIdList": null
+                },
+                "doNotIndex": false,
+                "allowDistribution": true,
+                "fileSystemType": "standard",
+                "fileByteCount": 50,
+                "originalRecipientCount": 0,
+                "transferHistory": null
+              },
+              "priority": 300,
+              "fileByteCount": 50
+            }"""
+        )
     }
 
     /** A legacy (pre-tag) group — >2 participants but no ConversationGroupTag. */
@@ -539,6 +611,24 @@ class ConversationServiceTestFixture : AutoCloseable {
         MainIndexMetaHelpers.upsertDriveMainIndex(dbm, record)
     }
 }
+
+// ---------- Shared outbox assertions ----------
+
+/**
+ * Decode a drained [Outbox] row as a hard-delete request, or null if it isn't one.
+ * Shared by the heal tests ([ConversationServiceHealTest]) and the recovery tests
+ * ([ConversationServiceRecoveryTest]).
+ */
+fun Outbox.asHardDeleteRequestOrNull(): DeleteLocalFilesByFileIdRequest? {
+    if (this.uploadType != DriveOutboxUploader.DeleteFile) return null
+    return try {
+        OdinSystemSerializer.deserialize<DeleteLocalFilesByFileIdRequest>(this.json.decodeToString())
+    } catch (_: Throwable) {
+        null
+    }
+}
+
+fun Outbox.isHardDeleteRequest(): Boolean = asHardDeleteRequestOrNull() != null
 
 // ---------- Test doubles ----------
 


### PR DESCRIPTION
## Problem

A corrupt conversation **header** file on the owner's *own* chat drive loops forever across launches:

```
FAILED map f642db19 → recover 582a3408 → deleteBy f642db19 (local) → write "1:1 repair" → next launch re-syncs f642db19 → repeat
```

The header is self-only (`recipients=[self]`) and unmappable, so:
1. `ConversationMapper.mapToBasic` flags it `ConversationState.Invalid`.
2. `ConversationStream.triggerRecoveryForInvalidRows` calls recovery (throttled once per launch by the session-scoped `recoveryAttemptedIds`).
3. `recoverConversation` writes a local-only `"1:1 repair"` placeholder.
4. Recovery is **local-only by design** — it deletes only the local row, never the file on our own *server* drive. The next sync re-downloads the same corrupt file and supersedes the placeholder → loop.

This is **not** an orphan-at-rest case (that sweep handles "messages, no header" and skips anything with a header). `582a3408` has a header that is simply corrupt, self-only, owner-authored, with 0 messages — nothing to reconstruct. The only durable fix is for recovery to remove the dead file from the owner's own server drive.

## Fix

`recoverConversation` now detects this before writing another doomed placeholder, via a new private `tryHardDeleteUnrecoverableOwnHeader(...)`. It is **conservatively gated** — it acts only when **all** hold:

- the existing header maps to `Invalid` (genuine content corruption),
- it was authored by us (`originalAuthor ?: senderOdinId ?: self == self`),
- its `recipients` list contains only ourselves (`!hasNonSelfParticipant`),
- there is **no peer message** in its group — a `QueryBatch` scan with `FileStateFilter.All`, so even soft-deleted tombstones count as a peer trace.

When all pass, it hard-deletes the file from our **own** server drive with `DeleteLocalFilesByFileIdRequest(recipients=null, hardDelete=true)` — the same own-drive primitive `GroupHealService` STEP 1 already uses (`recipients=null` ⇒ no peer fan-out; this is file removal, **not** distribution), drops the local row, refreshes the model, and writes no placeholder so the dead thread disappears. Every other case falls through to the existing local-placeholder path **unchanged**.

### Why this is safe

- **Healthy conversations are never touched, regardless of message-sync timing.** The gate keys on the header's own `recipients` list; a real 1:1/group header always carries the peer(s), so `hasNonSelfParticipant` is true and it maps to a valid state. A conversation whose messages haven't synced yet is still a valid header.
- **Note-to-self** (the one legitimately self-only conversation) is short-circuited at the top of `recoverConversation` before the gate.
- Even in a genuinely pathological race (real corruption left a self-only header *and* its peer messages are mid-sync), only the corrupt *header* is deleted — never message files; the messages re-derive via the live-orphan path as they arrive.

## Tests

`homebase-chat:jvmTest` (full suite green). The fixture runs a real in-memory SQLite DB and a real offline `OutboxSync`, so the enqueued delete is inspected field-by-field:

- **positive** — own-authored, self-only, message-less header → exactly one `DeleteLocalFilesByFileIdRequest` with `fileIds=[brokenFileId]`, `recipients=null`, `hardDelete=true`; local row gone; `removeConversation` called.
- **guard** — same header *with* a peer message → no delete, placeholder kept.
- **ownership gate** — self-only header authored by a *peer* → no delete.

Fixture changes: `originalAuthor` param on `seedOrphanedOneOnOneSelfOnly`, a `seedMessage(...)` helper, and `asHardDeleteRequestOrNull` promoted to a shared helper (de-duplicated from the heal test).

No `homebase-api` change (the guard reuses `QueryBatch`); no DI change.

## Note for reviewers

This inverts the prior contract for the self-only `Invalid` case: it used to revive as a `"1:1 repair"` group placeholder; it now hard-deletes. The old test asserting that behavior is rewritten accordingly.

## Manual unblock (no code)

To clear an already-stuck conversation on a live install before this ships, delete the corrupt header file from the chat drive via the owner console — deleting the in-app conversation or the placeholder won't work, since both re-derive from the server file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)