### PR TITLE
fix(audio): iOS audio playback crash for cross-platform files

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MediaDownloadHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MediaDownloadHandler.kt
@@ -7,6 +7,7 @@ import id.homebase.api.coroutines.ioDispatcher
 import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.video.FFmpegUtils
+import id.homebase.core.util.extensionForMimeType
 import id.homebase.api.video.VideoMetadata
 import id.homebase.chat.conversationlist.ConversationListUiEvent.SaveFileToDevice
 import id.homebase.chat.conversationlist.ConversationListUiEvent.ShareFile
@@ -69,11 +70,9 @@ internal class MediaDownloadHandler(
                     KeyHeader(payloadIv, message.keyHeader.aesKey)
                 )
                 if (bytes != null) {
-                    var extension = payload.contentType?.substringAfter("/") ?: "bin"
-                    extension = when (extension) {
-                        "jpeg" -> "jpg"
-                        else -> extension
-                    }
+                    val extension = payload.contentType?.let { extensionForMimeType(it) }
+                        ?: payload.contentType?.substringAfter("/")
+                        ?: "bin"
                     // Cleartext copy of an end-to-end-encrypted Homebase
                     // payload — sequestered into the share_outbound subdir so
                     // the cold-start + foreground sweepers can reap it as a
@@ -257,14 +256,15 @@ internal class MediaDownloadHandler(
                     )
                 )
 
-                val fileName = payload.filename() ?: payload.key
-                var extension = payload.contentType?.substringAfter("/") ?: "bin"
-                extension = when (extension) {
-                    "jpeg" -> "jpg"
-                    else -> extension
+                val rawName = payload.filename() ?: payload.key
+                val filePath = if (rawName.contains('.')) {
+                    "${fileOperationsProvider.getCacheDirectory()}/$rawName"
+                } else {
+                    val extension = payload.contentType?.let { extensionForMimeType(it) }
+                        ?: payload.contentType?.substringAfter("/")
+                        ?: "bin"
+                    "${fileOperationsProvider.getCacheDirectory()}/$rawName.$extension"
                 }
-                val filePath =
-                    "${fileOperationsProvider.getCacheDirectory()}/$fileName.$extension"
 
                 val success = driveFileProvider.streamPayloadDecryptedToPath(
                     driveId = chatTargetDrive.alias,

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/audio/IOSAudioPlayer.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/audio/IOSAudioPlayer.kt
@@ -21,6 +21,7 @@ import platform.AVFAudio.AVAudioSession
 import platform.AVFAudio.AVAudioSessionCategoryPlayback
 import platform.AVFAudio.setActive
 import platform.Foundation.NSError
+import platform.Foundation.NSFileManager
 import platform.Foundation.NSURL
 import platform.darwin.NSObject
 
@@ -50,22 +51,40 @@ class IOSAudioPlayer : AudioPlayer {
             }
         }
 
-        // Create and start player
+        // Create and start player — AVAudioPlayer's ObjC init returns nil for
+        // unplayable files, and K/N's interop bridge throws NPE for nil failable
+        // inits, so we must catch at the call site.
         val url = NSURL.fileURLWithPath(filePath)
-        memScoped {
+        val newPlayer: AVAudioPlayer? = memScoped {
             val error = alloc<ObjCObjectVar<NSError?>>()
-            player = AVAudioPlayer(url, error.ptr).also { p ->
+            try {
+                val p = AVAudioPlayer(url, error.ptr)
                 error.value?.let { err ->
                     Logger.e { "Failed to create audio player: ${err.localizedDescription}" }
-                    return
+                    return@memScoped null
                 }
-
-                p.delegate = delegate
-                p.prepareToPlay()
-                p.play()
+                p
+            } catch (_: Exception) {
+                val errMsg = error.value?.localizedDescription ?: "unknown"
+                Logger.e { "AVAudioPlayer init threw for: $filePath — $errMsg" }
+                null
             }
         }
 
+        if (newPlayer == null) {
+            val fm = NSFileManager.defaultManager
+            val exists = fm.fileExistsAtPath(filePath)
+            val attrs = fm.attributesOfItemAtPath(filePath, null)
+            val size = attrs?.get("NSFileSize") ?: "unknown"
+            Logger.e { "Audio player init failed — path=$filePath exists=$exists size=$size" }
+            delegate.observer?.onComplete()
+            return
+        }
+
+        newPlayer.delegate = delegate
+        newPlayer.prepareToPlay()
+        newPlayer.play()
+        player = newPlayer
         startPositionPolling()
     }
 
@@ -116,7 +135,7 @@ class IOSAudioPlayer : AudioPlayer {
 
         override fun audioPlayerDecodeErrorDidOccur(player: AVAudioPlayer, error: NSError?) {
             // Handle decode errors if needed
-            println("AudioPlayer decode error: ${error?.localizedDescription}")
+            Logger.e { "AudioPlayer decode error: ${error?.localizedDescription}" }
         }
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailViewModel.kt
@@ -8,6 +8,7 @@ import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.common.OdinId
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.core.util.extensionForMimeType
 import id.homebase.chat.conversationlist.FullScreenOverlay
 import id.homebase.chat.data.ContactUiModel
 import id.homebase.chat.services.convo.ConversationStream
@@ -513,10 +514,9 @@ class MomentDetailViewModel(
                     _events.tryEmit(MomentDetailUiEvent.ShareFailed("Could not download file"))
                     return@launch
                 }
-                val extension = when (val raw = payload.contentType?.substringAfter("/") ?: "bin") {
-                    "jpeg" -> "jpg"
-                    else -> raw
-                }
+                val extension = payload.contentType?.let { extensionForMimeType(it) }
+                    ?: payload.contentType?.substringAfter("/")
+                    ?: "bin"
                 val tempPath = fileOperationsProvider.writeBytesToShareOutboundFile(
                     bytes = bytes,
                     suffix = ".$extension",


### PR DESCRIPTION
## Summary
- Fixes iOS crash (`NullPointerException`) when playing audio files sent from Android
- **Root cause**: `MediaDownloadHandler` appended a content-type-derived extension to filenames that already had one (e.g. `recording.m4a` → `recording.m4a.mp3`). `AVAudioPlayer` used the wrong `.mp3` extension to pick its decoder, failed on M4A data, returned nil, and K/N's interop bridge threw NPE
- Replaced naive `contentType.substringAfter("/")` with `extensionForMimeType()` across 3 call sites — correctly maps `audio/mp4` → `m4a`, `image/jpeg` → `jpg`, etc.
- `IOSAudioPlayer` now catches the K/N bridge NPE for nil failable inits and logs file diagnostics instead of crashing

## Test plan
- [ ] Record audio on Android, send to iOS — verify playback works
- [ ] Record audio on iOS, play locally — verify no regression
- [ ] Share an image from chat — verify file extension is correct (`.jpg` not `.jpeg`)
- [ ] Share a video from Moments — verify file extension is correct
- [ ] Play an undecodable file on iOS — verify graceful failure (log + UI returns to idle), no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)