### PR TITLE
Run conversation-list reads on the read lane

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/ChatReadCountWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/ChatReadCountWrapper.kt
@@ -69,8 +69,12 @@ class ChatReadCountWrapper(
      * Select all conversations (fileType 8888) from DriveMainIndex
      * Note: This implementation is simplified and would need the generated SQLDelight queries
      */
-    fun selectAllConversations(identityId: Uuid): List<HomebaseFile> {
-        val list = delegate.selectAllCoversations(identityId).executeAsList()
+    suspend fun selectAllConversations(identityId: Uuid): List<HomebaseFile> {
+        // Read on the read lane so it doesn't serialize behind cold-load DriveSync writes
+        // on the single writer connection; map outside the lane (CPU-bound deserialize).
+        val list = databaseManager.readValue("selectAllConversations") {
+            delegate.selectAllCoversations(identityId).executeAsList()
+        }
         return list.mapNotNull {
             try {
                 OdinSystemSerializer.deserialize<HomebaseFile>(it)
@@ -109,11 +113,15 @@ class ChatReadCountWrapper(
      * Note: This implementation is simplified and would need the generated SQLDelight queries
      */
 
-    fun selectAllConversationPlusLastMessage(identityId: Uuid): List<ConversationWithLastMessage> {
+    suspend fun selectAllConversationPlusLastMessage(identityId: Uuid): List<ConversationWithLastMessage> {
 
         val start = Clock.System.now().toEpochMilliseconds()
 
-        val list = delegate.selectAllConversationPlusLastMessage(identityId).executeAsList()
+        // Read on the read lane (correlated-subquery aggregate — heavy on cold cache); map
+        // outside the lane. SlowDbRead logs this read's own queueWait/sql split.
+        val list = databaseManager.readValue("selectAllConversationPlusLastMessage") {
+            delegate.selectAllConversationPlusLastMessage(identityId).executeAsList()
+        }
 
         logger.d { "Fetched rows=${list.size} in ${Clock.System.now().toEpochMilliseconds() - start}ms" }
 
@@ -183,7 +191,12 @@ class ChatReadCountWrapper(
      * Note: This implementation is simplified and would need the generated SQLDelight queries
      */
     suspend fun selectAllUnreadCount(identityId: Uuid, originalAuthor: OdinId): List<ConversationUnreadCount> {
-        val list = delegate.selectAllUnreadCount(identityId, originalAuthor.domainName).executeAsList()
+        // The cold-load unread aggregate (full DriveMainIndex GROUP BY) — the read that the
+        // device log showed blocking early taps for ~2.8s while it contended with the sync
+        // writer on the single connection. On the read lane it runs concurrently instead.
+        val list = databaseManager.readValue("selectAllUnreadCount") {
+            delegate.selectAllUnreadCount(identityId, originalAuthor.domainName).executeAsList()
+        }
         return list.map {
             ConversationUnreadCount(
                 conversationId = it.groupId,

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
@@ -301,6 +301,37 @@ class DatabaseManager(
         }
     }
 
+    /**
+     * Run a read that uses the SQLDelight generated-query DSL (rather than raw SQL) on the
+     * read lane — the counterpart to [executeReadQuery] for the `*Wrapper` reads that call
+     * `delegate.x().executeAsList()`. Same [readDispatcher] + queue-wait/SQL split +
+     * SlowDbRead warn; [label] names the read in the log since there's no SQL string.
+     *
+     * Keep [block] to the DB read itself (executeAsList / executeAsOneOrNull) and do any
+     * mapping/deserialization outside, so a read-lane slot is held only for the SQL — not
+     * for CPU-bound row mapping.
+     */
+    suspend fun <R> readValue(label: String, block: () -> R): R {
+        val requestedAt = TimeSource.Monotonic.markNow()
+        return withContext(readDispatcher) {
+            val queueWait = requestedAt.elapsedNow()
+            val sqlStart = TimeSource.Monotonic.markNow()
+            try {
+                val result = block()
+                val sqlElapsed = sqlStart.elapsedNow()
+                _lastReadTiming.value =
+                    ReadTiming(queueWait.inWholeMilliseconds, sqlElapsed.inWholeMilliseconds)
+                if (queueWait + sqlElapsed > SLOW_READ_THRESHOLD) {
+                    logger.w { "SlowDbRead queueWait=$queueWait sql=$sqlElapsed read=$label" }
+                }
+                result
+            } catch (e: Exception) {
+                logger.e { "read failed [$label]: ${e.message}\nStack: ${e.stackTraceToString()}" }
+                throw e
+            }
+        }
+    }
+
     suspend fun withWriteTransaction(block: (OdinDatabase) -> Unit) {
         withContext(dispatcher) {
             database.transaction { block(database) }


### PR DESCRIPTION
## Summary

Move the cold-load conversation-list DB reads off the single writer connection onto the read lane, so they stop serializing behind cold-boot DriveSync writes. Follow-up to the merged "reads off the write dispatcher" change, which only covered raw-SQL `executeReadQuery` reads — not the `*Wrapper` reads that use the SQLDelight generated-query DSL.

## Why

Device-log analysis of a reported early-tap block (the list was visible **instantly**, but tapping a conversation stalled ~1.3s on cold boot, only on the first taps):

- The tap's **own** message read was fast — `SlowDbRead queueWait=153µs sql=98ms`, `loadAround took=97ms`. So the read lane works and the tap path isn't the problem.
- "Navigating to detail" fired **5ms after** `enrichAllConversationsWithUnreadCounts=2820ms (ColdLoad)` completed — the tap was waiting on that 2.8s pass.
- Root cause: `selectAllUnreadCount` (a full-`DriveMainIndex` GROUP-BY aggregate) still ran as a blocking `delegate.executeAsList()` on the **single writer connection**, so during cold load it contended with the DriveSync batch writes. The same applied to `selectAllConversations` and `selectAllConversationPlusLastMessage`.

## What

- **`DatabaseManager.readValue(label) { … }`** — a read-lane counterpart to `executeReadQuery` for generated-query reads: runs on `readDispatcher`, records the same `queueWait`/`sql` split into `lastReadTiming`, and emits a `SlowDbRead … read=<label>` warn over the threshold. (`executeReadQuery` is for raw SQL; this is for `delegate.x().executeAsList()`.)
- Route the three cold-load list reads through it: **`selectAllUnreadCount`**, **`selectAllConversations`**, **`selectAllConversationPlusLastMessage`**. The latter two become `suspend` (all callers are already `suspend` / inside `flow {}` / `runTest`). Row mapping/deserialization stays **outside** the read lane so a read-lane slot is held only for the SQL.

Under WAL these now run concurrently with the writer via each platform's reader pool, instead of serializing behind cold-load sync writes — exactly the "reads off the write dispatcher" model, now extended to the conversation-list reads.

## Extra logging (as requested)

Each routed read now logs its **own** `SlowDbRead queueWait=… sql=… read=<label>` when slow. So the next cold-boot device log will show, per read, whether the residual cost is **queue/scheduling**, **SQL** (e.g. the unread aggregate is just slow on cold cache), or gone — which tells us if the remaining work is write-contention (now fixed) vs Main-CPU (enrich/recompose churn) vs the aggregate itself.

## Verification

- `:homebase-api:jvmTest` + `:homebase-chat:jvmTest` green (incl. `ChatReadCountWrapperTest`, which exercises all three reads).
- Compiles on JVM, iOS (`compileKotlinIosSimulatorArm64`), and wasmJs.
- On-device: cold-boot and tap early; expect `Navigating to detail` to no longer wait on `enrichAllConversationsWithUnreadCounts`, and per-read `SlowDbRead … read=selectAllUnreadCount` to show its split.

## Scope notes

Only the three cold-load list reads are routed. Other wrapper reads (`selectOrphanedAtRestConversations`, `selectUnreadCountForConversation`, single-row lookups) are left as-is — they're cheap/rare; can follow if logs warrant. If the next log shows the residual stall is Main-CPU (enrich/recompose) rather than this contention, that's the next target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)