### PR TITLE
fix(db): QueryBatch cursor's userDate uses the same fallback as the SQL column

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/QueryBatch.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/QueryBatch.kt
@@ -311,9 +311,24 @@ class QueryBatch(
                     // above; it's the boundary we want the next fetch to skip.
                     val boundaryRowId = rowId ?: 0L
                     if (sortField === QueryBatchSortField.UserDate)
+                        // Use `sqlUserDateMs()` — the *exact same* projection
+                        // `MainIndexMeta.kt:127-128` writes into the SQL
+                        // `userDate` column: `appData.userDate ?: created.ms`.
+                        // The earlier `appData.userDate ?: 0L` here disagreed
+                        // with the SQL column for any row whose
+                        // `appData.userDate` is null (the chat "no version,
+                        // not edited" branch). That mismatch produced cursors
+                        // of shape `(0L, lastRowId)` while the SQL had real
+                        // ms timestamps in the userDate column, so the next
+                        // fetch's `WHERE (userDate, rowId) > (0L, lastRowId)`
+                        // matched the *entire timeline* from epoch and
+                        // ORDER BY ASC returned the oldest rows — already in
+                        // the window. Window stayed the same size, hasMore
+                        // stayed true, infinity-spinner on the bottom. See
+                        // QueryBatchCursorUserDateSourceTest.
                         workingCursor = workingCursor.copy(
                             paging = TimeRowCursor(
-                                UnixTimeUtc(header.fileMetadata.appData.userDate ?: 0L),
+                                UnixTimeUtc(header.sqlUserDateMs()),
                                 boundaryRowId
                             )
                         )

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/QueryBatch.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/QueryBatch.kt
@@ -2,7 +2,6 @@ package id.homebase.api.sync.database
 
 import app.cash.sqldelight.db.QueryResult
 import co.touchlab.kermit.Logger
-import id.homebase.api.common.IntRange
 import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.api.common.time.UnixTimeUtcRange
 import id.homebase.api.client.drives.FileState
@@ -356,130 +355,6 @@ class QueryBatch(
         ) { }
 
         return result.value;
-    }
-
-    /**
-     * Smart cursor variant with automatic boundary management for NewestFirst queries
-     */
-    suspend fun queryBatchSmartCursorAsync(
-        dbm: DatabaseManager,
-        driveId: Uuid,
-        noOfItems: Int,
-        cursor: QueryBatchCursor? = null,
-        sortOrder: QueryBatchSortOrder = QueryBatchSortOrder.NewestFirst,
-        sortField: QueryBatchSortField = QueryBatchSortField.CreatedDate,
-        fileSystemType: Int? = null,
-        fileState: FileStateFilter = FileStateFilter.Active,
-        requiredSecurityGroup: IntRange? = null,
-        globalTransitIdAnyOf: List<Uuid>? = null,
-        filetypesAnyOf: List<Int>? = null,
-        datatypesAnyOf: List<Int>? = null,
-        senderIdAnyOf: List<String>? = null,
-        groupIdAnyOf: List<Uuid>? = null,
-        uniqueIdAnyOf: List<Uuid>? = null,
-        archivalStatusAnyOf: List<Int>? = null,
-        userDateSpan: UnixTimeUtcRange? = null,
-        aclAnyOf: List<Uuid>? = null,
-        tagsAnyOf: List<Uuid>? = null,
-        tagsAllOf: List<Uuid>? = null,
-        localTagsAnyOf: List<Uuid>? = null,
-        localTagsAllOf: List<Uuid>? = null
-    ): QueryBatchResult {
-
-        val pagingCursorWasNull = cursor?.paging == null
-
-        val (result, moreRows, refCursor) = queryBatchAsync(
-            dbm,
-            driveId, noOfItems, cursor, sortOrder, sortField,
-            fileSystemType, fileState,
-            globalTransitIdAnyOf, filetypesAnyOf, datatypesAnyOf,
-            senderIdAnyOf, groupIdAnyOf, uniqueIdAnyOf, archivalStatusAnyOf,
-            userDateSpan, aclAnyOf, tagsAnyOf, tagsAllOf,
-            localTagsAnyOf, localTagsAllOf
-        )
-
-        if (sortOrder == QueryBatchSortOrder.OldestFirst) {
-            return QueryBatchResult(result, moreRows, refCursor)
-        }
-
-        if (result.isNotEmpty()) {
-            // Set nextBoundaryCursor for first set when pagingCursor was null
-            if (pagingCursorWasNull) {
-                val nextBoundaryCursor = when (sortField) {
-                    QueryBatchSortField.CreatedDate, QueryBatchSortField.FileId ->
-                        TimeRowCursor(UnixTimeUtc(result[0].fileMetadata.created.milliseconds), 0L)
-
-                    QueryBatchSortField.AnyChangeDate ->
-                        TimeRowCursor(UnixTimeUtc(result[0].fileMetadata.updated.milliseconds), 0L)
-
-                    QueryBatchSortField.UserDate ->
-                        TimeRowCursor(
-                            UnixTimeUtc(result[0].fileMetadata.appData.userDate ?: 0L),
-                            0L
-                        )
-
-                    QueryBatchSortField.OnlyModifiedDate ->
-                        TimeRowCursor(UnixTimeUtc(result[0].fileMetadata.updated.milliseconds), 0L)
-                }
-                return QueryBatchResult(result, moreRows, refCursor.copy(next = nextBoundaryCursor))
-            }
-
-            if (result.size < noOfItems) {
-                if (!moreRows) {
-                    // Advance cursor boundary
-                    val updatedCursor = if (refCursor.next != null) {
-                        refCursor.copy(
-                            stop = refCursor.next,
-                            next = null,
-                            paging = null
-                        )
-                    } else {
-                        refCursor.copy(next = null, paging = null)
-                    }
-
-                    // Recursive call to check for more items
-                    val (r2, moreRows2, refCursor2) = queryBatchSmartCursorAsync(
-                        dbm,
-                        driveId, noOfItems - result.size, updatedCursor,
-                        sortOrder, sortField, fileSystemType, fileState,
-                        requiredSecurityGroup, globalTransitIdAnyOf, filetypesAnyOf,
-                        datatypesAnyOf, senderIdAnyOf, groupIdAnyOf, uniqueIdAnyOf,
-                        archivalStatusAnyOf, userDateSpan, aclAnyOf, tagsAnyOf,
-                        tagsAllOf, localTagsAnyOf, localTagsAllOf
-                    )
-
-                    if (r2.isNotEmpty()) {
-                        // Combine results - r2 should be newer than result
-                        val combinedResult = (r2 + result)
-                        return QueryBatchResult(combinedResult, moreRows2, refCursor2)
-                    }
-                }
-            }
-        } else {
-            if (refCursor.next != null) {
-                val updatedCursor = refCursor.copy(
-                    stop = refCursor.next,
-                    next = null,
-                    paging = null
-                )
-                return queryBatchSmartCursorAsync(
-                    dbm,
-                    driveId, noOfItems, updatedCursor, sortOrder, sortField,
-                    fileSystemType, fileState, requiredSecurityGroup,
-                    globalTransitIdAnyOf, filetypesAnyOf, datatypesAnyOf,
-                    senderIdAnyOf, groupIdAnyOf, uniqueIdAnyOf, archivalStatusAnyOf,
-                    userDateSpan, aclAnyOf, tagsAnyOf, tagsAllOf, localTagsAnyOf, localTagsAllOf
-                )
-            } else {
-                return QueryBatchResult(
-                    result,
-                    moreRows,
-                    refCursor.copy(next = null, paging = null)
-                )
-            }
-        }
-
-        return QueryBatchResult(result, moreRows, refCursor)
     }
 
     // Helper functions

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/QueryBatchCursorAdvanceTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/QueryBatchCursorAdvanceTest.kt
@@ -232,6 +232,117 @@ class QueryBatchCursorAdvanceTest {
     }
 
     /**
+     * Pins the *userDate-source* cursor bug surfaced by Patrick Kitchell's
+     * conversation on prod 1.4.1678. Distinct from the rowId-tuple bug fixed
+     * in the same QueryBatch.kt cursor-build block — that one only manifested
+     * at tied userDate boundaries. This one fires on *any* row whose
+     * `appData.userDate` is null in the JSON header (the chat "no version,
+     * not edited" branch: older Web/RN clients didn't always emit
+     * `appData.userDate`).
+     *
+     * **Production projection** at `MainIndexMeta.kt:127-128`:
+     *   SQL `userDate` column = `appData.userDate ?: created.milliseconds`
+     *
+     * **Pre-fix `QueryBatch.kt:316`** wrote the cursor's userDate as:
+     *   `UnixTimeUtc(header.fileMetadata.appData.userDate ?: 0L)`
+     *
+     * For a null-`appData.userDate` row, that was `(0L, lastRowId)`. The next
+     * fetch's `WHERE (userDate, rowId) > (0L, lastRowId) ORDER BY userDate ASC`
+     * matched *every* row (because `userDate > 0` is true for every real row)
+     * and returned the **oldest 75** — already in the window. Window stayed
+     * the same size, `hasMore=true`, infinity-spinner on the bottom.
+     *
+     * **The fix**: use `header.sqlUserDateMs()` so the cursor's userDate
+     * matches the SQL column projection exactly.
+     *
+     * Seeds 9 rows with `appData.userDate=null` and distinct `created`
+     * timestamps (so the SQL column has spread-out timestamps). Paginates
+     * 3 at a time, asserts disjoint + exhaustive pages. Pre-fix: page 2
+     * returns the same rows as page 1. Post-fix: pages tile the dataset.
+     */
+    @Test
+    fun queryBatchAsync_oldestFirstUserDate_cursorAdvances_whenAppDataUserDateIsNull() {
+        runBlocking {
+            val dbm = DatabaseManager({ JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY) })
+
+            val identityId = Uuid.fromLongs(0L, 1L)
+            val driveId = Uuid.fromLongs(0L, 2L)
+            val groupId = Uuid.fromLongs(0L, 3L)
+
+            val totalRows = 9
+            val pageSize = 3
+            val baseCreated = 1_700_000_000_000L
+            val expectedAllIds = (1..totalRows).map { i ->
+                val fileId = Uuid.fromLongs(0L, 100L + i)
+                seedChatMessage(
+                    dbm = dbm,
+                    identityId = identityId,
+                    driveId = driveId,
+                    groupId = groupId,
+                    fileId = fileId,
+                    uniqueId = Uuid.fromLongs(0L, 200L + i),
+                    // userDate positional arg is unused when appDataUserDate=null
+                    // — SQL column falls back to `created`. Keep a placeholder.
+                    userDate = 0L,
+                    created = baseCreated + i,
+                    modified = baseCreated + i,
+                    appDataUserDate = null,
+                )
+                fileId
+            }.toSet()
+
+            val qb = QueryBatch(identityId)
+            val pages = mutableListOf<Set<Uuid>>()
+            var cursor: QueryBatchCursor? = null
+            var hasMore = true
+            var safetyCounter = 0
+            while (hasMore) {
+                if (++safetyCounter > 6) {
+                    error(
+                        "cursor never advanced when appData.userDate=null — paged ${pages.size} " +
+                            "times without exhausting the 9-row dataset (pages so far: $pages)"
+                    )
+                }
+                val batch = qb.queryBatchAsync(
+                    dbm = dbm,
+                    driveId = driveId,
+                    noOfItems = pageSize,
+                    cursor = cursor,
+                    sortOrder = QueryBatchSortOrder.OldestFirst,
+                    sortField = QueryBatchSortField.UserDate,
+                    fileSystemType = 0,
+                    filetypesAnyOf = listOf(CHAT_MESSAGE_FILE_TYPE),
+                    groupIdAnyOf = listOf(groupId),
+                )
+                val pageIds = batch.records.map { it.fileId }.toSet()
+                for ((idx, prior) in pages.withIndex()) {
+                    val overlap = pageIds.intersect(prior)
+                    assertTrue(
+                        overlap.isEmpty(),
+                        "[null appData.userDate] page #${pages.size + 1} overlaps with page #${idx + 1}: " +
+                            "overlap=$overlap thisPage=$pageIds priorPage=$prior",
+                    )
+                }
+                pages += pageIds
+                cursor = batch.cursor
+                hasMore = batch.hasMoreRows
+            }
+
+            assertEquals(
+                3, pages.size,
+                "with 9 rows whose appData.userDate is null (SQL falls back to created), " +
+                    "pagination should yield exactly 3 disjoint pages (got ${pages.size}: $pages)",
+            )
+            val union = pages.fold(emptySet<Uuid>()) { acc, p -> acc + p }
+            assertEquals(
+                expectedAllIds, union,
+                "union of all pages should equal the seeded set — missing=" +
+                    "${expectedAllIds - union} extra=${union - expectedAllIds}",
+            )
+        }
+    }
+
+    /**
      * Mirror of the OldestFirst variant above but in the *opposite* direction.
      *
      * The fix sets `cursor.row` to the *last-processed* row's actual `rowId`
@@ -597,16 +708,27 @@ class QueryBatchCursorAdvanceTest {
         userDate: Long,
         created: Long = userDate,
         modified: Long = userDate,
+        // When `appDataUserDate` is null, the JSON emits `"userDate": null`
+        // and the SQL `userDate` column falls back to `created.milliseconds`
+        // (mirroring `MainIndexMeta.kt:127-128`). This is the "no version /
+        // not edited" branch in production for chat messages from older
+        // clients — and the case that exposes the cursor-userDate-source bug
+        // fixed in [queryBatchAsync_oldestFirstUserDate_cursorAdvances_whenAppDataUserDateIsNull].
+        appDataUserDate: Long? = userDate,
     ) {
         val jsonHeader = buildChatMessageJson(
             fileId = fileId,
             driveId = driveId,
             uniqueId = uniqueId,
             groupId = groupId,
-            userDate = userDate,
+            appDataUserDate = appDataUserDate,
             created = created,
             modified = modified,
         )
+        // SQL `userDate` column mirrors the production projection:
+        // `appData.userDate ?: created`. Tests that seed `appDataUserDate=null`
+        // get `created` in the SQL column, matching real-world rows.
+        val sqlUserDate = appDataUserDate ?: created
         dbm.driveMainIndex.upsertDriveMainIndex(
             identityId = identityId,
             driveId = driveId,
@@ -621,7 +743,7 @@ class QueryBatchCursorAdvanceTest {
             archivalStatus = 1L,
             fileState = 1L,
             historyStatus = 0L,
-            userDate = userDate,
+            userDate = sqlUserDate,
             created = created,
             modified = modified,
             fileSystemType = 0L,
@@ -641,9 +763,9 @@ class QueryBatchCursorAdvanceTest {
         driveId: Uuid,
         uniqueId: Uuid,
         groupId: Uuid,
-        userDate: Long,
-        created: Long = userDate,
-        modified: Long = userDate,
+        appDataUserDate: Long?,
+        created: Long,
+        modified: Long,
     ): String = """
         {
             "fileId": "$fileId",
@@ -670,7 +792,7 @@ class QueryBatchCursorAdvanceTest {
                     "fileType": $CHAT_MESSAGE_FILE_TYPE,
                     "dataType": 0,
                     "groupId": "$groupId",
-                    "userDate": $userDate,
+                    "userDate": ${appDataUserDate ?: "null"},
                     "content": "",
                     "previewThumbnail": null,
                     "archivalStatus": 0


### PR DESCRIPTION
## Summary

Closes the *actual* Patrick-Kitchell infinity-spinner. The cursor-rowId fix in #612 addressed a real bug but not this one — empirically proven by Patrick still spinning on prod 1.4.1678 (which had #612 installed).

## Root cause: cursor / SQL-column userDate-source mismatch

- **`MainIndexMeta.kt:127-128`** (the writer) projects the SQL \`userDate\` column as:
  ```
  appData.userDate ?: created.milliseconds
  ```
- **`QueryBatch.kt:316`** (the cursor advance) used:
  ```
  UnixTimeUtc(appData.userDate ?: 0L)
  ```

For any row whose \`appData.userDate\` is null in the JSON header — the chat "no version, not edited" branch from older Web/RN clients — the SQL column stores the real \`created\` timestamp (~1.7e12 ms) but the cursor advance wrote \`0L\`. The next fetch's \`WHERE (userDate, rowId) > (0L, lastRowId)\` matched *every* real row (because \`userDate > 0\` is universally true) and \`ORDER BY userDate ASC LIMIT 75\` returned the **oldest** 75 — already in the window. Window stayed the same size, \`hasMore\` stayed true forever, spinner persisted on the bottom.

Patrick's log had dozens of these "no version" rows — that's why the symptom was reliable on his window and absent on other conversations with well-formed \`appData.userDate\` values.

## Fix

Use \`header.sqlUserDateMs()\` so the cursor's userDate matches the SQL projection exactly. One-line change at \`QueryBatch.kt:316\`.

## Empirical proof

Captured this morning in the test class: with the source fix temporarily reverted, the new test fails with:

\`\`\`
[null appData.userDate] page #2 overlaps with page #1:
overlap=[..0065, ..0066, ..0067]
thisPage=[..0065, ..0066, ..0067]
priorPage=[..0065, ..0066, ..0067]
\`\`\`

— same full page-1 fileIds returned on page 2, exact same symptom as Patrick's window staying at 75. With the fix applied: all 10 cursor-advance tests in the class pass.

## Test plan

- [x] New \`queryBatchAsync_oldestFirstUserDate_cursorAdvances_whenAppDataUserDateIsNull\` (homebase-api jvmTest). Seeds 9 rows with \`appData.userDate=null\` and distinct \`created\` timestamps so the SQL column has spread-out timestamps. Paginates 3 at a time, asserts disjoint + exhaustive pages. Tested both ways (revert source → fails; restore → passes).
- [x] Seed helper extended with \`appDataUserDate: Long? = userDate\` so future tests can simulate the null case (SQL column falls back to \`created\`, mirroring real rows). Existing tests unchanged.
- [x] \`./gradlew :homebase-api:jvmTest :homebase-chat:jvmTest compileKotlinIosSimulatorArm64 compileKotlinWasmJs\` — all green.
- [ ] **On device** (after this lands and a new prod build rolls out): Patrick's conversation opens, \`loadNewer\` either grows the window to its real tail or reports \`hasMore=false\` immediately. The bottom spinner disappears within the first fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)