### PR TITLE
fix(moments): show video poster instead of black tile after posting

### DIFF
--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -361,6 +361,7 @@
     <string name="moments_detail_comment_cancel">Cancel</string>
     <string name="moments_detail_menu_more">More options</string>
     <string name="moments_detail_menu_delete">Delete</string>
+    <string name="moments_detail_menu_save_current">Save current</string>
     <string name="moments_detail_menu_add_people">Add people</string>
     <string name="moments_add_people_title">Add people</string>
     <string name="moments_add_people_confirm">Add</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentsPostSenderService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentsPostSenderService.kt
@@ -760,21 +760,33 @@ class MomentsPostSenderService(
         val auditFileId = existing.fileId
         val auditTargets = genuinelyNew.map { it.domainName }.toSet()
         scope.launch {
+            Logger.i(tag = TAG) {
+                "MomentAddPeopleAudit: transfer-history poll STARTING moment=$momentUniqueId " +
+                    "fileId=$auditFileId addedTargets=$auditTargets"
+            }
             val pollDelaysMs = longArrayOf(5_000, 10_000, 15_000, 30_000, 60_000)
             for ((i, d) in pollDelaysMs.withIndex()) {
                 delay(d)
-                val history = runCatching {
+                val history = try {
                     driveFileProvider.getTransferHistory(drive, auditFileId)
-                }.getOrElse { e ->
+                } catch (e: Exception) {
                     Logger.w(throwable = e, tag = TAG) {
-                        "MomentAddPeopleAudit: transfer-history poll ${i + 1} threw moment=$momentUniqueId"
+                        "MomentAddPeopleAudit: transfer-history poll ${i + 1} THREW moment=$momentUniqueId"
                     }
-                    null
-                } ?: continue
+                    continue
+                }
+                if (history == null) {
+                    // 404 — no transfer history for this file (yet, or endpoint absent).
+                    Logger.i(tag = TAG) {
+                        "MomentAddPeopleAudit: transfer-history poll ${i + 1} NULL(404) moment=$momentUniqueId fileId=$auditFileId"
+                    }
+                    continue
+                }
                 val results = history.history.results
                 Logger.i(tag = TAG) {
                     "MomentAddPeopleAudit: transfer-history poll ${i + 1} moment=$momentUniqueId " +
                         "fileId=$auditFileId addedTargets=$auditTargets " +
+                        "originalRecipientCount=${history.originalRecipientCount} " +
                         "results=[${results.joinToString { "${it.recipient}=${it.latestTransferStatus}" +
                             "(inOutbox=${it.isInOutbox} deliveredVT=${it.latestSuccessfullyDeliveredVersionTag})" }}]"
                 }
@@ -786,6 +798,9 @@ class MomentsPostSenderService(
                     }
                     break
                 }
+            }
+            Logger.i(tag = TAG) {
+                "MomentAddPeopleAudit: transfer-history poll FINISHED moment=$momentUniqueId"
             }
         }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentsPostSenderService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentsPostSenderService.kt
@@ -26,6 +26,8 @@ import id.homebase.api.common.OdinId
 import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.api.crypto.ByteArrayUtil
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.image.ImageFormat
+import id.homebase.api.image.ImageUtils
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.OutboxSync
@@ -60,19 +62,33 @@ class MomentsPostSenderService(
 ) {
 
     /**
-     * Local file URI (from the user's picker) for the first renderable attachment
-     * of an in-flight moment. Populated by [postMomentAsync] right after the
-     * placeholder DB write, cleared once the real optimistic write lands (real
-     * `previewThumbnail` bytes are then available on `MomentFeedItem`).
+     * Coil model for the first renderable attachment of an in-flight moment:
+     * the local file URI (from the user's picker) for a photo, or the extracted
+     * poster-frame JPEG bytes for a video. Populated by [postMomentAsync] right
+     * after the placeholder DB write, cleared once the real optimistic write
+     * lands (real `previewThumbnail` bytes are then available on `MomentFeedItem`).
+     *
+     * Videos must hand over poster bytes rather than the raw video path — an
+     * image loader can't decode a video file, so a video path would render the
+     * tile black for the whole "Preparing…" window.
      *
      * The feed VM mirrors this into `MomentsFeedUiState.pendingLocalPreviews`
-     * so the tile can show the user's source image during the brief
+     * so the tile can show the user's source media during the brief
      * "Preparing…" window before thumbnails are generated.
      */
-    private val _pendingLocalPreviews = MutableStateFlow<PersistentMap<Uuid, String>>(persistentMapOf())
-    val pendingLocalPreviews: StateFlow<PersistentMap<Uuid, String>> = _pendingLocalPreviews.asStateFlow()
+    private val _pendingLocalPreviews = MutableStateFlow<PersistentMap<Uuid, Any>>(persistentMapOf())
+    val pendingLocalPreviews: StateFlow<PersistentMap<Uuid, Any>> = _pendingLocalPreviews.asStateFlow()
     companion object {
         private const val TAG = "MomentsPostSenderService"
+
+        /**
+         * Embedded video-poster thumbnail sizing for the optimistic row. The raw
+         * poster is a full-resolution frame; resize it to this cover size so the
+         * inline tile has a crisp-enough still to paint over the player during
+         * warm-up without bloating the local descriptor.
+         */
+        private const val PosterThumbnailMaxDimension = 640
+        private const val PosterThumbnailJpegQuality = 75
     }
 
     private val drive = momentsLabeledDrive.drive.alias
@@ -107,6 +123,11 @@ class MomentsPostSenderService(
         source: MomentSource? = null,
         mediaInfoByAttachment: List<MediaInfo?>? = null,
         commentsEnabled: Boolean = true,
+        // Aligned-by-index with [attachments]: the extracted poster-frame JPEG
+        // for each video attachment (null for non-video / extraction failures).
+        // Used both for the immediate local preview and as the optimistic row's
+        // embedded video thumbnail, so the tile never renders black.
+        posterByAttachment: List<ByteArray?>? = null,
     ): PostMomentResult {
         Logger.d(tag = TAG) {
             "postMomentAsync: enqueueing moment=$momentUniqueId attachments=${attachments.size} recipients=${recipients.size} source=$source"
@@ -150,16 +171,20 @@ class MomentsPostSenderService(
             ),
         )
 
-        // Cache the first renderable attachment's local URI BEFORE writing the
-        // placeholder. The optimistic writer immediately emits BatchReceived,
-        // so the feed VM resolves the tile in the same dispatch loop — by
-        // the time it asks `pendingLocalPreviews[id]`, the entry must already
-        // be there.
-        val firstRenderableUri = attachments.firstOrNull { input ->
+        // Cache the first renderable attachment's preview model BEFORE writing
+        // the placeholder. The optimistic writer immediately emits
+        // BatchReceived, so the feed VM resolves the tile in the same dispatch
+        // loop — by the time it asks `pendingLocalPreviews[id]`, the entry must
+        // already be there. For a video we hand over the poster JPEG bytes
+        // (an image loader can't decode a raw video path); for a photo, the
+        // local file path.
+        val firstRenderableIndex = attachments.indexOfFirst { input ->
             input.contentType.startsWith("image/") || input.contentType.startsWith("video/")
-        }?.filePath
-        if (firstRenderableUri != null) {
-            _pendingLocalPreviews.update { it.put(momentUniqueId, firstRenderableUri) }
+        }
+        if (firstRenderableIndex >= 0) {
+            val poster = posterByAttachment?.getOrNull(firstRenderableIndex)
+            val previewModel: Any = poster ?: attachments[firstRenderableIndex].filePath
+            _pendingLocalPreviews.update { it.put(momentUniqueId, previewModel) }
         }
 
         try {
@@ -199,6 +224,7 @@ class MomentsPostSenderService(
                 keyHeader = keyHeader,
                 tags = tags,
                 isLocalOnly = isLocalOnly,
+                posterByAttachment = posterByAttachment,
             )
         }
 
@@ -223,6 +249,7 @@ class MomentsPostSenderService(
         keyHeader: KeyHeader,
         tags: List<Uuid>?,
         isLocalOnly: Boolean,
+        posterByAttachment: List<ByteArray?>? = null,
     ) {
         // Once the outbox has accepted the request its event stream drives the
         // tile's status (Sending → Uploading → Completed/Failed). Before that,
@@ -232,6 +259,41 @@ class MomentsPostSenderService(
         try {
             // Server constraint: payload keys must match ^[a-z0-9_]{8,10}$.
             val keyForIndex: (Int) -> String = { i -> "mmt_${i.toString().padStart(4, '0')}" }
+
+            // Downscaled video posters keyed by the payload key the builder
+            // will use, so we can graft them onto the video payload descriptors
+            // below. The attachment builder produces no thumbnail for videos
+            // (see MessageAttachmentBuilder's `else` branch), so without this
+            // the optimistic video row has no embedded preview and the inline
+            // tile renders the bare player surface — black — during decoder
+            // warm-up. The raw poster is full-resolution (MediaMetadataRetriever
+            // returns the whole frame), so resize it to an embedded-thumbnail
+            // size before base64-ing it into the local descriptor — otherwise a
+            // multi-hundred-KB string would ride on every video row (and never
+            // get reclaimed for local-only "Save privately" moments, which have
+            // no server resync to replace the optimistic row).
+            @OptIn(ExperimentalEncodingApi::class)
+            val posterThumbByKey: Map<String, ThumbnailDescriptor> = buildMap {
+                posterByAttachment?.forEachIndexed { i, poster ->
+                    if (poster == null) return@forEachIndexed
+                    val thumb = runCatching {
+                        val resized = ImageUtils.resizePreserveAspect(
+                            srcBytes = poster,
+                            maxWidth = PosterThumbnailMaxDimension,
+                            maxHeight = PosterThumbnailMaxDimension,
+                            outputFormat = ImageFormat.JPEG,
+                            quality = PosterThumbnailJpegQuality,
+                        )
+                        ThumbnailDescriptor(
+                            pixelWidth = resized.size.pixelWidth,
+                            pixelHeight = resized.size.pixelHeight,
+                            contentType = "image/jpeg",
+                            content = Base64.encode(resized.bytes),
+                        )
+                    }.getOrNull()
+                    if (thumb != null) put(keyForIndex(i), thumb)
+                }
+            }
             val bundle = MessageAttachmentBuilder.build(
                 attachments = attachments,
                 fileOperationsProvider = fileOps,
@@ -307,19 +369,26 @@ class MomentsPostSenderService(
 
             @OptIn(ExperimentalEncodingApi::class)
             val payloadDescriptors = encrypted.payloads.map { payload ->
+                // Prefer the builder's own preview (photos/audio); fall back to
+                // the extracted video poster so the optimistic video tile has a
+                // still to show over the player surface during warm-up. This
+                // descriptor feeds the local `writeUpdate` only — it isn't part
+                // of the uploaded payload bundle, so there's no header-budget
+                // concern with the full-frame poster bytes.
+                val previewThumb = payload.previewThumbnail?.let {
+                    ThumbnailDescriptor(
+                        pixelWidth = it.pixelWidth,
+                        pixelHeight = it.pixelHeight,
+                        contentType = it.contentType,
+                        content = it.content,
+                    )
+                } ?: posterThumbByKey[payload.key]
                 PayloadDescriptor(
                     key = payload.key,
                     contentType = payload.contentType.ifEmpty { null },
                     iv = payload.iv?.let { Base64.encode(it) },
                     descriptorContent = payload.descriptorContent,
-                    previewThumbnail = payload.previewThumbnail?.let {
-                        ThumbnailDescriptor(
-                            pixelWidth = it.pixelWidth,
-                            pixelHeight = it.pixelHeight,
-                            contentType = it.contentType,
-                            content = it.content,
-                        )
-                    },
+                    previewThumbnail = previewThumb,
                 )
             }.ifEmpty { null }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentsPostSenderService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentsPostSenderService.kt
@@ -40,6 +40,7 @@ import id.homebase.core.config.momentsLabeledDrive
 import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -744,6 +745,47 @@ class MomentsPostSenderService(
         } catch (e: Exception) {
             Logger.e(throwable = e, tag = TAG) {
                 "addRecipientsToMoment: optimistic write failed (non-fatal) moment=$momentUniqueId"
+            }
+        }
+
+        // === MomentAddPeopleAudit ===
+        // The outbox logs only the INITIAL recipientStatus ("Enqueued" — queued
+        // in OUR server's outbound transit). The terminal per-recipient outcome
+        // (DeliveredToInbox vs a failure like RecipientReturnedAccessDenied or a
+        // CannotOverwriteNonExistentFile-style rejection of an update to a peer
+        // that never held the file) lands asynchronously in the server-side
+        // transfer history. Poll it a few times so the log captures the real
+        // outcome for the freshly-added recipients without needing their device.
+        // Detached on the service scope so it never delays the caller's UI.
+        val auditFileId = existing.fileId
+        val auditTargets = genuinelyNew.map { it.domainName }.toSet()
+        scope.launch {
+            val pollDelaysMs = longArrayOf(5_000, 10_000, 15_000, 30_000, 60_000)
+            for ((i, d) in pollDelaysMs.withIndex()) {
+                delay(d)
+                val history = runCatching {
+                    driveFileProvider.getTransferHistory(drive, auditFileId)
+                }.getOrElse { e ->
+                    Logger.w(throwable = e, tag = TAG) {
+                        "MomentAddPeopleAudit: transfer-history poll ${i + 1} threw moment=$momentUniqueId"
+                    }
+                    null
+                } ?: continue
+                val results = history.history.results
+                Logger.i(tag = TAG) {
+                    "MomentAddPeopleAudit: transfer-history poll ${i + 1} moment=$momentUniqueId " +
+                        "fileId=$auditFileId addedTargets=$auditTargets " +
+                        "results=[${results.joinToString { "${it.recipient}=${it.latestTransferStatus}" +
+                            "(inOutbox=${it.isInOutbox} deliveredVT=${it.latestSuccessfullyDeliveredVersionTag})" }}]"
+                }
+                // Terminal once every freshly-added recipient has left our outbox.
+                val stillPending = results.any { it.recipient in auditTargets && it.isInOutbox }
+                if (results.isNotEmpty() && !stillPending) {
+                    Logger.i(tag = TAG) {
+                        "MomentAddPeopleAudit: transfer-history terminal moment=$momentUniqueId — stopping poll"
+                    }
+                    break
+                }
             }
         }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentsPostSenderService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentsPostSenderService.kt
@@ -673,6 +673,32 @@ class MomentsPostSenderService(
             ),
         )
 
+        // === MomentAddPeopleAudit ===
+        // Diagnostic: "add people" never delivers to the new recipients. This
+        // path ships an UpdateFileByUniqueId (AppendOrOverwrite) transited to
+        // peers who have never held the moment. The decisive evidence is the
+        // per-recipient `recipientStatus` the outbox logs once this drains
+        // ("DriveOutboxUploader updateFile: success uniqueId=$momentUniqueId
+        // recipientStatus=..."). Log the full request shape here so that line
+        // can be correlated against exactly who we tried to reach and with what.
+        // Grep: "MomentAddPeopleAudit" + the moment uniqueId, and wait for the
+        // outbox to drain (~60s) before capturing so the result line is present.
+        Logger.i(tag = TAG) {
+            "MomentAddPeopleAudit: ENQUEUE updateFileByUniqueId moment=$momentUniqueId " +
+                "self=${self.domainName} " +
+                "requestedNew=${newRecipients.map { it.domainName }} " +
+                "existing=${existingRecipients.map { it.domainName }} " +
+                "genuinelyNew(transitTo)=${genuinelyNew.map { it.domainName }} " +
+                "merged=${mergedRecipients.map { it.domainName }} " +
+                "reusedPayloads=${reusedPayloads.map { it.key }} " +
+                "(${reusedPayloads.size}/${existing.fileMetadata.payloads.orEmpty().size} expected) " +
+                "reusedThumbs=${reusedThumbs.size} " +
+                "allowDistribution=${unencryptedMetadata.allowDistribution} " +
+                "isEncrypted=${unencryptedMetadata.isEncrypted} " +
+                "aclSet=${unencryptedMetadata.accessControlList != null} " +
+                "versionTag=$versionTag locale=Local useAppNotification=false"
+        }
+
         val request = UpdateFileByUniqueIdRequest(
             driveId = drive,
             uniqueId = momentUniqueId,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentAddRecipientsSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentAddRecipientsSheet.kt
@@ -18,9 +18,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.outlined.Group
-import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -36,6 +35,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import id.homebase.api.common.OdinId
+import id.homebase.core.avatars.AvatarOptions
+import id.homebase.core.avatars.FallbackAvatar
+import id.homebase.core.avatars.PublicAvatar
 import id.homebase.core.moments.services.MomentsRecipient
 import id.homebase.core.moments.services.MomentsRecipientId
 import id.homebase.core.moments.services.MomentsRecipientsSnapshot
@@ -216,21 +218,22 @@ private fun AddRecipientRow(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        Box(
-            modifier = Modifier
-                .size(40.dp)
-                .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.surfaceContainerHighest),
-            contentAlignment = Alignment.Center,
-        ) {
-            Icon(
-                imageVector = when (recipient) {
-                    is MomentsRecipient.Group -> Icons.Outlined.Group
-                    is MomentsRecipient.Individual -> Icons.Outlined.Person
-                },
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(20.dp),
+        // Render avatars the same way chat does: individuals resolve their
+        // public profile image from the odinId via PublicAvatar; groups fall
+        // back to chat's group glyph (mirrors ConversationAvatar's
+        // GroupFallback). See ConversationAvatar.kt / PublicAvatar.kt.
+        val avatarOptions = AvatarOptions(size = 40.dp)
+        when (recipient) {
+            is MomentsRecipient.Individual -> PublicAvatar(
+                odinId = recipient.odinId,
+                initials = recipient.avatarInitials,
+                options = avatarOptions,
+            )
+
+            is MomentsRecipient.Group -> FallbackAvatar(
+                initials = recipient.avatarInitials,
+                options = avatarOptions,
+                imageVector = Icons.Default.People,
             )
         }
         Column(modifier = Modifier.weight(1f)) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentAudienceViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentAudienceViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import id.homebase.api.common.time.UnixTimeUtc
+import id.homebase.chat.conversationlist.AttachmentPendingFile
 import id.homebase.core.moments.services.MomentCreateFlowState
 import id.homebase.core.moments.services.MomentSource
 import id.homebase.core.moments.services.MomentsPostSenderService
@@ -126,6 +127,13 @@ class MomentAudienceViewModel(
                     // by payload key, so an all-null list yields no `mediaInfo`.
                     mediaInfoByAttachment = draft.attachments
                         .map { it.toMediaInfo() }
+                        .takeIf { list -> list.any { it != null } },
+                    // Poster frame per video attachment (index-aligned with the
+                    // attachments above). Lets the sender render the video's
+                    // first frame in the placeholder tile and as the optimistic
+                    // row's embedded thumbnail instead of a black surface.
+                    posterByAttachment = draft.attachments
+                        .map { (it as? AttachmentPendingFile.FileVideo)?.thumbnailBytes }
                         .takeIf { list -> list.any { it != null } },
                     commentsEnabled = state.commentsEnabled,
                 )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
@@ -69,6 +69,8 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.SheetValue
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -81,6 +83,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.window.Dialog
@@ -107,6 +110,7 @@ import id.homebase.chat.widget.FullScreenVideoPlayer
 import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.PublicAvatar
 import id.homebase.core.image.ImageSize
+import id.homebase.core.localization.TranslationUtil
 import id.homebase.core.moments.MomentsPreferences
 import id.homebase.core.moments.MomentsViewMode
 import id.homebase.core.moments.services.MomentCommentItem
@@ -131,7 +135,10 @@ import id.homebase.resources.cancel
 import id.homebase.resources.chat_message_delete_for_everyone
 import id.homebase.resources.chat_message_delete_for_me
 import id.homebase.resources.delivered_to
+import id.homebase.resources.error_unknown
 import id.homebase.resources.failed
+import id.homebase.resources.file_save_failed
+import id.homebase.resources.file_saved_to
 import id.homebase.resources.menu_back
 import id.homebase.resources.moments_detail_add_comment_hint
 import id.homebase.resources.moments_detail_comment_cancel
@@ -144,6 +151,7 @@ import id.homebase.resources.moments_detail_delete_comment_dialog_title
 import id.homebase.resources.moments_detail_delete_dialog_title
 import id.homebase.resources.moments_detail_menu_delete
 import id.homebase.resources.moments_detail_menu_more
+import id.homebase.resources.moments_detail_menu_save_current
 import id.homebase.resources.moments_detail_description_hint
 import id.homebase.resources.moments_detail_description_save
 import id.homebase.resources.moments_detail_edit_description
@@ -170,6 +178,7 @@ import id.homebase.resources.read_by
 import id.homebase.resources.sending_to
 import id.homebase.resources.uploaded
 import kotlin.time.Instant
+import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.format.MonthNames
 import kotlinx.datetime.format.char
@@ -440,6 +449,8 @@ fun MomentDetailPane(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val fileSystemHandler = getUriHandler()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
 
     // Pop the detail screen as soon as the delete completes. The optimistic
     // writer has already removed the moment from the feed by this point;
@@ -453,6 +464,38 @@ fun MomentDetailPane(
                 is MomentDetailUiEvent.MomentDeleted -> onNavigateBack?.invoke()
                 is MomentDetailUiEvent.ShareFileReady ->
                     fileSystemHandler.shareFile(Path(event.filePath))
+                // "Save current": the VM has finished decrypting (+ remuxing)
+                // the visible payload to a cache file; hand it to the platform
+                // save-to-device flow and confirm with a snackbar. Reuses the
+                // same strings + handler chat's media download uses.
+                is MomentDetailUiEvent.MediaSaveReady ->
+                    fileSystemHandler.saveFile(
+                        file = Path(event.filePath),
+                        suggestedName = event.suggestedName,
+                        onSuccess = { location ->
+                            scope.launch {
+                                snackbarHostState.showSnackbar(
+                                    TranslationUtil.getString(MR.string.file_saved_to, location),
+                                )
+                            }
+                        },
+                        onError = { error ->
+                            scope.launch {
+                                val detail = error.message
+                                    ?: TranslationUtil.getString(MR.string.error_unknown)
+                                snackbarHostState.showSnackbar(
+                                    TranslationUtil.getString(MR.string.file_save_failed, detail),
+                                )
+                            }
+                        },
+                    )
+                is MomentDetailUiEvent.MediaSaveFailed -> scope.launch {
+                    val detail = event.message
+                        ?: TranslationUtil.getString(MR.string.error_unknown)
+                    snackbarHostState.showSnackbar(
+                        TranslationUtil.getString(MR.string.file_save_failed, detail),
+                    )
+                }
                 else -> Unit
             }
         }
@@ -481,6 +524,7 @@ fun MomentDetailPane(
                     uiState = uiState,
                     onAction = viewModel::onAction,
                     onNavigateBack = onNavigateBack,
+                    snackbarHostState = snackbarHostState,
                     sharedTransitionScope = this@SharedTransitionLayout,
                     animatedVisibilityScope = this@AnimatedContent,
                     isActivePage = isActivePage,
@@ -546,6 +590,7 @@ private fun DetailContent(
     uiState: MomentDetailUiState,
     onAction: (MomentDetailUiAction) -> Unit,
     onNavigateBack: (() -> Unit)?,
+    snackbarHostState: SnackbarHostState,
     sharedTransitionScope: SharedTransitionScope,
     animatedVisibilityScope: AnimatedVisibilityScope,
     isActivePage: Boolean,
@@ -576,11 +621,18 @@ private fun DetailContent(
         }
     }
 
+    // The carousel payload currently on screen, reported up from the inner
+    // pager in [MomentDetailContent] so the overflow "Save current" acts on
+    // exactly the photo/video the user is looking at. Null for description-only
+    // moments (nothing to save → the menu item hides).
+    var visiblePayloadKey by remember { mutableStateOf<String?>(null) }
+
     Scaffold(
         // Black so the letterbox bars around a Fit-scaled image or video
         // read as part of the cinematic surface rather than the surface
         // colour of the rest of the app.
         containerColor = Color.Black,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
                 // No screen title in the full-screen view — the post itself
@@ -608,6 +660,15 @@ private fun DetailContent(
                     if (uiState.moment != null) {
                         MomentOverflowMenu(
                             isDeleting = uiState.isDeleting,
+                            isSaving = uiState.isSavingMedia,
+                            // Hidden on description-only moments — nothing on
+                            // screen to save.
+                            showSave = visiblePayloadKey != null,
+                            onSaveClick = {
+                                visiblePayloadKey?.let {
+                                    onAction(MomentDetailUiAction.SaveMedia(it))
+                                }
+                            },
                             // Author-only: only the original author can widen
                             // the audience of a moment.
                             showAddPeople = uiState.isMine,
@@ -657,6 +718,7 @@ private fun DetailContent(
                 initialPayloadKey = uiState.initialPayloadKey,
                 onAction = onAction,
                 onOpenComments = { showCommentsSheet = true },
+                onVisiblePayloadChanged = { visiblePayloadKey = it },
                 commentsOpen = commentsShrinkActive,
                 sharedTransitionScope = sharedTransitionScope,
                 animatedVisibilityScope = animatedVisibilityScope,
@@ -751,20 +813,23 @@ private fun DetailContent(
 @Composable
 private fun MomentOverflowMenu(
     isDeleting: Boolean,
+    isSaving: Boolean,
+    showSave: Boolean,
+    onSaveClick: () -> Unit,
     showAddPeople: Boolean,
     onAddPeopleClick: () -> Unit,
     onDeleteClick: () -> Unit,
     iconTint: Color = Color.Unspecified,
 ) {
     var expanded by remember { mutableStateOf(false) }
+    // While a delete OR a save is in flight the icon is swapped for a spinner.
+    // Same shape as the per-comment delete indicator: tells the user
+    // "something is happening" — for save, that covers the decrypt/remux of
+    // the visible payload before the device-gallery write fires.
+    val busy = isDeleting || isSaving
     Box {
-        // While a delete is in flight the icon is swapped for a spinner.
-        // Same shape as the per-comment delete indicator: tells the user
-        // "something is happening" during the brief window between
-        // confirming the dialog and the optimistic write removing the
-        // moment from the feed (which triggers the nav-pop).
-        IconButton(onClick = { expanded = true }, enabled = !isDeleting) {
-            if (isDeleting) {
+        IconButton(onClick = { expanded = true }, enabled = !busy) {
+            if (busy) {
                 CircularProgressIndicator(
                     modifier = Modifier.size(20.dp),
                     strokeWidth = 2.dp,
@@ -784,6 +849,15 @@ private fun MomentOverflowMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
         ) {
+            if (showSave) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(MR.string.moments_detail_menu_save_current)) },
+                    onClick = {
+                        expanded = false
+                        onSaveClick()
+                    },
+                )
+            }
             if (showAddPeople) {
                 DropdownMenuItem(
                     text = { Text(stringResource(MR.string.moments_detail_menu_add_people)) },
@@ -1049,6 +1123,12 @@ private fun MomentDetailContent(
     initialPayloadKey: String?,
     onAction: (MomentDetailUiAction) -> Unit,
     onOpenComments: () -> Unit,
+    /**
+     * Reports the key of the carousel payload currently on screen (null for a
+     * description-only moment) so the overflow "Save current" acts on exactly
+     * what the user is looking at.
+     */
+    onVisiblePayloadChanged: (String?) -> Unit = {},
     commentsOpen: Boolean,
     sharedTransitionScope: SharedTransitionScope,
     animatedVisibilityScope: AnimatedVisibilityScope,
@@ -1105,6 +1185,19 @@ private fun MomentDetailContent(
         initialPage = initialPage,
         pageCount = { pageCount },
     )
+
+    // Report the on-screen carousel payload up to the overflow "Save current".
+    // Description-only moments have no payloads → report null so the item hides.
+    // snapshotFlow already dedups, so this only fires on a real page change.
+    LaunchedEffect(pagerState, moment.payloads) {
+        if (moment.payloads.isEmpty()) {
+            onVisiblePayloadChanged(null)
+            return@LaunchedEffect
+        }
+        snapshotFlow { pagerState.currentPage }.collect { page ->
+            onVisiblePayloadChanged(moment.payloads.getOrNull(page)?.key)
+        }
+    }
 
     val commentCount = uiState.comments.size
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
@@ -91,12 +91,14 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import co.touchlab.kermit.Logger
+import coil3.compose.AsyncImage
 import id.homebase.api.common.OdinId
 import id.homebase.chat.conversationlist.FullScreenOverlay
 import id.homebase.chat.services.ChatDeliveryStatus
@@ -1173,9 +1175,10 @@ private fun MomentDetailContent(
         // pointer detector so taps fall through (the surrounding sheets are
         // opened by the right-edge IconButtons below).
         if (moment.payloads.isEmpty()) {
-            // Description-only moment — there's no media to render, so fill
-            // with the description text centred over the black backdrop. A tap
-            // anywhere opens the detail panel (comments + description + edit).
+            // Either a just-posted moment whose payloads haven't landed yet, or
+            // a genuine description-only moment. A tap anywhere opens the detail
+            // panel (comments + description + edit).
+            val pendingPreview = uiState.pendingLocalPreviewModel
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -1188,7 +1191,19 @@ private fun MomentDetailContent(
                     ),
                 contentAlignment = Alignment.Center,
             ) {
-                if (moment.description.isNotBlank()) {
+                if (pendingPreview != null) {
+                    // Placeholder window after posting: show the picked media
+                    // (a video's poster bytes / a photo's path) with a spinner,
+                    // mirroring the timeline card — otherwise this branch is a
+                    // bare black backdrop until real payloads arrive.
+                    AsyncImage(
+                        model = pendingPreview,
+                        contentDescription = null,
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.Fit,
+                    )
+                    CircularProgressIndicator(color = Color.White)
+                } else if (moment.description.isNotBlank()) {
                     Text(
                         text = moment.description,
                         color = Color.White,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailUiState.kt
@@ -86,6 +86,15 @@ data class MomentDetailUiState(
     val isDeleting: Boolean = false,
 
     /**
+     * True while the "Save current" flow is decrypting (and, for HLS video,
+     * remuxing) the visible carousel payload to a cache file. Drives the
+     * overflow-menu spinner so the user knows the save is in progress — the
+     * decrypt/remux is the slow part; the device-gallery write that follows is
+     * near-instant.
+     */
+    val isSavingMedia: Boolean = false,
+
+    /**
      * Comment ids whose delete is currently in flight. The comment row reads
      * this to disable its Edit/Delete buttons and show a small spinner while
      * the optimistic write + outbox enqueue is running. Entries are removed
@@ -329,6 +338,14 @@ sealed interface MomentDetailUiAction {
      */
     data class ShareMedia(val payloadKey: String) : MomentDetailUiAction
 
+    /**
+     * Overflow-menu "Save current" tapped. Decrypts the given carousel payload
+     * (the one currently on screen) and emits [MomentDetailUiEvent.MediaSaveReady]
+     * so the screen can hand it to the platform save-to-device flow. HLS video
+     * is remuxed to a playable MP4 first.
+     */
+    data class SaveMedia(val payloadKey: String) : MomentDetailUiAction
+
     /** Open the "who reacted" bottom sheet and fetch the reactor list. */
     data object OpenReactionsSheet : MomentDetailUiAction
 
@@ -375,6 +392,17 @@ sealed interface MomentDetailUiEvent {
      */
     data class ShareFileReady(val filePath: String) : MomentDetailUiEvent
     data class ShareFailed(val message: String?) : MomentDetailUiEvent
+
+    /**
+     * Decrypted (and, for HLS, remuxed) payload is written to [filePath]; the
+     * screen should hand it + [suggestedName] to `FileSystemHandler.saveFile`
+     * to write it into the device gallery / Downloads.
+     */
+    data class MediaSaveReady(
+        val filePath: String,
+        val suggestedName: String,
+    ) : MomentDetailUiEvent
+    data class MediaSaveFailed(val message: String?) : MomentDetailUiEvent
 
     /** Audience successfully widened by [count] new recipients. */
     data class RecipientsAdded(val count: Int) : MomentDetailUiEvent

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailUiState.kt
@@ -13,6 +13,14 @@ import org.jetbrains.compose.resources.StringResource
 data class MomentDetailUiState(
     val moment: MomentFeedItem? = null,
     val isLoading: Boolean = true,
+    /**
+     * Coil model for a just-posted moment whose payloads haven't landed yet
+     * (photo file path, or a video's poster-frame JPEG bytes). Lets the
+     * reels/detail media area show the picked media + a spinner during the
+     * "Preparing…" window instead of a black backdrop — mirrors the timeline
+     * card's placeholder behaviour. Null once real payloads arrive.
+     */
+    val pendingLocalPreviewModel: Any? = null,
     val fullScreenOverlay: FullScreenOverlay? = null,
     /**
      * Payload key the detail carousel should land on when first opened —

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailViewModel.kt
@@ -7,7 +7,11 @@ import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.common.OdinId
+import id.homebase.api.coroutines.ioDispatcher
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.video.VideoCompressionService
+import id.homebase.api.video.VideoMetadata
 import id.homebase.core.util.extensionForMimeType
 import id.homebase.chat.conversationlist.FullScreenOverlay
 import id.homebase.chat.data.ContactUiModel
@@ -40,6 +44,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.time.Instant
@@ -98,6 +103,7 @@ class MomentDetailViewModel(
         val isSavingDescription: Boolean = false,
         val showDeleteDialog: Boolean = false,
         val isDeletingMoment: Boolean = false,
+        val isSavingMedia: Boolean = false,
         val deletingCommentIds: Set<Uuid> = emptySet(),
         val deleteCommentDialogTarget: Uuid? = null,
         val sharedWithExpanded: Boolean = false,
@@ -215,6 +221,7 @@ class MomentDetailViewModel(
             isMine = isMine,
             showDeleteDialog = local.showDeleteDialog,
             isDeleting = local.isDeletingMoment,
+            isSavingMedia = local.isSavingMedia,
             deletingCommentIds = local.deletingCommentIds,
             deleteCommentDialogTarget = local.deleteCommentDialogTarget,
             sharedWith = momentBundle.sharedWith,
@@ -500,6 +507,8 @@ class MomentDetailViewModel(
 
             is MomentDetailUiAction.ShareMedia -> shareMedia(action.payloadKey)
 
+            is MomentDetailUiAction.SaveMedia -> saveMedia(action.payloadKey)
+
             MomentDetailUiAction.OpenReactionsSheet -> openReactionsSheet()
 
             MomentDetailUiAction.DismissReactionsSheet ->
@@ -690,6 +699,214 @@ class MomentDetailViewModel(
                 _events.tryEmit(MomentDetailUiEvent.ShareFailed(t.message))
             }
         }
+    }
+
+    /**
+     * "Save current" — decrypt the visible carousel payload to a cache file and
+     * surface its path so the screen can write it into the device gallery via
+     * `FileSystemHandler.saveFile`. Mirrors `MediaDownloadHandler`'s download
+     * arms on the chat side: an HLS (segmented) video is remuxed to a playable
+     * MP4 first (a raw .ts segment saved as-is wouldn't open in Photos); images
+     * and progressive MP4s stream straight to the cache file.
+     *
+     * [isSavingMedia] gates the overflow-menu spinner over the whole
+     * decrypt/remux — the device write that follows (driven off
+     * [MomentDetailUiEvent.MediaSaveReady]) is near-instant.
+     */
+    @OptIn(ExperimentalEncodingApi::class)
+    private fun saveMedia(payloadKey: String) {
+        if (_screenLocal.value.isSavingMedia) return
+        val moment = uiState.value.moment ?: return
+        val payload = moment.payloads.firstOrNull { it.key == payloadKey } ?: return
+        val ivString = payload.iv ?: run {
+            Logger.e(tag = TAG) { "saveMedia: payload $payloadKey has no IV" }
+            _events.tryEmit(MomentDetailUiEvent.MediaSaveFailed("Payload missing key header"))
+            return
+        }
+        val keyHeader = KeyHeader(Base64.decode(ivString), moment.keyHeader.aesKey)
+
+        _screenLocal.update { it.copy(isSavingMedia = true) }
+        viewModelScope.launch {
+            try {
+                val hlsMetadata = resolveHlsVideoMetadata(
+                    descriptorContent = payload.descriptorContent,
+                    driveId = moment.driveId,
+                    fileId = moment.fileId,
+                    keyHeader = keyHeader,
+                )
+                if (hlsMetadata != null) {
+                    val remuxed = withContext(ioDispatcher) {
+                        downloadAndRemuxHlsToMp4(
+                            driveId = moment.driveId,
+                            fileId = moment.fileId,
+                            payloadKey = payloadKey,
+                            keyHeader = keyHeader,
+                            metadata = hlsMetadata,
+                            suggestedBaseName = payload.filename(),
+                        )
+                    }
+                    if (remuxed == null) {
+                        _events.tryEmit(MomentDetailUiEvent.MediaSaveFailed("Could not convert video"))
+                        return@launch
+                    }
+                    _events.tryEmit(
+                        MomentDetailUiEvent.MediaSaveReady(remuxed.first, remuxed.second),
+                    )
+                } else {
+                    val fullName = resolveDownloadFileName(
+                        payload.filename(), payloadKey, payload.contentType,
+                    )
+                    val filePath = "${fileOperationsProvider.getCacheDirectory()}/$fullName"
+                    val success = withContext(ioDispatcher) {
+                        driveFileProvider.streamPayloadDecryptedToPath(
+                            driveId = moment.driveId,
+                            fileId = moment.fileId,
+                            key = payloadKey,
+                            keyHeader = keyHeader,
+                            outputPath = filePath,
+                            fileOps = fileOperationsProvider,
+                        )
+                    }
+                    if (!success) {
+                        _events.tryEmit(MomentDetailUiEvent.MediaSaveFailed("Could not download file"))
+                        return@launch
+                    }
+                    _events.tryEmit(MomentDetailUiEvent.MediaSaveReady(filePath, fullName))
+                }
+            } catch (t: Throwable) {
+                Logger.e(throwable = t, tag = TAG) { "saveMedia failed: ${t.message}" }
+                _events.tryEmit(MomentDetailUiEvent.MediaSaveFailed(t.message))
+            } finally {
+                _screenLocal.update { it.copy(isSavingMedia = false) }
+            }
+        }
+    }
+
+    /**
+     * Resolve a segmented-video payload's full [VideoMetadata] (with the HLS
+     * playlist) from its descriptor, fetching the out-of-line descriptor blob
+     * when the header copy is a stub. Returns null for non-HLS payloads (images,
+     * progressive MP4) — those take the plain decrypt-to-file path above.
+     * Mirrors `MediaDownloadHandler.resolveHlsVideoMetadata`.
+     */
+    private suspend fun resolveHlsVideoMetadata(
+        descriptorContent: String?,
+        driveId: Uuid,
+        fileId: Uuid,
+        keyHeader: KeyHeader,
+    ): VideoMetadata? {
+        val stub = descriptorContent?.let {
+            try {
+                OdinSystemSerializer.deserialize<VideoMetadata>(it)
+            } catch (_: Exception) {
+                null
+            }
+        } ?: return null
+
+        if (!stub.isSegmented) return null
+
+        val full = if (stub.isDescriptorContentComplete) {
+            stub
+        } else {
+            val json = driveFileProvider.getPayloadBytesDecrypted(
+                driveId = driveId,
+                fileId = fileId,
+                key = stub.key,
+                keyHeader = keyHeader,
+            )?.bytes?.decodeToString() ?: return null
+            try {
+                OdinSystemSerializer.deserialize<VideoMetadata>(json)
+            } catch (_: Exception) {
+                return null
+            }
+        }
+
+        return if (full.isSegmented && !full.hlsPlaylist.isNullOrBlank()) full else null
+    }
+
+    /**
+     * Decrypt the HLS segment payload, synthesize a local playlist pointing at
+     * it, and remux into an MP4 via stream-copy (no re-encode). Returns
+     * (mp4Path, suggestedName) or null on failure. Mirrors
+     * `MediaDownloadHandler.downloadAndRemuxHlsToMp4`.
+     */
+    private suspend fun downloadAndRemuxHlsToMp4(
+        driveId: Uuid,
+        fileId: Uuid,
+        payloadKey: String,
+        keyHeader: KeyHeader,
+        metadata: VideoMetadata,
+        suggestedBaseName: String?,
+    ): Pair<String, String>? {
+        val cacheDir = fileOperationsProvider.getCacheDirectory()
+        val uid = Uuid.random().toString().take(8)
+        val tsFileName = "input_hlsdl_${uid}.ts"
+        val tsPath = "$cacheDir/$tsFileName"
+        val mp4Path = "$cacheDir/hlsdl_${uid}.mp4"
+
+        val tsOk = driveFileProvider.streamPayloadDecryptedToPath(
+            driveId = driveId,
+            fileId = fileId,
+            key = payloadKey,
+            keyHeader = keyHeader,
+            outputPath = tsPath,
+            fileOps = fileOperationsProvider,
+        )
+        if (!tsOk) return null
+
+        // Strip EXT-X-KEY (segments are already decrypted on disk) and rewrite
+        // segment references to point at the local .ts file we just wrote.
+        val rewrittenPlaylist = metadata.hlsPlaylist!!.lines()
+            .filter { !it.startsWith("#EXT-X-KEY") }
+            .joinToString("\n") { line ->
+                if (line.isNotBlank() && !line.startsWith("#")) tsFileName else line
+            }
+
+        // cacheInputVideo writes to "<cacheDir>/input_<fileName>", the same
+        // directory as tsPath, so the playlist's relative segment ref resolves.
+        val playlistPath = VideoCompressionService.cacheInputVideo(
+            fileName = "hlsdl_${uid}.m3u8",
+            data = rewrittenPlaylist.encodeToByteArray(),
+        )
+
+        val ok = VideoCompressionService.remuxHlsToMp4(
+            playlistPath = playlistPath,
+            outputPath = mp4Path,
+        )
+
+        runCatching { fileOperationsProvider.deleteTempFile(tsPath) }
+        runCatching { fileOperationsProvider.deleteTempFile(playlistPath) }
+
+        if (!ok) return null
+
+        val base = suggestedBaseName?.substringBeforeLast('.')?.takeIf { it.isNotBlank() } ?: "video"
+        val safeBase = base.replace('/', '_').replace('\\', '_').replace(' ', '_')
+        return mp4Path to "$safeBase.mp4"
+    }
+
+    /**
+     * Safe filename for a saved payload. Trusts the descriptor's original
+     * filename when it carries an extension; otherwise derives one from the
+     * content type. Mirrors `MediaDownloadHandler.resolveDownloadFileName`.
+     */
+    private fun resolveDownloadFileName(
+        originalName: String?,
+        fallbackKey: String,
+        contentType: String?,
+    ): String {
+        val safeName = originalName
+            ?.replace('/', '_')
+            ?.replace('\\', '_')
+            ?.replace(' ', '_')
+
+        if (safeName != null && safeName.contains('.')) return safeName
+
+        val name = safeName ?: fallbackKey
+        val ext = contentType?.let { extensionForMimeType(it) }
+            ?: contentType?.substringAfter("/")
+                ?.takeIf { it != "octet-stream" && !it.contains('.') && !it.contains('+') }
+            ?: "bin"
+        return "$name.$ext"
     }
 
     /**

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailViewModel.kt
@@ -112,6 +112,7 @@ class MomentDetailViewModel(
         val addRecipientsQuery: String = "",
         val addRecipientsSelected: Set<MomentsRecipientId> = emptySet(),
         val isAddingRecipients: Boolean = false,
+        val pendingLocalPreviewModel: Any? = null,
     )
 
     private val _screenLocal = MutableStateFlow(ScreenLocalState())
@@ -143,6 +144,19 @@ class MomentDetailViewModel(
             recipientLookup.recipients.collect { snapshot ->
                 _screenLocal.update { it.copy(addRecipientsSnapshot = snapshot) }
             }
+        }
+        // Mirror the post sender's transient local preview for *this* moment so
+        // the reels/detail media area can show the picked media (a video's
+        // poster bytes, a photo's path) during the "Preparing…" window before
+        // payloads land — otherwise the empty-payloads branch shows only a
+        // black backdrop (the timeline card already does this via the feed VM).
+        viewModelScope.launch {
+            postSender.pendingLocalPreviews
+                .map { it[momentId] }
+                .distinctUntilChanged()
+                .collect { model ->
+                    _screenLocal.update { it.copy(pendingLocalPreviewModel = model) }
+                }
         }
     }
 
@@ -184,6 +198,7 @@ class MomentDetailViewModel(
         MomentDetailUiState(
             moment = match,
             isLoading = match == null,
+            pendingLocalPreviewModel = local.pendingLocalPreviewModel,
             fullScreenOverlay = overlay,
             initialPayloadKey = initialPayloadKey,
             comments = comments,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsAlbumGrid.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsAlbumGrid.kt
@@ -73,7 +73,7 @@ fun MomentsAlbumGrid(
     zoom: MomentsAlbumZoom,
     onZoomChange: (MomentsAlbumZoom) -> Unit,
     onOpenMoment: (momentId: String, payloadKey: String?) -> Unit,
-    pendingLocalPreviews: ImmutableMap<Uuid, String> = persistentMapOf(),
+    pendingLocalPreviews: ImmutableMap<Uuid, Any> = persistentMapOf(),
     modifier: Modifier = Modifier,
 ) {
     // Group + sort once per (moments, zoom) pair. Sorting newest-first inside
@@ -114,7 +114,7 @@ fun MomentsAlbumGrid(
                 ) { moment ->
                     AlbumMomentCell(
                         moment = moment,
-                        pendingLocalPreviewUri = pendingLocalPreviews[moment.id],
+                        pendingLocalPreviewModel = pendingLocalPreviews[moment.id],
                         onClick = { onOpenMoment(moment.id.toString(), null) },
                     )
                 }
@@ -173,7 +173,7 @@ private fun AlbumDateHeader(
 @Composable
 private fun AlbumMomentCell(
     moment: MomentFeedItem,
-    pendingLocalPreviewUri: String?,
+    pendingLocalPreviewModel: Any?,
     onClick: () -> Unit,
 ) {
     val cellShape: Shape = RectangleShape
@@ -188,12 +188,13 @@ private fun AlbumMomentCell(
             .background(MaterialTheme.colorScheme.surfaceContainerHighest)
             .clickable(onClick = onClick),
     ) {
-        if (firstImagePayload == null && pendingLocalPreviewUri != null) {
+        if (firstImagePayload == null && pendingLocalPreviewModel != null) {
             // Placeholder window: row exists locally but thumbnails haven't
-            // been generated yet. Render the user's source file straight from
-            // disk so the album cell shows the picked photo immediately.
+            // been generated yet. Render the local preview model (photo file
+            // path, or a video's poster-frame JPEG bytes) so the album cell
+            // shows the picked media immediately.
             AsyncImage(
-                model = pendingLocalPreviewUri,
+                model = pendingLocalPreviewModel,
                 contentDescription = null,
                 modifier = Modifier.fillMaxSize(),
                 contentScale = ContentScale.Crop,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsAlbumGrid.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsAlbumGrid.kt
@@ -214,7 +214,13 @@ private fun AlbumMomentCell(
                         driveId = moment.driveId,
                         fileId = moment.fileId,
                         payloadKey = firstImagePayload.key,
-                        previewThumbnail = moment.previewThumbnail,
+                        // Prefer the payload's own embedded thumb (a just-posted
+                        // video carries its poster here) over the moment-level
+                        // one, which is null for a video-only moment — otherwise
+                        // the cell flips from poster to a bare grey backdrop
+                        // while it waits for the server-generated thumbnail.
+                        previewThumbnail = firstImagePayload.previewThumbnail?.toEmbeddedThumb()
+                            ?: moment.previewThumbnail,
                         requestedSize = ImageSize.THUMB_MEDIUM,
                         isEncrypted = true,
                         keyHeader = id.homebase.api.client.KeyHeader(

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsFeedUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsFeedUiState.kt
@@ -26,10 +26,15 @@ data class MomentsFeedUiState(
      * directly during the "Preparing…" window — without it, the tile would be
      * a description-only fallback until thumbnails land.
      *
+     * The value is a Coil model: a local file-path [String] for photos, or the
+     * extracted poster-frame JPEG [ByteArray] for videos. (A raw video path
+     * can't be decoded by an image loader, so videos must hand over their
+     * poster bytes — otherwise the tile renders black for the whole window.)
+     *
      * Populated by [id.homebase.core.moments.services.MomentsPostSenderService]
      * and cleared once the real optimistic write installs the embedded preview.
      */
-    val pendingLocalPreviews: ImmutableMap<Uuid, String> = persistentMapOf(),
+    val pendingLocalPreviews: ImmutableMap<Uuid, Any> = persistentMapOf(),
     val viewMode: MomentsViewMode = MomentsViewMode.Timeline,
     val albumZoom: MomentsAlbumZoom = MomentsAlbumZoom.Day,
 )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsScreen.kt
@@ -245,7 +245,7 @@ fun MomentsScreen(
 private fun CompactMomentsLayout(
     moments: List<MomentFeedItem>,
     uploadProgress: ImmutableMap<Uuid, UploadStatus>,
-    pendingLocalPreviews: ImmutableMap<Uuid, String>,
+    pendingLocalPreviews: ImmutableMap<Uuid, Any>,
     ownerSession: OwnerSession?,
     connectionStatus: AppConnectionStatus,
     driveIsSyncing: Boolean,
@@ -341,7 +341,7 @@ private fun CompactMomentsLayout(
 private fun WideMomentsLayout(
     moments: List<MomentFeedItem>,
     uploadProgress: ImmutableMap<Uuid, UploadStatus>,
-    pendingLocalPreviews: ImmutableMap<Uuid, String>,
+    pendingLocalPreviews: ImmutableMap<Uuid, Any>,
     ownerSession: OwnerSession?,
     connectionStatus: AppConnectionStatus,
     driveIsSyncing: Boolean,
@@ -527,7 +527,7 @@ private val FeedPaneMaxWidth = 480.dp
 private fun MomentsFeedList(
     moments: List<MomentFeedItem>,
     uploadProgress: ImmutableMap<Uuid, UploadStatus> = persistentMapOf(),
-    pendingLocalPreviews: ImmutableMap<Uuid, String> = persistentMapOf(),
+    pendingLocalPreviews: ImmutableMap<Uuid, Any> = persistentMapOf(),
     selfOdinId: OdinId?,
     onOpenMoment: (momentId: String, payloadKey: String?) -> Unit,
     onAddReaction: (Uuid, String) -> Unit,
@@ -626,7 +626,7 @@ private fun MomentsFeedList(
             MomentPostCard(
                 moment = moment,
                 uploadStatus = uploadProgress[moment.id],
-                pendingLocalPreviewUri = pendingLocalPreviews[moment.id],
+                pendingLocalPreviewModel = pendingLocalPreviews[moment.id],
                 selfOdinId = selfOdinId,
                 isSelected = !commentsSheetOnTap &&
                     selectedMomentId != null && moment.id == selectedMomentId,
@@ -910,7 +910,7 @@ private fun DisposableViewModelStoreOwner(
 private fun MomentPostCard(
     moment: MomentFeedItem,
     uploadStatus: UploadStatus?,
-    pendingLocalPreviewUri: String?,
+    pendingLocalPreviewModel: Any?,
     selfOdinId: OdinId?,
     isSelected: Boolean,
     // Carries the payload key of whichever carousel page was visible at tap
@@ -1039,29 +1039,34 @@ private fun MomentPostCard(
             },
     ) {
         if (moment.payloads.isEmpty()) {
-            if (pendingLocalPreviewUri != null) {
+            if (pendingLocalPreviewModel != null) {
                 // Placeholder window after postMomentAsync: the optimistic row
                 // exists but thumbnail generation / encryption are still
                 // running on the post sender's background scope. Render the
-                // user's selected source file straight from disk so the tile
-                // shows the picked photo immediately, with the upload overlay
-                // (Preparing → Sending → …) on top. Once writeUpdate lands
-                // real payload descriptors, this branch stops firing and the
-                // normal MomentMediaGallery path takes over.
+                // local preview model (photo file path, or the extracted poster
+                // JPEG bytes for a video — a raw video path can't be decoded by
+                // the image loader, so it would otherwise render black) so the
+                // tile shows the picked media immediately, with the upload
+                // overlay (Preparing → Sending → …) on top. Once writeUpdate
+                // lands real payload descriptors, this branch stops firing and
+                // the normal MomentMediaGallery path takes over.
                 Box {
                     AsyncImage(
-                        model = pendingLocalPreviewUri,
+                        model = pendingLocalPreviewModel,
                         contentDescription = null,
                         modifier = Modifier.fillMaxWidth(),
                         contentScale = ContentScale.Crop,
                     )
-                    if (uploadStatus != null) {
-                        MomentUploadProgressOverlay(
-                            status = uploadStatus,
-                            modifier = Modifier.matchParentSize(),
-                            onPermanentFailureTap = { failedSheetOpen = true },
-                        )
-                    }
+                    // Always surface a spinner while we're in the placeholder
+                    // window: being here means payloads haven't landed yet, so
+                    // the moment is still preparing even in the brief beat
+                    // before the first PayloadBundlingEvent.Preparing arrives
+                    // (which is when `uploadStatus` first becomes non-null).
+                    MomentUploadProgressOverlay(
+                        status = uploadStatus ?: UploadStatus.Preparing,
+                        modifier = Modifier.matchParentSize(),
+                        onPermanentFailureTap = { failedSheetOpen = true },
+                    )
                 }
             } else {
                 // Description-only / corrupt-payload moment — still render a tile so


### PR DESCRIPTION
A freshly-posted video moment rendered black until the real generated thumbnail landed: the placeholder tile handed Coil the raw video path (undecodable as an image), and the optimistic row carried no thumbnail (MessageAttachmentBuilder produces none for videos), so the autoplay tile showed the bare player surface during decoder warm-up.

Thread the extracted poster frame through the post path so the sender's local window matches what recipients already get via the transcode pipeline:
- pendingLocalPreviews carries a Coil model (file path for photos, poster JPEG bytes for videos) so the placeholder tile shows the first frame.
- finalizeMomentSend grafts a downscaled poster (640px/q75) onto the optimistic video payload descriptor as an embedded thumbnail, covering the player during warm-up without bloating the local row.
- the placeholder branch always shows the upload spinner (defaulting to Preparing), closing the brief gap before the first Preparing event.