### PR TITLE
fix(moments): shrink carousel/gallery images into the comments band

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
@@ -215,6 +215,13 @@ sealed interface ConversationListUiAction {
      * land at the bottom of the loaded window, not the latest message.
      */
     data class ScrollToLatest(val conversationId: Uuid) : ConversationListUiAction
+
+    /**
+     * Clears [MessageListUiState.scrollToLatestRequest] after ConversationContent
+     * has consumed it (animated to the latest item). Makes the scroll-follow a
+     * one-time event so a later unrelated remount doesn't re-scroll.
+     */
+    data object ConsumeScrollToLatestRequest : ConversationListUiAction
     data object HideReactionDetails : ConversationListUiAction
     data class StartRecording(val conversationId: Uuid) : ConversationListUiAction
     data object StopRecording : ConversationListUiAction

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -106,6 +106,16 @@ data class MessageListUiState(
      *  the screen renders [id.homebase.chat.event.EventDetailDialog] keyed off
      *  this state. Null means no host-level event detail is open. */
     val replyTargetEventDetail: ReplyTargetEventDetail? = null,
+    /** One-time "follow my own send to the bottom" token. Set to a fresh value
+     *  whenever the user sends a message through the full-screen attachment
+     *  editor (image/video/file): closing that overlay tears [ConversationContent]
+     *  — and its layout-growth auto-follow effect — out of composition, so the
+     *  effect restarts with `previousTotal = 0` and never observes the placeholder
+     *  as growth. ConversationContent collects this token on (re)mount, animates to
+     *  the latest item, and dispatches [ConversationListUiAction.ConsumeScrollToLatestRequest]
+     *  to clear it. Null once consumed, so unrelated remounts (closing the image
+     *  viewer) don't re-scroll. */
+    val scrollToLatestRequest: Uuid? = null,
 )
 
 /**

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -867,6 +867,10 @@ class ConversationListViewModel(
                 viewModelScope.launch { chatMessageStream.loadConversation(action.conversationId) }
             }
 
+            is ConversationListUiAction.ConsumeScrollToLatestRequest -> {
+                _messagesUiState.update { it.copy(scrollToLatestRequest = null) }
+            }
+
             is ConversationListUiAction.ClearHighlightedMessage -> messageActionsHandler.handleClearHighlightedMessage()
 
             is ConversationListUiAction.SaveFile -> mediaDownloadHandler.handleSaveFile(action)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -818,6 +818,11 @@ internal class MessageActionsHandler(
                     fullScreenOverlay = null,
                     isSendingMessage = false,
                     replyToMessage = if (replyTo != null) null else state.replyToMessage,
+                    // Closing fullScreenOverlay remounts ConversationContent with the
+                    // placeholder already present, so its layout-growth auto-follow can't
+                    // see growth. This token tells the freshly-mounted list to follow our
+                    // own send down to the bottom. See MessageListUiState.scrollToLatestRequest.
+                    scrollToLatestRequest = newMessageId,
                 )
             }
             messageInputTextState.clear()

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -210,6 +210,7 @@ import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
@@ -430,6 +431,24 @@ fun ConversationContent(
             wasAtBottom = total > 0 && lastVisibleIndex >= total - 1
             previousTotal = total
         }
+    }
+
+    // One-time own-send follow for sends that route through the full-screen
+    // attachment editor (image/video/file). Closing that overlay remounts this
+    // composable with the pending placeholder already in the list, so the
+    // layout-growth auto-follow above starts at previousTotal = 0 and never sees
+    // growth. The ViewModel sets scrollToLatestRequest in the same update that
+    // adds the placeholder and clears the overlay; we wait for the freshly
+    // mounted list to lay out, follow it to the bottom, then consume the token.
+    // Skipped (but still consumed) when paged into history — jumpToLatestAfterOwnSend
+    // handles that case with a ScrollToLatest reload once the send completes.
+    LaunchedEffect(uiState.scrollToLatestRequest) {
+        if (uiState.scrollToLatestRequest == null) return@LaunchedEffect
+        if (!uiState.hasNewerMessages) {
+            val total = snapshotFlow { listState.layoutInfo.totalItemsCount }.first { it > 0 }
+            listState.animateScrollToItem(total - 1)
+        }
+        onUiAction(ConversationListUiAction.ConsumeScrollToLatestRequest)
     }
 
     // Add this state to track keyboard height

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
@@ -1244,6 +1244,12 @@ private fun MomentDetailContent(
                             // (and vice versa). Letterbox bars take the Box's
                             // black background.
                             preserveAspectRatio = true,
+                            // While the comments sheet is open the pager is
+                            // height-constrained to the top band; fill that box
+                            // (Fit) instead of letting the image's own aspect
+                            // ratio size it and overflow the band — mirrors the
+                            // video tile's fitToContent here.
+                            fitBounds = commentsOpen,
                             messageId = moment.id,
                             shape = RectangleShape,
                             sharedTransitionScope = sharedTransitionScope,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
@@ -67,6 +67,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -75,6 +77,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -556,6 +559,21 @@ private fun DetailContent(
     // comment button lands with the thread already open.
     var showCommentsSheet by remember { mutableStateOf(openCommentsInitially) }
 
+    // Lifted out of [CommentsSheet] so the media-shrink animation can track the
+    // sheet's *target* state instead of the post-dismissal callback.
+    val commentsSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    // Drives the media shrink. `onDismissRequest` only fires once the sheet has
+    // finished sliding off-screen, so keying the shrink off `showCommentsSheet`
+    // alone makes the media wait for the slide to complete before re-expanding
+    // (a visible lag). Instead re-expand the moment the swipe-down starts
+    // settling toward Hidden — the media then grows in parallel with the slide.
+    val commentsShrinkActive by remember {
+        derivedStateOf {
+            showCommentsSheet && commentsSheetState.targetValue != SheetValue.Hidden
+        }
+    }
+
     Scaffold(
         // Black so the letterbox bars around a Fit-scaled image or video
         // read as part of the cinematic surface rather than the surface
@@ -637,7 +655,7 @@ private fun DetailContent(
                 initialPayloadKey = uiState.initialPayloadKey,
                 onAction = onAction,
                 onOpenComments = { showCommentsSheet = true },
-                commentsOpen = showCommentsSheet,
+                commentsOpen = commentsShrinkActive,
                 sharedTransitionScope = sharedTransitionScope,
                 animatedVisibilityScope = animatedVisibilityScope,
                 isActivePage = isActivePage,
@@ -663,6 +681,7 @@ private fun DetailContent(
             // Transparent scrim so the shrunk media above the sheet stays
             // bright instead of being dimmed by the default modal scrim.
             scrimColor = Color.Transparent,
+            sheetState = commentsSheetState,
         )
     }
 
@@ -1581,8 +1600,11 @@ private fun CommentsSheet(
     // the media it shrinks to the top third above the sheet stays bright;
     // other callers keep the default dimming scrim.
     scrimColor: Color? = null,
+    // Lifted in by the detail screen so it can observe the sheet's target state
+    // and re-expand the shrunk media in parallel with the slide-down. Defaults
+    // to a locally-remembered state for callers that don't need that coupling.
+    sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
@@ -1732,6 +1754,7 @@ private fun CommentRowFromState(
  * feed behind it until the user swipes it down or taps the scrim, so the thread
  * stays locked to the moment it was opened from.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun MomentCommentsSheet(
     uiState: MomentDetailUiState,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
@@ -337,6 +337,22 @@ private fun MomentDetailLoadedPager(
         // higher-index page coming from above — same as scrolling up the
         // timeline to see older posts.
         reverseLayout = true,
+        // Anchor pages to the moment IDENTITY, not the raw list index.
+        // `MomentsFeedService.emitSorted` re-emits a brand-new sorted list on
+        // every change (a reaction updates the moment header → BatchReceived →
+        // re-emit; new posts, deletes and sync catch-up all do too — see
+        // MomentsFeedService.kt:231). Without a key the pager tracks an integer
+        // index, so any insert/remove/re-sort shifts the index→moment mapping
+        // out from under a settled user: the moment under `currentPage` silently
+        // becomes a different one, `settledPage` remaps across the mounted
+        // panes, every pane's `isActivePage` flips, and the autoplay gate below
+        // tears down + rebuilds its ExoPlayer in a loop (the churn the TEMP
+        // instrumentation above was added to chase) — janking the Main thread so
+        // a quick vertical swipe registers nothing. With a key the pager keeps
+        // the same moment visible across re-emissions, so settledPage stays put
+        // and the players don't churn. Keys must be saveable, so stringify the
+        // Uuid (mirrors the comments LazyColumn's `key = { it.id.toString() }`).
+        key = { page -> feed[page].id.toString() },
     ) { page ->
         val moment = feed[page]
         val pageMomentId = moment.id
@@ -1169,6 +1185,18 @@ private fun MomentDetailContent(
                     .fillMaxWidth()
                     .fillMaxHeight(mediaHeightFraction)
                     .align(Alignment.TopCenter),
+                // This pager fills the whole page (mediaHeightFraction = 1f when
+                // comments are closed), so it sits under every swipe. A
+                // single-payload moment has nowhere to scroll horizontally, but
+                // an *enabled* horizontal Pager still installs a live orientation
+                // -locked `scrollable` that competes with the parent
+                // VerticalPager for the gesture: a slightly-diagonal swipe can
+                // cross horizontal touch-slop first and get claimed here, so the
+                // vertical swipe drops. Gate scrolling on having more than one
+                // page so single-payload moments (the common case) leave the
+                // vertical gesture entirely to the parent. Real carousels keep
+                // horizontal paging.
+                userScrollEnabled = pageCount > 1,
             ) { page ->
                 val payload = moment.payloads[page]
                 val contentType = payload.contentType ?: ""

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
@@ -1760,6 +1760,10 @@ internal fun MomentCommentsSheet(
     uiState: MomentDetailUiState,
     onAction: (MomentDetailUiAction) -> Unit,
     onDismiss: () -> Unit,
+    // Lifted in by the timeline feed list so it can observe the sheet's target
+    // state and drop the shrunk media band in parallel with the slide-down.
+    // Defaults to a locally-remembered state for any other caller.
+    sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
 ) {
     CommentsSheet(
         uiState = uiState,
@@ -1774,6 +1778,7 @@ internal fun MomentCommentsSheet(
         // Transparent scrim so the shrunk media band above the sheet stays
         // bright instead of being dimmed by the default modal scrim.
         scrimColor = Color.Transparent,
+        sheetState = sheetState,
     )
 
     val deleteCommentTarget = uiState.deleteCommentDialogTarget

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -47,6 +48,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -519,6 +522,7 @@ private const val FeedPaneWidthFraction = 0.28f
 private val FeedPaneMinWidth = 380.dp
 private val FeedPaneMaxWidth = 480.dp
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun MomentsFeedList(
     moments: List<MomentFeedItem>,
@@ -548,6 +552,13 @@ private fun MomentsFeedList(
     // opened, so the media band above the sheet shows that exact item (the
     // selected carousel page), not always page 0.
     var commentsPayloadKey by remember { mutableStateOf<String?>(null) }
+    // Lifted out of the comments sheet host so the media band can track the
+    // sheet's *target* state. The sheet's onDismissRequest only fires once the
+    // slide-down completes; keying the band off `commentsMomentId` alone makes
+    // the shrunk band linger over the feed for the whole slide before snapping
+    // away. Hiding it the moment the swipe-down settles toward Hidden restores
+    // the full-size feed in parallel with the slide instead.
+    val commentsSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     // Which moment (if any) has its "who reacted" roster open. Null = closed.
     // Opened by long-pressing a reaction toggle on a feed card.
     var reactionsMomentId by remember { mutableStateOf<Uuid?>(null) }
@@ -665,11 +676,25 @@ private fun MomentsFeedList(
         if (commentsSheetOnTap && bandMomentId != null) {
             val bandMoment = moments.firstOrNull { it.id == bandMomentId }
             if (bandMoment != null) {
+                // Crossfade the band with the sheet's slide rather than hard-
+                // cutting to the live feed. `onDismissRequest` only fires after
+                // the slide completes, so leaving the opaque band up for the
+                // whole slide felt laggy; hard-removing it the instant the swipe
+                // settles toward Hidden made the full-size feed card snap in
+                // behind the still-moving sheet (jarring). Fading the band out
+                // as the sheet settles reveals the feed gradually, in parallel
+                // with the slide. Stays composed (gated on `commentsMomentId`)
+                // until `onDismiss` clears it, so the fade always completes.
+                val bandAlpha by animateFloatAsState(
+                    targetValue = if (commentsSheetState.targetValue == SheetValue.Hidden) 0f else 1f,
+                    label = "momentCommentsBandFade",
+                )
                 MomentCommentsMediaBand(
                     moment = bandMoment,
                     initialPayloadKey = commentsPayloadKey,
                     isMuted = isMuted,
                     onToggleMute = videoSession::toggleMuted,
+                    modifier = Modifier.graphicsLayer { alpha = bandAlpha },
                 )
             }
         }
@@ -683,6 +708,7 @@ private fun MomentsFeedList(
     if (commentsSheetOnTap && sheetMomentId != null) {
         MomentCommentsSheetHost(
             momentId = sheetMomentId,
+            sheetState = commentsSheetState,
             onDismiss = { commentsMomentId = null },
         )
     }
@@ -709,9 +735,11 @@ private fun MomentsFeedList(
  * Reuses the detail screen's [MomentCommentsSheet] so the timeline and the
  * full-screen detail view show an identical thread.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun MomentCommentsSheetHost(
     momentId: Uuid,
+    sheetState: SheetState,
     onDismiss: () -> Unit,
 ) {
     DisposableViewModelStoreOwner {
@@ -723,6 +751,7 @@ private fun MomentCommentsSheetHost(
             uiState = uiState,
             onAction = detailVm::onAction,
             onDismiss = onDismiss,
+            sheetState = sheetState,
         )
     }
 }
@@ -754,12 +783,13 @@ private fun MomentCommentsMediaBand(
     initialPayloadKey: String?,
     isMuted: Boolean,
     onToggleMute: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val targetPayload = remember(moment.payloads, initialPayloadKey) {
         moment.payloads.firstOrNull { it.key == initialPayloadKey }
             ?: moment.payloads.firstOrNull()
     }
-    Box(modifier = Modifier.fillMaxSize().background(Color.Black)) {
+    Box(modifier = modifier.fillMaxSize().background(Color.Black)) {
         if (targetPayload != null) {
             Box(
                 modifier = Modifier

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaCarousel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaCarousel.kt
@@ -152,7 +152,14 @@ fun MomentMediaCarousel(
         }
     }
 
-    Box(modifier = modifier.fillMaxWidth().aspectRatio(aspect)) {
+    // When shrunk for the comments sheet the host gives us an explicit (1/3)
+    // height — fill it instead of re-imposing the standardised carousel aspect,
+    // which would otherwise keep the carousel at its full width/aspect height
+    // and ignore the band (the single-image and video paths already honor this).
+    Box(
+        modifier = if (fitToContent) modifier.fillMaxSize()
+        else modifier.fillMaxWidth().aspectRatio(aspect),
+    ) {
         HorizontalPager(
             state = pagerState,
             modifier = Modifier.fillMaxSize(),
@@ -208,9 +215,13 @@ fun MomentMediaCarousel(
                         ?: previewThumbnail,
                     modifier = Modifier.fillMaxSize(),
                     imageSize = ImageSize.THUMB_LARGE,
-                    // The carousel box is the aspect-locked region; let images
-                    // crop to it the same way the existing 4-up grid does.
-                    preserveAspectRatio = false,
+                    // Normally the carousel box is the aspect-locked region and
+                    // images crop to fill it (like the 4-up grid). While shrunk
+                    // for the comments sheet ([fitToContent]) the box is the 1/3
+                    // band, so fit the whole image into it instead — matching the
+                    // single-image and video paths.
+                    preserveAspectRatio = fitToContent,
+                    fitBounds = fitToContent,
                     shape = RectangleShape,
                     onClick = onMediaClick?.let { handler -> { handler(payload) } },
                     onLongPress = onMediaLongPress?.let { handler -> { offset -> handler(payload, offset) } },

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaGallery.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaGallery.kt
@@ -155,8 +155,13 @@ private fun SingleImageLayout(
         else Modifier.fillMaxWidth().aspectRatio(aspect),
         imageSize = ImageSize.THUMB_LARGE,
         // Aspect set on the modifier — let the image fill it (Crop is a no-op
-        // when source aspect matches the box).
+        // when source aspect matches the box). When shrunk for the comments
+        // band, fill the host box (Fit, whole image) instead of re-imposing the
+        // image's own aspect ratio — without this the intrinsic `.aspectRatio()`
+        // keeps the image at its natural ratio and it never collapses into the
+        // 1/3 band (same fix the carousel and reels detail pager use).
         preserveAspectRatio = fitToContent,
+        fitBounds = fitToContent,
         shape = RectangleShape,
         // Preserve nullability so MomentMediaItem only installs its inner
         // pointerInput when there's an actual click/long-press handler.

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaItem.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaItem.kt
@@ -90,6 +90,14 @@ fun MomentMediaItem(
     keyHeader: KeyHeader,
     imageSize: ImageSize? = ImageSize.THUMB_MEDIUM,
     preserveAspectRatio: Boolean = false,
+    // Fill the box the parent hands us (Fit, whole image visible) instead of
+    // imposing the media's own aspect ratio on the layout. Set when the host
+    // gives an explicit size — e.g. the comments-shrink band or the detail/reels
+    // pager page — so the image collapses into that box like the video tile does
+    // (which fills via plain fillMaxSize). Without this the intrinsic
+    // `.aspectRatio()` modifier below lets the image size to its own ratio inside
+    // a height-constrained pager and overflow the band.
+    fitBounds: Boolean = false,
     onClick: (() -> Unit)? = null,
     onLongPress: ((Offset) -> Unit)? = null,
     onRequestDecryptedFile: (() -> Unit)? = null,
@@ -105,7 +113,7 @@ fun MomentMediaItem(
     isUploading: Boolean = false,
 ) {
     val contentType = payload.contentType ?: ""
-    val imageContentScale = if (preserveAspectRatio) ContentScale.Fit else ContentScale.Crop
+    val imageContentScale = if (preserveAspectRatio || fitBounds) ContentScale.Fit else ContentScale.Crop
     val localVideoContextStore = koinInject<LocalAttachmentContextStore>()
     val localContext = if (messageId != null) {
         val ctx by localVideoContextStore.observe(messageId, payload.key)
@@ -128,7 +136,7 @@ fun MomentMediaItem(
     val baseModifier = modifier.clip(shape)
 
     val finalModifier =
-        if (preserveAspectRatio && aspectRatio != null) {
+        if (preserveAspectRatio && aspectRatio != null && !fitBounds) {
             baseModifier.aspectRatio(aspectRatio)
         } else {
             baseModifier


### PR DESCRIPTION
When the comments sheet opens the media shrinks to a top 1/3 band. Video filled the band (its tile fills via fillMaxSize), but images kept their intrinsic `.aspectRatio()` modifier and never collapsed into the band — they stayed at their natural ratio in the timeline feed band, the multi-image carousel, and the reels detail pager.

Add a `fitBounds` flag to MomentMediaItem meaning "fill the box my parent gives me (Fit, whole image), don't impose my own aspect ratio." Route the three comments-shrink paths through it so images behave like the video tile's fitToContent:
- SingleImageLayout (timeline comments band)
- MomentMediaCarousel (container fills + image fits when fitToContent)
- MomentDetailContent reels image page (fitBounds = commentsOpen)