### PR TITLE
Fix asymmetric unread badge: widen Stopped gate to cover DriveSync writes

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMessageBump.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMessageBump.kt
@@ -1,5 +1,6 @@
 package id.homebase.chat.services.convo
 
+import co.touchlab.kermit.Logger
 import id.homebase.api.common.OdinId
 import id.homebase.api.util.truncateToCodePoints
 import id.homebase.chat.data.ConversationUiModel
@@ -76,7 +77,7 @@ internal fun applyIncomingMessageBump(
         // userDate as the original message) don't bump unread.
         if (sqlUserDate <= existing.latestMessageTimestamp) return@map existing
         didChange = true
-        existing.copy(
+        val next = existing.copy(
             unreadCount = existing.unreadCount + increment,
             latestMessageTimestamp = sqlUserDate,
             lastMessage = m.content.truncateToCodePoints(40),
@@ -86,6 +87,65 @@ internal fun applyIncomingMessageBump(
             lastMessageHasMultiplePayloads = (m.payloads?.size ?: 0) > 1,
             lastMessageIsFromActiveUser = m.isAuthoredBy(activeDomain),
         )
+        // Diagnostic for the asymmetric-badge investigation (plan
+        // snazzy-frolicking-crown). Fires only when the strict-> check
+        // passes, so reaction re-emits stay silent. Pairs with the
+        // UnreadDiag lines in ConversationStream.enrichUnreadLocked
+        // and is what lets us distinguish hypotheses H1 (lastRead
+        // saturated) vs H2 (SQL excluded the row) on a real capture.
+        Logger.d(tag = "UnreadDiag") {
+            "bump convo=$targetConversationId sqlUserDateMs=${sqlUserDate.toEpochMilliseconds()} " +
+                "originalAuthor=${m.originalAuthor?.domainName ?: "null"} " +
+                "isAuthoredBy(self)=${m.isAuthoredBy(activeDomain)} " +
+                "isEdited=${m.isEdited} isStatusMessage=${m.isStatusMessage} " +
+                "increment=$increment unreadCount=${next.unreadCount}"
+        }
+        next
     }
     return if (didChange) updated else null
 }
+
+/**
+ * Decide whether the `BackendEvent.DriveEvent.Stopped` handler should
+ * run a fresh unread recount.
+ *
+ * Today's gate is `hasDirtyUnread()` alone — that fires only when
+ * `processConversationBatchIncrementally` set the dirty bit, which itself
+ * only runs on WS-push `BatchReceived`. The DriveSync QueryBatch path
+ * intentionally never emits per-row events (see `DriveSync.kt:199-201`
+ * "DriveSync is a silent batched DB write"), so message rows written by
+ * BG sync — FCM cold-wake, post-reconnect catch-up, retries — never trip
+ * the dirty bit and the badge stays stale (the original asymmetric-badge
+ * bug, captured in homebase.log 2026-06-01 Session 5).
+ *
+ * The widened gate adds `isChatDrive && totalCount > 0` so the recount
+ * runs whenever the chat drive's just-finished sync wrote anything to
+ * `DriveMainIndex`. We deliberately do NOT gate on `result == Completed`:
+ * the `BackendEvent.DriveResult` kdoc warns that earlier batches commit
+ * before a later batch can Abort, so a chat-drive Aborted with
+ * `totalCount > 0` still represents real rows in DB that affect the
+ * count. Same for PermissionDenied (kdoc: "earlier batches' DB writes
+ * commit before any later batch can fail").
+ *
+ * Cost when this widens the gate: one `selectAllUnreadCount` pass
+ * (covering-index — measured 121-163 ms in homebase.log). Cheap enough
+ * to pay per chat-drive Stopped that carried rows.
+ *
+ * Pure function so the gate is unit-testable without the ConversationStream
+ * graph.
+ *
+ * @param isChatDrive    true if the Stopped event was for the chat drive
+ *                       (other drives — contacts, vault, moments — never
+ *                       affect chat unread counts).
+ * @param totalCount     rows written to DriveMainIndex during this sync
+ *                       round (across all file types — conversations,
+ *                       messages, etc.). 0 ⇒ nothing landed ⇒ skip.
+ * @param hasDirtyUnread the existing dirty bit, set by
+ *                       `processConversationBatchIncrementally` on
+ *                       WS-push conv-file arrivals.
+ */
+internal fun shouldRunUnreadRecountOnStopped(
+    isChatDrive: Boolean,
+    totalCount: Int,
+    hasDirtyUnread: Boolean,
+): Boolean = hasDirtyUnread || (isChatDrive && totalCount > 0)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -252,17 +252,42 @@ class ConversationStream(
                         // First three steps unconditional (DriveSync may have
                         // changed conversation files, last-messages, or admin
                         // membership without dirtying lastRead). The unread-count
-                        // recount is the ~500ms full-DB pass and is gated on
-                        // [hasDirtyUnread] — it only materially changes the result
-                        // when a conversation file's lastRead actually advanced
-                        // during the round (peer-device mark-as-read echo).
+                        // recount goes through [shouldRunUnreadRecountOnStopped]:
+                        // pre-fix the gate was `hasDirtyUnread()` alone, which
+                        // missed the common case of "BG sync wrote message rows
+                        // via QueryBatch" because the dirty bit is only set by
+                        // the WS-push code path (BatchReceived ->
+                        // processConversationBatchIncrementally). The widened
+                        // gate adds `chatDrive && totalCount > 0`, so any
+                        // DriveSync round that landed chat rows triggers a
+                        // recount — the original asymmetric-badge bug
+                        // (homebase.log 2026-06-01 Session 5: warm-swipe +
+                        // FCM Frodo + WS-push Sam; Sam bumped via WS, Frodo's
+                        // QB-delivered rows never tripped the gate).
+                        // Cost: one selectAllUnreadCount (~121-163ms covering-
+                        // index pass measured live) per chat-drive Stopped
+                        // that carried rows. Cheap; trades a small recurrent
+                        // cost for badge correctness.
                         if (event.totalCount > 0) {
+                            val isDirty = hasDirtyUnread()
+                            val shouldRecount = shouldRunUnreadRecountOnStopped(
+                                isChatDrive = true, // filtered above at line 233
+                                totalCount = event.totalCount,
+                                hasDirtyUnread = isDirty,
+                            )
+                            Logger.i(tag = "UnreadDiag") {
+                                "Stopped recount-gate driveId=${event.driveId} " +
+                                    "totalCount=${event.totalCount} " +
+                                    "result=${event.result::class.simpleName} " +
+                                    "hasDirtyUnread=$isDirty " +
+                                    "decision=${if (shouldRecount) "RECOUNT" else "SKIP"}"
+                            }
                             scope.launch {
                                 try {
                                     loadBasicConversations()
                                     enrichWithLastMessages()
                                     enrichWithAdmins()
-                                    if (hasDirtyUnread()) {
+                                    if (shouldRecount) {
                                         requestUnreadEnrichment("DriveSyncStopped")
                                     }
                                 } catch (e: Exception) {
@@ -570,6 +595,24 @@ class ConversationStream(
         // Sort by descending timestamp (adjust based on your UI needs)
         val sortedList = _conversations.value.items.sortedByDescending { it.latestMessageTimestamp }
         _conversations.value = _conversations.value.copy(dataReady = true, items = sortedList)
+
+        // Diagnostic for the asymmetric-badge investigation (plan
+        // snazzy-frolicking-crown). End-of-batch snapshot of every
+        // conversation touched by this batch, so a later enrichUnreadLocked
+        // overwrite that drops the badge can be correlated against the
+        // value the in-memory bump actually landed on. The existing
+        // `unread++` log at line 620 only fires when the count rose; this
+        // covers the no-bump-but-touched case (e.g. suppressed by
+        // `sqlUserDate <= existing.latestMessageTimestamp`).
+        val touchedIds = incoming.map { it.second.conversationId }.distinct()
+        for (id in touchedIds) {
+            val c = sortedList.firstOrNull { it.id == id } ?: continue
+            Logger.d(tag = "UnreadDiag") {
+                "batchDone convo=$id unreadCount=${c.unreadCount} " +
+                    "latestMessageMs=${c.latestMessageTimestamp.toEpochMilliseconds()} " +
+                    "lastReadMs=${c.lastRead.toEpochMilliseconds()}"
+            }
+        }
     }
 
     /**
@@ -1165,6 +1208,25 @@ class ConversationStream(
         val current = _conversations.value
         val updated = current.items.map { convo ->
             val newCount = unreadMap[convo.id] ?: 0
+            // Diagnostic for the asymmetric-badge investigation (plan
+            // snazzy-frolicking-crown). Fires only when an in-memory unread
+            // count is about to be erased to zero — the exact "badge
+            // disappeared" symptom the user reported. We distinguish the
+            // two hypotheses by whether the convo appears in unreadMap:
+            //   - absent  ⇒ H2: the SQL filter excluded the row entirely
+            //                   (originalAuthor IS NULL / fileState / dataType).
+            //   - present ⇒ H1: the row is counted but lastReadTime is
+            //                   saturated past the message.
+            if (convo.unreadCount > 0 && newCount == 0) {
+                val rowAbsent = !unreadMap.containsKey(convo.id)
+                Logger.w(tag = "UnreadDiag") {
+                    "badge-disappeared convo=${convo.id} oldCount=${convo.unreadCount} " +
+                        "newCount=0 rowAbsentFromSqlMap=$rowAbsent " +
+                        "lastReadMs=${convo.lastRead.toEpochMilliseconds()} " +
+                        "latestMessageMs=${convo.latestMessageTimestamp.toEpochMilliseconds()} " +
+                        "dirty=${convo.dirty} trigger=$trigger"
+                }
+            }
             if (newCount != convo.unreadCount) {
                 changed++
                 Logger.d("ConversationStream: unreadSync convo=${convo.id} ${convo.unreadCount}->${newCount}")

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationMessageBumpTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationMessageBumpTest.kt
@@ -308,6 +308,129 @@ class ConversationMessageBumpTest {
         assertNull(updated)
     }
 
+    /**
+     * Mirrors the in-memory write loop inside
+     * [id.homebase.chat.services.convo.ConversationStream.enrichUnreadLocked]
+     * (commonMain). Kept inline so the recount seam can be exercised
+     * without ConversationStream's DB + DI graph. If that loop changes,
+     * change this too — the two are deliberately coupled.
+     */
+    private fun simulateEnrichUnreadOverwrite(
+        items: List<ConversationUiModel>,
+        unreadMap: Map<Uuid, Int>,
+    ): List<ConversationUiModel> = items.map { convo ->
+        val newCount = unreadMap[convo.id] ?: 0
+        if (newCount != convo.unreadCount) convo.copy(unreadCount = newCount) else convo
+    }
+
+    /**
+     * Characterization test for the **H2** asymmetric-badge path (the Sam vs.
+     * Frodo bug captured in plan `snazzy-frolicking-crown`). When a fresh
+     * incoming message bumps the in-memory unread count BUT the
+     * `selectAllUnreadCount` SQL filter excludes that conversation's row
+     * entirely (e.g. `originalAuthor IS NULL`, or `fileState=0`), the
+     * conversation is absent from `unreadMap` and the enrich loop overrides
+     * the in-memory bump back to 0 — silently losing the badge.
+     *
+     * This documents the seam as it stands today: present row keeps its
+     * bump, absent row gets reset. The fix (once H2 is confirmed by Phase B
+     * logs) will likely make `applyIncomingMessageBump` skip increments
+     * whose SQL counterpart would be excluded, at which point this test
+     * should be updated to assert the corrected behavior.
+     */
+    @Test
+    fun recount_resets_unreadCount_to_zero_when_convo_absent_from_unreadMap() {
+        // Two conversations: "sam" (the asymmetric victim) + "frodo" (the
+        // working one). Both start at 0 unread; both receive a fresh peer
+        // message via applyIncomingMessageBump.
+        val samId = convoId
+        val frodoId = otherConvoId
+        var items: List<ConversationUiModel> = listOf(
+            convo(id = samId, unread = 0),
+            convo(id = frodoId, unread = 0),
+        )
+
+        for ((cid, dateMs) in listOf(samId to 1_000L, frodoId to 1_000L)) {
+            // applyIncomingMessageBump matches by `targetConversationId`, not by
+            // `m.conversationId`, so we don't need to vary the message field.
+            val msg = message(author = alice, userDateMs = dateMs)
+            val next = applyIncomingMessageBump(
+                items = items,
+                targetConversationId = cid,
+                m = msg,
+                sqlUserDate = Instant.fromEpochMilliseconds(dateMs),
+                activeDomain = me,
+            )
+            assertNotNull(next, "bump for convo=$cid must produce a list change")
+            items = next
+        }
+        // After the two bumps, both convos show unread=1 in memory.
+        assertEquals(1, items.first { it.id == samId }.unreadCount)
+        assertEquals(1, items.first { it.id == frodoId }.unreadCount)
+
+        // Simulate the SQL recount: Sam's row is excluded entirely (e.g.
+        // originalAuthor IS NULL), so the map only contains Frodo.
+        val unreadMap = mapOf(frodoId to 1)
+        val afterRecount = simulateEnrichUnreadOverwrite(items, unreadMap)
+
+        // Sam silently loses the badge; Frodo keeps it.
+        assertEquals(
+            0,
+            afterRecount.first { it.id == samId }.unreadCount,
+            "absent-from-map convo gets reset to 0 — this is the asymmetric-badge mechanism",
+        )
+        assertEquals(1, afterRecount.first { it.id == frodoId }.unreadCount)
+    }
+
+    /**
+     * Characterization test for the **H1** asymmetric-badge path. Same
+     * symptom as the H2 test above, but here the SQL row for Sam IS in
+     * the recount result — it just comes back with `unreadCount = 0`
+     * because the stored `lastReadTime` is already ≥ the new message's
+     * `userDate` (saturated lastRead, e.g. from a peer-device echo or a
+     * markAllAsRead against a future-stamped status-message row).
+     *
+     * Note the in-memory `latestMessageTimestamp` still advances — this is
+     * what makes the bug user-visible: the conversation row shows the
+     * correct latest-message preview, but no badge.
+     */
+    @Test
+    fun recount_resets_unreadCount_to_zero_when_lastRead_saturates_past_new_message() {
+        val samId = convoId
+        val frodoId = otherConvoId
+        var items: List<ConversationUiModel> = listOf(
+            convo(id = samId, unread = 0),
+            convo(id = frodoId, unread = 0),
+        )
+
+        for ((cid, dateMs) in listOf(samId to 1_000L, frodoId to 1_000L)) {
+            // applyIncomingMessageBump matches by `targetConversationId`, not by
+            // `m.conversationId`, so we don't need to vary the message field.
+            val msg = message(author = alice, userDateMs = dateMs)
+            items = applyIncomingMessageBump(
+                items = items,
+                targetConversationId = cid,
+                m = msg,
+                sqlUserDate = Instant.fromEpochMilliseconds(dateMs),
+                activeDomain = me,
+            ) ?: items
+        }
+        assertEquals(1, items.first { it.id == samId }.unreadCount)
+        assertEquals(1_000L, items.first { it.id == samId }.latestMessageTimestamp.toEpochMilliseconds())
+
+        // SQL recount: Sam's row IS in the map but with count 0 (lastReadTime
+        // saturated past the message). Frodo's row reports 1 unread.
+        val unreadMap = mapOf(samId to 0, frodoId to 1)
+        val afterRecount = simulateEnrichUnreadOverwrite(items, unreadMap)
+
+        val samAfter = afterRecount.first { it.id == samId }
+        assertEquals(0, samAfter.unreadCount, "saturated lastRead drops Sam's badge")
+        // Preview-side latestMessageTimestamp survived the recount — this is
+        // why the user reports "no badge but latest-message preview is correct".
+        assertEquals(1_000L, samAfter.latestMessageTimestamp.toEpochMilliseconds())
+        assertEquals(1, afterRecount.first { it.id == frodoId }.unreadCount)
+    }
+
     @Test
     fun bump_doesNotTouchOtherConversations() {
         val target = convo(id = convoId, unread = 0)
@@ -330,4 +453,91 @@ class ConversationMessageBumpTest {
         assertEquals(7, updated.first { it.id == otherConvoId }.unreadCount)
         assertEquals(1, updated.first { it.id == convoId }.unreadCount)
     }
+
+    // region shouldRunUnreadRecountOnStopped — gate-predicate tests
+    //
+    // Locks down the decision that the BackendEvent.DriveEvent.Stopped
+    // handler makes about whether to run a fresh unread recount. The
+    // gate originally was `hasDirtyUnread()` alone; that misses message
+    // rows written by DriveSync's QueryBatch path (silent, no
+    // BatchReceived emitted), which is what produced the asymmetric-
+    // badge bug captured in homebase.log 2026-06-01 Session 5.
+
+    @Test
+    fun recountGate_dirtyBitSet_returnsTrue_evenWhenNotChatDrive() {
+        // Dirty wins on its own — OR semantics. A non-chat drive that
+        // somehow set the dirty bit (peer-device lastRead echo coming
+        // through a future code path, e.g.) still triggers a recount.
+        assertEquals(
+            true,
+            shouldRunUnreadRecountOnStopped(
+                isChatDrive = false,
+                totalCount = 0,
+                hasDirtyUnread = true,
+            ),
+        )
+    }
+
+    @Test
+    fun recountGate_chatDriveWithRecords_returnsTrue() {
+        // THE FIX. The asymmetric-badge bug: BG sync's QueryBatch writes
+        // message rows, emits Stopped(totalCount > 0), but never sets
+        // the dirty bit. Pre-fix this returned false and the badge
+        // stayed stale. The widened gate catches it.
+        assertEquals(
+            true,
+            shouldRunUnreadRecountOnStopped(
+                isChatDrive = true,
+                totalCount = 8,
+                hasDirtyUnread = false,
+            ),
+        )
+    }
+
+    @Test
+    fun recountGate_chatDriveAbortedWithPartialRows_returnsTrue() {
+        // BackendEvent.DriveResult kdoc warns: "earlier batches' DB
+        // writes commit before any later batch can fail." Aborted
+        // syncs with totalCount > 0 still represent real rows in DB
+        // that affect the count, so we deliberately don't gate on
+        // result == Completed. This test pins that decision.
+        assertEquals(
+            true,
+            shouldRunUnreadRecountOnStopped(
+                isChatDrive = true,
+                totalCount = 3,
+                hasDirtyUnread = false,
+            ),
+        )
+    }
+
+    @Test
+    fun recountGate_chatDriveWithZeroRecords_returnsFalse() {
+        // Nothing landed in the DB this round, nothing to recount.
+        // Skips the ~150 ms covering-index scan in the no-op case.
+        assertEquals(
+            false,
+            shouldRunUnreadRecountOnStopped(
+                isChatDrive = true,
+                totalCount = 0,
+                hasDirtyUnread = false,
+            ),
+        )
+    }
+
+    @Test
+    fun recountGate_nonChatDriveWithRecords_returnsFalse() {
+        // Contacts / Vault / Moments drives never carry chat messages;
+        // their Stopped events shouldn't trigger a chat-unread recount.
+        assertEquals(
+            false,
+            shouldRunUnreadRecountOnStopped(
+                isChatDrive = false,
+                totalCount = 25,
+                hasDirtyUnread = false,
+            ),
+        )
+    }
+
+    // endregion
 }


### PR DESCRIPTION
## Summary

Unread badges went stale when chat messages arrived via DriveSync's QueryBatch path (cold sync, BG sync after FCM, post-reconnect catch-up). The Stopped handler's recount gate was `hasDirtyUnread()` alone — that bit is only set by the WS-push code path, so pure message-only QB batches never tripped it. Widen the gate so a chat-drive Stopped that carried rows always triggers a recount.

## Background

Most recent repro in `homebase.log` 2026-06-01 (Session 5 from the FCM-headless verification): warm-swipe + FCM Frodo + FCM Sam, with the WS in mid-reconnect at the time of Frodo's FCM.

- Frodo's message landed via DriveSync **QueryBatch retry** (08:47:20.128). `Stopped(8)` fired. No recount because `hasDirtyUnread() == false`.
- Sam's message landed ~3 seconds later via **WS push** (`WSPush: drainOnce ... emitting BatchReceived`). `applyIncomingMessageBump` fired. Sam's badge bumped to 2.
- Frodo's badge stayed one behind.

Identical messages, different delivery paths.

## Root cause (confirmed from source)

| Path | Emits | What runs in ConversationStream | Result |
|---|---|---|---|
| WS push (`DriveWebSocketUpsertWorker.drainOnce`) | per-row `BatchReceived` | `processMessageBatchIncrementally` → `applyIncomingMessageBump` → in-memory bump | ✅ |
| DriveSync QueryBatch (`DriveSync.performSync`) | aggregate `Stopped(totalCount)` only | `loadBasicConversations` + `enrichWithLastMessages` + `enrichWithAdmins`, then recount **only if `hasDirtyUnread()`** | ❌ never recounts on pure-message batches |

The intent is documented at `DriveSync.kt:199-201`: *"DriveSync is a silent batched DB write — no per-batch BatchReceived (consumers reload from DriveMainIndex on Stopped(Completed))."* The ConversationStream reload IS run on every Stopped — but the unread-count step was gated tighter than its three siblings.

## The fix

New pure-function predicate in `ConversationMessageBump.kt`:

```kotlin
internal fun shouldRunUnreadRecountOnStopped(
    isChatDrive: Boolean,
    totalCount: Int,
    hasDirtyUnread: Boolean,
): Boolean = hasDirtyUnread || (isChatDrive && totalCount > 0)
```

Deliberately **not** gated on `result == Completed` — the `BackendEvent.DriveResult` kdoc explicitly warns that earlier batches commit before any later batch can Abort, so an `Aborted` Stopped with `totalCount > 0` still represents real rows in DB. Same for `PermissionDenied`.

Wired into `ConversationStream`'s Stopped handler, replacing the bare `hasDirtyUnread()` check. The new code also emits one `UnreadDiag Stopped recount-gate` INFO line per Stopped event, so the decision is observable in every future capture:

```
UnreadDiag Stopped recount-gate driveId=... totalCount=8 result=Completed
                hasDirtyUnread=false decision=RECOUNT
```

## Tests

`ConversationMessageBumpTest` adds **5 predicate tests** plus **2 characterization tests** for the in-memory ⇄ SQL recount seam that we used during investigation (these are documentation, not regression triggers — they encode current seam behavior).

- `recountGate_dirtyBitSet_returnsTrue_evenWhenNotChatDrive` — dirty wins on its own (OR semantics).
- `recountGate_chatDriveWithRecords_returnsTrue` — **the fix**.
- `recountGate_chatDriveAbortedWithPartialRows_returnsTrue` — pins the no-result-gating decision.
- `recountGate_chatDriveWithZeroRecords_returnsFalse` — no rows, no recount.
- `recountGate_nonChatDriveWithRecords_returnsFalse` — contacts/vault/moments drives never trigger chat recount.

Pure-function tests run in microseconds; the predicate is testable without standing up the `ConversationStream` graph.

Adjacent `UnreadDiag` instrumentation (bump log in `applyIncomingMessageBump`, badge-disappeared warn in `enrichUnreadLocked`, batchDone snapshot in `processMessageBatchIncrementally`) ships with this PR — these were the logs that proved the mechanism during investigation and are useful regression telltales going forward.

## Cost

One `selectAllUnreadCount` pass per chat-drive Stopped that carried rows — measured 121-163ms in `homebase.log` (covering-index scan, no row-level lookup). Negligible against the alternative of silently missing badges. The recount is also skipped cleanly when `totalCount == 0` (the common reconnect-no-op case), so steady-state cost is unchanged.

## Out of scope

- **Carrying touched conversation IDs in the `Stopped` event.** Cleaner architecturally — recount only what changed — but a larger change touching `BackendEvent.DriveEvent.Stopped` shape, DriveSync, and every consumer. Defer until profile data says the full-table recount is actually a problem.
- **The Stopped handler's behavior in headless mode.** In headless mode the handler's 3-step reload (and now the recount) writes to `_conversations.value` even though no UI is observing it — that work is discarded when `promoteToForeground` calls `reset() + start()`. Pre-existing pattern; not made worse by this PR.

## Test plan

- [x] `./gradlew homebase-chat:jvmTest --tests "*ConversationMessageBumpTest*" --rerun-tasks` — 20 tests pass (13 existing + 5 predicate + 2 characterization).
- [x] `./gradlew :homebase-chat:compileKotlinJvm :homebase-chat:compileAndroidMain` — clean.
- [ ] Live verification on emulator: reproduce Session 5 (warm-swipe + FCM Frodo + FCM Sam), confirm both badges update; grep `UnreadDiag.*Stopped recount-gate` for `decision=RECOUNT` lines.
- [ ] iOS verification (needs macOS host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)