### PR TITLE
fix(ui): eliminate image flash during shared element zoom transitions

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
@@ -2,6 +2,8 @@ package id.homebase.chat.widget
 
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -53,6 +55,7 @@ import id.homebase.chat.services.LocalAttachmentContextStore
 import id.homebase.chat.services.builder.LinkPreviewDescriptor
 import id.homebase.chat.services.builder.LocationPreviewDescriptor
 import id.homebase.chat.widget.video.formatDurationLabel
+import id.homebase.core.HomebaseConstants
 import id.homebase.core.image.HomebaseImage
 import id.homebase.core.image.HomebaseImageData
 import id.homebase.core.image.ImageSize
@@ -226,7 +229,7 @@ fun MediaItem(
         contentType.startsWith("image/") -> {
             val imageLocalContext = localContext as? LocalAttachmentContext.Image
             if (imageLocalContext != null) {
-                val gestureModifier = if (onClick != null || onLongPress != null) {
+                var imageModifier = if (onClick != null || onLongPress != null) {
                     finalModifier.pointerInput(onClick, onLongPress) {
                         detectTapGestures(
                             onTap = { onClick?.invoke() },
@@ -236,10 +239,25 @@ fun MediaItem(
                 } else {
                     finalModifier
                 }
+                if (sharedTransitionScope != null && animatedVisibilityScope != null) {
+                    with(sharedTransitionScope) {
+                        imageModifier = imageModifier.sharedBounds(
+                            rememberSharedContentState(key = "image-${fileId}-${payload.key}"),
+                            animatedVisibilityScope = animatedVisibilityScope,
+                            boundsTransform = { _, _ ->
+                                tween(
+                                    durationMillis = HomebaseConstants.Animation.CHAT_IMAGE_FULL_SCREEN_TRANSITION_DURATION,
+                                    easing = FastOutSlowInEasing,
+                                )
+                            },
+                            resizeMode = SharedTransitionScope.ResizeMode.RemeasureToBounds,
+                        )
+                    }
+                }
                 AsyncImage(
                     model = imageLocalContext.localFilePath,
                     contentDescription = stringResource(MR.string.chat_message_image_attachment),
-                    modifier = gestureModifier,
+                    modifier = imageModifier,
                     contentScale = imageContentScale,
                 )
             } else {

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImage.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImage.kt
@@ -151,13 +151,22 @@ fun HomebaseImage(
     ) {
         val state by painter.state.collectAsStateWithLifecycle()
 
-        // Animate blur: 10f -> 0f on success
+        // Blur only the low-res embedded preview; cached thumbnails and full
+        // images are already sharp so the target is 0f for those states.
+        val hasSharpImage = state is AsyncImagePainter.State.Success ||
+            (state is AsyncImagePainter.State.Loading &&
+                (state as AsyncImagePainter.State.Loading).painter != null)
+
         val blurRadius by
         animateFloatAsState(
-            targetValue = if (state is AsyncImagePainter.State.Success) 0f else 10f,
+            targetValue = if (hasSharpImage) 0f else 10f,
             animationSpec = tween(durationMillis = 300),
             label = "blur"
         )
+
+        // Applied to every branch so the animation transitions smoothly
+        // across state changes (e.g. blurred preview → sharp full image).
+        val blurMod = if (blurRadius >= 0.5f) Modifier.blur(blurRadius.dp) else Modifier
 
         when (state) {
             is AsyncImagePainter.State.Loading -> {
@@ -168,14 +177,14 @@ fun HomebaseImage(
                         painter = loadingPainter,
                         contentDescription = contentDescription,
                         contentScale = contentScale,
-                        modifier = Modifier.fillMaxSize()
+                        modifier = Modifier.fillMaxSize().then(blurMod)
                     )
                 } else if (previewBitmap != null) {
                     Image(
                         bitmap = previewBitmap,
                         contentDescription = contentDescription,
                         contentScale = contentScale,
-                        modifier = Modifier.fillMaxSize().blur(blurRadius.dp)
+                        modifier = Modifier.fillMaxSize().then(blurMod)
                     )
                 } else {
                     placeholder?.invoke()
@@ -188,7 +197,7 @@ fun HomebaseImage(
                         bitmap = previewBitmap,
                         contentDescription = contentDescription,
                         contentScale = contentScale,
-                        modifier = Modifier.fillMaxSize().blur(blurRadius.dp)
+                        modifier = Modifier.fillMaxSize().then(blurMod)
                     )
                 } else {
                     placeholder?.invoke()
@@ -197,7 +206,7 @@ fun HomebaseImage(
 
             is AsyncImagePainter.State.Success -> {
                 SubcomposeAsyncImageContent(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier.fillMaxSize().then(blurMod),
                     contentScale = contentScale
                 )
             }
@@ -212,7 +221,7 @@ fun HomebaseImage(
                             bitmap = previewBitmap,
                             contentDescription = contentDescription,
                             contentScale = contentScale,
-                            modifier = Modifier.fillMaxSize().blur(blurRadius.dp)
+                            modifier = Modifier.fillMaxSize().then(blurMod)
                         )
                     } else {
                         placeholder?.invoke()

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
@@ -1,8 +1,10 @@
 package id.homebase.core.ui.screens.moments
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -202,6 +204,8 @@ fun MomentDetailPane(
                     uiState = uiState,
                     onAction = viewModel::onAction,
                     onNavigateBack = onNavigateBack,
+                    sharedTransitionScope = this@SharedTransitionLayout,
+                    animatedVisibilityScope = this@AnimatedContent,
                 )
 
                 is FullScreenOverlay.ViewMessageData -> FullScreenMediaViewer(
@@ -246,6 +250,8 @@ private fun DetailContent(
     uiState: MomentDetailUiState,
     onAction: (MomentDetailUiAction) -> Unit,
     onNavigateBack: (() -> Unit)?,
+    sharedTransitionScope: SharedTransitionScope,
+    animatedVisibilityScope: AnimatedVisibilityScope,
 ) {
     Scaffold(
         topBar = {
@@ -318,6 +324,8 @@ private fun DetailContent(
                 moment = moment,
                 initialPayloadKey = uiState.initialPayloadKey,
                 onAction = onAction,
+                sharedTransitionScope = sharedTransitionScope,
+                animatedVisibilityScope = animatedVisibilityScope,
                 modifier = Modifier
                     .fillMaxSize()
                     .consumeWindowInsets(innerPadding)
@@ -655,6 +663,8 @@ private fun MomentDetailContent(
     moment: MomentFeedItem,
     initialPayloadKey: String?,
     onAction: (MomentDetailUiAction) -> Unit,
+    sharedTransitionScope: SharedTransitionScope,
+    animatedVisibilityScope: AnimatedVisibilityScope,
     modifier: Modifier = Modifier,
 ) {
     val pageCount = moment.payloads.size.coerceAtLeast(1)
@@ -722,8 +732,8 @@ private fun MomentDetailContent(
                             preserveAspectRatio = false,
                             messageId = moment.id,
                             shape = RectangleShape,
-                            sharedTransitionScope = null,
-                            animatedVisibilityScope = null,
+                            sharedTransitionScope = sharedTransitionScope,
+                            animatedVisibilityScope = animatedVisibilityScope,
                             onClick = {
                                 onAction(MomentDetailUiAction.MediaClicked(payload.key))
                             },

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaItem.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaItem.kt
@@ -2,6 +2,8 @@ package id.homebase.core.ui.screens.moments.widget
 
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -54,6 +56,7 @@ import id.homebase.chat.services.builder.LocationPreviewDescriptor
 import id.homebase.chat.widget.DocumentMediaItem
 import id.homebase.chat.widget.LinkPreviewCard
 import id.homebase.chat.widget.LocationPreviewCard
+import id.homebase.core.HomebaseConstants
 import id.homebase.core.image.HomebaseImage
 import id.homebase.core.image.HomebaseImageData
 import id.homebase.core.image.ImageSize
@@ -204,7 +207,7 @@ fun MomentMediaItem(
         contentType.startsWith("image/") -> {
             val imageLocalContext = localContext as? LocalAttachmentContext.Image
             if (imageLocalContext != null) {
-                val gestureModifier = if (onClick != null || onLongPress != null) {
+                var imageModifier = if (onClick != null || onLongPress != null) {
                     finalModifier.pointerInput(onClick, onLongPress) {
                         detectTapGestures(
                             onTap = { onClick?.invoke() },
@@ -214,10 +217,25 @@ fun MomentMediaItem(
                 } else {
                     finalModifier
                 }
+                if (sharedTransitionScope != null && animatedVisibilityScope != null) {
+                    with(sharedTransitionScope) {
+                        imageModifier = imageModifier.sharedBounds(
+                            rememberSharedContentState(key = "image-${fileId}-${payload.key}"),
+                            animatedVisibilityScope = animatedVisibilityScope,
+                            boundsTransform = { _, _ ->
+                                tween(
+                                    durationMillis = HomebaseConstants.Animation.CHAT_IMAGE_FULL_SCREEN_TRANSITION_DURATION,
+                                    easing = FastOutSlowInEasing,
+                                )
+                            },
+                            resizeMode = SharedTransitionScope.ResizeMode.RemeasureToBounds,
+                        )
+                    }
+                }
                 AsyncImage(
                     model = imageLocalContext.localFilePath,
                     contentDescription = stringResource(MR.string.chat_message_image_attachment),
-                    modifier = gestureModifier,
+                    modifier = imageModifier,
                     contentScale = imageContentScale,
                 )
             } else {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultEntryCard.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultEntryCard.kt
@@ -27,9 +27,12 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import id.homebase.core.HomebaseConstants
 import id.homebase.core.image.decodeBitmap
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.runtime.remember
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
@@ -247,6 +250,13 @@ private fun VaultCardThumbnail(
                 imageModifier = imageModifier.sharedBounds(
                     rememberSharedContentState(key = "image-${file.fileId}-${firstPayloadKey}"),
                     animatedVisibilityScope = animatedVisibilityScope,
+                    boundsTransform = { _, _ ->
+                        tween(
+                            durationMillis = HomebaseConstants.Animation.CHAT_IMAGE_FULL_SCREEN_TRANSITION_DURATION,
+                            easing = FastOutSlowInEasing,
+                        )
+                    },
+                    resizeMode = SharedTransitionScope.ResizeMode.RemeasureToBounds,
                 )
             }
         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultZoomableImage.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultZoomableImage.kt
@@ -4,6 +4,8 @@ package id.homebase.core.ui.screens.vault.gallery
 
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -29,6 +31,7 @@ import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.drives.files.PayloadDescriptor
 import id.homebase.chat.services.LocalAttachmentContext
 import id.homebase.chat.services.LocalAttachmentContextStore
+import id.homebase.core.HomebaseConstants
 import id.homebase.core.image.HomebaseImage
 import id.homebase.core.image.HomebaseImageData
 import id.homebase.core.media.ZoomState
@@ -81,10 +84,26 @@ fun VaultZoomableImage(
     if (localFilePath != null) {
         ZoomableContainer(state = zoomState, onTap = onToggleUI) {
             Box(modifier = Modifier.fillMaxSize()) {
+                var imageModifier: Modifier = Modifier.fillMaxSize()
+                if (sharedTransitionScope != null && animatedVisibilityScope != null) {
+                    with(sharedTransitionScope) {
+                        imageModifier = imageModifier.sharedBounds(
+                            rememberSharedContentState(key = "image-${file.fileId}-${descriptor.key}"),
+                            animatedVisibilityScope = animatedVisibilityScope,
+                            boundsTransform = { _, _ ->
+                                tween(
+                                    durationMillis = HomebaseConstants.Animation.CHAT_IMAGE_FULL_SCREEN_TRANSITION_DURATION,
+                                    easing = FastOutSlowInEasing,
+                                )
+                            },
+                            resizeMode = SharedTransitionScope.ResizeMode.RemeasureToBounds,
+                        )
+                    }
+                }
                 AsyncImage(
                     model = localFilePath,
                     contentDescription = file.label?.ifBlank { null } ?: file.fileName,
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = imageModifier,
                     contentScale = ContentScale.Fit,
                 )
                 if (isPending) {


### PR DESCRIPTION
## Summary
- **Root cause**: Local-image code paths (`AsyncImage` for cached files) were missing `sharedBounds` modifiers, causing one-sided shared element transitions — the full-screen gallery target rendered at its unconstrained natural size during the `AnimatedContent` crossfade, producing visible flashes
- **HomebaseImage blur fix**: The blur animation snapped instantly from 10dp to 0 on Loading→Success state changes instead of animating smoothly — the blur modifier was only applied to the Loading/Error branches, not the Success branch, and the blur target didn't account for cached thumbnail availability
- **Scope threading**: Moments feature had `sharedTransitionScope = null` passed to `MomentMediaItem`, disabling shared transitions entirely — now threads the real scopes through `DetailContent` → `MomentDetailContent` → `MomentMediaItem`

### Files changed (6)
| File | Change |
|---|---|
| `VaultZoomableImage.kt` | Added `sharedBounds` to local-image `AsyncImage` (was missing) |
| `VaultEntryCard.kt` | Standardized `sharedBounds` params to `tween(300ms)` + `RemeasureToBounds` (was using defaults) |
| `MediaItem.kt` | Added `sharedBounds` to local-image `AsyncImage` in chat (was missing) |
| `MomentMediaItem.kt` | Added `sharedBounds` to local-image `AsyncImage` in moments (was missing) |
| `MomentDetailScreen.kt` | Threaded shared transition scopes through to `MomentMediaItem` (was passing null) |
| `HomebaseImage.kt` | Fixed blur target to account for cached thumbnails; applied blur to all branches for smooth transitions |

## Test plan
- [ ] Vault: tap an image → verify smooth zoom animation without flash (both locally-cached and server images)
- [ ] Vault: tap a multi-page entry → verify first page animates, other pages fade normally
- [ ] Chat: tap an image in a message → verify smooth zoom to full-screen without flash
- [ ] Moments: tap a moment image → open detail → tap to full-screen → verify smooth transition
- [ ] Verify progressive image loading still works: blurry preview → sharp thumbnail → full image (no snap)
- [ ] Verify error state still shows blurred preview with error icon overlay
- [ ] Test on iOS and Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)