### PR TITLE
fix(login): disable autocorrect on Homebase ID input

### DIFF
--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/HomebaseIdField.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/HomebaseIdField.kt
@@ -66,6 +66,7 @@ fun HomebaseIdField(
         keyboardOptions = KeyboardOptions(
             keyboardType = KeyboardType.Uri,
             capitalization = KeyboardCapitalization.None,
+            autoCorrectEnabled = false,
             imeAction = imeAction,
         ),
         keyboardActions = KeyboardActions(


### PR DESCRIPTION
## Summary
- Disables autocorrect on the `HomebaseIdField` used for login identity input
- Autocorrect aggressively replaces domain-style text (e.g. `samwise.gamgee` → `samwise.ganges`), making it difficult to type a Homebase identity
- Auto-suggest remains enabled so users still get keyboard suggestions

## Test plan
- [ ] Open the login screen on Android/iOS
- [ ] Type a Homebase identity — verify autocorrect does not replace text
- [ ] Verify the keyboard still shows suggestions above the keyboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)