### PR TITLE
Instrument Android cold-start path

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
@@ -27,6 +27,7 @@ import id.homebase.core.notifications.NotificationIntentDecision
 import id.homebase.core.notifications.NotificationNavigationEvent
 import id.homebase.core.notifications.NotificationService
 import id.homebase.core.notifications.RichNotificationDisplayer
+import id.homebase.core.logging.StartupLogger
 import id.homebase.core.notifications.decideNotificationIntent
 import id.homebase.core.notifications.isReplayedFromHistory
 import id.homebase.feed.share.ShareShortcutPublisher
@@ -49,6 +50,11 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+        // The gap from MainApplication's "onCreate end" to here is process-idle /
+        // background→foreground (a background-woken process sits here until the user
+        // opens it). The gap from here to "App() first composition" is the real
+        // user-perceived cold start. See StartupLogger.
+        StartupLogger.checkpoint("activity onCreate start")
         handleIntent(intent)
 
         ActivityProvider.initialize(this)
@@ -63,6 +69,9 @@ class MainActivity : AppCompatActivity() {
         FileKit.manualFileKitCoreInitialization(this)
         FileKit.init(this)
 
+        // Marked here (not inside the composable body, which re-fires per recomposition):
+        // setContent → "App() first composition" is the first-frame / composition cost.
+        StartupLogger.checkpoint("setContent")
         setContent {
             val userPreferences = koinInject<UserPreferences>()
             val prefState by userPreferences.preferenceState.collectAsStateWithLifecycle()

--- a/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
@@ -51,6 +51,11 @@ class MainApplication : Application(), KoinComponent {
 
         if (getProcessName() != packageName) return
 
+        // Earliest app-code mark. The existing "APP STARTUP" header is logged late (after
+        // DB + Koin), so these checkpoints are what actually size the cold-start phases —
+        // diff their log timestamps. See StartupLogger.
+        StartupLogger.checkpoint("onCreate start")
+
         // Register the application Context up-front so components that only
         // need Context (cacheDir, ContentResolver — e.g. FFmpegUtils Android
         // actuals, VideoThumbnailExtractor) can resolve it before MainActivity
@@ -65,6 +70,7 @@ class MainApplication : Application(), KoinComponent {
         runBlocking {
             DatabaseManager.initializeWithRecovery(DatabaseDriverFactory(applicationContext))
         }
+        StartupLogger.checkpoint("db init done")
 
         startKoin {
             // Log Koin into Android logger
@@ -74,6 +80,7 @@ class MainApplication : Application(), KoinComponent {
             // Load modules
             modules(allModules)
         }
+        StartupLogger.checkpoint("koin started")
 
         // Configure Crashlytics based on user preference
         val userPreferences = get<UserPreferences>()
@@ -124,6 +131,9 @@ class MainApplication : Application(), KoinComponent {
         // before the UI composes are not lost
         val notificationService: NotificationService = get()
         notificationService.startListening()
+        // Brackets createNotificationChannels + NotifierManager.initialize() (KMPNotifier/
+        // Firebase) — a prime suspect for cold-process stalls on the FCM boot.
+        StartupLogger.checkpoint("notifications init done")
 
         // Publish share shortcuts when conversations change
         initShareShortcuts()
@@ -138,6 +148,8 @@ class MainApplication : Application(), KoinComponent {
         // Cold-start is covered by StartupCacheAudit; this is the bound on
         // a same-process share's on-disk lifetime.
         registerShareOutboundForegroundSweep()
+
+        StartupLogger.checkpoint("onCreate end")
     }
 
     private fun registerShareOutboundForegroundSweep() {


### PR DESCRIPTION
## Summary

Diagnostic-only instrumentation of the Android cold-start path. **No behavior change**, Android only — 7 added `StartupLogger.checkpoint()` calls.

## Why

Analyzing a real-device `homebase.log` (build 1672, with the merged list/spinner fixes) across **13 cold boots**:

- The merged chat fixes are working: the conversation list renders in **0–150ms** every boot (`ConvListPerf combine first eval at 0–2ms`), notification tap is fast, and there are no `SlowMessageFetch` / spinner-watchdog / `MainThreadWatchdog` events.
- **12 of 13 boots reach first composition in ~40ms** (warm relaunches).
- **1 boot measured 9.26s** header→first-composition — the only one coinciding with an **FCM push + DriveSyncWorker**. That number is misleading: `Application.onCreate` ran at `06:48:54.27`, but the app's logic (auth collector, session restore) didn't start until `06:49:00.96` (~6.5s later, when the push/worker fired). The process was **woken in the background**, ran `onCreate`, then **sat idle with no UI** until foregrounded — so the real tap→first-frame wait was **~2s**, not a 9s freeze.

We can't attribute any of this today: the only checkpoints (`App() first composition`, `App() Koin injections done`) are emitted *after* the heavy work, the `APP STARTUP` header is logged late (after the blocking `runBlocking { DatabaseManager.initializeWithRecovery() }` and `startKoin { allModules }`), and there's **no `MainActivity.onCreate`/foreground marker** to separate background-idle from the user-perceived window.

## What

Add `StartupLogger.checkpoint(name)` (existing helper; the log timestamp is the data) at:

- **`MainApplication.onCreate`**: `onCreate start` (earliest app mark) · `db init done` · `koin started` · `notifications init done` (brackets `NotifierManager.initialize()` / Firebase) · `onCreate end`.
- **`MainActivity.onCreate`**: `activity onCreate start` · `setContent` (marked before the call, not in the composable body).

Existing `App.kt` checkpoints are kept.

## How to read it

Diff consecutive checkpoint timestamps in a cold/FCM boot:

- `onCreate end → activity onCreate start` = **background-idle** (process woken with no UI; *not* user-perceived — expect this to be the large chunk on an FCM boot).
- `activity onCreate start → App() first composition` = **the real user-perceived cold start** (the ~2s) — the number that matters.
- `onCreate start → db init done` / `db init done → koin started` / `koin started → notifications init done` = main-thread DB open / Koin graph / KMPNotifier+Firebase (relevant when the user's own tap cold-starts the process).
- `setContent → App() first composition` = first frame / ART JIT.

## Next steps

Capture a cold/FCM boot, attribute the phases, then decide on a targeted follow-up (e.g. take the DB `runBlocking` off the first-frame critical path, defer Firebase/KMPNotifier, or add a Baseline Profile) — or conclude it's normal cold start and leave it. **Not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)