### PR TITLE
fix(ui): input bar safe-area gap and shadow on iOS

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -152,6 +152,7 @@ import id.homebase.core.util.isDesktop
 import id.homebase.core.util.isMobile
 import id.homebase.core.util.isWeb
 import id.homebase.core.util.keyboardAsState
+import id.homebase.core.util.rememberImeOffsetState
 import id.homebase.core.util.programmaticBackspace
 import id.homebase.core.util.rememberCameraManager
 import id.homebase.core.util.rememberVideoRecorderManager
@@ -385,6 +386,7 @@ fun ConversationContent(
     var keyboardHeight by remember { mutableStateOf(0.dp) }
     val density = LocalDensity.current
     val imeInsets = WindowInsets.ime
+    val imeState = rememberImeOffsetState()
 
     val imeVisible by remember { derivedStateOf { imeInsets.getBottom(density) > 0 } }
 
@@ -788,13 +790,11 @@ fun ConversationContent(
                 modifier = Modifier.fillMaxSize()
                     .offset {
                         val imeHeight = imeInsets.getBottom(this)
+                        val pureImeHeight = imeState.pureImeBottomPx
                         val sheetHeight = keyboardHeight.coerceAtLeast(300.dp).roundToPx()
                         val sheetOffset = when {
-                            // Emoji search: keyboard + emoji sheet both visible
-                            showEmojiSheet && imeHeight > 0 -> imeHeight + sheetHeight
-                            // Regular keyboard only
-                            imeHeight > 0 -> imeHeight
-                            // Sheet only (no keyboard)
+                            showEmojiSheet && imeHeight > 0 -> pureImeHeight + sheetHeight
+                            imeHeight > 0 -> pureImeHeight
                             showEmojiSheet || showAttachmentSheet -> sheetHeight
                             else -> 0
                         }
@@ -1214,7 +1214,7 @@ fun ConversationContent(
                     }
                 }
 
-                Surface(shadowElevation = 8.dp, tonalElevation = 0.dp) {
+                Surface(tonalElevation = 0.dp) {
                     if (conversation.conversation.conversationState == ConversationState.Left) {
                         Box(
                             modifier = Modifier.fillMaxWidth()

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/util/ImeOffsetUtils.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/util/ImeOffsetUtils.kt
@@ -1,0 +1,60 @@
+package id.homebase.core.util
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntOffset
+
+/**
+ * Returns the pure keyboard height in pixels, excluding the navigation bar
+ * (home indicator) inset that [WindowInsets.ime] includes on iOS.
+ *
+ * On iOS, [WindowInsets.ime] reports keyboard height + safe area bottom.
+ * Using the raw value as an offset overshoots by the safe area, leaving a
+ * gap between the content and the keyboard. Subtracting [WindowInsets.navigationBars]
+ * gives the keyboard-only height.
+ */
+fun pureImeBottomPx(
+    imeInsets: WindowInsets,
+    navBarInsets: WindowInsets,
+    density: Density,
+): Int {
+    val ime = imeInsets.getBottom(density)
+    val nav = navBarInsets.getBottom(density)
+    return (ime - nav).coerceAtLeast(0)
+}
+
+/**
+ * Whether the IME (software keyboard) is currently visible.
+ */
+fun isImeVisible(imeInsets: WindowInsets, density: Density): Boolean =
+    imeInsets.getBottom(density) > 0
+
+/**
+ * Remembers the [WindowInsets.ime] and [WindowInsets.navigationBars] so they
+ * can be read inside non-composable lambdas (e.g. [Modifier.offset]).
+ */
+data class ImeOffsetState(
+    val imeInsets: WindowInsets,
+    val navBarInsets: WindowInsets,
+    val density: Density,
+) {
+    val pureImeBottomPx: Int get() = pureImeBottomPx(imeInsets, navBarInsets, density)
+    val imeBottomPx: Int get() = imeInsets.getBottom(density)
+    val isImeVisible: Boolean get() = imeBottomPx > 0
+}
+
+@Composable
+fun rememberImeOffsetState(): ImeOffsetState {
+    val imeInsets = WindowInsets.ime
+    val navBarInsets = WindowInsets.navigationBars
+    val density = LocalDensity.current
+    return remember(imeInsets, navBarInsets, density) {
+        ImeOffsetState(imeInsets, navBarInsets, density)
+    }
+}

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/util/ImeOffsetUtilsTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/util/ImeOffsetUtilsTest.kt
@@ -1,0 +1,76 @@
+package id.homebase.core.util
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.ui.unit.Density
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ImeOffsetUtilsTest {
+
+    private val density = Density(3f)
+
+    private fun insets(bottom: Int) = WindowInsets(0, 0, 0, bottom)
+
+    @Test
+    fun `pureImeBottomPx subtracts nav bar from ime`() {
+        val ime = insets(bottom = 914)
+        val nav = insets(bottom = 102)
+        assertEquals(812, pureImeBottomPx(ime, nav, density))
+    }
+
+    @Test
+    fun `pureImeBottomPx returns zero when ime is zero`() {
+        val ime = insets(bottom = 0)
+        val nav = insets(bottom = 102)
+        assertEquals(0, pureImeBottomPx(ime, nav, density))
+    }
+
+    @Test
+    fun `pureImeBottomPx returns zero when nav exceeds ime`() {
+        val ime = insets(bottom = 50)
+        val nav = insets(bottom = 102)
+        assertEquals(0, pureImeBottomPx(ime, nav, density))
+    }
+
+    @Test
+    fun `pureImeBottomPx returns full ime when nav is zero`() {
+        val ime = insets(bottom = 914)
+        val nav = insets(bottom = 0)
+        assertEquals(914, pureImeBottomPx(ime, nav, density))
+    }
+
+    @Test
+    fun `isImeVisible returns true when ime has bottom inset`() {
+        assertTrue(isImeVisible(insets(bottom = 914), density))
+    }
+
+    @Test
+    fun `isImeVisible returns false when ime is zero`() {
+        assertFalse(isImeVisible(insets(bottom = 0), density))
+    }
+
+    @Test
+    fun `ImeOffsetState exposes correct values`() {
+        val state = ImeOffsetState(
+            imeInsets = insets(bottom = 900),
+            navBarInsets = insets(bottom = 100),
+            density = density,
+        )
+        assertEquals(800, state.pureImeBottomPx)
+        assertEquals(900, state.imeBottomPx)
+        assertTrue(state.isImeVisible)
+    }
+
+    @Test
+    fun `ImeOffsetState with no keyboard`() {
+        val state = ImeOffsetState(
+            imeInsets = insets(bottom = 0),
+            navBarInsets = insets(bottom = 100),
+            density = density,
+        )
+        assertEquals(0, state.pureImeBottomPx)
+        assertFalse(state.isImeVisible)
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/note/VaultNoteEditorScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/note/VaultNoteEditorScreen.kt
@@ -11,7 +11,8 @@ import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.offset
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -79,6 +80,7 @@ import id.homebase.resources.vault_note_share
 import id.homebase.resources.vault_note_title_placeholder
 import id.homebase.resources.vault_note_title_required
 import id.homebase.resources.vault_permission_cancel
+import id.homebase.core.util.rememberImeOffsetState
 import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalRichTextApi::class, ExperimentalComposeUiApi::class)
@@ -91,6 +93,7 @@ fun VaultNoteEditorScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val richTextState = rememberRichTextState()
     val snackbarHostState = remember { SnackbarHostState() }
+    val imeState = rememberImeOffsetState()
     var showDeleteConfirm by remember { mutableStateOf(false) }
     var showDiscardConfirm by remember { mutableStateOf(false) }
     var seedGeneration by remember { mutableStateOf(0) }
@@ -219,7 +222,7 @@ fun VaultNoteEditorScreen(
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
-                        .imePadding(),
+                        .offset { IntOffset(0, -imeState.pureImeBottomPx) },
                 ) {
                     NoteTitle(
                         title = uiState.title,


### PR DESCRIPTION
## Summary
- On iOS, `WindowInsets.ime` includes the safe area (home indicator) height, causing the keyboard offset to overshoot by ~34pt — leaving a visible gap between the input bar and the keyboard
- Extracted a reusable `ImeOffsetUtils` utility (`pureImeBottomPx()`) that subtracts navigation bar inset from IME inset to get the pure keyboard height
- Applied the fix to `ConversationContent` (chat input bar) and `VaultNoteEditorScreen` (note editor formatting toolbar)
- Removed `shadowElevation` from the input bar `Surface` — the shadow looked jarring against the keyboard on iOS
- 8 unit tests for the new utility covering edge cases (zero IME, zero nav bar, nav > IME, etc.)

## Test plan
- [ ] Open a conversation on iOS — input bar should sit flush against the keyboard with no gap
- [ ] Open the vault note editor on iOS — formatting toolbar should sit flush against the keyboard
- [ ] Verify emoji sheet and attachment sheet still work correctly in conversations
- [ ] Verify Android chat and vault note screens are not affected negatively
- [ ] Verify desktop input bar still looks correct (no shadow change regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)