### PR TITLE
Route remaining wrapper reads through the read lane

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/AppNotificationsWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/AppNotificationsWrapper.kt
@@ -12,7 +12,7 @@ class AppNotificationsWrapper(
 ) {
     private val delegate = AppNotificationsQueries(driver, appNotificationsAdapter)
 
-    fun <T : Any> selectByNotificationId(
+    suspend fun <T : Any> selectByNotificationId(
         identityId: Uuid,
         notificationId: Uuid,
         mapper: (
@@ -26,14 +26,19 @@ class AppNotificationsWrapper(
             created: Long,
             modified: Long,
         ) -> T,
-    ): T? = delegate.selectByNotificationId(identityId, notificationId, mapper).executeAsOneOrNull()
+    ): T? = databaseManager.readValue("appNotifications.selectByNotificationId(mapper)") {
+        delegate.selectByNotificationId(identityId, notificationId, mapper).executeAsOneOrNull()
+    }
 
-    fun selectByNotificationId(
+    suspend fun selectByNotificationId(
         identityId: Uuid,
         notificationId: Uuid,
-    ): AppNotifications? = delegate.selectByNotificationId(identityId, notificationId).executeAsOneOrNull()
+    ): AppNotifications? =
+        databaseManager.readValue("appNotifications.selectByNotificationId") {
+            delegate.selectByNotificationId(identityId, notificationId).executeAsOneOrNull()
+        }
 
-    fun <T : Any> selectFirstPage(
+    suspend fun <T : Any> selectFirstPage(
         identityId: Uuid,
         limit: Long,
         mapper: (
@@ -47,14 +52,19 @@ class AppNotificationsWrapper(
             created: Long,
             modified: Long,
         ) -> T,
-    ): List<T> = delegate.selectFirstPage(identityId, limit, mapper).executeAsList()
+    ): List<T> = databaseManager.readValue("appNotifications.selectFirstPage(mapper)") {
+        delegate.selectFirstPage(identityId, limit, mapper).executeAsList()
+    }
 
-    fun selectFirstPage(
+    suspend fun selectFirstPage(
         identityId: Uuid,
         limit: Long,
-    ): List<AppNotifications> = delegate.selectFirstPage(identityId, limit).executeAsList()
+    ): List<AppNotifications> =
+        databaseManager.readValue("appNotifications.selectFirstPage") {
+            delegate.selectFirstPage(identityId, limit).executeAsList()
+        }
 
-    fun <T : Any> selectNextPage(
+    suspend fun <T : Any> selectNextPage(
         identityId: Uuid,
         rowId: Long,
         limit: Long,
@@ -69,13 +79,18 @@ class AppNotificationsWrapper(
             created: Long,
             modified: Long,
         ) -> T,
-    ): List<T> = delegate.selectNextPage(identityId, rowId, limit, mapper).executeAsList()
+    ): List<T> = databaseManager.readValue("appNotifications.selectNextPage(mapper)") {
+        delegate.selectNextPage(identityId, rowId, limit, mapper).executeAsList()
+    }
 
-    fun selectNextPage(
+    suspend fun selectNextPage(
         identityId: Uuid,
         rowId: Long,
         limit: Long,
-    ): List<AppNotifications> = delegate.selectNextPage(identityId, rowId, limit).executeAsList()
+    ): List<AppNotifications> =
+        databaseManager.readValue("appNotifications.selectNextPage") {
+            delegate.selectNextPage(identityId, rowId, limit).executeAsList()
+        }
 
     suspend fun insertNotification(
         identityId: Uuid,

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/ChatReadCountWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/ChatReadCountWrapper.kt
@@ -90,19 +90,23 @@ class ChatReadCountWrapper(
      * set. Cheap (index-backed, empty in the normal case); intended to run once per cold
      * start after the chat drive's initial sync settles.
      */
-    fun selectOrphanedAtRestConversations(
+    suspend fun selectOrphanedAtRestConversations(
         identityId: Uuid,
         selfDomain: String,
     ): List<OrphanedAtRestConversation> {
-        return delegate.selectOrphanedAtRestConversations(identityId = identityId, selfDomain = selfDomain)
-            .executeAsList()
-            .map {
-                OrphanedAtRestConversation(
-                    conversationId = it.groupId,
-                    messageCount = it.messageCount,
-                    counterpartyAuthor = it.counterpartyAuthor,
-                )
-            }
+        val rows = databaseManager.readValue("chatReadCount.selectOrphanedAtRestConversations") {
+            delegate.selectOrphanedAtRestConversations(
+                identityId = identityId,
+                selfDomain = selfDomain,
+            ).executeAsList()
+        }
+        return rows.map {
+            OrphanedAtRestConversation(
+                conversationId = it.groupId,
+                messageCount = it.messageCount,
+                counterpartyAuthor = it.counterpartyAuthor,
+            )
+        }
     }
 
     private val logger = Logger.withTag("ConversationQueries")
@@ -171,19 +175,19 @@ class ChatReadCountWrapper(
      * Get unread message count for a specific conversation
      * Note: This implementation is simplified and would need the generated SQLDelight queries
      */
-    fun selectUnreadCountForConversation(
+    suspend fun selectUnreadCountForConversation(
         identityId: Uuid,
         groupId: Uuid,
         selfDomain: OdinId,
     ): Long {
-        val result = delegate.selectUnreadCountForConversation(
-            identityId, groupId, selfDomain.domainName
-        ).executeAsOneOrNull()
-
-        if (result == null)
-            return 0
-
-        return result
+        val result = databaseManager.readValue("chatReadCount.selectUnreadCountForConversation") {
+            delegate.selectUnreadCountForConversation(
+                identityId,
+                groupId,
+                selfDomain.domainName,
+            ).executeAsOneOrNull()
+        }
+        return result ?: 0
     }
 
     /**
@@ -207,9 +211,10 @@ class ChatReadCountWrapper(
     }
 
     /** Raw stored lastReadTime (epoch ms) for a conversation, or null if none. */
-    fun selectLastReadTimeMs(groupId: Uuid): Long? {
-        return delegate.selectLastReadTime(groupId).executeAsOneOrNull()
-    }
+    suspend fun selectLastReadTimeMs(groupId: Uuid): Long? =
+        databaseManager.readValue("chatReadCount.selectLastReadTimeMs") {
+            delegate.selectLastReadTime(groupId).executeAsOneOrNull()
+        }
 
     /**
      * Upsert last read time for a conversation

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/ConnectionCacheWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/ConnectionCacheWrapper.kt
@@ -10,11 +10,18 @@ class ConnectionCacheWrapper(
 ) {
     private val delegate = ConnectionCacheQueries(driver, connectionCacheAdapter)
 
-    fun selectByIdentity(identityId: Uuid): List<ConnectionCache> =
-        delegate.selectByIdentity(identityId).executeAsList()
+    suspend fun selectByIdentity(identityId: Uuid): List<ConnectionCache> =
+        databaseManager.readValue("connectionCache.selectByIdentity") {
+            delegate.selectByIdentity(identityId).executeAsList()
+        }
 
-    fun selectByIdentityAndStatus(identityId: Uuid, status: String): List<ConnectionCache> =
-        delegate.selectByIdentityAndStatus(identityId, status).executeAsList()
+    suspend fun selectByIdentityAndStatus(
+        identityId: Uuid,
+        status: String,
+    ): List<ConnectionCache> =
+        databaseManager.readValue("connectionCache.selectByIdentityAndStatus") {
+            delegate.selectByIdentityAndStatus(identityId, status).executeAsList()
+        }
 
     suspend fun upsert(
         identityId: Uuid,

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/CursorStorage.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/CursorStorage.kt
@@ -29,7 +29,12 @@ class CursorStorage(
      *   wipes the whole KeyValue table.
      */
     fun loadCursor(expectFresh: Boolean = false): QueryBatchCursor? {
-        val cursor = databaseManager.keyValue.selectByKey(driveId)?.let {
+        // Bootstrap-only sync read — called from DriveSync.init / MainIndexMeta
+        // outside a coroutine context. See KeyValueWrapper.selectByKeyBootstrapSync
+        // for why we can't be suspend here (commonMain has no runBlocking on
+        // wasmJs). The follow-up to async-init these bootstrap paths is tracked
+        // separately.
+        val cursor = databaseManager.keyValue.selectByKeyBootstrapSync(driveId)?.let {
             QueryBatchCursor.fromJson(it.data_.decodeToString())
         }
         if (expectFresh && cursor != null) {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DriveLocalTagIndexWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DriveLocalTagIndexWrapper.kt
@@ -12,7 +12,7 @@ class DriveLocalTagIndexWrapper(
 ) {
     private val delegate = DriveLocalTagIndexQueries(driver, driveLocalTagIndexAdapter)
 
-    fun <T : Any> selectByFile(
+    suspend fun <T : Any> selectByFile(
         identityId: Uuid,
         driveId: Uuid,
         fileId: Uuid,
@@ -23,15 +23,21 @@ class DriveLocalTagIndexWrapper(
             fileId: Uuid,
             tagId: Uuid,
         ) -> T,
-    ): List<T> = delegate.selectByFile(identityId, driveId, fileId, mapper).executeAsList()
+    ): List<T> = databaseManager.readValue("driveLocalTagIndex.selectByFile(mapper)") {
+        delegate.selectByFile(identityId, driveId, fileId, mapper).executeAsList()
+    }
 
-    fun selectByFile(
+    suspend fun selectByFile(
         identityId: Uuid,
         driveId: Uuid,
         fileId: Uuid,
-    ): List<DriveLocalTagIndex> = delegate.selectByFile(identityId, driveId, fileId).executeAsList()
+    ): List<DriveLocalTagIndex> = databaseManager.readValue("driveLocalTagIndex.selectByFile") {
+        delegate.selectByFile(identityId, driveId, fileId).executeAsList()
+    }
 
-    fun countAll(): Long = delegate.countAll().executeAsOne()
+    suspend fun countAll(): Long = databaseManager.readValue("driveLocalTagIndex.countAll") {
+        delegate.countAll().executeAsOne()
+    }
 
     suspend fun insertLocalTag(
         identityId: Uuid,

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DriveTagIndexWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DriveTagIndexWrapper.kt
@@ -25,13 +25,17 @@ class DriveTagIndexWrapper(
 //        ) -> T,
 //    ): Query<T> = delegate.selectByFile(identityId, driveId, fileId, mapper)
 
-    fun selectByFile(
+    suspend fun selectByFile(
         identityId: Uuid,
         driveId: Uuid,
         fileId: Uuid,
-    ): List<DriveTagIndex> = delegate.selectByFile(identityId, driveId, fileId).executeAsList()
+    ): List<DriveTagIndex> = databaseManager.readValue("driveTagIndex.selectByFile") {
+        delegate.selectByFile(identityId, driveId, fileId).executeAsList()
+    }
 
-    fun countAll(): Long = delegate.countAll().executeAsOne()
+    suspend fun countAll(): Long = databaseManager.readValue("driveTagIndex.countAll") {
+        delegate.countAll().executeAsOne()
+    }
 
     suspend fun insertTag(
         identityId: Uuid,

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/KeyValueWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/KeyValueWrapper.kt
@@ -42,8 +42,15 @@ class KeyValueWrapper(
      *  - `DiceRollPreferences.readInt / readMode` (3 reads/cold-start)
      *  - `CursorStorage.loadCursor` (called from `DriveSync.init`, `MainIndexMeta`)
      *
-     * If you find yourself wanting this for anything else, refactor the caller
-     * to async-init instead.
+     * **KeyValue-specific by design**: the other wrappers don't expose a
+     * bootstrap-sync sibling because their callers can all afford to be
+     * suspend. If you ever need a sync read of another table at constructor
+     * time, refactor the *caller* to async-init (seed the StateFlow with a
+     * default and `scope.launch { _flow.value = read() }` in `init {}`)
+     * rather than adding another sync hatch here. Each new hatch is a place
+     * where a Main-thread caller can deadlock the DB, and they're hard to
+     * unwind once they exist. Should be tracked as a follow-up to migrate
+     * these four bootstrap callers off this API entirely.
      */
     fun <T : Any> selectByKeyBootstrapSync(
         key: Uuid,

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/KeyValueWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/KeyValueWrapper.kt
@@ -11,7 +11,41 @@ class KeyValueWrapper(
 ) {
     private val delegate = KeyValueQueries(driver, keyValueAdapter)
 
-    fun <T : Any> selectByKey(
+    suspend fun <T : Any> selectByKey(
+        key: Uuid,
+        mapper: (
+            key: Uuid,
+            data: ByteArray,
+        ) -> T,
+    ): T? = databaseManager.readValue("keyValue.selectByKey(mapper)") {
+        delegate.selectByKey(key, mapper).executeAsOneOrNull()
+    }
+
+    suspend fun selectByKey(key: Uuid): KeyValue? =
+        databaseManager.readValue("keyValue.selectByKey") {
+            delegate.selectByKey(key).executeAsOneOrNull()
+        }
+
+    /**
+     * Synchronous read for cold-start bootstrap **only** — used by classes that
+     * seed `StateFlow`s in their constructor (`VaultPreferences`,
+     * `MomentsPreferences`, `DiceRollPreferences`) and by `CursorStorage.init`.
+     * These can't `suspend` because the constructor is invoked from non-suspend
+     * DI / sync code paths, and `runBlocking` isn't available in commonMain
+     * (wasmJs has no real blocking).
+     *
+     * Bypasses both lanes — runs on the caller's thread. **Do not use** for any
+     * non-bootstrap path; prefer the suspend [selectByKey] variants which route
+     * through `readValue` and show up in `SlowDbRead`. Audited callers:
+     *  - `VaultPreferences.readBoolean` (icon-visible, biometrics — 2 reads/cold-start)
+     *  - `MomentsPreferences.readBoolean / readViewMode` (3 reads/cold-start)
+     *  - `DiceRollPreferences.readInt / readMode` (3 reads/cold-start)
+     *  - `CursorStorage.loadCursor` (called from `DriveSync.init`, `MainIndexMeta`)
+     *
+     * If you find yourself wanting this for anything else, refactor the caller
+     * to async-init instead.
+     */
+    fun <T : Any> selectByKeyBootstrapSync(
         key: Uuid,
         mapper: (
             key: Uuid,
@@ -19,16 +53,9 @@ class KeyValueWrapper(
         ) -> T,
     ): T? = delegate.selectByKey(key, mapper).executeAsOneOrNull()
 
-    fun selectByKey(
-        key: Uuid,
-    ): KeyValue? {
-        try {
-            return delegate.selectByKey(key).executeAsOneOrNull()
-        } catch (e: Exception) {
-            println { "executeReadQuery failed: ${e.message}\n" }
-            throw e  // Rethrow if you want the caller to handle, or return a fallback QueryResult
-        }
-    }
+    /** @see selectByKeyBootstrapSync — bootstrap-only synchronous variant. */
+    fun selectByKeyBootstrapSync(key: Uuid): KeyValue? =
+        delegate.selectByKey(key).executeAsOneOrNull()
 
     suspend fun upsertValue(
         key: Uuid,

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxWrapper.kt
@@ -32,18 +32,20 @@ class OutboxWrapper(
         return databaseManager.withWriteValue { delegate.checkout(getUniqueId(), UnixTimeUtc.now().milliseconds).executeAsOneOrNull() }
     }
 
-    fun nextScheduled(): UnixTimeUtc?
-    {
-        val n = delegate.nextScheduled().executeAsOneOrNull()
-
-        return if (n == null) null else return UnixTimeUtc(n)
+    suspend fun nextScheduled(): UnixTimeUtc? {
+        val n = databaseManager.readValue("outbox.nextScheduled") {
+            delegate.nextScheduled().executeAsOneOrNull()
+        }
+        return if (n == null) null else UnixTimeUtc(n)
     }
 
-    fun selectCheckedOut(
-        checkOutStamp: Long,
-    ): Outbox? = delegate.selectCheckedOut(checkOutStamp).executeAsOneOrNull()
+    suspend fun selectCheckedOut(checkOutStamp: Long): Outbox? =
+        databaseManager.readValue("outbox.selectCheckedOut") {
+            delegate.selectCheckedOut(checkOutStamp).executeAsOneOrNull()
+        }
 
-    fun count(): Long = delegate.count().executeAsOne()
+    suspend fun count(): Long =
+        databaseManager.readValue("outbox.count") { delegate.count().executeAsOne() }
 
     suspend fun insert(
         driveId: Uuid,

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/WrapperReadsRouteThroughLaneTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/WrapperReadsRouteThroughLaneTest.kt
@@ -174,4 +174,106 @@ class WrapperReadsRouteThroughLaneTest {
             assertEquals(viaSuspend.data_.toList(), viaSync.data_.toList())
         }
     }
+
+    // -- Mapper-variant suspend overloads -------------------------------------
+    //
+    // These exist for API symmetry with the SQLDelight-generated typed-callback
+    // signatures (callers pass a row → T mapper instead of getting back the
+    // generated row type). No production code calls them today, but they're
+    // still on the wrapper's public surface so a future caller using them must
+    // get the same read-lane routing as the no-mapper variants. Tests below
+    // pin: (a) routing through readValue, (b) the mapper actually runs and
+    // sees the column values from the row.
+
+    @Test
+    fun keyValueSuspendMapperRead_routesThroughLane_andMapperReceivesRowData() {
+        runBlocking {
+            val dbm = newDbm()
+            val key = Uuid.fromLongs(0L, 7L)
+            val payload = byteArrayOf(0x10, 0x20, 0x30)
+            dbm.keyValue.upsertValue(key, payload)
+            assertNull(
+                dbm.lastReadTiming,
+                "writes should not populate lastReadTiming (baseline)",
+            )
+
+            // The mapper is the user-supplied (key, data) -> T callback that
+            // SQLDelight invokes once per row inside executeAsOneOrNull. We
+            // ferry the payload back out so the assertion below proves the
+            // mapper actually ran against the real row, not an empty stand-in.
+            val data: ByteArray? = dbm.keyValue.selectByKey(key) { _, d -> d }
+            assertNotNull(data)
+            assertEquals(payload.toList(), data.toList())
+            assertNotNull(
+                dbm.lastReadTiming,
+                "keyValue.selectByKey(mapper) suspend variant must route through readValue",
+            )
+        }
+    }
+
+    @Test
+    fun appNotificationsSuspendMapperReads_routeThroughLane() {
+        runBlocking {
+            val dbm = newDbm()
+            val identityId = Uuid.fromLongs(0L, 1L)
+            val notificationId = Uuid.fromLongs(0L, 9L)
+            // Empty-table reads still go through readValue (the routing happens
+            // before the SQL runs), so we don't need to seed rows to prove the
+            // contract. The functional behaviour (mapper actually runs per
+            // matched row) is the same code path as keyValue's mapper variant
+            // above; this test scopes to "does the routing fire".
+
+            dbm.appNotifications.selectByNotificationId(
+                identityId,
+                notificationId,
+            ) { rowId, _, _, _, _, _, _, _, _ -> rowId }
+            assertNotNull(
+                dbm.lastReadTiming,
+                "appNotifications.selectByNotificationId(mapper) must route through readValue",
+            )
+
+            dbm.appNotifications.selectFirstPage(
+                identityId,
+                limit = 10L,
+            ) { rowId, _, _, _, _, _, _, _, _ -> rowId }
+            assertNotNull(
+                dbm.lastReadTiming,
+                "appNotifications.selectFirstPage(mapper) must route through readValue",
+            )
+
+            dbm.appNotifications.selectNextPage(
+                identityId,
+                rowId = 0L,
+                limit = 10L,
+            ) { rowId, _, _, _, _, _, _, _, _ -> rowId }
+            assertNotNull(
+                dbm.lastReadTiming,
+                "appNotifications.selectNextPage(mapper) must route through readValue",
+            )
+        }
+    }
+
+    @Test
+    fun driveLocalTagIndexSuspendMapperRead_routesThroughLane() {
+        runBlocking {
+            val dbm = newDbm()
+            val identityId = Uuid.fromLongs(0L, 1L)
+            val driveId = Uuid.fromLongs(0L, 2L)
+            val fileId = Uuid.fromLongs(0L, 3L)
+            // Empty-table read: enough to prove the routing wraps the mapper
+            // variant. The downstream SQL plan is irrelevant — what we're
+            // pinning is "this method went through readValue, not direct
+            // executeAsList".
+
+            dbm.driveLocalTagIndex.selectByFile(
+                identityId,
+                driveId,
+                fileId,
+            ) { rowId, _, _, _, _ -> rowId }
+            assertNotNull(
+                dbm.lastReadTiming,
+                "driveLocalTagIndex.selectByFile(mapper) must route through readValue",
+            )
+        }
+    }
 }

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/WrapperReadsRouteThroughLaneTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/WrapperReadsRouteThroughLaneTest.kt
@@ -1,0 +1,177 @@
+package id.homebase.api.sync.database
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import id.homebase.api.common.OdinId
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.uuid.Uuid
+
+/**
+ * Regression guard for PR C ("read-lane coverage audit"): every wrapper read
+ * now routes through `DatabaseManager.readValue("<label>") { … }` so it shows
+ * up in `SlowDbRead` logs and queues on the read lane instead of bypassing
+ * both lanes. Pre-PR the reads in these wrappers were synchronous `fun`s
+ * calling `delegate.x().executeAs*()` directly, which left them invisible to
+ * the diagnostic + queue-wait split.
+ *
+ * The contract: a read that's gone through the lane updates
+ * `DatabaseManager.lastReadTiming` (only `executeReadQuery` / `readValue`
+ * populate that cell — writes don't, raw `executeAs*` outside the lane
+ * doesn't). So the cheapest pin is: call the wrapper, assert `lastReadTiming`
+ * is now non-null.
+ *
+ * The companion pin — that `selectByKeyBootstrapSync` deliberately does NOT
+ * route (it's the documented escape hatch for class-constructor reads where
+ * `runBlocking` is unavailable on wasmJs) — also lives here.
+ */
+class WrapperReadsRouteThroughLaneTest {
+
+    private fun newDbm(): DatabaseManager =
+        DatabaseManager({ JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY) })
+
+    @Test
+    fun outboxReads_routeThroughLane() {
+        runBlocking {
+            val dbm = newDbm()
+            assertNull(dbm.lastReadTiming, "fresh DBM should have no read timing")
+
+            dbm.outbox.count()
+            assertNotNull(
+                dbm.lastReadTiming,
+                "outbox.count() must route through readValue (populates lastReadTiming)",
+            )
+
+            dbm.outbox.nextScheduled()
+            assertNotNull(dbm.lastReadTiming, "outbox.nextScheduled() must route through readValue")
+
+            dbm.outbox.selectCheckedOut(0L)
+            assertNotNull(dbm.lastReadTiming, "outbox.selectCheckedOut() must route through readValue")
+        }
+    }
+
+    @Test
+    fun keyValueSuspendRead_routesThroughLane() {
+        runBlocking {
+            val dbm = newDbm()
+            val key = Uuid.fromLongs(0L, 1L)
+            dbm.keyValue.upsertValue(key, byteArrayOf(1))
+            // Baseline: only writes have happened, so lastReadTiming must still
+            // be null (writes don't populate it). This makes the post-read
+            // assertion meaningful — anything non-null after must have come
+            // from the read we're about to do.
+            assertNull(
+                dbm.lastReadTiming,
+                "writes should not populate lastReadTiming (baseline)",
+            )
+
+            val v = dbm.keyValue.selectByKey(key)
+            assertNotNull(v)
+            assertNotNull(
+                dbm.lastReadTiming,
+                "keyValue.selectByKey (suspend) must route through readValue",
+            )
+        }
+    }
+
+    @Test
+    fun keyValueBootstrapSync_doesNotRouteThroughLane() {
+        // Escape-hatch contract: the bootstrap-sync variant is the documented
+        // exception. It runs synchronously on the caller's thread for
+        // class-constructor reads (Vault/Moments/DiceRoll/CursorStorage init)
+        // where `runBlocking` isn't available on wasmJs. Pin that it stays an
+        // escape hatch — if someone "accidentally" routes it through readValue
+        // in the future, the bootstrap callers would deadlock on Main from a
+        // ViewModel constructor.
+        runBlocking {
+            val dbm = newDbm()
+            val key = Uuid.fromLongs(0L, 1L)
+            dbm.keyValue.upsertValue(key, byteArrayOf(1))
+            assertNull(
+                dbm.lastReadTiming,
+                "writes should not populate lastReadTiming (baseline)",
+            )
+
+            val v = dbm.keyValue.selectByKeyBootstrapSync(key)
+            assertNotNull(v, "bootstrap-sync read must still return the value")
+            assertNull(
+                dbm.lastReadTiming,
+                "selectByKeyBootstrapSync must NOT route through readValue — it's the documented " +
+                    "escape hatch for class-constructor reads. If this test fails, the bootstrap " +
+                    "callers (VaultPreferences/MomentsPreferences/DiceRollPreferences/CursorStorage) " +
+                    "may now deadlock on Main.",
+            )
+        }
+    }
+
+    @Test
+    fun chatReadCountReads_routeThroughLane() {
+        runBlocking {
+            val dbm = newDbm()
+            val identityId = Uuid.fromLongs(0L, 1L)
+            val groupId = Uuid.fromLongs(0L, 2L)
+            val selfDomain = OdinId("self.test")
+
+            dbm.chatReadCount.selectLastReadTimeMs(groupId)
+            assertNotNull(
+                dbm.lastReadTiming,
+                "chatReadCount.selectLastReadTimeMs must route through readValue",
+            )
+
+            dbm.chatReadCount.selectUnreadCountForConversation(identityId, groupId, selfDomain)
+            assertNotNull(
+                dbm.lastReadTiming,
+                "chatReadCount.selectUnreadCountForConversation must route through readValue",
+            )
+
+            dbm.chatReadCount.selectOrphanedAtRestConversations(identityId, selfDomain.domainName)
+            assertNotNull(
+                dbm.lastReadTiming,
+                "chatReadCount.selectOrphanedAtRestConversations must route through readValue",
+            )
+        }
+    }
+
+    @Test
+    fun connectionCacheReads_routeThroughLane() {
+        runBlocking {
+            val dbm = newDbm()
+            val identityId = Uuid.fromLongs(0L, 1L)
+
+            dbm.connectionCache.selectByIdentity(identityId)
+            assertNotNull(
+                dbm.lastReadTiming,
+                "connectionCache.selectByIdentity must route through readValue",
+            )
+
+            dbm.connectionCache.selectByIdentityAndStatus(identityId, "connected")
+            assertNotNull(
+                dbm.lastReadTiming,
+                "connectionCache.selectByIdentityAndStatus must route through readValue",
+            )
+        }
+    }
+
+    @Test
+    fun bootstrapSyncRoundTrip_isEquivalentToSuspendVariant() {
+        // Beyond "doesn't route through the lane", the bootstrap-sync variant
+        // must still produce the same row data as the suspend variant — they're
+        // two windows onto the same row. Catches typos / wrong delegate calls
+        // in the escape hatch.
+        runBlocking {
+            val dbm = newDbm()
+            val key = Uuid.fromLongs(0L, 1L)
+            val payload = byteArrayOf(0x42, 0x43)
+            dbm.keyValue.upsertValue(key, payload)
+
+            val viaSuspend = dbm.keyValue.selectByKey(key)
+            val viaSync = dbm.keyValue.selectByKeyBootstrapSync(key)
+            assertNotNull(viaSuspend)
+            assertNotNull(viaSync)
+            assertEquals(viaSuspend.key, viaSync.key)
+            assertEquals(viaSuspend.data_.toList(), viaSync.data_.toList())
+        }
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/dice/DiceRollPreferences.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/dice/DiceRollPreferences.kt
@@ -42,8 +42,11 @@ class DiceRollPreferences(private val databaseManager: DatabaseManager) {
     }
 
     private fun readInt(key: Uuid, default: Int): Int {
+        // Bootstrap-only sync read — seeds the StateFlow at construction. See
+        // KeyValueWrapper.selectByKeyBootstrapSync for the rationale (commonMain
+        // has no runBlocking on wasmJs).
         val bytes: ByteArray = runCatching {
-            keyValue.selectByKey(key)?.data_
+            keyValue.selectByKeyBootstrapSync(key)?.data_
         }.getOrNull() ?: return default
         if (bytes.size != 4) return default
         return (bytes[0].toInt() and 0xFF shl 24) or
@@ -60,8 +63,9 @@ class DiceRollPreferences(private val databaseManager: DatabaseManager) {
     )
 
     private fun readMode(): DiceRollMode {
+        // Bootstrap-only sync read — see readInt above.
         val bytes: ByteArray = runCatching {
-            keyValue.selectByKey(LAST_MODE_KEY)?.data_
+            keyValue.selectByKeyBootstrapSync(LAST_MODE_KEY)?.data_
         }.getOrNull() ?: return DEFAULT_MODE
         if (bytes.isEmpty()) return DEFAULT_MODE
         return when (bytes[0].toInt()) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -979,7 +979,7 @@ class ConversationStream(
     }
 
     /** Reads the persisted orphaned-at-rest sweep version (0 when never run). */
-    private fun readOrphanSweepVersion(): Int {
+    private suspend fun readOrphanSweepVersion(): Int {
         val bytes = runCatching { dbm.keyValue.selectByKey(ORPHAN_SWEEP_KEY)?.data_ }.getOrNull() ?: return 0
         if (bytes.size != 4) return 0
         return (bytes[0].toInt() and 0xFF shl 24) or

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ConnectionCacheRepository.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ConnectionCacheRepository.kt
@@ -136,7 +136,12 @@ class ConnectionCacheRepository(
         dbm.connectionCache.deleteByIdentityAndOdinId(identityId, odinId.domainName)
     }
 
-    private suspend inline fun <T> runReading(block: (kotlin.uuid.Uuid) -> T?): T? {
+    // The block runs the suspend `dbm.connectionCache.select*` reads, which
+    // route through `databaseManager.readValue(...)` for SlowDbRead
+    // instrumentation and read-lane queue-wait tracking.
+    private suspend inline fun <T> runReading(
+        crossinline block: suspend (kotlin.uuid.Uuid) -> T?,
+    ): T? {
         val identityId = try {
             credentialsManager.getActiveCredentials()?.getIdentityId()
         } catch (e: Exception) {

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceTestFixture.kt
@@ -178,7 +178,7 @@ class ChatMessageSenderServiceTestFixture : AutoCloseable {
         )
     }
 
-    fun outboxRowCount(): Long = dbm.outbox.count()
+    suspend fun outboxRowCount(): Long = dbm.outbox.count()
 
     /**
      * Drain checked-out rows. Same caveat as the helper in

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceTestFixture.kt
@@ -331,7 +331,7 @@ class ConversationServiceTestFixture : AutoCloseable {
         return conversationId
     }
 
-    fun outboxRowCount(): Long = dbm.outbox.count()
+    suspend fun outboxRowCount(): Long = dbm.outbox.count()
 
     /**
      * Drain the outbox (checkout everything eligible at real `now`) so callers can

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/moments/MomentsPreferences.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/moments/MomentsPreferences.kt
@@ -38,15 +38,18 @@ class MomentsPreferences(private val databaseManager: DatabaseManager) {
     }
 
     private fun readBoolean(key: Uuid, default: Boolean): Boolean {
+        // Bootstrap-only sync read — seeds the StateFlow at construction. See
+        // KeyValueWrapper.selectByKeyBootstrapSync for the rationale (commonMain
+        // has no runBlocking on wasmJs).
         val bytes: ByteArray = runCatching {
-            keyValue.selectByKey(key) { _, data -> data }
+            keyValue.selectByKeyBootstrapSync(key) { _, data -> data }
         }.getOrNull() ?: return default
         return if (bytes.isEmpty()) default else bytes[0].toInt() != 0
     }
 
     private fun readViewMode(): MomentsViewMode {
         val bytes: ByteArray = runCatching {
-            keyValue.selectByKey(VIEW_MODE_KEY) { _, data -> data }
+            keyValue.selectByKeyBootstrapSync(VIEW_MODE_KEY) { _, data -> data }
         }.getOrNull() ?: return MomentsViewMode.Timeline
         if (bytes.isEmpty()) return MomentsViewMode.Timeline
         val name = bytes.decodeToString()

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/vault/VaultPreferences.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/vault/VaultPreferences.kt
@@ -76,8 +76,11 @@ class VaultPreferences(private val databaseManager: DatabaseManager) {
     }
 
     private fun readBoolean(key: Uuid, default: Boolean): Boolean {
+        // Bootstrap-only sync read — seeds the StateFlow at construction. See
+        // KeyValueWrapper.selectByKeyBootstrapSync for the rationale (commonMain
+        // has no runBlocking on wasmJs).
         val bytes: ByteArray = runCatching {
-            keyValue.selectByKey(key) { _, data -> data }
+            keyValue.selectByKeyBootstrapSync(key) { _, data -> data }
         }.getOrNull() ?: return default
         return if (bytes.isEmpty()) default else bytes[0].toInt() != 0
     }


### PR DESCRIPTION
## Summary

- Every wrapper read that was still a synchronous \`fun delegate.x().executeAs*()\` is now \`suspend\` + \`databaseManager.readValue(\"<label>\") { ... }\`. Closes the read-lane coverage gap left after #605/#606/#608: anything that takes long enough now surfaces in \`SlowDbRead\`, and nothing competes with writes for the writer slot.
- Caller cascade is shallow — most production callers were already in suspend contexts (`ConversationService` outbox-count bookkeeping, `OutboxSync.outboxSend`, `ConversationStream.advancedLastRead` / `recoverOrphanedAtRestConversations`, `ConnectionCacheRepository.hydrate*`).
- Cold-start class constructors (`VaultPreferences`, `MomentsPreferences`, `DiceRollPreferences`, `CursorStorage`) seed `StateFlow`s / cursor caches from KeyValue synchronously and *cannot* `suspend` (no coroutine in scope, and \`runBlocking\` is unavailable in commonMain on wasmJs). Rather than refactor all four to async-init in this PR, I added a single labeled escape hatch on `KeyValueWrapper`: \`selectByKeyBootstrapSync(...)\`. It bypasses the lane, documents why, and lists the four legitimate callers. Future PR can async-init those classes; for now the bootstrap reads are pinned to a clearly-named API so a new caller can't drift in unnoticed.

## Files affected

- **Wrappers suspendified** (7 of them):
  - `OutboxWrapper`: \`nextScheduled\`, \`selectCheckedOut\`, \`count\`
  - `DriveTagIndexWrapper`: \`selectByFile\`, \`countAll\`
  - `DriveLocalTagIndexWrapper`: \`selectByFile\` (×2), \`countAll\`
  - `ConnectionCacheWrapper`: \`selectByIdentity\`, \`selectByIdentityAndStatus\`
  - `AppNotificationsWrapper`: all 6 reads
  - `ChatReadCountWrapper`: \`selectOrphanedAtRestConversations\`, \`selectUnreadCountForConversation\`, \`selectLastReadTimeMs\`
  - `KeyValueWrapper`: \`selectByKey\` (×2) + new \`selectByKeyBootstrapSync\` (×2)
- **Caller cascade** (4 production sites + 2 test fixtures): \`ConversationStream.readOrphanSweepVersion\` is now suspend; \`ConnectionCacheRepository.runReading\`'s block param is now suspend; \`outboxRowCount()\` in two test fixtures is now suspend.
- **Bootstrap-sync callers** (4 sites): \`VaultPreferences.readBoolean\`, \`MomentsPreferences.readBoolean\`/\`readViewMode\`, \`DiceRollPreferences.readInt\`/\`readMode\`, \`CursorStorage.loadCursor\` — all switched to the new \`selectByKeyBootstrapSync\` with a comment explaining why.
- **DriveMainIndexWrapper.selectFileIdAndJsonByDriveSince** is deliberately left as-is — it's used only by the Defragmenter, which runs explicitly off the hot path on a worker dispatcher.

## Test plan

- [x] New \`WrapperReadsRouteThroughLaneTest\` (`homebase-api` jvmTest) pins the contract via \`DatabaseManager.lastReadTiming\` (only \`executeReadQuery\` / \`readValue\` populate that cell). 6 cases:
  - outbox/chatReadCount/connectionCache reads each populate the timing cell after a fresh-DB write baseline.
  - \`keyValue.selectByKey\` (suspend) populates the cell.
  - \`keyValue.selectByKeyBootstrapSync\` deliberately does NOT populate it — pins the escape hatch.
  - Bootstrap-sync round-trips equivalent to the suspend variant.
- [x] \`./gradlew :homebase-api:jvmTest :homebase-chat:jvmTest :homebase-common:jvmTest compileKotlinIosSimulatorArm64 compileKotlinWasmJs\` — full suites green, pre-existing warnings unchanged.
- [x] **On device** (after #609 lands too): existing \`(MarkAsRead)\` / orphan-sweep / cursor-load arcs should now appear in \`SlowDbRead\` with queue-wait + sql (+ mapper, post-#609) splits, where today they're invisible.

## Why ship this after #609 mentally

The diagnostic win is doubled by #609's sql/mapper split: a hidden read that lands in \`SlowDbRead\` for the first time after this PR also benefits from the post-#609 split being honest about whether the time was real SQL or mapper CPU. PRs are independent (disjoint files) so they can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)