### PR TITLE
Show a Failed icon on permanently-dropped chat sends

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -20,6 +20,7 @@ import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.QueryBatch
 import id.homebase.chat.data.MessageUiModel
 import id.homebase.chat.services.convo.contact.ContactService
+import id.homebase.chat.services.outbox.OptimisticWriter
 import id.homebase.core.config.chatTargetDrive
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -40,7 +41,8 @@ class ChatMessageStream(
     private val dbm: DatabaseManager,
     private val eventBus: EventBus,
     private val scope: CoroutineScope,
-    private val driveFileProvider: DriveFileProvider
+    private val driveFileProvider: DriveFileProvider,
+    private val optimisticWriter: OptimisticWriter
 ) : MessageLookup {
     /** Set by ConversationStream to let us skip messages for left conversations. */
     var isConversationLeft: (Uuid) -> Boolean = { false }
@@ -67,6 +69,18 @@ class ChatMessageStream(
                     is BackendEvent.OutboxEvent.OptimisticRollback -> {
                         if (event.driveId == chatDrive) {
                             paginatedState.removeMessage(event.uniqueId)
+                        }
+                    }
+
+                    // The outbox permanently gave up on this item (permanent failure
+                    // or 20 retries exhausted). For a message that means it will never
+                    // arrive back from the server to clear isPendingSendTag — so the
+                    // bubble would spin forever. Swap the pending tag for the failed
+                    // tag so the bubble shows the error icon. Conversation/admin file
+                    // drops are ignored in markSendFailed (no bubble).
+                    is BackendEvent.OutboxEvent.OutboxItemDropped -> {
+                        if (event.driveId == chatDrive) {
+                            scope.launch { markSendFailed(event.uniqueId) }
                         }
                     }
 
@@ -370,6 +384,28 @@ class ChatMessageStream(
             chatDrive,
             messageId
         )
+    }
+
+    /**
+     * An outbox item for [uniqueId] was permanently dropped. If it's a chat *message*,
+     * swap its [ChatProtocol.isPendingSendTag] for [ChatProtocol.isFailedSendTag] so the
+     * bubble shows the Failed icon instead of spinning forever.
+     *
+     * Non-message drops are ignored: a dropped conversation file
+     * (`uniqueId == conversationId`) or admin file has no message bubble; its dependent
+     * messages each surface their own outcome via this same handler when they drop.
+     */
+    private suspend fun markSendFailed(uniqueId: Uuid) {
+        val file = getMessageFile(uniqueId) ?: return
+        if (file.fileMetadata.appData.fileType != ChatProtocol.MessageFileType) return
+
+        val existingTags = file.fileMetadata.localAppData?.tags.orEmpty()
+        // Already terminal — nothing to do (avoids a redundant upsert/BatchReceived).
+        if (ChatProtocol.isFailedSendTag in existingTags) return
+
+        val newTags = existingTags
+            .filterNot { it == ChatProtocol.isPendingSendTag } + ChatProtocol.isFailedSendTag
+        optimisticWriter.updateLocalTags(chatDrive, uniqueId, newTags)
     }
 
     /** Walk the open conversations' in-memory message lists for a model whose

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatProtocol.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatProtocol.kt
@@ -72,6 +72,17 @@ object ChatProtocol {
     /** Indicates a file was optimistically written and not coming from the server */
     val isPendingSendTag = Uuid.parse("6e87beb3-412a-4a8c-aaec-b21a7ec620a7")
 
+    /**
+     * Local metadata tag: the optimistic send was permanently dropped by the outbox
+     * (permanent failure or retries exhausted). Set by [ChatMessageStream] on
+     * [id.homebase.api.client.eventbus.BackendEvent.OutboxEvent.OutboxItemDropped],
+     * replacing [isPendingSendTag]. The mapper reads it to show the Failed delivery
+     * icon instead of the pending spinner — without it a never-uploaded message maps
+     * to Sent (no server transfer history → checkmark). Local-only; never sent to the
+     * server.
+     */
+    val isFailedSendTag = Uuid.parse("7a1c0e3d-4b6f-4c2a-9e8d-5f3b2a1c0d4e")
+
     /** Local metadata tag: conversation has been archived by the user */
     val ConversationArchivedTag = Uuid.parse("a569e5cd-6fd8-41e0-8ccc-b6b31dac6b73")
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/MessageMapper.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/MessageMapper.kt
@@ -97,9 +97,12 @@ suspend fun mapToMessageData(
     val isStatusMessage = appData.dataType == ChatProtocol.ChatStatusMessageDataType
     val hasMore =
         metadata.payloads?.any { it.key == ChatProtocol.DefaultPayloadKey } == true
+    val localTags = metadata.localAppData?.tags
+    // A permanently-dropped send (isFailedSendTag) wins over pending: the bubble must
+    // show the Failed icon, not keep spinning. See ChatProtocol.isFailedSendTag.
+    val isFailedSend = localTags?.contains(ChatProtocol.isFailedSendTag) ?: false
     val isPendingSend =
-        metadata.localAppData?.tags?.contains(ChatProtocol.isPendingSendTag)
-            ?: false
+        (localTags?.contains(ChatProtocol.isPendingSendTag) ?: false) && !isFailedSend
 
     val localReadTimestamp = metadata.localAppData?.readTime
     // localReactions on the wire are JSON-encoded ReactionContent objects
@@ -157,7 +160,8 @@ suspend fun mapToMessageData(
         require(appData.uniqueId != null)
         require(appData.groupId != null)
 
-        val delivery = getDeliveryStatus(header).value
+        val delivery =
+            if (isFailedSend) ChatDeliveryStatus.Failed.value else getDeliveryStatus(header).value
 
         val messageAppData: MessageAppData
         // Try the typed-content parser first. Returns non-null when

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageStreamMapperTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageStreamMapperTest.kt
@@ -172,4 +172,56 @@ class ChatMessageStreamMapperTest {
         assertTrue(result.isDeleted)
         assertEquals(expectedOwnReactions, result.ownReactions.toList())
     }
+
+    // region isFailedSendTag → Failed bubble (OutboxItemDropped surface)
+
+    @Test
+    fun mapToMessageData_pendingTagOnly_isPendingSendTrue() = runTest {
+        val cm = createTestCredentialsManager()
+        val header = buildChatMessageHeader(
+            localAppDataJson = """{"tags": ["${ChatProtocol.isPendingSendTag}"]}"""
+        )
+
+        val result = mapToMessageData(header, cm)
+
+        assertNotNull(result)
+        assertTrue(result.isPendingSend, "pending tag → spinner")
+    }
+
+    @Test
+    fun mapToMessageData_failedTag_isPendingSendFalseAndDeliveryFailed() = runTest {
+        val cm = createTestCredentialsManager()
+        val header = buildChatMessageHeader(
+            localAppDataJson = """{"tags": ["${ChatProtocol.isFailedSendTag}"]}"""
+        )
+
+        val result = mapToMessageData(header, cm)
+
+        assertNotNull(result)
+        assertEquals(false, result.isPendingSend, "failed send must not show the spinner")
+        assertEquals(
+            ChatDeliveryStatus.Failed.value,
+            result.messageAppData.deliveryStatus,
+            "failed send must map to the Failed delivery icon (not the default Sent)",
+        )
+    }
+
+    @Test
+    fun mapToMessageData_bothTags_failedWins() = runTest {
+        // The drop handler swaps pending→failed, but if both linger (or a race),
+        // failed must win so the bubble can't get stuck spinning.
+        val cm = createTestCredentialsManager()
+        val header = buildChatMessageHeader(
+            localAppDataJson =
+                """{"tags": ["${ChatProtocol.isPendingSendTag}", "${ChatProtocol.isFailedSendTag}"]}"""
+        )
+
+        val result = mapToMessageData(header, cm)
+
+        assertNotNull(result)
+        assertEquals(false, result.isPendingSend, "failed wins over pending")
+        assertEquals(ChatDeliveryStatus.Failed.value, result.messageAppData.deliveryStatus)
+    }
+
+    // endregion
 }


### PR DESCRIPTION
## Summary

A chat send could sit on **"Done" + an infinite spinner** forever. The spinner is driven solely by the local `ChatProtocol.isPendingSendTag`, which is added on optimistic write and clears *implicitly* when the server-confirmed message syncs back and replaces the optimistic row. A message that **never uploads** — e.g. one blocked behind a dependency that permanently fails, like the conversation-file AES-key conflict (#641) — never comes back, so the tag never clears and the bubble spins indefinitely.

The outbox already gives up correctly and emits `OutboxEvent.OutboxItemDropped` (permanent failure or 20 retries exhausted). **Moments** and **Vault** both consume it and show a failed state; **chat had no consumer**. The failure UI already exists — `DeliveryStatus` in `MessageBubble.kt` renders `Icons.Default.ErrorOutline` for `ChatDeliveryStatus.Failed` — nothing triggered it for chat.

## Change

- **`ChatMessageStream`** subscribes to `OutboxItemDropped` (it already has an always-on, chat-drive-filtered event loop). For a dropped **message** file it swaps `isPendingSendTag` → a new `isFailedSendTag`. Persisted locally via the existing `OptimisticWriter.updateLocalTags` (writes the DB + emits `BatchReceived`, which the same stream consumes → the bubble re-maps).
- **`MessageMapper`** reads `isFailedSendTag`: `isPendingSend` becomes false and `deliveryStatus` becomes `Failed` (**failed wins over pending**). A bare strip of the pending tag was *not* enough — `getDeliveryStatus` returns `Sent` when there's no server transfer history, which would show a checkmark.
- **`ChatProtocol.isFailedSendTag`** — new local-only tag (never sent to the server).

### Why a durable tag (not the transient `uploadProgress` map)
The bubble's delivery icon is driven by the DB-backed message model (`isPendingSend` + `deliveryStatus`), not by `ConversationListViewModel`'s transient `uploadProgress`. A Moments/Vault-style transient flag wouldn't flip the icon.

### Non-message drops are ignored (the deliberate "cascade" decision)
`OutboxItemDropped` also fires for the **conversation file** (`uniqueId == conversationId`) and admin files — these have no message bubble, so `markSendFailed` ignores them. Their dependent messages auto-unblock once the blocker is gone (existing SQL behaviour) and each surfaces its **own** outcome via this same handler if it later drops. We deliberately do **not** pre-emptively cascade-fail dependents: in the AES case the conversation file exists server-side, so the dependents can often still deliver.

## Scope
Failure **surface only**. Tap-to-retry is deferred: dropped media can't be resent as-is because `cleanupPayloadsForDroppedRow` reaps the payload temps on drop.

## Testing
- `ChatMessageStreamMapperTest` gains three cases: pending-only → spinner; failed tag → `isPendingSend=false` + `deliveryStatus=Failed`; both tags → failed wins.
- `./gradlew homebase-chat:jvmTest` green (incl. Konsist architecture test).
- Compiles on JVM, wasmJs, and Android.
- A full `markSendFailed` integration test is intentionally omitted — `ChatMessageStream` has no `ContactService`/`DriveFileProvider` test double (documented limitation in `ChatMessageStreamPagingTest`). DI auto-wires `OptimisticWriter` via the existing `singleOf` constructor DSL.

## Related
- Builds on #641 (the AES-key permanent-failure guardrail) — that makes the drop happen fast (attempt 1) instead of after ~48h, so this Failed icon appears promptly in that scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)