### PR TITLE
Add Groodle group-scheduling message kind

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,6 @@
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this
 repository.
 
-**_NOTE:_**  At the end of every task, Codex will review your work
-
 ## Discussions
 
 If I push back and you still think you're right, hold the position and

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groodle/GroodleBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groodle/GroodleBubble.kt
@@ -1,0 +1,261 @@
+package id.homebase.chat.groodle
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.HowToVote
+import androidx.compose.material.icons.filled.LockClock
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import id.homebase.api.client.drives.files.ReactionSummary
+import id.homebase.api.common.OdinId
+import id.homebase.resources.MR
+import id.homebase.resources.chat_groodle_closed
+import id.homebase.resources.chat_groodle_closes_in
+import id.homebase.resources.chat_groodle_option_count
+import id.homebase.resources.chat_groodle_option_count_one
+import id.homebase.resources.chat_groodle_tap_to_vote
+import id.homebase.resources.chat_groodle_unparseable
+import id.homebase.resources.chat_groodle_you_voted
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.delay
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.toLocalDateTime
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * In-stream bubble for a Groodle message. Renders entirely from the message
+ * header — no payload fetch on scroll, and **no tally**: results live only in the
+ * fullscreen [GroodleDetailDialog]. The bubble is a compact card (title,
+ * description, option count, deadline state) plus a "you've voted / tap to vote"
+ * hint derived from the viewer's own reactions.
+ *
+ * Tap-to-open is self-contained: when [messageId] and [conversationId] are
+ * non-null the bubble opens its own detail dialog. When null (composer preview,
+ * fallbacks) the bubble is read-only.
+ */
+@OptIn(ExperimentalUuidApi::class, ExperimentalFoundationApi::class)
+@Composable
+fun GroodleBubble(
+    descriptor: GroodleDescriptor?,
+    modifier: Modifier = Modifier,
+    messageId: Uuid? = null,
+    conversationId: Uuid? = null,
+    ownReactions: ImmutableList<String> = persistentListOf(),
+    reactionSummary: ReactionSummary? = null,
+    organizer: OdinId? = null,
+    onLongClick: (() -> Unit)? = null,
+    contentColor: Color = MaterialTheme.colorScheme.onSurface,
+    containerColor: Color = MaterialTheme.colorScheme.surfaceContainerHigh,
+) {
+    if (descriptor == null) {
+        UnparseableGroodleBubble(modifier = modifier, contentColor = contentColor, containerColor = containerColor)
+        return
+    }
+
+    var showDetail by remember(messageId) { mutableStateOf(false) }
+    val canOpenDetail = messageId != null && conversationId != null
+
+    // 30s ticker so the deadline state flips to "closed" live without a refresh.
+    val nowMs = remember(descriptor.deadlineUtcMs) {
+        mutableLongStateOf(Clock.System.now().toEpochMilliseconds())
+    }
+    val deadline = descriptor.deadlineUtcMs
+    LaunchedEffect(descriptor.deadlineUtcMs) {
+        if (deadline != null) {
+            while (nowMs.longValue < deadline) {
+                delay(30.seconds)
+                nowMs.longValue = Clock.System.now().toEpochMilliseconds()
+            }
+        }
+    }
+    val isClosed = deadline != null && nowMs.longValue >= deadline
+
+    val hasVoted = remember(ownReactions, descriptor) {
+        GroodleVote.myVotes(ownReactions, descriptor.slots.size, descriptor.allowMaybe).isNotEmpty()
+    }
+
+    val baseModifier = modifier
+        .widthIn(min = 240.dp, max = 320.dp)
+        .clip(RoundedCornerShape(16.dp))
+        .background(containerColor)
+        .let {
+            if (canOpenDetail || onLongClick != null) {
+                it.combinedClickable(
+                    onClick = { if (canOpenDetail) showDetail = true },
+                    onLongClick = onLongClick,
+                )
+            } else it
+        }
+        .padding(12.dp)
+
+    Row(modifier = baseModifier, verticalAlignment = Alignment.Top) {
+        Icon(
+            imageVector = Icons.Default.CalendarMonth,
+            contentDescription = null,
+            tint = contentColor.copy(alpha = 0.85f),
+            modifier = Modifier.size(28.dp).padding(top = 2.dp),
+        )
+        Spacer(Modifier.width(12.dp))
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Text(
+                text = descriptor.title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = contentColor,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (descriptor.description.isNotBlank()) {
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    text = descriptor.description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = contentColor.copy(alpha = 0.75f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Spacer(Modifier.height(6.dp))
+            val optionsLabel = if (descriptor.slots.size == 1) {
+                stringResource(MR.string.chat_groodle_option_count_one)
+            } else {
+                stringResource(MR.string.chat_groodle_option_count, descriptor.slots.size)
+            }
+            Text(
+                text = optionsLabel,
+                style = MaterialTheme.typography.labelMedium,
+                color = contentColor.copy(alpha = 0.7f),
+            )
+            if (deadline != null) {
+                Spacer(Modifier.height(2.dp))
+                val deadlineText = if (isClosed) {
+                    stringResource(MR.string.chat_groodle_closed)
+                } else {
+                    stringResource(MR.string.chat_groodle_closes_in, rememberDeadlineLabel(deadline))
+                }
+                Text(
+                    text = deadlineText,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = contentColor.copy(alpha = 0.6f),
+                )
+            }
+            Spacer(Modifier.height(8.dp))
+            VotedHint(hasVoted = hasVoted, isClosed = isClosed, contentColor = contentColor)
+        }
+    }
+
+    if (showDetail && messageId != null && conversationId != null) {
+        GroodleDetailDialog(
+            descriptor = descriptor,
+            messageId = messageId,
+            conversationId = conversationId,
+            ownReactions = ownReactions,
+            reactionSummary = reactionSummary,
+            organizer = organizer,
+            onDismiss = { showDetail = false },
+        )
+    }
+}
+
+@Composable
+private fun VotedHint(hasVoted: Boolean, isClosed: Boolean, contentColor: Color) {
+    val icon = if (hasVoted || isClosed) Icons.Default.CheckCircle else Icons.Default.HowToVote
+    val tint = if (hasVoted) MaterialTheme.colorScheme.primary else contentColor.copy(alpha = 0.7f)
+    val label = when {
+        hasVoted -> stringResource(MR.string.chat_groodle_you_voted)
+        isClosed -> stringResource(MR.string.chat_groodle_closed)
+        else -> stringResource(MR.string.chat_groodle_tap_to_vote)
+    }
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            imageVector = if (isClosed && !hasVoted) Icons.Default.LockClock else icon,
+            contentDescription = null,
+            tint = tint,
+            modifier = Modifier.size(16.dp),
+        )
+        Spacer(Modifier.width(6.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = if (hasVoted) FontWeight.SemiBold else FontWeight.Normal,
+            color = tint,
+        )
+    }
+}
+
+@Composable
+private fun UnparseableGroodleBubble(
+    modifier: Modifier,
+    contentColor: Color,
+    containerColor: Color,
+) {
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(16.dp))
+            .background(containerColor)
+            .padding(horizontal = 14.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.Default.CalendarMonth,
+            contentDescription = null,
+            tint = contentColor.copy(alpha = 0.7f),
+            modifier = Modifier.size(18.dp),
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text = stringResource(MR.string.chat_groodle_unparseable),
+            style = MaterialTheme.typography.bodyMedium,
+            color = contentColor.copy(alpha = 0.85f),
+        )
+    }
+}
+
+/** Absolute deadline in the viewer's local zone, e.g. "May 14 · 14:00". */
+@Composable
+private fun rememberDeadlineLabel(deadlineUtcMs: Long): String {
+    val local = rememberViewerLocalDateTime(deadlineUtcMs)
+    return "${local.month.name.take(3)} ${local.day} · ${formatHourMinute(local)}"
+}
+
+@Composable
+private fun rememberViewerLocalDateTime(utcMs: Long): LocalDateTime {
+    val tz = kotlinx.datetime.TimeZone.currentSystemDefault()
+    return remember(utcMs, tz) {
+        kotlin.time.Instant.fromEpochMilliseconds(utcMs).toLocalDateTime(tz)
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groodle/GroodleComposerSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groodle/GroodleComposerSheet.kt
@@ -1,0 +1,545 @@
+package id.homebase.chat.groodle
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberTimePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import id.homebase.api.util.truncateToCodePoints
+import id.homebase.chat.event.TimezonePickerSheet
+import id.homebase.chat.event.friendlyZoneLabel
+import id.homebase.chat.services.ChatMessageSenderService
+import id.homebase.chat.services.content.MessageContent
+import id.homebase.core.ui.theme.HomebaseTheme
+import id.homebase.resources.MR
+import id.homebase.resources.cancel
+import id.homebase.resources.menu_back
+import id.homebase.resources.ok
+import id.homebase.resources.chat_groodle_add_time
+import id.homebase.resources.chat_groodle_allow_maybe
+import id.homebase.resources.chat_groodle_composer_title
+import id.homebase.resources.chat_groodle_deadline
+import id.homebase.resources.chat_groodle_deadline_24h
+import id.homebase.resources.chat_groodle_deadline_48h
+import id.homebase.resources.chat_groodle_deadline_none
+import id.homebase.resources.chat_groodle_deadline_week
+import id.homebase.resources.chat_groodle_duration
+import id.homebase.resources.chat_groodle_duration_minutes
+import id.homebase.resources.chat_groodle_err_duplicate
+import id.homebase.resources.chat_groodle_err_times_missing
+import id.homebase.resources.chat_groodle_field_description
+import id.homebase.resources.chat_groodle_field_timezone
+import id.homebase.resources.chat_groodle_field_title
+import id.homebase.resources.chat_groodle_max_options
+import id.homebase.resources.chat_groodle_remove_option
+import id.homebase.resources.chat_groodle_send
+import id.homebase.resources.chat_groodle_set_time
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Instant
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.launch
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
+
+private const val MAX_TITLE_CODEPOINTS = GroodleDescriptor.MAX_TITLE_CODEPOINTS
+private const val MAX_DESCRIPTION_CODEPOINTS = GroodleDescriptor.MAX_DESCRIPTION_CODEPOINTS
+private const val MAX_SLOTS = GroodleDescriptor.MAX_SLOTS
+private const val DEFAULT_DURATION_MINUTES = 60
+private const val DURATION_STEP_MINUTES = 15
+private const val MIN_DURATION_MINUTES = 15
+
+/** One editable candidate slot. [id] is a stable local key for list rendering. */
+private data class SlotDraft(
+    val id: Long,
+    val date: LocalDate,
+    val startTime: LocalTime?,
+    val durationMinutes: Int,
+)
+
+private enum class DeadlinePreset { NONE, H24, H48, WEEK }
+
+/**
+ * Fullscreen composer for a Groodle. State is local `remember` — the composer is
+ * short-lived (open → fill → send → dismiss). Mirrors `event/EventComposerSheet`.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalUuidApi::class)
+@Composable
+fun GroodleComposerSheet(
+    conversationId: Uuid,
+    onDismiss: () -> Unit,
+    onSent: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        GroodleComposerContent(
+            conversationId = conversationId,
+            onDismiss = onDismiss,
+            onSent = onSent,
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalUuidApi::class)
+@Composable
+private fun GroodleComposerContent(
+    conversationId: Uuid,
+    onDismiss: () -> Unit,
+    onSent: () -> Unit,
+) {
+    val sender: ChatMessageSenderService = koinInject()
+    val scope = rememberCoroutineScope()
+
+    val systemTz = remember { TimeZone.currentSystemDefault() }
+    val today = remember {
+        Clock.System.now().toLocalDateTime(systemTz).date
+    }
+
+    var title by remember { mutableStateOf("") }
+    var description by remember { mutableStateOf("") }
+    var timezone by remember { mutableStateOf(systemTz.id) }
+    var allowMaybe by remember { mutableStateOf(true) }
+    var deadlinePreset by remember { mutableStateOf(DeadlinePreset.H48) }
+
+    val slots = remember { mutableStateListOf<SlotDraft>() }
+    var nextId by remember { mutableStateOf(0L) }
+
+    var sending by remember { mutableStateOf(false) }
+    var showAddDate by remember { mutableStateOf(false) }
+    var timePickerForId by remember { mutableStateOf<Long?>(null) }
+    var tzExpanded by remember { mutableStateOf(false) }
+
+    val allTimesSet by remember { derivedStateOf { slots.all { it.startTime != null } } }
+    val hasDuplicate by remember {
+        derivedStateOf {
+            val keys = slots.mapNotNull { s -> s.startTime?.let { Triple(s.date, it, s.durationMinutes) } }
+            keys.size != keys.toSet().size
+        }
+    }
+    val isValid by remember {
+        derivedStateOf {
+            title.isNotBlank() && slots.isNotEmpty() && allTimesSet && !hasDuplicate && !sending
+        }
+    }
+
+    val doSend: () -> Unit = {
+        if (isValid) {
+            sending = true
+            scope.launch {
+                val tz = runCatching { TimeZone.of(timezone) }.getOrDefault(systemTz)
+                val wireSlots = slots.mapNotNull { draft ->
+                    val time = draft.startTime ?: return@mapNotNull null
+                    val startLdt = LocalDateTime(draft.date.year, draft.date.month, draft.date.day, time.hour, time.minute)
+                    val startMs = startLdt.toInstant(tz).toEpochMilliseconds()
+                    GroodleSlot(startUtcMs = startMs, endUtcMs = startMs + draft.durationMinutes * 60_000L)
+                }.sortedBy { it.startUtcMs }
+
+                val deadlineUtcMs = computeDeadline(deadlinePreset, wireSlots.firstOrNull()?.startUtcMs)
+
+                val descriptor = GroodleDescriptor(
+                    title = title.truncateToCodePoints(MAX_TITLE_CODEPOINTS),
+                    description = description.truncateToCodePoints(MAX_DESCRIPTION_CODEPOINTS),
+                    timezone = tz.id,
+                    allowMaybe = allowMaybe,
+                    deadlineUtcMs = deadlineUtcMs,
+                    slots = wireSlots,
+                )
+                runCatching {
+                    sender.sendNewTypedMessage(
+                        messageUniqueId = Uuid.random(),
+                        conversationId = conversationId,
+                        content = MessageContent.Groodle(descriptor),
+                        previousMessageUniqueId = null,
+                    )
+                }
+                sending = false
+                onSent()
+            }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(MR.string.chat_groodle_composer_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onDismiss) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(MR.string.menu_back),
+                        )
+                    }
+                },
+            )
+        },
+        modifier = Modifier.fillMaxSize(),
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            OutlinedTextField(
+                value = title,
+                onValueChange = { title = it },
+                label = { Text(stringResource(MR.string.chat_groodle_field_title)) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            OutlinedTextField(
+                value = description,
+                onValueChange = { description = it },
+                label = { Text(stringResource(MR.string.chat_groodle_field_description)) },
+                modifier = Modifier.fillMaxWidth().height(96.dp),
+            )
+
+            // Timezone (reused from Event).
+            Box(modifier = Modifier.fillMaxWidth()) {
+                OutlinedTextField(
+                    value = friendlyZoneLabel(timezone),
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text(stringResource(MR.string.chat_groodle_field_timezone)) },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Box(
+                    modifier = Modifier.matchParentSize().clickable(onClick = { tzExpanded = true }),
+                )
+            }
+
+            // Allow-Maybe toggle.
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(MR.string.chat_groodle_allow_maybe),
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.weight(1f),
+                )
+                Switch(checked = allowMaybe, onCheckedChange = { allowMaybe = it })
+            }
+
+            // Deadline presets.
+            Text(
+                text = stringResource(MR.string.chat_groodle_deadline),
+                style = MaterialTheme.typography.labelLarge,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                DeadlineChip(stringResource(MR.string.chat_groodle_deadline_24h), deadlinePreset == DeadlinePreset.H24) { deadlinePreset = DeadlinePreset.H24 }
+                DeadlineChip(stringResource(MR.string.chat_groodle_deadline_48h), deadlinePreset == DeadlinePreset.H48) { deadlinePreset = DeadlinePreset.H48 }
+                DeadlineChip(stringResource(MR.string.chat_groodle_deadline_week), deadlinePreset == DeadlinePreset.WEEK) { deadlinePreset = DeadlinePreset.WEEK }
+                DeadlineChip(stringResource(MR.string.chat_groodle_deadline_none), deadlinePreset == DeadlinePreset.NONE) { deadlinePreset = DeadlinePreset.NONE }
+            }
+
+            // Slot rows.
+            slots.forEach { draft ->
+                SlotDraftRow(
+                    draft = draft,
+                    onPickTime = { timePickerForId = draft.id },
+                    onDurationChange = { delta ->
+                        val idx = slots.indexOfFirst { it.id == draft.id }
+                        if (idx >= 0) {
+                            val next = (slots[idx].durationMinutes + delta).coerceAtLeast(MIN_DURATION_MINUTES)
+                            slots[idx] = slots[idx].copy(durationMinutes = next)
+                        }
+                    },
+                    onRemove = { slots.removeAll { it.id == draft.id } },
+                )
+            }
+
+            OutlinedButton(
+                onClick = { showAddDate = true },
+                enabled = slots.size < MAX_SLOTS,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Icon(imageVector = Icons.Default.Add, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text(stringResource(MR.string.chat_groodle_add_time))
+            }
+            Text(
+                text = stringResource(MR.string.chat_groodle_max_options, MAX_SLOTS),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            // Validation hints.
+            if (slots.isNotEmpty() && !allTimesSet) {
+                Text(
+                    text = stringResource(MR.string.chat_groodle_err_times_missing),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+            if (hasDuplicate) {
+                Text(
+                    text = stringResource(MR.string.chat_groodle_err_duplicate),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            Button(
+                onClick = doSend,
+                enabled = isValid,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = HomebaseTheme.extendedColors.bubbleSentSurface,
+                    contentColor = HomebaseTheme.extendedColors.bubbleSentOnSurface,
+                ),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Icon(imageVector = Icons.AutoMirrored.Filled.Send, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text(stringResource(MR.string.chat_groodle_send))
+            }
+
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+
+    if (showAddDate) {
+        DatePickerSheet(
+            initialDate = today,
+            onConfirm = { date ->
+                if (slots.size < MAX_SLOTS) {
+                    val inheritedDuration = slots.lastOrNull()?.durationMinutes ?: DEFAULT_DURATION_MINUTES
+                    slots.add(SlotDraft(id = nextId, date = date, startTime = null, durationMinutes = inheritedDuration))
+                    nextId += 1
+                }
+                showAddDate = false
+            },
+            onDismiss = { showAddDate = false },
+        )
+    }
+
+    timePickerForId?.let { id ->
+        val idx = slots.indexOfFirst { it.id == id }
+        if (idx >= 0) {
+            TimePickerSheet(
+                initial = slots[idx].startTime ?: LocalTime(9, 0),
+                onConfirm = { time ->
+                    val cur = slots.indexOfFirst { it.id == id }
+                    if (cur >= 0) slots[cur] = slots[cur].copy(startTime = time)
+                    timePickerForId = null
+                },
+                onDismiss = { timePickerForId = null },
+            )
+        } else {
+            timePickerForId = null
+        }
+    }
+
+    if (tzExpanded) {
+        TimezonePickerSheet(
+            currentZoneId = timezone,
+            onPick = { picked ->
+                timezone = picked
+                tzExpanded = false
+            },
+            onDismiss = { tzExpanded = false },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DeadlineChip(label: String, selected: Boolean, onClick: () -> Unit) {
+    FilterChip(selected = selected, onClick = onClick, label = { Text(label) })
+}
+
+@Composable
+private fun SlotDraftRow(
+    draft: SlotDraft,
+    onPickTime: () -> Unit,
+    onDurationChange: (Int) -> Unit,
+    onRemove: () -> Unit,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        shape = RoundedCornerShape(12.dp),
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = formatDateLabel(draft.date),
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.weight(1f),
+                )
+                IconButton(onClick = onRemove) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = stringResource(MR.string.chat_groodle_remove_option),
+                    )
+                }
+            }
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedButton(onClick = onPickTime, modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = draft.startTime?.let {
+                            it.hour.toString().padStart(2, '0') + ":" + it.minute.toString().padStart(2, '0')
+                        } ?: stringResource(MR.string.chat_groodle_set_time),
+                    )
+                }
+                // Duration stepper.
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    IconButton(onClick = { onDurationChange(-DURATION_STEP_MINUTES) }) {
+                        Icon(imageVector = Icons.Default.Remove, contentDescription = stringResource(MR.string.chat_groodle_duration))
+                    }
+                    Text(
+                        text = stringResource(MR.string.chat_groodle_duration_minutes, draft.durationMinutes),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    IconButton(onClick = { onDurationChange(DURATION_STEP_MINUTES) }) {
+                        Icon(imageVector = Icons.Default.Add, contentDescription = stringResource(MR.string.chat_groodle_duration))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DatePickerSheet(
+    initialDate: LocalDate,
+    onConfirm: (LocalDate) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val initialMonthMs = remember(initialDate) {
+        initialDate.atStartOfDayIn(TimeZone.UTC).toEpochMilliseconds()
+    }
+    // Open with nothing selected and no OK button: the first tap on a day both
+    // selects AND commits it (single click adds the option). Adding one by
+    // mistake is cheap — each row has its own remove button. Only Cancel remains.
+    val state = rememberDatePickerState(
+        initialSelectedDateMillis = null,
+        initialDisplayedMonthMillis = initialMonthMs,
+    )
+    LaunchedEffect(state.selectedDateMillis) {
+        val ms = state.selectedDateMillis ?: return@LaunchedEffect
+        val ldt = Instant.fromEpochMilliseconds(ms).toLocalDateTime(TimeZone.UTC)
+        onConfirm(LocalDate(ldt.year, ldt.month, ldt.day))
+    }
+    DatePickerDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {},
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(MR.string.cancel)) }
+        },
+    ) {
+        DatePicker(state = state, showModeToggle = false)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TimePickerSheet(
+    initial: LocalTime,
+    onConfirm: (LocalTime) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val state = rememberTimePickerState(initialHour = initial.hour, initialMinute = initial.minute, is24Hour = true)
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = { onConfirm(LocalTime(state.hour, state.minute)) }) {
+                Text(stringResource(MR.string.ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(MR.string.cancel)) }
+        },
+        text = { TimePicker(state = state) },
+    )
+}
+
+private fun formatDateLabel(date: LocalDate): String =
+    "${date.dayOfWeek.name.take(3)}, ${date.month.name.take(3)} ${date.day}"
+
+/**
+ * Resolves the deadline preset to an absolute UTC instant, clamped so it never
+ * lands after the earliest slot (the descriptor's `isValid` requires
+ * `deadlineUtcMs <= slots.first().startUtcMs`).
+ */
+private fun computeDeadline(preset: DeadlinePreset, earliestSlotStartUtcMs: Long?): Long? {
+    val durationMs = when (preset) {
+        DeadlinePreset.NONE -> return null
+        DeadlinePreset.H24 -> 24.hours.inWholeMilliseconds
+        DeadlinePreset.H48 -> 48.hours.inWholeMilliseconds
+        DeadlinePreset.WEEK -> 7.days.inWholeMilliseconds
+    }
+    val raw = Clock.System.now().toEpochMilliseconds() + durationMs
+    return if (earliestSlotStartUtcMs != null) minOf(raw, earliestSlotStartUtcMs) else raw
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groodle/GroodleDescriptor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groodle/GroodleDescriptor.kt
@@ -1,0 +1,101 @@
+package id.homebase.chat.groodle
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Wire format for a Groodle (group-scheduling poll) message. Serialized as JSON
+ * into the chat message header's `appData.content` field (alongside
+ * `appData.dataType = ChatProtocol.ChatGroodleMessageDataType`), so it loads
+ * with the message index — no payload fetch on scroll.
+ *
+ * The sender proposes 1..10 candidate time [slots]; recipients vote Yes / No /
+ * Maybe per slot. Votes are recorded as ordinary chat reactions encoded by
+ * [GroodleVote] (e.g. `_1Y`), not as message payloads, so they ride the existing
+ * reaction sync for free.
+ *
+ * Identity / sender / creation time are NOT in the descriptor — read them from
+ * the surrounding HomebaseFile envelope (`uniqueId`,
+ * `fileMetadata.originalAuthor`, `userDate`). See the "Don't duplicate envelope
+ * fields in the descriptor" rule under "Adding a New Typed Message Kind" in
+ * `CLAUDE.md`.
+ *
+ * Worst case (full title/description + 10 slots with end times) is ~900 bytes,
+ * comfortably under [id.homebase.chat.services.ChatProtocol.MaxHeaderContentBytes].
+ */
+@Serializable
+data class GroodleDescriptor(
+    val schemaVersion: Int = 1,
+    val title: String,
+    val description: String = "",
+    /** IANA zone the slots were authored in, e.g. "Europe/Copenhagen". */
+    val timezone: String,
+    /** When false the poll is Yes/No only — the Maybe option is hidden. */
+    val allowMaybe: Boolean = true,
+    /** Voting deadline in UTC millis; null = no deadline. Past it, voting locks. */
+    val deadlineUtcMs: Long? = null,
+    val slots: List<GroodleSlot>,
+) {
+    /** One-liner for the conversation-list preview / push notification / search index. */
+    fun summaryLine(): String = title
+
+    /**
+     * Strict bounds check. The parser treats an invalid descriptor exactly like
+     * malformed JSON — it renders the unparseable chip — so be conservative here.
+     */
+    fun isValid(): Boolean {
+        if (schemaVersion < 1) return false
+        if (title.isBlank()) return false
+        if (title.codePointLength() !in 1..MAX_TITLE_CODEPOINTS) return false
+        if (description.codePointLength() > MAX_DESCRIPTION_CODEPOINTS) return false
+        if (timezone.isBlank()) return false
+        if (slots.size !in 1..MAX_SLOTS) return false
+
+        for (i in slots.indices) {
+            val slot = slots[i]
+            // End (when present) must be strictly after start.
+            if (slot.endUtcMs != null && slot.endUtcMs <= slot.startUtcMs) return false
+            // Ascending by start; equal starts are allowed (same date, different
+            // duration), but the full-slot duplicate check below rejects exact ties.
+            if (i > 0 && slot.startUtcMs < slots[i - 1].startUtcMs) return false
+        }
+
+        // No two identical slots (same start AND same end). Duplicates would make
+        // two vote columns indistinguishable.
+        val seen = HashSet<Pair<Long, Long?>>(slots.size)
+        for (slot in slots) {
+            if (!seen.add(slot.startUtcMs to slot.endUtcMs)) return false
+        }
+
+        // A deadline can't fall after voting would already be moot.
+        if (deadlineUtcMs != null && deadlineUtcMs > slots.first().startUtcMs) return false
+
+        return true
+    }
+
+    companion object {
+        const val MAX_TITLE_CODEPOINTS = 80
+        const val MAX_DESCRIPTION_CODEPOINTS = 280
+        const val MAX_SLOTS = 10
+    }
+}
+
+@Serializable
+data class GroodleSlot(
+    val startUtcMs: Long,
+    /** Optional end; null = unspecified duration. When set, must be > [startUtcMs]. */
+    val endUtcMs: Long? = null,
+)
+
+/**
+ * Counts Unicode code points (not UTF-16 chars), so emoji and other non-BMP
+ * characters in user text count as one each — matching `truncateToCodePoints`.
+ */
+private fun String.codePointLength(): Int {
+    var count = 0
+    var i = 0
+    while (i < length) {
+        i += if (i + 1 < length && this[i].isHighSurrogate() && this[i + 1].isLowSurrogate()) 2 else 1
+        count += 1
+    }
+    return count
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groodle/GroodleDetailDialog.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groodle/GroodleDetailDialog.kt
@@ -1,0 +1,402 @@
+package id.homebase.chat.groodle
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.LockClock
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import id.homebase.api.client.drives.files.ReactionSummary
+import id.homebase.api.common.OdinId
+import id.homebase.chat.services.ChatMessageActionService
+import id.homebase.chat.services.convo.contact.ContactService
+import id.homebase.resources.MR
+import id.homebase.resources.chat_event_organized_by
+import id.homebase.resources.chat_groodle_closed
+import id.homebase.resources.chat_groodle_tally
+import id.homebase.resources.chat_groodle_vote_maybe
+import id.homebase.resources.chat_groodle_vote_no
+import id.homebase.resources.chat_groodle_vote_yes
+import id.homebase.resources.chat_groodle_winner
+import id.homebase.resources.chat_groodle_scheduled_in_zone
+import id.homebase.resources.menu_back
+import kotlin.time.Clock
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
+
+/**
+ * Fullscreen detail view for a Groodle. This is the **only** place the tally is
+ * shown — the in-stream bubble stays results-free. Provides:
+ *  - hero (title, description, organizer, deadline state)
+ *  - one row per candidate slot, in the viewer's local zone (with a "Scheduled
+ *    in <zone>" tagline when the authoring zone differs), the per-slot Y/M/N
+ *    tally, and Yes / Maybe / No vote buttons reflecting the viewer's choice
+ *  - the leading slot highlighted by score (Y=2, M=1, N=0)
+ *
+ * Voting writes ordinary chat reactions ([GroodleVote] codes). Tapping a
+ * different choice clears the user's prior vote for that slot first (clear-then-
+ * set), so the two can't coexist. Past the deadline the buttons lock.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalUuidApi::class)
+@Composable
+fun GroodleDetailDialog(
+    descriptor: GroodleDescriptor,
+    messageId: Uuid,
+    conversationId: Uuid,
+    ownReactions: ImmutableList<String>,
+    reactionSummary: ReactionSummary?,
+    organizer: OdinId?,
+    onDismiss: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        GroodleDetailContent(
+            descriptor = descriptor,
+            messageId = messageId,
+            conversationId = conversationId,
+            ownReactions = ownReactions,
+            reactionSummary = reactionSummary,
+            organizer = organizer,
+            onDismiss = onDismiss,
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalUuidApi::class)
+@Composable
+private fun GroodleDetailContent(
+    descriptor: GroodleDescriptor,
+    messageId: Uuid,
+    conversationId: Uuid,
+    ownReactions: ImmutableList<String>,
+    reactionSummary: ReactionSummary?,
+    organizer: OdinId?,
+    onDismiss: () -> Unit,
+) {
+    val actionService: ChatMessageActionService = koinInject()
+    val contactService: ContactService = koinInject()
+    val scope = rememberCoroutineScope()
+
+    val slotCount = descriptor.slots.size
+    val myVotes = remember(ownReactions, slotCount, descriptor.allowMaybe) {
+        GroodleVote.myVotes(ownReactions, slotCount, descriptor.allowMaybe)
+    }
+    val counts = remember(reactionSummary, slotCount, descriptor.allowMaybe) {
+        GroodleVote.counts(reactionSummary, slotCount, descriptor.allowMaybe)
+    }
+    // 1-based index of the leading slot, or null when nobody has voted yet.
+    val leadingSlot = remember(counts) {
+        counts.entries
+            .filter { it.value.score > 0 }
+            .maxByOrNull { it.value.score }
+            ?.key
+    }
+
+    // Deadline lock, ticked once on entry (re-evaluated on recomposition is fine
+    // — the dialog is short-lived).
+    val nowMs by remember { mutableLongStateOf(Clock.System.now().toEpochMilliseconds()) }
+    val isClosed = descriptor.deadlineUtcMs != null && nowMs >= descriptor.deadlineUtcMs
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = {},
+                navigationIcon = {
+                    IconButton(onClick = onDismiss) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(MR.string.menu_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 20.dp),
+        ) {
+            Text(
+                text = descriptor.title,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+
+            organizer?.let { host ->
+                Spacer(Modifier.height(4.dp))
+                val resolved = contactService.resolveByOdinId(host)?.name ?: host.domainName
+                Text(
+                    text = stringResource(MR.string.chat_event_organized_by) + " " + resolved,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            if (descriptor.description.isNotBlank()) {
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    text = descriptor.description,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+
+            if (isClosed) {
+                Spacer(Modifier.height(12.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.LockClock,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Spacer(Modifier.width(6.dp))
+                    Text(
+                        text = stringResource(MR.string.chat_groodle_closed),
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            descriptor.slots.forEachIndexed { i, slot ->
+                val slotIndex = i + 1
+                SlotRow(
+                    slot = slot,
+                    authoredZoneId = descriptor.timezone,
+                    counts = counts[slotIndex] ?: GroodleVote.SlotCounts(0, 0, 0),
+                    myChoice = myVotes[slotIndex],
+                    allowMaybe = descriptor.allowMaybe,
+                    isLeading = leadingSlot == slotIndex,
+                    isClosed = isClosed,
+                    onVote = { choice ->
+                        scope.launch {
+                            applyVote(actionService, conversationId, messageId, myVotes[slotIndex], slotIndex, choice)
+                        }
+                    },
+                )
+                Spacer(Modifier.height(12.dp))
+            }
+
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun SlotRow(
+    slot: GroodleSlot,
+    authoredZoneId: String,
+    counts: GroodleVote.SlotCounts,
+    myChoice: GroodleVote.Choice?,
+    allowMaybe: Boolean,
+    isLeading: Boolean,
+    isClosed: Boolean,
+    onVote: (GroodleVote.Choice) -> Unit,
+) {
+    val times = rememberSlotTimes(slot, authoredZoneId)
+    val container = if (isLeading) MaterialTheme.colorScheme.primaryContainer
+    else MaterialTheme.colorScheme.surfaceContainerHigh
+    val onContainer = if (isLeading) MaterialTheme.colorScheme.onPrimaryContainer
+    else MaterialTheme.colorScheme.onSurface
+
+    Surface(
+        modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(14.dp)),
+        color = container,
+    ) {
+        Column(modifier = Modifier.padding(14.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = slotHeadline(times),
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = onContainer,
+                    modifier = Modifier.weight(1f),
+                )
+                if (isLeading) {
+                    Spacer(Modifier.width(8.dp))
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(MaterialTheme.colorScheme.primary)
+                            .padding(horizontal = 8.dp, vertical = 2.dp),
+                    ) {
+                        Text(
+                            text = stringResource(MR.string.chat_groodle_winner),
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onPrimary,
+                        )
+                    }
+                }
+            }
+
+            if (times.authoredStartLocal != null && times.authoredTzId != null) {
+                Spacer(Modifier.height(2.dp))
+                val authoredDayTime = "${times.authoredStartLocal.dayOfWeek.name.take(3)} " +
+                    formatHourMinute(times.authoredStartLocal)
+                val authoredZoneShort = times.authoredTzId.substringAfterLast('/').replace('_', ' ')
+                Text(
+                    text = stringResource(MR.string.chat_groodle_scheduled_in_zone, authoredDayTime, authoredZoneShort),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = onContainer.copy(alpha = 0.7f),
+                )
+            }
+
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = stringResource(MR.string.chat_groodle_tally, counts.yes, counts.maybe, counts.no),
+                style = MaterialTheme.typography.labelMedium,
+                color = onContainer.copy(alpha = 0.8f),
+            )
+
+            Spacer(Modifier.height(10.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                VoteChip(
+                    label = stringResource(MR.string.chat_groodle_vote_yes),
+                    selected = myChoice == GroodleVote.Choice.YES,
+                    enabled = !isClosed,
+                    onClick = { onVote(GroodleVote.Choice.YES) },
+                    modifier = Modifier.weight(1f),
+                )
+                if (allowMaybe) {
+                    VoteChip(
+                        label = stringResource(MR.string.chat_groodle_vote_maybe),
+                        selected = myChoice == GroodleVote.Choice.MAYBE,
+                        enabled = !isClosed,
+                        onClick = { onVote(GroodleVote.Choice.MAYBE) },
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+                VoteChip(
+                    label = stringResource(MR.string.chat_groodle_vote_no),
+                    selected = myChoice == GroodleVote.Choice.NO,
+                    enabled = !isClosed,
+                    onClick = { onVote(GroodleVote.Choice.NO) },
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun VoteChip(
+    label: String,
+    selected: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val container = when {
+        selected -> MaterialTheme.colorScheme.primary
+        else -> MaterialTheme.colorScheme.surface
+    }
+    val content = when {
+        selected -> MaterialTheme.colorScheme.onPrimary
+        enabled -> MaterialTheme.colorScheme.onSurface
+        else -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
+    }
+    Surface(
+        modifier = modifier
+            .height(44.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .let { if (enabled) it.clickable(onClick = onClick) else it },
+        color = if (enabled || selected) container else container.copy(alpha = 0.5f),
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+                color = content,
+            )
+        }
+    }
+}
+
+/** "Thu · May 14 · 14:00–15:00" in the viewer's local zone. */
+private fun slotHeadline(times: GroodleSlotTimes): String {
+    val start = times.viewerStartLocal
+    val dow = start.dayOfWeek.name.take(3)
+    val date = "${start.month.name.take(3)} ${start.day}"
+    val startTime = formatHourMinute(start)
+    val end = times.viewerEndLocal
+    return if (end == null) {
+        "$dow · $date · $startTime"
+    } else {
+        "$dow · $date · $startTime–${formatHourMinute(end)}"
+    }
+}
+
+@OptIn(ExperimentalUuidApi::class)
+private suspend fun applyVote(
+    actionService: ChatMessageActionService,
+    conversationId: Uuid,
+    messageId: Uuid,
+    currentChoice: GroodleVote.Choice?,
+    slotIndex: Int,
+    newChoice: GroodleVote.Choice,
+) {
+    val newCode = GroodleVote.encode(slotIndex, newChoice)
+    if (currentChoice == newChoice) {
+        // Same choice tapped twice → toggle off (clear the vote).
+        actionService.toggleReaction(conversationId, messageId, newCode)
+        return
+    }
+    if (currentChoice != null) {
+        // Switch choice: clear the prior vote for this slot first.
+        actionService.toggleReaction(conversationId, messageId, GroodleVote.encode(slotIndex, currentChoice))
+    }
+    actionService.toggleReaction(conversationId, messageId, newCode)
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groodle/GroodleTimes.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groodle/GroodleTimes.kt
@@ -1,0 +1,59 @@
+package id.homebase.chat.groodle
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import kotlin.time.Instant
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+/**
+ * Viewer-first timezone view of a single Groodle slot. Mirrors
+ * `event/EventTimes.kt`, but per slot rather than per descriptor (a Groodle has
+ * one authoring zone shared across all its slots).
+ *
+ * `viewer*` fields are always populated, in the device's current zone.
+ * `authored*` fields are populated only when the authoring zone differs from the
+ * device zone — letting the slot row render the viewer's local clock with a
+ * "Scheduled in <city>" tagline showing the organizer's intended wall-clock.
+ */
+data class GroodleSlotTimes(
+    val viewerStartLocal: LocalDateTime,
+    val viewerEndLocal: LocalDateTime?,
+    val viewerTz: TimeZone,
+    val authoredStartLocal: LocalDateTime?,
+    val authoredTzId: String?,
+)
+
+/** Pure variant — testable. */
+fun computeSlotTimes(slot: GroodleSlot, authoredZoneId: String, viewerTz: TimeZone): GroodleSlotTimes {
+    val authoredTz = runCatching { TimeZone.of(authoredZoneId) }.getOrElse { viewerTz }
+    val viewerStart = Instant.fromEpochMilliseconds(slot.startUtcMs).toLocalDateTime(viewerTz)
+    val viewerEnd = slot.endUtcMs?.let {
+        Instant.fromEpochMilliseconds(it).toLocalDateTime(viewerTz)
+    }
+    val zonesDiffer = authoredTz.id != viewerTz.id
+    val authoredStart = if (zonesDiffer) {
+        Instant.fromEpochMilliseconds(slot.startUtcMs).toLocalDateTime(authoredTz)
+    } else null
+    return GroodleSlotTimes(
+        viewerStartLocal = viewerStart,
+        viewerEndLocal = viewerEnd,
+        viewerTz = viewerTz,
+        authoredStartLocal = authoredStart,
+        authoredTzId = if (zonesDiffer) authoredTz.id else null,
+    )
+}
+
+@Composable
+fun rememberSlotTimes(slot: GroodleSlot, authoredZoneId: String): GroodleSlotTimes =
+    remember(slot.startUtcMs, slot.endUtcMs, authoredZoneId) {
+        computeSlotTimes(slot, authoredZoneId, TimeZone.currentSystemDefault())
+    }
+
+/** "HH:MM" in 24h, from a LocalDateTime. */
+fun formatHourMinute(local: LocalDateTime): String {
+    val h = local.hour.toString().padStart(2, '0')
+    val m = local.minute.toString().padStart(2, '0')
+    return "$h:$m"
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groodle/GroodleVote.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groodle/GroodleVote.kt
@@ -1,0 +1,113 @@
+package id.homebase.chat.groodle
+
+import id.homebase.api.client.drives.files.ReactionSummary
+import id.homebase.api.client.drives.files.reactions.ReactionContent
+import id.homebase.api.serialization.OdinSystemSerializer
+
+/**
+ * Groodle votes are stored as ordinary chat reactions on the poll message,
+ * encoded as a short ASCII code rather than an emoji. The leading underscore
+ * marks the reaction as "not an emoji to render" — the generic reaction UI
+ * ([id.homebase.core.widget.ReactionList] /
+ * [id.homebase.core.widget.ReactionsBottomSheet]) filters out any reaction whose
+ * decoded text starts with `_`, so vote codes never show up as pills. The
+ * Groodle detail dialog renders the tally itself.
+ *
+ * Code shape: `_<slotIndex><Y|N|M>` where slotIndex is 1-based and matches the
+ * descriptor's [GroodleDescriptor.slots] order (stable — the descriptor is never
+ * edited after send). Examples: `_1Y`, `_3M`, `_10N`. Max 4 chars, within
+ * [id.homebase.chat.services.ChatMessageActionService]'s `length <= 8` reaction
+ * cap.
+ *
+ * Mirrors `event/EventRsvp.kt`, generalized to per-slot voting.
+ */
+object GroodleVote {
+
+    enum class Choice(val letter: Char) {
+        YES('Y'),
+        NO('N'),
+        MAYBE('M'),
+    }
+
+    private val CODE_REGEX = Regex("^_(\\d{1,2})([YNM])$")
+
+    /** Encodes a 1-based slot index + choice into its reaction code. */
+    fun encode(slotIndex1Based: Int, choice: Choice): String = "_$slotIndex1Based${choice.letter}"
+
+    /**
+     * Decodes a raw reaction code to (1-based slot index, choice), or null when it
+     * doesn't match the vote grammar (stray emoji, other content). Pass [slotCount]
+     * and [allowMaybe] to reject out-of-range slots and disallowed Maybe votes.
+     */
+    fun decode(code: String, slotCount: Int, allowMaybe: Boolean): Pair<Int, Choice>? {
+        val match = CODE_REGEX.matchEntire(code) ?: return null
+        val slot = match.groupValues[1].toIntOrNull() ?: return null
+        if (slot !in 1..slotCount) return null
+        val choice = when (match.groupValues[2]) {
+            "Y" -> Choice.YES
+            "N" -> Choice.NO
+            "M" -> if (allowMaybe) Choice.MAYBE else return null
+            else -> return null
+        }
+        return slot to choice
+    }
+
+    /**
+     * Extracts the emoji/code string from a single `ownReactions` entry. The stored
+     * shape is JSON-encoded [ReactionContent] (`{"emoji":"_1Y"}`).
+     */
+    fun codeOf(rawReaction: String): String? = runCatching {
+        OdinSystemSerializer.deserialize<ReactionContent>(rawReaction).emoji
+    }.getOrNull()
+
+    /**
+     * The current user's vote per slot, decoded from their own reactions. Last
+     * write wins per slot (the detail dialog clears a prior vote before setting a
+     * new one, so well-behaved clients have at most one per slot anyway).
+     */
+    fun myVotes(
+        ownReactions: Iterable<String>,
+        slotCount: Int,
+        allowMaybe: Boolean,
+    ): Map<Int, Choice> {
+        val result = HashMap<Int, Choice>()
+        for (raw in ownReactions) {
+            val code = codeOf(raw) ?: raw
+            val (slot, choice) = decode(code, slotCount, allowMaybe) ?: continue
+            result[slot] = choice
+        }
+        return result
+    }
+
+    /** Aggregate Y/N/M counts for one slot. */
+    data class SlotCounts(val yes: Int, val no: Int, val maybe: Int) {
+        val total: Int get() = yes + no + maybe
+
+        /** Y=2, M=1, N=0 — used to rank slots and highlight the winner. */
+        val score: Int get() = yes * 2 + maybe
+    }
+
+    /**
+     * Per-slot tally across all reactors, read from the server-side reaction
+     * preview. Returns an entry for every slot in `1..slotCount` (zeroed when no
+     * votes). Aggregate counts can't be de-duped per voter, so correctness relies
+     * on the detail dialog's clear-then-set on vote change (same as Event RSVP).
+     */
+    fun counts(summary: ReactionSummary?, slotCount: Int, allowMaybe: Boolean): Map<Int, SlotCounts> {
+        val yes = IntArray(slotCount + 1)
+        val no = IntArray(slotCount + 1)
+        val maybe = IntArray(slotCount + 1)
+        if (summary != null) {
+            for ((_, entry) in summary.reactions) {
+                val code = codeOf(entry.reactionContent) ?: entry.key
+                val (slot, choice) = decode(code, slotCount, allowMaybe) ?: continue
+                when (choice) {
+                    Choice.YES -> yes[slot] += entry.count
+                    Choice.NO -> no[slot] += entry.count
+                    Choice.MAYBE -> maybe[slot] += entry.count
+                }
+            }
+        }
+        return (1..slotCount).associateWith { SlotCounts(yes[it], no[it], maybe[it]) }
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatProtocol.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatProtocol.kt
@@ -51,6 +51,15 @@ object ChatProtocol {
      */
     const val ChatDiceRollMessageDataType = 212
 
+    /**
+     * Groodle (group-scheduling poll) message kind. Like [ChatEventMessageDataType],
+     * the full descriptor (title, candidate time slots, deadline) lives in
+     * `appData.content` — no payloads, no fetch on scroll. Votes ride as ordinary
+     * chat reactions encoded by [id.homebase.chat.groodle.GroodleVote]. See
+     * [id.homebase.chat.groodle.GroodleDescriptor].
+     */
+    const val ChatGroodleMessageDataType = 213
+
     const val MessageFileType = 7878
 
     /** Derives a deterministic uniqueId for the admin file from a conversationId. */

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/content/MessageContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/content/MessageContent.kt
@@ -2,6 +2,7 @@ package id.homebase.chat.services.content
 
 import id.homebase.chat.dice.DiceRollDescriptor
 import id.homebase.chat.event.EventDescriptor
+import id.homebase.chat.groodle.GroodleDescriptor
 import id.homebase.notifshared.EVENT_NOTIF_SENTINEL
 
 /**
@@ -96,6 +97,20 @@ sealed interface MessageContent {
     }
 
     /**
+     * A group-scheduling poll: candidate time slots that recipients vote on
+     * (Yes/No/Maybe per slot). Votes are recorded as chat reactions, not edits,
+     * and the tally is rendered inside the bubble's own fullscreen detail dialog —
+     * so [actions] is [ActionPolicy.StructuredOneShot]: no edit (the poll is
+     * immutable; it can only be deleted), no reply/forward, and no inline-reaction
+     * surface (the vote codes would otherwise leak into the long-press emoji
+     * strip). Deletion is not governed by ActionPolicy and remains available.
+     * [descriptor] follows the same nullability contract as [Event.descriptor].
+     */
+    data class Groodle(val descriptor: GroodleDescriptor?) : MessageContent {
+        override val displayLabel: String get() = descriptor?.summaryLine() ?: UNPARSEABLE_GROODLE_LABEL
+    }
+
+    /**
      * A typed message whose [dataType] this client doesn't recognize — typically
      * a newer kind (poll, doodle, …) sent from a more up-to-date peer. The
      * receiver can't render the content itself; the bubble shows an
@@ -115,6 +130,7 @@ sealed interface MessageContent {
         // from a @Composable; this getter must work outside composition.
         const val UNPARSEABLE_EVENT_LABEL = "Event"
         const val UNPARSEABLE_DICE_LABEL = "Dice roll"
+        const val UNPARSEABLE_GROODLE_LABEL = "Groodle"
         const val UNKNOWN_LABEL = "Unknown message"
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/content/MessageContentParser.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/content/MessageContentParser.kt
@@ -4,6 +4,7 @@ import co.touchlab.kermit.Logger
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.chat.dice.DiceRollDescriptor
 import id.homebase.chat.event.EventDescriptor
+import id.homebase.chat.groodle.GroodleDescriptor
 import id.homebase.chat.services.ChatProtocol
 
 /**
@@ -36,6 +37,7 @@ object MessageContentParser {
         return when (dataType) {
             ChatProtocol.ChatEventMessageDataType -> parseEvent(content)
             ChatProtocol.ChatDiceRollMessageDataType -> parseDiceRoll(content)
+            ChatProtocol.ChatGroodleMessageDataType -> parseGroodle(content)
             // MessageAppData-shaped dataTypes — caller deserializes content
             // as MessageAppData. 0 = plain text/media; 211 = Location, whose
             // descriptor lives on a payload (the header content is still a
@@ -86,6 +88,24 @@ object MessageContentParser {
         MessageContent.DiceRoll(descriptor = null)
     }
 
+    private fun parseGroodle(content: String): MessageContent.Groodle = try {
+        val descriptor = OdinSystemSerializer.deserialize<GroodleDescriptor>(content)
+        if (descriptor.isValid()) {
+            MessageContent.Groodle(descriptor)
+        } else {
+            Logger.w(tag = TAG) {
+                "Groodle descriptor failed validation; " +
+                    "slots=${descriptor.slots.size} " +
+                    "titleLen=${descriptor.title.length} " +
+                    "tz=${descriptor.timezone}"
+            }
+            MessageContent.Groodle(descriptor = null)
+        }
+    } catch (e: Exception) {
+        Logger.w(tag = TAG, throwable = e) { "failed to parse Groodle descriptor; rendering unsupported-format chip" }
+        MessageContent.Groodle(descriptor = null)
+    }
+
     /**
      * Senders only ever construct a [MessageContent] subtype with a real
      * descriptor, so a null descriptor — or a [MessageContent.Unknown] kind —
@@ -100,6 +120,10 @@ object MessageContentParser {
             OdinSystemSerializer.serialize(
                 requireNotNull(content.descriptor) { "DiceRoll descriptor must be non-null on send" }
             )
+        is MessageContent.Groodle ->
+            OdinSystemSerializer.serialize(
+                requireNotNull(content.descriptor) { "Groodle descriptor must be non-null on send" }
+            )
         is MessageContent.Unknown ->
             error("Unknown message kind (dataType=${content.dataType}) cannot be serialized")
     }
@@ -107,6 +131,7 @@ object MessageContentParser {
     fun dataTypeFor(content: MessageContent): Int = when (content) {
         is MessageContent.Event -> ChatProtocol.ChatEventMessageDataType
         is MessageContent.DiceRoll -> ChatProtocol.ChatDiceRollMessageDataType
+        is MessageContent.Groodle -> ChatProtocol.ChatGroodleMessageDataType
         is MessageContent.Unknown ->
             error("Unknown message kind (dataType=${content.dataType}) cannot be re-sent")
     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/AttachmentOptions.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/AttachmentOptions.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Casino
 import androidx.compose.material.icons.filled.Event
 import androidx.compose.material.icons.filled.Image
@@ -66,6 +67,7 @@ import id.homebase.resources.chat_message_attachment_file
 import id.homebase.resources.chat_message_attachment_gallery
 import id.homebase.resources.chat_dice_share
 import id.homebase.resources.chat_event_share
+import id.homebase.resources.chat_groodle_share
 import id.homebase.resources.chat_location_share
 import id.homebase.resources.chat_message_needs_gallery_permission
 import id.homebase.resources.chat_message_needs_gallery_permission_button_text
@@ -253,6 +255,7 @@ fun AttachmentOptions(
     onContactClick: () -> Unit,
     onLocationClick: () -> Unit,
     onEventClick: () -> Unit,
+    onGroodleClick: () -> Unit,
     onDicesClick: () -> Unit,
 ) {
     Column(
@@ -297,6 +300,14 @@ fun AttachmentOptions(
                     icon = Icons.Default.Event,
                     label = stringResource(MR.string.chat_event_share),
                     onClick = onEventClick,
+                )
+            }
+            item {
+                AttachmentOption(
+                    modifier = Modifier.testTag("attachment_groodle"),
+                    icon = Icons.Default.CalendarMonth,
+                    label = stringResource(MR.string.chat_groodle_share),
+                    onClick = onGroodleClick,
                 )
             }
             item {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -119,6 +119,7 @@ import id.homebase.chat.dice.DiceRollDescriptor
 import id.homebase.chat.dice.computeBattleChainCap
 import id.homebase.chat.services.content.MessageContent
 import id.homebase.chat.event.EventComposerSheet
+import id.homebase.chat.groodle.GroodleComposerSheet
 import id.homebase.chat.event.EventDetailDialog
 import id.homebase.chat.event.EventRsvp
 import id.homebase.chat.location.LocationResult
@@ -243,6 +244,7 @@ fun ConversationContent(
     val focusManager = LocalFocusManager.current
     var showAttachmentSheet by remember { mutableStateOf(false) }
     var showEventComposer by remember { mutableStateOf(false) }
+    var showGroodleComposer by remember { mutableStateOf(false) }
     var showDiceRollComposer by remember { mutableStateOf(false) }
     var showEmojiSheet by remember { mutableStateOf(false) }
     var showConversationMenu by remember { mutableStateOf(false) }
@@ -1574,6 +1576,9 @@ fun ConversationContent(
                     }, onEventClick = {
                         showAttachmentSheet = false
                         showEventComposer = true
+                    }, onGroodleClick = {
+                        showAttachmentSheet = false
+                        showGroodleComposer = true
                     }, onDicesClick = {
                         showAttachmentSheet = false
                         showDiceRollComposer = true
@@ -1588,6 +1593,14 @@ fun ConversationContent(
             conversationId = conversation.conversation.id,
             onDismiss = { showEventComposer = false },
             onSent = { showEventComposer = false },
+        )
+    }
+
+    if (showGroodleComposer) {
+        GroodleComposerSheet(
+            conversationId = conversation.conversation.id,
+            onDismiss = { showGroodleComposer = false },
+            onSent = { showGroodleComposer = false },
         )
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -59,6 +59,7 @@ import id.homebase.chat.conversationlist.UploadStatus
 import id.homebase.chat.data.MessageUiModel
 import id.homebase.chat.dice.DiceRollBubble
 import id.homebase.chat.event.EventBubble
+import id.homebase.chat.groodle.GroodleBubble
 import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.content.MessageContent
 import id.homebase.core.config.chatTargetDrive
@@ -156,6 +157,19 @@ fun MessageBubbleRaw(
                 currentOdinId = currentOdinId,
                 chainCap = chainCap,
                 modifier = modifier,
+            )
+            return
+        }
+        is MessageContent.Groodle -> {
+            GroodleBubble(
+                descriptor = content.descriptor,
+                modifier = modifier,
+                messageId = message.id,
+                conversationId = message.conversationId,
+                ownReactions = message.ownReactions,
+                reactionSummary = message.reactionPreview,
+                organizer = message.originalAuthor,
+                onLongClick = onLongClick,
             )
             return
         }

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/groodle/GroodleDescriptorTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/groodle/GroodleDescriptorTest.kt
@@ -1,0 +1,158 @@
+package id.homebase.chat.groodle
+
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.chat.services.ChatProtocol
+import id.homebase.chat.services.content.MessageContent
+import id.homebase.chat.services.content.MessageContentParser
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class GroodleDescriptorTest {
+
+    private fun base(
+        title: String = "Q2 Planning Sync",
+        description: String = "Pick the times that work for you.",
+        timezone: String = "Europe/Copenhagen",
+        allowMaybe: Boolean = true,
+        deadlineUtcMs: Long? = null,
+        slots: List<GroodleSlot> = listOf(
+            GroodleSlot(startUtcMs = 1_747_929_600_000L, endUtcMs = 1_747_933_200_000L),
+            GroodleSlot(startUtcMs = 1_748_016_000_000L, endUtcMs = 1_748_019_600_000L),
+        ),
+    ) = GroodleDescriptor(
+        title = title,
+        description = description,
+        timezone = timezone,
+        allowMaybe = allowMaybe,
+        deadlineUtcMs = deadlineUtcMs,
+        slots = slots,
+    )
+
+    @Test
+    fun valid_descriptor_passes_and_summary_is_title() {
+        val d = base()
+        assertTrue(d.isValid())
+        assertEquals("Q2 Planning Sync", d.summaryLine())
+    }
+
+    @Test
+    fun rejects_blank_title() {
+        assertFalse(base(title = "   ").isValid())
+    }
+
+    @Test
+    fun rejects_title_over_80_codepoints() {
+        assertFalse(base(title = "a".repeat(81)).isValid())
+        assertTrue(base(title = "a".repeat(80)).isValid())
+    }
+
+    @Test
+    fun rejects_description_over_280_codepoints() {
+        assertFalse(base(description = "a".repeat(281)).isValid())
+        assertTrue(base(description = "a".repeat(280)).isValid())
+    }
+
+    @Test
+    fun rejects_blank_timezone() {
+        assertFalse(base(timezone = "  ").isValid())
+    }
+
+    @Test
+    fun rejects_empty_slots() {
+        assertFalse(base(slots = emptyList()).isValid())
+    }
+
+    @Test
+    fun rejects_more_than_ten_slots() {
+        val eleven = (0 until 11).map { GroodleSlot(startUtcMs = 1_000_000L + it * 1_000L) }
+        assertFalse(base(slots = eleven, deadlineUtcMs = null).isValid())
+        val ten = (0 until 10).map { GroodleSlot(startUtcMs = 1_000_000L + it * 1_000L) }
+        assertTrue(base(slots = ten, deadlineUtcMs = null).isValid())
+    }
+
+    @Test
+    fun rejects_unsorted_slots() {
+        val unsorted = listOf(
+            GroodleSlot(startUtcMs = 2_000_000L),
+            GroodleSlot(startUtcMs = 1_000_000L),
+        )
+        assertFalse(base(slots = unsorted).isValid())
+    }
+
+    @Test
+    fun rejects_identical_slots() {
+        val dup = listOf(
+            GroodleSlot(startUtcMs = 1_000_000L, endUtcMs = 2_000_000L),
+            GroodleSlot(startUtcMs = 1_000_000L, endUtcMs = 2_000_000L),
+        )
+        assertFalse(base(slots = dup).isValid())
+    }
+
+    @Test
+    fun allows_same_start_different_end() {
+        val sameStart = listOf(
+            GroodleSlot(startUtcMs = 1_000_000L, endUtcMs = 2_000_000L),
+            GroodleSlot(startUtcMs = 1_000_000L, endUtcMs = 3_000_000L),
+        )
+        assertTrue(base(slots = sameStart).isValid())
+    }
+
+    @Test
+    fun rejects_end_before_or_equal_start() {
+        assertFalse(base(slots = listOf(GroodleSlot(startUtcMs = 1_000L, endUtcMs = 1_000L))).isValid())
+        assertFalse(base(slots = listOf(GroodleSlot(startUtcMs = 2_000L, endUtcMs = 1_000L))).isValid())
+    }
+
+    @Test
+    fun rejects_deadline_after_first_slot() {
+        val firstStart = 1_747_929_600_000L
+        assertFalse(base(deadlineUtcMs = firstStart + 1).isValid())
+        assertTrue(base(deadlineUtcMs = firstStart).isValid())
+        assertTrue(base(deadlineUtcMs = firstStart - 86_400_000L).isValid())
+    }
+
+    @Test
+    fun rejects_schema_version_below_one() {
+        assertFalse(base().copy(schemaVersion = 0).isValid())
+    }
+
+    @Test
+    fun round_trips_through_parser() {
+        val original = base(deadlineUtcMs = 1_747_843_200_000L)
+        val serialized = MessageContentParser.serialize(MessageContent.Groodle(original))
+        val parsed = MessageContentParser.parse(ChatProtocol.ChatGroodleMessageDataType, serialized)
+        val groodle = assertIs<MessageContent.Groodle>(parsed)
+        assertEquals(original, groodle.descriptor)
+    }
+
+    @Test
+    fun invalid_descriptor_parses_to_null_not_dropped() {
+        // Serializes fine but fails validation (empty slots).
+        val bogus = OdinSystemSerializer.serialize(
+            base(slots = emptyList()),
+        )
+        val parsed = MessageContentParser.parse(ChatProtocol.ChatGroodleMessageDataType, bogus)
+        val groodle = assertIs<MessageContent.Groodle>(parsed)
+        assertNull(groodle.descriptor)
+        assertEquals(MessageContent.UNPARSEABLE_GROODLE_LABEL, groodle.displayLabel)
+    }
+
+    @Test
+    fun malformed_json_parses_to_null_not_dropped() {
+        val parsed = MessageContentParser.parse(ChatProtocol.ChatGroodleMessageDataType, "{not valid json")
+        val groodle = assertIs<MessageContent.Groodle>(parsed)
+        assertNull(groodle.descriptor)
+    }
+
+    @Test
+    fun data_type_for_is_213() {
+        assertEquals(
+            ChatProtocol.ChatGroodleMessageDataType,
+            MessageContentParser.dataTypeFor(MessageContent.Groodle(base())),
+        )
+    }
+}

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/groodle/GroodleVoteTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/groodle/GroodleVoteTest.kt
@@ -1,0 +1,103 @@
+package id.homebase.chat.groodle
+
+import id.homebase.api.client.drives.files.ReactionEntry
+import id.homebase.api.client.drives.files.ReactionSummary
+import id.homebase.api.client.drives.files.reactions.ReactionContent
+import id.homebase.api.serialization.OdinSystemSerializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class GroodleVoteTest {
+
+    private fun reactionJson(code: String): String =
+        OdinSystemSerializer.serialize(ReactionContent(emoji = code))
+
+    private fun summaryOf(vararg codeToCount: Pair<String, Int>): ReactionSummary {
+        val map = codeToCount.associate { (code, count) ->
+            code to ReactionEntry(key = code, count = count, reactionContent = reactionJson(code))
+        }
+        return ReactionSummary(reactions = map)
+    }
+
+    @Test
+    fun encode_produces_expected_codes() {
+        assertEquals("_1Y", GroodleVote.encode(1, GroodleVote.Choice.YES))
+        assertEquals("_3M", GroodleVote.encode(3, GroodleVote.Choice.MAYBE))
+        assertEquals("_10N", GroodleVote.encode(10, GroodleVote.Choice.NO))
+    }
+
+    @Test
+    fun decode_round_trips_valid_codes() {
+        assertEquals(1 to GroodleVote.Choice.YES, GroodleVote.decode("_1Y", slotCount = 10, allowMaybe = true))
+        assertEquals(10 to GroodleVote.Choice.NO, GroodleVote.decode("_10N", slotCount = 10, allowMaybe = true))
+        assertEquals(3 to GroodleVote.Choice.MAYBE, GroodleVote.decode("_3M", slotCount = 10, allowMaybe = true))
+    }
+
+    @Test
+    fun decode_rejects_maybe_when_disallowed() {
+        assertNull(GroodleVote.decode("_3M", slotCount = 10, allowMaybe = false))
+        // Y/N still fine.
+        assertEquals(3 to GroodleVote.Choice.YES, GroodleVote.decode("_3Y", slotCount = 10, allowMaybe = false))
+    }
+
+    @Test
+    fun decode_rejects_out_of_range_slot() {
+        assertNull(GroodleVote.decode("_0Y", slotCount = 10, allowMaybe = true))
+        assertNull(GroodleVote.decode("_11Y", slotCount = 10, allowMaybe = true))
+    }
+
+    @Test
+    fun decode_rejects_stray_strings_and_emoji() {
+        assertNull(GroodleVote.decode("1Y", slotCount = 10, allowMaybe = true))   // no underscore
+        assertNull(GroodleVote.decode("_1X", slotCount = 10, allowMaybe = true))  // bad choice
+        assertNull(GroodleVote.decode("😀", slotCount = 10, allowMaybe = true))
+        assertNull(GroodleVote.decode("_", slotCount = 10, allowMaybe = true))
+        assertNull(GroodleVote.decode("_1", slotCount = 10, allowMaybe = true))
+    }
+
+    @Test
+    fun counts_tally_and_score_per_slot() {
+        val summary = summaryOf("_1Y" to 2, "_1N" to 1, "_2M" to 3)
+        val counts = GroodleVote.counts(summary, slotCount = 2, allowMaybe = true)
+
+        val slot1 = counts.getValue(1)
+        assertEquals(GroodleVote.SlotCounts(yes = 2, no = 1, maybe = 0), slot1)
+        assertEquals(4, slot1.score) // 2*2 + 0
+
+        val slot2 = counts.getValue(2)
+        assertEquals(GroodleVote.SlotCounts(yes = 0, no = 0, maybe = 3), slot2)
+        assertEquals(3, slot2.score) // 0*2 + 3
+    }
+
+    @Test
+    fun counts_ignores_maybe_when_disallowed() {
+        val summary = summaryOf("_1Y" to 1, "_1M" to 5)
+        val counts = GroodleVote.counts(summary, slotCount = 1, allowMaybe = false)
+        assertEquals(GroodleVote.SlotCounts(yes = 1, no = 0, maybe = 0), counts.getValue(1))
+    }
+
+    @Test
+    fun counts_returns_zeroed_entries_for_null_summary() {
+        val counts = GroodleVote.counts(null, slotCount = 3, allowMaybe = true)
+        assertEquals(3, counts.size)
+        assertEquals(GroodleVote.SlotCounts(0, 0, 0), counts.getValue(2))
+    }
+
+    @Test
+    fun my_votes_decodes_own_reactions_last_write_wins() {
+        val own = listOf(reactionJson("_1Y"), reactionJson("_2N"), reactionJson("_3M"))
+        val votes = GroodleVote.myVotes(own, slotCount = 3, allowMaybe = true)
+        assertEquals(
+            mapOf(1 to GroodleVote.Choice.YES, 2 to GroodleVote.Choice.NO, 3 to GroodleVote.Choice.MAYBE),
+            votes,
+        )
+    }
+
+    @Test
+    fun my_votes_drops_maybe_when_disallowed() {
+        val own = listOf(reactionJson("_1Y"), reactionJson("_3M"))
+        val votes = GroodleVote.myVotes(own, slotCount = 3, allowMaybe = false)
+        assertEquals(mapOf(1 to GroodleVote.Choice.YES), votes)
+    }
+}

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/AttachmentOptionsTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/AttachmentOptionsTest.kt
@@ -21,6 +21,7 @@ class AttachmentOptionsTest {
                     onContactClick = {},
                     onLocationClick = {},
                     onEventClick = {},
+                    onGroodleClick = {},
                     onDicesClick = {},
                 )
             }
@@ -40,6 +41,7 @@ class AttachmentOptionsTest {
                     onContactClick = {},
                     onLocationClick = {},
                     onEventClick = {},
+                    onGroodleClick = {},
                     onDicesClick = {},
                 )
             }
@@ -59,6 +61,7 @@ class AttachmentOptionsTest {
                     onContactClick = {},
                     onLocationClick = {},
                     onEventClick = {},
+                    onGroodleClick = {},
                     onDicesClick = {},
                 )
             }

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -736,6 +736,42 @@
     <string name="chat_dice_battle_and">and</string>
     <string name="chat_dice_mode_oe_label">1d100OE (open-ended)</string>
     <string name="chat_dice_mode_oe_hint">2d10 read as percentile. 96+ rolls again up, 04- rolls again down.</string>
+
+    <!-- Groodle (group-scheduling poll) -->
+    <string name="chat_groodle_share">Groodle</string>
+    <string name="chat_groodle_composer_title">New Groodle</string>
+    <string name="chat_groodle_unparseable">Unable to display this Groodle. Please update the app.</string>
+    <string name="chat_groodle_field_title">Title</string>
+    <string name="chat_groodle_field_description">Description (optional)</string>
+    <string name="chat_groodle_field_timezone">Time zone</string>
+    <string name="chat_groodle_allow_maybe">Allow \"Maybe\"</string>
+    <string name="chat_groodle_deadline">Voting deadline</string>
+    <string name="chat_groodle_deadline_24h">24 hours</string>
+    <string name="chat_groodle_deadline_48h">48 hours</string>
+    <string name="chat_groodle_deadline_week">1 week</string>
+    <string name="chat_groodle_deadline_none">No deadline</string>
+    <string name="chat_groodle_add_time">Add a time</string>
+    <string name="chat_groodle_set_time">Set time</string>
+    <string name="chat_groodle_duration">Duration</string>
+    <string name="chat_groodle_duration_minutes">%1$d min</string>
+    <string name="chat_groodle_remove_option">Remove option</string>
+    <string name="chat_groodle_option_count">%1$d options</string>
+    <string name="chat_groodle_option_count_one">1 option</string>
+    <string name="chat_groodle_max_options">Up to %1$d options.</string>
+    <string name="chat_groodle_closes_in">Voting closes %1$s</string>
+    <string name="chat_groodle_closed">Voting closed</string>
+    <string name="chat_groodle_you_voted">You've voted</string>
+    <string name="chat_groodle_tap_to_vote">Tap to vote</string>
+    <string name="chat_groodle_vote_yes">Yes</string>
+    <string name="chat_groodle_vote_no">No</string>
+    <string name="chat_groodle_vote_maybe">Maybe</string>
+    <string name="chat_groodle_winner">Leading</string>
+    <string name="chat_groodle_tally">%1$d yes · %2$d maybe · %3$d no</string>
+    <string name="chat_groodle_scheduled_in_zone">Scheduled: %1$s %2$s</string>
+    <string name="chat_groodle_err_times_missing">Set a time for every option.</string>
+    <string name="chat_groodle_err_duplicate">Two options have the same date and time.</string>
+    <string name="chat_groodle_send">Send Groodle</string>
+
     <string name="chat_unknown_message_type">Unknown message type — please update the app.</string>
     <string name="chat_unknown_message_type_diagnostic">(type %1$d)</string>
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionList.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionList.kt
@@ -154,7 +154,11 @@ fun ReactionList(
 
 private fun extractEmoji(reactionContent: String): String? {
     return try {
-        OdinSystemSerializer.deserialize<ReactionContent>(reactionContent).emoji
+        val emoji = OdinSystemSerializer.deserialize<ReactionContent>(reactionContent).emoji
+        // A leading underscore marks a machine reaction (e.g. a Groodle vote code
+        // like "_1Y") that is not meant to be rendered as an emoji. Its own kind's
+        // bubble surfaces it; the generic reaction pill ignores it.
+        if (emoji.startsWith('_')) null else emoji
     } catch (_: Exception) {
         null
     }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionsBottomSheet.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionsBottomSheet.kt
@@ -106,7 +106,7 @@ fun ReactionsBottomSheet(
                 }
 
                 ReactionsContent(
-                    reactions = reactions,
+                    rawReactions = reactions,
                     ownerOdinId = ownerOdinId,
                     onContactClick = onContactClick,
                     onAddEmoji = onAddReaction?.let { { showEmojiPicker = true } },
@@ -129,12 +129,17 @@ fun ReactionsBottomSheet(
 
 @Composable
 private fun ColumnScope.ReactionsContent(
-    reactions: List<ReactionDisplayItem>,
+    rawReactions: List<ReactionDisplayItem>,
     ownerOdinId: String?,
     onContactClick: (odinId: String) -> Unit,
     onAddEmoji: (() -> Unit)? = null,
     onToggleReaction: ((String) -> Unit)? = null,
 ) {
+    // Drop machine reactions whose code starts with "_" (e.g. Groodle vote codes
+    // like "_1Y") — they are surfaced by their own kind's bubble, not as emoji.
+    val reactions = remember(rawReactions) {
+        rawReactions.filterNot { it.emoji.startsWith('_') }
+    }
     val grouped = remember(reactions) {
         reactions.groupBy { it.emoji }
     }


### PR DESCRIPTION
## Overview

Adds **Groodle** (Group + Doodle), a third typed chat message kind
(`ChatProtocol.ChatGroodleMessageDataType = 213`) for scheduling a meeting
across candidate time slots — alongside **Event** (210) and **DiceRoll** (212).
Built per `ADDING_TYPED_MESSAGE_KIND.md`.

The sender proposes **1–10 candidate time slots**; recipients vote
**Yes / No / Maybe** per slot. The descriptor rides on the message header
(`appData.content`, ~900 B worst case, well under the 7 KB cap) — no payloads,
no fetch on scroll.

## How voting works

Votes are recorded as **ordinary chat reactions**, encoded as short ASCII codes
(`_1Y`, `_3M`, `_10N`) instead of emoji — so they reuse the existing reaction
sync with no new transport. The leading underscore marks a reaction as
"not an emoji to render": `ReactionList` and `ReactionsBottomSheet` now drop any
reaction whose decoded text starts with `_`, so vote codes never show up as
emoji pills. This is the one shared-code change and is reusable by future
machine-reactions.

Voting uses clear-then-set (like Event RSVP) so a slot can't hold two choices
at once. Voting **locks after the deadline**.

## UX decisions

- **Bubble shows no results** — just title, option count, deadline countdown,
  and a "you've voted / tap to vote" hint. The full per-slot tally and the
  leading slot appear **only** in the fullscreen detail dialog.
- **Slot builder**: each calendar tap adds a removable row (cap 10); duration
  auto-fills from the previous row on rows 2+. A **single tap on a date
  selects-and-commits** (no OK button, Cancel only) — accidental adds are
  removed via the row's ✕.
- Times always render in the **viewer's local zone**, with a "Scheduled in
  <zone>" tagline when the organizer's zone differs (reuses the Event pattern).
- No editing — a Groodle can only be deleted (`ActionPolicy.StructuredOneShot`).

## Files

**New** (`homebase-chat/.../chat/groodle/`): `GroodleDescriptor`, `GroodleVote`,
`GroodleTimes`, `GroodleBubble`, `GroodleDetailDialog`, `GroodleComposerSheet`
(+ `GroodleDescriptorTest`, `GroodleVoteTest`).

**Wiring**: `ChatProtocol`, `MessageContent` (+`Groodle` subtype), `MessageContentParser`
(parse/serialize/dataTypeFor), `MessageBubbleRaw` dispatch, `AttachmentOptions`
(CalendarMonth icon, between Event and Dice), `ConversationContent`, `strings.xml`.

**Shared**: `ReactionList`, `ReactionsBottomSheet` (the `_` filter).

## Tests / verification

- `homebase-chat:jvmTest` + `homebase-common:jvmTest` green; descriptor bounds,
  parser round-trip, parse-failure→`Groodle(null)`, and vote encode/decode/
  counts/score/myVotes covered.
- Konsist `ArchitectureTest` (no hardcoded `Text("…")`) green.
- `homebase-chat:compileAndroidMain` green. (Native targets disabled on this
  machine; all code is `commonMain` using the same multiplatform APIs Event
  already ships on iOS.)
- Driven end-to-end in the desktop app (compose, send, vote, timezone display).

## Notes for reviewers

- **One open decision:** `notificationLabel` defaults to the title, so a Groodle
  title reaches the recipient's push provider in clear. Event deliberately
  overrides this (sentinel + timestamp) to keep titles off push. This matched
  the original spec, but it's the only place Groodle knowingly diverges from
  Event's privacy stance — happy to add the override if we'd rather not leak
  titles.
- The second commit (`docs: drop stale "Codex will review" note from CLAUDE.md`)
  is an unrelated one-line doc cleanup, kept as its own commit; drop it if you'd
  prefer it out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)