### PR TITLE
feat(image): native HEIC rendering support for AsyncImage

### DIFF
--- a/homebase-api/src/skiaMain/kotlin/id/homebase/api/image/ImageUtil.skia.kt
+++ b/homebase-api/src/skiaMain/kotlin/id/homebase/api/image/ImageUtil.skia.kt
@@ -32,7 +32,10 @@ import org.jetbrains.skia.Surface
  */
 actual fun ByteArray.toImageBitmap(): ImageBitmap? {
     return try {
-        Image.makeFromEncoded(this).toComposeImageBitmap()
+        val inputBytes = if (ImageFormatDetector.isHeic(this)) {
+            convertHeicToJpeg(this) ?: return null
+        } else this
+        Image.makeFromEncoded(inputBytes).toComposeImageBitmap()
     } catch (e: Exception) {
         null
     }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HeicDetection.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HeicDetection.kt
@@ -1,0 +1,22 @@
+package id.homebase.core.image
+
+import coil3.fetch.SourceFetchResult
+import id.homebase.api.lib.image.ImageFormatDetector
+
+/**
+ * Shared HEIC detection for Coil3 [SourceFetchResult]s.
+ * Checks mimeType first (fast), then peeks at the ISOBMFF ftyp header bytes.
+ */
+fun isHeicSource(result: SourceFetchResult): Boolean {
+    if (result.mimeType == "image/heic" || result.mimeType == "image/heif") {
+        return true
+    }
+    return try {
+        val peek = result.source.source().peek()
+        val header = ByteArray(12)
+        if (peek.read(header) < 12) return false
+        ImageFormatDetector.isHeic(header)
+    } catch (_: Exception) {
+        false
+    }
+}

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/image/HeicDecoder.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/image/HeicDecoder.kt
@@ -1,0 +1,85 @@
+package id.homebase.core.image
+
+import co.touchlab.kermit.Logger
+import coil3.ImageLoader
+import coil3.asImage
+import coil3.decode.DecodeResult
+import coil3.decode.DecodeUtils
+import coil3.decode.Decoder
+import coil3.decode.ImageSource
+import coil3.fetch.SourceFetchResult
+import coil3.request.Options
+import coil3.request.maxBitmapSize
+import coil3.size.Precision
+import id.homebase.api.image.convertHeicToJpeg
+import okio.use
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.Canvas
+import org.jetbrains.skia.Image
+import org.jetbrains.skia.Rect
+import org.jetbrains.skia.impl.use
+
+/**
+ * Coil3 Decoder that handles HEIC/HEIF images on Desktop (JVM).
+ * Uses the existing FFmpeg-based convertHeicToJpeg, then decodes the
+ * resulting JPEG via Skia's standard pipeline.
+ */
+class HeicDecoder(
+    private val source: ImageSource,
+    private val options: Options,
+) : Decoder {
+
+    override suspend fun decode(): DecodeResult? {
+        val heicBytes = source.source().use { it.readByteArray() }
+        val jpegBytes = convertHeicToJpeg(heicBytes) ?: return null
+        val image = try {
+            Image.makeFromEncoded(jpegBytes)
+        } catch (e: Exception) {
+            Logger.e(tag = TAG) { "Skia failed to decode converted JPEG (${jpegBytes.size} bytes): ${e.message}" }
+            return null
+        }
+
+        val srcW = image.width
+        val srcH = image.height
+        @OptIn(coil3.annotation.ExperimentalCoilApi::class)
+        val dstSize = DecodeUtils.computeDstSize(srcW, srcH, options.size, options.scale, options.maxBitmapSize)
+        @OptIn(coil3.annotation.ExperimentalCoilApi::class)
+        var multiplier = DecodeUtils.computeSizeMultiplier(srcW, srcH, dstSize.first, dstSize.second, options.scale, options.maxBitmapSize)
+        if (options.precision == Precision.INEXACT) multiplier = multiplier.coerceAtMost(1.0)
+
+        val outW = (multiplier * srcW).toInt()
+        val outH = (multiplier * srcH).toInt()
+
+        val bitmap = Bitmap()
+        if (!bitmap.allocN32Pixels(outW, outH)) {
+            image.close()
+            return null
+        }
+        Canvas(bitmap).use { canvas ->
+            canvas.drawImageRect(
+                image,
+                Rect.makeWH(srcW.toFloat(), srcH.toFloat()),
+                Rect.makeWH(outW.toFloat(), outH.toFloat()),
+            )
+        }
+        bitmap.setImmutable()
+        val isSampled = outW < srcW || outH < srcH
+        image.close()
+        return DecodeResult(image = bitmap.asImage(), isSampled = isSampled)
+    }
+
+    class Factory : Decoder.Factory {
+        override fun create(
+            result: SourceFetchResult,
+            options: Options,
+            imageLoader: ImageLoader,
+        ): Decoder? {
+            if (!isHeicSource(result)) return null
+            return HeicDecoder(result.source, options)
+        }
+    }
+
+    private companion object {
+        private const val TAG = "HeicDecoder"
+    }
+}

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/image/HeicDecoderFactoryTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/image/HeicDecoderFactoryTest.kt
@@ -1,0 +1,123 @@
+package id.homebase.core.image
+
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.decode.ImageSource
+import coil3.fetch.SourceFetchResult
+import coil3.request.Options
+import coil3.decode.DataSource
+import okio.Buffer
+import okio.FileSystem
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class HeicDecoderFactoryTest {
+
+    private val factory = HeicDecoder.Factory()
+    private val options = Options(PlatformContext.INSTANCE)
+    private val imageLoader = ImageLoader.Builder(PlatformContext.INSTANCE).build()
+
+    private fun sourceResult(bytes: ByteArray, mimeType: String? = null): SourceFetchResult {
+        val buffer = Buffer().write(bytes)
+        val source = ImageSource(buffer, FileSystem.SYSTEM)
+        return SourceFetchResult(source, mimeType, DataSource.MEMORY)
+    }
+
+    // --- HEIC by mimeType ---
+
+    @Test
+    fun `factory returns decoder for image-heic mimeType`() {
+        val result = sourceResult(ByteArray(16), mimeType = "image/heic")
+        assertNotNull(factory.create(result, options, imageLoader))
+    }
+
+    @Test
+    fun `factory returns decoder for image-heif mimeType`() {
+        val result = sourceResult(ByteArray(16), mimeType = "image/heif")
+        assertNotNull(factory.create(result, options, imageLoader))
+    }
+
+    // --- HEIC by magic bytes ---
+
+    @Test
+    fun `factory returns decoder for heic ftyp header`() {
+        val header = makeHeicHeader("heic")
+        val result = sourceResult(header, mimeType = null)
+        assertNotNull(factory.create(result, options, imageLoader))
+    }
+
+    @Test
+    fun `factory returns decoder for mif1 ftyp header`() {
+        val header = makeHeicHeader("mif1")
+        val result = sourceResult(header, mimeType = null)
+        assertNotNull(factory.create(result, options, imageLoader))
+    }
+
+    // --- Non-HEIC ---
+
+    @Test
+    fun `factory returns null for image-jpeg mimeType`() {
+        val jpegHeader = byteArrayOf(
+            0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0xE0.toByte(),
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        )
+        val result = sourceResult(jpegHeader, mimeType = "image/jpeg")
+        assertNull(factory.create(result, options, imageLoader))
+    }
+
+    @Test
+    fun `factory returns null for png bytes with no mimeType`() {
+        val pngHeader = byteArrayOf(
+            0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+            0x00, 0x00, 0x00, 0x00,
+        )
+        val result = sourceResult(pngHeader, mimeType = null)
+        assertNull(factory.create(result, options, imageLoader))
+    }
+
+    @Test
+    fun `factory returns null for empty bytes with no mimeType`() {
+        val result = sourceResult(ByteArray(0), mimeType = null)
+        assertNull(factory.create(result, options, imageLoader))
+    }
+
+    @Test
+    fun `factory returns null for mp4 ftyp header`() {
+        val header = makeHeicHeader("mp41")
+        val result = sourceResult(header, mimeType = null)
+        assertNull(factory.create(result, options, imageLoader))
+    }
+
+    // --- isHeicSource shared function ---
+
+    @Test
+    fun `isHeicSource returns true for heic mimeType`() {
+        val result = sourceResult(ByteArray(16), mimeType = "image/heic")
+        assertTrue(isHeicSource(result))
+    }
+
+    @Test
+    fun `isHeicSource returns true for heic ftyp bytes with null mimeType`() {
+        val result = sourceResult(makeHeicHeader("heic"), mimeType = null)
+        assertTrue(isHeicSource(result))
+    }
+
+    @Test
+    fun `isHeicSource returns false for jpeg mimeType`() {
+        val result = sourceResult(ByteArray(16), mimeType = "image/jpeg")
+        assertFalse(isHeicSource(result))
+    }
+
+    private fun makeHeicHeader(brand: String): ByteArray {
+        require(brand.length == 4)
+        val bytes = ByteArray(12)
+        bytes[0] = 0; bytes[1] = 0; bytes[2] = 0; bytes[3] = 12
+        bytes[4] = 0x66; bytes[5] = 0x74; bytes[6] = 0x79; bytes[7] = 0x70
+        val b = brand.toByteArray(Charsets.US_ASCII)
+        bytes[8] = b[0]; bytes[9] = b[1]; bytes[10] = b[2]; bytes[11] = b[3]
+        return bytes
+    }
+}

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/image/HeicDecoder.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/image/HeicDecoder.kt
@@ -1,0 +1,76 @@
+package id.homebase.core.image
+
+import coil3.ImageLoader
+import coil3.asImage
+import coil3.decode.DecodeResult
+import coil3.decode.DecodeUtils
+import coil3.decode.Decoder
+import coil3.decode.ImageSource
+import coil3.fetch.SourceFetchResult
+import coil3.request.Options
+import coil3.request.maxBitmapSize
+import coil3.size.Precision
+import okio.use
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.Canvas
+import org.jetbrains.skia.Rect
+import org.jetbrains.skia.impl.use
+
+/**
+ * Coil3 Decoder that handles HEIC/HEIF images on iOS by decoding them
+ * through native UIImage APIs instead of Skia's makeFromEncoded (which
+ * does not support HEIC).
+ *
+ * Register before SkiaImageDecoder so it gets first crack at HEIC sources.
+ */
+class HeicDecoder(
+    private val source: ImageSource,
+    private val options: Options,
+) : Decoder {
+
+    override suspend fun decode(): DecodeResult? {
+        val bytes = source.source().use { it.readByteArray() }
+        val image = NativeImageDecoder.decode(bytes) ?: return null
+
+        val srcW = image.width
+        val srcH = image.height
+        @OptIn(coil3.annotation.ExperimentalCoilApi::class)
+        val dstSize = DecodeUtils.computeDstSize(srcW, srcH, options.size, options.scale, options.maxBitmapSize)
+        @OptIn(coil3.annotation.ExperimentalCoilApi::class)
+        var multiplier = DecodeUtils.computeSizeMultiplier(
+            srcW, srcH, dstSize.first, dstSize.second, options.scale, options.maxBitmapSize,
+        )
+        if (options.precision == Precision.INEXACT) multiplier = multiplier.coerceAtMost(1.0)
+
+        val outW = (multiplier * srcW).toInt()
+        val outH = (multiplier * srcH).toInt()
+
+        val bitmap = Bitmap()
+        if (!bitmap.allocN32Pixels(outW, outH)) {
+            image.close()
+            return null
+        }
+        Canvas(bitmap).use { canvas ->
+            canvas.drawImageRect(
+                image,
+                Rect.makeWH(srcW.toFloat(), srcH.toFloat()),
+                Rect.makeWH(outW.toFloat(), outH.toFloat()),
+            )
+        }
+        bitmap.setImmutable()
+        val isSampled = outW < srcW || outH < srcH
+        image.close()
+        return DecodeResult(image = bitmap.asImage(), isSampled = isSampled)
+    }
+
+    class Factory : Decoder.Factory {
+        override fun create(
+            result: SourceFetchResult,
+            options: Options,
+            imageLoader: ImageLoader,
+        ): Decoder? {
+            if (!isHeicSource(result)) return null
+            return HeicDecoder(result.source, options)
+        }
+    }
+}

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/image/NativeBitmapInfo.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/image/NativeBitmapInfo.kt
@@ -1,0 +1,5 @@
+package id.homebase.core.image
+
+// kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little → BGRA in memory.
+// Used by NativeImageDecoder and PdfRenderer when blitting into Skia via CGBitmapContext.
+val CG_BGRA_PREMUL_BITMAP_INFO: UInt = 2u or 8192u

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/image/NativeImageDecoder.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/image/NativeImageDecoder.kt
@@ -1,0 +1,100 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package id.homebase.core.image
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import kotlinx.cinterop.useContents
+import org.jetbrains.skia.ColorAlphaType
+import org.jetbrains.skia.ColorType
+import org.jetbrains.skia.ImageInfo
+import platform.CoreGraphics.CGBitmapContextCreate
+import platform.CoreGraphics.CGColorSpaceCreateDeviceRGB
+import platform.CoreGraphics.CGColorSpaceRelease
+import platform.CoreGraphics.CGContextRelease
+import platform.CoreGraphics.CGContextScaleCTM
+import platform.CoreGraphics.CGContextTranslateCTM
+import platform.CoreGraphics.CGRectMake
+import platform.Foundation.NSData
+import platform.Foundation.dataWithBytes
+import platform.UIKit.UIGraphicsPopContext
+import platform.UIKit.UIGraphicsPushContext
+import platform.UIKit.UIImage
+import org.jetbrains.skia.Image as SkiaImage
+
+/**
+ * Decodes image bytes (including HEIC/HEIF) to a Skia Image using iOS native APIs.
+ *
+ * Pipeline: ByteArray → NSData → UIImage → CGBitmapContext (BGRA) → Skia Image.
+ * UIImage.drawInRect applies EXIF orientation automatically, so the returned
+ * image is always orientation-normalized. No intermediate JPEG encoding.
+ *
+ * Follows the same CGBitmapContext → Skia pixel pattern used by PdfRenderer.
+ */
+object NativeImageDecoder {
+
+    // Max pixel buffer size to prevent Int overflow in bytesPerRow * height.
+    // ~512 MP (e.g. 23170×23170) — well above any real camera output.
+    private const val MAX_PIXEL_BYTES = Int.MAX_VALUE.toLong()
+
+    fun decode(imageBytes: ByteArray): SkiaImage? {
+        val nsData = imageBytes.usePinned { pinned ->
+            NSData.dataWithBytes(pinned.addressOf(0), imageBytes.size.toULong())
+        }
+        return decode(nsData)
+    }
+
+    fun decode(nsData: NSData): SkiaImage? {
+        val uiImage = UIImage.imageWithData(nsData) ?: return null
+        return decodeUIImage(uiImage)
+    }
+
+    fun decodeUIImage(uiImage: UIImage): SkiaImage? {
+        val width: Int
+        val height: Int
+        uiImage.size.useContents {
+            width = (this.width * uiImage.scale).toInt()
+            height = (this.height * uiImage.scale).toInt()
+        }
+        if (width <= 0 || height <= 0) return null
+
+        val bytesPerRow = width.toLong() * 4
+        if (bytesPerRow * height.toLong() > MAX_PIXEL_BYTES) return null
+        val pixelData = ByteArray(bytesPerRow.toInt() * height)
+
+        val colorSpace = CGColorSpaceCreateDeviceRGB()
+        try {
+            pixelData.usePinned { pinned ->
+                val context = CGBitmapContextCreate(
+                    data = pinned.addressOf(0),
+                    width = width.toULong(),
+                    height = height.toULong(),
+                    bitsPerComponent = 8u,
+                    bytesPerRow = bytesPerRow.toULong(),
+                    space = colorSpace,
+                    bitmapInfo = CG_BGRA_PREMUL_BITMAP_INFO,
+                ) ?: return null
+
+                // CG uses bottom-left origin; flip to UIKit's top-left convention
+                // so UIImage.drawInRect applies orientation correctly
+                CGContextTranslateCTM(context, 0.0, height.toDouble())
+                CGContextScaleCTM(context, 1.0, -1.0)
+
+                UIGraphicsPushContext(context)
+                uiImage.drawInRect(CGRectMake(0.0, 0.0, width.toDouble(), height.toDouble()))
+                UIGraphicsPopContext()
+
+                CGContextRelease(context)
+            }
+        } finally {
+            CGColorSpaceRelease(colorSpace)
+        }
+
+        return SkiaImage.makeRaster(
+            imageInfo = ImageInfo(width, height, ColorType.BGRA_8888, ColorAlphaType.PREMUL),
+            bytes = pixelData,
+            rowBytes = bytesPerRow.toInt(),
+        )
+    }
+}

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/image/NativeImageDecoder.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/image/NativeImageDecoder.kt
@@ -39,6 +39,8 @@ object NativeImageDecoder {
     private const val MAX_PIXEL_BYTES = Int.MAX_VALUE.toLong()
 
     fun decode(imageBytes: ByteArray): SkiaImage? {
+        if (imageBytes.isEmpty()) return null
+
         val nsData = imageBytes.usePinned { pinned ->
             NSData.dataWithBytes(pinned.addressOf(0), imageBytes.size.toULong())
         }

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/image/PHAssetFetcher.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/image/PHAssetFetcher.kt
@@ -1,7 +1,5 @@
 package id.homebase.core.image
 
-import androidx.compose.ui.graphics.asSkiaBitmap
-import androidx.compose.ui.graphics.toComposeImageBitmap
 import coil3.ImageLoader
 import coil3.Uri
 import coil3.asImage
@@ -11,11 +9,15 @@ import coil3.fetch.Fetcher
 import coil3.fetch.ImageFetchResult
 import coil3.request.Options
 import coil3.size.Dimension
+import id.homebase.api.lib.image.ImageFormatDetector
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.usePinned
 import kotlinx.coroutines.suspendCancellableCoroutine
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.Canvas
+import org.jetbrains.skia.impl.use
 import platform.CoreGraphics.CGSizeMake
 import platform.Foundation.NSData
 import platform.Photos.PHAsset
@@ -124,14 +126,36 @@ class PHAssetFetcher(
 
     @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
     private fun imageFromNSData(nsData: NSData): FetchResult {
-        val bytes = ByteArray(nsData.length.toInt())
-        bytes.usePinned { pinned ->
-            memcpy(pinned.addressOf(0), nsData.bytes, nsData.length)
+        // Peek at header to detect HEIC without copying the full image
+        val header = ByteArray(minOf(12, nsData.length.toInt()))
+        if (header.isNotEmpty()) {
+            header.usePinned { pinned ->
+                memcpy(pinned.addressOf(0), nsData.bytes, header.size.toULong())
+            }
         }
-        val skiaImage = org.jetbrains.skia.Image.makeFromEncoded(bytes)
-        val imageBitmap = skiaImage.toComposeImageBitmap()
+
+        val skiaImage = if (ImageFormatDetector.isHeic(header)) {
+            NativeImageDecoder.decode(nsData)
+                ?: throw IllegalStateException("Failed to decode HEIC image via native decoder")
+        } else {
+            val bytes = ByteArray(nsData.length.toInt())
+            bytes.usePinned { pinned ->
+                memcpy(pinned.addressOf(0), nsData.bytes, nsData.length)
+            }
+            org.jetbrains.skia.Image.makeFromEncoded(bytes)
+        }
+
+        val bitmap = Bitmap()
+        if (!bitmap.allocN32Pixels(skiaImage.width, skiaImage.height)) {
+            skiaImage.close()
+            throw IllegalStateException("Failed to allocate bitmap for ${skiaImage.width}x${skiaImage.height} image")
+        }
+        Canvas(bitmap).use { canvas -> canvas.drawImage(skiaImage, 0f, 0f) }
+        bitmap.setImmutable()
+        skiaImage.close()
+
         return ImageFetchResult(
-            image = imageBitmap.asSkiaBitmap().asImage(),
+            image = bitmap.asImage(),
             isSampled = false,
             dataSource = DataSource.DISK,
         )

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfConstants.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/pdf/PdfConstants.kt
@@ -1,4 +1,5 @@
 package id.homebase.core.pdf
 
-// kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little → BGRA in memory
-internal val PDF_BITMAP_INFO: UInt = 2u or 8192u
+import id.homebase.core.image.CG_BGRA_PREMUL_BITMAP_INFO
+
+internal val PDF_BITMAP_INFO: UInt = CG_BGRA_PREMUL_BITMAP_INFO

--- a/homebase-core/src/jvmMain/kotlin/id/homebase/core/di/AppModule.desktop.kt
+++ b/homebase-core/src/jvmMain/kotlin/id/homebase/core/di/AppModule.desktop.kt
@@ -20,6 +20,7 @@ import id.homebase.core.audio.JvmWaveFormGenerator
 import id.homebase.core.gallery.GalleryCache
 import id.homebase.core.gallery.JvmGalleryManager
 import id.homebase.core.gallery.PlatformGalleryManager
+import id.homebase.core.image.HeicDecoder
 import id.homebase.core.image.HomebaseImageFetcher
 import id.homebase.core.image.HomebaseImageKeyer
 import id.homebase.core.image.PublicImageFetcher
@@ -69,6 +70,7 @@ actual fun platformModule(): Module = module {
                     add(HomebaseImageFetcher.Factory(get(), get()))
                     add(PublicImageFetcher.Factory(get()))
                     add(PlatformFileFetcher.Factory())
+                    add(HeicDecoder.Factory())
                 }
                 .diskCache(null)
                 .build()

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/di/AppModule.native.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/di/AppModule.native.kt
@@ -21,6 +21,7 @@ import id.homebase.core.gallery.GalleryCache
 import id.homebase.core.gallery.IOSGalleryLibraryObserver
 import id.homebase.core.gallery.IOSGalleryManager
 import id.homebase.core.gallery.PlatformGalleryManager
+import id.homebase.core.image.HeicDecoder
 import id.homebase.core.image.HomebaseImageFetcher
 import id.homebase.core.image.HomebaseImageKeyer
 import id.homebase.core.image.PHAssetFetcher
@@ -62,6 +63,7 @@ actual fun platformModule(): Module = module {
                     add(HomebaseImageFetcher.Factory(get(), get()))
                     add(PublicImageFetcher.Factory(get()))
                     add(PlatformFileFetcher.Factory())
+                    add(HeicDecoder.Factory())
                 }
                 .diskCache(null)
                 .build()


### PR DESCRIPTION
## Summary
- **iOS**: Decodes HEIC directly via `UIImage → CGBitmapContext → Skia` pixel buffer — no JPEG conversion, orientation-normalized
- **Desktop**: Uses existing FFmpeg-based `convertHeicToJpeg` + Skia decode
- **Android**: No changes needed — `BitmapFactory` handles HEIC natively on API 28+
- Fixes `PHAssetFetcher` which was passing raw HEIC bytes to `Image.makeFromEncoded()` (silently fails)
- Adds HEIC detection to `ByteArray.toImageBitmap()` in skiaMain as a safety net

## Files changed (11)
| File | What |
|------|------|
| `NativeImageDecoder.kt` | **New.** UIImage→CGBitmapContext→Skia with overflow guard |
| `HeicDecoder.kt` (native) | **New.** Coil3 Decoder for iOS with Options.size downsampling |
| `HeicDecoder.kt` (jvm) | **New.** Coil3 Decoder for Desktop via FFmpeg |
| `HeicDetection.kt` | **New.** Shared `isHeicSource()` for SourceFetchResult |
| `NativeBitmapInfo.kt` | **New.** Shared CG BGRA bitmap info constant |
| `HeicDecoderFactoryTest.kt` | **New.** 11 tests for factory + detection |
| `PHAssetFetcher.kt` | Fixed HEIC path, eliminated double memcpy |
| `ImageUtil.skia.kt` | Added HEIC detection to `toImageBitmap()` |
| `PdfConstants.kt` | References shared BGRA constant |
| `AppModule.native.kt` | Registers HeicDecoder |
| `AppModule.desktop.kt` | Registers HeicDecoder |

## Test plan
- [x] JVM tests pass (`homebase-common:jvmTest`, `homebase-api:jvmTest`)
- [x] iOS compiles (`compileKotlinIosSimulatorArm64`)
- [x] Desktop compiles (`homebase-core:compileKotlinJvm`)
- [ ] Test on iPhone: open HEIC photo from camera roll via PHAsset picker
- [ ] Test on iPhone: receive HEIC image in chat, view in full-screen viewer
- [ ] Test on Desktop: open HEIC file (requires FFmpeg installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)