### PR TITLE
fix(notifications): open companion-app taps on own identity (+ cold-start fix)

### DIFF
--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
@@ -9,6 +9,7 @@ import id.homebase.api.client.notifications.PushSubscriptionResponse
 import id.homebase.api.client.profile.PublicProfileProviderCached
 import id.homebase.api.common.OdinId
 import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.youauth.YouAuthState
 import id.homebase.core.config.AppConfig
 import id.homebase.core.config.COMMUNITY_APP_ID
 import id.homebase.core.config.FEED_APP_ID
@@ -16,6 +17,7 @@ import id.homebase.core.config.MAIL_APP_ID
 import id.homebase.core.config.OWNER_APP_ID
 import id.homebase.core.navigation.ActiveConversation
 import id.homebase.core.settings.UserPreferences
+import id.homebase.core.sync.awaitAuthRestored
 import id.homebase.core.util.Platform
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
@@ -23,12 +25,15 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import kotlin.random.Random
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
 import kotlin.uuid.Uuid
 
@@ -85,6 +90,41 @@ internal fun buildCompanionAppUrlEvent(
     }
 }
 
+/** Apps whose notifications open the logged-in identity's own web app in the browser. */
+internal val COMPANION_APP_IDS = setOf(COMMUNITY_APP_ID, OWNER_APP_ID, MAIL_APP_ID, FEED_APP_ID)
+
+/**
+ * How long a companion-app tap waits for credentials to be restored before
+ * giving up. Mirrors BackgroundSyncOrchestrator's AUTH_RESTORE_TIMEOUT: the
+ * observed cold-wake restore window is ~12 ms, and 2 s leaves headroom for a
+ * slow-disk / contended-Koin-init start without hanging a logged-out tap.
+ */
+private val COMPANION_AUTH_RESTORE_TIMEOUT = 2.seconds
+
+/**
+ * Resolves the companion-app redirect event, AWAITING auth restoration so a tap
+ * from a killed app isn't dropped while `YouAuthFlowManager.restoreSession()` is
+ * still loading credentials — the cold-start counterpart of the background-sync
+ * race closed by [awaitAuthRestored]. The own-identity domain is read from the
+ * resolved [YouAuthState.Authenticated]; returns null when auth does not resolve
+ * to Authenticated within [timeout] (logged out / wedged restore) or the app is
+ * not a companion.
+ *
+ * Extracted as a top-level suspend function so it's unit-testable with virtual
+ * time, without constructing NotificationService's dependency graph.
+ */
+internal suspend fun resolveCompanionAppUrlEvent(
+    appId: String,
+    authState: StateFlow<YouAuthState>,
+    typeId: String,
+    tagId: String,
+    timeout: Duration,
+): NotificationNavigationEvent.OpenUrl? {
+    val resolved = awaitAuthRestored(authState, timeout)
+    val ownDomain = (resolved as? YouAuthState.Authenticated)?.identity?.domainName
+    return buildCompanionAppUrlEvent(appId, ownDomain, typeId, tagId)
+}
+
 /**
  * Central notification service that wraps KMPNotifier and handles incoming push/local
  * notifications. Register as a singleton in Koin.
@@ -98,6 +138,13 @@ class NotificationService(
     private val pendingNotificationTap: PendingNotificationTap,
     private val notificationBackend: NotificationBackend,
     private val eventBus: EventBus,
+    /**
+     * Narrow seam onto [id.homebase.api.youauth.YouAuthFlowManager.authState] so
+     * a companion-app tap can await credential restoration (cold-start race).
+     * A `StateFlow<YouAuthState>` rather than the whole manager keeps the
+     * resolver unit-testable — same pattern as [id.homebase.core.sync.BackgroundSyncOrchestrator].
+     */
+    private val authState: StateFlow<YouAuthState>,
 ) {
 
     private var isListening = false
@@ -474,6 +521,12 @@ class NotificationService(
         } else null
     }
 
+    /** Logs and queues a navigation event onto the buffered nav Channel. */
+    private fun emitNavigationEvent(event: NotificationNavigationEvent) {
+        Logger.i(tag = "NotificationService") { "navigationEvent emit: $event" }
+        _navigationEvents.trySend(event)
+    }
+
     /**
      * Handles notification tap — emits navigation event for the UI layer.
      * Called from KMPNotifier's onNotificationClicked callback and also
@@ -486,8 +539,8 @@ class NotificationService(
             val appId = notification.options.appId
             val typeId = notification.options.typeId
             val tagId = notification.options.tagId
-            val event = when (appId) {
-                Uuid.parse(AppConfig.APP_ID).toString() -> {
+            when {
+                appId == Uuid.parse(AppConfig.APP_ID).toString() -> {
                     // Only set the pending tap when BOTH conversationId and
                     // messageId are present — a messageId-less payload is
                     // ambient "new activity" and should not auto-navigate
@@ -508,26 +561,38 @@ class NotificationService(
                     // Tapping clears only this conversation's notifications + count,
                     // leaving other senders' notifications in the tray.
                     clearConversationNotifications(typeId)
-                    NotificationNavigationEvent.OpenConversation(typeId)
+                    emitNavigationEvent(NotificationNavigationEvent.OpenConversation(typeId))
                 }
 
-                // Community, owner, mail and feed open the *logged-in* identity's
-                // own web app in the browser (see buildCompanionAppUrlEvent). The
-                // sender's host has no session for us, so senderId must NOT be used.
-                else -> buildCompanionAppUrlEvent(
-                    appId = appId,
-                    ownDomain = credentialsManager.credentialsFlow.value?.domain?.domainName,
-                    typeId = typeId,
-                    tagId = tagId,
-                )
-            }
+                appId in COMPANION_APP_IDS -> {
+                    // Community, owner, mail and feed open the *logged-in* identity's
+                    // own web app in the browser (see buildCompanionAppUrlEvent) —
+                    // never the sender's host. Resolve the domain by AWAITING auth
+                    // restoration so a tap from a KILLED app isn't dropped while
+                    // restoreSession() is still loading credentials (cold-start
+                    // race). Emit off the injected scope into the buffered nav
+                    // Channel, which queues the event until the UI collector attaches.
+                    scope.launch {
+                        val event = resolveCompanionAppUrlEvent(
+                            appId = appId,
+                            authState = authState,
+                            typeId = typeId,
+                            tagId = tagId,
+                            timeout = COMPANION_AUTH_RESTORE_TIMEOUT,
+                        )
+                        if (event != null) {
+                            emitNavigationEvent(event)
+                        } else {
+                            Logger.w(tag = "NotificationService") {
+                                "Companion tap produced no navigation " +
+                                        "(credentials unavailable) appId=$appId"
+                            }
+                        }
+                    }
+                }
 
-            if (event != null) {
-                Logger.i(tag = "NotificationService") { "navigationEvent emit: $event" }
-                _navigationEvents.trySend(event)
-            } else {
-                Logger.w(tag = "NotificationService") {
-                    "No navigationEvent produced from click (appId unmatched?)"
+                else -> Logger.w(tag = "NotificationService") {
+                    "No navigationEvent produced from click (appId unmatched: $appId)"
                 }
             }
         } catch (e: Exception) {

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
@@ -43,6 +43,49 @@ data class SubscriptionVerificationDetail(
 )
 
 /**
+ * Builds the browser-redirect navigation event for a tapped notification from a
+ * web-app companion (community, owner, mail, feed). These open the *logged-in*
+ * identity's own web app — never the message sender's domain: the companion web
+ * clients are served from and authenticated against our own identity, and the
+ * author's host has no session for us. Faithful to the RN app, which built these
+ * from getIdentity(), and to the in-app Feed WebView (https://{ownDomain}/apps/feed).
+ *
+ * @param ownDomain the active (logged-in) identity's domain, or null when logged
+ *   out / credentials not yet ready — in which case there is nothing to open.
+ * @return the [NotificationNavigationEvent.OpenUrl] to emit, or null for a null
+ *   domain or a non-companion appId (e.g. chat, which navigates in-app).
+ */
+internal fun buildCompanionAppUrlEvent(
+    appId: String,
+    ownDomain: String?,
+    typeId: String,
+    tagId: String,
+): NotificationNavigationEvent.OpenUrl? {
+    if (ownDomain.isNullOrBlank()) return null
+    return when (appId) {
+        COMMUNITY_APP_ID ->
+            NotificationNavigationEvent.OpenUrl(
+                "https://$ownDomain/apps/community/redirect/$typeId/$tagId"
+            )
+
+        OWNER_APP_ID ->
+            NotificationNavigationEvent.OpenUrl("https://$ownDomain/owner/connections")
+
+        MAIL_APP_ID ->
+            NotificationNavigationEvent.OpenUrl("https://$ownDomain/apps/mail/inbox/$typeId")
+
+        FEED_APP_ID ->
+            if (tagId.isNotBlank()) {
+                NotificationNavigationEvent.OpenUrl("https://$ownDomain/apps/feed/post/$tagId")
+            } else {
+                NotificationNavigationEvent.OpenUrl("https://$ownDomain/apps/feed")
+            }
+
+        else -> null
+    }
+}
+
+/**
  * Central notification service that wraps KMPNotifier and handles incoming push/local
  * notifications. Register as a singleton in Koin.
  */
@@ -468,33 +511,15 @@ class NotificationService(
                     NotificationNavigationEvent.OpenConversation(typeId)
                 }
 
-                COMMUNITY_APP_ID ->
-                    NotificationNavigationEvent.OpenUrl(
-                        "https://${notification.senderId}/apps/community/redirect/${typeId}/${tagId}"
-                    )
-
-                OWNER_APP_ID ->
-                    NotificationNavigationEvent.OpenUrl(
-                        "https://${notification.senderId}/owner/connections"
-                    )
-
-                MAIL_APP_ID ->
-                    NotificationNavigationEvent.OpenUrl(
-                        "https://${notification.senderId}/apps/mail/inbox/$typeId"
-                    )
-
-                FEED_APP_ID ->
-                    if (tagId.isNotBlank()) {
-                        NotificationNavigationEvent.OpenUrl(
-                            "https://${notification.senderId}/apps/feed/post/$tagId"
-                        )
-                    } else {
-                        NotificationNavigationEvent.OpenUrl(
-                            "https://${notification.senderId}/apps/feed"
-                        )
-                    }
-
-                else -> null
+                // Community, owner, mail and feed open the *logged-in* identity's
+                // own web app in the browser (see buildCompanionAppUrlEvent). The
+                // sender's host has no session for us, so senderId must NOT be used.
+                else -> buildCompanionAppUrlEvent(
+                    appId = appId,
+                    ownDomain = credentialsManager.credentialsFlow.value?.domain?.domainName,
+                    typeId = typeId,
+                    tagId = tagId,
+                )
             }
 
             if (event != null) {

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/CompanionAppUrlTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/CompanionAppUrlTest.kt
@@ -1,0 +1,93 @@
+package id.homebase.core.notifications
+
+import id.homebase.core.config.COMMUNITY_APP_ID
+import id.homebase.core.config.FEED_APP_ID
+import id.homebase.core.config.MAIL_APP_ID
+import id.homebase.core.config.OWNER_APP_ID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Pins the redirect URL a tapped notification builds for the web-app companions
+ * (community, owner, mail, feed). These open the *logged-in* identity's own web
+ * app — NOT the message sender's domain. The companion web clients are served
+ * from and authenticated against our own identity; the author's host has no
+ * session for us. Mirrors the RN app (which built these from getIdentity()) and
+ * the in-app Feed WebView (https://{ownDomain}/apps/feed).
+ *
+ * Regression guard: the original KMP port used notification.senderId here, which
+ * sent the user to a stranger's domain on tap.
+ */
+class CompanionAppUrlTest {
+
+    private val ownDomain = "frodo.dotyou.cloud"
+
+    @Test
+    fun community_opensOwnIdentityRedirect() {
+        val event = buildCompanionAppUrlEvent(
+            appId = COMMUNITY_APP_ID,
+            ownDomain = ownDomain,
+            typeId = "channel-1",
+            tagId = "msg-9",
+        )
+        assertEquals(
+            NotificationNavigationEvent.OpenUrl(
+                "https://frodo.dotyou.cloud/apps/community/redirect/channel-1/msg-9"
+            ),
+            event,
+        )
+    }
+
+    @Test
+    fun owner_opensOwnConnections() {
+        val event = buildCompanionAppUrlEvent(OWNER_APP_ID, ownDomain, "x", "y")
+        assertEquals(
+            NotificationNavigationEvent.OpenUrl("https://frodo.dotyou.cloud/owner/connections"),
+            event,
+        )
+    }
+
+    @Test
+    fun mail_opensOwnInbox() {
+        val event = buildCompanionAppUrlEvent(MAIL_APP_ID, ownDomain, "thread-1", "")
+        assertEquals(
+            NotificationNavigationEvent.OpenUrl(
+                "https://frodo.dotyou.cloud/apps/mail/inbox/thread-1"
+            ),
+            event,
+        )
+    }
+
+    @Test
+    fun feed_withTag_opensPost() {
+        val event = buildCompanionAppUrlEvent(FEED_APP_ID, ownDomain, "", "post-7")
+        assertEquals(
+            NotificationNavigationEvent.OpenUrl(
+                "https://frodo.dotyou.cloud/apps/feed/post/post-7"
+            ),
+            event,
+        )
+    }
+
+    @Test
+    fun feed_withoutTag_opensFeedRoot() {
+        val event = buildCompanionAppUrlEvent(FEED_APP_ID, ownDomain, "", "")
+        assertEquals(
+            NotificationNavigationEvent.OpenUrl("https://frodo.dotyou.cloud/apps/feed"),
+            event,
+        )
+    }
+
+    @Test
+    fun nullDomain_whenLoggedOut_returnsNull() {
+        // No active credentials → nothing to open; must not fabricate a URL.
+        assertNull(buildCompanionAppUrlEvent(COMMUNITY_APP_ID, null, "a", "b"))
+    }
+
+    @Test
+    fun unknownApp_returnsNull() {
+        // Chat (and anything else) navigates in-app, not via this helper.
+        assertNull(buildCompanionAppUrlEvent("2d78140138044b57b4aad8e4e2ef39f4", ownDomain, "a", "b"))
+    }
+}

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/CompanionAppUrlTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/CompanionAppUrlTest.kt
@@ -1,12 +1,21 @@
 package id.homebase.core.notifications
 
+import id.homebase.api.common.OdinId
+import id.homebase.api.youauth.YouAuthState
+import id.homebase.core.config.AppConfig
 import id.homebase.core.config.COMMUNITY_APP_ID
 import id.homebase.core.config.FEED_APP_ID
 import id.homebase.core.config.MAIL_APP_ID
 import id.homebase.core.config.OWNER_APP_ID
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Pins the redirect URL a tapped notification builds for the web-app companions
@@ -16,12 +25,25 @@ import kotlin.test.assertNull
  * session for us. Mirrors the RN app (which built these from getIdentity()) and
  * the in-app Feed WebView (https://{ownDomain}/apps/feed).
  *
- * Regression guard: the original KMP port used notification.senderId here, which
- * sent the user to a stranger's domain on tap.
+ * Regression guards:
+ *  - the original KMP port used notification.senderId here, sending the user to
+ *    a stranger's domain on tap;
+ *  - reading the domain synchronously dropped the tap on cold start, before
+ *    restoreSession() had populated credentials — [resolveCompanionAppUrlEvent]
+ *    awaits auth restoration (reusing awaitAuthRestored) to close that race.
  */
 class CompanionAppUrlTest {
 
     private val ownDomain = "frodo.dotyou.cloud"
+
+    private val authenticated =
+        YouAuthState.Authenticated(
+            identity = OdinId(ownDomain),
+            clientAuthToken = "tok",
+            sharedSecret = "sec",
+        )
+
+    // region buildCompanionAppUrlEvent — pure URL mapping
 
     @Test
     fun community_opensOwnIdentityRedirect() {
@@ -86,8 +108,92 @@ class CompanionAppUrlTest {
     }
 
     @Test
+    fun blankDomain_returnsNull() {
+        // Guards the isBlank() half of the isNullOrBlank() check: an empty domain
+        // must not produce "https:///apps/community/...".
+        assertNull(buildCompanionAppUrlEvent(COMMUNITY_APP_ID, "", "a", "b"))
+    }
+
+    @Test
     fun unknownApp_returnsNull() {
         // Chat (and anything else) navigates in-app, not via this helper.
-        assertNull(buildCompanionAppUrlEvent("2d78140138044b57b4aad8e4e2ef39f4", ownDomain, "a", "b"))
+        assertNull(buildCompanionAppUrlEvent(AppConfig.APP_ID, ownDomain, "a", "b"))
     }
+
+    // endregion
+
+    // region resolveCompanionAppUrlEvent — awaits credential restoration (cold-start race)
+
+    @Test
+    fun resolve_whenAlreadyAuthenticated_returnsUrl() = runTest {
+        val authState = MutableStateFlow<YouAuthState>(authenticated)
+
+        val event = resolveCompanionAppUrlEvent(
+            appId = COMMUNITY_APP_ID,
+            authState = authState,
+            typeId = "channel-1",
+            tagId = "msg-9",
+            timeout = 2.seconds,
+        )
+
+        assertEquals(
+            NotificationNavigationEvent.OpenUrl(
+                "https://frodo.dotyou.cloud/apps/community/redirect/channel-1/msg-9"
+            ),
+            event,
+        )
+    }
+
+    @Test
+    fun resolve_awaitsRestoration_thenReturnsUrl() = runTest {
+        // Cold start: authState is still Initializing at tap time, then flips to
+        // Authenticated ~12 ms later as restoreSession() completes.
+        val authState = MutableStateFlow<YouAuthState>(YouAuthState.Initializing)
+
+        val job = launch {
+            val event = resolveCompanionAppUrlEvent(
+                appId = COMMUNITY_APP_ID,
+                authState = authState,
+                typeId = "c",
+                tagId = "m",
+                timeout = 2.seconds,
+            )
+            assertEquals(
+                NotificationNavigationEvent.OpenUrl(
+                    "https://frodo.dotyou.cloud/apps/community/redirect/c/m"
+                ),
+                event,
+            )
+        }
+
+        launch {
+            delay(12.milliseconds)
+            authState.value = authenticated
+        }
+
+        job.join()
+    }
+
+    @Test
+    fun resolve_timesOut_whenStuckInitializing_returnsNull() = runTest {
+        // Wedged restoration — credentials never arrive within the budget. The tap
+        // produces no navigation rather than hanging.
+        val authState = MutableStateFlow<YouAuthState>(YouAuthState.Initializing)
+
+        assertNull(
+            resolveCompanionAppUrlEvent(COMMUNITY_APP_ID, authState, "c", "m", 2.seconds)
+        )
+    }
+
+    @Test
+    fun resolve_whenUnauthenticated_returnsNull() = runTest {
+        // Logged-out tap of a stale notification resolves immediately to null.
+        val authState = MutableStateFlow<YouAuthState>(YouAuthState.Unauthenticated)
+
+        assertNull(
+            resolveCompanionAppUrlEvent(COMMUNITY_APP_ID, authState, "c", "m", 2.seconds)
+        )
+    }
+
+    // endregion
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -362,7 +362,22 @@ val appModule = module {
     // and the CoroutineScope, which are intentionally Kotlin-default args.
     // Use the explicit lambda form so the defaults take effect.
     single { PendingNotificationTap() }
-    singleOf(::NotificationService)
+    // Explicit `single` (not `singleOf`) because the ctor takes a
+    // `StateFlow<YouAuthState>` seam that Koin can't resolve reflectively.
+    // Same narrow-seam pattern as BackgroundSyncOrchestrator above.
+    single {
+        NotificationService(
+            api = get(),
+            scope = get(),
+            profileProvider = get(),
+            userPreferences = get(),
+            credentialsManager = get(),
+            pendingNotificationTap = get(),
+            notificationBackend = get(),
+            eventBus = get(),
+            authState = get<id.homebase.api.youauth.YouAuthFlowManager>().authState,
+        )
+    }
     singleOf(::NotificationEntry)
     single {
         val upgradeProvider = get<IdentityUpgradeProvider>()


### PR DESCRIPTION
## Problem

A tapped notification from a web-app **companion** (Community, Owner, Mail, Feed) built its redirect URL from `notification.senderId` — the *message author's* domain. The companion web clients are served from and authenticated against **our own** identity, and Owner's `/owner/connections` is only ever our own, so the sender's host is wrong and has no session for us. Tapping a Community notification sent the user to a stranger's domain.

This mirrors the old React Native app, which built these URLs from `getIdentity()` (our own identity), and the in-app Feed WebView, which loads `https://{ownDomain}/apps/feed`.

## Fix

Two commits:

1. **`open companion-app taps on own identity, not sender`** — extract a pure, testable `buildCompanionAppUrlEvent(appId, ownDomain, typeId, tagId)` and route the companion branches through it using the logged-in identity instead of `senderId`. Chat tap handling is unchanged (still navigates in-app); unknown app IDs still yield no navigation.

2. **`await auth restore so cold-start companion taps aren't dropped`** — found during code review. Reading the domain synchronously at tap time loses a race on **cold start**: `YouAuthFlowManager.restoreSession()` populates credentials asynchronously from secure storage, so a tap that launches the app from a killed state (the primary notification case) read a null domain and the tap was silently dropped. Reuse the existing `awaitAuthRestored` helper (which already closes this exact race for background sync) via a new `resolveCompanionAppUrlEvent`: await auth leaving `Initializing` (2s budget), read the domain from the resolved `YouAuthState.Authenticated.identity`, then emit. `NotificationService` gains a `StateFlow<YouAuthState>` seam (same narrow-seam pattern as `BackgroundSyncOrchestrator`), wired explicitly in Koin.

The destination still opens in the **external browser** (`uriHandler.openUrl`) per the chosen approach — only the domain is corrected. The change is cross-platform: `handleNotificationClicked` is the shared tap entry point for both Android and iOS.

## Notes / known limitation

Opening in the system browser relies on an existing owner-session cookie for the identity; on a browser with no session the user will hit a login wall (an in-app authenticated WebView, like the old RN `CommunityPage`, would avoid this but was intentionally not chosen here).

## Test plan

- New `CompanionAppUrlTest` (homebase-common jvmTest):
  - `buildCompanionAppUrlEvent` pins own-identity URLs for community/owner/mail/feed + null/blank-domain + non-companion cases.
  - `resolveCompanionAppUrlEvent` (virtual time): resolves immediately when authenticated, **awaits then resolves** after restoration, times out to null when stuck `Initializing`, null when unauthenticated.
- `./gradlew homebase-common:jvmTest` — full module suite green (incl. Konsist `ArchitectureTest` and existing notification tests).
- `./gradlew homebase-core:compileKotlinJvm` — DI change compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)