### PR TITLE
fix(vault): fall back to descriptor previewThumbnail in VaultZoomableImage

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultZoomableImage.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultZoomableImage.kt
@@ -59,25 +59,26 @@ fun VaultZoomableImage(
         )
     val localFilePath = (localImage as? LocalAttachmentContext.Image)?.localFilePath
 
-    val pageImageData = remember(file.fileId, descriptor.key, descriptor.iv, descriptor.lastModified) {
-        val payloadIv = descriptor.iv?.let {
-            try {
-                Base64.decode(it)
-            } catch (_: Exception) {
-                null
-            }
-        } ?: return@remember null
-        HomebaseImageData(
-            driveId = file.driveId,
-            fileId = file.fileId,
-            payloadKey = descriptor.key,
-            previewThumbnail = file.previewThumbnail,
-            loadFullPayload = true,
-            lastModified = descriptor.lastModified,
-            isEncrypted = file.isEncrypted,
-            keyHeader = KeyHeader(iv = payloadIv, aesKey = file.keyHeader.aesKey),
-        )
-    }
+    val pageImageData =
+        remember(file.fileId, descriptor.key, descriptor.iv, descriptor.lastModified) {
+            val payloadIv = descriptor.iv?.let {
+                try {
+                    Base64.decode(it)
+                } catch (_: Exception) {
+                    null
+                }
+            } ?: return@remember null
+            HomebaseImageData(
+                driveId = file.driveId,
+                fileId = file.fileId,
+                payloadKey = descriptor.key,
+                previewThumbnail = file.previewThumbnail ?: descriptor.previewThumbnail?.toEmbeddedThumb(),
+                loadFullPayload = true,
+                lastModified = descriptor.lastModified,
+                isEncrypted = file.isEncrypted,
+                keyHeader = KeyHeader(iv = payloadIv, aesKey = file.keyHeader.aesKey),
+            )
+        }
 
     val isPending = descriptor.iv == null
     val zoomState = remember(descriptor.key) { ZoomState() }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultZoomableImage.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultZoomableImage.kt
@@ -72,7 +72,7 @@ fun VaultZoomableImage(
                 driveId = file.driveId,
                 fileId = file.fileId,
                 payloadKey = descriptor.key,
-                previewThumbnail = file.previewThumbnail ?: descriptor.previewThumbnail?.toEmbeddedThumb(),
+                previewThumbnail = descriptor.previewThumbnail?.toEmbeddedThumb() ?: file.previewThumbnail,
                 loadFullPayload = true,
                 lastModified = descriptor.lastModified,
                 isEncrypted = file.isEncrypted,


### PR DESCRIPTION
## Summary
- When `file.previewThumbnail` is null, fall back to `descriptor.previewThumbnail?.toEmbeddedThumb()` so the blur placeholder renders while the full image loads
- Uses the existing `ThumbnailDescriptor.toEmbeddedThumb()` extension instead of manual construction

## Test plan
- [ ] Open Vault gallery and view an image where the file-level preview thumbnail is missing
- [ ] Verify a blurred placeholder appears during load instead of a blank/empty state
- [ ] Verify images with existing file-level thumbnails still work as before