### PR TITLE
Generic haptic feedback component (semantic, settings-gated)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/dice/BattleRollSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/dice/BattleRollSheet.kt
@@ -42,8 +42,6 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalHapticFeedback
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -53,6 +51,8 @@ import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.chat.data.MessageUiModel
 import id.homebase.chat.services.ChatMessageSenderService
 import id.homebase.chat.services.content.MessageContent
+import id.homebase.core.haptics.HapticEvent
+import id.homebase.core.haptics.rememberHaptics
 import id.homebase.resources.MR
 import id.homebase.resources.chat_dice_battle_target
 import id.homebase.resources.chat_dice_battle_title
@@ -105,7 +105,7 @@ private fun BattleRollSheetContent(
     val sender: ChatMessageSenderService = koinInject()
     val ownerSession: OwnerSessionRepository = koinInject()
     val shakeDetector: ShakeDetector = koinInject()
-    val haptic = LocalHapticFeedback.current
+    val haptics = rememberHaptics()
     val scope = rememberCoroutineScope()
 
     val parentDescriptor = (parentMessage.messageContent as? MessageContent.DiceRoll)?.descriptor
@@ -142,7 +142,7 @@ private fun BattleRollSheetContent(
     val doRoll: () -> Unit = roll@{
         if (isBusy) return@roll
         if (ownerOdinId == null) return@roll
-        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+        haptics.perform(HapticEvent.LongPress)
         rolling = true
         val seed = if (shakeTriggered) shakeSamples else null
         val finalResults = if (mode == DiceRollMode.OpenEndedD100) {
@@ -160,7 +160,7 @@ private fun BattleRollSheetContent(
             )
             while (displayValues.size < finalResults.size) displayValues.add(null)
             for (i in finalResults.indices) displayValues[i] = finalResults[i]
-            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+            haptics.perform(HapticEvent.LongPress)
             rolling = false
             sending = true
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/dice/DiceRollComposerSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/dice/DiceRollComposerSheet.kt
@@ -48,9 +48,7 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -60,6 +58,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.chat.services.ChatMessageSenderService
 import id.homebase.chat.services.content.MessageContent
+import id.homebase.core.haptics.HapticEvent
+import id.homebase.core.haptics.rememberHaptics
 import id.homebase.resources.MR
 import id.homebase.resources.chat_dice_composer_title
 import id.homebase.resources.chat_dice_count_label
@@ -119,7 +119,7 @@ private fun DiceRollComposerContent(
     val ownerSession: OwnerSessionRepository = koinInject()
     val preferences: DiceRollPreferences = koinInject()
     val shakeDetector: ShakeDetector = koinInject()
-    val haptic = LocalHapticFeedback.current
+    val haptics = rememberHaptics()
     val scope = rememberCoroutineScope()
 
     val initialFaces by preferences.lastFaces.collectAsStateWithLifecycle()
@@ -157,7 +157,7 @@ private fun DiceRollComposerContent(
 
     val doRoll: () -> Unit = roll@{
         if (isBusy) return@roll
-        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+        haptics.perform(HapticEvent.LongPress)
         rolling = true
         val seed = if (shakeTriggered) shakeSamples else null
         val finalResults = if (mode == DiceRollMode.OpenEndedD100) {
@@ -180,7 +180,7 @@ private fun DiceRollComposerContent(
             // in the final faces.
             while (displayValues.size < finalResults.size) displayValues.add(null)
             for (i in finalResults.indices) displayValues[i] = finalResults[i]
-            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+            haptics.perform(HapticEvent.LongPress)
             rolling = false
             sending = true
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -82,6 +82,8 @@ import id.homebase.chat.services.content.MessageContent
 import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.PublicAvatar
 import id.homebase.core.clipboard.clipEntryOf
+import id.homebase.core.haptics.HapticEvent
+import id.homebase.core.haptics.rememberHaptics
 import id.homebase.core.image.HomebaseImage
 import id.homebase.core.image.HomebaseImageData
 import id.homebase.core.image.ImageSize
@@ -192,6 +194,7 @@ fun SentMessageBubble(
     // frame then snaps to bubble width on the next composition.
     var bubbleWidthPx by remember { mutableIntStateOf(0) }
     val density = LocalDensity.current
+    val haptics = rememberHaptics()
 
     Row(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)
@@ -343,6 +346,7 @@ fun SentMessageBubble(
                         clusterPosition = clusterPosition,
                         onLongClick = {
                             if (onMessageInfo != null) {
+                                haptics.perform(HapticEvent.LongPress)
                                 popupMode = MessagePopupMode.All
                             }
                         },
@@ -497,6 +501,7 @@ fun ReceivedMessageBubble(
     val hasVisibleBackground = !mediaOnly && !emojiOnly
     val clipboardManager = LocalClipboard.current
     val scope = rememberCoroutineScope()
+    val haptics = rememberHaptics()
 
     Row(
         modifier = Modifier.fillMaxWidth()
@@ -585,6 +590,7 @@ fun ReceivedMessageBubble(
                             else null,
                             onLongClick = {
                                 if (onMessageInfo != null) {
+                                    haptics.perform(HapticEvent.LongPress)
                                     popupMode = MessagePopupMode.All
                                 }
                             },

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
@@ -78,7 +78,6 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.isCtrlPressed
@@ -91,7 +90,6 @@ import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.SpanStyle
@@ -112,6 +110,8 @@ import id.homebase.chat.conversationlist.RecordingData
 import id.homebase.chat.services.renderer.PayloadRenderer
 import id.homebase.chat.services.renderer.LinkPreviewRenderer
 import id.homebase.core.audio.rememberRecordAudioPermissionState
+import id.homebase.core.haptics.HapticEvent
+import id.homebase.core.haptics.rememberHaptics
 import id.homebase.core.clipboard.clipboardImageReceiverModifier
 import id.homebase.core.clipboard.getImageFromClipboard
 import id.homebase.core.ui.theme.HomebaseTheme
@@ -177,6 +177,7 @@ fun MessageInputBar(
     val interactionSource = remember { MutableInteractionSource() }
     val isHovered by interactionSource.collectIsHoveredAsState()
     var showExpanded by remember { mutableStateOf(false) }
+    val haptics = rememberHaptics()
 
     // URL-detector private state. Lives here (not in the parent) because it's an
     // implementation detail of how LinkPreviewRenderer gets produced from typed text:
@@ -247,6 +248,7 @@ fun MessageInputBar(
         // send because they're not LinkPreviewRenderer.
         val hasUserInitiatedAttachment = payloadRenderers.any { it !is LinkPreviewRenderer }
         if (!isSendingMessage && (hasText || hasUserInitiatedAttachment)) {
+            haptics.perform(HapticEvent.Confirm)
             onSendMessage(textFieldState.toMarkdown(), payloadRenderers)
             // Don't clear here — the ViewModel clears after the send is queued,
             // so the text stays in the edit box if the send fails.
@@ -526,7 +528,7 @@ fun MessageTextFieldCompact(
     var isRecordingActive by remember { mutableStateOf(false) }
     var recordingSeconds by remember { mutableStateOf(0) }
     var dragOffset by remember { mutableStateOf(0f) }
-    val hapticFeedback = LocalHapticFeedback.current
+    val haptics = rememberHaptics()
     val density = LocalDensity.current
     val cancelThresholdPx = with(density) { 200.dp.toPx() }
     var isKeyboardFocused by remember { mutableStateOf(false) }
@@ -574,7 +576,7 @@ fun MessageTextFieldCompact(
     // is released (isMicrophonePressed → false) before the delay elapses.
     LaunchedEffect(isMicrophonePressed) {
         if (isMicrophonePressed) {
-            hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+            haptics.perform(HapticEvent.LongPress)
             delay(300)
 
             if (!recordAudioPermissionState.hasPermission) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/SwipeableMessageWrapper.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/SwipeableMessageWrapper.kt
@@ -26,13 +26,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import id.homebase.core.haptics.HapticEvent
+import id.homebase.core.haptics.rememberHaptics
 import id.homebase.core.util.isMobile
 import id.homebase.resources.MR
 import id.homebase.resources.chat_message_reply
@@ -61,7 +61,7 @@ fun SwipeableMessageWrapper(
     var dragOffset by remember { mutableFloatStateOf(0f) }
     var isDragging by remember { mutableStateOf(false) }
     val animatable = remember { Animatable(0f) }
-    val haptic = LocalHapticFeedback.current
+    val haptics = rememberHaptics()
     var hapticFired by remember { mutableStateOf(false) }
 
     // The displayed offset: drag value while dragging, animated value while springing back
@@ -175,7 +175,7 @@ fun SwipeableMessageWrapper(
                             // Fire haptic at threshold
                             if (!hapticFired && newValue.absoluteValue >= thresholdPx) {
                                 hapticFired = true
-                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                haptics.perform(HapticEvent.LongPress)
                             } else if (hapticFired && newValue.absoluteValue < thresholdPx) {
                                 hapticFired = false
                             }

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -168,6 +168,7 @@
 
     <!-- Settings screen -->
     <string name="settings_appearance">Appearance</string>
+    <string name="settings_haptic_feedback">Haptic Feedback</string>
     <string name="settings_connections">Connections</string>
     <string name="connections_already_sent_title">Request already sent</string>
     <string name="connections_already_sent_text">A connection request to %1$s already exists. Open the owner console to view or manage it.</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/haptics/ComposeHaptics.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/haptics/ComposeHaptics.kt
@@ -1,0 +1,47 @@
+package id.homebase.core.haptics
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.hapticfeedback.HapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.homebase.core.settings.UserPreferences
+import org.koin.compose.koinInject
+
+/** Maps a semantic [HapticEvent] to Compose's [HapticFeedbackType]. */
+internal fun HapticEvent.toComposeType(): HapticFeedbackType = when (this) {
+    HapticEvent.Selection -> HapticFeedbackType.TextHandleMove
+    HapticEvent.LongPress -> HapticFeedbackType.LongPress
+    HapticEvent.Confirm -> HapticFeedbackType.Confirm
+}
+
+/** [Haptics] backed by Compose's [HapticFeedback] — the only Compose-aware impl. */
+class ComposeHaptics(
+    private val hapticFeedback: HapticFeedback,
+) : Haptics {
+    override fun perform(event: HapticEvent) {
+        hapticFeedback.performHapticFeedback(event.toComposeType())
+    }
+}
+
+/**
+ * The app-wide way to obtain [Haptics] inside a composable. Reads
+ * `LocalHapticFeedback` at composition (so it works from gesture lambdas, the
+ * same way the raw API did) and gates on the persisted `hapticsEnabled`
+ * preference.
+ */
+@Composable
+fun rememberHaptics(): Haptics {
+    val hapticFeedback = LocalHapticFeedback.current
+    val userPreferences: UserPreferences = koinInject()
+    // No `by` delegate — keep the State object so the enabled lambda reads
+    // `.value` live on each perform (matters for the per-degree RotationDial path).
+    val prefState = userPreferences.preferenceState.collectAsStateWithLifecycle()
+    return remember(hapticFeedback) {
+        GatedHaptics(
+            delegate = ComposeHaptics(hapticFeedback),
+            enabled = { prefState.value.hapticsEnabled },
+        )
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/haptics/Haptics.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/haptics/Haptics.kt
@@ -1,0 +1,39 @@
+package id.homebase.core.haptics
+
+/**
+ * Semantic haptic events. Call sites speak intent (e.g. [Confirm]) rather than
+ * Compose's raw HapticFeedbackType. The mapping to platform haptics lives in
+ * ComposeHaptics; this enum stays free of any Compose dependency so the gating
+ * logic in [GatedHaptics] is plain-Kotlin testable.
+ */
+enum class HapticEvent {
+    /** Light incremental tick — e.g. a rotation-dial scrub crossing a degree. */
+    Selection,
+
+    /** Firm press / threshold cross — swipe threshold, press-and-hold, long-press. */
+    LongPress,
+
+    /** Positive action completed — message sent, reaction added. */
+    Confirm,
+}
+
+/** Plays a [HapticEvent]. Obtain one inside a composable via `rememberHaptics()`. */
+interface Haptics {
+    fun perform(event: HapticEvent)
+}
+
+/**
+ * Wraps another [Haptics] and only forwards events while [enabled] returns true.
+ * This is what makes every call site respect the user's "Haptic feedback"
+ * setting with no per-site code. Pure Kotlin — no Compose — so it is unit tested
+ * directly with a fake delegate. [enabled] is re-read on every [perform] so the
+ * toggle takes effect immediately.
+ */
+class GatedHaptics(
+    private val delegate: Haptics,
+    private val enabled: () -> Boolean,
+) : Haptics {
+    override fun perform(event: HapticEvent) {
+        if (enabled()) delegate.perform(event)
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/settings/UserPreferences.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/settings/UserPreferences.kt
@@ -9,6 +9,7 @@ class UserPreferences(private val settings: Settings) {
     private val _preferenceState = MutableStateFlow(
         PreferenceState(
             theme = theme,
+            hapticsEnabled = hapticsEnabled,
         )
     )
     val preferenceState: StateFlow<PreferenceState> = _preferenceState
@@ -30,6 +31,14 @@ class UserPreferences(private val settings: Settings) {
     var showDeveloperMenu: Boolean
         get() = settings.getBoolean("show_developer_menu", false)
         set(value) = settings.putBoolean("show_developer_menu", value)
+
+    /** Master switch for in-app haptic feedback (default on). Read by GatedHaptics. */
+    var hapticsEnabled: Boolean
+        get() = settings.getBoolean("haptics_enabled", true)
+        set(value) {
+            settings.putBoolean("haptics_enabled", value)
+            _preferenceState.value = _preferenceState.value.copy(hapticsEnabled = value)
+        }
 
     /**
      * Developer/test escape hatch (default off). When on, uploaded 10-bit
@@ -106,6 +115,7 @@ class UserPreferences(private val settings: Settings) {
 
 data class PreferenceState(
     val theme: ThemeState,
+    val hapticsEnabled: Boolean,
 )
 
 enum class ThemeState {

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionList.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ReactionList.kt
@@ -44,6 +44,8 @@ import id.homebase.api.client.drives.files.reactions.ReactionContent
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.core.emoji.EmojiNormalization.containsEmoji
 import id.homebase.core.emoji.EmojiNormalization.distinctByEmoji
+import id.homebase.core.haptics.HapticEvent
+import id.homebase.core.haptics.rememberHaptics
 import id.homebase.resources.MR
 import id.homebase.resources.chat_message_emoji_options
 import id.homebase.resources.chat_message_reaction
@@ -187,6 +189,7 @@ fun ReactionMenu(
     val baseDefaults = listOf("❤️", "👍", "👎", "😂", "😮", "😢")
     val reactions = (userDefaultReactions + baseDefaults).distinctByEmoji().take(6)
     val scrollState = rememberScrollState()
+    val haptics = rememberHaptics()
 
     Surface(
         modifier = modifier
@@ -211,7 +214,10 @@ fun ReactionMenu(
                     modifier = Modifier
                         .size(40.dp)
                         .clip(CircleShape)
-                        .clickable { onSelect(emoji) }
+                        .clickable {
+                            haptics.perform(HapticEvent.Confirm)
+                            onSelect(emoji)
+                        }
                         .let { if (isOwn) it.testTag("reaction_chip_own") else it },
                 ) {
                     Box(

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/SettingsToggleRow.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/SettingsToggleRow.kt
@@ -1,0 +1,41 @@
+package id.homebase.core.widget
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * A settings list row with a label and a trailing Material3 [Switch].
+ * [contentPadding] defaults to the standard settings-row inset; pass
+ * PaddingValues(0.dp) when the parent already provides horizontal padding.
+ */
+@Composable
+fun SettingsToggleRow(
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
+) {
+    Row(
+        modifier = modifier.fillMaxWidth().padding(contentPadding),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.weight(1f),
+        )
+        Switch(checked = checked, onCheckedChange = onCheckedChange)
+    }
+}

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/haptics/GatedHapticsTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/haptics/GatedHapticsTest.kt
@@ -1,0 +1,48 @@
+package id.homebase.core.haptics
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private class FakeHaptics : Haptics {
+    val received = mutableListOf<HapticEvent>()
+    override fun perform(event: HapticEvent) {
+        received.add(event)
+    }
+}
+
+class GatedHapticsTest {
+
+    @Test
+    fun forwardsEventWhenEnabled() {
+        val fake = FakeHaptics()
+        val haptics = GatedHaptics(delegate = fake, enabled = { true })
+
+        haptics.perform(HapticEvent.LongPress)
+
+        assertEquals(listOf(HapticEvent.LongPress), fake.received)
+    }
+
+    @Test
+    fun suppressesEventWhenDisabled() {
+        val fake = FakeHaptics()
+        val haptics = GatedHaptics(delegate = fake, enabled = { false })
+
+        haptics.perform(HapticEvent.Confirm)
+
+        assertTrue(fake.received.isEmpty())
+    }
+
+    @Test
+    fun reEvaluatesEnabledOnEachPerform() {
+        val fake = FakeHaptics()
+        var on = false
+        val haptics = GatedHaptics(delegate = fake, enabled = { on })
+
+        haptics.perform(HapticEvent.Selection)   // off -> suppressed
+        on = true
+        haptics.perform(HapticEvent.Selection)   // on -> forwarded
+
+        assertEquals(listOf(HapticEvent.Selection), fake.received)
+    }
+}

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/haptics/HapticEventMappingTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/haptics/HapticEventMappingTest.kt
@@ -1,0 +1,23 @@
+package id.homebase.core.haptics
+
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HapticEventMappingTest {
+
+    @Test
+    fun selectionMapsToTextHandleMove() {
+        assertEquals(HapticFeedbackType.TextHandleMove, HapticEvent.Selection.toComposeType())
+    }
+
+    @Test
+    fun longPressMapsToLongPress() {
+        assertEquals(HapticFeedbackType.LongPress, HapticEvent.LongPress.toComposeType())
+    }
+
+    @Test
+    fun confirmMapsToConfirm() {
+        assertEquals(HapticFeedbackType.Confirm, HapticEvent.Confirm.toComposeType())
+    }
+}

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/settings/InMemorySettings.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/settings/InMemorySettings.kt
@@ -1,0 +1,31 @@
+package id.homebase.core.settings
+
+import com.russhwolf.settings.Settings
+
+/** In-memory [Settings] test fake. Shared by commonTest and jvmTest. */
+internal class InMemorySettings(seed: Map<String, Any> = emptyMap()) : Settings {
+    private val backing: MutableMap<String, Any> = seed.toMutableMap()
+    override val keys: Set<String> get() = backing.keys.toSet()
+    override val size: Int get() = backing.size
+    override fun clear() = backing.clear()
+    override fun remove(key: String) { backing.remove(key) }
+    override fun hasKey(key: String): Boolean = backing.containsKey(key)
+    override fun putInt(key: String, value: Int) { backing[key] = value }
+    override fun getInt(key: String, defaultValue: Int): Int = (backing[key] as? Int) ?: defaultValue
+    override fun getIntOrNull(key: String): Int? = backing[key] as? Int
+    override fun putLong(key: String, value: Long) { backing[key] = value }
+    override fun getLong(key: String, defaultValue: Long): Long = (backing[key] as? Long) ?: defaultValue
+    override fun getLongOrNull(key: String): Long? = backing[key] as? Long
+    override fun putString(key: String, value: String) { backing[key] = value }
+    override fun getString(key: String, defaultValue: String): String = (backing[key] as? String) ?: defaultValue
+    override fun getStringOrNull(key: String): String? = backing[key] as? String
+    override fun putFloat(key: String, value: Float) { backing[key] = value }
+    override fun getFloat(key: String, defaultValue: Float): Float = (backing[key] as? Float) ?: defaultValue
+    override fun getFloatOrNull(key: String): Float? = backing[key] as? Float
+    override fun putDouble(key: String, value: Double) { backing[key] = value }
+    override fun getDouble(key: String, defaultValue: Double): Double = (backing[key] as? Double) ?: defaultValue
+    override fun getDoubleOrNull(key: String): Double? = backing[key] as? Double
+    override fun putBoolean(key: String, value: Boolean) { backing[key] = value }
+    override fun getBoolean(key: String, defaultValue: Boolean): Boolean = (backing[key] as? Boolean) ?: defaultValue
+    override fun getBooleanOrNull(key: String): Boolean? = backing[key] as? Boolean
+}

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/ReactionMenuTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/ReactionMenuTest.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
-import com.russhwolf.settings.Settings
+import id.homebase.core.settings.InMemorySettings
 import id.homebase.core.settings.UserPreferences
 import kotlinx.collections.immutable.persistentListOf
 import org.koin.compose.KoinApplication
@@ -19,37 +19,6 @@ import org.koin.dsl.module
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
-// ---------------------------------------------------------------------------
-// Minimal in-memory Settings for tests — avoids pulling in the
-// multiplatform-settings-test artifact just to get MapSettings.
-// ---------------------------------------------------------------------------
-private class InMemorySettings : Settings {
-    private val backing = mutableMapOf<String, Any>()
-    override val keys: Set<String> get() = backing.keys.toSet()
-    override val size: Int get() = backing.size
-    override fun clear() = backing.clear()
-    override fun remove(key: String) { backing.remove(key) }
-    override fun hasKey(key: String): Boolean = backing.containsKey(key)
-    override fun putInt(key: String, value: Int) { backing[key] = value }
-    override fun getInt(key: String, defaultValue: Int): Int = (backing[key] as? Int) ?: defaultValue
-    override fun getIntOrNull(key: String): Int? = backing[key] as? Int
-    override fun putLong(key: String, value: Long) { backing[key] = value }
-    override fun getLong(key: String, defaultValue: Long): Long = (backing[key] as? Long) ?: defaultValue
-    override fun getLongOrNull(key: String): Long? = backing[key] as? Long
-    override fun putString(key: String, value: String) { backing[key] = value }
-    override fun getString(key: String, defaultValue: String): String = (backing[key] as? String) ?: defaultValue
-    override fun getStringOrNull(key: String): String? = backing[key] as? String
-    override fun putFloat(key: String, value: Float) { backing[key] = value }
-    override fun getFloat(key: String, defaultValue: Float): Float = (backing[key] as? Float) ?: defaultValue
-    override fun getFloatOrNull(key: String): Float? = backing[key] as? Float
-    override fun putDouble(key: String, value: Double) { backing[key] = value }
-    override fun getDouble(key: String, defaultValue: Double): Double = (backing[key] as? Double) ?: defaultValue
-    override fun getDoubleOrNull(key: String): Double? = backing[key] as? Double
-    override fun putBoolean(key: String, value: Boolean) { backing[key] = value }
-    override fun getBoolean(key: String, defaultValue: Boolean): Boolean = (backing[key] as? Boolean) ?: defaultValue
-    override fun getBooleanOrNull(key: String): Boolean? = backing[key] as? Boolean
-}
 
 // ---------------------------------------------------------------------------
 // Koin module that satisfies the UserPreferences dependency required by

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/ReactionMenuTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/ReactionMenuTest.kt
@@ -1,6 +1,7 @@
 package id.homebase.core.widget
 
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.onAllNodesWithTag
@@ -9,10 +10,70 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
+import com.russhwolf.settings.Settings
+import id.homebase.core.settings.UserPreferences
 import kotlinx.collections.immutable.persistentListOf
+import org.koin.compose.KoinApplication
+import org.koin.dsl.koinConfiguration
+import org.koin.dsl.module
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+
+// ---------------------------------------------------------------------------
+// Minimal in-memory Settings for tests — avoids pulling in the
+// multiplatform-settings-test artifact just to get MapSettings.
+// ---------------------------------------------------------------------------
+private class InMemorySettings : Settings {
+    private val backing = mutableMapOf<String, Any>()
+    override val keys: Set<String> get() = backing.keys.toSet()
+    override val size: Int get() = backing.size
+    override fun clear() = backing.clear()
+    override fun remove(key: String) { backing.remove(key) }
+    override fun hasKey(key: String): Boolean = backing.containsKey(key)
+    override fun putInt(key: String, value: Int) { backing[key] = value }
+    override fun getInt(key: String, defaultValue: Int): Int = (backing[key] as? Int) ?: defaultValue
+    override fun getIntOrNull(key: String): Int? = backing[key] as? Int
+    override fun putLong(key: String, value: Long) { backing[key] = value }
+    override fun getLong(key: String, defaultValue: Long): Long = (backing[key] as? Long) ?: defaultValue
+    override fun getLongOrNull(key: String): Long? = backing[key] as? Long
+    override fun putString(key: String, value: String) { backing[key] = value }
+    override fun getString(key: String, defaultValue: String): String = (backing[key] as? String) ?: defaultValue
+    override fun getStringOrNull(key: String): String? = backing[key] as? String
+    override fun putFloat(key: String, value: Float) { backing[key] = value }
+    override fun getFloat(key: String, defaultValue: Float): Float = (backing[key] as? Float) ?: defaultValue
+    override fun getFloatOrNull(key: String): Float? = backing[key] as? Float
+    override fun putDouble(key: String, value: Double) { backing[key] = value }
+    override fun getDouble(key: String, defaultValue: Double): Double = (backing[key] as? Double) ?: defaultValue
+    override fun getDoubleOrNull(key: String): Double? = backing[key] as? Double
+    override fun putBoolean(key: String, value: Boolean) { backing[key] = value }
+    override fun getBoolean(key: String, defaultValue: Boolean): Boolean = (backing[key] as? Boolean) ?: defaultValue
+    override fun getBooleanOrNull(key: String): Boolean? = backing[key] as? Boolean
+}
+
+// ---------------------------------------------------------------------------
+// Koin module that satisfies the UserPreferences dependency required by
+// rememberHaptics() → koinInject<UserPreferences>() inside ReactionMenu.
+// ---------------------------------------------------------------------------
+private val hapticsTestModule = module {
+    single { UserPreferences(InMemorySettings()) }
+}
+
+/**
+ * Wraps [content] inside a [KoinApplication] scoped to this composition,
+ * providing [hapticsTestModule] so that [id.homebase.core.haptics.rememberHaptics]
+ * can resolve [UserPreferences] without a globally-started Koin context.
+ *
+ * Using the composable KoinApplication (rather than startKoin/stopKoin) keeps
+ * each test's Koin instance lifecycle tied to the Compose composition, avoiding
+ * cross-test contamination.
+ */
+@Composable
+private fun WithHapticsKoin(content: @Composable () -> Unit) {
+    KoinApplication(configuration = koinConfiguration { modules(hapticsTestModule) }) {
+        content()
+    }
+}
 
 @OptIn(ExperimentalTestApi::class)
 class ReactionMenuTest {
@@ -20,42 +81,48 @@ class ReactionMenuTest {
     @Test
     fun showsDefaultReactions_whenNoUserReactions() = runComposeUiTest {
         setContent {
-            MaterialTheme {
-                ReactionMenu(
-                    onSelect = {},
-                    onShowAllEmojis = {},
-                )
+            WithHapticsKoin {
+                MaterialTheme {
+                    ReactionMenu(
+                        onSelect = {},
+                        onShowAllEmojis = {},
+                    )
+                }
             }
         }
-        onNodeWithText("\u2764\uFE0F").assertExists()  // ❤️
-        onNodeWithText("\uD83D\uDC4D").assertExists()  // 👍
-        onNodeWithText("\uD83D\uDC4E").assertExists()  // 👎
-        onNodeWithText("\uD83D\uDE02").assertExists()  // 😂
+        onNodeWithText("❤️").assertExists()  // ❤️
+        onNodeWithText("👍").assertExists()  // 👍
+        onNodeWithText("👎").assertExists()  // 👎
+        onNodeWithText("😂").assertExists()  // 😂
     }
 
     @Test
     fun selectCallbackFires() = runComposeUiTest {
         var selected = ""
         setContent {
-            MaterialTheme {
-                ReactionMenu(
-                    onSelect = { selected = it },
-                    onShowAllEmojis = {},
-                )
+            WithHapticsKoin {
+                MaterialTheme {
+                    ReactionMenu(
+                        onSelect = { selected = it },
+                        onShowAllEmojis = {},
+                    )
+                }
             }
         }
-        onNodeWithText("\uD83D\uDC4D").performClick()  // 👍
-        assertEquals("\uD83D\uDC4D", selected)
+        onNodeWithText("👍").performClick()  // 👍
+        assertEquals("👍", selected)
     }
 
     @Test
     fun showsMoreButton() = runComposeUiTest {
         setContent {
-            MaterialTheme {
-                ReactionMenu(
-                    onSelect = {},
-                    onShowAllEmojis = {},
-                )
+            WithHapticsKoin {
+                MaterialTheme {
+                    ReactionMenu(
+                        onSelect = {},
+                        onShowAllEmojis = {},
+                    )
+                }
             }
         }
         onNodeWithTag("emoji_options_button").assertExists()
@@ -65,11 +132,13 @@ class ReactionMenuTest {
     fun moreButtonFiresShowAllEmojis() = runComposeUiTest {
         var showAll = false
         setContent {
-            MaterialTheme {
-                ReactionMenu(
-                    onSelect = {},
-                    onShowAllEmojis = { showAll = true },
-                )
+            WithHapticsKoin {
+                MaterialTheme {
+                    ReactionMenu(
+                        onSelect = {},
+                        onShowAllEmojis = { showAll = true },
+                    )
+                }
             }
         }
         onNodeWithTag("emoji_options_button").performClick()
@@ -81,12 +150,14 @@ class ReactionMenuTest {
         // userDefault has the bare-codepoint form; baseDefaults has the VS-16 form.
         // Both render as the same thumbs-up but compare unequal as Strings.
         setContent {
-            MaterialTheme {
-                ReactionMenu(
-                    userDefaultReactions = persistentListOf("👍"),  // bare 👍
-                    onSelect = {},
-                    onShowAllEmojis = {},
-                )
+            WithHapticsKoin {
+                MaterialTheme {
+                    ReactionMenu(
+                        userDefaultReactions = persistentListOf("👍"),  // bare 👍
+                        onSelect = {},
+                        onShowAllEmojis = {},
+                    )
+                }
             }
         }
         // Only one rendition of either form should appear.
@@ -98,12 +169,14 @@ class ReactionMenuTest {
     @Test
     fun ownReactionEmojiIsHighlighted() = runComposeUiTest {
         setContent {
-            MaterialTheme {
-                ReactionMenu(
-                    ownReactions = persistentListOf("👍"),  // 👍
-                    onSelect = {},
-                    onShowAllEmojis = {},
-                )
+            WithHapticsKoin {
+                MaterialTheme {
+                    ReactionMenu(
+                        ownReactions = persistentListOf("👍"),  // 👍
+                        onSelect = {},
+                        onShowAllEmojis = {},
+                    )
+                }
             }
         }
         onAllNodesWithTag("reaction_chip_own").assertCountEquals(1)
@@ -114,12 +187,14 @@ class ReactionMenuTest {
         // ownReactions has the VS-16 form; popup row has the bare form (or vice versa).
         // The chip should still highlight.
         setContent {
-            MaterialTheme {
-                ReactionMenu(
-                    ownReactions = persistentListOf("👍️"),  // 👍 + VS-16
-                    onSelect = {},
-                    onShowAllEmojis = {},
-                )
+            WithHapticsKoin {
+                MaterialTheme {
+                    ReactionMenu(
+                        ownReactions = persistentListOf("👍️"),  // 👍 + VS-16
+                        onSelect = {},
+                        onShowAllEmojis = {},
+                    )
+                }
             }
         }
         onAllNodesWithTag("reaction_chip_own").assertCountEquals(1)
@@ -128,18 +203,20 @@ class ReactionMenuTest {
     @Test
     fun userReactionsReplaceDefaults() = runComposeUiTest {
         setContent {
-            MaterialTheme {
-                ReactionMenu(
-                    userDefaultReactions = persistentListOf("\uD83C\uDF89", "\uD83D\uDD25"),  // 🎉, 🔥
-                    onSelect = {},
-                    onShowAllEmojis = {},
-                )
+            WithHapticsKoin {
+                MaterialTheme {
+                    ReactionMenu(
+                        userDefaultReactions = persistentListOf("🎉", "🔥"),  // 🎉, 🔥
+                        onSelect = {},
+                        onShowAllEmojis = {},
+                    )
+                }
             }
         }
-        onNodeWithText("\uD83C\uDF89").assertExists()  // 🎉
-        onNodeWithText("\uD83D\uDD25").assertExists()  // 🔥
+        onNodeWithText("🎉").assertExists()  // 🎉
+        onNodeWithText("🔥").assertExists()  // 🔥
         // Default reactions should fill remaining slots
-        onNodeWithText("\u2764\uFE0F").assertExists()  // ❤️
-        onNodeWithText("\uD83D\uDC4D").assertExists()  // 👍
+        onNodeWithText("❤️").assertExists()  // ❤️
+        onNodeWithText("👍").assertExists()  // 👍
     }
 }

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/settings/UserPreferencesScrollAnchorTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/settings/UserPreferencesScrollAnchorTest.kt
@@ -1,6 +1,5 @@
 package id.homebase.core.settings
 
-import com.russhwolf.settings.Settings
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -70,34 +69,3 @@ class UserPreferencesScrollAnchorTest {
     }
 }
 
-/**
- * Minimal in-memory [Settings] for unit tests. Pulling the official
- * `multiplatform-settings-test` artifact for one test file would add a
- * dependency just to get `MapSettings`; this is simpler.
- */
-private class InMemorySettings(seed: Map<String, Any> = emptyMap()) : Settings {
-    private val backing: MutableMap<String, Any> = seed.toMutableMap()
-    override val keys: Set<String> get() = backing.keys.toSet()
-    override val size: Int get() = backing.size
-    override fun clear() = backing.clear()
-    override fun remove(key: String) { backing.remove(key) }
-    override fun hasKey(key: String): Boolean = backing.containsKey(key)
-    override fun putInt(key: String, value: Int) { backing[key] = value }
-    override fun getInt(key: String, defaultValue: Int): Int = (backing[key] as? Int) ?: defaultValue
-    override fun getIntOrNull(key: String): Int? = backing[key] as? Int
-    override fun putLong(key: String, value: Long) { backing[key] = value }
-    override fun getLong(key: String, defaultValue: Long): Long = (backing[key] as? Long) ?: defaultValue
-    override fun getLongOrNull(key: String): Long? = backing[key] as? Long
-    override fun putString(key: String, value: String) { backing[key] = value }
-    override fun getString(key: String, defaultValue: String): String = (backing[key] as? String) ?: defaultValue
-    override fun getStringOrNull(key: String): String? = backing[key] as? String
-    override fun putFloat(key: String, value: Float) { backing[key] = value }
-    override fun getFloat(key: String, defaultValue: Float): Float = (backing[key] as? Float) ?: defaultValue
-    override fun getFloatOrNull(key: String): Float? = backing[key] as? Float
-    override fun putDouble(key: String, value: Double) { backing[key] = value }
-    override fun getDouble(key: String, defaultValue: Double): Double = (backing[key] as? Double) ?: defaultValue
-    override fun getDoubleOrNull(key: String): Double? = backing[key] as? Double
-    override fun putBoolean(key: String, value: Boolean) { backing[key] = value }
-    override fun getBoolean(key: String, defaultValue: Boolean): Boolean = (backing[key] as? Boolean) ?: defaultValue
-    override fun getBooleanOrNull(key: String): Boolean? = backing[key] as? Boolean
-}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/appearance/AppearanceSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/appearance/AppearanceSettingsScreen.kt
@@ -2,8 +2,10 @@ package id.homebase.core.ui.screens.appearance
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -15,14 +17,18 @@ import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.core.settings.Language
@@ -38,6 +44,7 @@ import id.homebase.resources.language_english_us
 import id.homebase.resources.language_system
 import id.homebase.resources.menu_back
 import id.homebase.resources.settings_appearance
+import id.homebase.resources.settings_haptic_feedback
 import id.homebase.resources.theme
 import id.homebase.resources.theme_dark
 import id.homebase.resources.theme_light
@@ -137,7 +144,35 @@ fun AppearanceSettingsUi(
                     onAction(AppearanceSettingsUiAction.ThemeSelected(it))
                 },
             )
+
+            SettingsToggleRow(
+                modifier = Modifier.testTag("hapticFeedbackToggle"),
+                label = stringResource(MR.string.settings_haptic_feedback),
+                checked = uiState.hapticsEnabled,
+                onCheckedChange = { onAction(AppearanceSettingsUiAction.HapticsEnabledChanged(it)) },
+            )
         }
+    }
+}
+
+@Composable
+private fun SettingsToggleRow(
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.weight(1f),
+        )
+        Switch(checked = checked, onCheckedChange = onCheckedChange)
     }
 }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/appearance/AppearanceSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/appearance/AppearanceSettingsScreen.kt
@@ -2,10 +2,9 @@ package id.homebase.core.ui.screens.appearance
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -17,15 +16,12 @@ import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
@@ -36,6 +32,7 @@ import id.homebase.core.settings.ThemeState
 import id.homebase.core.settings.setPlatformSystemLocale
 import id.homebase.core.widget.SettingsClickableRow
 import id.homebase.core.widget.SettingsRowItemData
+import id.homebase.core.widget.SettingsToggleRow
 import id.homebase.resources.MR
 import id.homebase.resources.language
 import id.homebase.resources.language_danish
@@ -150,29 +147,9 @@ fun AppearanceSettingsUi(
                 label = stringResource(MR.string.settings_haptic_feedback),
                 checked = uiState.hapticsEnabled,
                 onCheckedChange = { onAction(AppearanceSettingsUiAction.HapticsEnabledChanged(it)) },
+                contentPadding = PaddingValues(0.dp),
             )
         }
-    }
-}
-
-@Composable
-private fun SettingsToggleRow(
-    label: String,
-    checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.weight(1f),
-        )
-        Switch(checked = checked, onCheckedChange = onCheckedChange)
     }
 }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/appearance/AppearanceSettingsUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/appearance/AppearanceSettingsUiState.kt
@@ -7,12 +7,14 @@ data class AppearanceSettingsUiState(
     val selectedLanguage: Language = Language.SYSTEM,
     val selectedTheme: ThemeState = ThemeState.System,
     val availableLanguages: List<Language> = Language.entries,
+    val hapticsEnabled: Boolean = true,
     val uiEvent: AppearanceSettingsUiEvent? = null,
 )
 
 sealed interface AppearanceSettingsUiAction {
     data class LanguageSelected(val language: Language) : AppearanceSettingsUiAction
     data class ThemeSelected(val theme: ThemeState) : AppearanceSettingsUiAction
+    data class HapticsEnabledChanged(val enabled: Boolean) : AppearanceSettingsUiAction
 }
 
 sealed interface AppearanceSettingsUiEvent {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/appearance/AppearanceSettingsViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/appearance/AppearanceSettingsViewModel.kt
@@ -35,6 +35,11 @@ class AppearanceSettingsViewModel(
                 userPreferences.theme = action.theme
                 _uiState.value = _uiState.value.copy(selectedTheme = action.theme)
             }
+
+            is AppearanceSettingsUiAction.HapticsEnabledChanged -> {
+                userPreferences.hapticsEnabled = action.enabled
+                _uiState.value = _uiState.value.copy(hapticsEnabled = action.enabled)
+            }
         }
     }
 
@@ -48,7 +53,8 @@ class AppearanceSettingsViewModel(
 
         _uiState.value = _uiState.value.copy(
             selectedLanguage = selectedLanguage,
-            selectedTheme = userPreferences.theme
+            selectedTheme = userPreferences.theme,
+            hapticsEnabled = userPreferences.hapticsEnabled,
         )
     }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentInlineVideoTile.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentInlineVideoTile.kt
@@ -43,10 +43,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import id.homebase.api.client.KeyHeader
@@ -62,6 +60,8 @@ import id.homebase.common.widget.VideoInfoOverlay
 import id.homebase.core.image.HomebaseImage
 import id.homebase.core.moments.services.MomentsVideoSession
 import org.koin.compose.koinInject
+import id.homebase.core.haptics.HapticEvent
+import id.homebase.core.haptics.rememberHaptics
 import id.homebase.core.image.HomebaseImageData
 import id.homebase.core.image.ImageSize
 import id.homebase.resources.MR
@@ -336,6 +336,8 @@ fun MomentInlineVideoTile(
         }
     }
 
+    val haptics = rememberHaptics()
+
     Box(modifier = modifier) {
         // Layer 1: video surface (only while playing). Rendered FIRST so it
         // sits at the bottom of the stack; the thumbnail above covers it
@@ -350,7 +352,6 @@ fun MomentInlineVideoTile(
                     payload = payload,
                 )
             }
-            val haptic = LocalHapticFeedback.current
             VideoPlayerSurface(
                 data = fullScreenData,
                 modifier = Modifier
@@ -380,12 +381,12 @@ fun MomentInlineVideoTile(
                     // register a tap when the user lifts their finger. The
                     // `finally` guarantees we un-pause even if the gesture is
                     // cancelled (e.g. the tile scrolls away mid-hold).
-                    .pointerInput(haptic) {
+                    .pointerInput(haptics) {
                         awaitEachGesture {
                             val down = awaitFirstDown(requireUnconsumed = false)
                             val longPressed = awaitLongPressOrCancellation(down.id)
                                 ?: return@awaitEachGesture
-                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            haptics.perform(HapticEvent.LongPress)
                             try {
                                 heldPaused = true
                                 longPressed.consume()

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/notifications/NotificationSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/notifications/NotificationSettingsScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Switch
+import id.homebase.core.widget.SettingsToggleRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -488,25 +488,6 @@ private fun SectionHeader(title: String, modifier: Modifier = Modifier) {
         color = MaterialTheme.colorScheme.onSurface,
         modifier = modifier.padding(horizontal = 4.dp)
     )
-}
-
-@Composable
-private fun SettingsToggleRow(
-    modifier: Modifier = Modifier,
-    label: String,
-    checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit
-) {
-    Row(
-        modifier = modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Text(
-            text = label, style = MaterialTheme.typography.bodyLarge, modifier = Modifier.weight(1f)
-        )
-        Switch(checked = checked, onCheckedChange = onCheckedChange)
-    }
 }
 
 @Composable

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/appearance/AppearanceSettingsUiTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/appearance/AppearanceSettingsUiTest.kt
@@ -107,6 +107,21 @@ class AppearanceSettingsUiTest {
     }
 
     @Test
+    fun showsHapticFeedbackRow() = runComposeUiTest {
+        setTestLocale("en-US")
+        setContent {
+            MaterialTheme {
+                AppearanceSettingsUi(
+                    uiState = AppearanceSettingsUiState(),
+                    onAction = {},
+                    onBackClick = {},
+                )
+            }
+        }
+        onNodeWithText("Haptic Feedback").assertExists()
+    }
+
+    @Test
     fun backClickFires() = runComposeUiTest {
         setTestLocale("en-US")
         var backClicked = false

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/appearance/AppearanceSettingsUiTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/appearance/AppearanceSettingsUiTest.kt
@@ -2,6 +2,7 @@ package id.homebase.core.ui.screens.appearance
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.isToggleable
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -10,6 +11,7 @@ import id.homebase.core.settings.Language
 import id.homebase.core.settings.ThemeState
 import id.homebase.core.test.setTestLocale
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
@@ -119,6 +121,27 @@ class AppearanceSettingsUiTest {
             }
         }
         onNodeWithText("Haptic Feedback").assertExists()
+    }
+
+    @Test
+    fun hapticFeedbackToggleFiresAction() = runComposeUiTest {
+        setTestLocale("en-US")
+        var newValue: Boolean? = null
+        setContent {
+            MaterialTheme {
+                AppearanceSettingsUi(
+                    uiState = AppearanceSettingsUiState(hapticsEnabled = true),
+                    onAction = { action ->
+                        if (action is AppearanceSettingsUiAction.HapticsEnabledChanged) {
+                            newValue = action.enabled
+                        }
+                    },
+                    onBackClick = {},
+                )
+            }
+        }
+        onNode(isToggleable()).performClick()
+        assertEquals(false, newValue)
     }
 
     @Test

--- a/image-editor-ui/src/commonMain/kotlin/id/homebase/imageeditor/ui/widget/RotationDial.kt
+++ b/image-editor-ui/src/commonMain/kotlin/id/homebase/imageeditor/ui/widget/RotationDial.kt
@@ -32,12 +32,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.Dp
+import id.homebase.core.haptics.HapticEvent
+import id.homebase.core.haptics.rememberHaptics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlin.math.abs
@@ -67,7 +67,7 @@ fun RotationDial(
     modifier: Modifier = Modifier,
     @Suppress("UNUSED_PARAMETER") label: String = "",
 ) {
-    val hapticFeedback = LocalHapticFeedback.current
+    val haptics = rememberHaptics()
     val spaceBetweenIndicatorsPx = with(LocalDensity.current) { SPACE_BETWEEN_INDICATORS.toPx() }
 
     var degrees by remember(valueDegrees) { mutableFloatStateOf(valueDegrees) }
@@ -105,7 +105,7 @@ fun RotationDial(
                         val offEndOfMin = newDialDegrees >= MAX_DEGREES / 2f && prevDialDegrees <= MIN_DEGREES / 2f
 
                         if (prevDialDegrees.roundToInt() != newDialDegrees.roundToInt()) {
-                            hapticFeedback.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                            haptics.perform(HapticEvent.Selection)
                         }
 
                         val newDegrees = when {


### PR DESCRIPTION
## Summary

Replaces the scattered, raw `LocalHapticFeedback` calls with a single generic, **semantic, settings-gated** haptic component, migrates every existing site to it, and adds feedback to a few bare interactions.

Before: 6 composables each grabbed `LocalHapticFeedback.current` and called `performHapticFeedback(HapticFeedbackType.X)` inline, using only 2 raw types, with no way to turn haptics off.

### What's new
- **`id.homebase.core.haptics`** (in `homebase-common`):
  - `HapticEvent` — semantic vocabulary (`Selection`, `LongPress`, `Confirm`)
  - `Haptics` interface + `GatedHaptics` — a pure-Kotlin decorator that suppresses events when haptics are disabled (the settings gate)
  - `ComposeHaptics` — the only place that maps to Compose's `HapticFeedbackType`
  - `rememberHaptics()` — the `@Composable` accessor; reads `LocalHapticFeedback` and gates on the persisted preference
- **Settings toggle:** `UserPreferences.hapticsEnabled` (default on) + a "Haptic Feedback" switch in **Appearance** settings. Every call site respects it automatically.
- **Migrated 6 sites** (behavior-preserving — `LongPress`→`LongPress`, `TextHandleMove`→`Selection`): swipe-to-reply, mic press-to-record, dice roll (×2), moments video long-press, image rotation dial.
- **New haptics:** message long-press, send, emoji reaction.

Pull-to-refresh was intentionally skipped — it doesn't exist in the codebase.

### Design / architecture
The valuable logic (the settings gate + semantic mapping) is isolated from Compose so it's unit-testable without a Compose runtime. `GatedHaptics` and the event→type mapping are covered by `commonTest`; the Compose glue stays thin.

Built test-first, phase by phase, with two-stage (spec + code-quality) review per phase. Review caught and fixed: a conditional `remember`, a **double-buzz** on message long-press (consolidated to the single guarded `MessageBubbleRaw` long-press path), and a Koin-context regression in `ReactionMenuTest`.

## Test plan
- [x] `homebase-common:jvmTest` — 270 tests pass (incl. Konsist `ArchitectureTest`, `GatedHapticsTest`, `HapticEventMappingTest`)
- [x] `homebase-chat:jvmTest` + `homebase-core:jvmTest` pass (incl. new `AppearanceSettingsUiTest` row test)
- [x] Compiles on **JVM, Android, wasmJs, iOS (simulatorArm64)** for `homebase-common`, `homebase-chat`, `homebase-core`, `image-editor-ui`
- [ ] **Manual (device-only, can't be automated):** on a real Android/iOS device, trigger swipe-reply, mic hold, dice roll, moments video long-press, image rotation, message long-press, send, and reaction — confirm each buzzes; then toggle **Settings → Appearance → Haptic Feedback** off and confirm they all go silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)