### PR TITLE
fix(notifications): scope notification clearing to the tapped conversation

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/receivers/NotificationMarkReadReceiver.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/receivers/NotificationMarkReadReceiver.kt
@@ -8,6 +8,7 @@ import co.touchlab.kermit.Logger
 import id.homebase.chat.services.ChatMessageActionService
 import id.homebase.core.notifications.NotificationService
 import id.homebase.core.notifications.RichNotificationDisplayer
+import id.homebase.core.notifications.conversationNotificationIds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -35,9 +36,10 @@ class NotificationMarkReadReceiver : BroadcastReceiver(), KoinComponent {
             "Marking conversation as read: $conversationId"
         }
 
-        // Dismiss notification and clear accumulated message count
+        // Dismiss the notification + its group summary, and clear accumulated count
         val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         nm.cancel(notificationId)
+        nm.cancel(conversationNotificationIds(conversationId).second)
         notificationService.clearNotificationCount(conversationId)
 
         val pendingResult = goAsync()

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/notifications/BadgeManager.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/notifications/BadgeManager.android.kt
@@ -6,7 +6,6 @@ import android.content.Context
 /**
  * Android badge management.
  * Badge count is managed per-notification via setNumber() on the notification builder.
- * clear() cancels all notifications (resetting badge count).
  */
 actual object BadgeManager {
     internal var badgeCount = 0
@@ -16,10 +15,23 @@ actual object BadgeManager {
         badgeCount++
     }
 
-    actual fun clear() {
+    actual fun resetCount() {
         badgeCount = 0
-        val context = RichNotificationDisplayer.appContext ?: return
-        val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        nm.cancelAll()
+    }
+
+    actual fun cancelAll() {
+        badgeCount = 0
+        notificationManager()?.cancelAll()
+    }
+
+    actual fun cancelConversationNotifications(messageId: Int, summaryId: Int) {
+        val nm = notificationManager() ?: return
+        nm.cancel(messageId)
+        nm.cancel(summaryId)
+    }
+
+    private fun notificationManager(): NotificationManager? {
+        val context = RichNotificationDisplayer.appContext ?: return null
+        return context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
     }
 }

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/notifications/RichNotificationDisplayer.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/notifications/RichNotificationDisplayer.android.kt
@@ -152,12 +152,18 @@ actual class RichNotificationDisplayer actual constructor() {
             .setGroup(data.conversationId)
             .setGroupSummary(true)
             .setAutoCancel(true)
+            // Route a summary tap through the same conversation-tap path as a
+            // per-message tap, so tapping the group clears only this conversation.
+            .setContentIntent(buildContentIntent(context, data))
         if (data.silent) {
             summaryBuilder.setSilent(true)
         }
         val summary = summaryBuilder.build()
 
-        val summaryId = SUMMARY_ID_OFFSET + (data.conversationId?.hashCode()?.and(0x7FFFFFFF) ?: 0)
+        // Shares conversationNotificationIds()'s summary-id formula so display and
+        // cancellation always target the same id.
+        val summaryId = data.conversationId?.let { conversationNotificationIds(it).second }
+            ?: SUMMARY_ID_OFFSET
         nm.notify(summaryId, summary)
     }
 
@@ -216,9 +222,6 @@ actual class RichNotificationDisplayer actual constructor() {
     }
 
     companion object {
-        /** Reserved offset so summary IDs don't collide with per-message notification IDs. */
-        private const val SUMMARY_ID_OFFSET = 100_000
-
         const val ACTION_REPLY = "id.homebase.feed.NOTIFICATION_REPLY"
         const val ACTION_MARK_READ = "id.homebase.feed.NOTIFICATION_MARK_READ"
         const val EXTRA_CONVERSATION_ID = "conversation_id"

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/BadgeManager.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/BadgeManager.kt
@@ -3,5 +3,22 @@ package id.homebase.core.notifications
 /** Platform-specific badge count management for app icon badges. */
 expect object BadgeManager {
     fun increment()
-    fun clear()
+
+    /**
+     * Resets the in-memory badge counter to 0 without dismissing any posted
+     * notifications. Use on app resume so the icon-badge total stays accurate
+     * while leaving the tray intact (the user clears notifications per
+     * conversation by tapping or reading them).
+     */
+    fun resetCount()
+
+    /** Resets the counter AND dismisses every posted notification. Logout only. */
+    fun cancelAll()
+
+    /**
+     * Dismisses a single conversation's posted notification and its group
+     * summary, leaving all other conversations' notifications in place.
+     * [messageId] and [summaryId] come from [conversationNotificationIds].
+     */
+    fun cancelConversationNotifications(messageId: Int, summaryId: Int)
 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/ConversationNotificationCounts.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/ConversationNotificationCounts.kt
@@ -1,0 +1,35 @@
+package id.homebase.core.notifications
+
+/**
+ * Tracks the per-conversation count of undismissed notifications, used to render
+ * the "$n new messages" summary body. A conversation's count is reset whenever
+ * its notifications are cleared — by opening the conversation, tapping its
+ * notification, marking it read, or logging out — so the next incoming message
+ * restarts the count at 1 rather than inflating a stale total.
+ *
+ * Not thread-safe; all access happens on the NotificationService coroutine scope.
+ */
+class ConversationNotificationCounts {
+
+    private val counts = mutableMapOf<String, Int>()
+
+    /** Increments the count for [conversationId] and returns the new running total. */
+    fun increment(conversationId: String): Int {
+        val next = (counts[conversationId] ?: 0) + 1
+        counts[conversationId] = next
+        return next
+    }
+
+    /** Current count for [conversationId], or 0 if none is tracked. */
+    fun peek(conversationId: String): Int = counts[conversationId] ?: 0
+
+    /** Forgets the count for [conversationId] (e.g. on tap, open, or mark-as-read). */
+    fun clear(conversationId: String) {
+        counts.remove(conversationId)
+    }
+
+    /** Forgets every conversation's count (e.g. on logout). */
+    fun clearAll() {
+        counts.clear()
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
@@ -61,7 +61,7 @@ class NotificationService(
     private val richDisplayer = RichNotificationDisplayer()
 
     /** Per-conversation message count for notification summary display. */
-    private val conversationMessageCounts = mutableMapOf<String, Int>()
+    private val counts = ConversationNotificationCounts()
 
     /** Chime cooldown: suppress alert sounds within this window. */
     private val ALERT_COOLDOWN = 15.minutes
@@ -94,7 +94,7 @@ class NotificationService(
         // Clear message counts when user opens a conversation
         scope.launch {
             ActiveConversation.conversation.collect { id ->
-                if (id != null) conversationMessageCounts.remove(id.toString())
+                if (id != null) clearConversationNotifications(id.toString())
             }
         }
         // Logout: drop per-conversation unread counts and the chime cooldown so the
@@ -116,12 +116,26 @@ class NotificationService(
 
     /** Clears the accumulated message count for a conversation (e.g. on mark-as-read). */
     fun clearNotificationCount(conversationId: String) {
-        conversationMessageCounts.remove(conversationId)
+        counts.clear(conversationId)
+    }
+
+    /**
+     * Clears a single conversation's notification state: forgets its summary
+     * count and cancels its posted notification + group summary from the tray.
+     * Called when the user taps the conversation's notification or opens the
+     * conversation in-app — scoped to one conversation so other senders'
+     * notifications are left intact.
+     */
+    private fun clearConversationNotifications(conversationId: String) {
+        counts.clear(conversationId)
+        val (messageId, summaryId) = conversationNotificationIds(conversationId)
+        BadgeManager.cancelConversationNotifications(messageId, summaryId)
     }
 
     /** Logout: clear all accumulated per-conversation counts and reset the chime cooldown. */
     fun reset() {
-        conversationMessageCounts.clear()
+        counts.clearAll()
+        BadgeManager.cancelAll()
         lastAlertMark = TimeSource.Monotonic.markNow() - ALERT_COOLDOWN
     }
 
@@ -260,7 +274,7 @@ class NotificationService(
                     Logger.d(tag = "NotificationService") {
                         "Suppressing notification — user is on chat screen"
                     }
-                    conversationMessageCounts.remove(conversationId)
+                    counts.clear(conversationId)
                     return@launch
                 }
 
@@ -301,9 +315,7 @@ class NotificationService(
 
                 // Track per-conversation message count for summary display
                 val messageCount = if (conversationId != null) {
-                    val count = (conversationMessageCounts[conversationId] ?: 0) + 1
-                    conversationMessageCounts[conversationId] = count
-                    count
+                    counts.increment(conversationId)
                 } else 1
 
                 // Override body with count summary when multiple messages accumulated
@@ -450,6 +462,9 @@ class NotificationService(
                                     "typeId=$typeId tagId=$tagId; no auto-navigate"
                         }
                     }
+                    // Tapping clears only this conversation's notifications + count,
+                    // leaving other senders' notifications in the tray.
+                    clearConversationNotifications(typeId)
                     NotificationNavigationEvent.OpenConversation(typeId)
                 }
 
@@ -702,4 +717,31 @@ internal fun extractChatTapIds(typeId: String, tagId: String): Pair<Uuid, Uuid>?
     val msgUuid = tagId.takeIf { it.isNotBlank() }?.let { Uuid.parseOrNull(it) }
         ?: return null
     return convoUuid to msgUuid
+}
+
+/**
+ * Reserved offset so a conversation's group-summary id never collides with a
+ * per-message notification id. Shared between the Android displayer (which posts
+ * with these ids) and [conversationNotificationIds] (which cancels by them) so
+ * the two can never drift.
+ */
+internal const val SUMMARY_ID_OFFSET = 100_000
+
+/**
+ * Derives the (per-message id, group-summary id) pair that a chat conversation's
+ * notifications were posted under, so a single conversation can be cancelled
+ * without touching any other. Must reproduce exactly what the display path used:
+ *  - per-message id = [PushNotificationPayloadOptions.conversationNotificationId]
+ *    (the raw, unmasked `typeId.hashCode()`), and
+ *  - summary id = [SUMMARY_ID_OFFSET] + the masked hash (see
+ *    RichNotificationDisplayer.postSummaryNotification).
+ *
+ * Degenerate case: if `conversationId.hashCode() == 0` the display path posts the
+ * per-message notification under a random id instead, so a derived cancel would
+ * miss it — astronomically rare for a UUID string, not special-cased.
+ */
+fun conversationNotificationIds(conversationId: String): Pair<Int, Int> {
+    val messageId = conversationId.hashCode()
+    val summaryId = SUMMARY_ID_OFFSET + (conversationId.hashCode() and 0x7FFFFFFF)
+    return messageId to summaryId
 }

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/notifications/BadgeManager.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/notifications/BadgeManager.jvm.kt
@@ -1,7 +1,9 @@
 package id.homebase.core.notifications
 
-/** Desktop: No badge support. */
+/** Desktop: No badge support; toasts can't be cancelled individually. */
 actual object BadgeManager {
     actual fun increment() { /* no-op */ }
-    actual fun clear() { /* no-op */ }
+    actual fun resetCount() { /* no-op */ }
+    actual fun cancelAll() { /* no-op */ }
+    actual fun cancelConversationNotifications(messageId: Int, summaryId: Int) { /* no-op */ }
 }

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/ConversationNotificationCountsTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/ConversationNotificationCountsTest.kt
@@ -1,0 +1,78 @@
+package id.homebase.core.notifications
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+
+/**
+ * Locks down the per-conversation notification counter that drives the
+ * "$n new messages" summary body. The bug this guards against: the count was
+ * only reset on conversation-open / mark-as-read / logout, never on a
+ * notification tap or swipe-dismiss, so a tapped-away conversation kept its
+ * stale count and the next incoming message read "$n+1 new messages" instead
+ * of restarting at 1.
+ */
+class ConversationNotificationCountsTest {
+
+    private val a = Uuid.random().toString()
+    private val b = Uuid.random().toString()
+
+    @Test
+    fun increment_returnsRunningCount() {
+        val counts = ConversationNotificationCounts()
+        assertEquals(1, counts.increment(a))
+        assertEquals(2, counts.increment(a))
+        assertEquals(3, counts.increment(a))
+    }
+
+    @Test
+    fun peek_returnsZeroForUnknownConversation() {
+        val counts = ConversationNotificationCounts()
+        assertEquals(0, counts.peek(a))
+    }
+
+    @Test
+    fun peek_reflectsLastIncrement() {
+        val counts = ConversationNotificationCounts()
+        counts.increment(a)
+        counts.increment(a)
+        assertEquals(2, counts.peek(a))
+    }
+
+    /** Bug #2: after a tap/open clears the conversation, the next message restarts at 1. */
+    @Test
+    fun clear_restartsConversationAtOne() {
+        val counts = ConversationNotificationCounts()
+        repeat(5) { counts.increment(a) }
+        assertEquals(5, counts.peek(a))
+
+        counts.clear(a)
+        assertEquals(0, counts.peek(a))
+        assertEquals(1, counts.increment(a))
+    }
+
+    /** Clearing one conversation must not touch another (mirror of Bug #1's intent). */
+    @Test
+    fun clear_isScopedToOneConversation() {
+        val counts = ConversationNotificationCounts()
+        repeat(3) { counts.increment(a) }
+        repeat(2) { counts.increment(b) }
+
+        counts.clear(a)
+
+        assertEquals(0, counts.peek(a))
+        assertEquals(2, counts.peek(b))
+    }
+
+    @Test
+    fun clearAll_wipesEverything() {
+        val counts = ConversationNotificationCounts()
+        counts.increment(a)
+        counts.increment(b)
+
+        counts.clearAll()
+
+        assertEquals(0, counts.peek(a))
+        assertEquals(0, counts.peek(b))
+    }
+}

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/ConversationNotificationIdsTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/ConversationNotificationIdsTest.kt
@@ -1,0 +1,54 @@
+package id.homebase.core.notifications
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * Locks down the conversation -> (messageId, summaryId) derivation used to
+ * cancel a single conversation's notifications. The bug this guards against:
+ * tapping any notification ran NotificationManager.cancelAll(), wiping every
+ * conversation's notifications. The fix cancels only the tapped conversation's
+ * two ids — so distinct conversations MUST yield disjoint id pairs, and the
+ * derivation MUST match what the Android displayer actually posted.
+ */
+class ConversationNotificationIdsTest {
+
+    private val a = Uuid.random().toString()
+    private val b = Uuid.random().toString()
+
+    /** Per-message id matches the display path (RichNotificationData.conversationNotificationId, unmasked). */
+    @Test
+    fun messageId_matchesUnmaskedHashCode() {
+        val (messageId, _) = conversationNotificationIds(a)
+        assertEquals(a.hashCode(), messageId)
+    }
+
+    /** Summary id matches RichNotificationDisplayer.postSummaryNotification's formula. */
+    @Test
+    fun summaryId_matchesDisplayerFormula() {
+        val (_, summaryId) = conversationNotificationIds(a)
+        assertEquals(SUMMARY_ID_OFFSET + (a.hashCode() and 0x7FFFFFFF), summaryId)
+    }
+
+    /** Bug #1 proof: a scoped cancel of A can never collide with B's notifications. */
+    @Test
+    fun differentConversations_produceDisjointIds() {
+        val (msgA, summaryA) = conversationNotificationIds(a)
+        val (msgB, summaryB) = conversationNotificationIds(b)
+
+        val idsA = setOf(msgA, summaryA)
+        val idsB = setOf(msgB, summaryB)
+
+        assertTrue(idsA.intersect(idsB).isEmpty(), "conversation A and B share a notification id")
+    }
+
+    @Test
+    fun summaryId_isAlwaysPositive() {
+        repeat(50) {
+            val (_, summaryId) = conversationNotificationIds(Uuid.random().toString())
+            assertTrue(summaryId >= SUMMARY_ID_OFFSET, "summary id underflowed the offset")
+        }
+    }
+}

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/notifications/BadgeManager.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/notifications/BadgeManager.native.kt
@@ -10,7 +10,15 @@ actual object BadgeManager {
         app.applicationIconBadgeNumber = app.applicationIconBadgeNumber + 1
     }
 
-    actual fun clear() {
+    actual fun resetCount() {
         UIApplication.sharedApplication.applicationIconBadgeNumber = 0
     }
+
+    actual fun cancelAll() {
+        UIApplication.sharedApplication.applicationIconBadgeNumber = 0
+    }
+
+    // The iOS Notification Service Extension owns per-notification display; there
+    // is no Kotlin-side handle to cancel an individual conversation's notification.
+    actual fun cancelConversationNotifications(messageId: Int, summaryId: Int) { /* no-op */ }
 }

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/notifications/BadgeManager.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/notifications/BadgeManager.web.kt
@@ -3,5 +3,7 @@ package id.homebase.core.notifications
 /** Web: No badge support. */
 actual object BadgeManager {
     actual fun increment() { /* no-op */ }
-    actual fun clear() { /* no-op */ }
+    actual fun resetCount() { /* no-op */ }
+    actual fun cancelAll() { /* no-op */ }
+    actual fun cancelConversationNotifications(messageId: Int, summaryId: Int) { /* no-op */ }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppViewModel.kt
@@ -116,7 +116,10 @@ class AppViewModel(
         authConnectionCoordinator.setForeground(true)
         refreshData()
         checkForUpdate()
-        BadgeManager.clear()
+        // Reset the icon-badge counter without wiping the tray — notifications
+        // clear per conversation when the user taps or reads them, so opening
+        // the app from the launcher leaves other senders' notifications intact.
+        BadgeManager.resetCount()
     }
 
     /** Called when the app leaves RESUMED state. */


### PR DESCRIPTION
## Problem

Two related notification bugs on Android:

1. **Tapping any notification cleared the entire tray** — including notifications from *other* senders. Tapping "Fyr sent you 5 messages" wiped Alice's notifications too.
2. **Stale, inflated per-conversation count** — after a conversation's notifications were cleared, its message count wasn't reset, so the next incoming message read "6 new messages" instead of restarting at 1.

## Root causes (confirmed in code, then pinned by tests)

- `AppViewModel.onResumed()` called `BadgeManager.clear()`, which on Android runs `nm.cancelAll()`. Tapping a notification brings the app to the foreground → `onResumed()` → the **whole tray is wiped**.
- The group **summary** notification (`postSummaryNotification`) had **no `setContentIntent()`**, so tapping "Fyr sent you 5 messages" never routed through `handleNotificationClicked` — it just launched the default activity and fell through to the blanket `cancelAll()`, with no per-conversation clear.
- `NotificationService.conversationMessageCounts` was reset **only** on conversation-open, mark-as-read, and logout — **never on notification tap or swipe-dismiss**. A tapped-away conversation kept its stale count.

## Approach (TDD)

Wrote failing JVM unit tests first, then made them green:

- **`ConversationNotificationCountsTest`** — count restarts at 1 after `clear`; clearing conversation A leaves B's count untouched.
- **`ConversationNotificationIdsTest`** — two distinct conversations produce **disjoint** (message id, summary id) pairs (so a scoped cancel of A can never hit B), and the derivation matches exactly what the Android displayer posts.

## Changes

**New testable seams (commonMain)**
- `ConversationNotificationCounts` — small, directly testable counter (`increment`/`peek`/`clear`/`clearAll`) replacing the inline `conversationMessageCounts` map.
- `conversationNotificationIds(conversationId)` + shared `SUMMARY_ID_OFFSET` — single source of truth for the (per-message id, group-summary id) derivation, used by both display and cancellation so they can't drift.

**BadgeManager API (expect + all 4 actuals: android / jvm / native / web)**
- Split `clear()` into:
  - `resetCount()` — zeroes the in-memory badge counter **without** dismissing notifications (used on resume).
  - `cancelAll()` — counter reset **and** `nm.cancelAll()` (logout only).
- Added `cancelConversationNotifications(messageId, summaryId)` — dismisses one conversation's notification + summary, leaving others intact.

**Behavior wiring**
- `onResumed()` now calls `resetCount()` instead of `clear()` → opening the app from the launcher no longer wipes the tray.
- A single private `clearConversationNotifications(id)` helper (count + scoped cancel) is shared by the **tap path** (`handleNotificationClicked`) and the **conversation-open** collector — no duplicated blocks.
- The summary notification gets a `setContentIntent` so tapping the group routes through the same per-conversation clear.
- `NotificationMarkReadReceiver` also cancels the summary id so the group doesn't linger after mark-as-read.
- Logout (`NotificationService.reset()`) still wipes everything via `cancelAll()`.

## Resulting behavior

- Tapping or reading a conversation clears **only** that conversation (notification + summary + count); other senders' notifications stay.
- After clearing, the next message restarts the count at 1.
- Opening the app from the launcher (not via a notification) leaves the tray intact — notifications clear per conversation when tapped or read. *(Confirmed UX choice.)*
- Opening a conversation in-app dismisses its system notification + summary, not just the count. *(Confirmed UX choice.)*

## Platform notes

- **iOS**: the count map is unused there (the native Notification Service Extension renders/dedupes), so the counter and tap-clear changes are no-ops; `cancelConversationNotifications` is a native no-op by design (`resetCount`/`cancelAll` zero the app icon badge).
- **Desktop (Nucleus)**: `cancelConversationNotifications` is a no-op — desktop can't cancel individual toasts and has no badge.

## Testing

- `./gradlew homebase-common:jvmTest homebase-core:jvmTest` — 10 new tests pass; existing notification suites unchanged.
- Compiles on all four platform actuals: `homebase-common:compileAndroidMain`, `compileKotlinIosSimulatorArm64`, `compileKotlinWasmJs`, and `androidApp:compileDebugKotlin`.
- **Manual Android check still recommended** (needs a device, two senders): tap Fyr's notification → only Fyr's clears, Alice's stays; next Fyr message reads as a single message, not "6 new messages"; opening Fyr's conversation clears its tray entry; launcher-open leaves the tray intact; logout clears everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)