### PR TITLE
Fix desktop/web stuck-on-sync + group-settings sync-audit

### DIFF
--- a/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
+++ b/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
@@ -27,6 +27,7 @@ import id.homebase.api.sync.database.DatabaseDriverFactory
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.app.lifecycle.rememberDesktopLifecycleOwner
 import id.homebase.core.App
+import id.homebase.core.auth.AuthConnectionCoordinator
 import id.homebase.core.di.allModules
 import id.homebase.core.diagnostics.MainThreadWatchdog
 import id.homebase.core.logging.CrashLogger
@@ -96,6 +97,17 @@ fun main() {
 
     val platformInfo = GlobalContext.get().get<PlatformInfo>()
     StartupLogger.logAppStartupInfo(platformInfo.versionName, platformInfo.versionCode, BuildConfig.APP_BUILD_TIME)
+
+    // Promote AuthConnectionCoordinator out of headless mode. AuthCC starts
+    // headless = true to suppress foreground-only work (WebSocket connect,
+    // driveRegistry.start, loadProfile, UI preload) during FCM cold-wakes on
+    // mobile. Desktop has no background FCM wake — launching the process IS
+    // the foreground signal — so without this call the Authenticated branch
+    // defers connect() forever and the app hangs on "syncing" after login.
+    // Mirrors MainActivity.onCreate (Android) and MainViewController() (iOS).
+    // Idempotent and order-independent: if Authenticated hasn't fired yet it
+    // simply flips the flag so the next Authenticated runs the full sequence.
+    GlobalContext.get().get<AuthConnectionCoordinator>().promoteToForeground()
 
     // Bridge the local callback server's /permission-callback hit (after the user
     // returns from the owner-console "Extend Permissions" flow) to the in-app event

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsScreen.kt
@@ -1128,8 +1128,9 @@ private fun FileExistsStatusIcon(
  *
  * - **All present signals OK** (transfer Delivered, peer-exists
  *   PresentAuthoredByMe) → green check.
- * - **Any signal still resolving** (transfer history null entry, peer-exists
- *   Loading) → spinner.
+ * - **Any signal still resolving** (peer-exists Loading) → spinner. A null
+ *   transfer-history entry is NOT "resolving" — the map loads atomically, so a
+ *   missing peer entry means that peer was never a recipient of that file.
  * - **Anything else** (Problem, Missing, PresentAuthoredByOther, Error) →
  *   red-dashed cloud (`Icons.Default.CloudOff`), tinted with the error color.
  *
@@ -1156,10 +1157,15 @@ private fun GroupParticipantSummaryIcon(
     val size = 16.dp
 
     // Loading wins over OK/problem so we don't flash a red cloud while the
-    // peer-exists check is still in flight.
+    // peer-exists check is still in flight. The only genuine in-flight signal
+    // is the peer-exists Loading enum: the transfer-history map loads
+    // atomically (null → fully populated in one update), so once its column is
+    // shown a missing peer entry means "this peer was never a recipient of
+    // that file" — a permanent state, not loading. Treating a null transfer
+    // entry as loading left peers who never received a file (e.g. the admin
+    // file) spinning forever instead of showing the red cloud their Missing
+    // peer-exists already implies.
     val anyLoading =
-        (showMainColumn && mainStatus == null) ||
-        (showAdminColumn && adminStatus == null) ||
         (showMainPeerExistsColumn && mainPeerExists is MemberFileExistsStatus.Loading) ||
         (showAdminPeerExistsColumn && adminPeerExists is MemberFileExistsStatus.Loading)
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsViewModel.kt
@@ -43,7 +43,8 @@ import id.homebase.core.util.initials
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.uuid.Uuid
@@ -63,19 +64,31 @@ class GroupSettingsViewModel(
     private val _uiState = MutableStateFlow(GroupSettingsUiState())
     val uiState: StateFlow<GroupSettingsUiState> = _uiState.asStateFlow()
 
+    /** Identity + recipient set of the last conversation we ran the peer/transfer
+     *  audit for. Lets [loadData] skip the network-heavy audit when a conversation
+     *  re-emits with the same recipients (new message, unread/read-state change). */
+    private data class PeerAuditKey(val conversationId: Uuid, val participants: List<OdinId>)
+    private var lastPeerAuditKey: PeerAuditKey? = null
+
     init {
         viewModelScope.launch {
             conversationStream.start()
+            // conversationStream.conversations is a StateFlow over the WHOLE
+            // conversation list; it re-emits on every message arrival, unread
+            // count change, admin enrichment, and re-sort — for ANY
+            // conversation. The old collector filtered only on "is our
+            // conversation present?", so unrelated list churn re-ran the full
+            // audit. Map to our conversation and dedup so a change elsewhere in
+            // the list (or a re-sort) no longer triggers loadData; the
+            // network-heavy peer/transfer audit is gated again inside loadData
+            // on the fields it actually depends on.
             conversationStream.conversations
-                .filter { conversations ->
-                    conversations.items.any { it.id.toString() == route.conversationId }
+                .mapNotNull { conversations ->
+                    conversations.items.find { it.id.toString() == route.conversationId }
                 }
-                .collect { conversations ->
-                    val conversation =
-                        conversations.items.find { it.id.toString() == route.conversationId }
-                    conversation?.let {
-                        loadData(conversation)
-                    }
+                .distinctUntilChanged()
+                .collect { conversation ->
+                    loadData(conversation)
                 }
         }
     }
@@ -402,10 +415,27 @@ class GroupSettingsViewModel(
                 }
 
                 if (conversation.isGroupConversation && !conversation.isLegacyGroup) {
-                    loadTransferHistory(conversation)
-                    // Sibling probe — independent of file-state, so kicked off
-                    // in parallel rather than chained.
-                    launch { loadIntroductionPreflight(conversation, reason = "screen-open") }
+                    // Gate the network-heavy audit (per-recipient peer-exists
+                    // GETs + transfer-history fetch + introduction preflight)
+                    // on the only conversation fields it actually depends on:
+                    // identity + the recipient set. The lightweight state above
+                    // (name, contacts, admin flags) still refreshes on every
+                    // emission, but a model change that leaves the recipients
+                    // untouched (a new message bumping latestMessageTimestamp,
+                    // an unread-count or lastRead update) no longer re-fires the
+                    // audit. Participant add/remove changes the key and re-audits.
+                    val auditKey = PeerAuditKey(conversation.id, conversation.participants)
+                    if (auditKey != lastPeerAuditKey) {
+                        lastPeerAuditKey = auditKey
+                        loadTransferHistory(conversation)
+                        // Sibling probe — independent of file-state, so kicked off
+                        // in parallel rather than chained.
+                        launch { loadIntroductionPreflight(conversation, reason = "screen-open") }
+                    } else {
+                        Logger.d(tag = "HealAudit") {
+                            "loadData: recipients unchanged for ${conversation.id} — skipping peer/transfer audit"
+                        }
+                    }
                 }
             } catch (e: Exception) {
                 Logger.e("Failed to load conversation", e)

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/util/AndroidPlatformInfo.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/util/AndroidPlatformInfo.kt
@@ -41,4 +41,6 @@ class AndroidPlatformInfo(private val context: Context) : PlatformInfo {
             0
         }
 
+    // FCM data messages can cold-wake the process headless.
+    override val supportsBackgroundWake: Boolean = true
 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -42,6 +42,14 @@ class AuthConnectionCoordinator(
     private val databaseManager: DatabaseManager,
     private val driveRegistry: DriveRegistry,
     private val onPostAuthenticated: () -> Unit = {},
+    /**
+     * Initial value of [headless]. True only on platforms that can cold-wake the
+     * process in the background (see [PlatformInfo.supportsBackgroundWake]); those
+     * defer foreground-only work until [promoteToForeground]. Defaults to false so
+     * a platform that forgets to wire [promoteToForeground] fails open (connects on
+     * Authenticated) rather than fail closed (hangs on "syncing").
+     */
+    startsHeadless: Boolean = false,
 ) {
     // SupervisorJob so one child's failure doesn't cancel its siblings, plus a
     // top-level handler so an *uncaught* exception in any child (notably a transient
@@ -79,13 +87,16 @@ class AuthConnectionCoordinator(
     // [BackgroundSyncOrchestrator.syncIfAuthenticated] only needs the
     // drive mounts and registry bootstrap to do its QueryBatch.
     //
-    // [headless] starts true. The first foreground entry point
-    // ([MainActivity.onCreate] on Android, `MainViewController()` on iOS)
-    // calls [promoteToForeground], which flips the flag and replays the
-    // deferred work if Authenticated already fired during the headless
-    // window. If Authenticated hasn't fired yet, the next Authenticated
-    // observes !headless and runs the full sequence.
-    @Volatile private var headless: Boolean = true
+    // [headless] starts true ONLY on background-wake-capable platforms
+    // (Android/iOS — see [startsHeadless] / [PlatformInfo.supportsBackgroundWake]);
+    // Desktop and Web start false and connect on Authenticated directly. On the
+    // headless platforms, the first foreground entry point
+    // ([MainActivity.onCreate] on Android, `MainViewController()` on iOS) calls
+    // [promoteToForeground], which flips the flag and replays the deferred work if
+    // Authenticated already fired during the headless window. If Authenticated
+    // hasn't fired yet, the next Authenticated observes !headless and runs the full
+    // sequence.
+    @Volatile private var headless: Boolean = startsHeadless
 
     /**
      * Captured drives from the Authenticated branch's bootstrap step, so

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/util/PlatformInfo.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/util/PlatformInfo.kt
@@ -3,4 +3,20 @@ package id.homebase.core.util
 interface PlatformInfo {
     val versionName: String
     val versionCode: Int
+
+    /**
+     * True on platforms whose OS can wake the process in the background without a
+     * user-facing UI (Android FCM data messages, iOS APNs/BGTask). Such a wake
+     * fires `YouAuthState.Authenticated` while no one is looking at the screen, so
+     * [id.homebase.core.auth.AuthConnectionCoordinator] starts headless on these
+     * platforms and waits for `promoteToForeground()` before opening the WebSocket,
+     * running the UI preload, or loading the profile.
+     *
+     * False on platforms with no background-wake mechanism (Desktop/JVM, Web): the
+     * process only runs when a user launched it, so the coordinator starts in
+     * foreground mode and connects on `Authenticated` directly. This makes a missing
+     * `promoteToForeground()` call fail open (connect) instead of fail closed (hang
+     * on "syncing").
+     */
+    val supportsBackgroundWake: Boolean
 }

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/util/JvmPlatformInfo.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/util/JvmPlatformInfo.kt
@@ -22,4 +22,6 @@ class JvmPlatformInfo: PlatformInfo {
             0
         }
 
+    // Desktop has no OS background-wake — the process only runs when launched.
+    override val supportsBackgroundWake: Boolean = false
 }

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/IOSPlatformInfo.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/IOSPlatformInfo.kt
@@ -8,4 +8,7 @@ class IOSPlatformInfo: PlatformInfo {
 
     override val versionCode: Int
         get() = (NSBundle.mainBundle.infoDictionary?.get("CFBundleVersion") as? String)?.toIntOrNull() ?: 0
+
+    // APNs / BGTask can cold-wake the process headless.
+    override val supportsBackgroundWake: Boolean = true
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -61,6 +61,7 @@ import id.homebase.chat.services.outbox.OptimisticWriter
 import id.homebase.chat.services.requests.ConnectionRequestService
 import id.homebase.core.NotificationActionBridge
 import id.homebase.core.auth.AuthConnectionCoordinator
+import id.homebase.core.util.PlatformInfo
 import id.homebase.core.vault.VaultPreferences
 import id.homebase.core.ui.screens.vault.VaultService
 import id.homebase.core.ui.screens.vault.VaultStream
@@ -250,6 +251,10 @@ val appModule = module {
             eventBus = get(),
             databaseManager = get(),
             driveRegistry = get(),
+            // Start headless only where the OS can cold-wake us in the background
+            // (Android/iOS). Desktop/Web report false → start in foreground mode so
+            // a missing promoteToForeground() can't hang the app on "syncing".
+            startsHeadless = get<PlatformInfo>().supportsBackgroundWake,
             onPostAuthenticated = {
                 // Preload conversations and contacts from local DB while navigation
                 // and Compose composition are still in progress, saving ~800ms.

--- a/homebase-core/src/wasmJsMain/kotlin/id/homebase/core/di/WebPlatformStubs.kt
+++ b/homebase-core/src/wasmJsMain/kotlin/id/homebase/core/di/WebPlatformStubs.kt
@@ -35,6 +35,9 @@ internal class WebGalleryManager : PlatformGalleryManager {
 internal class WebPlatformInfo : PlatformInfo {
     override val versionName: String = "web"
     override val versionCode: Int = 1
+
+    // The browser tab has no OS background-wake — it only runs while open.
+    override val supportsBackgroundWake: Boolean = false
 }
 
 internal class WebAudioRecorder : AudioRecorder {

--- a/webApp/src/wasmJsMain/kotlin/id/homebase/app/main.wasm.kt
+++ b/webApp/src/wasmJsMain/kotlin/id/homebase/app/main.wasm.kt
@@ -8,9 +8,11 @@ import id.homebase.api.sync.database.DatabaseDriverFactory
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.initWebSqlJs
 import id.homebase.core.App
+import id.homebase.core.auth.AuthConnectionCoordinator
 import id.homebase.core.di.allModules
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
+import org.koin.core.context.GlobalContext
 import org.koin.core.context.startKoin
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -22,6 +24,12 @@ fun main() {
         initWebSqlJs()
         DatabaseManager.initializeWithRecovery(DatabaseDriverFactory())
         startKoin { modules(allModules) }
+        // Promote AuthConnectionCoordinator out of headless mode. Like desktop,
+        // the web app has no FCM cold-wake — loading the page IS the foreground
+        // signal — so without this the Authenticated branch defers connect()
+        // forever and the app hangs on "syncing". Mirrors MainActivity.onCreate
+        // (Android) and MainViewController() (iOS). Idempotent.
+        GlobalContext.get().get<AuthConnectionCoordinator>().promoteToForeground()
         ComposeViewport("ComposeApp") {
             App(onNavHostReady = { it.bindToBrowserNavigation() })
         }


### PR DESCRIPTION
## Summary

Two independent fixes, both surfaced while reading `homebase.log`. Bundled per request.

---

## 1. Desktop & Web hang on "syncing" after login

**Root cause.** The `headless-fcm-bg-sync` change made `AuthConnectionCoordinator` start `headless = true` on **every** platform and defer all foreground-only work — `connect()` (WebSocket), `driveRegistry.start`, `loadProfile`, and the `onPostAuthenticated` UI preload — until the first foreground entry point calls `promoteToForeground()`. That call was wired only into **Android** (`MainActivity.onCreate`) and **iOS** (`MainViewController()`). **Desktop** (`Main.kt`) and **Web** (`main.wasm.kt`) never call it, so they stayed headless forever:

```
AuthCC: Authenticated branch — mode=headless deferred=[onPostAuthenticated, connect, driveRegistry.start, loadProfile]
… wsClient=null  isConnected=false  dsmRunning=false   (AuthState: Loading, forever)
```

The drives mount and the registry bootstraps (the unconditional part), then the `if (headless)` fork stops — no socket, DriveSync never `start()`ed, profile never loads → "stuck on sync". It bites after logout→login because logout doesn't reset `headless` and desktop/web have no promote at all.

**Fixes**
- **Immediate:** call `promoteToForeground()` from the desktop and web entry points, mirroring Android/iOS.
- **Structural (fail-open default):** `headless` now defaults to `false` and is set `true` only on platforms that can cold-wake the process in the background, via a new `PlatformInfo.supportsBackgroundWake` (Android/iOS = `true`; Desktop/Web = `false`), wired through `AppModule`. A forgotten `promoteToForeground()` on a non-background-wake platform now **fails open** (connects on `Authenticated`) instead of **fail closed** (hangs). Mobile keeps the battery behavior unchanged — it still starts headless and relies on its entry-point promote.

---

## 2. Group-settings sync-audit

**`doron` infinite spinner.** `GroupParticipantSummaryIcon` treated a `null` transfer-history entry as "still loading". The transfer-history map loads atomically, so once its column is shown a missing peer entry means **"never a recipient of that file"**, not "loading". A member who never received the admin file (`adminStatus == null`, peer-exists `Missing`) spun forever, while a member who had received it then lost it (`adminStatus == Ok`, peer-exists `Missing`) correctly showed the red cloud. Dropped the two null-transfer clauses from `anyLoading`; the genuine in-flight signal is the peer-exists `Loading` enum. The affected member now falls through to the red `CloudOff` its `Missing` peer-exists already implies.

**Redundant audit churn.** The screen re-ran the full per-recipient peer-exists + transfer-history + introduction-preflight audit on **every** `conversationStream` emission — i.e. on any message/unread/enrichment/re-sort for *any* conversation — because the collector filtered only on the conversation being *present*. One trace showed 6 full re-audits including a burst of 3 byte-identical ones within 114 ms, each firing 12 peer GETs + a preflight POST. Now:
- map the flow to *this* conversation + `distinctUntilChanged` (drops other-conversation churn), and
- gate the network audit on `PeerAuditKey(id, participants)` so a new message / read-state change in this group refreshes lightweight UI state without re-firing the peer probes. Participant add/remove changes the key and re-audits.

---

## Testing

Compiles green on **JVM, Android, and wasmJs** for every touched module (`homebase-common`, `homebase-core`, `homebase-chat`, `desktopApp`, `webApp`). The iOS `nativeMain` change is a one-line constant (`supportsBackgroundWake = true`); not compiled here (macOS-only host). No automated tests added — these are UI/wiring changes verified against the captured `homebase.log` traces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)