### PR TITLE
Run DB reads off the single write dispatcher

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
@@ -5,12 +5,16 @@ import app.cash.sqldelight.db.SqlCursor
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlPreparedStatement
 import co.touchlab.kermit.Logger
+import id.homebase.api.coroutines.ioDispatcher
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TimeSource
 
 /**
  * One-shot signal that the local DB was just wiped because the on-disk schema
@@ -71,13 +75,36 @@ private val connectionCacheAdapter = ConnectionCache.Adapter(
     identityIdAdapter = UuidAdapter
 )
 
+/**
+ * Latency breakdown of the most recent [DatabaseManager.executeReadQuery] call,
+ * split so we can tell "the read was slow because it waited for a dispatcher
+ * slot" (`queueWaitMs`) apart from "the SQL itself was slow" (`sqlMs`). Surfaced
+ * via [DatabaseManager.lastReadTiming]; also folded into the `SlowMessageFetch`
+ * log so the split is visible on-device during a heavy sync.
+ */
+data class ReadTiming(val queueWaitMs: Long, val sqlMs: Long)
+
 class DatabaseManager(
     driverProvider: () -> SqlDriver,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.Default.limitedParallelism(1)
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Default.limitedParallelism(1),
+    // Reads run off the single write [dispatcher] so they don't queue behind a long
+    // write transaction. True concurrency comes from each platform driver's reader
+    // pool under WAL (iOS NativeSqliteDriver.maxReaderConnections, Android's framework
+    // WAL pool, desktop's per-thread JDBC connections); where a platform can't serve a
+    // concurrent reader the reads simply serialize — benign, never incorrect. We still
+    // run on the *existing* single driver — no second managed SqlDriver/connection.
+    private val readDispatcher: CoroutineDispatcher =
+        ioDispatcher.limitedParallelism(READ_PARALLELISM)
 ) : AutoCloseable {
     private val logger = Logger.withTag("DatabaseManager")
     private var database: OdinDatabase
     internal var driver: SqlDriver = driverProvider()
+
+    // Latency split of the most recent read; see [ReadTiming]. Updated on every
+    // executeReadQuery; readers should treat it as best-effort (concurrent reads
+    // race on this single cell) — it's a diagnostic, not a correctness signal.
+    private val _lastReadTiming = atomic<ReadTiming?>(null)
+    val lastReadTiming: ReadTiming? get() = _lastReadTiming.value
 
     init {
         OdinDatabase.Schema.create(driver) // Create the tables if they are missing
@@ -110,6 +137,15 @@ class DatabaseManager(
     companion object {
         private const val DATABASE_VERSION =
             5  // Increase to wipe the database and rebuild all tables
+
+        // Max concurrent reads on [readDispatcher]. Kept in step with iOS
+        // NativeSqliteDriver.maxReaderConnections so the dispatcher doesn't admit
+        // more readers than the platform pool can serve. Tunable.
+        private const val READ_PARALLELISM = 4
+
+        // A read slower than this logs a SlowDbRead warn with its queueWait/sql split.
+        private val SLOW_READ_THRESHOLD = 50.milliseconds
+
         private lateinit var instance: DatabaseManager
         val appDb: DatabaseManager get() = instance
 
@@ -230,18 +266,38 @@ class DatabaseManager(
         ConnectionCacheWrapper(driver, connectionCacheAdapter, this)
     }
 
+    // Reads run on [readDispatcher], NOT the single write [dispatcher], so a read
+    // issued while a long write transaction holds the writer slot starts
+    // immediately instead of queueing behind it. [requestedAt]..inside-withContext
+    // measures that queue-wait; the inner mark measures the SQL itself. The split is
+    // stored in [lastReadTiming] and warn-logged when slow, so device logs show
+    // whether read latency was scheduling or SQL.
     suspend fun <R> executeReadQuery(
         identifier: Int?,
         sql: String,
         mapper: (SqlCursor) -> QueryResult<R>,
         parameters: Int,
         binders: (SqlPreparedStatement.() -> Unit)? = null
-    ): QueryResult<R> = withContext(dispatcher) {
-        try {
-            driver.executeQuery(identifier, sql, mapper, parameters, binders)
-        } catch (e: Exception) {
-            logger.e { "executeReadQuery failed: ${e.message}\nSQL: $sql\nStack: ${e.stackTraceToString()}" }
-            throw e  // Rethrow if you want the caller to handle, or return a fallback QueryResult
+    ): QueryResult<R> {
+        val requestedAt = TimeSource.Monotonic.markNow()
+        return withContext(readDispatcher) {
+            val queueWait = requestedAt.elapsedNow()
+            val sqlStart = TimeSource.Monotonic.markNow()
+            try {
+                val result = driver.executeQuery(identifier, sql, mapper, parameters, binders)
+                val sqlElapsed = sqlStart.elapsedNow()
+                _lastReadTiming.value =
+                    ReadTiming(queueWait.inWholeMilliseconds, sqlElapsed.inWholeMilliseconds)
+                if (queueWait + sqlElapsed > SLOW_READ_THRESHOLD) {
+                    logger.w {
+                        "SlowDbRead queueWait=$queueWait sql=$sqlElapsed sqlPreview=${sql.take(120)}"
+                    }
+                }
+                result
+            } catch (e: Exception) {
+                logger.e { "executeReadQuery failed: ${e.message}\nSQL: $sql\nStack: ${e.stackTraceToString()}" }
+                throw e  // Rethrow if you want the caller to handle, or return a fallback QueryResult
+            }
         }
     }
 

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/DatabaseReadConcurrencyTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/DatabaseReadConcurrencyTest.kt
@@ -1,0 +1,128 @@
+package id.homebase.api.sync.database
+
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.uuid.Uuid
+
+/**
+ * Proves the read path is decoupled from the single write dispatcher and that the
+ * new "reads run off-writer" model doesn't crash SQLite / the driver.
+ *
+ * Both tests use real dispatchers + real threads (not `runTest` virtual time)
+ * against the existing single in-memory [JdbcSqliteDriver] — the same single-driver
+ * substrate production uses. The in-memory JDBC URL maps to SQLDelight's
+ * `StaticConnectionManager` (one shared connection), so reads here serialize at the
+ * driver lock rather than running truly concurrently — that's fine: this exercises
+ * the *coroutine-level* decoupling and the safety of concurrent access to the one
+ * driver. The mobile concurrency win (iOS reader pool / Android WAL pool) is
+ * validated on-device, not here.
+ */
+class DatabaseReadConcurrencyTest {
+
+    private fun newDbm(): DatabaseManager {
+        // DatabaseManager.init creates the schema (CREATE TABLE IF NOT EXISTS) and
+        // audits pragmas, so the driver needs no pre-setup.
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        return DatabaseManager({ driver })
+    }
+
+    private suspend fun keyValueCount(dbm: DatabaseManager): Long =
+        dbm.executeReadQuery(
+            identifier = null,
+            sql = "SELECT COUNT(*) FROM KeyValue",
+            mapper = { cursor ->
+                cursor.next()
+                QueryResult.Value(cursor.getLong(0) ?: 0L)
+            },
+            parameters = 0,
+        ).value
+
+    /**
+     * A read issued while the single write dispatcher slot is held must NOT queue
+     * behind it: it runs on the separate read dispatcher and completes while the
+     * write is still parked, with `queueWait ~0`. Before this change the read ran
+     * `withContext(writeDispatcher)` and would block until the write released.
+     */
+    @Test
+    fun readDoesNotQueueBehindHeldWriteDispatcher() = runBlocking {
+        val dbm = newDbm()
+
+        val writeStarted = CountDownLatch(1)
+        val releaseWrite = CountDownLatch(1)
+
+        // Occupy the single write dispatcher slot. The block is non-suspend, so we
+        // block the writer thread synchronously — what a long write would do to the
+        // slot. No SQL runs inside, so the shared connection itself stays free.
+        val writeJob = launch(Dispatchers.Default) {
+            dbm.withWrite {
+                writeStarted.countDown()
+                releaseWrite.await()
+            }
+        }
+        assertTrue(writeStarted.await(5, TimeUnit.SECONDS), "write never acquired the slot")
+
+        // Issue a read while the writer slot is held; it must return before release.
+        val count = withTimeout(5.seconds) { keyValueCount(dbm) }
+        assertEquals(0L, count)
+
+        assertEquals(
+            1L, releaseWrite.count,
+            "read only completed after the write was released — it queued behind the writer",
+        )
+
+        val timing = dbm.lastReadTiming
+        assertNotNull(timing, "no read timing recorded")
+        assertTrue(
+            timing.queueWaitMs < 100,
+            "read queued behind the write dispatcher: queueWait=${timing.queueWaitMs}ms",
+        )
+
+        releaseWrite.countDown()
+        writeJob.join()
+    }
+
+    /**
+     * Many concurrent writers (serialized through the write dispatcher) racing many
+     * concurrent readers (on the read dispatcher) against the one driver must not
+     * throw or corrupt: the final row count equals the number of distinct keys
+     * written. This is the proof the new architecture is safe on the single driver.
+     */
+    @Test
+    fun concurrentReadsAndWritesDoNotCrash() = runBlocking {
+        val dbm = newDbm()
+
+        val writerCount = 50
+        val readerCount = 200
+
+        val writers = (0 until writerCount).map { i ->
+            launch(Dispatchers.Default) {
+                val key = Uuid.fromLongs(0L, i.toLong()) // distinct per writer
+                dbm.withWriteValue { db ->
+                    db.keyValueQueries.upsertValue(key, byteArrayOf(i.toByte()))
+                }
+            }
+        }
+        val readers = (0 until readerCount).map {
+            launch(Dispatchers.Default) {
+                keyValueCount(dbm) // result unused; we're proving it doesn't throw
+            }
+        }
+
+        // Any exception in a child cancels the scope and fails the test here.
+        (writers + readers).joinAll()
+
+        assertEquals(writerCount.toLong(), keyValueCount(dbm))
+    }
+}

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.native.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.native.kt
@@ -23,7 +23,16 @@ import platform.Foundation.NSURLIsExcludedFromBackupKey
 actual class DatabaseDriverFactory {
     actual fun createDriver(passphrase: String?): SqlDriver {
         val driver = NativeSqliteDriver(
-            schema = OdinDatabase.Schema, name = DB_FILE_NAME, onConfiguration = { config ->
+            schema = OdinDatabase.Schema,
+            name = DB_FILE_NAME,
+            // Open a pool of reader connections (default is 1 = writer only) so reads
+            // dispatched off DatabaseManager's single write dispatcher run concurrently
+            // with the writer under WAL (configured below). This is the iOS half of the
+            // "reads don't queue behind writes" change — it's the same driver's internal
+            // pool, not a second managed SqlDriver. Kept in step with
+            // DatabaseManager.READ_PARALLELISM.
+            maxReaderConnections = 4,
+            onConfiguration = { config ->
                 // Configure via sqliter's typed DatabaseConfiguration fields — the idiomatic
                 // path for NativeSqliteDriver/SQLiter, not raw PRAGMA strings. This mirrors the
                 // shared SQLITE_TUNING_PRAGMAS values (desktop/Android use that map directly):

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -438,11 +438,17 @@ class ChatMessageStream(
         val mapElapsed = mapStart.elapsedNow()
 
         if (queryElapsed + mapElapsed > 200.milliseconds) {
+            // queueWait splits dbQuery into "waited for a read slot" vs SQL. Best-effort:
+            // getMessages does a single (non-recursive) queryBatchAsync -> one
+            // executeReadQuery, so lastReadTiming normally reflects this query, but a
+            // concurrent read on another coroutine can overwrite it — it's a diagnostic.
+            val queueWaitMs = dbm.lastReadTiming?.queueWaitMs
             Logger.w(tag = "SlowMessageFetch") {
                 "conversationId=$conversationId " +
                         "rawRecords=${result.records.size} " +
                         "mappedRecords=${records.size} " +
                         "dbQuery=$queryElapsed " +
+                        "queueWait=${queueWaitMs}ms " +
                         "mapping=$mapElapsed"
             }
         }


### PR DESCRIPTION
## What & why

`DatabaseManager.executeReadQuery` ran `withContext` on the **same** `Dispatchers.Default.limitedParallelism(1)` slot the writer uses. So a read issued while a long write transaction holds that slot was **queued behind the write at the coroutine level** — even though WAL (already enabled on every platform) could have served it from a reader connection right away. During a heavy sync this shows up as read latency that is really queue-wait, not SQL time.

This routes reads onto a **separate `readDispatcher`** (`ioDispatcher.limitedParallelism(4)`) against the **existing single driver** — no second managed `SqlDriver`/connection, and the single writer is untouched.

This is **not a new concurrency model**: the SQLDelight-generated wrapper reads (`ChatReadCountWrapper.selectAll*`, …) already run off the writer, concurrently with it. We just move `executeReadQuery` onto the same path.

## Where the concurrency actually comes from

True concurrency is delivered by each platform driver's own reader pool under WAL, not by us adding connections:

| Platform | Mechanism | Change |
|---|---|---|
| iOS / native | `NativeSqliteDriver.maxReaderConnections` (was 1 = writer only) | **set to 4** |
| Android | framework WAL connection pool over SQLCipher | none |
| Desktop / JVM (file) | `JdbcSqliteDriver` `ThreadedConnectionManager` → one connection per thread | none |

The failure mode is benign everywhere: if a platform can't serve a concurrent reader, reads degrade to serialized — never incorrect.

## Instrumentation

`executeReadQuery` now records a `ReadTiming(queueWaitMs, sqlMs)` split (exposed via `DatabaseManager.lastReadTiming`), logs a `SlowDbRead` warn above 50 ms, and the existing `SlowMessageFetch` log now includes `queueWait=` — so a slow read can be attributed to scheduling vs SQL on-device.

## Tests

New `DatabaseReadConcurrencyTest` (`homebase-api` jvmTest, single in-memory driver, real threads):
- **`readDoesNotQueueBehindHeldWriteDispatcher`** — a read issued while the write dispatcher slot is held returns *before* the write releases, with `queueWait ~0`. (Before this change it would block on the writer slot.)
- **`concurrentReadsAndWritesDoNotCrash`** — 50 writers × 200 readers against the one driver don't throw, and the final row count is consistent. Proves the model doesn't crash SQLite / the driver.

### Verification
- `./gradlew homebase-api:jvmTest` (incl. new test) — green
- `./gradlew homebase-chat:jvmTest homebase-common:jvmTest homebase-auth:jvmTest` — green
- `iosSimulatorArm64Test` runs on CI/macOS; the native `maxReaderConnections` arg is confirmed against the SQLDelight 2.3.2 constructor signature.

## What this PR acknowledges

- The **mobile** concurrency win depends on the platform reader pools (iOS `maxReaderConnections`, Android WAL pool) and is validated **on-device**, not by the JVM unit tests. Real-world chat effect is expected to be small — this is a low-blast-radius architecture improvement.
- The JVM **in-memory** test driver shares one connection, so reads serialize there at the driver lock (acceptable; benign). Note the JVM **file** driver (desktop) actually uses per-thread connections and *does* benefit — a correction to the assumption that "JVM stays single-connection," which is only true of the in-memory test URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)