### PR TITLE
Make image attachments work on web (materialize + previews)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/OkioFileOperationsProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/OkioFileOperationsProvider.kt
@@ -1,0 +1,81 @@
+package id.homebase.api.file
+
+import io.ktor.client.request.forms.InputProvider
+import kotlinx.coroutines.flow.Flow
+import kotlinx.io.Buffer
+import okio.FileSystem
+import okio.buffer
+import okio.Path.Companion.toPath
+import kotlin.random.Random
+
+/**
+ * okio-backed [FileOperationsProvider]. The [fileSystem] is injected, so the exact same logic runs
+ * over any okio `FileSystem` — a real disk, the web's in-memory `FakeFileSystem`, or a test
+ * `FakeFileSystem`. The web provider ([WebFileOperationsProvider]) is just this bound to the wasm
+ * [systemFileSystem]; keeping the logic here (not in the wasm-only source set) lets it be unit
+ * tested generically against a `FakeFileSystem` without any wasm test harness.
+ */
+open class OkioFileOperationsProvider(
+    private val fileSystem: FileSystem,
+    private val cacheDir: String,
+) : FileOperationsProvider {
+
+    override fun openFileInput(path: String): InputProvider {
+        val bytes = fileSystem.read(path.toPath()) { readByteArray() }
+        return InputProvider(size = bytes.size.toLong()) { Buffer().apply { write(bytes) } }
+    }
+
+    override suspend fun readFileBytes(path: String): ByteArray =
+        fileSystem.read(path.toPath()) { readByteArray() }
+
+    override fun deleteTempFile(path: String): Boolean {
+        val p = path.toPath()
+        if (!fileSystem.exists(p)) return true
+        return runCatching { fileSystem.delete(p); true }.getOrDefault(false)
+    }
+
+    override fun getCacheDirectory(): String = cacheDir
+
+    override fun getFileSize(path: String): Long =
+        fileSystem.metadataOrNull(path.toPath())?.size ?: 0L
+
+    override suspend fun writeBytesToTempFile(
+        bytes: ByteArray,
+        prefix: String,
+        suffix: String
+    ): String {
+        val dir = cacheDir.toPath()
+        fileSystem.createDirectories(dir)
+        val path = dir / "$prefix${randomToken()}$suffix"
+        fileSystem.write(path) { write(bytes) }
+        return path.toString()
+    }
+
+    override suspend fun writeBytesToShareOutboundFile(
+        bytes: ByteArray,
+        suffix: String,
+    ): String {
+        val dir = cacheDir.toPath() / SHARE_OUTBOUND_DIR_NAME
+        fileSystem.createDirectories(dir)
+        val path = dir / "share_${randomToken()}$suffix"
+        fileSystem.write(path) { write(bytes) }
+        return path.toString()
+    }
+
+    override suspend fun writeStream(
+        path: String,
+        data: Flow<ByteArray>
+    ) {
+        val p = path.toPath()
+        p.parent?.let { fileSystem.createDirectories(it) }
+        // okio's write{} block is non-suspend, so stream into a buffered sink instead.
+        val sink = fileSystem.sink(p).buffer()
+        try {
+            data.collect { chunk -> sink.write(chunk) }
+        } finally {
+            sink.close()
+        }
+    }
+
+    private fun randomToken(): String = Random.nextLong().toULong().toString(16)
+}

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/file/OkioFileOperationsProviderTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/file/OkioFileOperationsProviderTest.kt
@@ -1,0 +1,70 @@
+package id.homebase.api.file
+
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression guard for the file-operations layer the web upload/attachment pipeline runs on.
+ *
+ * The web ([WebFileOperationsProvider]) is exactly [OkioFileOperationsProvider] bound to the wasm
+ * [systemFileSystem], which is an in-memory okio `FakeFileSystem`. These tests exercise the same
+ * provider over a `FakeFileSystem` — so they cover the real web behavior (write/read/size/stream/
+ * delete) while running in the normal JVM test job (no wasm harness needed). If the web file ops
+ * regress, sending media on web breaks with "file not found"; this catches that.
+ */
+class OkioFileOperationsProviderTest {
+
+    private fun provider() = OkioFileOperationsProvider(FakeFileSystem(), "/tmp/homebase")
+
+    @Test
+    fun writeTempRoundTripsThroughReadSizeHeaderOpenAndDelete() = runTest {
+        val ops = provider()
+        val bytes = byteArrayOf(10, 20, 30, 40)
+
+        val path = ops.writeBytesToTempFile(bytes, "guard_", ".bin")
+        assertTrue(path.isNotBlank(), "temp path must be returned")
+        assertTrue(path.endsWith(".bin"), "suffix preserved: $path")
+
+        assertEquals(4L, ops.getFileSize(path), "getFileSize must match written bytes")
+        assertContentEquals(bytes, ops.readFileBytes(path), "readFileBytes must round-trip")
+        assertContentEquals(bytes, ops.readFileHeaderBytes(path, 64), "header read must return the bytes")
+        assertEquals(4L, ops.openFileInput(path).size, "openFileInput must report the size")
+
+        assertTrue(ops.deleteTempFile(path), "delete must succeed")
+        assertEquals(0L, ops.getFileSize(path), "size must be 0 after delete")
+        assertTrue(ops.deleteTempFile(path), "deleting a missing file is a no-op success")
+    }
+
+    @Test
+    fun writeStreamConcatenatesChunksInOrder() = runTest {
+        val ops = provider()
+        val path = "${ops.getCacheDirectory()}/streamed.bin"
+
+        ops.writeStream(path, flowOf(byteArrayOf(1, 2), byteArrayOf(3), byteArrayOf(4, 5)))
+
+        assertContentEquals(
+            byteArrayOf(1, 2, 3, 4, 5),
+            ops.readFileBytes(path),
+            "streamed chunks must concatenate in order",
+        )
+    }
+
+    @Test
+    fun shareOutboundWritesUnderItsSubdir() = runTest {
+        val ops = provider()
+        val path = ops.writeBytesToShareOutboundFile(byteArrayOf(7, 8, 9), ".dat")
+
+        assertTrue(path.contains(SHARE_OUTBOUND_DIR_NAME), "must live under the share-outbound subdir: $path")
+        assertContentEquals(byteArrayOf(7, 8, 9), ops.readFileBytes(path), "share file must round-trip")
+    }
+
+    @Test
+    fun getFileSizeOfMissingFileIsZero() {
+        assertEquals(0L, provider().getFileSize("/tmp/homebase/does-not-exist.bin"))
+    }
+}

--- a/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/file/WebFileOperationsProvider.kt
+++ b/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/file/WebFileOperationsProvider.kt
@@ -1,78 +1,13 @@
 package id.homebase.api.file
 
-import io.ktor.client.request.forms.InputProvider
-import kotlinx.coroutines.flow.Flow
-import kotlinx.io.Buffer
-import okio.buffer
-import okio.Path.Companion.toPath
-import kotlin.random.Random
-
 /**
- * In-memory web implementation backed by the wasmJs [systemFileSystem] (an okio
- * `FakeFileSystem`). Everything lives in RAM and is cleared on page refresh — adequate for the
- * transient temp files the upload/share pipeline produces; durable browser storage
- * (IndexedDB / OPFS) is out of scope for the first-pass wasm support.
+ * Web file operations, backed by the in-memory wasm [systemFileSystem] (an okio `FakeFileSystem`).
+ * Everything lives in RAM and is cleared on page refresh — adequate for the transient temp files
+ * the upload/share pipeline produces; durable browser storage (IndexedDB / OPFS) is out of scope
+ * for the first-pass wasm support.
+ *
+ * All behavior is the shared [OkioFileOperationsProvider]; this just binds it to the web filesystem
+ * and cache dir. The logic is unit-tested generically in `OkioFileOperationsProviderTest` against a
+ * `FakeFileSystem` (the same FS type [systemFileSystem] is on web).
  */
-class WebFileOperationsProvider : FileOperationsProvider {
-
-    private val cacheDir = "/tmp/homebase"
-
-    override fun openFileInput(path: String): InputProvider {
-        val bytes = systemFileSystem.read(path.toPath()) { readByteArray() }
-        return InputProvider(size = bytes.size.toLong()) { Buffer().apply { write(bytes) } }
-    }
-
-    override suspend fun readFileBytes(path: String): ByteArray =
-        systemFileSystem.read(path.toPath()) { readByteArray() }
-
-    override fun deleteTempFile(path: String): Boolean {
-        val p = path.toPath()
-        if (!systemFileSystem.exists(p)) return true
-        return runCatching { systemFileSystem.delete(p); true }.getOrDefault(false)
-    }
-
-    override fun getCacheDirectory(): String = cacheDir
-
-    override fun getFileSize(path: String): Long =
-        systemFileSystem.metadataOrNull(path.toPath())?.size ?: 0L
-
-    override suspend fun writeBytesToTempFile(
-        bytes: ByteArray,
-        prefix: String,
-        suffix: String
-    ): String {
-        val dir = cacheDir.toPath()
-        systemFileSystem.createDirectories(dir)
-        val path = dir / "$prefix${randomToken()}$suffix"
-        systemFileSystem.write(path) { write(bytes) }
-        return path.toString()
-    }
-
-    override suspend fun writeBytesToShareOutboundFile(
-        bytes: ByteArray,
-        suffix: String,
-    ): String {
-        val dir = cacheDir.toPath() / SHARE_OUTBOUND_DIR_NAME
-        systemFileSystem.createDirectories(dir)
-        val path = dir / "share_${randomToken()}$suffix"
-        systemFileSystem.write(path) { write(bytes) }
-        return path.toString()
-    }
-
-    override suspend fun writeStream(
-        path: String,
-        data: Flow<ByteArray>
-    ) {
-        val p = path.toPath()
-        p.parent?.let { systemFileSystem.createDirectories(it) }
-        // okio's write{} block is non-suspend, so stream into a buffered sink instead.
-        val sink = systemFileSystem.sink(p).buffer()
-        try {
-            data.collect { chunk -> sink.write(chunk) }
-        } finally {
-            sink.close()
-        }
-    }
-
-    private fun randomToken(): String = Random.nextLong().toULong().toString(16)
-}
+class WebFileOperationsProvider : OkioFileOperationsProvider(systemFileSystem, "/tmp/homebase")

--- a/homebase-chat/src/androidMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.android.kt
+++ b/homebase-chat/src/androidMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.android.kt
@@ -1,0 +1,8 @@
+package id.homebase.chat.conversationlist
+
+import id.homebase.api.file.FileOperationsProvider
+import io.github.vinceglb.filekit.PlatformFile
+
+// Native PlatformFile carries a real path / content:// URI; the existing path-based send
+// pipeline (and resolveToFilePath for content URIs) already handles it. No copy needed.
+actual suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): String = toString()

--- a/homebase-chat/src/appleMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.apple.kt
+++ b/homebase-chat/src/appleMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.apple.kt
@@ -1,0 +1,8 @@
+package id.homebase.chat.conversationlist
+
+import id.homebase.api.file.FileOperationsProvider
+import io.github.vinceglb.filekit.PlatformFile
+
+// iOS PlatformFile carries a real file path; the path-based send pipeline reads it directly.
+// No copy needed.
+actual suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): String = toString()

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.kt
@@ -1,0 +1,36 @@
+package id.homebase.chat.conversationlist
+
+import id.homebase.api.file.FileOperationsProvider
+import io.github.vinceglb.filekit.PlatformFile
+
+/**
+ * Resolves a picked [PlatformFile] to a path that [fileOps] can read for upload.
+ *
+ * The send pipeline is path-based: it takes `attachment.file.toString()` and later reads the
+ * bytes via [FileOperationsProvider]. That works on native, where a picked [PlatformFile] is
+ * backed by a real filesystem path (or an Android `content://` URI that `resolveToFilePath`
+ * copies downstream) — so the native actuals return [PlatformFile.toString] unchanged, with no
+ * extra copy.
+ *
+ * On the web there is NO path: FileKit's `PlatformFile.path` lives in its non-web source set,
+ * and a browser-picked file's bytes are reachable only through `readBytes()`. So `file.toString()`
+ * is not an okio path and the upload's `readFileBytes(...)` fails with "file not found". The web
+ * actual fixes this by copying the picked bytes into the okio (in-memory) cache via [fileOps] and
+ * returning that path, so the rest of the path-based pipeline just works.
+ */
+expect suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): String
+
+/**
+ * Shared materialize step used by the web actual: copy [bytes] into a temp file via [fileOps]
+ * and return its path, preserving [fileName]'s extension in the suffix. Extracted to commonMain
+ * so the copy-and-readability contract can be unit-tested without a browser.
+ */
+internal suspend fun materializeBytesToUploadPath(
+    fileOps: FileOperationsProvider,
+    fileName: String,
+    bytes: ByteArray,
+): String {
+    val ext = fileName.substringAfterLast('.', "")
+    val suffix = if (ext.isNotEmpty()) ".$ext" else ""
+    return fileOps.writeBytesToTempFile(bytes, "attach_", suffix)
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -625,7 +625,7 @@ internal class MessageActionsHandler(
                     is AttachmentPendingFile.File -> {
                         attachments.add(
                             AttachmentInput(
-                                filePath = attachment.file.toString(),
+                                filePath = attachment.file.toUploadPath(fileOperationsProvider),
                                 contentType = resolveContentType(
                                     fileName = attachment.file.name,
                                     platformMimeType = attachment.file.mimeType()?.toString(),
@@ -636,7 +636,7 @@ internal class MessageActionsHandler(
                     }
 
                     is AttachmentPendingFile.FileImage -> {
-                        var filePath = attachment.file.toString()
+                        var filePath = attachment.file.toUploadPath(fileOperationsProvider)
                         var contentType = resolveContentType(
                             fileName = attachment.file.name,
                             platformMimeType = attachment.file.mimeType()?.toString(),
@@ -665,7 +665,7 @@ internal class MessageActionsHandler(
                     is AttachmentPendingFile.FileVideo -> {
                         attachments.add(
                             AttachmentInput(
-                                filePath = attachment.file.toString(),
+                                filePath = attachment.file.toUploadPath(fileOperationsProvider),
                                 contentType = resolveContentType(
                                     fileName = attachment.file.name,
                                     platformMimeType = attachment.file.mimeType()?.toString(),
@@ -678,7 +678,7 @@ internal class MessageActionsHandler(
                     }
 
                     is AttachmentPendingFile.Gallery -> {
-                        var filePath = attachment.image.file.toString()
+                        var filePath = attachment.image.file.toUploadPath(fileOperationsProvider)
                         var contentType = resolveContentType(
                             fileName = attachment.image.fileName,
                         )
@@ -706,13 +706,13 @@ internal class MessageActionsHandler(
                     is AttachmentPendingFile.Audio -> {
                         attachments.add(
                             AttachmentInput(
-                                filePath = attachment.audioFile.toString(),
+                                filePath = attachment.audioFile.toUploadPath(fileOperationsProvider),
                                 contentType = resolveContentType(
                                     fileName = attachment.audioFile.name,
                                     platformMimeType = attachment.audioFile.mimeType()?.toString(),
                                 ),
                                 displayName = attachment.audioFile.name,
-                                waveformFile = attachment.waveformFile?.toString(),
+                                waveformFile = attachment.waveformFile?.toUploadPath(fileOperationsProvider),
                                 audioLengthSeconds = attachment.lengthSeconds,
                             )
                         )
@@ -859,7 +859,12 @@ internal class MessageActionsHandler(
                                 .toPersistentList(),
                         )
                     }
-                } catch (e: Exception) {
+                } catch (e: Throwable) {
+                    // Throwable, not Exception: a missing platform impl throws kotlin.NotImplementedError
+                    // (an Error, not an Exception). Catching only Exception let that escape, killing the
+                    // coroutine and leaving the bubble stuck on "Preparing" forever. Re-throw
+                    // CancellationException so structured-concurrency cancellation still propagates.
+                    if (e is kotlin.coroutines.cancellation.CancellationException) throw e
                     Logger.e(
                         throwable = e,
                         tag = TAG

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/image/PlatformFileFetcher.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/image/PlatformFileFetcher.kt
@@ -1,0 +1,41 @@
+package id.homebase.chat.image
+
+import coil3.ImageLoader
+import coil3.decode.DataSource
+import coil3.decode.ImageSource
+import coil3.fetch.FetchResult
+import coil3.fetch.Fetcher
+import coil3.fetch.SourceFetchResult
+import coil3.request.Options
+import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.readBytes
+import okio.Buffer
+
+/**
+ * Coil fetcher for a picked [PlatformFile], so composer/attachment previews can pass the
+ * `PlatformFile` itself as the Coil `model`.
+ *
+ * This is what makes previews render on the web: a browser-picked `PlatformFile` has no
+ * filesystem path (FileKit's `PlatformFile.path` is non-web only), so the old `file.toString()`
+ * model was an unloadable string → blank thumbnail. Reading bytes via FileKit's cross-platform
+ * `readBytes()` works on every target (on web it reads the underlying browser `File`).
+ */
+class PlatformFileFetcher(
+    private val file: PlatformFile,
+    private val options: Options,
+) : Fetcher {
+
+    override suspend fun fetch(): FetchResult {
+        val bytes = file.readBytes()
+        return SourceFetchResult(
+            source = ImageSource(Buffer().apply { write(bytes) }, options.fileSystem),
+            mimeType = null,
+            dataSource = DataSource.DISK,
+        )
+    }
+
+    class Factory : Fetcher.Factory<PlatformFile> {
+        override fun create(data: PlatformFile, options: Options, imageLoader: ImageLoader): Fetcher =
+            PlatformFileFetcher(data, options)
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/AttachmentOptions.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/AttachmentOptions.kt
@@ -154,7 +154,7 @@ fun AttachmentGallery(
                             ) {
                                 AsyncImage(
                                     imageLoader = imageLoader,
-                                    model = galleryImage.file.toString(),
+                                    model = galleryImage.file,
                                     contentDescription = stringResource(MR.string.cd_gallery_thumbnail),
                                     modifier = Modifier
                                         .size(160.dp)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenAttachmentEditor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenAttachmentEditor.kt
@@ -183,7 +183,7 @@ fun FullScreenAttachmentEditor(
                     is AttachmentPendingFile.FileImage -> {
                         AsyncImage(
                             imageLoader = imageLoader,
-                            model = attachment.file.toString(),
+                            model = attachment.file,
                             contentDescription = stringResource(MR.string.cd_image_attachment),
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -256,7 +256,7 @@ fun FullScreenAttachmentEditor(
                     is AttachmentPendingFile.Gallery -> {
                         AsyncImage(
                             imageLoader = imageLoader,
-                            model = attachment.image.thumbnailUri ?: attachment.image.file.toString(),
+                            model = attachment.image.thumbnailUri ?: attachment.image.file,
                             contentDescription = stringResource(MR.string.cd_gallery_thumbnail),
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -398,7 +398,7 @@ fun FullScreenAttachmentEditor(
                             is AttachmentPendingFile.FileImage -> {
                                 AsyncImage(
                                     imageLoader = imageLoader,
-                                    model = attachment.file.toString(),
+                                    model = attachment.file,
                                     contentDescription = stringResource(MR.string.cd_image_attachment),
                                     modifier = Modifier.fillMaxSize(),
                                     contentScale = ContentScale.Crop
@@ -426,7 +426,7 @@ fun FullScreenAttachmentEditor(
                             is AttachmentPendingFile.Gallery -> {
                                 AsyncImage(
                                     imageLoader = imageLoader,
-                                    model = attachment.image.thumbnailUri ?: attachment.image.file.toString(),
+                                    model = attachment.image.thumbnailUri ?: attachment.image.file,
                                     contentDescription = stringResource(MR.string.cd_gallery_thumbnail),
                                     modifier = Modifier.fillMaxSize(),
                                     contentScale = ContentScale.Crop

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenAttachmentEditor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenAttachmentEditor.kt
@@ -228,6 +228,13 @@ fun FullScreenAttachmentEditor(
                             } else {
                                 // Duration not known yet — show poster while extractThumbnailAsync
                                 // resolves. Player mounts as soon as durationMs lands.
+                                // Video poster intentionally falls back to the file PATH string, NOT the
+                                // PlatformFile model: routing a video through PlatformFileFetcher would
+                                // read the whole video into memory just for a poster. Posters come from
+                                // VideoThumbnailExtractor.extractPosterFrame (desktop/iOS via ffmpeg,
+                                // Android via MediaMetadataRetriever). Web's extractor is unimplemented on
+                                // main, so thumbnailBytes is null and this is blank for now; the web impl
+                                // (browser <video>+canvas, no 22 MB ffmpeg core) ships with the video PR.
                                 val posterModel: Any = attachment.thumbnailBytes
                                     ?: attachment.file.toString()
                                 AsyncImage(
@@ -409,6 +416,9 @@ fun FullScreenAttachmentEditor(
                                     modifier = Modifier.fillMaxSize(),
                                     contentAlignment = Alignment.Center
                                 ) {
+                                    // Poster falls back to the file PATH string, not the PlatformFile model
+                                    // (see the player-mount branch above for why). Blank on web until the web
+                                    // VideoThumbnailExtractor lands with the video PR.
                                     AsyncImage(
                                         imageLoader = imageLoader,
                                         model = attachment.thumbnailBytes ?: attachment.file.toString(),

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolveTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolveTest.kt
@@ -1,0 +1,79 @@
+package id.homebase.chat.conversationlist
+
+import id.homebase.api.file.FileOperationsProvider
+import io.ktor.client.request.forms.InputProvider
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Guards the contract the web `PlatformFile.toUploadPath` actual relies on: a picked file's
+ * bytes, once materialized, must be READABLE BACK through the same [FileOperationsProvider] the
+ * send pipeline uses. The web Gallery/image send bug was exactly this contract being skipped —
+ * the raw browser PlatformFile was never copied into okio, so `readFileBytes` couldn't find it.
+ *
+ * (The web `readBytes()` interop itself can't run without a browser; this covers the shared
+ * copy-and-readability logic, which is the part that was missing.)
+ */
+class AttachmentUploadResolveTest {
+
+    @Test
+    fun materializedPathIsReadableBackWithSameProvider() = runTest {
+        val fs = InMemoryFileOps()
+        val bytes = byteArrayOf(1, 2, 3, 4, 5, 6, 7)
+
+        val path = materializeBytesToUploadPath(fs, "photo.JPG", bytes)
+
+        // The upload pipeline reads attachment paths via this provider — it must succeed.
+        assertEquals(bytes.toList(), fs.readFileBytes(path).toList())
+        // Extension is preserved so downstream content-type / muxer logic still works.
+        assertTrue(path.endsWith(".JPG"), "expected .JPG suffix, got: $path")
+    }
+
+    @Test
+    fun materializeHandlesNameWithoutExtension() = runTest {
+        val fs = InMemoryFileOps()
+        val bytes = byteArrayOf(42)
+
+        val path = materializeBytesToUploadPath(fs, "noextension", bytes)
+
+        assertEquals(bytes.toList(), fs.readFileBytes(path).toList())
+        assertTrue(!path.endsWith("."), "no trailing dot when name has no extension: $path")
+    }
+
+    @Test
+    fun eachMaterializeGetsADistinctPath() = runTest {
+        val fs = InMemoryFileOps()
+        val a = materializeBytesToUploadPath(fs, "a.png", byteArrayOf(1))
+        val b = materializeBytesToUploadPath(fs, "a.png", byteArrayOf(2))
+        assertTrue(a != b, "two attachments must not collide on one temp path")
+        assertEquals(listOf<Byte>(1), fs.readFileBytes(a).toList())
+        assertEquals(listOf<Byte>(2), fs.readFileBytes(b).toList())
+    }
+}
+
+/** Minimal in-memory [FileOperationsProvider] — only the members the materialize path touches. */
+private class InMemoryFileOps : FileOperationsProvider {
+    private val store = mutableMapOf<String, ByteArray>()
+    private var counter = 0
+
+    override suspend fun writeBytesToTempFile(bytes: ByteArray, prefix: String, suffix: String): String {
+        val path = "/tmp/$prefix${counter++}$suffix"
+        store[path] = bytes
+        return path
+    }
+
+    override suspend fun readFileBytes(path: String): ByteArray =
+        store[path] ?: error("file not found: $path")
+
+    override fun getFileSize(path: String): Long = (store[path]?.size ?: 0).toLong()
+    override fun deleteTempFile(path: String): Boolean = store.remove(path) != null
+    override fun getCacheDirectory(): String = "/tmp"
+
+    override fun openFileInput(path: String): InputProvider = throw NotImplementedError()
+    override suspend fun writeBytesToShareOutboundFile(bytes: ByteArray, suffix: String): String =
+        throw NotImplementedError()
+    override suspend fun writeStream(path: String, data: Flow<ByteArray>) = throw NotImplementedError()
+}

--- a/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.jvm.kt
+++ b/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.jvm.kt
@@ -1,0 +1,8 @@
+package id.homebase.chat.conversationlist
+
+import id.homebase.api.file.FileOperationsProvider
+import io.github.vinceglb.filekit.PlatformFile
+
+// Desktop PlatformFile carries a real filesystem path; the path-based send pipeline reads it
+// directly. No copy needed.
+actual suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): String = toString()

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/image/PlatformFileFetcherTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/image/PlatformFileFetcherTest.kt
@@ -1,0 +1,62 @@
+package id.homebase.chat.image
+
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.fetch.SourceFetchResult
+import coil3.request.Options
+import io.github.vinceglb.filekit.PlatformFile
+import kotlinx.coroutines.test.runTest
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Guards the Coil seam that makes composer/attachment previews render: a picked [PlatformFile]
+ * passed as the Coil model must be read back byte-for-byte. On the web a browser-picked file has
+ * no path, so this fetcher (reading via FileKit `readBytes()`) is the only thing that loads the
+ * preview — if it regresses, web image previews silently go blank again. Runs on the JVM because
+ * [PlatformFile] is built from a real [File] here; the fetch path itself is common code.
+ */
+class PlatformFileFetcherTest {
+
+    private val tmp: File = File.createTempFile("platform-file-fetcher", ".bin")
+
+    @AfterTest
+    fun cleanup() {
+        tmp.delete()
+    }
+
+    @Test
+    fun fetch_readsFileBytesIntoImageSource() = runTest {
+        val payload = ByteArray(2048) { (it % 251).toByte() }
+        tmp.writeBytes(payload)
+
+        val fetcher = PlatformFileFetcher(PlatformFile(tmp), Options(PlatformContext.INSTANCE))
+        val result = fetcher.fetch()
+
+        assertTrue(result is SourceFetchResult, "expected a SourceFetchResult")
+        val readBack = result.source.source().readByteArray()
+        assertContentEquals(payload, readBack, "fetched bytes must round-trip the file content")
+    }
+
+    @Test
+    fun fetch_emptyFile_yieldsEmptySource() = runTest {
+        tmp.writeBytes(ByteArray(0))
+
+        val fetcher = PlatformFileFetcher(PlatformFile(tmp), Options(PlatformContext.INSTANCE))
+        val result = fetcher.fetch() as SourceFetchResult
+
+        assertEquals(0L, result.source.source().readByteArray().size.toLong(), "empty file -> empty source")
+    }
+
+    @Test
+    fun factory_createsFetcherForPlatformFile() {
+        val imageLoader = ImageLoader.Builder(PlatformContext.INSTANCE).build()
+        val fetcher = PlatformFileFetcher.Factory()
+            .create(PlatformFile(tmp), Options(PlatformContext.INSTANCE), imageLoader)
+        assertTrue(fetcher is PlatformFileFetcher, "factory must produce a PlatformFileFetcher")
+    }
+}

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.web.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.web.kt
@@ -1,0 +1,13 @@
+package id.homebase.chat.conversationlist
+
+import id.homebase.api.file.FileOperationsProvider
+import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.name
+import io.github.vinceglb.filekit.readBytes
+
+// The browser has no filesystem path for a picked PlatformFile (FileKit's PlatformFile.path is
+// non-web-only); its bytes are reachable only via readBytes(). Copy them into the okio in-memory
+// cache so the path-based send pipeline can read them back. Without this, web sends fail because
+// file.toString() isn't an okio path ("file not found").
+actual suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): String =
+    materializeBytesToUploadPath(fileOps, name, readBytes())

--- a/homebase-core/src/androidMain/kotlin/id/homebase/core/di/AppModule.android.kt
+++ b/homebase-core/src/androidMain/kotlin/id/homebase/core/di/AppModule.android.kt
@@ -10,6 +10,7 @@ import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.sync.database.AndroidDatabaseSizeProbe
 import id.homebase.chat.dice.AndroidShakeDetector
 import id.homebase.chat.dice.ShakeDetector
+import id.homebase.chat.image.PlatformFileFetcher
 import id.homebase.api.sync.database.DatabaseSizeProbe
 import id.homebase.core.audio.AndroidAudioPlayer
 import id.homebase.core.audio.AndroidAudioRecorder
@@ -74,6 +75,7 @@ actual fun platformModule(): Module = module {
                     add(HomebaseImageKeyer())
                     add(HomebaseImageFetcher.Factory(get(), get()))
                     add(PublicImageFetcher.Factory(get()))
+                    add(PlatformFileFetcher.Factory())
                     add(VideoFrameDecoder.Factory())
                 }
             .memoryCache {

--- a/homebase-core/src/jvmMain/kotlin/id/homebase/core/di/AppModule.desktop.kt
+++ b/homebase-core/src/jvmMain/kotlin/id/homebase/core/di/AppModule.desktop.kt
@@ -10,6 +10,7 @@ import id.homebase.api.sync.database.DatabaseSizeProbe
 import id.homebase.api.sync.database.JvmDatabaseSizeProbe
 import id.homebase.chat.dice.JvmShakeDetector
 import id.homebase.chat.dice.ShakeDetector
+import id.homebase.chat.image.PlatformFileFetcher
 import id.homebase.core.audio.AudioPlayer
 import id.homebase.core.audio.AudioRecorder
 import id.homebase.core.audio.AudioWaveFormGenerator
@@ -67,6 +68,7 @@ actual fun platformModule(): Module = module {
                     add(HomebaseImageKeyer())
                     add(HomebaseImageFetcher.Factory(get(), get()))
                     add(PublicImageFetcher.Factory(get()))
+                    add(PlatformFileFetcher.Factory())
                 }
                 .diskCache(null)
                 .build()

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/di/AppModule.native.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/di/AppModule.native.kt
@@ -10,6 +10,7 @@ import id.homebase.api.sync.database.DatabaseSizeProbe
 import id.homebase.api.sync.database.NativeDatabaseSizeProbe
 import id.homebase.chat.dice.IosShakeDetector
 import id.homebase.chat.dice.ShakeDetector
+import id.homebase.chat.image.PlatformFileFetcher
 import id.homebase.core.audio.AudioPlayer
 import id.homebase.core.audio.AudioRecorder
 import id.homebase.core.audio.AudioWaveFormGenerator
@@ -60,6 +61,7 @@ actual fun platformModule(): Module = module {
                     add(PHAssetFetcher.Factory())
                     add(HomebaseImageFetcher.Factory(get(), get()))
                     add(PublicImageFetcher.Factory(get()))
+                    add(PlatformFileFetcher.Factory())
                 }
                 .diskCache(null)
                 .build()

--- a/homebase-core/src/wasmJsMain/kotlin/id/homebase/core/di/AppModule.web.kt
+++ b/homebase-core/src/wasmJsMain/kotlin/id/homebase/core/di/AppModule.web.kt
@@ -6,6 +6,7 @@ import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.file.WebFileOperationsProvider
 import id.homebase.api.sync.database.DatabaseSizeProbe
 import id.homebase.chat.dice.ShakeDetector
+import id.homebase.chat.image.PlatformFileFetcher
 import id.homebase.core.audio.AudioPlayer
 import id.homebase.core.audio.AudioRecorder
 import id.homebase.core.audio.AudioWaveFormGenerator
@@ -54,6 +55,7 @@ actual fun platformModule(): Module = module {
                 .components {
                     add(HomebaseImageKeyer())
                     add(HomebaseImageFetcher.Factory(get(), get()))
+                    add(PlatformFileFetcher.Factory())
                 }
                 .build()
     }

--- a/webApp/webpack.config.d/devserver.js
+++ b/webApp/webpack.config.d/devserver.js
@@ -16,3 +16,18 @@ config.devServer.historyApiFallback = {
         { from: new RegExp('^' + escapedPublicPath + 'authorization-code-callback'), to: publicPath + 'index.html' }
     ]
 };
+
+// Open Chrome (not the OS default browser) when running `wasmJsBrowserDevelopmentRun`.
+// webpack-dev-server delegates to the `open` npm package, whose Chrome app name differs per OS.
+// If Chrome isn't installed the dev server still starts — it just won't auto-open a tab, so this
+// is safe for teammates on other setups.
+const chromeAppName =
+    process.platform === 'darwin' ? 'google chrome' :
+    process.platform === 'win32' ? 'chrome' :
+    'google-chrome';
+// Default: open plain Chrome. When HB_DEBUG_CHROME=1, suppress auto-open so a separate
+// remote-debugging Chrome (launched out-of-band with --remote-debugging-port) is the only
+// app window — lets the console be captured over CDP without a competing tab.
+config.devServer.open = process.env.HB_DEBUG_CHROME === '1'
+    ? false
+    : { app: { name: chromeAppName } };


### PR DESCRIPTION
Web (wasmJs) image attachments: picking, previewing, and staging now work. Stacks on the merged Skia `ImageUtils` work (#603), which supplies the thumbnail/compression pipeline this relies on.

## Commits
1. **`refactor(file)` — extract `OkioFileOperationsProvider` to commonMain + generic test.** The web file-ops were bespoke okio code in wasmJs; now a shared, `FileSystem`-injected provider (web binds the in-memory `FakeFileSystem`). Unit-tested generically against a `FakeFileSystem` on JVM (`OkioFileOperationsProviderTest`) — no wasm harness needed.
2. **`fix(web)` — materialize picked files into okio (+ hang-guard).** A web-picked FileKit `PlatformFile` has **no path** (`PlatformFile.path` is non-web-only); bytes are only reachable via `readBytes()`, so the old `file.toString()` wasn't an okio path → "file not found". New `PlatformFile.toUploadPath(fileOps)` seam at the send chokepoint: native returns `toString()` unchanged (no copy), web copies `readBytes()` into okio. Also broadens the send `catch` `Exception`→`Throwable` (rethrow `CancellationException`) so a missing web impl surfaces as a failed send instead of a permanent "Preparing".
3. **`feat(web)` — `PlatformFileFetcher` for previews.** Composer previews passed `file.toString()` (blank on web). Add a cross-platform Coil `Fetcher.Factory<PlatformFile>` (reads bytes via FileKit), registered in all 4 `AppModule`s; preview call sites pass the `PlatformFile` itself. Fixes the blank preview.
4. **`chore(web)` — dev server opens Chrome** (`HB_DEBUG_CHROME=1` suppresses auto-open for CDP capture). Dev-only.

## Verification
Compiles for **wasmJs, JVM, Android**; `OkioFileOperationsProviderTest` (4) + `AttachmentUploadResolveTest` (3) pass; picked-image preview confirmed rendering in-browser. iOS builds in CI. **Native behavior unchanged** (`toUploadPath` = `toString()`; previews use the same `PlatformFile` model + fetcher).

## Out of scope (follow-up)
Actual **sending** on web still hangs because the in-memory sql.js DB is wiped on reload, losing the conversation's AES key → server rejects the conversation-file update ("AES key must match the existing key"), which blocks the outbox dependency chain. The fix is **durable web storage** (OPFS-backed SQLite in a Web Worker) — its own PR (no off-the-shelf okio browser FileSystem exists; OPFS sync access is worker-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
