### PR TITLE
fix(desktop): ESC no longer deselects the active conversation

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -716,7 +716,7 @@ fun ConversationListUi(
         scope.launch {
             if (messagesUiState.fullScreenOverlay != null) {
                 onUiAction(ConversationListUiAction.CloseFullScreenOverlay)
-            } else {
+            } else if (!isDesktop()) {
                 scaffoldNavigator.navigateBack(BackNavigationBehavior.PopUntilContentChange)
             }
         }


### PR DESCRIPTION
## Summary
- On desktop, pressing ESC while viewing a conversation triggered `scaffoldNavigator.navigateBack()`, which deselected the conversation and showed the "select a conversation" empty state
- Added an `isDesktop()` guard so ESC does nothing when a conversation is open on desktop
- Full-screen overlay dismissal (ESC to close image viewer, etc.) still works
- Mobile back button behavior is completely unchanged

## Test plan
- [ ] Desktop: open a conversation, press ESC — conversation should remain visible
- [ ] Desktop: open a full-screen overlay (e.g., image viewer), press ESC — overlay should close
- [ ] Desktop: open search mode, press ESC — search should close (handled by ConversationContent BackHandler)
- [ ] Android: open a conversation, press back — should navigate back to conversation list as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)