### PR TITLE
fix(desktop): initialize database before Koin to prevent startup crash

### DIFF
--- a/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
+++ b/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
@@ -79,7 +79,18 @@ fun main() {
     // OS-level ANR, so without this a freeze leaves no evidence at all.
     MainThreadWatchdog().start()
 
-    // Initialize Koin first
+    // Initialize the database BEFORE Koin. startKoin eagerly instantiates `createdAtStart`
+    // singletons (e.g. DesktopChatNotificationBridge), and that chain resolves
+    // `DatabaseManager.appDb`, which reads the lateinit `instance`. If the DB isn't initialized
+    // first, eager creation throws UninitializedPropertyAccessException during startKoin. The
+    // recovery open only needs DatabaseDriverFactory + DatabaseKeyManager — no Koin dependency —
+    // so it's safe to run here.
+    runBlocking {
+        DatabaseManager.initializeWithRecovery(DatabaseDriverFactory())
+    }
+    StartupLogger.checkpoint("database initialized")
+
+    // Initialize Koin
     startKoin { modules(allModules) }
     StartupLogger.checkpoint("Koin DI graph built")
 
@@ -127,10 +138,6 @@ fun main() {
     val minWidth = 480
     val minHeight = 400
     val config = DesktopPreferences()
-
-    runBlocking {
-        DatabaseManager.initializeWithRecovery(DatabaseDriverFactory())
-    }
 
     application {
         remember { StartupLogger.checkpoint("Compose application{} entered") }


### PR DESCRIPTION
## Problem

The desktop app crashes at launch with `UninitializedPropertyAccessException: lateinit property instance has not been initialized`:

```
at id.homebase.api.sync.database.DatabaseManager$Companion.getAppDb(DatabaseManager.kt:180)
at id.homebase.api.di.ApiModuleKt.apiModule$lambda$0$0(ApiModule.kt:51)
```

`Main.kt` calls `startKoin` **before** `DatabaseManager.initializeWithRecovery(...)`. But `startKoin` eagerly instantiates `createdAtStart` singletons — `DesktopChatNotificationBridge` → `NotificationService` → `YouAuthFlowManager` → `DriveSyncManager` → `DatabaseManager` — and that chain resolves `DatabaseManager.appDb`, which reads a `lateinit instance`. Since the DB hasn't been initialized yet, eager creation throws and the process exits at startup.

## Fix

Move `DatabaseManager.initializeWithRecovery(DatabaseDriverFactory())` ahead of `startKoin`. The recovery open depends only on `DatabaseDriverFactory` + `DatabaseKeyManager` (no Koin), so it is safe to run first.

## Notes

- One-file change to the desktop entry point; no behavior change beyond init ordering.
- Independent of any feature work — reproduces on `main` as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)