### PR TITLE
Truly headless FCM background sync + credentials race fix

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
@@ -22,6 +22,7 @@ import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.youauth.YouAuthFlowManager
 import id.homebase.core.App
+import id.homebase.core.auth.AuthConnectionCoordinator
 import id.homebase.core.notifications.NotificationEntry
 import id.homebase.core.notifications.NotificationIntentDecision
 import id.homebase.core.notifications.NotificationNavigationEvent
@@ -46,6 +47,7 @@ class MainActivity : AppCompatActivity() {
     private val notificationService: NotificationService by inject()
     private val notificationEntry: NotificationEntry by inject()
     private val eventBus: EventBus by inject()
+    private val authConnectionCoordinator: AuthConnectionCoordinator by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
@@ -55,6 +57,12 @@ class MainActivity : AppCompatActivity() {
         // opens it). The gap from here to "App() first composition" is the real
         // user-perceived cold start. See StartupLogger.
         StartupLogger.checkpoint("activity onCreate start")
+
+        // Promote AuthCC out of headless mode — this is the first reliable signal
+        // that the user is looking at the UI (FCM-cold-wake doesn't reach here).
+        // Idempotent; safe across Activity recreation. See AuthCC.promoteToForeground.
+        authConnectionCoordinator.promoteToForeground()
+
         handleIntent(intent)
 
         ActivityProvider.initialize(this)

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlin.concurrent.Volatile
 import kotlin.uuid.Uuid
 
 class AuthConnectionCoordinator(

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -68,6 +68,33 @@ class AuthConnectionCoordinator(
     private val _connectionState = MutableStateFlow(AuthConnectionState())
     val connectionState: StateFlow<AuthConnectionState> = _connectionState.asStateFlow()
 
+    // region Headless mode — FCM-cold-wake suppression of foreground-only work.
+    //
+    // On Android (and iOS) the process is woken for FCM data messages before
+    // the user is looking at the UI. Application init + Koin spin-up means
+    // [onAuthStateChanged] still fires Authenticated, but for a headless
+    // wake-up we should NOT open the WebSocket, run [onPostAuthenticated]'s
+    // UI preload, start the registry observer, or load the profile.
+    // [BackgroundSyncOrchestrator.syncIfAuthenticated] only needs the
+    // drive mounts and registry bootstrap to do its QueryBatch.
+    //
+    // [headless] starts true. The first foreground entry point
+    // ([MainActivity.onCreate] on Android, `MainViewController()` on iOS)
+    // calls [promoteToForeground], which flips the flag and replays the
+    // deferred work if Authenticated already fired during the headless
+    // window. If Authenticated hasn't fired yet, the next Authenticated
+    // observes !headless and runs the full sequence.
+    @Volatile private var headless: Boolean = true
+
+    /**
+     * Captured drives from the Authenticated branch's bootstrap step, so
+     * [promoteToForeground] can replay [connect]/[driveRegistry.start] with
+     * the same drive list the headless Authenticated branch already
+     * mounted. Null until the first Authenticated lands.
+     */
+    @Volatile private var lastAuthenticatedDrives: List<LabeledDrive>? = null
+    // endregion
+
     /**
      * True when the WebSocket is connected AND the server handshake has completed
      * successfully. This is the canonical online check — use this instead of reading
@@ -111,18 +138,26 @@ class AuthConnectionCoordinator(
         logLifecycleSnapshot("onAuthStateChanged:${state::class.simpleName}")
         when (state) {
             is YouAuthState.Authenticated -> {
-                onPostAuthenticated()
+                // Foreground-only UI preload — see kdoc on [headless]. Runs FIRST in
+                // foreground mode (matches pre-headless-mode ordering: preload starts
+                // local-DB warmups while drive mount + WS handshake happen in
+                // parallel). Deferred to [promoteToForeground] in headless mode.
+                if (!headless) {
+                    onPostAuthenticated()
+                }
 
                 // Mount mandatory drives FIRST — before bootstrap, before any network I/O.
                 // Encodes the invariant that this app's sync engine always syncs these
                 // drives; nothing about the WS handshake or the registry should be able to
                 // prevent them from appearing in driveStatuses.
+                // Unconditional: BG sync's syncAll() needs the drives mounted.
                 driveSyncManager.ensureMandatoryMounted()
 
                 // Resolve the cross-device registry: local DB on cold boot (free), or one
                 // targeted server fetch on fresh login. Either way we have the canonical
                 // list before opening the WebSocket, so the first WS connect already
                 // subscribes to the full set — no late observer-driven reconnect.
+                // Unconditional: BG sync's syncAll() needs the drive list.
                 val initialDrives = driveRegistry.bootstrap()
                 // Pre-mount optional drives so they're in driveSyncs when
                 // onConnected fires start() + syncAll(). mountDrive() defers
@@ -132,6 +167,18 @@ class AuthConnectionCoordinator(
                     driveSyncManager.mountDrive(drive.drive.alias, drive.label)
                 }
                 logLifecycleSnapshot("drives mounted")
+
+                // Stash for [promoteToForeground] replay if we're headless.
+                lastAuthenticatedDrives = initialDrives
+
+                if (headless) {
+                    Logger.i(tag = "AuthLifecycle") {
+                        "AuthCC: Authenticated branch — mode=headless " +
+                            "deferred=[onPostAuthenticated, connect, driveRegistry.start, loadProfile]"
+                    }
+                    return
+                }
+
                 connect(extraDrives = initialDrives)
                 // Observe cross-device registry changes. We seed the diff baseline with the
                 // bootstrap result so the chat-drive sync that later writes the same file
@@ -164,6 +211,52 @@ class AuthConnectionCoordinator(
             else -> {
                 disconnect()
             }
+        }
+    }
+
+    /**
+     * Flip out of headless mode and run any deferred foreground-only work
+     * (`onPostAuthenticated`, `connect`, `driveRegistry.start`,
+     * `loadProfile`) that the headless [onAuthStateChanged] branch skipped.
+     *
+     * Called by the first foreground entry point per process —
+     * `MainActivity.onCreate` on Android, `MainViewController()` on iOS.
+     * Both fire only on actual UI launch (FCM cold-wake doesn't trigger
+     * either), which is exactly the signal we want.
+     *
+     * Idempotent: safe on Activity recreation (config change, return from
+     * background) and on multiple iOS view-controller creates. Non-suspend
+     * for caller ergonomics — the actual replay runs on the AuthCC scope.
+     */
+    fun promoteToForeground() {
+        if (!headless) {
+            Logger.d(tag = "AuthLifecycle") {
+                "AuthCC: promoteToForeground() — already foreground, no-op"
+            }
+            return
+        }
+        headless = false
+        val drives = lastAuthenticatedDrives
+        if (drives == null) {
+            Logger.i(tag = "AuthLifecycle") {
+                "AuthCC: promoteToForeground() — flipped to foreground; auth not yet resolved, " +
+                    "deferred work will run on the next Authenticated"
+            }
+            return
+        }
+        Logger.i(tag = "AuthLifecycle") {
+            "AuthCC: promoteToForeground() — running deferred=[onPostAuthenticated, connect, " +
+                "driveRegistry.start, loadProfile]"
+        }
+        scope.launch {
+            onPostAuthenticated()
+            connect(extraDrives = drives)
+            driveRegistry.start(
+                onMount = { drive -> mountDrive(drive, persist = false) },
+                onUnmount = { driveId -> unmountDrive(driveId, persist = false) },
+                initialBaseline = drives.mapTo(HashSet()) { it.drive.alias },
+            )
+            loadProfile()
         }
     }
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/BackgroundSyncOrchestrator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/BackgroundSyncOrchestrator.kt
@@ -4,21 +4,51 @@ import co.touchlab.kermit.Logger
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.drives.files.DriveFileHttpProvider
 import id.homebase.api.sync.DriveSyncManager
+import id.homebase.api.youauth.YouAuthState
 import id.homebase.core.auth.AuthConnectionCoordinator
 import id.homebase.core.config.chatTargetDrive
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.mp.KoinPlatformTools
+import kotlin.time.Duration.Companion.seconds
 
+/**
+ * @param authState narrow seam onto [id.homebase.api.youauth.YouAuthFlowManager.authState].
+ *   Taken as a `StateFlow<YouAuthState>` (not the whole manager) so the
+ *   credential-race fix is unit-testable without constructing a real
+ *   YouAuthFlowManager and its DriveSyncManager / HttpClient deps.
+ */
 class BackgroundSyncOrchestrator(
     private val credentialsManager: CredentialsManager,
     private val driveSyncManager: DriveSyncManager,
     @Suppress("unused") private val driveFileHttpProvider: DriveFileHttpProvider,
     private val authConnectionCoordinator: AuthConnectionCoordinator,
+    private val authState: StateFlow<YouAuthState>,
 ) {
     suspend fun syncIfAuthenticated(): SyncOutcome {
         Logger.d(tag = "BackgroundSync") { "syncIfAuthenticated: checking..." }
+
+        // Close the ~12 ms FCM-vs-credentials-restore race observed in the wild
+        // (see [awaitAuthRestored] kdoc for the full mechanism).
+        val initialState = authState.value
+        val resolved = awaitAuthRestored(authState, AUTH_RESTORE_TIMEOUT)
+        if (resolved == null) {
+            Logger.w(tag = "BackgroundSync") {
+                "syncIfAuthenticated: auth state still Initializing after " +
+                    "${AUTH_RESTORE_TIMEOUT.inWholeSeconds}s — skipping"
+            }
+            return SyncOutcome.NoCredentials
+        }
+        if (initialState is YouAuthState.Initializing) {
+            Logger.i(tag = "BackgroundSync") {
+                "syncIfAuthenticated: awaited credentials restoration — resolved to ${resolved::class.simpleName}"
+            }
+        }
+
         if (!credentialsManager.hasActiveCredentials()) {
             Logger.i(tag = "BackgroundSync") { "syncIfAuthenticated: no credentials, skipping" }
             return SyncOutcome.NoCredentials
@@ -70,6 +100,14 @@ class BackgroundSyncOrchestrator(
     }
 
     companion object {
+        /**
+         * Bound to the observed FCM credential-restore race window with comfortable
+         * headroom: in the homebase.log capture the restoration completed in ~12 ms;
+         * we use 2 s so a slow-disk or contended-Koin-init case still resolves
+         * cleanly, while staying well under the WorkManager job's overall budget.
+         */
+        private val AUTH_RESTORE_TIMEOUT = 2.seconds
+
         fun fromKoin(): BackgroundSyncOrchestrator = KoinPlatformTools.defaultContext().get().get()
     }
 }
@@ -78,4 +116,32 @@ sealed interface SyncOutcome {
     data object Success : SyncOutcome
     data object NoCredentials : SyncOutcome
     data class Failed(val cause: Throwable) : SyncOutcome
+}
+
+/**
+ * Waits for [authState] to leave [YouAuthState.Initializing] within [timeout].
+ *
+ * Closes the FCM-cold-wake credential-restore race:
+ * `YouAuthFlowManager.restoreSession()` runs asynchronously on
+ * construction, so the in-memory credentials don't exist until its disk
+ * I/O completes. An FCM-driven `BackgroundSyncOrchestrator.syncIfAuthenticated()`
+ * call can otherwise lose a ~12 ms race and incorrectly decide
+ * "no credentials, skipping" while restoration is in flight (observed in
+ * homebase.log on 2026-06-01).
+ *
+ * Returns the resolved [YouAuthState] (Authenticated, Unauthenticated,
+ * Authenticating, or Error) on success, or `null` if the wait hit
+ * [timeout]. A `null` return implies a wedged restoration; callers should
+ * treat it as a "skip" rather than retrying without a bound.
+ *
+ * Extracted as a top-level function so it's unit-testable with virtual
+ * time (`kotlinx.coroutines.test.runTest`) without constructing
+ * `DriveSyncManager`, `AuthConnectionCoordinator`, and the rest of
+ * `BackgroundSyncOrchestrator`'s heavy dependency graph.
+ */
+internal suspend fun awaitAuthRestored(
+    authState: StateFlow<YouAuthState>,
+    timeout: kotlin.time.Duration,
+): YouAuthState? = withTimeoutOrNull(timeout) {
+    authState.first { it !is YouAuthState.Initializing }
 }

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/sync/AwaitAuthRestoredTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/sync/AwaitAuthRestoredTest.kt
@@ -1,0 +1,111 @@
+package id.homebase.core.sync
+
+import id.homebase.api.youauth.YouAuthState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Locks down the [awaitAuthRestored] helper that backs the FCM
+ * credential-restore race fix in [BackgroundSyncOrchestrator].
+ *
+ * Background: on FCM cold-wake, `YouAuthFlowManager.restoreSession()`
+ * runs asynchronously and stamps credentials only after disk I/O. Prior
+ * to the fix, `syncIfAuthenticated` lost a ~12 ms race against that
+ * restoration and silently bailed with "no credentials, skipping",
+ * preventing the BG sync from running for a foreground-killed app.
+ *
+ * The helper waits for `authState` to leave `Initializing` with a
+ * timeout. These tests use virtual time so they run instantly and stay
+ * deterministic.
+ */
+class AwaitAuthRestoredTest {
+
+    private val authenticated =
+        YouAuthState.Authenticated(
+            identity = id.homebase.api.common.OdinId("test.example.com"),
+            clientAuthToken = "tok",
+            sharedSecret = "sec",
+        )
+
+    @Test
+    fun returnsImmediately_whenAlreadyResolved() = runTest {
+        // No race — authState was already populated by the time we asked.
+        val authState = MutableStateFlow<YouAuthState>(authenticated)
+
+        val resolved = awaitAuthRestored(authState, 2.seconds)
+
+        assertNotNull(resolved)
+        assertSame(authenticated, resolved)
+    }
+
+    @Test
+    fun returnsImmediately_whenAlreadyUnauthenticated() = runTest {
+        // Logged-out cold-wake still resolves — caller will then short-circuit
+        // on hasActiveCredentials(). The point is we don't hang.
+        val authState = MutableStateFlow<YouAuthState>(YouAuthState.Unauthenticated)
+
+        val resolved = awaitAuthRestored(authState, 2.seconds)
+
+        assertEquals(YouAuthState.Unauthenticated, resolved)
+    }
+
+    @Test
+    fun awaits_whenInitializing_thenResolvesAfterTransition() = runTest {
+        // The exact scenario from homebase.log 2026-06-01: a tight race where
+        // authState is still Initializing at the call site, then flips
+        // ~12 ms later as restoreSession() completes.
+        val authState = MutableStateFlow<YouAuthState>(YouAuthState.Initializing)
+
+        val job = launch {
+            val resolved = awaitAuthRestored(authState, 2.seconds)
+            assertNotNull(resolved, "should resolve once authState leaves Initializing")
+            assertSame(authenticated, resolved)
+        }
+
+        // Simulate the disk restoration completing after a short delay,
+        // well inside the timeout.
+        launch {
+            kotlinx.coroutines.delay(12.milliseconds)
+            authState.value = authenticated
+        }
+
+        job.join()
+    }
+
+    @Test
+    fun timesOut_whenStaysInitializing() = runTest {
+        // Wedged restoration — credentials never arrive within the budget.
+        // The helper must return null so the caller can treat it as a skip
+        // (and not hang the WorkManager job).
+        val authState = MutableStateFlow<YouAuthState>(YouAuthState.Initializing)
+
+        val resolved = awaitAuthRestored(authState, 2.seconds)
+
+        assertNull(resolved, "must return null on timeout, not hang")
+    }
+
+    @Test
+    fun timesOut_whenResolutionRacesPastDeadline() = runTest {
+        // Resolution arrives JUST after the timeout — must still be treated
+        // as a timeout. Guards against an off-by-one where a state change at
+        // exactly `timeout` would be picked up.
+        val authState = MutableStateFlow<YouAuthState>(YouAuthState.Initializing)
+
+        launch {
+            kotlinx.coroutines.delay(3.seconds)
+            authState.value = authenticated
+        }
+
+        val resolved = awaitAuthRestored(authState, 2.seconds)
+
+        assertNull(resolved)
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -296,7 +296,17 @@ val appModule = module {
             }
         )
     }
-    singleOf(::BackgroundSyncOrchestrator)
+    single {
+        BackgroundSyncOrchestrator(
+            credentialsManager = get(),
+            driveSyncManager = get(),
+            driveFileHttpProvider = get(),
+            authConnectionCoordinator = get(),
+            // Narrow seam — pass the StateFlow, not the whole YouAuthFlowManager.
+            // See BackgroundSyncOrchestrator's class kdoc.
+            authState = get<id.homebase.api.youauth.YouAuthFlowManager>().authState,
+        )
+    }
 
     factoryOf(::PayloadBundleEncryptionService) bind PayloadBundleEncryptor::class
     factoryOf(::OptimisticWriter)

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/MainViewController.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/MainViewController.kt
@@ -84,6 +84,15 @@ fun initializeApp() {
 @OptIn(ExperimentalForeignApi::class)
 fun MainViewController(): UIViewController {
     initializeApp()
+    // Promote AuthCC out of headless mode — this is the iOS analogue of
+    // Android's MainActivity.onCreate: it fires only when SwiftUI actually
+    // presents the UI (ContentView.body builds ComposeView, which calls
+    // makeUIViewController). FCM background-fetch wake-ups don't reach
+    // here, so headless work stays headless. Idempotent. See
+    // AuthConnectionCoordinator.promoteToForeground.
+    val authCC: id.homebase.core.auth.AuthConnectionCoordinator =
+        org.koin.mp.KoinPlatformTools.defaultContext().get().get()
+    authCC.promoteToForeground()
     val controller = ComposeUIViewController { App() }
     MainViewControllerRef.instance = controller
     return controller

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/MainViewController.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/MainViewController.kt
@@ -1,3 +1,17 @@
+/*
+ * iOS-only — despite the platform-neutral filename.
+ *
+ * Lives in `homebase-core/src/nativeMain/` because iOS's app shell is Swift
+ * (`iosApp/`) rather than its own Kotlin module — there's no `iosApp` Kotlin
+ * counterpart to Android's `androidApp/` Gradle module, so the Kotlin entry
+ * point Swift calls into has to live in this multiplatform module's iOS
+ * source set. The `nativeMain` source set in this project is wired to
+ * iOS targets only (per CLAUDE.md "KMP Source Set Convention").
+ *
+ * Swift entry: `iosApp/iosApp/ContentView.swift` ->
+ * `MainViewControllerKt.MainViewController()` (the wrapper class name comes
+ * from this file's name, so renaming the file requires updating Swift).
+ */
 package id.homebase.core
 
 import androidx.compose.ui.window.ComposeUIViewController


### PR DESCRIPTION
## Summary

Two fixes to the FCM cold-wake path on Android (and the equivalent iOS path):

- **Credentials race** — `BackgroundSyncOrchestrator.syncIfAuthenticated()` lost a ~12 ms race against `YouAuthFlowManager.restoreSession()` on FCM cold-wake and bailed with `no credentials, skipping`. Now it awaits `authState` leaving `Initializing` with a 2 s timeout.
- **Headless mode** — process-wake from FCM brought up the full session (WS handshake, profile load, UI preload) as a side effect of Application init / Koin / AuthCC. None of that is needed for BG-sync's QueryBatch contract. AuthCC now starts headless; the first foreground entry point (`MainActivity.onCreate` on Android, `MainViewController()` on iOS) calls `promoteToForeground()` to flip mode and replay deferred work.

## Background

While diagnosing an asymmetric unread-badge bug, the captured `homebase.log` showed an FCM-cold-wake bringing the WebSocket up, then `syncIfAuthenticated` skipping with `WS online — skipping (WS handles sync)`. The skip was correct given the in-process WS was up — but the WS shouldn't have been up for a pure FCM wake-up in the first place. The breadcrumbs in `NotificationEntry.kt` and `BackgroundSyncOrchestrator.kt` confirmed the design intent was lightweight QB-only. The seam missing was on the `AuthCC.onAuthStateChanged` side.

The earlier capture also showed `BackgroundSync: no credentials, skipping` firing 12 ms before `onAuthStateChanged(Authenticated)` — credentials were on disk, but `YouAuthFlowManager.restoreSession()` runs asynchronously and the FCM handler beat it.

## What changed

### `BackgroundSyncOrchestrator`
- New `awaitAuthRestored(authState, timeout)` top-level helper that returns the resolved `YouAuthState` or `null` on timeout. Extracted as a pure function so it's unit-testable with virtual time — no need to construct the full `BackgroundSyncOrchestrator` and its `DriveSyncManager` / `AuthConnectionCoordinator` graph.
- `syncIfAuthenticated()` awaits the helper before checking `hasActiveCredentials()`. Two new log lines: `awaited credentials restoration — resolved to X` (race was hit) and `auth state still Initializing after 2s — skipping` (wedged).
- Constructor now takes a `StateFlow<YouAuthState>` directly instead of the full `YouAuthFlowManager` — narrowest possible seam, easiest to test.

### `AuthConnectionCoordinator`
- New `@Volatile headless: Boolean = true` and `lastAuthenticatedDrives` fields.
- `onAuthStateChanged(Authenticated)` always runs `ensureMandatoryMounted` + `driveRegistry.bootstrap` + the mount loop (BG sync needs these). In headless mode it skips `onPostAuthenticated`, `connect`, `driveRegistry.start`, and `loadProfile`, and logs the decision.
- New `promoteToForeground()` (non-suspend, idempotent) flips out of headless and replays the deferred work on the AuthCC scope. Three log branches make the lifecycle traceable.

### Foreground entry points
- `MainActivity.onCreate` (Android) — injects `AuthConnectionCoordinator` and calls `promoteToForeground()` at the top.
- `MainViewController.kt` (iOS) — resolves AuthCC via Koin and calls `promoteToForeground()` after `initializeApp()`. Fires only when SwiftUI actually presents the UI (FCM background-fetch doesn't reach `MainViewController()`).

### Test coverage
- New `AwaitAuthRestoredTest` (jvmTest) — five characterization cases using `runTest` virtual time: immediate resolve when already `Authenticated`, immediate resolve when already `Unauthenticated`, await + resolve after a 12 ms transition, timeout when stuck, timeout when resolution races past the deadline. Total runtime ~milliseconds.
- AuthCC's headless / promote interplay is covered by log instrumentation rather than a unit test (8+ heavy dependencies to fake; not worth the scaffolding).

## Verification

Tested live on the Android emulator across five paths:

| # | Scenario | Outcome |
|---|---|---|
| 1 | Cold-icon launch | `promoteToForeground()` runs before `Authenticated`; full sequence runs; WS opens. |
| 2 | FCM cold-wake (process killed) | `mode=headless deferred=[…]`; no `connect()` called; QB() runs; messages land in DB. |
| 3 | User opens app after FCM cold-wake | `promoteToForeground — running deferred=[…]`; `connect()` + WS handshake follow. |
| 4 | Cold reopen (kill + launch) | Same as #1. |
| 5 | Warm-swipe + FCM | Process alive → headless never engaged; WS reconnect + DriveSync retry deliver messages. |

For path 2, `homebase.log` shows:
```
AuthCC: onAuthStateChanged(Initializing)
NotificationService: FCM message received (Frodo)
BackgroundSync: syncIfAuthenticated: checking...
AuthCC: onAuthStateChanged(Authenticated)
BackgroundSync: syncIfAuthenticated: awaited credentials restoration — resolved to Authenticated  ✅
BackgroundSync: syncIfAuthenticated: WS offline — running background sync
AuthCC: Authenticated branch — mode=headless deferred=[onPostAuthenticated, connect, driveRegistry.start, loadProfile]  ✅
```

No `connect() called` and no `WS[N] handshake successful` anywhere in the FCM-wake window. BG sync completes with rows upserted.

## Out of scope

- Asymmetric unread-badge bug (the post-cold-sync re-enrich). Diagnostic instrumentation for that work exists in this branch's working tree but is intentionally not committed here — it belongs with the eventual fix, not with the FCM-headless change.

## Test plan

- [x] `./gradlew homebase-common:jvmTest --tests "*AwaitAuthRestoredTest*"`
- [x] `./gradlew :homebase-common:compileKotlinJvm :homebase-common:compileAndroidMain :homebase-core:compileKotlinJvm :homebase-core:compileAndroidMain :homebase-chat:compileKotlinJvm :homebase-chat:compileAndroidMain :androidApp:assembleDebug`
- [x] Live verification on Android emulator across all five paths above (see homebase.log).
- [ ] iOS verification (Linux dev host can't cross-compile cinterops; please verify on macOS host before merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)