### PR TITLE
fix(chat): ESC/back exits message search mode

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -466,7 +466,12 @@ fun ConversationContent(
         computeBattleChainCap(conversation.conversation.participants.size)
     }
 
-    @Suppress("DEPRECATION") BackHandler(showEmojiSheet || showAttachmentSheet || isKeyboardVisible || uiState.isEditingMessageId != null) {
+    @Suppress("DEPRECATION") BackHandler(uiState.isSearchActive || showEmojiSheet || showAttachmentSheet || isKeyboardVisible || uiState.isEditingMessageId != null) {
+        if (uiState.isSearchActive) {
+            onUiAction(ConversationListUiAction.SearchMessagesBackClicked)
+            searchTextState.clearText()
+            return@BackHandler
+        }
         showEmojiSheet = false
         showAttachmentSheet = false
         keyboardController?.hide()


### PR DESCRIPTION
## Summary
- The `BackHandler` in `ConversationContent` did not include `isSearchActive`, so pressing ESC (desktop) or back (Android/iOS) while searching messages navigated away from the conversation instead of closing the search bar
- Added `isSearchActive` to the `BackHandler` condition with early return that dispatches `SearchMessagesBackClicked` and clears the search text — matching the existing search bar back button behavior

## Test plan
- [ ] Open a conversation, tap the search icon to enter message search mode
- [ ] Press ESC (desktop) or back button (Android/iOS) — search bar should close, conversation should remain visible
- [ ] Verify the conversation-list-level search still closes with ESC/back (already had its own BackHandler)
- [ ] Verify emoji sheet, attachment sheet, and edit-message back handling still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)