### PR TITLE
fix(ios): harden shareFile flow — file validation, error surfacing, write check

### DIFF
--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/IOSFileOperationsProvider.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/IOSFileOperationsProvider.kt
@@ -142,7 +142,9 @@ class IOSFileOperationsProvider : FileOperationsProvider {
         val data = bytes.usePinned { pinned ->
             NSData.create(bytes = pinned.addressOf(0), length = bytes.size.toULong())
         }
-        data.writeToFile(filePath, atomically = true)
+        if (!data.writeToFile(filePath, atomically = true)) {
+            error("Failed to write share file to $filePath")
+        }
         return filePath
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -101,6 +101,7 @@ import id.homebase.resources.discard
 import id.homebase.resources.error_unknown
 import id.homebase.resources.file_save_failed
 import id.homebase.resources.file_saved_to
+import id.homebase.resources.file_share_failed
 import kotlinx.coroutines.launch
 import kotlinx.io.files.Path
 import org.jetbrains.compose.resources.stringResource
@@ -194,7 +195,20 @@ fun ConversationListScreen(
 
             is ConversationListUiEvent.ShareFile -> {
                 viewModel.eventConsumed()
-                fileSystemHandler.shareFile(Path(event.filePath))
+                fileSystemHandler.shareFile(
+                    file = Path(event.filePath),
+                    onError = { error ->
+                        scope.launch {
+                            val fallback = error.message
+                                ?: TranslationUtil.getString(MR.string.error_unknown)
+                            val msg = TranslationUtil.getString(
+                                MR.string.file_share_failed,
+                                fallback,
+                            )
+                            snackbarHostState.showSnackbar(msg)
+                        }
+                    },
+                )
             }
 
             is ConversationListUiEvent.OpenFile -> {

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1028,6 +1028,7 @@
     <!-- File save snackbar -->
     <string name="file_saved_to">Saved to %1$s</string>
     <string name="file_save_failed">Failed to save: %1$s</string>
+    <string name="file_share_failed">Failed to share: %1$s</string>
     <string name="error_unknown">Unknown error</string>
 
 </resources>

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/FileUtilities.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/FileUtilities.native.kt
@@ -70,12 +70,27 @@ actual fun getUriHandler(): FileSystemHandler {
         @OptIn(ExperimentalForeignApi::class)
         override fun shareFile(file: Path, onError: (Throwable) -> Unit) {
             try {
-                val fileUrl = NSURL.fileURLWithPath(file.toString())
+                val filePath = file.toString()
+                if (!NSFileManager.defaultManager.fileExistsAtPath(filePath)) {
+                    onError(Exception("Share file not found at $filePath"))
+                    return
+                }
+                val fileUrl = NSURL.fileURLWithPath(filePath)
                 val activityVC = UIActivityViewController(
                     activityItems = listOf(fileUrl), applicationActivities = null
                 )
+                activityVC.completionWithItemsHandler =
+                    { _, _, _, error ->
+                        if (error != null) {
+                            onError(Exception(error.localizedDescription))
+                        }
+                    }
                 val rootVC = UIApplication.sharedApplication.keyWindow?.rootViewController
-                rootVC?.presentViewController(activityVC, animated = true, completion = null)
+                if (rootVC != null) {
+                    rootVC.presentViewController(activityVC, animated = true, completion = null)
+                } else {
+                    onError(Exception("Unable to present share sheet"))
+                }
             } catch (e: Exception) {
                 onError(e)
             }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/help/HelpScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/help/HelpScreen.kt
@@ -82,7 +82,16 @@ fun HelpScreen(
 
             is HelpUiEvent.ShareFile -> {
                 viewModel.eventConsumed()
-                uriHandler.shareFile(event.filePath)
+                uriHandler.shareFile(
+                    file = event.filePath,
+                    onError = { error ->
+                        scope.launch {
+                            snackbarHostState.showSnackbar(
+                                message = "Failed to share log: ${error.message}"
+                            )
+                        }
+                    },
+                )
             }
 
             is HelpUiEvent.ShowError -> {


### PR DESCRIPTION
## Summary
- **File validation**: `shareFile()` now checks the file exists before presenting `UIActivityViewController` — returns a clear error instead of letting iOS show a cryptic "couldn't open file" background failure
- **Error capture**: Added `completionWithItemsHandler` to `UIActivityViewController` so share-sheet errors are routed to the `onError` callback instead of being silently dropped
- **Write check**: `writeBytesToShareOutboundFile` now verifies `NSData.writeToFile` succeeded — previously returned a path to a potentially non-existent file on write failure
- **Error surfacing**: Both call sites (`ConversationListScreen` for chat media, `HelpScreen` for debug log submit) now wire up `onError` with snackbar display — previously passed no callback, so `onError = {}` swallowed everything
- **Nil rootVC guard**: Explicit check for `keyWindow?.rootViewController` being nil with error callback, instead of silent `?.` optional chaining

## Test plan
- [ ] Open a chat conversation, long-press a media message, tap Share — verify share sheet appears and file shares successfully
- [ ] Go to Settings → Help → Submit Debug Log — verify share sheet appears with the log file
- [ ] If either fails, verify a snackbar appears with a descriptive error message instead of silent failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)