### PR TITLE
diag(db): SlowDbRead splits sql=cursor.next() vs mapper=CPU-between-rows

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
@@ -13,7 +13,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.TimeSource
 
 /**
@@ -76,9 +78,19 @@ private val connectionCacheAdapter = ConnectionCache.Adapter(
 )
 
 /**
- * Latency breakdown of the most recent read, split so we can tell "the read was slow
- * because it waited for a dispatcher slot" (`queueWaitMs`) apart from "the SQL itself was
- * slow" (`sqlMs`).
+ * Latency breakdown of the most recent read.
+ *
+ * - [queueWaitMs] — time the request sat waiting for a read-dispatcher slot. A large
+ *   value means scheduling pressure, not a slow query.
+ * - [sqlMs] — total wall-clock spent inside `driver.executeQuery` (raw-SQL path) or
+ *   the SQLDelight `executeAs*` block (typed-query path). This is "SQL + mapper",
+ *   not "SQL alone".
+ * - [mapperMs] — for the raw-SQL path, the subset of [sqlMs] spent on mapper CPU
+ *   *between* `SqlCursor.next()` calls (field gets, object construction, JSON
+ *   deserialization). The "real SQL" portion is therefore `sqlMs - mapperMs`.
+ *   Zero for the typed-query path ([readValue]) because we don't instrument the
+ *   SQLDelight-generated mapper there (its mapper is a thin code-gen constructor,
+ *   not a JSON deserialization, so the split would be noise).
  *
  * Surfaced via [DatabaseManager.lastReadTiming] — but note this is a SINGLE shared cell
  * overwritten by every read, so it is only reliable when you control concurrency (e.g. the
@@ -87,7 +99,11 @@ private val connectionCacheAdapter = ConnectionCache.Adapter(
  * (this caused garbled `queueWait` in `SlowMessageFetch`). For accurate per-query timing,
  * use the `SlowDbRead` log line that [executeReadQuery]/[readValue] emit for that exact read.
  */
-data class ReadTiming(val queueWaitMs: Long, val sqlMs: Long)
+data class ReadTiming(
+    val queueWaitMs: Long,
+    val sqlMs: Long,
+    val mapperMs: Long = 0,
+)
 
 class DatabaseManager(
     driverProvider: () -> SqlDriver,
@@ -286,6 +302,17 @@ class DatabaseManager(
     // measures that queue-wait; the inner mark measures the SQL itself. The split is
     // stored in [lastReadTiming] and warn-logged when slow, so device logs show
     // whether read latency was scheduling or SQL.
+    //
+    // SlowDbRead reports a triple: `queueWait` / `sql` / `mapper`. The
+    // driver invokes the user [mapper] *inline* (cursor.open → mapper(cursor)
+    // → cursor.close all under `driver.executeQuery`), and for shapes like
+    // QueryBatch that mapper does `OdinSystemSerializer.deserialize<HomebaseFile>(jsonHeader)`
+    // per row. Without splitting, big-payload deserialization shows up under
+    // `sql=` and looks like a slow query plan. We instrument the cursor's
+    // `next()` (each call is a row pull from SQLite) and treat that as
+    // "real SQL"; whatever wall-clock the mapper spends between `next()`
+    // calls is reported as `mapper=`. The two should sum to the legacy
+    // `sql=` number ± a few µs of accounting noise.
     suspend fun <R> executeReadQuery(
         identifier: Int?,
         sql: String,
@@ -298,13 +325,38 @@ class DatabaseManager(
             val queueWait = requestedAt.elapsedNow()
             val sqlStart = TimeSource.Monotonic.markNow()
             try {
-                val result = driver.executeQuery(identifier, sql, mapper, parameters, binders)
-                val sqlElapsed = sqlStart.elapsedNow()
-                _lastReadTiming.value =
-                    ReadTiming(queueWait.inWholeMilliseconds, sqlElapsed.inWholeMilliseconds)
-                if (queueWait + sqlElapsed > SLOW_READ_THRESHOLD) {
+                // Capture the wrapper used for the (single) mapper invocation so
+                // we can read its accumulated next()-time after the driver call
+                // returns. A `var` is fine here — `driver.executeQuery` is
+                // synchronous within this coroutine continuation.
+                var timing: TimingCursor? = null
+                val result = driver.executeQuery(
+                    identifier,
+                    sql,
+                    { rawCursor ->
+                        val tc = TimingCursor(rawCursor)
+                        timing = tc
+                        mapper(tc)
+                    },
+                    parameters,
+                    binders,
+                )
+                val total = sqlStart.elapsedNow()
+                // If for some reason the driver never invoked the mapper (it
+                // shouldn't, but be defensive), credit everything to SQL.
+                val sqlOnly = timing?.nextNanos?.nanoseconds ?: total
+                // Monotonic clocks guarantee mapper ≥ 0, but coerce as a belt-
+                // and-braces against any future driver oddity (cached cursors,
+                // pre-fetched rows where next() reports near-zero).
+                val mapperOnly = (total - sqlOnly).coerceAtLeast(Duration.ZERO)
+                _lastReadTiming.value = ReadTiming(
+                    queueWaitMs = queueWait.inWholeMilliseconds,
+                    sqlMs = total.inWholeMilliseconds,
+                    mapperMs = mapperOnly.inWholeMilliseconds,
+                )
+                if (queueWait + total > SLOW_READ_THRESHOLD) {
                     logger.w {
-                        "SlowDbRead queueWait=$queueWait sql=$sqlElapsed sqlPreview=${sql.take(120)}"
+                        "SlowDbRead queueWait=$queueWait sql=$sqlOnly mapper=$mapperOnly sqlPreview=${sql.take(120)}"
                     }
                 }
                 result
@@ -316,10 +368,42 @@ class DatabaseManager(
     }
 
     /**
+     * Wraps an [SqlCursor] to accumulate the wall-clock time spent in `next()`
+     * calls. Everything `next()` does is server-side / driver-side row pull
+     * work — that's the "SQL" portion. Mapper CPU (column gets, object
+     * construction, JSON deserialization) happens *between* `next()` calls and
+     * is what the surrounding wall-clock-minus-`nextNanos` measures in
+     * [executeReadQuery].
+     *
+     * Uses Kotlin's interface delegation so `getString`/`getLong`/etc. forward
+     * to the underlying cursor unchanged — only `next()` is instrumented.
+     */
+    private class TimingCursor(private val delegate: SqlCursor) : SqlCursor by delegate {
+        var nextNanos: Long = 0L
+            private set
+
+        override fun next(): QueryResult<Boolean> {
+            val s = TimeSource.Monotonic.markNow()
+            try {
+                return delegate.next()
+            } finally {
+                nextNanos += s.elapsedNow().inWholeNanoseconds
+            }
+        }
+    }
+
+    /**
      * Run a read that uses the SQLDelight generated-query DSL (rather than raw SQL) on the
      * read lane — the counterpart to [executeReadQuery] for the `*Wrapper` reads that call
      * `delegate.x().executeAsList()`. Same [readDispatcher] + queue-wait/SQL split +
      * SlowDbRead warn; [label] names the read in the log since there's no SQL string.
+     *
+     * **No `sql=` / `mapper=` split here** (unlike [executeReadQuery]). The mapper that
+     * runs inside `executeAsList` is owned by SQLDelight code-gen — typically a thin
+     * `(col1, col2, …) -> Row(col1, col2, …)` — so the legacy single-timer reading is
+     * accurate enough for the typed-query path. The split exists for [executeReadQuery]
+     * because QueryBatch's mapper does row-level JSON deserialization that can dwarf the
+     * SQL itself; SQLDelight rows don't have that hazard.
      *
      * Keep [block] to the DB read itself (executeAsList / executeAsOneOrNull) and do any
      * mapping/deserialization outside, so a read-lane slot is held only for the SQL — not

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
@@ -368,12 +368,20 @@ class DatabaseManager(
     }
 
     /**
-     * Wraps an [SqlCursor] to accumulate the wall-clock time spent in `next()`
-     * calls. Everything `next()` does is server-side / driver-side row pull
-     * work — that's the "SQL" portion. Mapper CPU (column gets, object
-     * construction, JSON deserialization) happens *between* `next()` calls and
-     * is what the surrounding wall-clock-minus-`nextNanos` measures in
-     * [executeReadQuery].
+     * Accumulates the wall-clock time spent in [SqlCursor.next] (the row-
+     * advance call) for the wrapping read. This is a close proxy for SQL
+     * time in practice — but it isn't literally "all driver work":
+     * column extraction via `getString` / `getLong` etc. is also driver
+     * work, just typically trivial against an already-fetched cursor row
+     * buffer. Whatever wall-clock the mapper spends *between* `next()`
+     * calls (column gets + object construction + JSON deserialization)
+     * is what the surrounding `total - nextNanos` in [executeReadQuery]
+     * reports as `mapper=`. The split is honest for the case that
+     * motivated it (QueryBatch's per-row `HomebaseFile` deserialization);
+     * a hypothetical mapper that pushed heavy work into `getString`
+     * callbacks (e.g. lazy column decryption) would land that work in
+     * `mapper=` even though it's driver-side — read the numbers with
+     * that nuance in mind.
      *
      * Uses Kotlin's interface delegation so `getString`/`getLong`/etc. forward
      * to the underlying cursor unchanged — only `next()` is instrumented.

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/SlowDbReadTimingSplitTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/SlowDbReadTimingSplitTest.kt
@@ -1,0 +1,139 @@
+package id.homebase.api.sync.database
+
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * Pins the `SlowDbRead` triple split (`queueWait` / `sql` / `mapper`).
+ *
+ * Background: before this split, `sql=` was actually "wall-clock spent inside
+ * `driver.executeQuery`", which silently bundled mapper CPU — for QueryBatch
+ * that's per-row `OdinSystemSerializer.deserialize<HomebaseFile>(jsonHeader)`,
+ * which can be the dominant cost. A multi-second `SlowDbRead sql=…` then
+ * misleadingly pointed at the query plan when the real culprit was
+ * deserialization. The cursor's `next()` is the genuine "row pull" call, so we
+ * time it separately and report the residual as mapper CPU.
+ *
+ * These tests deliberately make the mapper sleep between `next()` calls so
+ * `mapper=` accumulates predictably, and assert (a) the mapper time is at
+ * least the sleep total and (b) it never exceeds the legacy total. A
+ * no-work mapper test pins the other direction: real-SQL queries against the
+ * in-memory driver report near-zero mapper time.
+ */
+class SlowDbReadTimingSplitTest {
+
+    private fun newDbm(): DatabaseManager {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        return DatabaseManager({ driver })
+    }
+
+    @Test
+    fun mapperSleep_isAttributedToMapper_notSql() = runBlocking {
+        val dbm = newDbm()
+        val rows = 5
+        // Seed rows so the cursor has something to iterate.
+        repeat(rows) { i ->
+            dbm.withWriteValue { db ->
+                db.keyValueQueries.upsertValue(
+                    Uuid.fromLongs(0L, i.toLong()),
+                    byteArrayOf(i.toByte()),
+                )
+            }
+        }
+
+        val sleepPerRowMs = 30L
+        dbm.executeReadQuery(
+            identifier = null,
+            sql = "SELECT key FROM KeyValue",
+            mapper = { cursor ->
+                while (cursor.next().value) {
+                    // Mapper-CPU stand-in: this is exactly the window between
+                    // `next()` calls that the TimingCursor classifies as
+                    // mapper time rather than SQL. Production mappers (e.g.
+                    // QueryBatch) do JSON deserialization here.
+                    Thread.sleep(sleepPerRowMs)
+                }
+                QueryResult.Value(Unit)
+            },
+            parameters = 0,
+        )
+
+        val timing = assertNotNull(dbm.lastReadTiming, "no read timing recorded")
+        val expectedMapperFloorMs = (sleepPerRowMs * rows) - 20 // small slack for jitter
+        assertTrue(
+            timing.mapperMs >= expectedMapperFloorMs,
+            "mapper time should reflect sleep total; expected ≥${expectedMapperFloorMs}ms, " +
+                "got mapperMs=${timing.mapperMs} sqlMs=${timing.sqlMs}",
+        )
+        assertTrue(
+            timing.mapperMs <= timing.sqlMs,
+            "mapper portion cannot exceed the total wall-clock spent in driver.executeQuery; " +
+                "mapperMs=${timing.mapperMs} sqlMs=${timing.sqlMs}",
+        )
+        // Real-SQL = sqlMs - mapperMs should be tiny for an in-memory SELECT
+        // — proves the split is doing its job, not just reporting `mapper ≈ sql`.
+        val realSqlMs = timing.sqlMs - timing.mapperMs
+        assertTrue(
+            realSqlMs < 50,
+            "the real-SQL residual should be small for an in-memory query; was ${realSqlMs}ms " +
+                "(sqlMs=${timing.sqlMs} mapperMs=${timing.mapperMs})",
+        )
+    }
+
+    @Test
+    fun noWorkMapper_reportsNegligibleMapperTime() = runBlocking {
+        val dbm = newDbm()
+        dbm.withWriteValue { db ->
+            db.keyValueQueries.upsertValue(Uuid.fromLongs(0L, 1L), byteArrayOf(1))
+        }
+
+        dbm.executeReadQuery(
+            identifier = null,
+            sql = "SELECT key FROM KeyValue",
+            mapper = { cursor ->
+                while (cursor.next().value) { /* no work */ }
+                QueryResult.Value(Unit)
+            },
+            parameters = 0,
+        )
+
+        val timing = assertNotNull(dbm.lastReadTiming, "no read timing recorded")
+        // Mapper time is measured in ms; sub-ms loop overhead rounds to 0 or 1.
+        // Anything larger than a few ms means our accounting is wrong.
+        assertTrue(
+            timing.mapperMs <= 5,
+            "no-work mapper should report near-zero mapper time; was ${timing.mapperMs}ms",
+        )
+    }
+
+    @Test
+    fun readValue_doesNotPopulateMapperSplit() = runBlocking {
+        // The split lives only on the raw-SQL path; `readValue` (used by
+        // SQLDelight typed queries) intentionally leaves mapperMs=0 because the
+        // SQLDelight-generated row mapper is a thin code-gen constructor, not
+        // a JSON deserialization, so splitting it would just be noise. Pin
+        // that contract here so a future refactor doesn't quietly start
+        // attributing typed-query mapper CPU to the wrong bucket.
+        val dbm = newDbm()
+        dbm.withWriteValue { db ->
+            db.keyValueQueries.upsertValue(Uuid.fromLongs(0L, 1L), byteArrayOf(1))
+        }
+
+        dbm.readValue("test-typed-read") {
+            // No-op block — the contract under test is that readValue leaves
+            // mapperMs=0 regardless of what the block does.
+        }
+
+        val timing = assertNotNull(dbm.lastReadTiming, "no read timing recorded")
+        assertTrue(
+            timing.mapperMs == 0L,
+            "readValue must leave mapperMs=0 (the split is opt-in for executeReadQuery); " +
+                "was ${timing.mapperMs}",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- The 3.21s `SlowDbRead` we saw in the post-#606 on-device log looked like a slow query plan but was actually `MarkAsRead`'s `getMessages` mapper running `OdinSystemSerializer.deserialize<HomebaseFile>(jsonHeader)` per row. The legacy `sql=` value timed the whole `driver.executeQuery(...)` call, which the SQLDelight driver invokes the user mapper *inline* within — so JSON deserialization showed up under \"SQL\".
- This PR splits the timer at the cursor boundary: `cursor.next()` time is the genuine \"row pull from SQLite\" portion (\"real SQL\"); wall-clock *between* `next()` calls is whatever the mapper itself spent (\"mapper\").
- `SlowDbRead` now logs a triple: `queueWait=… sql=… mapper=… sqlPreview=…`. Future log captures will let us tell at a glance whether a slow read is the plan, the deserialization payload, or pure scheduling.

## Scope

- Only `executeReadQuery` (raw-SQL / QueryBatch path) is instrumented. That's where the QueryBatch JSON deserialization runs and where the misleading number came from.
- `readValue` (typed-query path) intentionally leaves `mapperMs = 0`. The SQLDelight-generated row mapper is a thin code-gen constructor, not a JSON deserialization, so splitting it would be noise. Documented as a contract in the `readValue` KDoc.
- `ReadTiming.sqlMs` keeps its legacy meaning (\"total wall-clock inside `driver.executeQuery`\"); `mapperMs` is the new subset. \"Real SQL\" = `sqlMs - mapperMs`. Existing consumer (`DatabaseReadConcurrencyTest`) only reads `queueWaitMs`, so no breaking change.

## Implementation

`TimingCursor` wraps `SqlCursor` via Kotlin's interface delegation (`SqlCursor by delegate`), so only `next()` is overridden — `getString` / `getLong` / etc. forward unchanged. The wrapper is private to `DatabaseManager`. Three tests pin the math: a mapper that sleeps proves attribution, a no-work mapper pins the near-zero floor, and `readValue` pins the opt-out contract.

## Test plan

- [x] `./gradlew :homebase-api:jvmTest --tests \"id.homebase.api.sync.database.SlowDbReadTimingSplitTest\"` — passes.
- [x] `./gradlew :homebase-api:jvmTest :homebase-chat:jvmTest compileKotlinIosSimulatorArm64 compileKotlinWasmJs` — all green, pre-existing warnings unchanged.
- [ ] **On device** (after this and #608 land): the next slow conversation-open log should show the triple, and we'll be able to tell whether the residual outliers are real query-plan misses, deserialization cost, or scheduling pressure — instead of having to guess from a misleading bundled \`sql=\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)