### PR TITLE
Speed up conversation-open: pin the per-conversation index for chat message fetch

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
@@ -8,11 +8,7 @@ import co.touchlab.kermit.Logger
 import id.homebase.api.coroutines.ioDispatcher
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -109,11 +105,6 @@ class DatabaseManager(
     private var database: OdinDatabase
     internal var driver: SqlDriver = driverProvider()
 
-    // Long-lived scope for one-shot DB maintenance (e.g. the startup [optimize]). Runs on the
-    // single write [dispatcher]; SupervisorJob so a maintenance failure can't tear down the
-    // singleton DatabaseManager.
-    private val maintenanceScope = CoroutineScope(dispatcher + SupervisorJob())
-
     // Latency split of the most recent read; see [ReadTiming]. Updated on every
     // executeReadQuery; readers should treat it as best-effort (concurrent reads
     // race on this single cell) — it's a diagnostic, not a correctness signal.
@@ -146,16 +137,6 @@ class DatabaseManager(
         logger.i {
             "DB pragmas: journal_mode=$journalMode busy_timeout=${busyTimeoutMs}ms " +
                 "synchronous=$synchronous readParallelism=$READ_PARALLELISM"
-        }
-
-        // Refresh planner statistics off the cold-start critical path. Bounded (~ms) and runs
-        // on the write lane; finishes well before the user opens a conversation, so the
-        // per-conversation message read picks a selective groupId index seek instead of a
-        // global userDate scan. See [optimize].
-        maintenanceScope.launch {
-            // Don't swallow silently: a failure here (e.g. a platform rejecting a pragma) would
-            // make the planner-stats fix a silent no-op, so surface it.
-            runCatching { optimize() }.onFailure { logger.w(it) { "DB optimize failed: ${it.message}" } }
         }
     }
 
@@ -375,30 +356,6 @@ class DatabaseManager(
         withContext(dispatcher) { block(database) }
     }
 
-    /**
-     * Refresh SQLite's query-planner statistics (sqlite_stat1) so it picks selective per-row
-     * seeks over global scans. The concrete win this was added for: the per-conversation chat
-     * message read filters identityId+driveId+fileSystemType+fileState+groupId+fileType and has
-     * a selective groupId index available (idx_chatmessage_convid_userDate / Idx3DriveMainIndex),
-     * but with NO stats the planner can't tell groupId is selective and falls back to a global
-     * userDate scan (Idx2) — ~900ms to open an old, sparse conversation. With stats it uses the
-     * groupId seek (sub-ms). SQLDelight/SQLCipher never run ANALYZE on their own, so we do it here.
-     *
-     * `analysis_limit=400` bounds the work to a few ms regardless of table size (SQLite's
-     * recommended setting); `PRAGMA optimize` then ANALYZEs only the tables that need it. Runs
-     * on the single write lane (it writes sqlite_stat1). Cheap no-op once stats are current.
-     */
-    suspend fun optimize() {
-        withContext(dispatcher) {
-            val mark = TimeSource.Monotonic.markNow()
-            driver.execute(null, "PRAGMA analysis_limit=400", 0)
-            driver.execute(null, "PRAGMA optimize", 0)
-            // Logged so a run is verifiable on-device/desktop (optimize is otherwise silent) and
-            // so we can see its cost. A failure is surfaced by the caller's onFailure (below).
-            logger.i { "DB optimize done in ${mark.elapsedNow()}" }
-        }
-    }
-
     suspend fun <R> withWriteValue(block: (OdinDatabase) -> R): R = withContext(dispatcher) {
         block(database)
     }
@@ -586,7 +543,6 @@ class DatabaseManager(
     }
 
     override fun close() {
-        maintenanceScope.cancel()
         driver.close()
         logger.i { "Database closed" }
     }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
@@ -8,7 +8,11 @@ import co.touchlab.kermit.Logger
 import id.homebase.api.coroutines.ioDispatcher
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -105,6 +109,11 @@ class DatabaseManager(
     private var database: OdinDatabase
     internal var driver: SqlDriver = driverProvider()
 
+    // Long-lived scope for one-shot DB maintenance (e.g. the startup [optimize]). Runs on the
+    // single write [dispatcher]; SupervisorJob so a maintenance failure can't tear down the
+    // singleton DatabaseManager.
+    private val maintenanceScope = CoroutineScope(dispatcher + SupervisorJob())
+
     // Latency split of the most recent read; see [ReadTiming]. Updated on every
     // executeReadQuery; readers should treat it as best-effort (concurrent reads
     // race on this single cell) — it's a diagnostic, not a correctness signal.
@@ -138,6 +147,12 @@ class DatabaseManager(
             "DB pragmas: journal_mode=$journalMode busy_timeout=${busyTimeoutMs}ms " +
                 "synchronous=$synchronous readParallelism=$READ_PARALLELISM"
         }
+
+        // Refresh planner statistics off the cold-start critical path. Bounded (~ms) and runs
+        // on the write lane; finishes well before the user opens a conversation, so the
+        // per-conversation message read picks a selective groupId index seek instead of a
+        // global userDate scan. See [optimize].
+        maintenanceScope.launch { runCatching { optimize() } }
     }
 
     companion object {
@@ -356,6 +371,26 @@ class DatabaseManager(
         withContext(dispatcher) { block(database) }
     }
 
+    /**
+     * Refresh SQLite's query-planner statistics (sqlite_stat1) so it picks selective per-row
+     * seeks over global scans. The concrete win this was added for: the per-conversation chat
+     * message read filters identityId+driveId+fileSystemType+fileState+groupId+fileType and has
+     * a selective groupId index available (idx_chatmessage_convid_userDate / Idx3DriveMainIndex),
+     * but with NO stats the planner can't tell groupId is selective and falls back to a global
+     * userDate scan (Idx2) — ~900ms to open an old, sparse conversation. With stats it uses the
+     * groupId seek (sub-ms). SQLDelight/SQLCipher never run ANALYZE on their own, so we do it here.
+     *
+     * `analysis_limit=400` bounds the work to a few ms regardless of table size (SQLite's
+     * recommended setting); `PRAGMA optimize` then ANALYZEs only the tables that need it. Runs
+     * on the single write lane (it writes sqlite_stat1). Cheap no-op once stats are current.
+     */
+    suspend fun optimize() {
+        withContext(dispatcher) {
+            driver.execute(null, "PRAGMA analysis_limit=400", 0)
+            driver.execute(null, "PRAGMA optimize", 0)
+        }
+    }
+
     suspend fun <R> withWriteValue(block: (OdinDatabase) -> R): R = withContext(dispatcher) {
         block(database)
     }
@@ -543,6 +578,7 @@ class DatabaseManager(
     }
 
     override fun close() {
+        maintenanceScope.cancel()
         driver.close()
         logger.i { "Database closed" }
     }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
@@ -152,7 +152,11 @@ class DatabaseManager(
         // on the write lane; finishes well before the user opens a conversation, so the
         // per-conversation message read picks a selective groupId index seek instead of a
         // global userDate scan. See [optimize].
-        maintenanceScope.launch { runCatching { optimize() } }
+        maintenanceScope.launch {
+            // Don't swallow silently: a failure here (e.g. a platform rejecting a pragma) would
+            // make the planner-stats fix a silent no-op, so surface it.
+            runCatching { optimize() }.onFailure { logger.w(it) { "DB optimize failed: ${it.message}" } }
+        }
     }
 
     companion object {
@@ -386,8 +390,12 @@ class DatabaseManager(
      */
     suspend fun optimize() {
         withContext(dispatcher) {
+            val mark = TimeSource.Monotonic.markNow()
             driver.execute(null, "PRAGMA analysis_limit=400", 0)
             driver.execute(null, "PRAGMA optimize", 0)
+            // Logged so a run is verifiable on-device/desktop (optimize is otherwise silent) and
+            // so we can see its cost. A failure is surfaced by the caller's onFailure (below).
+            logger.i { "DB optimize done in ${mark.elapsedNow()}" }
         }
     }
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/QueryBatch.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/QueryBatch.kt
@@ -247,9 +247,27 @@ class QueryBatch(
 
         val orderString = "$timeField $direction, driveMainIndex.rowId $direction"
 
+        // Force the per-conversation index for the chat-message-fetch shape (groupId filter +
+        // userDate ordering). Without this hint and without ANALYZE statistics, SQLite picks
+        // the global userDate index (Idx2) and walks the whole timeline filtering groupId per
+        // row — fine for recent-anchored opens, but tens-of-ms-to-seconds for old/quiet
+        // conversations whose few rows sit deep in the timeline (the "spinner" symptom). The
+        // groupId-leading index seeks straight to the conversation regardless of how many
+        // other rows exist. fileState handling is unaffected: when filtered (note-to-self) it
+        // becomes a cheap per-row check on the few rows the groupId seek already narrowed to.
+        //
+        // Moments / feed / contacts queries also ORDER BY userDate but do NOT pass groupIdAnyOf,
+        // so this branch doesn't fire for them — they continue to use Idx2 (which is exactly
+        // right for global newest-first scans).
+        val from = if (sortField == QueryBatchSortField.UserDate && !groupIdAnyOf.isNullOrEmpty()) {
+            "driveMainIndex INDEXED BY idx_chatmessage_convid_userDate"
+        } else {
+            "driveMainIndex"
+        }
+
         // Read +1 more than requested to see if we're at the end of the dataset
         val sqlStatement =
-            "SELECT DISTINCT $SELECT_OUTPUT_FIELDS FROM driveMainIndex $leftJoin WHERE ${
+            "SELECT DISTINCT $SELECT_OUTPUT_FIELDS FROM $from $leftJoin WHERE ${
                 listWhereAnd.joinToString(" AND ")
             } ORDER BY $orderString LIMIT ${actualNoOfItems + 1}"
 

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/MessageFetchPlanTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/MessageFetchPlanTest.kt
@@ -3,73 +3,70 @@ package id.homebase.api.sync.database
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
-import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
 /**
- * Regression guard for the conversation-open "spinner": the per-conversation chat message
- * fetch must use the selective per-conversation index seek ([Idx3DriveMainIndex]), not a global
- * userDate scan ([Idx2DriveMainIndex]).
+ * Regression guard for the conversation-open "spinner": without intervention, opening an
+ * old/quiet conversation walked the global newest→oldest timeline filtering by `groupId`
+ * per row (~hundreds of ms to seconds on-device). Pin the per-conversation index for
+ * `QueryBatch`'s chat-message-fetch shape so the planner always seeks by `groupId`
+ * regardless of query-planner statistics or connection state. Moments-style scans (no
+ * `groupId` filter) must NOT be affected — they should continue using the global userDate
+ * index for newest-first scans.
  *
- * Without ANALYZE statistics (production state — SQLDelight/SQLCipher never run ANALYZE) SQLite
- * can't tell `groupId` is selective and plans the global scan, so opening an old/sparse
- * conversation walks the whole newest→oldest timeline (~900ms on-device). [DatabaseManager.optimize]
- * (PRAGMA analysis_limit + optimize) gives the planner stats and flips it to the index seek
- * (sub-ms). This test proves that flip on the same single in-memory driver production uses.
+ * This test asserts both branches by `EXPLAIN QUERY PLAN` on the same in-memory driver
+ * production uses.
  */
 class MessageFetchPlanTest {
 
-    // Mirrors the SQL QueryBatch emits for ChatMessageStream.fetchMessages: a per-conversation
-    // page filtered by identityId+driveId+fileSystemType+fileState+groupId+fileType, paged by a
-    // (userDate,rowId) cursor, newest-first. Literals stand in for bound params; the chosen plan
-    // is identical.
-    private val messageFetchSql = """
+    private val chatFetchSql = """
+        SELECT DISTINCT rowId, jsonHeader FROM DriveMainIndex INDEXED BY idx_chatmessage_convid_userDate
+        WHERE (userDate, rowId) < (2000000000, 0)
+          AND identityId = x'00' AND driveId = x'01' AND fileSystemType = 0
+          AND fileType IN (7878) AND groupId IN (x'3b')
+        ORDER BY userDate DESC, rowId DESC LIMIT 50
+    """.trimIndent()
+
+    private val momentsFetchSql = """
         SELECT DISTINCT rowId, jsonHeader FROM DriveMainIndex
         WHERE (userDate, rowId) < (2000000000, 0)
           AND identityId = x'00' AND driveId = x'01' AND fileSystemType = 0
-          AND fileState = 1 AND fileType IN (7878) AND groupId IN (x'3b')
+          AND fileType IN (8888)
         ORDER BY userDate DESC, rowId DESC LIMIT 50
     """.trimIndent()
 
     @Test
-    fun optimizeFlipsMessageFetchFromGlobalScanToPerConversationSeek() = runBlocking {
+    fun chatShape_usesPerConversationIndex() {
         val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
-        // Build schema + seed on the raw driver BEFORE constructing a DatabaseManager, so the
-        // baseline is captured with no ANALYZE stats. (DatabaseManager.init kicks off optimize()
-        // asynchronously — establishing the baseline first keeps this deterministic.)
         OdinDatabase.Schema.create(driver)
         seedMessages(driver)
-
-        // Production state: no stats yet → global userDate scan (the regression).
-        val before = explainPlan(driver, messageFetchSql)
+        val plan = explainPlan(driver, chatFetchSql)
         assertTrue(
-            before.contains("Idx2DriveMainIndex"),
-            "without stats the planner should fall back to the global userDate scan; was:\n$before",
+            plan.contains("idx_chatmessage_convid_userDate"),
+            "the chat fetch (with INDEXED BY) should use the per-conversation index; was:\n$plan",
         )
         assertTrue(
-            !before.contains("idx_chatmessage_convid_userDate") && !before.contains("Idx3DriveMainIndex"),
-            "without stats it should NOT already use a per-conversation seek; was:\n$before",
+            !plan.contains("Idx2DriveMainIndex"),
+            "the chat fetch must not fall to the global userDate scan; was:\n$plan",
         )
+    }
 
-        DatabaseManager({ driver }).use { dbm ->
-            dbm.optimize()
-
-            // After optimize the planner must use a per-conversation seek (a groupId-leading
-            // index) rather than the global userDate scan. SQLite picks whichever groupId index
-            // it judges best — idx_chatmessage_convid_userDate (groupId,fileType,userDate) or
-            // Idx3DriveMainIndex (…,groupId,fileType,userDate); the bundled version varies, and
-            // either is the fast path. The regression signal is simply: NOT the Idx2 global scan.
-            val after = explainPlan(driver, messageFetchSql)
-            assertTrue(
-                after.contains("idx_chatmessage_convid_userDate") || after.contains("Idx3DriveMainIndex"),
-                "after optimize the planner should use a per-conversation (groupId) index seek; was:\n$after",
-            )
-            assertTrue(
-                !after.contains("Idx2DriveMainIndex"),
-                "after optimize it should no longer use the global userDate scan; was:\n$after",
-            )
-        }
+    @Test
+    fun momentsShape_stillUsesGlobalUserDateIndex() {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        OdinDatabase.Schema.create(driver)
+        seedMessages(driver)
+        val plan = explainPlan(driver, momentsFetchSql)
+        assertTrue(
+            plan.contains("Idx2DriveMainIndex"),
+            "Moments-style scans (no groupId filter) should still use the global userDate " +
+                "index; was:\n$plan",
+        )
+        assertTrue(
+            !plan.contains("idx_chatmessage_convid_userDate"),
+            "Moments-style scans must not get pinned to the chat index; was:\n$plan",
+        )
     }
 
     /**

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/MessageFetchPlanTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/MessageFetchPlanTest.kt
@@ -1,0 +1,112 @@
+package id.homebase.api.sync.database
+
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Regression guard for the conversation-open "spinner": the per-conversation chat message
+ * fetch must use the selective per-conversation index seek ([Idx3DriveMainIndex]), not a global
+ * userDate scan ([Idx2DriveMainIndex]).
+ *
+ * Without ANALYZE statistics (production state — SQLDelight/SQLCipher never run ANALYZE) SQLite
+ * can't tell `groupId` is selective and plans the global scan, so opening an old/sparse
+ * conversation walks the whole newest→oldest timeline (~900ms on-device). [DatabaseManager.optimize]
+ * (PRAGMA analysis_limit + optimize) gives the planner stats and flips it to the index seek
+ * (sub-ms). This test proves that flip on the same single in-memory driver production uses.
+ */
+class MessageFetchPlanTest {
+
+    // Mirrors the SQL QueryBatch emits for ChatMessageStream.fetchMessages: a per-conversation
+    // page filtered by identityId+driveId+fileSystemType+fileState+groupId+fileType, paged by a
+    // (userDate,rowId) cursor, newest-first. Literals stand in for bound params; the chosen plan
+    // is identical.
+    private val messageFetchSql = """
+        SELECT DISTINCT rowId, jsonHeader FROM DriveMainIndex
+        WHERE (userDate, rowId) < (2000000000, 0)
+          AND identityId = x'00' AND driveId = x'01' AND fileSystemType = 0
+          AND fileState = 1 AND fileType IN (7878) AND groupId IN (x'3b')
+        ORDER BY userDate DESC, rowId DESC LIMIT 50
+    """.trimIndent()
+
+    @Test
+    fun optimizeFlipsMessageFetchFromGlobalScanToPerConversationSeek() = runBlocking {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        // Build schema + seed on the raw driver BEFORE constructing a DatabaseManager, so the
+        // baseline is captured with no ANALYZE stats. (DatabaseManager.init kicks off optimize()
+        // asynchronously — establishing the baseline first keeps this deterministic.)
+        OdinDatabase.Schema.create(driver)
+        seedMessages(driver)
+
+        // Production state: no stats yet → global userDate scan (the regression).
+        val before = explainPlan(driver, messageFetchSql)
+        assertTrue(
+            before.contains("Idx2DriveMainIndex"),
+            "without stats the planner should fall back to the global userDate scan; was:\n$before",
+        )
+        assertTrue(
+            !before.contains("idx_chatmessage_convid_userDate") && !before.contains("Idx3DriveMainIndex"),
+            "without stats it should NOT already use a per-conversation seek; was:\n$before",
+        )
+
+        DatabaseManager({ driver }).use { dbm ->
+            dbm.optimize()
+
+            // After optimize the planner must use a per-conversation seek (a groupId-leading
+            // index) rather than the global userDate scan. SQLite picks whichever groupId index
+            // it judges best — idx_chatmessage_convid_userDate (groupId,fileType,userDate) or
+            // Idx3DriveMainIndex (…,groupId,fileType,userDate); the bundled version varies, and
+            // either is the fast path. The regression signal is simply: NOT the Idx2 global scan.
+            val after = explainPlan(driver, messageFetchSql)
+            assertTrue(
+                after.contains("idx_chatmessage_convid_userDate") || after.contains("Idx3DriveMainIndex"),
+                "after optimize the planner should use a per-conversation (groupId) index seek; was:\n$after",
+            )
+            assertTrue(
+                !after.contains("Idx2DriveMainIndex"),
+                "after optimize it should no longer use the global userDate scan; was:\n$after",
+            )
+        }
+    }
+
+    /**
+     * Many recent messages spread across many conversations + one OLD, SPARSE target
+     * (groupId x'3b', 7 rows at low userDate). This is the shape that makes the global-scan
+     * plan pathological: the target's few rows sit deep below everyone else's newer messages.
+     */
+    private fun seedMessages(driver: SqlDriver) {
+        driver.execute(
+            null,
+            """
+            WITH RECURSIVE seq(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM seq WHERE n < 5000)
+            INSERT INTO DriveMainIndex(
+                identityId, driveId, fileId, groupId, fileType, dataType, archivalStatus,
+                fileState, historyStatus, userDate, created, modified, fileSystemType, jsonHeader)
+            SELECT x'00', x'01', randomblob(16),
+                   CASE WHEN n <= 7 THEN x'3b' ELSE randomblob(16) END,
+                   7878, 0, 1, 1, 0,
+                   CASE WHEN n <= 7 THEN n ELSE 1000000 + n END,
+                   n, n, 0, 'hdr'
+            FROM seq
+            """.trimIndent(),
+            0,
+        )
+    }
+
+    private fun explainPlan(driver: SqlDriver, sql: String): String =
+        driver.executeQuery(
+            identifier = null,
+            sql = "EXPLAIN QUERY PLAN $sql",
+            mapper = { cursor ->
+                val sb = StringBuilder()
+                while (cursor.next().value) {
+                    sb.append(cursor.getString(3) ?: "").append('\n') // column 3 = "detail"
+                }
+                QueryResult.Value(sb.toString())
+            },
+            parameters = 0,
+        ).value
+}


### PR DESCRIPTION
## Symptom
Opening *some* conversations shows a spinner for 200ms–2s+ (`SlowMessageFetch dbQuery=…`), while most open in <90ms. The slow ones are old / quiet conversations.

## Root cause
The chat message fetch (`ChatMessageStream.fetchMessages` → `QueryBatch.queryBatchAsync`) filters `groupId = listOf(conversationId)` and orders by `userDate DESC`. There's a perfect index for this — `idx_chatmessage_convid_userDate (groupId, fileType, userDate DESC)` — but without ANALYZE statistics, SQLite's planner can't see that `groupId` is selective and falls back to **`Idx2DriveMainIndex (identityId, driveId, fileSystemType, userDate, rowId)`** — a global newest→oldest scan that walks past every other conversation's recent messages to find the target's few rows. Fast for recent-anchored opens, hundreds of ms to seconds for old/sparse ones.

## What we tried first (and why it didn't stick)
`PRAGMA optimize` does flip the plan **when stats are visible to the connection running the query**. But on the multi-connection platforms we run on — Android SQLCipher's WAL pool, desktop's encrypted JDBC — read-pool connections cache the schema at open time and don't reload `sqlite_stat1` after ANALYZE. Confirmed on both platforms: stats got written, plans didn't change. Reverted that machinery.

## The fix
Force the per-conversation index deterministically, via `INDEXED BY`. `QueryBatch` auto-detects the shape that wants it:

```kotlin
val from = if (sortField == QueryBatchSortField.UserDate && !groupIdAnyOf.isNullOrEmpty()) {
    "driveMainIndex INDEXED BY idx_chatmessage_convid_userDate"
} else {
    "driveMainIndex"
}
```

Why this is correct for every chat shape and *only* chat shapes:
- **Regular chat** and **note-to-self** both pass `groupIdAnyOf` and sort by `userDate` → both hit the branch and get the groupId-leading seek. `fileState` (filtered only for note-to-self) is a cheap per-row check on the few rows the seek already narrowed to.
- **Moments / feed / comments** also sort by `userDate` but do *not* pass `groupIdAnyOf` → the branch doesn't fire, they keep `Idx2` (which is what they want for global newest-first scans).
- No schema change. No new index. Nothing dropped. Works on every connection, every launch, regardless of ANALYZE state.

## Test
`MessageFetchPlanTest` — two cases via `EXPLAIN QUERY PLAN` on the same in-memory driver production uses:
1. Chat shape with `INDEXED BY idx_chatmessage_convid_userDate` → plan must use `idx_chatmessage_convid_userDate`, not `Idx2DriveMainIndex`.
2. Moments-style shape (no `groupIdAnyOf`) → plan must still use `Idx2DriveMainIndex` and must NOT touch the chat index.

## Verification
- `homebase-api` + `homebase-chat` `jvmTest` ✅
- On device (returning user, old/quiet conversation): `SlowMessageFetch dbQuery` should drop to tens of ms; no more global-scan signature on the message query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)