### PR TITLE
Drop "AES key must match" outbox updates as permanent failures

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
@@ -101,6 +101,19 @@ class OutboxSync(
             // sibling quota messages the server emits in the same shape
             // with errorCode collapsed to UnhandledScenario.
             if (msg.contains(Regex("size of \\d+ exceeds \\d+", RegexOption.IGNORE_CASE))) return true
+            // Encrypted-file key mismatch on update: the server rejects an update
+            // whose AES key differs from the existing file's ("When updating an
+            // encrypted file, the AES key must match the existing key …"). The
+            // outbox row carries a fixed key, so every retry replays the same
+            // wrong key against an unchanging server file — deterministically
+            // unrecoverable. Drop it instead of burning ~48h of retries.
+            // GUARDRAIL, not the fix: the root cause is DriveOutboxUploader.
+            // retryAsUpdate adopting the server's versionTag but reusing the
+            // client's freshly-minted keyHeader (seen when the local DB lost the
+            // conversation's key, e.g. the in-memory web DB after a reload, and
+            // optimistically recreated the conversation with a new key). The real
+            // fix re-hydrates the existing server key on ExistingFileWithUniqueId.
+            if (msg.contains("AES key must match", ignoreCase = true)) return true
             // Client-side pre-flight rejections from
             // [UploadValidation.kt]. The validator throws ClientException
             // shaped like a server response so we land here on attempt 1.

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSyncTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSyncTest.kt
@@ -738,6 +738,62 @@ class OutboxSyncTest {
     }
 
     /**
+     * Regression for the web video-send "stuck on Done forever" scenario
+     * (PR #640 follow-up): a conversation file whose UploadNewFile recovers via
+     * `DriveOutboxUploader.retryAsUpdate` is rejected by the server with HTTP 400
+     * "When updating an encrypted file, the AES key must match the existing key …"
+     * (errorCode collapsed to UnhandledScenario). The outbox row carries a fixed
+     * key, so every retry replays the same wrong key — deterministically
+     * unrecoverable. Without the title-match in `isPermanentFailure` it loops for
+     * 20 retries / ~48h and dependency-chains every message behind it. After the
+     * fix it drops on attempt 1.
+     */
+    @Test
+    fun testPermanentFailure_AesKeyMismatchDroppedOnFirstAttempt() = runOutboxTest { db ->
+        val eventBus = EventBus()
+        val uploader = TestUploader()
+        uploader.failureException = clientException(
+            errorCode = OdinClientErrorCode.UnhandledScenario,
+            message = "When updating an encrypted file, the AES key must match the existing key. " +
+                    "Changing the AES key can invalidate existing encrypted payloads. " +
+                    "If you need to rotate keys, re-upload the file instead.",
+        )
+
+        val sync = OutboxSync(
+            databaseManager = db, uploader = uploader, eventBus = eventBus, scope = backgroundScope
+        )
+        sync.setOnline(true)
+
+        val droppedDeferred = async {
+            eventBus.events.filterIsInstance<BackendEvent.OutboxEvent.OutboxItemDropped>().first()
+        }
+        testScheduler.runCurrent()
+
+        val driveId = Uuid.random()
+        val uniqueId = Uuid.random()
+        db.outbox.insert(
+            driveId = driveId,
+            uniqueId = uniqueId,
+            dependencyUniqueId = null,
+            priority = 0,
+            uploadType = 0,
+            json = byteArrayOf(),
+            filePaths = null,
+        )
+
+        try { sync.send() } catch (_: Exception) {}
+        advanceUntilIdle()
+
+        val dropped = droppedDeferred.await()
+
+        assertEquals(0L, db.outbox.count(), "row must be dropped on first attempt")
+        assertEquals(uniqueId, dropped.uniqueId)
+        assertEquals(driveId, dropped.driveId)
+        assertEquals(1, dropped.attempts, "drop must happen on attempt 1, not after MAX_RETRIES")
+        sync.clearCheckout(timeoutMs = 5_000)  // drain before db.close(); see file kdoc
+    }
+
+    /**
      * Regression: once the head of a dependency chain is dropped (permanent
      * failure), the next message in the chain must become eligible to
      * checkout. This locks in the SQL behavior in `OutboxQueries.kt`


### PR DESCRIPTION
## Summary

A chat send can hang forever in a **"Done" + infinite spinner** state with no upload progress when the message's **conversation file** is in a broken sync state. This fixes the retry side of that bug.

When a conversation-file `UploadNewFile` recovers via `DriveOutboxUploader.retryAsUpdate`, the server can reject the update with HTTP 400:

> *When updating an encrypted file, the AES key must match the existing key. Changing the AES key can invalidate existing encrypted payloads. If you need to rotate keys, re-upload the file instead.*

This is **deterministically unrecoverable**: the outbox row carries a fixed key, so every retry replays the *same wrong key* against an *unchanging server file*. The result is **20 retries over ~48h**, and because messages enqueue with `dep=<conversationId>`, every message queued behind that conversation file is blocked the entire time — the user sees the send spin forever.

## Change

Classify it in `OutboxSync.isPermanentFailure` via a message-text match (the server collapses the structured `errorCode` to `UnhandledScenario`, so we match the title the same way the existing version-tag / thumbnail-size cases do). The row now **drops on attempt 1** and emits `OutboxItemDropped`.

`isPermanentFailure` was chosen deliberately over `DriveOutboxUploader`'s "return normally" terminal path (used for `Cannot transfer to yourself` / `VersionTagMismatch`): that path reports a *false success* (`ItemCompleted`), whereas this is a genuine failure. Routing it through `OutboxItemDropped` also feeds the planned chat drop→`Failed` UX handler.

## This is a guardrail, not the root-cause fix

The real cause is one level up: `DriveOutboxUploader.retryAsUpdate` adopts the server file's **versionTag** but reuses the client's freshly-minted **keyHeader** (`keyHeader = original.keyHeader`). That guarantees the mismatch whenever the local DB lost the conversation's key and recreated it with a new one — which is exactly what happens with the **in-memory web DB after a reload**. The principled fix re-hydrates the existing server key on `ExistingFileWithUniqueId` and is tracked as a separate follow-up.

## Testing

- New: `OutboxSyncTest.testPermanentFailure_AesKeyMismatchDroppedOnFirstAttempt` — asserts the row drops on attempt 1 and emits `OutboxItemDropped` (mirrors the existing `*DroppedOnFirstAttempt` regression tests, using the full real server message).
- `./gradlew :homebase-api:jvmTest --tests "id.homebase.api.sync.database.OutboxSyncTest"` — green (14 tests).

## Follow-ups (not in this PR)
- Root cause: `retryAsUpdate` should adopt the existing server key (re-hydrate the conversation) rather than mint a new one.
- UX: chat has no `OutboxItemDropped` consumer (Moments/Vault both flip to a `Failed` state). A dropped chat message still shows the pending spinner instead of the already-wired `ErrorOutline` failure icon. Includes deciding the dependent-message cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)