### PR TITLE
Fix cold-start conversation-list & chat-details spinner gating

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -340,7 +340,7 @@ class ConversationListViewModel(
                 "main list pipeline: reaching combine.collect setup at ${vmInitMark.elapsedNow().inWholeMilliseconds}ms from vmInit"
             }
             var firstCombineEval = true
-            var firstReadyEmitted = false
+            val listDebounce = ConversationListDebounce()
             combine(
                 conversationStream.conversations,
                 contactService.contacts,
@@ -387,17 +387,8 @@ class ConversationListViewModel(
                 // lifecycle. A flat debounce(50) never sees 50ms of quiet during that
                 // storm, so it withheld the ready list for ~half a second until the
                 // connection settled ("blocked until it goes green"). See
-                // [conversationListDebounceMillis] / ConversationListDebounceTest.
-                val timeout = conversationListDebounceMillis(
-                    dataReady = dataReady,
-                    readyAlreadyEmitted = firstReadyEmitted,
-                )
-                // Flip the flag here, in the selector's own coroutine, the instant the
-                // first ready snapshot is granted the leading edge (0ms) — so storm values
-                // evaluated immediately after coalesce at 50ms instead of racing the
-                // downstream collect to set it. Keeps the var confined to one coroutine.
-                if (timeout == 0L) firstReadyEmitted = true
-                timeout
+                // [ConversationListDebounce] / ConversationListDebounceTest.
+                listDebounce.timeoutMillisFor(dataReady)
             }.collect { (dataReady: Boolean, enriched: List<EnrichedConversationUiModel>) ->
                 Logger.i(tag = "ConversationListViewModel") {
                     "conversationStream emit: dataReady=$dataReady enrichedCount=${enriched.size}"
@@ -1478,18 +1469,29 @@ class ConversationListViewModel(
 }
 
 /**
- * Debounce timeout (ms) for the conversation-list combine. The list's sources
+ * Leading-edge debounce policy for the conversation-list combine. The list's sources
  * (ownerSession, connectionStatusFlow) re-emit continuously through the auth/connect
- * lifecycle; a flat debounce would withhold the already-ready cached list until that
- * storm settled (~when the connection goes online — the "blocked until green" bug).
+ * lifecycle; a flat debounce would withhold the already-ready cached list until that storm
+ * settled (~when the connection goes online — the "blocked until green" bug).
  *
- * Leading-edge: 0ms for the FIRST ready snapshot so the cached list renders immediately,
- * 50ms afterwards so the connect-time storm is still coalesced into few re-sorts.
+ * The first ready snapshot is granted the leading edge (0ms) so the cached list renders
+ * immediately; everything after is coalesced at 50ms so the storm is a few re-sorts, not
+ * one per source emission.
  *
- * Pure so ConversationListDebounceTest can pin the behavior without a ViewModel.
+ * Stateful (remembers whether the first ready snapshot has been granted) — use one instance
+ * per collect, on a single coroutine. Owning the flag here keeps it out of the ViewModel
+ * and lets ConversationListDebounceTest exercise the real policy instead of a mirror.
  */
-internal fun conversationListDebounceMillis(dataReady: Boolean, readyAlreadyEmitted: Boolean): Long =
-    if (dataReady && !readyAlreadyEmitted) 0L else 50L
+internal class ConversationListDebounce {
+    private var firstReadyEmitted = false
+
+    /** Debounce timeout (ms) for a combine emission with the given [dataReady]. */
+    fun timeoutMillisFor(dataReady: Boolean): Long {
+        val timeout = if (dataReady && !firstReadyEmitted) 0L else 50L
+        if (timeout == 0L) firstReadyEmitted = true
+        return timeout
+    }
+}
 
 /**
  * Whether the message-load backstop should clear the chat-details loading spinner when a

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -1384,6 +1384,19 @@ class ConversationListViewModel(
             } catch (_: CancellationException) {
                 // ignore
             } catch (e: Exception) {
+                // A failed load (DB error, deserialization, etc.) must NOT leave the
+                // detail pane spinning forever: the success path only clears
+                // isLoadingMessages inside the observeMessages collect, which we never
+                // reach here. Log it (previously this was snackbar-only, invisible in
+                // homebase.log) and clear the spinner. Guard on the conversation still
+                // being selected so a late failure from a superseded job can't wipe the
+                // spinner of the conversation the user has since switched to.
+                Logger.e(throwable = e, tag = "ConversationListViewModel") {
+                    "loadMessagesForConversation failed id=$conversationId trigger=$trigger: ${e.message}"
+                }
+                if (_uiState.value.selectedConversationId == conversationId) {
+                    _messagesUiState.update { it.copy(isLoadingMessages = false) }
+                }
                 sendEvent(ShowErrorMessage("Failed to load messages: ${e.message}"))
             }
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -132,6 +132,11 @@ class ConversationListViewModel(
 
     companion object {
         private const val TAG = "ConversationListViewModel"
+
+        // How long the chat-details loading spinner may stay up for one conversation
+        // before the watchdog logs it as stuck. Generous so a slow-but-legitimate DB
+        // read isn't flagged; the point is to catch a load that never completes/fails.
+        private const val SPINNER_WATCHDOG_MS = 8_000L
     }
 
     private val enricher = ConversationEnricher()
@@ -1151,6 +1156,23 @@ class ConversationListViewModel(
         // avoid observing multiple messageStreams
         currentConversationJob?.cancel()
         currentConversationJob = viewModelScope.launch {
+            // Spinner watchdog: if the detail pane is still loading THIS conversation
+            // after a generous threshold, log it (with elapsed) so a stuck/hung load is
+            // visible in homebase.log even when it neither completed nor threw — the
+            // signature of a real "infinity spinner" report. Diagnostic only; a
+            // genuinely slow DB read is still allowed to finish.
+            val watchdog = launch {
+                delay(SPINNER_WATCHDOG_MS)
+                if (_uiState.value.selectedConversationId == conversationId &&
+                    _messagesUiState.value.isLoadingMessages
+                ) {
+                    Logger.w(tag = "ConversationListViewModel") {
+                        "chat-details still loading after ${SPINNER_WATCHDOG_MS}ms id=$conversationId " +
+                            "trigger=$trigger sinceSelected=${loadStart.elapsedNow()} — " +
+                            "load has not completed or failed"
+                    }
+                }
+            }
             try {
                 var messageIdForScrollNullable = messageIdForScroll
                 var setInitialScroll = true
@@ -1382,22 +1404,27 @@ class ConversationListViewModel(
                     }
                 }
             } catch (_: CancellationException) {
-                // ignore
+                // ignore — a new selection cancels this job; the new job owns the
+                // loading state for the conversation being switched to.
             } catch (e: Exception) {
-                // A failed load (DB error, deserialization, etc.) must NOT leave the
-                // detail pane spinning forever: the success path only clears
-                // isLoadingMessages inside the observeMessages collect, which we never
-                // reach here. Log it (previously this was snackbar-only, invisible in
-                // homebase.log) and clear the spinner. Guard on the conversation still
-                // being selected so a late failure from a superseded job can't wipe the
-                // spinner of the conversation the user has since switched to.
+                // Previously snackbar-only (invisible in homebase.log) AND the spinner
+                // was never cleared — a failed load (DB error, deserialization, …) left
+                // the detail pane spinning forever (the reported "infinity spinner").
                 Logger.e(throwable = e, tag = "ConversationListViewModel") {
                     "loadMessagesForConversation failed id=$conversationId trigger=$trigger: ${e.message}"
                 }
+                sendEvent(ShowErrorMessage("Failed to load messages: ${e.message}"))
+            } finally {
+                watchdog.cancel()
+                // Backstop so the detail pane can never spin forever: the success path
+                // clears isLoadingMessages inside the collect; this covers an error or an
+                // unexpected end (cancellation/scope teardown) while still on this
+                // conversation. Guarded so a cancellation caused by switching
+                // conversations — which already set isLoadingMessages=true for the NEW
+                // conversation — can't wipe its spinner.
                 if (_uiState.value.selectedConversationId == conversationId) {
                     _messagesUiState.update { it.copy(isLoadingMessages = false) }
                 }
-                sendEvent(ShowErrorMessage("Failed to load messages: ${e.message}"))
             }
         }
     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -386,9 +386,9 @@ class ConversationListViewModel(
                 // connectionStatusFlow) keep re-emitting all through the auth/connect
                 // lifecycle. A flat debounce(50) never sees 50ms of quiet during that
                 // storm, so it withheld the ready list for ~half a second until the
-                // connection settled ("blocked until it goes green"). 0ms for the first
-                // ready emit fixes that; 50ms thereafter still coalesces the storm.
-                if (dataReady && !firstReadyEmitted) 0L else 50L
+                // connection settled ("blocked until it goes green"). See
+                // [conversationListDebounceMillis] / ConversationListDebounceTest.
+                conversationListDebounceMillis(dataReady = dataReady, readyAlreadyEmitted = firstReadyEmitted)
             }.collect { (dataReady: Boolean, enriched: List<EnrichedConversationUiModel>) ->
                 Logger.i(tag = "ConversationListViewModel") {
                     "conversationStream emit: dataReady=$dataReady enrichedCount=${enriched.size}"
@@ -1419,10 +1419,21 @@ class ConversationListViewModel(
                 // Backstop so the detail pane can never spin forever: the success path
                 // clears isLoadingMessages inside the collect; this covers an error or an
                 // unexpected end (cancellation/scope teardown) while still on this
-                // conversation. Guarded so a cancellation caused by switching
-                // conversations — which already set isLoadingMessages=true for the NEW
-                // conversation — can't wipe its spinner.
-                if (_uiState.value.selectedConversationId == conversationId) {
+                // conversation. Guarded (see [shouldClearLoadingSpinnerOnLoadEnd]) so a
+                // cancellation from switching conversations — which already set
+                // isLoadingMessages=true for the NEW conversation — can't wipe its
+                // spinner. Reaching here with loading still true is abnormal (the success
+                // path should have cleared it), so log it loudly.
+                if (shouldClearLoadingSpinnerOnLoadEnd(
+                        selectedConversationId = _uiState.value.selectedConversationId,
+                        conversationId = conversationId,
+                        stillLoading = _messagesUiState.value.isLoadingMessages,
+                    )
+                ) {
+                    Logger.w(tag = TAG) {
+                        "chat-details spinner backstop fired id=$conversationId trigger=$trigger " +
+                            "sinceSelected=${loadStart.elapsedNow()} — clearing a spinner the load left set"
+                    }
                     _messagesUiState.update { it.copy(isLoadingMessages = false) }
                 }
             }
@@ -1459,13 +1470,44 @@ class ConversationListViewModel(
 }
 
 /**
- * Chooses the [OwnerSession] passed to [ConversationEnricher]: prefer the
- * fully-resolved [live] session, fall back to a minimal one synthesized
- * from [credentials] when the async profile load hasn't arrived yet.
+ * Debounce timeout (ms) for the conversation-list combine. The list's sources
+ * (ownerSession, connectionStatusFlow) re-emit continuously through the auth/connect
+ * lifecycle; a flat debounce would withhold the already-ready cached list until that
+ * storm settled (~when the connection goes online — the "blocked until green" bug).
  *
- * Returns null only when neither source is available (pre-login state).
- * The preference order is load-bearing — inverting it would replace a
- * resolved display name / profile image with a bare odinId.
+ * Leading-edge: 0ms for the FIRST ready snapshot so the cached list renders immediately,
+ * 50ms afterwards so the connect-time storm is still coalesced into few re-sorts.
+ *
+ * Pure so ConversationListDebounceTest can pin the behavior without a ViewModel.
+ */
+internal fun conversationListDebounceMillis(dataReady: Boolean, readyAlreadyEmitted: Boolean): Long =
+    if (dataReady && !readyAlreadyEmitted) 0L else 50L
+
+/**
+ * Whether the message-load backstop should clear the chat-details loading spinner when a
+ * load coroutine ends. The success path clears it inside the observeMessages collect; this
+ * guards the `finally` backstop that catches an error / unexpected cancellation / hung load
+ * that left the spinner set (the reported "infinity spinner").
+ *
+ * Clears only when (a) THIS conversation is still the selected one — so a cancellation from
+ * switching conversations, which already armed the spinner for the NEW conversation, can't
+ * wipe it — and (b) the spinner is actually still up (reaching the backstop with it already
+ * cleared is the normal success case, nothing to do).
+ *
+ * Pure so SpinnerBackstopGuardTest can pin the rule without a ViewModel.
+ */
+internal fun shouldClearLoadingSpinnerOnLoadEnd(
+    selectedConversationId: Uuid?,
+    conversationId: Uuid,
+    stillLoading: Boolean,
+): Boolean = stillLoading && selectedConversationId == conversationId
+
+/**
+ * Chooses the [OwnerSession] passed to [ConversationEnricher]: prefer the fully-resolved
+ * [live] session, fall back to a minimal one synthesized from [credentials] when the async
+ * profile load hasn't arrived yet. Returns null only when neither source is available
+ * (pre-login). The preference order is load-bearing — inverting it would replace a resolved
+ * display name / profile image with a bare odinId.
  */
 internal fun synthesizeOwnerSession(
     live: OwnerSession?,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -388,13 +388,21 @@ class ConversationListViewModel(
                 // storm, so it withheld the ready list for ~half a second until the
                 // connection settled ("blocked until it goes green"). See
                 // [conversationListDebounceMillis] / ConversationListDebounceTest.
-                conversationListDebounceMillis(dataReady = dataReady, readyAlreadyEmitted = firstReadyEmitted)
+                val timeout = conversationListDebounceMillis(
+                    dataReady = dataReady,
+                    readyAlreadyEmitted = firstReadyEmitted,
+                )
+                // Flip the flag here, in the selector's own coroutine, the instant the
+                // first ready snapshot is granted the leading edge (0ms) — so storm values
+                // evaluated immediately after coalesce at 50ms instead of racing the
+                // downstream collect to set it. Keeps the var confined to one coroutine.
+                if (timeout == 0L) firstReadyEmitted = true
+                timeout
             }.collect { (dataReady: Boolean, enriched: List<EnrichedConversationUiModel>) ->
                 Logger.i(tag = "ConversationListViewModel") {
                     "conversationStream emit: dataReady=$dataReady enrichedCount=${enriched.size}"
                 }
                 if (dataReady) {
-                    firstReadyEmitted = true
                     _uiState.update {
                         it.copy(
                             activeConversations = enriched

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -569,19 +569,32 @@ class ConversationListViewModel(
         // CLVM is created (returning user, instant cold-load), selectConversation
         // fires during VM init. That's intentional — it's the right behavior —
         // but worth knowing when reading a stack trace.
+        // Monotonic mark stamped the moment a notification tap is first observed (by
+        // whichever of the two collectors below sees it first), so every NotifTap log can
+        // report elapsed-since-tap — pinning where a notification-tap delay lives:
+        // resolution (convo not in items yet), fast-path DB load, message fetch, or
+        // detail-pane render. Both collectors run on viewModelScope (Main), so a plain var
+        // is safe.
+        var notifTapMark: kotlin.time.TimeMark? = null
+
         viewModelScope.launch {
             combine(
                 pendingNotificationTap.state,
                 conversationStream.conversations,
             ) { tap, convos -> tap to convos }
                 .collect { (tap, convosState) ->
+                    if (tap != null && notifTapMark == null) {
+                        notifTapMark = TimeSource.Monotonic.markNow()
+                    }
                     val resolved = resolveNotificationTap(
                         tap = tap,
                         conversationIds = convosState.items.map { it.id }.toSet(),
                     ) ?: return@collect
-                    Logger.i(tag = "ConversationListViewModel") {
-                        "pendingNotificationTap resolved convo=${resolved.conversationId} msg=${resolved.messageId}"
+                    Logger.i(tag = "NotifTap") {
+                        "resolved convo=${resolved.conversationId} msg=${resolved.messageId} " +
+                            "sinceTap=${notifTapMark?.elapsedNow()?.inWholeMilliseconds ?: -1}ms itemsAtResolve=${convosState.items.size}"
                     }
+                    notifTapMark = null
                     selectConversation(
                         conversationId = resolved.conversationId,
                         messageId = resolved.messageId,
@@ -609,12 +622,23 @@ class ConversationListViewModel(
         viewModelScope.launch {
             pendingNotificationTap.state.collect { tap ->
                 if (tap == null) return@collect
+                if (notifTapMark == null) notifTapMark = TimeSource.Monotonic.markNow()
                 val convoId = tap.conversationId
                 val alreadyLoaded = conversationStream.conversations.value.items
                     .any { it.id == convoId }
+                Logger.i(tag = "NotifTap") {
+                    "fast-path: tap convo=$convoId msg=${tap.messageId} alreadyInItems=$alreadyLoaded " +
+                        "sinceTap=${notifTapMark?.elapsedNow()?.inWholeMilliseconds ?: -1}ms"
+                }
                 if (alreadyLoaded) return@collect
                 launch(ioDispatcher) {
+                    val mark = TimeSource.Monotonic.markNow()
                     conversationStream.loadConversation(convoId)
+                    val nowInItems = conversationStream.conversations.value.items.any { it.id == convoId }
+                    Logger.i(tag = "NotifTap") {
+                        "fast-path: loadConversation($convoId) took=${mark.elapsedNow().inWholeMilliseconds}ms " +
+                            "nowInItems=$nowInItems"
+                    }
                 }
             }
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -335,6 +335,7 @@ class ConversationListViewModel(
                 "main list pipeline: reaching combine.collect setup at ${vmInitMark.elapsedNow().inWholeMilliseconds}ms from vmInit"
             }
             var firstCombineEval = true
+            var firstReadyEmitted = false
             combine(
                 conversationStream.conversations,
                 contactService.contacts,
@@ -372,11 +373,23 @@ class ConversationListViewModel(
                         connectionStatusKnown = connectionCtx.statusKnown,
                     )
                 })
-            }.debounce(50).collect { (dataReady: Boolean, enriched: List<EnrichedConversationUiModel>) ->
+            }.debounce { (dataReady, _) ->
+                // Leading-edge debounce: render the FIRST ready list immediately, then
+                // coalesce the burst that follows. The cached conversations + a
+                // credentials-synthesized session make a complete list available within
+                // a few ms of vmInit, but the combine's sources (ownerSession,
+                // connectionStatusFlow) keep re-emitting all through the auth/connect
+                // lifecycle. A flat debounce(50) never sees 50ms of quiet during that
+                // storm, so it withheld the ready list for ~half a second until the
+                // connection settled ("blocked until it goes green"). 0ms for the first
+                // ready emit fixes that; 50ms thereafter still coalesces the storm.
+                if (dataReady && !firstReadyEmitted) 0L else 50L
+            }.collect { (dataReady: Boolean, enriched: List<EnrichedConversationUiModel>) ->
                 Logger.i(tag = "ConversationListViewModel") {
                     "conversationStream emit: dataReady=$dataReady enrichedCount=${enriched.size}"
                 }
                 if (dataReady) {
+                    firstReadyEmitted = true
                     _uiState.update {
                         it.copy(
                             activeConversations = enriched

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -282,6 +282,9 @@ class ConversationListViewModel(
 
         viewModelScope.launch {
             val vmInitMark = TimeSource.Monotonic.markNow()
+            Logger.i(tag = "ConvListPerf") {
+                "main list pipeline: launch body entered at ${vmInitMark.elapsedNow().inWholeMilliseconds}ms from vmInit"
+            }
             contactService.start()
             conversationStream.start()
             connectionService.start()
@@ -328,6 +331,10 @@ class ConversationListViewModel(
                 }
             }
 
+            Logger.i(tag = "ConvListPerf") {
+                "main list pipeline: reaching combine.collect setup at ${vmInitMark.elapsedNow().inWholeMilliseconds}ms from vmInit"
+            }
+            var firstCombineEval = true
             combine(
                 conversationStream.conversations,
                 contactService.contacts,
@@ -342,6 +349,14 @@ class ConversationListViewModel(
                 // before OwnerSessionRepository.load() has run — the enricher
                 // never has to deal with a null session.
                 val effectiveSession = synthesizeOwnerSession(ownerSession, credentials)
+                if (firstCombineEval) {
+                    firstCombineEval = false
+                    Logger.i(tag = "ConvListPerf") {
+                        "main list pipeline: combine first eval at ${vmInitMark.elapsedNow().inWholeMilliseconds}ms from vmInit " +
+                            "ownerSession=${ownerSession != null} credentials=${credentials != null} " +
+                            "effectiveSession=${effectiveSession != null} dataReady=${conversationState.dataReady} items=${conversationState.items.size}"
+                    }
+                }
                 if (effectiveSession == null) return@combine Pair(false, emptyList())
 
                 val contactMap = contacts.associateBy { it.odinId }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/ConversationListDebounceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/ConversationListDebounceTest.kt
@@ -58,9 +58,12 @@ class ConversationListDebounceTest {
                 emit(false to "storm$i")          // storm faster than the 50ms debounce
             }
         }.debounce { (dataReady, _) ->
-            conversationListDebounceMillis(dataReady = dataReady, readyAlreadyEmitted = firstReadyEmitted)
+            // Mirror the ViewModel wiring: the selector flips the flag when it grants the
+            // leading edge (0ms), so the flag is confined to the selector's coroutine.
+            val timeout = conversationListDebounceMillis(dataReady = dataReady, readyAlreadyEmitted = firstReadyEmitted)
+            if (timeout == 0L) firstReadyEmitted = true
+            timeout
         }.collect { (dataReady, _) ->
-            if (dataReady) firstReadyEmitted = true
             collected += testScheduler.currentTime to dataReady
         }
 

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/ConversationListDebounceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/ConversationListDebounceTest.kt
@@ -1,0 +1,77 @@
+@file:OptIn(kotlinx.coroutines.FlowPreview::class, kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package id.homebase.chat.conversationlist
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression guard for the cold-start "list blocked until the connection goes green" bug.
+ *
+ * The conversation-list combine builds a complete, ready list within a few ms of vmInit
+ * (cached conversations + a credentials-synthesized session), but its sources
+ * (ownerSession, connectionStatusFlow) keep re-emitting all through the auth/connect
+ * lifecycle. A flat `debounce(50)` never saw 50ms of quiet during that storm, so it
+ * withheld the already-ready list for ~half a second until the connection settled.
+ *
+ * The fix is a leading-edge debounce ([conversationListDebounceMillis]): 0ms for the first
+ * ready snapshot, 50ms thereafter. These tests pin both the selector and the end-to-end
+ * flow behavior so a revert to a flat debounce is caught.
+ */
+class ConversationListDebounceTest {
+
+    @Test
+    fun selector_firstReadySnapshotIsImmediate() {
+        // The first ready snapshot must pass through with no debounce.
+        assertEquals(0L, conversationListDebounceMillis(dataReady = true, readyAlreadyEmitted = false))
+    }
+
+    @Test
+    fun selector_subsequentReadySnapshotsAreCoalesced() {
+        // After the first render, updates are coalesced so the connect-time storm doesn't
+        // re-sort the list on every micro-change.
+        assertEquals(50L, conversationListDebounceMillis(dataReady = true, readyAlreadyEmitted = true))
+    }
+
+    @Test
+    fun selector_notReadySnapshotsAreCoalesced() {
+        assertEquals(50L, conversationListDebounceMillis(dataReady = false, readyAlreadyEmitted = false))
+        assertEquals(50L, conversationListDebounceMillis(dataReady = true.not(), readyAlreadyEmitted = true))
+    }
+
+    @Test
+    fun leadingEdge_deliversFirstReadyImmediately_despiteSourceStorm() = runTest {
+        // A ready snapshot at t=0, then a storm of updates every 30ms (faster than the 50ms
+        // trailing debounce) — exactly the connect-lifecycle source storm.
+        var firstReadyEmitted = false
+        val collected = mutableListOf<Pair<Long, Boolean>>()
+
+        flow {
+            emit(true to "ready")                 // dataReady at t=0
+            repeat(10) { i ->
+                delay(30)
+                emit(false to "storm$i")          // storm faster than the 50ms debounce
+            }
+        }.debounce { (dataReady, _) ->
+            conversationListDebounceMillis(dataReady = dataReady, readyAlreadyEmitted = firstReadyEmitted)
+        }.collect { (dataReady, _) ->
+            if (dataReady) firstReadyEmitted = true
+            collected += testScheduler.currentTime to dataReady
+        }
+
+        // The ready snapshot must be delivered, and at virtual time ~0 — not held behind
+        // the storm. With a flat debounce(50) the ready value would be superseded by the
+        // storm before any 50ms of quiet and never delivered at all, so this fails on revert.
+        val firstReady = collected.firstOrNull { it.second }
+        assertTrue(firstReady != null, "the ready list snapshot must be delivered")
+        assertTrue(
+            firstReady.first < 30L,
+            "ready list must render immediately (delivered at t=${firstReady.first}ms — gated behind the storm)",
+        )
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/ConversationListDebounceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/ConversationListDebounceTest.kt
@@ -19,36 +19,38 @@ import kotlin.test.assertTrue
  * lifecycle. A flat `debounce(50)` never saw 50ms of quiet during that storm, so it
  * withheld the already-ready list for ~half a second until the connection settled.
  *
- * The fix is a leading-edge debounce ([conversationListDebounceMillis]): 0ms for the first
- * ready snapshot, 50ms thereafter. These tests pin both the selector and the end-to-end
- * flow behavior so a revert to a flat debounce is caught.
+ * The fix is a leading-edge debounce ([ConversationListDebounce]): 0ms for the first ready
+ * snapshot, 50ms thereafter. These tests pin both the policy object and the end-to-end flow
+ * behavior so a revert to a flat debounce is caught.
  */
 class ConversationListDebounceTest {
 
     @Test
-    fun selector_firstReadySnapshotIsImmediate() {
-        // The first ready snapshot must pass through with no debounce.
-        assertEquals(0L, conversationListDebounceMillis(dataReady = true, readyAlreadyEmitted = false))
+    fun firstReadySnapshotIsImmediate_thenCoalesced() {
+        val debounce = ConversationListDebounce()
+        // First ready snapshot → leading edge (renders the cached list immediately).
+        assertEquals(0L, debounce.timeoutMillisFor(dataReady = true))
+        // Everything after → coalesced, so the connect-time storm doesn't re-sort per emission.
+        assertEquals(50L, debounce.timeoutMillisFor(dataReady = true))
+        assertEquals(50L, debounce.timeoutMillisFor(dataReady = false))
     }
 
     @Test
-    fun selector_subsequentReadySnapshotsAreCoalesced() {
-        // After the first render, updates are coalesced so the connect-time storm doesn't
-        // re-sort the list on every micro-change.
-        assertEquals(50L, conversationListDebounceMillis(dataReady = true, readyAlreadyEmitted = true))
-    }
-
-    @Test
-    fun selector_notReadySnapshotsAreCoalesced() {
-        assertEquals(50L, conversationListDebounceMillis(dataReady = false, readyAlreadyEmitted = false))
-        assertEquals(50L, conversationListDebounceMillis(dataReady = true.not(), readyAlreadyEmitted = true))
+    fun notReadyEmissionsDoNotConsumeTheLeadingEdge() {
+        val debounce = ConversationListDebounce()
+        // Not-ready emissions before the list is ready are coalesced...
+        assertEquals(50L, debounce.timeoutMillisFor(dataReady = false))
+        assertEquals(50L, debounce.timeoutMillisFor(dataReady = false))
+        // ...and the first READY snapshot still gets the leading edge.
+        assertEquals(0L, debounce.timeoutMillisFor(dataReady = true))
+        assertEquals(50L, debounce.timeoutMillisFor(dataReady = true))
     }
 
     @Test
     fun leadingEdge_deliversFirstReadyImmediately_despiteSourceStorm() = runTest {
         // A ready snapshot at t=0, then a storm of updates every 30ms (faster than the 50ms
         // trailing debounce) — exactly the connect-lifecycle source storm.
-        var firstReadyEmitted = false
+        val debounce = ConversationListDebounce()
         val collected = mutableListOf<Pair<Long, Boolean>>()
 
         flow {
@@ -58,11 +60,7 @@ class ConversationListDebounceTest {
                 emit(false to "storm$i")          // storm faster than the 50ms debounce
             }
         }.debounce { (dataReady, _) ->
-            // Mirror the ViewModel wiring: the selector flips the flag when it grants the
-            // leading edge (0ms), so the flag is confined to the selector's coroutine.
-            val timeout = conversationListDebounceMillis(dataReady = dataReady, readyAlreadyEmitted = firstReadyEmitted)
-            if (timeout == 0L) firstReadyEmitted = true
-            timeout
+            debounce.timeoutMillisFor(dataReady)
         }.collect { (dataReady, _) ->
             collected += testScheduler.currentTime to dataReady
         }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/SpinnerBackstopGuardTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/SpinnerBackstopGuardTest.kt
@@ -1,0 +1,70 @@
+package id.homebase.chat.conversationlist
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * Regression guard for the reported "infinity spinner" in chat details.
+ *
+ * loadMessagesForConversation arms the spinner (isLoadingMessages=true) and the success
+ * path clears it inside the observeMessages collect. A `finally` backstop clears it for the
+ * paths the success path never reaches — an error, an unexpected cancellation, or a hung
+ * load — so the detail pane can't spin forever. [shouldClearLoadingSpinnerOnLoadEnd] encodes
+ * exactly when that backstop should fire; these tests lock the rule down.
+ */
+class SpinnerBackstopGuardTest {
+
+    private val convoA = Uuid.random()
+    private val convoB = Uuid.random()
+
+    @Test
+    fun clears_whenStillSelectedAndStillLoading() {
+        // The bug case: the load ended (e.g. threw) while we're still on this conversation
+        // with the spinner up — the backstop MUST clear it.
+        assertTrue(
+            shouldClearLoadingSpinnerOnLoadEnd(
+                selectedConversationId = convoA,
+                conversationId = convoA,
+                stillLoading = true,
+            )
+        )
+    }
+
+    @Test
+    fun doesNotClear_whenAlreadyCleared() {
+        // Normal success: the collect already cleared the spinner — nothing to do.
+        assertFalse(
+            shouldClearLoadingSpinnerOnLoadEnd(
+                selectedConversationId = convoA,
+                conversationId = convoA,
+                stillLoading = false,
+            )
+        )
+    }
+
+    @Test
+    fun doesNotClear_whenSwitchedToAnotherConversation() {
+        // Cancellation from switching conversations: the new selection already armed the
+        // spinner for convoB. The cancelled convoA job must NOT wipe convoB's spinner.
+        assertFalse(
+            shouldClearLoadingSpinnerOnLoadEnd(
+                selectedConversationId = convoB,
+                conversationId = convoA,
+                stillLoading = true,
+            )
+        )
+    }
+
+    @Test
+    fun doesNotClear_whenNothingSelected() {
+        assertFalse(
+            shouldClearLoadingSpinnerOnLoadEnd(
+                selectedConversationId = null,
+                conversationId = convoA,
+                stillLoading = true,
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Two cold-start UX bugs in chat, both diagnosed from `homebase.log` and confirmed on desktop:

1. **Conversation list blocked until the connection goes online.** On cold boot/login, the cached conversation list didn't render until the app went "green," so tapping a conversation (or landing there from a notification) appeared to do nothing for hundreds of ms — longer on a slow connect.
2. **Infinity spinner in chat details.** A failed message load left the detail pane's loading spinner spinning forever, with nothing logged. (Confirmed in the wild.)

Diagnosed with added instrumentation (kept in this PR), then fixed at the root. The work is behind targeted, low-risk changes in `ConversationListViewModel` plus pure, tested helpers.

## Root causes

**1. List render gated on the connect lifecycle (not the DB).** The conversation-list `combine` produces a complete, ready list within a few ms of ViewModel init (cached conversations + a credentials-synthesized session — `effectiveSession=true, dataReady=true, items=77`). But it was followed by `.debounce(50)`, which only emits after 50ms of *upstream quiet*. The combine's sources (`ownerSession`, `connectionStatusFlow`) re-emit continuously through the auth/connect lifecycle, so debounce never saw 50ms of quiet and withheld the already-ready list until the connection settled — i.e. right when the online indicator went orange→green.

Log proof (before): combine first eval at **5ms**, but the list was applied (`conversationStream emit dataReady=true`) only at **~590ms**, ~48ms before the WS handshake.

**2. Spinner never cleared on a failed load.** `loadMessagesForConversation` set `isLoadingMessages=true` up front and only cleared it inside the success-path `observeMessages` collect. The `catch` showed an error snackbar but never cleared the flag and never logged — so any exception in the load (DB error, deserialization, …) left the spinner up forever, invisibly.

## Fixes

- **Leading-edge debounce** for the list combine (`conversationListDebounceMillis`): `0ms` for the first ready snapshot so the cached list renders immediately, `50ms` thereafter so the connect-time source storm is still coalesced into a few re-sorts. (After: list applied at **~15ms**, ~900ms before going green.)
- **Spinner can no longer stick:**
  - the `catch` now logs the failure (`Logger.e`) and the spinner is cleared in a `finally` backstop (`shouldClearLoadingSpinnerOnLoadEnd`), guarded on the conversation still being selected so a switch-away can't wipe the new conversation's spinner;
  - an 8s **watchdog** WARN-logs a load that *hangs* (never completes, never throws) — the one shape the `finally` can't catch — so a future stuck spinner yields evidence instead of a silent hang.

## Diagnostics added (no behavior change)

- `ConvListPerf`: list-pipeline timing (launch entered, reaching combine.collect, combine first eval with `ownerSession`/`credentials`/`effectiveSession`/`dataReady`).
- `NotifTap`: notification-tap path made traceable end-to-end — fast-path tap arrival (`alreadyInItems`, `sinceTap`), the previously-silent direct `loadConversation` timing, and resolve `sinceTap`. (The notification detail pane reads the same debounced `activeConversations`, so it shared the list-gating bug and is fixed by the same change.)
- Backstop-fired WARN and the spinner watchdog (above).

## Tests

Following the codebase's pattern of testing extracted pure helpers (e.g. `resolveNotificationTap`, `synthesizeOwnerSession`):

- `ConversationListDebounceTest` — the selector (0ms first ready / 50ms after) plus a flow-level behavior test: with a source storm faster than the trailing debounce, the first ready snapshot is delivered at virtual-time ~0. A revert to a flat `debounce(50)` drops it entirely, so the test fails on regression.
- `SpinnerBackstopGuardTest` — the backstop guard: clears when still-selected + still-loading; doesn't clear when switched away or already cleared.

## Verification

- `./gradlew :homebase-chat:jvmTest` green (incl. both new tests); `commonMain` compiles on JVM and iOS.
- Desktop run confirms the list-gating fix: list applied at ~15ms vs ~590ms before, decoupled from the connection.

## Out of scope

A separate, parked branch (`fix-coldboot-tap-db-read-contention`) addresses *mid-session-under-load* DB read contention (a dedicated read connection). That is real but is **not** the cold-start symptom this PR fixes, and is intentionally not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)