### PR TITLE
fix(vault): stop keyboard from pushing title off-screen in note editor

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/note/VaultNoteEditorScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/note/VaultNoteEditorScreen.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -219,10 +217,11 @@ fun VaultNoteEditorScreen(
                 enter = fadeIn(),
                 exit = fadeOut(),
             ) {
+                val pureImeBottomDp = with(imeState.density) { imeState.pureImeBottomPx.toDp() }
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
-                        .offset { IntOffset(0, -imeState.pureImeBottomPx) },
+                        .padding(bottom = pureImeBottomDp),
                 ) {
                     NoteTitle(
                         title = uiState.title,


### PR DESCRIPTION
## Summary
- The vault note editor used `Modifier.offset` to shift the entire edit-mode column upward by the keyboard height, which pushed the title off-screen on Android when the keyboard opened
- Replaced with `Modifier.padding(bottom = ...)` so the `RichTextEditor` (which has `weight(1f)`) shrinks to make room for the keyboard while the title stays anchored at the top

## Test plan
- [ ] Open Vault → create/edit a note on Android
- [ ] Tap the body field so the keyboard opens
- [ ] Verify the title stays visible at the top
- [ ] Verify the formatting toolbar sits just above the keyboard
- [ ] Repeat on iOS — same behavior expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)