### PR TITLE
feat(crashlytics): record Kotlin/Native crashes on iOS + log-trail br…

### DIFF
--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/logging/CrashReporter.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/logging/CrashReporter.android.kt
@@ -1,0 +1,11 @@
+package id.homebase.core.logging
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+
+actual fun crashlyticsLog(message: String) {
+    FirebaseCrashlytics.getInstance().log(message)
+}
+
+actual fun crashlyticsRecordException(throwable: Throwable) {
+    FirebaseCrashlytics.getInstance().recordException(throwable)
+}

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1050,6 +1050,12 @@
     <string name="dev_menu_test_notification">Test Rich Notification</string>
     <string name="dev_menu_allow_ten_bit_video">Allow 10-bit video</string>
     <string name="dev_menu_allow_ten_bit_video_description">Keep uploaded 10-bit videos at 10-bit (High 10) instead of downconverting to 8-bit. For testing only — the result may not play on all devices.</string>
+    <string name="dev_menu_section_crashlytics">Crashlytics</string>
+    <string name="dev_menu_trigger_test_crash">Trigger test crash</string>
+    <string name="dev_menu_trigger_test_crash_description">Intentionally crashes the app right now to verify crash reporting. The app will close immediately — reopen it afterward to let the crash report upload to Crashlytics.</string>
+    <string name="dev_menu_crash_confirm_title">Crash the app?</string>
+    <string name="dev_menu_crash_confirm_message">This will intentionally crash the app immediately to test Crashlytics. You\'ll need to reopen the app afterward.</string>
+    <string name="dev_menu_crash_confirm_action">Crash now</string>
 
     <!-- Video debug info overlay (long-press the MP4/HLS tag) -->
     <string name="video_info_title">Video info</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/logging/CrashLogger.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/logging/CrashLogger.kt
@@ -14,7 +14,10 @@ object CrashLogger {
             Logger.e(tag = TAG) { "Thread: $thread" }
             Logger.e(tag = TAG) { "Exception: ${exception::class.simpleName}" }
             Logger.e(tag = TAG) { "Message: ${exception.message}" }
-            Logger.e(throwable = exception, tag = TAG) { "Stack trace:" }
+            // Log the stack as text (not via the `throwable` parameter) so this
+            // fatal isn't double-reported as a non-fatal by CrashlyticsLogWriter
+            // — fatals are captured by the dedicated crash handlers instead.
+            Logger.e(tag = TAG) { "Stack trace:\n${exception.stackTraceToString()}" }
             Logger.e(tag = TAG) { "========================================" }
 
             // TODO: Force flush logs to ensure they're written before crash

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/logging/CrashReporter.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/logging/CrashReporter.kt
@@ -1,0 +1,54 @@
+package id.homebase.core.logging
+
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.Severity
+
+/**
+ * Forwards a breadcrumb [message] to the platform crash reporter (Firebase
+ * Crashlytics on Android/iOS). These messages are attached to the next crash
+ * report so the dashboard stack carries the recent log trail leading up to a
+ * crash. No-op on Desktop/Web, where no crash backend is wired.
+ *
+ * The Crashlytics SDK gates upload on its own collection flag (see
+ * [setErrorCollectionEnabled]), so callers don't need to re-check the user's
+ * error-collection preference here.
+ */
+expect fun crashlyticsLog(message: String)
+
+/**
+ * Records a non-fatal [throwable] to the platform crash reporter so handled
+ * exceptions (caught, logged, recovered-from) surface in the dashboard with a
+ * full stack — not just as breadcrumb text. No-op on Desktop/Web.
+ */
+expect fun crashlyticsRecordException(throwable: Throwable)
+
+/**
+ * Kermit [LogWriter] that mirrors app logs into the platform crash reporter:
+ *
+ *  - every log at [minBreadcrumbSeverity] or above becomes a Crashlytics
+ *    breadcrumb ([crashlyticsLog]) — this is the "recent log trail" attached to
+ *    the next crash report.
+ *  - every log at [minRecordSeverity] or above that carries a [Throwable] is
+ *    also recorded as a non-fatal ([crashlyticsRecordException]), so handled
+ *    exceptions surface in the dashboard instead of vanishing into the log file.
+ *
+ * Fatal/uncaught crashes are captured by the dedicated crash handlers
+ * (Firebase's native uncaught handler on Android, [setupIOSCrashHandler] on
+ * iOS), NOT by this writer — [CrashLogger] deliberately logs the fatal stack as
+ * text (no `throwable` parameter) so it is not double-reported here as a
+ * non-fatal.
+ */
+class CrashlyticsLogWriter(
+    private val minBreadcrumbSeverity: Severity = Severity.Info,
+    private val minRecordSeverity: Severity = Severity.Error,
+) : LogWriter() {
+    override fun isLoggable(tag: String, severity: Severity): Boolean =
+        severity >= minBreadcrumbSeverity
+
+    override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
+        crashlyticsLog("${severity.name.first()}/$tag: $message")
+        if (throwable != null && severity >= minRecordSeverity) {
+            crashlyticsRecordException(throwable)
+        }
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/logging/LoggerConfig.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/logging/LoggerConfig.kt
@@ -40,6 +40,11 @@ object LoggerConfig {
         // Add platform-specific console logger (Logcat on Android, NSLog on iOS, etc.)
         logWriters.add(platformLogWriter())
 
+        // Mirror logs into the platform crash reporter: Info+ become Crashlytics
+        // breadcrumbs (the recent log trail attached to the next crash report)
+        // and Error+ throwables are recorded as non-fatals. No-op on Desktop/Web.
+        logWriters.add(CrashlyticsLogWriter())
+
         // Add rolling file logger
         try {
             val fileLogWriter = createFileLogWriter(

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/logging/CrashReporter.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/logging/CrashReporter.jvm.kt
@@ -1,0 +1,9 @@
+package id.homebase.core.logging
+
+actual fun crashlyticsLog(message: String) {
+    // No-op on Desktop — no crash-reporting backend is wired here yet.
+}
+
+actual fun crashlyticsRecordException(throwable: Throwable) {
+    // No-op on Desktop — no crash-reporting backend is wired here yet.
+}

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/logging/CrashReporter.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/logging/CrashReporter.native.kt
@@ -1,0 +1,17 @@
+package id.homebase.core.logging
+
+import kotlin.experimental.ExperimentalNativeApi
+
+actual fun crashlyticsLog(message: String) {
+    CrashlyticsBridgeHolder.getBridge()?.log(message)
+}
+
+@OptIn(ExperimentalNativeApi::class)
+actual fun crashlyticsRecordException(throwable: Throwable) {
+    val bridge = CrashlyticsBridgeHolder.getBridge() ?: return
+    bridge.recordException(
+        name = throwable::class.qualifiedName ?: throwable::class.simpleName ?: "KotlinException",
+        reason = throwable.message ?: throwable.toString(),
+        stackTrace = throwable.getStackTrace().toList(),
+    )
+}

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/logging/CrashlyticsBridge.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/logging/CrashlyticsBridge.kt
@@ -10,6 +10,24 @@ interface CrashlyticsBridge {
      * @param enabled true to enable, false to disable
      */
     fun setCrashlyticsCollectionEnabled(enabled: Boolean)
+
+    /**
+     * Append a breadcrumb message to the Crashlytics on-device log. Attached to
+     * the next crash report so the dashboard stack carries the recent log trail.
+     */
+    fun log(message: String)
+
+    /**
+     * Record an exception so it surfaces in the Crashlytics dashboard with a
+     * readable stack. Used both for fatal Kotlin/Native & Objective-C crashes
+     * (which the SDK's signal handler would otherwise capture only as an opaque
+     * native backtrace) and for non-fatal handled exceptions.
+     *
+     * @param name exception type/name (e.g. the Kotlin class or `NSException.name`)
+     * @param reason exception message/reason
+     * @param stackTrace symbolic stack frames, outermost-first
+     */
+    fun recordException(name: String, reason: String, stackTrace: List<String>)
 }
 
 /**

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/logging/IOSCrashHandler.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/logging/IOSCrashHandler.kt
@@ -47,6 +47,15 @@ fun setupIOSCrashHandler() {
                 Logger.e(tag = TAG) { "Call Stack: ${it.callStackSymbols}" }
                 Logger.e(tag = TAG) { "==========================================" }
 
+                // Record to Crashlytics with the readable ObjC name/reason/stack.
+                // The SDK's signal handler would otherwise capture this only as an
+                // opaque native backtrace.
+                CrashlyticsBridgeHolder.getBridge()?.recordException(
+                    name = it.name ?: "NSException",
+                    reason = it.reason ?: "",
+                    stackTrace = it.callStackSymbols.mapNotNull { sym -> sym as? String },
+                )
+
                 // Give the file log writer a moment to flush before the process dies.
                 NSThread.sleepForTimeInterval(0.1)
             } catch (e: Exception) {
@@ -63,6 +72,11 @@ fun setupIOSCrashHandler() {
     var previousHook: ((Throwable) -> Unit)? = null
     previousHook = setUnhandledExceptionHook { throwable ->
         try {
+            // Record to Crashlytics first — a Kotlin/Native exception aborts the
+            // process without raising an NSException, so the SDK never sees it
+            // unless we record it explicitly here. This is the only path that
+            // gets pure-Kotlin crashes into the dashboard with a readable stack.
+            crashlyticsRecordException(throwable)
             CrashLogger.logCrash(thread = "Kotlin/Native", exception = throwable)
             // Give the file log writer a moment to flush before the process dies.
             NSThread.sleepForTimeInterval(0.1)

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/logging/CrashReporter.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/logging/CrashReporter.web.kt
@@ -1,0 +1,9 @@
+package id.homebase.core.logging
+
+actual fun crashlyticsLog(message: String) {
+    // No-op on Web — error collection backend (Sentry, etc.) is not wired here yet.
+}
+
+actual fun crashlyticsRecordException(throwable: Throwable) {
+    // No-op on Web — error collection backend (Sentry, etc.) is not wired here yet.
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/devmenu/DeveloperMenuScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/devmenu/DeveloperMenuScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -21,12 +22,15 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -35,10 +39,15 @@ import id.homebase.core.ui.screens.help.HelpClickableRow
 import id.homebase.core.ui.screens.help.HelpSectionHeader
 import id.homebase.core.widget.CheckboxRow
 import id.homebase.resources.MR
+import id.homebase.resources.cancel
 import id.homebase.resources.dev_menu_allow_ten_bit_video
 import id.homebase.resources.dev_menu_allow_ten_bit_video_description
 import id.homebase.resources.dev_menu_clear_data
+import id.homebase.resources.dev_menu_crash_confirm_action
+import id.homebase.resources.dev_menu_crash_confirm_message
+import id.homebase.resources.dev_menu_crash_confirm_title
 import id.homebase.resources.dev_menu_force_sync
+import id.homebase.resources.dev_menu_section_crashlytics
 import id.homebase.resources.dev_menu_section_database
 import id.homebase.resources.dev_menu_section_misc
 import id.homebase.resources.dev_menu_section_sync
@@ -46,6 +55,8 @@ import id.homebase.resources.dev_menu_section_testing
 import id.homebase.resources.dev_menu_section_video
 import id.homebase.resources.dev_menu_test_notification
 import id.homebase.resources.dev_menu_title
+import id.homebase.resources.dev_menu_trigger_test_crash
+import id.homebase.resources.dev_menu_trigger_test_crash_description
 import id.homebase.resources.menu_back
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
@@ -96,6 +107,33 @@ fun DeveloperMenuUi(
     onBackClick: () -> Unit,
 ) {
     val scrollState = rememberScrollState()
+    var showCrashConfirm by remember { mutableStateOf(false) }
+
+    if (showCrashConfirm) {
+        AlertDialog(
+            onDismissRequest = { showCrashConfirm = false },
+            title = { Text(stringResource(MR.string.dev_menu_crash_confirm_title)) },
+            text = { Text(stringResource(MR.string.dev_menu_crash_confirm_message)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showCrashConfirm = false
+                        onAction(DeveloperMenuUiAction.TriggerTestCrash)
+                    },
+                ) {
+                    Text(
+                        text = stringResource(MR.string.dev_menu_crash_confirm_action),
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showCrashConfirm = false }) {
+                    Text(stringResource(MR.string.cancel))
+                }
+            },
+        )
+    }
 
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
@@ -181,6 +219,25 @@ fun DeveloperMenuUi(
             )
             Text(
                 text = stringResource(MR.string.dev_menu_allow_ten_bit_video_description),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 4.dp)
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Crashlytics Section
+            HelpSectionHeader(title = stringResource(MR.string.dev_menu_section_crashlytics))
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column {
+                    HelpClickableRow(
+                        label = stringResource(MR.string.dev_menu_trigger_test_crash),
+                        showChevron = false,
+                        onClick = { showCrashConfirm = true }
+                    )
+                }
+            }
+            Text(
+                text = stringResource(MR.string.dev_menu_trigger_test_crash_description),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(horizontal = 4.dp)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/devmenu/DeveloperMenuViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/devmenu/DeveloperMenuViewModel.kt
@@ -47,6 +47,10 @@ class DeveloperMenuViewModel(
                 clearAllData()
             }
 
+            is DeveloperMenuUiAction.TriggerTestCrash -> {
+                triggerTestCrash()
+            }
+
             is DeveloperMenuUiAction.ToggleAllowTenBitVideo -> {
                 val isEnabled = !userPreferences.allowTenBitVideo
                 userPreferences.allowTenBitVideo = isEnabled
@@ -117,6 +121,19 @@ class DeveloperMenuViewModel(
         }
     }
 
+    /**
+     * Intentionally crash the app to verify crash reporting end-to-end. Throws
+     * an uncaught exception on the calling (main) thread so it propagates through
+     * the platform crash handlers we install at startup — Firebase's native
+     * uncaught handler on Android, and the Kotlin/Native unhandled-exception hook
+     * on iOS ([id.homebase.core.logging.setupIOSCrashHandler], which records it to
+     * Crashlytics). The report uploads on the next launch.
+     */
+    private fun triggerTestCrash() {
+        Logger.w(tag = "DeveloperMenu") { "Triggering intentional test crash for Crashlytics verification" }
+        throw RuntimeException("Test crash triggered from the developer menu (Crashlytics verification)")
+    }
+
     fun eventConsumed() {
         _uiState.update { it.copy(uiEvent = null) }
     }
@@ -143,6 +160,7 @@ sealed interface DeveloperMenuUiAction {
     data object TestRichNotification : DeveloperMenuUiAction
     data object ForceSyncAll : DeveloperMenuUiAction
     data object ClearAllData : DeveloperMenuUiAction
+    data object TriggerTestCrash : DeveloperMenuUiAction
     data object ForceReconnectWebSocket : DeveloperMenuUiAction
     data object ToggleAllowTenBitVideo : DeveloperMenuUiAction
 }

--- a/iosApp/iosApp/CrashlyticsBridgeImpl.swift
+++ b/iosApp/iosApp/CrashlyticsBridgeImpl.swift
@@ -9,4 +9,14 @@ class CrashlyticsBridgeImpl: CrashlyticsBridge {
     func setCrashlyticsCollectionEnabled(enabled: Bool) {
         Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(enabled)
     }
+
+    func log(message: String) {
+        Crashlytics.crashlytics().log(message)
+    }
+
+    func recordException(name: String, reason: String, stackTrace: [String]) {
+        let model = ExceptionModel(name: name, reason: reason)
+        model.stackTrace = stackTrace.map { StackFrame(symbol: $0, file: "unknown", line: 0) }
+        Crashlytics.crashlytics().record(exceptionModel: model)
+    }
 }


### PR DESCRIPTION
…idge + test crash

iOS previously only captured Objective-C crashes; pure Kotlin/Native uncaught exceptions abort via Kotlin's hook without raising an NSException, so they never reached the Crashlytics dashboard. Extend CrashlyticsBridge with log()/recordException(); the Swift impl builds a Firebase ExceptionModel so both the Kotlin/Native hook and the NSException handler record a readable stack before the process dies.

Add a cross-platform CrashlyticsLogWriter (Kermit) wired into LoggerConfig that forwards Info+ logs as Crashlytics breadcrumbs and Error+ throwables as non-fatals, so crash reports carry the recent log trail. CrashLogger now logs the fatal stack as text (not via the throwable param) so fatals captured by the dedicated handlers aren't double-reported as non-fatals. No-op on Desktop/Web.

Add a "Crashlytics" section to the developer menu with a confirmation-gated "Trigger test crash" button (descriptive text noting it intentionally crashes the app) to verify the pipeline end-to-end.