### PR TITLE
fix(ios): capture launch crashes + attach Kotlin exception context to Crashlytics

### DIFF
--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/logging/CrashlyticsBridge.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/logging/CrashlyticsBridge.kt
@@ -10,6 +10,22 @@ interface CrashlyticsBridge {
      * @param enabled true to enable, false to disable
      */
     fun setCrashlyticsCollectionEnabled(enabled: Boolean)
+
+    /**
+     * Append a message to the Crashlytics log buffer. The buffer is written to
+     * Crashlytics' on-disk crash context, so anything logged before a crash is
+     * included in the report. Used by the crash handlers to attach the Kotlin /
+     * ObjC stack to the fatal report (which otherwise shows only a bare abort()).
+     */
+    fun log(message: String)
+
+    /**
+     * Set a custom key/value pair on the next Crashlytics report. Like [log],
+     * keys live in the mmap'd crash context, so values set immediately before a
+     * crash are included. Used to record the uncaught exception's class and
+     * message so the fatal report is identifiable instead of "abort in libsystem".
+     */
+    fun setCustomKey(key: String, value: String)
 }
 
 /**

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/logging/IOSCrashHandler.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/logging/IOSCrashHandler.kt
@@ -12,6 +12,40 @@ import platform.Foundation.NSThread
 private const val TAG = "IOSCrashHandler"
 
 /**
+ * Attaches uncaught-exception context to the Crashlytics report so the fatal crash
+ * carries the Kotlin / ObjC class, message, and stack — instead of a bare
+ * `abort()`/`SIGABRT` with no app frames.
+ *
+ * Crashlytics custom keys and log lines are written to its mmap'd crash context, so
+ * values set on the crashing thread immediately before termination are included in
+ * the report Crashlytics writes from its signal/Mach handler. This requires that
+ * `FirebaseApp.configure()` has already run (see `AppDelegate`); if it hasn't, the
+ * bridge is null and this is a no-op.
+ *
+ * `internal` (not private) and bridge-injectable so it can be unit-tested.
+ */
+@Suppress("TooGenericExceptionCaught")
+internal fun pushCrashContextToCrashlytics(
+    source: String,
+    exceptionClass: String,
+    message: String?,
+    stackLines: List<String>,
+    bridge: CrashlyticsBridge? = CrashlyticsBridgeHolder.getBridge(),
+) {
+    bridge ?: return
+    try {
+        bridge.setCustomKey("crash_source", source)
+        bridge.setCustomKey("exception_class", exceptionClass)
+        bridge.setCustomKey("exception_message", message ?: "")
+        bridge.log("$source uncaught: $exceptionClass: ${message ?: ""}")
+        stackLines.forEach { line -> if (line.isNotBlank()) bridge.log(line) }
+    } catch (e: Throwable) {
+        // Crash reporting must never trigger a secondary crash.
+        println("pushCrashContextToCrashlytics failed: ${e.message}")
+    }
+}
+
+/**
  * Installs the iOS crash handlers so fatal errors are written to `homebase.log`
  * (via Kermit / [CrashLogger]) before the process dies — matching the
  * `Thread.setDefaultUncaughtExceptionHandler` → [CrashLogger.logCrash] wiring
@@ -33,7 +67,15 @@ private const val TAG = "IOSCrashHandler"
  * channels log to the same file support reads, and both still let the process
  * crash normally so Crashlytics keeps capturing the native backtrace.
  *
- * Call once, on the main thread, at startup (see `MainViewController`).
+ * Both channels also enrich the Crashlytics report via [pushCrashContextToCrashlytics]
+ * before terminating. Without this, a Kotlin/Native crash reaches Crashlytics only
+ * as a bare `abort()`/`SIGABRT` with no app frames (the rich Throwable detail lived
+ * only in `homebase.log`). The exception class/message/stack are now attached to the
+ * fatal report as Crashlytics custom keys + logs, so the crash is identifiable.
+ *
+ * Call once, on the main thread, at startup (see `MainViewController`). For the
+ * Crashlytics enrichment to be captured, `FirebaseApp.configure()` must already
+ * have run — it is called first in `AppDelegate.didFinishLaunchingWithOptions`.
  */
 @OptIn(ExperimentalForeignApi::class, ExperimentalNativeApi::class)
 fun setupIOSCrashHandler() {
@@ -46,6 +88,13 @@ fun setupIOSCrashHandler() {
                 Logger.e(tag = TAG) { "Reason: ${it.reason}" }
                 Logger.e(tag = TAG) { "Call Stack: ${it.callStackSymbols}" }
                 Logger.e(tag = TAG) { "==========================================" }
+
+                pushCrashContextToCrashlytics(
+                    source = "NSException",
+                    exceptionClass = it.name ?: "NSException",
+                    message = it.reason,
+                    stackLines = it.callStackSymbols.map { frame -> frame.toString() },
+                )
 
                 // Give the file log writer a moment to flush before the process dies.
                 NSThread.sleepForTimeInterval(0.1)
@@ -64,6 +113,14 @@ fun setupIOSCrashHandler() {
     previousHook = setUnhandledExceptionHook { throwable ->
         try {
             CrashLogger.logCrash(thread = "Kotlin/Native", exception = throwable)
+            pushCrashContextToCrashlytics(
+                source = "Kotlin/Native",
+                exceptionClass = throwable::class.qualifiedName
+                    ?: throwable::class.simpleName
+                    ?: "Throwable",
+                message = throwable.message,
+                stackLines = throwable.stackTraceToString().lineSequence().toList(),
+            )
             // Give the file log writer a moment to flush before the process dies.
             NSThread.sleepForTimeInterval(0.1)
         } catch (e: Throwable) {

--- a/iosApp/iosApp/CrashlyticsBridgeImpl.swift
+++ b/iosApp/iosApp/CrashlyticsBridgeImpl.swift
@@ -9,4 +9,12 @@ class CrashlyticsBridgeImpl: CrashlyticsBridge {
     func setCrashlyticsCollectionEnabled(enabled: Bool) {
         Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(enabled)
     }
+
+    func log(message: String) {
+        Crashlytics.crashlytics().log(message)
+    }
+
+    func setCustomKey(key: String, value: String) {
+        Crashlytics.crashlytics().setCustomValue(value, forKey: key)
+    }
 }

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -10,12 +10,20 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
   func application(_ application: UIApplication,
                    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
 
+      // Configure Firebase FIRST — before any heavy init. FirebaseApp.configure()
+      // is what arms Crashlytics' signal/Mach/NSException handlers; until it runs,
+      // nothing is captured. initializeApp() below starts Koin, file logging, and a
+      // runBlocking database open/migration, all of which can crash on launch for
+      // some users. Configuring first means those launch crashes are reported
+      // instead of vanishing. (Android gets this for free via Firebase's auto-init
+      // ContentProvider, which runs before Application.onCreate; iOS has no such
+      // hook, so ordering here is load-bearing.)
+      FirebaseApp.configure()
+
       // Run Koin, logging, and database init before any UI framework setup.
       // This keeps the main-thread run-loop free between heavy init and the
       // first Compose frame, preventing the iOS text-rendering race condition.
       MainViewControllerKt.initializeApp()
-
-      FirebaseApp.configure() //important
 
       //By default showPushNotification value is true.
       //When set showPushNotification to false foreground push  notification will not be shown.


### PR DESCRIPTION
## Why

iOS Crashlytics was recording little to nothing useful, across debug/dev/release/prod:
- **Some users crash on app open and nothing is recorded.**
- Release does record some crashes, but **the important ones are missing or too vague to understand** (`abort`/`libsystem` with no app frames).

Investigation found these are **iOS-specific** — Android is fine by construction (Firebase auto-inits via a ContentProvider before `Application.onCreate`, JVM `Throwable`s carry full stacks, and the Crashlytics Gradle plugin uploads the R8 mapping file).

## Root causes & fixes

### 1. Launch crashes were invisible (the crash-on-open reports)
`FirebaseApp.configure()` — which arms Crashlytics' signal/Mach/NSException handlers — ran **after** `MainViewControllerKt.initializeApp()` in `AppDelegate.didFinishLaunchingWithOptions`. But `initializeApp()` runs Koin startup, file logging, and a `runBlocking { DatabaseManager.initializeWithRecovery(...) }` (DB open/migration/decryption). Any crash during that init happened **before Crashlytics existed**, so it was never captured. (It also touched `Crashlytics.crashlytics()` before `configure()`, which Firebase warns against.)

**Fix:** call `FirebaseApp.configure()` first, before `initializeApp()`.

### 2. Kotlin/ObjC crashes reached Crashlytics with no context (the "vague" reports)
`CrashLogger.logCrash` writes the exception class/message/stack **only to `homebase.log`** (Kermit). Uncaught Kotlin/Native exceptions go through `terminateWithUnhandledException()` → `abort()` → `SIGABRT`, so Crashlytics saw only a context-free abort. `CrashlyticsBridge` had no API to enrich the report.

**Fix:** add `log()` / `setCustomKey()` to `CrashlyticsBridge` (+ Swift impl) and push `crash_source` / `exception_class` / `exception_message` + the stack onto the fatal report from **both** crash channels (NSException + Kotlin/Native hook) via the new `pushCrashContextToCrashlytics()` helper.

## Files
- `iosApp/iosApp/iOSApp.swift` — `FirebaseApp.configure()` moved before `initializeApp()`
- `homebase-common/.../logging/CrashlyticsBridge.kt` — `log()` / `setCustomKey()` added to the contract
- `iosApp/iosApp/CrashlyticsBridgeImpl.swift` — Swift implementations
- `homebase-common/.../logging/IOSCrashHandler.kt` — `pushCrashContextToCrashlytics()` + wiring into both channels

## Verification status (draft)
- ✅ `:homebase-common:compileKotlinIosSimulatorArm64` passes (native interop compiles)
- ⚠️ Full `xcodebuild` currently **fails in the `Compile Kotlin Framework` (embedAndSign) phase** — under investigation; the module compiles in isolation, so likely environmental. **Not yet resolved.**
- ❌ Runtime proof (force a crash on a device/sim **without debugger**, reopen, confirm Crashlytics shows it with the enriched context) — not yet done.

## Not included (follow-ups)
- **FFmpegKit native dSYMs** aren't shipped/uploaded, so native FFmpeg frames stay unsymbolicated even after this PR (fix #2 mitigates by attaching Kotlin context). 
- **Debug** config is `dwarf` (no dSYM); and recall Crashlytics never uploads while a debugger is attached — debug/dev crashes from Xcode won't appear regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)