### PR TITLE
Unblock cold-boot taps: route single-row DB reads off Main, index + coalesce the unread aggregate

### DIFF
--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.android.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.android.kt
@@ -11,6 +11,13 @@ actual class DatabaseDriverFactory(private val context: Context) {
     actual fun createDriver(passphrase: String?): SqlDriver {
         System.loadLibrary("sqlcipher")
         val factory = SupportOpenHelperFactory((passphrase ?: "").toByteArray())
+        // Reader concurrency note: unlike iOS (NativeSqliteDriver maxReaderConnections=4),
+        // SupportOpenHelperFactory exposes no pool-size knob — the SQLCipher WAL connection
+        // pool is sized by the platform. WAL (enabled in onConfigure below) is what allows
+        // concurrent readers; DatabaseManager.READ_PARALLELISM is kept at 4 to match iOS and
+        // not over-admit readers. If the pool serves fewer, the surplus reads wait in
+        // SQLiteConnectionPool.waitForConnection (off the Main thread, since all reads route
+        // through the read lane) — see READ_PARALLELISM for the verification signal.
         return AndroidSqliteDriver(
             schema = OdinDatabase.Schema,
             context = context,

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
@@ -76,11 +76,16 @@ private val connectionCacheAdapter = ConnectionCache.Adapter(
 )
 
 /**
- * Latency breakdown of the most recent [DatabaseManager.executeReadQuery] call,
- * split so we can tell "the read was slow because it waited for a dispatcher
- * slot" (`queueWaitMs`) apart from "the SQL itself was slow" (`sqlMs`). Surfaced
- * via [DatabaseManager.lastReadTiming]; also folded into the `SlowMessageFetch`
- * log so the split is visible on-device during a heavy sync.
+ * Latency breakdown of the most recent read, split so we can tell "the read was slow
+ * because it waited for a dispatcher slot" (`queueWaitMs`) apart from "the SQL itself was
+ * slow" (`sqlMs`).
+ *
+ * Surfaced via [DatabaseManager.lastReadTiming] — but note this is a SINGLE shared cell
+ * overwritten by every read, so it is only reliable when you control concurrency (e.g. the
+ * read-lane unit test). Do NOT read it after the fact to attribute timing to a specific
+ * query from arbitrary code — a concurrent read on another coroutine will have clobbered it
+ * (this caused garbled `queueWait` in `SlowMessageFetch`). For accurate per-query timing,
+ * use the `SlowDbRead` log line that [executeReadQuery]/[readValue] emit for that exact read.
  */
 data class ReadTiming(val queueWaitMs: Long, val sqlMs: Long)
 
@@ -130,7 +135,8 @@ class DatabaseManager(
         val busyTimeoutMs = readPragmaLong("PRAGMA busy_timeout") ?: -1L
         val synchronous = readPragmaLong("PRAGMA synchronous") ?: -1L
         logger.i {
-            "DB pragmas: journal_mode=$journalMode busy_timeout=${busyTimeoutMs}ms synchronous=$synchronous"
+            "DB pragmas: journal_mode=$journalMode busy_timeout=${busyTimeoutMs}ms " +
+                "synchronous=$synchronous readParallelism=$READ_PARALLELISM"
         }
     }
 
@@ -139,8 +145,16 @@ class DatabaseManager(
             5  // Increase to wipe the database and rebuild all tables
 
         // Max concurrent reads on [readDispatcher]. Kept in step with iOS
-        // NativeSqliteDriver.maxReaderConnections so the dispatcher doesn't admit
-        // more readers than the platform pool can serve. Tunable.
+        // NativeSqliteDriver.maxReaderConnections=4 so the dispatcher doesn't admit more
+        // readers than the platform connection pool can serve. On Android the SQLCipher WAL
+        // pool size is platform-determined (net.zetetic's SupportOpenHelperFactory exposes no
+        // knob, unlike iOS) — if it serves fewer than this, the extra reads block in
+        // SQLiteConnectionPool.waitForConnection, which is counted inside the read's `sql=`
+        // time (the wait happens inside driver.executeQuery), so it surfaces as an inflated
+        // `sql=` in a SlowDbRead line. That's the verification signal: if device logs show a
+        // normally-fast read with a large `sql=` during a read burst, lower this to match the
+        // pool. Since reads are off the Main thread (DriveMainIndexWrapper + the list readers
+        // both route through the read lane), such a wait queues a background read, not the UI.
         private const val READ_PARALLELISM = 4
 
         // A read slower than this logs a SlowDbRead warn with its queueWait/sql split.

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DriveMainIndexWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DriveMainIndexWrapper.kt
@@ -17,7 +17,14 @@ class DriveMainIndexWrapper(
 ) {
     private val delegate = DriveMainIndexQueries(driver, driveMainIndexAdapter)
 
-    fun <T : Any> selectByIdentityAndDriveAndFile(
+    // All reads below run on DatabaseManager's read lane (readValue → readDispatcher), NOT
+    // on the caller's thread. This is the single-row counterpart to PR #600's list-read
+    // routing: a synchronous SQLite read here on the Main thread (e.g. a header lookup from
+    // a viewModelScope/Main.immediate coroutine) would block in
+    // SQLiteConnectionPool.waitForConnection behind a long cold-load read and wedge the UI —
+    // the proven cold-boot "tap does nothing until green" cause. Row→model deserialization is
+    // done OUTSIDE readValue so the lane's slot (and SlowDbRead sql= timing) cover only SQL.
+    suspend fun <T : Any> selectByIdentityAndDriveAndFile(
         identityId: Uuid,
         driveId: Uuid,
         fileId: Uuid,
@@ -42,24 +49,28 @@ class DriveMainIndexWrapper(
             fileSystemType: Long,
             jsonHeader: String,
         ) -> T,
-    ): T? = delegate.selectByIdentityAndDriveAndFile(identityId, driveId, fileId, mapper)
-        .executeAsOneOrNull()
+    ): T? = databaseManager.readValue("selectByIdentityAndDriveAndFile(mapper)") {
+        delegate.selectByIdentityAndDriveAndFile(identityId, driveId, fileId, mapper)
+            .executeAsOneOrNull()
+    }
 
-    fun selectByIdentityAndDriveAndFile(
+    suspend fun selectByIdentityAndDriveAndFile(
         identityId: Uuid,
         driveId: Uuid,
         fileId: Uuid,
-    ): DriveMainIndex? =
+    ): DriveMainIndex? = databaseManager.readValue("selectByIdentityAndDriveAndFile") {
         delegate.selectByIdentityAndDriveAndFile(identityId, driveId, fileId).executeAsOneOrNull()
+    }
 
-    fun selectByIdentityAndDriveAndUnique(
+    suspend fun selectByIdentityAndDriveAndUnique(
         identityId: Uuid,
         driveId: Uuid,
         uniqueId: Uuid,
-    ): DriveMainIndex? = delegate.selectByIdentityAndDriveAndUnique(identityId, driveId, uniqueId)
-        .executeAsOneOrNull()
+    ): DriveMainIndex? = databaseManager.readValue("selectByIdentityAndDriveAndUnique") {
+        delegate.selectByIdentityAndDriveAndUnique(identityId, driveId, uniqueId).executeAsOneOrNull()
+    }
 
-    fun selectHomebaseFileByUnique(
+    suspend fun selectHomebaseFileByUnique(
         identityId: Uuid,
         driveId: Uuid,
         uniqueId: Uuid,
@@ -68,17 +79,19 @@ class DriveMainIndexWrapper(
         return OdinSystemSerializer.deserialize<HomebaseFile>(row.jsonHeader)
     }
 
-    fun selectByIdentityAndDriveAndUniqueIds(
+    suspend fun selectByIdentityAndDriveAndUniqueIds(
         identityId: Uuid,
         driveId: Uuid,
         uniqueIds: Collection<Uuid>,
     ): List<DriveMainIndex> {
         if (uniqueIds.isEmpty()) return emptyList()
-        return delegate.selectByIdentityAndDriveAndUniqueIds(identityId, driveId, uniqueIds)
-            .executeAsList()
+        return databaseManager.readValue("selectByIdentityAndDriveAndUniqueIds") {
+            delegate.selectByIdentityAndDriveAndUniqueIds(identityId, driveId, uniqueIds)
+                .executeAsList()
+        }
     }
 
-    fun selectHomebaseFilesByUniqueIds(
+    suspend fun selectHomebaseFilesByUniqueIds(
         identityId: Uuid,
         driveId: Uuid,
         uniqueIds: Collection<Uuid>,
@@ -92,16 +105,17 @@ class DriveMainIndexWrapper(
         return result
     }
 
-    fun selectByIdentityAndDriveAndGlobal(
+    suspend fun selectByIdentityAndDriveAndGlobal(
         identityId: Uuid,
         driveId: Uuid,
         globalTransitId: Uuid,
-    ): DriveMainIndex? =
+    ): DriveMainIndex? = databaseManager.readValue("selectByIdentityAndDriveAndGlobal") {
         delegate.selectByIdentityAndDriveAndGlobal(identityId, driveId, globalTransitId)
             .executeAsOneOrNull()
+    }
 
 
-    fun <T : Any> selectAll(
+    suspend fun <T : Any> selectAll(
         mapper: (
             rowId: Long,
             identityId: Uuid,
@@ -123,14 +137,20 @@ class DriveMainIndexWrapper(
             fileSystemType: Long,
             jsonHeader: String,
         ) -> T,
-    ): List<T> = delegate.selectAll(mapper).executeAsList()
+    ): List<T> = databaseManager.readValue("selectAll(mapper)") {
+        delegate.selectAll(mapper).executeAsList()
+    }
 
-    fun selectAll(): List<DriveMainIndex> = delegate.selectAll().executeAsList()
+    suspend fun selectAll(): List<DriveMainIndex> =
+        databaseManager.readValue("selectAll") { delegate.selectAll().executeAsList() }
 
-    fun countAll(): Long = delegate.countAll().executeAsOne()
+    suspend fun countAll(): Long =
+        databaseManager.readValue("countAll") { delegate.countAll().executeAsOne() }
 
-    fun countByIdentityAndDrive(identityId: Uuid, driveId: Uuid): Long =
-        delegate.countByIdentityAndDrive(identityId, driveId).executeAsOne()
+    suspend fun countByIdentityAndDrive(identityId: Uuid, driveId: Uuid): Long =
+        databaseManager.readValue("countByIdentityAndDrive") {
+            delegate.countByIdentityAndDrive(identityId, driveId).executeAsOne()
+        }
 
     /**
      * Row shape for the Defragmenter's streaming scan — carries enough to

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ChatReadCount.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ChatReadCount.sq
@@ -13,6 +13,17 @@ CREATE INDEX IF NOT EXISTS idx_chatmessage_convid_userDate ON DriveMainIndex(gro
 CREATE INDEX IF NOT EXISTS idx_messages_filetype_datatype_groupid_userDate
   ON DriveMainIndex(fileType, dataType, groupId, userDate DESC);
 
+-- Covering index for selectAllUnreadCount. The index above does NOT lead with identityId,
+-- so that query still had to hit the table per row to check identityId/originalAuthor/
+-- fileState/archivalStatus — a full GROUP BY that measured ~2.9s on a cold page cache (and
+-- tens of seconds under heavy sync while it held a SQLCipher pool connection). Leading with
+-- the equality predicates (identityId, fileType, dataType), then the GROUP BY key (groupId),
+-- then userDate and the residual filter columns makes the scan index-covering (no per-row
+-- table lookup). Applied to existing installs automatically via OdinDatabase.Schema.create's
+-- IF NOT EXISTS on next launch (one-time build cost).
+CREATE INDEX IF NOT EXISTS idx_unread_cover
+  ON DriveMainIndex(identityId, fileType, dataType, groupId, userDate, originalAuthor, fileState, archivalStatus);
+
 -- Get full list of conversations (8888) from the DriveMainIndex table
 -- here to not contaminate it. Can also be easily fetched with QB()
 selectAllCoversations:

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ChatReadCount.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ChatReadCount.sq
@@ -8,19 +8,19 @@ CREATE TABLE IF NOT EXISTS ChatReadCount(
 -- To make the conversation + last-message performant
 CREATE INDEX IF NOT EXISTS idx_chatmessage_convid_userDate ON DriveMainIndex(groupId,fileType,userDate DESC);
 
--- Speeds up message scans in selectAllConversationPlusLastMessage and selectAllUnreadCount
--- (fileType first lets SQLite seek directly to message rows without a full table scan)
-CREATE INDEX IF NOT EXISTS idx_messages_filetype_datatype_groupid_userDate
-  ON DriveMainIndex(fileType, dataType, groupId, userDate DESC);
-
--- Covering index for selectAllUnreadCount. The index above does NOT lead with identityId,
--- so that query still had to hit the table per row to check identityId/originalAuthor/
--- fileState/archivalStatus — a full GROUP BY that measured ~2.9s on a cold page cache (and
--- tens of seconds under heavy sync while it held a SQLCipher pool connection). Leading with
--- the equality predicates (identityId, fileType, dataType), then the GROUP BY key (groupId),
--- then userDate and the residual filter columns makes the scan index-covering (no per-row
--- table lookup). Applied to existing installs automatically via OdinDatabase.Schema.create's
--- IF NOT EXISTS on next launch (one-time build cost).
+-- Covering index for the message scans in selectAllUnreadCount,
+-- selectAllConversationPlusLastMessage, selectUnreadCountForConversation and
+-- selectOrphanedAtRestConversations. EVERY query that filters fileType/dataType on this table
+-- also filters identityId, so leading with identityId is strictly better than a fileType-
+-- leading index; including the residual filter columns makes selectAllUnreadCount index-
+-- COVERING (no per-row table lookup), which fixes its ~2.9s cold GROUP BY. EXPLAIN QUERY PLAN
+-- confirms selectAllUnreadCount and selectAllConversationPlusLastMessage (outer scan +
+-- correlated last-message subquery) all use this as a covering index.
+--
+-- This is the correct shape — it replaces the former fileType-leading
+-- idx_messages_filetype_datatype_groupid_userDate. No migration code: it's just a schema
+-- index, so new installs get it directly and existing installs that still carry the old index
+-- simply shed it whenever the DB is next rebuilt on a major (version-bump) upgrade.
 CREATE INDEX IF NOT EXISTS idx_unread_cover
   ON DriveMainIndex(identityId, fileType, dataType, groupId, userDate, originalAuthor, fileState, archivalStatus);
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -438,17 +438,16 @@ class ChatMessageStream(
         val mapElapsed = mapStart.elapsedNow()
 
         if (queryElapsed + mapElapsed > 200.milliseconds) {
-            // queueWait splits dbQuery into "waited for a read slot" vs SQL. Best-effort:
-            // getMessages does a single (non-recursive) queryBatchAsync -> one
-            // executeReadQuery, so lastReadTiming normally reflects this query, but a
-            // concurrent read on another coroutine can overwrite it — it's a diagnostic.
-            val queueWaitMs = dbm.lastReadTiming?.queueWaitMs
+            // dbQuery (queue-wait + SQL) and mapping are measured locally here, so both are
+            // accurate. The queue-wait-vs-SQL split for THIS exact query is in the paired
+            // SlowDbRead line that executeReadQuery emits — we deliberately no longer read
+            // DatabaseManager.lastReadTiming, a single shared cell a concurrent read can
+            // clobber (it produced a garbled queueWait here).
             Logger.w(tag = "SlowMessageFetch") {
                 "conversationId=$conversationId " +
                         "rawRecords=${result.records.size} " +
                         "mappedRecords=${records.size} " +
                         "dbQuery=$queryElapsed " +
-                        "queueWait=${queueWaitMs}ms " +
                         "mapping=$mapElapsed"
             }
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/CoalescingTrigger.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/CoalescingTrigger.kt
@@ -1,0 +1,51 @@
+package id.homebase.chat.services.convo
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Collapses a burst of [request] calls into at most one in-flight [action] run.
+ *
+ * Backed by a CONFLATED channel (keeps only the latest payload) drained by a SINGLE collector
+ * coroutine that waits [debounceMs] — to batch a tight burst — then runs [action]. Because the
+ * collector is a plain `for` loop, runs never overlap, and while one runs only the latest
+ * pending payload survives in the channel. So a storm of N requests collapses to ~one run
+ * (plus at most one coalesced rerun for whatever arrived mid-run) instead of N concurrent runs.
+ *
+ * Built for unread-count enrichment in [ConversationStream]: each run is a full-DB GROUP BY
+ * plus a single-writer mirror upsert, and firing one per WebSocket batch / DriveSync-Stopped
+ * during a sync storm spawned N concurrent passes that piled onto the read lane and the writer
+ * (observed at 47–131s in homebase.log).
+ *
+ * [action] exceptions are caught and logged so a single failure doesn't kill the collector.
+ *
+ * The collector lives for the lifetime of [scope]; cancel the scope to stop it.
+ */
+class CoalescingTrigger<T>(
+    scope: CoroutineScope,
+    private val debounceMs: Long,
+    private val action: suspend (T) -> Unit,
+) {
+    private val requests = Channel<T>(Channel.CONFLATED)
+
+    init {
+        scope.launch {
+            for (value in requests) {
+                if (debounceMs > 0) delay(debounceMs)
+                try {
+                    action(value)
+                } catch (e: Exception) {
+                    Logger.e(e) { "CoalescingTrigger action failed: ${e.message}" }
+                }
+            }
+        }
+    }
+
+    /** Request a run. Never blocks; coalesces with any already-pending request. */
+    fun request(value: T) {
+        requests.trySend(value)
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -29,6 +29,8 @@ import id.homebase.core.share.ShareableConversation
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -47,6 +49,11 @@ import kotlin.uuid.Uuid
 private val ORPHAN_SWEEP_KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000b0101")
 private const val ORPHAN_AT_REST_SWEEP_VERSION = 1
 private const val ORPHAN_SWEEP_BOOT_DELAY_MS = 10_000L
+
+// Debounce for coalesced unread-count enrichment: a sync burst of triggers collapses into a
+// single run after this quiet window. Small enough that a normal mark-as-read echo still
+// reflects quickly. See the coalesced-enrichment region in ConversationStream.
+private const val UNREAD_ENRICH_DEBOUNCE_MS = 250L
 
 class ConversationStream(
     private val credentialsManager: CredentialsManager,
@@ -169,6 +176,25 @@ class ConversationStream(
     }
     // endregion
 
+    // region Coalesced unread enrichment
+    //
+    // A sync burst used to fire one enrichAllConversationsWithUnreadCounts per WebSocket
+    // batch / DriveSync-Stopped, each a full-DB GROUP BY + single-writer mirror upsert. With
+    // no guard, N triggers spawned N concurrent runs that piled onto the read lane and the
+    // writer — measured at 47–131s under heavy sync. Funnel the recurring triggers through a
+    // [CoalescingTrigger]: rapid requests collapse to the latest, a short debounce batches a
+    // burst, and its single collector runs them one at a time. [enrichMutex] additionally
+    // guards against overlap with the ColdLoad direct call in start().
+    private val enrichMutex = Mutex()
+    private val unreadEnrichTrigger = CoalescingTrigger<String>(scope, UNREAD_ENRICH_DEBOUNCE_MS) {
+        enrichAllConversationsWithUnreadCounts(it)
+    }
+
+    private fun requestUnreadEnrichment(trigger: String) {
+        unreadEnrichTrigger.request(trigger)
+    }
+    // endregion
+
 
     // Two paths converge on _conversations:
     //
@@ -236,7 +262,7 @@ class ConversationStream(
                                     enrichWithLastMessages()
                                     enrichWithAdmins()
                                     if (hasDirtyUnread()) {
-                                        enrichAllConversationsWithUnreadCounts(trigger = "DriveSyncStopped")
+                                        requestUnreadEnrichment("DriveSyncStopped")
                                     }
                                 } catch (e: Exception) {
                                     Logger.e(e) {
@@ -672,15 +698,7 @@ class ConversationStream(
         // There's no Started/Stopped envelope to defer to — this batch IS the
         // whole event. If anything dirtied an unread count, run enrichAll now.
         if (hasDirtyUnread()) {
-            scope.launch {
-                try {
-                    enrichAllConversationsWithUnreadCounts(trigger = "WebSocketBatch")
-                } catch (e: Exception) {
-                    Logger.e(e) {
-                        "ConversationStream: WebSocket-batch enrich failed: ${e.message}"
-                    }
-                }
-            }
+            requestUnreadEnrichment("WebSocketBatch")
         }
     }
 
@@ -1102,7 +1120,13 @@ class ConversationStream(
      *
      * Safe to defer, safe to skip, safe to retry.
      */
-    suspend fun enrichAllConversationsWithUnreadCounts(trigger: String) {
+    // Serialized entry point: [enrichMutex] ensures the ColdLoad direct call (start()) and the
+    // channel-driven reruns (init collector) never overlap — each is a full-DB read + mirror
+    // write, and concurrent runs were the 47–131s pileup.
+    suspend fun enrichAllConversationsWithUnreadCounts(trigger: String) =
+        enrichMutex.withLock { enrichUnreadLocked(trigger) }
+
+    private suspend fun enrichUnreadLocked(trigger: String) {
         val startedAt = Clock.System.now().toEpochMilliseconds()
         // Take ownership of the current dirty set as we begin work. New
         // bits set during this call's lifetime persist for the next

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -51,9 +51,10 @@ private const val ORPHAN_AT_REST_SWEEP_VERSION = 1
 private const val ORPHAN_SWEEP_BOOT_DELAY_MS = 10_000L
 
 // Debounce for coalesced unread-count enrichment: a sync burst of triggers collapses into a
-// single run after this quiet window. Small enough that a normal mark-as-read echo still
-// reflects quickly. See the coalesced-enrichment region in ConversationStream.
-private const val UNREAD_ENRICH_DEBOUNCE_MS = 250L
+// single run after this quiet window. Unread counts aren't latency-critical, so a generous
+// window is fine — it just has to settle a sync storm into one full-DB pass. See the
+// coalesced-enrichment region in ConversationStream.
+private const val UNREAD_ENRICH_DEBOUNCE_MS = 500L
 
 class ConversationStream(
     private val credentialsManager: CredentialsManager,

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/CoalescingTriggerTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/CoalescingTriggerTest.kt
@@ -1,0 +1,78 @@
+package id.homebase.chat.services.convo
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression guard for the unread-enrichment pileup: a sync storm used to fire one full-DB
+ * enrichment per WebSocket batch / DriveSync-Stopped with no coalescing, spawning N concurrent
+ * passes (47–131s in homebase.log). [CoalescingTrigger] must collapse a burst into ~one run and
+ * survive a failing action.
+ *
+ * The collector is launched on a child scope sharing the test dispatcher (so advanceUntilIdle
+ * drives it) but with its own [Job] we cancel at the end, so its infinite drain loop doesn't
+ * trip runTest's "uncompleted coroutines" check.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CoalescingTriggerTest {
+
+    @Test
+    fun rapidBurst_collapsesToASingleRun() = runTest {
+        val collectorJob = Job()
+        val scope = CoroutineScope(coroutineContext + collectorJob)
+        var runs = 0
+        val trigger = CoalescingTrigger<String>(scope, debounceMs = 100) { runs++ }
+
+        // 20 requests with no suspension between them: the CONFLATED channel keeps only the
+        // latest, so the collector should run exactly once.
+        repeat(20) { trigger.request("t$it") }
+        advanceUntilIdle()
+        collectorJob.cancel()
+
+        assertEquals(1, runs, "a rapid burst of 20 requests should coalesce to a single run")
+    }
+
+    @Test
+    fun requestDuringRun_triggersASingleRerun() = runTest {
+        val collectorJob = Job()
+        val scope = CoroutineScope(coroutineContext + collectorJob)
+        var runs = 0
+        lateinit var trigger: CoalescingTrigger<Int>
+        trigger = CoalescingTrigger(scope, debounceMs = 0) { value ->
+            runs++
+            // While the first run executes, enqueue several more — they must coalesce into
+            // exactly one rerun, not one-per-request.
+            if (value == 0) repeat(5) { trigger.request(it + 1) }
+        }
+
+        trigger.request(0)
+        advanceUntilIdle()
+        collectorJob.cancel()
+
+        assertEquals(2, runs, "requests made during a run should coalesce to a single rerun")
+    }
+
+    @Test
+    fun failingAction_doesNotKillTheCollector() = runTest {
+        val collectorJob = Job()
+        val scope = CoroutineScope(coroutineContext + collectorJob)
+        var runs = 0
+        val trigger = CoalescingTrigger<Int>(scope, debounceMs = 0) { value ->
+            runs++
+            if (value == 1) error("boom")
+        }
+
+        trigger.request(1)
+        advanceUntilIdle()
+        trigger.request(2)
+        advanceUntilIdle()
+        collectorJob.cancel()
+
+        assertEquals(2, runs, "the collector must survive a failing action and process later requests")
+    }
+}

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/sync/TestDatabaseManagerHelper.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/sync/TestDatabaseManagerHelper.kt
@@ -3,9 +3,33 @@ package id.homebase.core.sync
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.OdinDatabase
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 
-fun createTestDatabaseManager(): DatabaseManager {
+/**
+ * Builds an in-memory [DatabaseManager] whose write AND read lanes run on the test scheduler.
+ *
+ * The read lane (DatabaseManager.readValue / executeReadQuery) normally hops to the real
+ * [id.homebase.api.coroutines.ioDispatcher] (Dispatchers.IO on JVM). Once the single-row
+ * DriveMainIndex reads became `suspend` + read-lane-dispatched, a read issued *inside* an
+ * observer (e.g. DriveRegistry's BatchReceived collector calling loadDrives →
+ * selectHomebaseFileByUnique) escaped the test scheduler, so `advanceUntilIdle()` no longer
+ * waited for it and the emission assertions raced. Injecting an [UnconfinedTestDispatcher]
+ * backed by this scope's [TestScope.testScheduler] for both lanes makes `withContext` run the
+ * read/write inline (eagerly), matching the old synchronous reads so observer-driven reads
+ * complete in step with the collector instead of escaping to a real thread.
+ *
+ * Must be called from within `runTest` (it's a [TestScope] extension).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+fun TestScope.createTestDatabaseManager(): DatabaseManager {
     val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
     OdinDatabase.Schema.create(driver)
-    return DatabaseManager({ driver })
+    val testDispatcher = UnconfinedTestDispatcher(testScheduler)
+    return DatabaseManager(
+        { driver },
+        dispatcher = testDispatcher,
+        readDispatcher = testDispatcher,
+    )
 }


### PR DESCRIPTION
## The bug (proven, with a Main-thread stack)

On cold boot — worst right after a reinstall — the conversation list renders instantly but **tapping a row does nothing for ~1–2s**, then "takes" the instant the connection dot turns green. A captured Main-thread stack (diag build) pinned it:

```
SQLiteConnectionPool.waitForConnection        ← Main BLOCKED acquiring a DB connection
SQLiteDatabase.query
DriveMainIndexQueries$SelectByIdentityAndDriveAndUniqueQuery.execute
DriveMainIndexWrapper.selectHomebaseFileByUnique
```

A `DriveMainIndex` header read ran **on the Main thread** and blocked in `SQLiteConnectionPool.waitForConnection` because the cold-load `selectAllUnreadCount` aggregate (sql=**2.94s**; **47–131s** under heavy sync) was holding a SQLCipher pool connection. Main stayed wedged ~1.7s; the taps you made queued on it and flushed the instant the connection freed — which is the same moment the dot goes green.

Ruled out via logs first: gesture drops (every tap logged `Press→Release`), the click path, recomposition churn, the navigation scaffold.

## The fixes (one PR)

**1. Route `DriveMainIndexWrapper` single-row reads off Main** — they were raw synchronous `delegate.x()` calls; now `suspend` + routed through `DatabaseManager.readValue` (read lane), deserialize outside the lane. The single-row counterpart to PR #600's list reads. With no DB read on Main, Main can't block on the pool regardless of how slow another query is — this alone fixes the symptom. All production callers were already in suspend contexts.

**2a. Covering index `idx_unread_cover`** on the existing `DriveMainIndex` table. The only close index didn't lead with `identityId`, forcing per-row table lookups for `identityId/originalAuthor/fileState/archivalStatus` (~2.9s cold). The new index `(identityId, fileType, dataType, groupId, userDate, originalAuthor, fileState, archivalStatus)` makes the scan index-only. **No new table/column, no migration** — ships via `Schema.create`'s `IF NOT EXISTS` on next launch (one-time index build).

**2b. Coalesce unread enrichment.** It was fired with a bare `scope.launch` per WebSocket batch / DriveSync-Stopped, so a sync storm spawned N concurrent full-DB passes + single-writer mirror upserts (the 47–131s pileup). New `CoalescingTrigger` (CONFLATED channel + debounced single collector) + an `enrichMutex` serialize runs; rapid triggers collapse to ~one. `ColdLoad` still runs directly in `start()`. Unit-tested (`CoalescingTriggerTest`).

**3. Align read parallelism with the SQLCipher pool.** iOS sets `maxReaderConnections=4`; Android's WAL pool is platform-sized (net.zetetic exposes no knob). Keep `READ_PARALLELISM=4` (iOS parity), document that pool-wait surfaces as inflated `sql=` in `SlowDbRead`, and log `readParallelism` in the startup DB-pragmas audit line for verification.

**Cleanup:** `SlowMessageFetch` no longer reads the shared racy `DatabaseManager.lastReadTiming` for `queueWait` (a concurrent read could clobber it — garbled logging); the accurate split is in the paired `SlowDbRead` line.

## Verification
- `homebase-api` + `homebase-chat` `jvmTest` ✅ (incl. new `CoalescingTriggerTest`)
- `compileKotlin{IosSimulatorArm64,WasmJs}` for api + chat ✅
- `androidApp:assembleDebug` ✅
- On device (layer onto the diag branch for the watchdog + ConvRowTap/ConvNav logs): the cold-boot `MainThreadWatchdog … waitForConnection` stall should be gone, the tap should navigate without waiting on the unread enrichment, `SlowDbRead read=selectAllUnreadCount` should drop from ~2.9s to tens of ms, and the enrichment shouldn't stack into tens of seconds under sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)