### PR TITLE
perf(images): instant, sharp fullscreen image opens (byte cache + bitmap prefetch + cross-fade)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
@@ -60,6 +60,7 @@ import id.homebase.core.HomebaseConstants
 import id.homebase.core.image.HomebaseImage
 import id.homebase.core.image.HomebaseImageData
 import id.homebase.core.image.ImageSize
+import id.homebase.core.image.rememberFullScreenImagePrefetch
 import id.homebase.core.ui.theme.Dimens
 import id.homebase.core.widget.AudioPlayerWidget
 import id.homebase.resources.MR
@@ -263,6 +264,7 @@ fun MediaItem(
                 )
             } else {
                 // Render image via HomebaseImage
+                val prefetchImage = rememberFullScreenImagePrefetch()
                 // Remember the image data to avoid creating a new instance on every recomposition,
                 // which would cause Coil to restart the image loading pipeline and cause flickering.
                 val imageData =
@@ -287,7 +289,14 @@ fun MediaItem(
                         modifier = finalModifier,
                         contentScale = imageContentScale,
                         contentDescription = stringResource(MR.string.chat_message_image_attachment),
-                        onClick = onClick,
+                        onClick = onClick?.let { click ->
+                            {
+                                // Warm the fullscreen bitmap on tap so the viewer
+                                // opens instantly (mirrors the Vault grid).
+                                prefetchImage(imageData.copy(loadFullPayload = true))
+                                click()
+                            }
+                        },
                         onLongPress = onLongPress,
                         sharedTransitionScope = sharedTransitionScope,
                         animatedVisibilityScope = animatedVisibilityScope,

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/FullPayloadByteCache.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/FullPayloadByteCache.kt
@@ -1,0 +1,96 @@
+package id.homebase.core.image
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Bounded, in-memory LRU of decrypted full-payload image bytes with in-flight
+ * request coalescing.
+ *
+ * Why it exists:
+ * - The fullscreen viewer fetches the same full payload several times per open
+ *   (the base image, the subsampling tiler, and any re-decode). Coalescing +
+ *   caching collapses that to a single fetch+decrypt.
+ * - It lets [HomebaseImageLoader.prefetchFullPayload] warm the bytes on press so
+ *   the image is ready by the time the open animation finishes.
+ *
+ * Security: RAM-only by design. Decrypted bytes are never written to disk — this
+ * matches the deliberate `diskCache(null)` choice, and holds strictly less data
+ * than the decoded bitmaps Coil already keeps in memory. Cleared via [clear]
+ * from the app's existing cache-clear / logout paths.
+ *
+ * Concurrency: all mutable state ([entries], [inFlight], [sizeBytes]) is guarded
+ * by [mutex]. The actual load runs on [scope] (not the caller), so a cancelled
+ * caller (e.g. a navigated-away prefetch) does not abort a load other callers
+ * are awaiting.
+ */
+internal class FullPayloadByteCache(
+    private val maxBytes: Long,
+    private val scope: CoroutineScope,
+) {
+    private val mutex = Mutex()
+
+    // Insertion-ordered map used as a manual LRU: most-recently-used is last,
+    // eldest is first. (commonMain LinkedHashMap has no access-order ctor, so
+    // hits are moved to the end by remove+reinsert.)
+    private val entries = LinkedHashMap<String, CachedImage>()
+    private val inFlight = HashMap<String, Deferred<CachedImage?>>()
+    private var sizeBytes = 0L
+
+    /**
+     * Returns the cached image for [key], or loads it via [loader] exactly once
+     * (coalescing concurrent callers) and caches a non-null result.
+     */
+    suspend fun getOrLoad(key: String, loader: suspend () -> CachedImage?): CachedImage? {
+        val deferred: Deferred<CachedImage?> = mutex.withLock {
+            entries[key]?.let { hit ->
+                // Mark most-recently-used.
+                entries.remove(key)
+                entries[key] = hit
+                return hit
+            }
+            inFlight[key] ?: scope.async(start = CoroutineStart.LAZY) {
+                try {
+                    val result = loader()
+                    mutex.withLock {
+                        inFlight.remove(key)
+                        if (result != null) putLocked(key, result)
+                    }
+                    result
+                } catch (t: Throwable) {
+                    // Drop the shared slot so the next caller retries instead of
+                    // re-receiving this failure. Cancellation propagates too.
+                    mutex.withLock { inFlight.remove(key) }
+                    throw t
+                }
+            }.also { inFlight[key] = it }
+        }
+        deferred.start()
+        return deferred.await()
+    }
+
+    /** Caller must hold [mutex]. Inserts as most-recently-used and evicts LRU. */
+    private fun putLocked(key: String, image: CachedImage) {
+        entries.remove(key)?.let { sizeBytes -= it.bytes.size }
+        if (image.bytes.size > maxBytes) return // never cache an entry larger than the whole budget
+        entries[key] = image
+        sizeBytes += image.bytes.size
+        val iterator = entries.entries.iterator()
+        while (sizeBytes > maxBytes && iterator.hasNext()) {
+            val eldest = iterator.next()
+            sizeBytes -= eldest.value.bytes.size
+            iterator.remove()
+        }
+    }
+
+    suspend fun clear() {
+        mutex.withLock {
+            entries.clear()
+            sizeBytes = 0L
+        }
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/FullPayloadByteCache.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/FullPayloadByteCache.kt
@@ -15,8 +15,9 @@ import kotlinx.coroutines.sync.withLock
  * - The fullscreen viewer fetches the same full payload several times per open
  *   (the base image, the subsampling tiler, and any re-decode). Coalescing +
  *   caching collapses that to a single fetch+decrypt.
- * - It lets [HomebaseImageLoader.prefetchFullPayload] warm the bytes on press so
- *   the image is ready by the time the open animation finishes.
+ * - It backs the press-time fullscreen prefetch (a Coil preload that decodes the
+ *   bitmap and, via the fetcher, populates this cache) so the viewer opens
+ *   instantly.
  *
  * Security: RAM-only by design. Decrypted bytes are never written to disk — this
  * matches the deliberate `diskCache(null)` choice, and holds strictly less data

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/FullPayloadByteCache.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/FullPayloadByteCache.kt
@@ -42,6 +42,14 @@ internal class FullPayloadByteCache(
     private val inFlight = HashMap<String, Deferred<CachedImage?>>()
     private var sizeBytes = 0L
 
+    // Bumped by [clear]. A load captures the generation it was scheduled under
+    // and only writes its result back if the generation still matches — so a
+    // decrypt that was already in flight when [clear] ran (e.g. logout fires
+    // mid-load) cannot repopulate the cache afterward. The capture and the
+    // bump both happen under [mutex], so there is no window where a stale
+    // write-back slips past a clear.
+    private var generation = 0
+
     /**
      * Returns the cached image for [key], or loads it via [loader] exactly once
      * (coalescing concurrent callers) and caches a non-null result.
@@ -54,12 +62,15 @@ internal class FullPayloadByteCache(
                 entries[key] = hit
                 return hit
             }
+            val loadGeneration = generation
             inFlight[key] ?: scope.async(start = CoroutineStart.LAZY) {
                 try {
                     val result = loader()
                     mutex.withLock {
                         inFlight.remove(key)
-                        if (result != null) putLocked(key, result)
+                        // Skip the write-back if a clear happened since this load
+                        // was scheduled — its bytes belong to a now-cleared epoch.
+                        if (result != null && loadGeneration == generation) putLocked(key, result)
                     }
                     result
                 } catch (t: Throwable) {
@@ -92,6 +103,11 @@ internal class FullPayloadByteCache(
         mutex.withLock {
             entries.clear()
             sizeBytes = 0L
+            // Forget the in-flight slots and advance the epoch so any load still
+            // running (e.g. a decrypt that was underway when logout fired) cannot
+            // write its now-stale bytes back into the cache when it finishes.
+            inFlight.clear()
+            generation++
         }
     }
 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/FullScreenImageRequest.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/FullScreenImageRequest.kt
@@ -1,0 +1,70 @@
+package id.homebase.core.image
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalWindowInfo
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.compose.LocalPlatformContext
+import coil3.request.ImageRequest
+import coil3.size.Size
+import org.koin.compose.koinInject
+
+/**
+ * Canonical Coil request for the fullscreen base image.
+ *
+ * The decode size is pinned to [size] (the window) rather than left to the
+ * measured composable, so a press-time prefetch and the fullscreen viewer
+ * produce the SAME Coil memory-cache key. That lets a cold open hit an
+ * already-decoded bitmap instead of decoding the 6 MB JPEG again.
+ *
+ * Deep zoom is unaffected: the subsampling generator streams full-resolution
+ * tiles from the payload bytes independently of this base size.
+ */
+fun fullScreenImageRequest(
+    context: PlatformContext,
+    data: HomebaseImageData,
+    size: Size,
+): ImageRequest =
+    ImageRequest.Builder(context)
+        .data(data)
+        .size(size)
+        .build()
+
+/**
+ * Decode and cache the fullscreen bitmap (and, via the fetcher, the byte cache)
+ * so the viewer opens instantly. Fire-and-forget Coil preload — it has no
+ * target, so it survives the press composable leaving the screen. A press that
+ * does not lead to an open wastes at most one image's decode.
+ */
+fun ImageLoader.prefetchFullScreen(
+    context: PlatformContext,
+    data: HomebaseImageData,
+    size: Size,
+) {
+    if (data.isPending) return
+    enqueue(fullScreenImageRequest(context, data, size))
+}
+
+/**
+ * Returns a press handler that warms an image's fullscreen bitmap via
+ * [prefetchFullScreen]. Encapsulates the Coil loader, platform context, and
+ * window size so press sites (grid tiles, chat photos) share one implementation
+ * instead of each re-reading them. The returned lambda is a no-op until the
+ * window has been measured.
+ */
+@Composable
+fun rememberFullScreenImagePrefetch(): (HomebaseImageData) -> Unit {
+    val imageLoader: ImageLoader = koinInject()
+    val context = LocalPlatformContext.current
+    val windowSize = LocalWindowInfo.current.containerSize
+    return remember(imageLoader, context, windowSize) {
+        { data ->
+            if (windowSize.width > 0 && windowSize.height > 0) {
+                imageLoader.prefetchFullScreen(
+                    context, data, Size(windowSize.width, windowSize.height)
+                )
+            }
+        }
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImage.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImage.kt
@@ -81,10 +81,20 @@ fun HomebaseImage(
     // Get ImageLoader with HomebaseImageFetcher from Koin DI
     val imageLoader: ImageLoader = koinInject()
 
-    // When loading full payload, use the cached thumbnail as a placeholder
+    // Paint the already-decoded thumbnail synchronously on the first frame
+    // instead of the tiny embedded preview. The thumbnail cache key is
+    // size-independent (see HomebaseImageKeyer), so whatever thumbnail is in
+    // memory for this image — a list/grid tile, or a previously loaded
+    // full-screen thumb — is shown immediately while the request resolves:
+    //   - full-payload request: bridges thumb -> full (low-res to sharp),
+    //   - thumbnail request (e.g. the full-screen viewer's placeholder): the
+    //     placeholder key equals the request's own key, so a grid/list tile
+    //     already in memory paints on frame 0 rather than the ~20px tinyThumb.
+    // Pending (local, not-yet-uploaded) files have no server thumbnail to key
+    // against, so they fall through to the raw data + embedded preview.
     val platformContext = LocalPlatformContext.current
     val model: Any = remember(imageData, platformContext) {
-        if (imageData.loadFullPayload && !imageData.isPending) {
+        if (!imageData.isPending) {
             ImageRequest.Builder(platformContext)
                 .data(imageData)
                 .placeholderMemoryCacheKey(HomebaseImageKeyer.thumbnailCacheKey(imageData))

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
@@ -178,26 +178,6 @@ class HomebaseImageLoader(
     }
 
     /**
-     * Best-effort warm-up of an image's full payload so the fullscreen viewer
-     * opens sharp without waiting on a fetch. Fire-and-forget; the load runs on
-     * [cacheScope] so it survives the caller leaving composition (e.g. the grid
-     * item that was pressed). A press that does not lead to an open wastes at
-     * most one image's fetch.
-     */
-    fun prefetchFullPayload(data: HomebaseImageData) {
-        if (data.isPending) return
-        cacheScope.launch {
-            try {
-                loadFullPayload(data)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (_: Throwable) {
-                // Best-effort warm-up; a real open will retry on a genuine miss.
-            }
-        }
-    }
-
-    /**
      * Drop all cached decrypted full-payload bytes. Wire to the same triggers as
      * the Coil memory cache (manual "Clear cache", logout/account switch).
      */

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
@@ -205,6 +205,15 @@ class HomebaseImageLoader(
         fullPayloadCache.clear()
     }
 
+    /**
+     * Non-suspending best-effort clear for call sites that aren't coroutines
+     * (e.g. the logout hook). Schedules the clear on [cacheScope] so decrypted
+     * bytes for the outgoing user don't linger in RAM.
+     */
+    fun clearMemoryCacheAsync() {
+        cacheScope.launch { fullPayloadCache.clear() }
+    }
+
     private fun fullPayloadCacheKey(data: HomebaseImageData): String =
         "${data.driveId}/${data.fileId}/${data.payloadKey}/${data.lastModified ?: 0}"
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
@@ -10,6 +10,10 @@ import id.homebase.core.clipboard.platformFileFromPath
 import io.github.vinceglb.filekit.extension
 import io.github.vinceglb.filekit.mimeType
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlin.uuid.Uuid
 
 /** Image data container */
@@ -39,8 +43,21 @@ class HomebaseImageLoader(
     private val driveFileProvider: DriveFileProvider,
     private val fileOperationsProvider: FileOperationsProvider,
 ) {
+    // Durable scope hosting full-payload loads so a cancelled caller (e.g. a
+    // prefetch whose grid item left composition) does not abort a load that
+    // other callers are awaiting.
+    private val cacheScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val fullPayloadCache = FullPayloadByteCache(
+        maxBytes = MAX_FULL_PAYLOAD_CACHE_BYTES,
+        scope = cacheScope,
+    )
+
     companion object {
         private const val TAG = "HomebaseImageLoader"
+
+        // In-memory budget for cached decrypted full-payload bytes (compressed,
+        // ~a handful of photos). Small next to Coil's decoded-bitmap cache.
+        private const val MAX_FULL_PAYLOAD_CACHE_BYTES = 48L * 1024 * 1024
 
         // Content types whose payload is rendered as-is, bypassing the
         // thumbnail pipeline. GIF stays here because we want the
@@ -152,7 +169,48 @@ class HomebaseImageLoader(
             return fileOperationsProvider.loadPendingFile(data)
         }
 
-        // Fetch from server with retry
+        // Serve from (and populate) the in-memory cache. Concurrent callers for
+        // the same image — the base painter, the subsampling tiler, a prefetch —
+        // coalesce onto a single fetch+decrypt instead of repeating it.
+        return fullPayloadCache.getOrLoad(fullPayloadCacheKey(data)) {
+            fetchFullPayloadUncached(data, retryConfig)
+        }
+    }
+
+    /**
+     * Best-effort warm-up of an image's full payload so the fullscreen viewer
+     * opens sharp without waiting on a fetch. Fire-and-forget; the load runs on
+     * [cacheScope] so it survives the caller leaving composition (e.g. the grid
+     * item that was pressed). A press that does not lead to an open wastes at
+     * most one image's fetch.
+     */
+    fun prefetchFullPayload(data: HomebaseImageData) {
+        if (data.isPending) return
+        cacheScope.launch {
+            try {
+                loadFullPayload(data)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Throwable) {
+                // Best-effort warm-up; a real open will retry on a genuine miss.
+            }
+        }
+    }
+
+    /**
+     * Drop all cached decrypted full-payload bytes. Wire to the same triggers as
+     * the Coil memory cache (manual "Clear cache", logout/account switch).
+     */
+    suspend fun clearMemoryCache() {
+        fullPayloadCache.clear()
+    }
+
+    private fun fullPayloadCacheKey(data: HomebaseImageData): String =
+        "${data.driveId}/${data.fileId}/${data.payloadKey}/${data.lastModified ?: 0}"
+
+    private suspend fun fetchFullPayloadUncached(
+        data: HomebaseImageData, retryConfig: RetryConfig
+    ): CachedImage? {
         return withRetry(retryConfig, TAG) {
             val response = try {
                 driveFileProvider.getPayloadBytesDecrypted(

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/media/subsample/ZoomableSubSamplingImage.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/media/subsample/ZoomableSubSamplingImage.kt
@@ -114,16 +114,19 @@ fun ZoomableSubSamplingImage(
     }
 
     Box(modifier = containerModifier) {
-        // While the full-resolution payload downloads, show a thumbnail sized to
-        // this fullscreen container (loadFullPayload = false) instead of letting
-        // the viewer blow up a tiny list/grid thumbnail. HomebaseImage shows the
-        // embedded blurred preview first and sharpens to a screen-resolution
-        // server thumbnail, so the user never sees the low-res-to-sharp jump.
-        // A local file is already the original on disk, so the image below loads
-        // it directly with no intermediate fetch.
+        // While the full-resolution payload downloads, show a thumbnail
+        // (loadFullPayload = false) as the bridge under the cross-fade.
+        // HomebaseImage paints the already-decoded list/grid tile for this image
+        // synchronously on the first frame — its thumbnail cache key is
+        // size-independent, so the tile the user just tapped is reused as a
+        // placeholder — then sharpens to a screen-resolution server thumbnail.
+        // So the bridge is the sharp tile, not the ~20px embedded blur, and there
+        // is no low-res-to-sharp jump. A local file is already the original on
+        // disk, so the image below loads it directly with no intermediate fetch.
         if (sharpAlpha < 1f && source is SubSamplingImageSource.Remote) {
-            val thumbnailData = remember(source) {
-                source.imageData.copy(loadFullPayload = false)
+            val imageData = source.imageData
+            val thumbnailData = remember(imageData) {
+                imageData.copy(loadFullPayload = false)
             }
             HomebaseImage(
                 imageData = thumbnailData,

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/media/subsample/ZoomableSubSamplingImage.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/media/subsample/ZoomableSubSamplingImage.kt
@@ -63,12 +63,15 @@ fun ZoomableSubSamplingImage(
     // Cross-fade the sharp image in over the placeholder so the unavoidable
     // decode (a 6 MB JPEG can take a few hundred ms on older devices) reads as a
     // smooth focus-pull instead of an abrupt pop. (Modifier.blur is API 31+, so
-    // a blur-up isn't available on older devices; a cross-fade is.)
+    // a blur-up isn't available on older devices; a cross-fade is.) Only remote
+    // images have a placeholder to fade over; a local original loads fast with
+    // nothing beneath it, so it is shown at full opacity (no fade, no blank).
     val sharpAlpha by animateFloatAsState(
         targetValue = if (imageLoaded) 1f else 0f,
         animationSpec = tween(durationMillis = 250, easing = FastOutSlowInEasing),
         label = "sharpFade",
     )
+    val contentAlpha = if (source is SubSamplingImageSource.Remote) sharpAlpha else 1f
 
     // Shared-element bounds go on the container (not the inner image) so the
     // placeholder animates with the open/close transition instead of popping in
@@ -113,7 +116,7 @@ fun ZoomableSubSamplingImage(
             model = model,
             contentDescription = contentDescription,
             imageLoader = coilImageLoader,
-            modifier = Modifier.fillMaxSize().alpha(sharpAlpha),
+            modifier = Modifier.fillMaxSize().alpha(contentAlpha),
             contentScale = ContentScale.Fit,
             zoomState = zoomState,
             scrollBar = null,

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/media/subsample/ZoomableSubSamplingImage.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/media/subsample/ZoomableSubSamplingImage.kt
@@ -18,14 +18,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.IntSize
 import coil3.ImageLoader
+import coil3.compose.LocalPlatformContext
+import coil3.size.Size
 import com.github.panpf.zoomimage.CoilZoomAsyncImage
 import com.github.panpf.zoomimage.compose.zoom.ZoomableState
 import com.github.panpf.zoomimage.rememberCoilZoomState
 import id.homebase.core.HomebaseConstants
 import id.homebase.core.image.HomebaseImage
 import id.homebase.core.image.HomebaseImageLoader
+import id.homebase.core.image.fullScreenImageRequest
 import kotlinx.collections.immutable.persistentListOf
 import org.koin.compose.koinInject
 
@@ -53,8 +57,24 @@ fun ZoomableSubSamplingImage(
     // resets to fit.
     PreserveUserZoomAcrossContentSizeChange(zoomState.zoomable)
 
+    val platformContext = LocalPlatformContext.current
+    val windowSize = LocalWindowInfo.current.containerSize
     val model: Any? = when (source) {
-        is SubSamplingImageSource.Remote -> source.imageData
+        is SubSamplingImageSource.Remote -> {
+            val imageData = source.imageData
+            remember(imageData, platformContext, windowSize) {
+                if (windowSize.width > 0 && windowSize.height > 0) {
+                    // Pin the base decode to the window size so a press-time
+                    // prefetch and this request share one Coil memory-cache entry
+                    // — a cold open then hits the already-decoded bitmap.
+                    fullScreenImageRequest(
+                        platformContext, imageData, Size(windowSize.width, windowSize.height)
+                    )
+                } else {
+                    imageData
+                }
+            }
+        }
         is SubSamplingImageSource.LocalFile -> source.filePath
     }
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/media/subsample/ZoomableSubSamplingImage.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/media/subsample/ZoomableSubSamplingImage.kt
@@ -3,8 +3,8 @@ package id.homebase.core.media.subsample
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -15,22 +15,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.blur
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.dp
 import coil3.ImageLoader
-import coil3.compose.LocalPlatformContext
-import coil3.request.ImageRequest
 import com.github.panpf.zoomimage.CoilZoomAsyncImage
 import com.github.panpf.zoomimage.compose.zoom.ZoomableState
 import com.github.panpf.zoomimage.rememberCoilZoomState
 import id.homebase.core.HomebaseConstants
-import id.homebase.core.image.HomebaseImageKeyer
+import id.homebase.core.image.HomebaseImage
 import id.homebase.core.image.HomebaseImageLoader
-import id.homebase.core.image.decodeBitmap
 import kotlinx.collections.immutable.persistentListOf
 import org.koin.compose.koinInject
 
@@ -58,31 +53,26 @@ fun ZoomableSubSamplingImage(
     // resets to fit.
     PreserveUserZoomAcrossContentSizeChange(zoomState.zoomable)
 
-    val platformContext = LocalPlatformContext.current
     val model: Any? = when (source) {
-        is SubSamplingImageSource.Remote -> {
-            val imageData = source.imageData
-            remember(imageData, platformContext) {
-                ImageRequest.Builder(platformContext)
-                    .data(imageData)
-                    .placeholderMemoryCacheKey(HomebaseImageKeyer.thumbnailCacheKey(imageData))
-                    .build()
-            }
-        }
+        is SubSamplingImageSource.Remote -> source.imageData
         is SubSamplingImageSource.LocalFile -> source.filePath
     }
 
-    // Decode the embedded tiny thumbnail so a blurred preview shows immediately
-    // while an uncached thumbnail/full image loads (cold cache). When a real
-    // thumbnail is cached it renders on top via placeholderMemoryCacheKey.
-    val previewBitmap: ImageBitmap? = remember(source) {
-        (source as? SubSamplingImageSource.Remote)?.imageData?.previewThumbnail?.decodeBitmap()
-    }
     var imageLoaded by remember(model) { mutableStateOf(false) }
 
+    // Cross-fade the sharp image in over the placeholder so the unavoidable
+    // decode (a 6 MB JPEG can take a few hundred ms on older devices) reads as a
+    // smooth focus-pull instead of an abrupt pop. (Modifier.blur is API 31+, so
+    // a blur-up isn't available on older devices; a cross-fade is.)
+    val sharpAlpha by animateFloatAsState(
+        targetValue = if (imageLoaded) 1f else 0f,
+        animationSpec = tween(durationMillis = 250, easing = FastOutSlowInEasing),
+        label = "sharpFade",
+    )
+
     // Shared-element bounds go on the container (not the inner image) so the
-    // blurred preview animates with the open/close transition instead of
-    // popping in full-screen behind the still-animating image.
+    // placeholder animates with the open/close transition instead of popping in
+    // full-screen behind the still-animating image.
     var containerModifier: Modifier = modifier.fillMaxSize()
     if (sharedContentStateKey != null && sharedTransitionScope != null && animatedVisibilityScope != null) {
         with(sharedTransitionScope) {
@@ -101,19 +91,29 @@ fun ZoomableSubSamplingImage(
     }
 
     Box(modifier = containerModifier) {
-        if (!imageLoaded && previewBitmap != null) {
-            Image(
-                bitmap = previewBitmap,
+        // While the full-resolution payload downloads, show a thumbnail sized to
+        // this fullscreen container (loadFullPayload = false) instead of letting
+        // the viewer blow up a tiny list/grid thumbnail. HomebaseImage shows the
+        // embedded blurred preview first and sharpens to a screen-resolution
+        // server thumbnail, so the user never sees the low-res-to-sharp jump.
+        // A local file is already the original on disk, so the image below loads
+        // it directly with no intermediate fetch.
+        if (sharpAlpha < 1f && source is SubSamplingImageSource.Remote) {
+            val thumbnailData = remember(source) {
+                source.imageData.copy(loadFullPayload = false)
+            }
+            HomebaseImage(
+                imageData = thumbnailData,
                 contentDescription = null,
                 contentScale = ContentScale.Fit,
-                modifier = Modifier.fillMaxSize().blur(PreviewBlurRadius),
+                modifier = Modifier.fillMaxSize(),
             )
         }
         CoilZoomAsyncImage(
             model = model,
             contentDescription = contentDescription,
             imageLoader = coilImageLoader,
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier.fillMaxSize().alpha(sharpAlpha),
             contentScale = ContentScale.Fit,
             zoomState = zoomState,
             scrollBar = null,
@@ -198,4 +198,3 @@ private data class ContentZoomSample(
 )
 
 private const val USER_SCALE_EPSILON = 1.01f
-private val PreviewBlurRadius = 12.dp

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/image/FullPayloadByteCacheTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/image/FullPayloadByteCacheTest.kt
@@ -119,6 +119,32 @@ class FullPayloadByteCacheTest {
     }
 
     @Test
+    fun `clear while a load is in flight does not repopulate the cache`() = runTest {
+        val cache = newCache(10_000)
+        val gate = CompletableDeferred<Unit>()
+        var calls = 0
+        val loader: suspend () -> CachedImage? = { calls++; gate.await(); cachedImage(100) }
+
+        // A decrypt is in flight: the load registers and parks at the gate.
+        val inFlight = async { cache.getOrLoad("k", loader) }
+        advanceUntilIdle()
+        assertEquals(1, calls)
+
+        // Logout-style clear runs while the load is still parked.
+        cache.clear()
+
+        // The parked load now finishes. Its bytes belong to the cleared epoch,
+        // so they must NOT be written back — but the awaiter still gets them.
+        gate.complete(Unit)
+        advanceUntilIdle()
+        assertEquals(100, inFlight.await()?.bytes?.size)
+
+        // A fresh request reloads, proving the stale load did not repopulate.
+        cache.getOrLoad("k") { calls++; cachedImage(100) }
+        assertEquals(2, calls)
+    }
+
+    @Test
     fun `entry larger than the whole budget is served but not retained`() = runTest {
         val cache = newCache(100)
         var calls = 0

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/image/FullPayloadByteCacheTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/image/FullPayloadByteCacheTest.kt
@@ -1,0 +1,134 @@
+package id.homebase.core.image
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FullPayloadByteCacheTest {
+
+    private fun cachedImage(size: Int) = CachedImage(ByteArray(size), "image/jpeg", null)
+
+    // Mirror the production scope: a SupervisorJob so a failing load does not
+    // cancel the cache, on the test scheduler so advanceUntilIdle drives it.
+    private fun TestScope.newCache(maxBytes: Long) = FullPayloadByteCache(
+        maxBytes = maxBytes,
+        scope = CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler)),
+    )
+
+    @Test
+    fun `cache hit returns stored value without reloading`() = runTest {
+        val cache = newCache(10_000)
+        var calls = 0
+        val loader: suspend () -> CachedImage? = { calls++; cachedImage(100) }
+
+        val first = cache.getOrLoad("k", loader)
+        val second = cache.getOrLoad("k", loader)
+
+        assertEquals(100, first?.bytes?.size)
+        assertEquals(100, second?.bytes?.size)
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun `concurrent callers coalesce onto a single load`() = runTest {
+        val cache = newCache(10_000)
+        val gate = CompletableDeferred<Unit>()
+        var calls = 0
+        val loader: suspend () -> CachedImage? = { calls++; gate.await(); cachedImage(100) }
+
+        val d1 = async { cache.getOrLoad("k", loader) }
+        val d2 = async { cache.getOrLoad("k", loader) }
+        advanceUntilIdle() // both register and park on the in-flight load at the gate
+
+        assertEquals(1, calls)
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(100, d1.await()?.bytes?.size)
+        assertEquals(100, d2.await()?.bytes?.size)
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun `evicts least-recently-used when over the byte budget`() = runTest {
+        val cache = newCache(100)
+        var callsA = 0
+        var callsB = 0
+        val loadA: suspend () -> CachedImage? = { callsA++; cachedImage(60) }
+        val loadB: suspend () -> CachedImage? = { callsB++; cachedImage(60) }
+
+        cache.getOrLoad("A", loadA)   // {A:60}
+        cache.getOrLoad("B", loadB)   // 60+60 > 100 -> evict A -> {B:60}
+        cache.getOrLoad("B", loadB)   // hit, no reload
+        cache.getOrLoad("A", loadA)   // A was evicted -> reload
+
+        assertEquals(2, callsA)
+        assertEquals(1, callsB)
+    }
+
+    @Test
+    fun `null result is not cached`() = runTest {
+        val cache = newCache(10_000)
+        var calls = 0
+        val loader: suspend () -> CachedImage? = { calls++; null }
+
+        assertNull(cache.getOrLoad("k", loader))
+        assertNull(cache.getOrLoad("k", loader))
+        assertEquals(2, calls)
+    }
+
+    @Test
+    fun `loader failure drops the in-flight slot so the next call retries`() = runTest {
+        val cache = newCache(10_000)
+        var calls = 0
+        val loader: suspend () -> CachedImage? = {
+            calls++
+            if (calls == 1) throw IllegalStateException("boom") else cachedImage(50)
+        }
+
+        assertFailsWith<IllegalStateException> { cache.getOrLoad("k", loader) }
+        val recovered = cache.getOrLoad("k", loader)
+
+        assertEquals(50, recovered?.bytes?.size)
+        assertEquals(2, calls)
+    }
+
+    @Test
+    fun `clear drops cached entries`() = runTest {
+        val cache = newCache(10_000)
+        var calls = 0
+        val loader: suspend () -> CachedImage? = { calls++; cachedImage(50) }
+
+        cache.getOrLoad("k", loader)
+        cache.clear()
+        cache.getOrLoad("k", loader)
+
+        assertEquals(2, calls)
+    }
+
+    @Test
+    fun `entry larger than the whole budget is served but not retained`() = runTest {
+        val cache = newCache(100)
+        var calls = 0
+        val loader: suspend () -> CachedImage? = { calls++; cachedImage(500) }
+
+        val first = cache.getOrLoad("big", loader)
+        val second = cache.getOrLoad("big", loader)
+
+        assertEquals(500, first?.bytes?.size)
+        assertEquals(500, second?.bytes?.size)
+        assertEquals(2, calls) // not retained (too big), so reloaded
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -210,6 +210,7 @@ val appModule = module {
     // YouAuthFlowManager.logout() invokes immediately before this hook.
     single {
         val imageLoader: ImageLoader = get()
+        val homebaseImageLoader: HomebaseImageLoader = get()
         val fileOps: FileOperationsProvider = get()
         val pendingUpgradeManager: PendingUpgradeManager = get()
         YouAuthFlowManager(
@@ -234,6 +235,14 @@ val appModule = module {
                     .onFailure {
                         Logger.w(tag = "YouAuthFlowManager", throwable = it) {
                             "coil memory cache clear failed on logout"
+                        }
+                    }
+                // Decrypted full-payload bytes must not survive the outgoing
+                // identity either — same rationale as the Coil clear above.
+                runCatching { homebaseImageLoader.clearMemoryCacheAsync() }
+                    .onFailure {
+                        Logger.w(tag = "YouAuthFlowManager", throwable = it) {
+                            "full-payload cache clear failed on logout"
                         }
                     }
                 pendingUpgradeManager.reset()

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import coil3.ImageLoader
+import id.homebase.core.image.HomebaseImageLoader
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.cache.CacheStats
 import id.homebase.api.client.drives.cache.DriveFileProviderCached
@@ -34,6 +35,7 @@ class StorageSettingsViewModel(
     private val credentialsManager: CredentialsManager,
     private val databaseManager: DatabaseManager,
     private val imageLoader: ImageLoader,
+    private val homebaseImageLoader: HomebaseImageLoader,
     private val databaseSizeProbe: DatabaseSizeProbe,
     private val fileOperationsProvider: FileOperationsProvider,
     private val driveRegistry: DriveRegistry,
@@ -200,6 +202,8 @@ class StorageSettingsViewModel(
                 .onFailure { Logger.w(tag = "StorageSettings", throwable = it) { "drive clearCaches failed" } }
             runCatching { imageLoader.memoryCache?.clear() }
                 .onFailure { Logger.w(tag = "StorageSettings", throwable = it) { "coil memory clear failed" } }
+            runCatching { homebaseImageLoader.clearMemoryCache() }
+                .onFailure { Logger.w(tag = "StorageSettings", throwable = it) { "full-payload cache clear failed" } }
             // CacheSweeper absorbs the role of "delete orphan coil3_disk_cache" + adds
             // diagnostic logging for any other untracked entries — replaces the
             // standalone safeDeleteRecursively("coil3_disk_cache") line that used to

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultEntryCard.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultEntryCard.kt
@@ -45,13 +45,12 @@ import id.homebase.core.image.HomebaseImage
 import id.homebase.resources.vault_pdf_badge
 import id.homebase.resources.vault_upload_failed
 import id.homebase.core.image.HomebaseImageData
-import id.homebase.core.image.HomebaseImageLoader
 import id.homebase.core.image.ImageSize
+import id.homebase.core.image.rememberFullScreenImagePrefetch
 import id.homebase.resources.MR
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 import org.jetbrains.compose.resources.stringResource
-import org.koin.compose.koinInject
 
 private val CARD_WIDTH = 100.dp
 private val CARD_HEIGHT = 120.dp
@@ -76,7 +75,7 @@ fun VaultEntryCard(
 
     // Warm the full image on press so the fullscreen viewer opens sharp instead
     // of showing the grid tile upscaled while the payload downloads + decodes.
-    val homebaseImageLoader: HomebaseImageLoader = koinInject()
+    val prefetchImage = rememberFullScreenImagePrefetch()
     val prefetchData: HomebaseImageData? = remember(file.fileId, file.payloadDescriptors) {
         val descriptor = file.payloadDescriptors.firstOrNull() ?: return@remember null
         if (descriptor.contentType?.startsWith("image/") != true) return@remember null
@@ -103,7 +102,7 @@ fun VaultEntryCard(
             .clickable(
                 onClickLabel = description,
                 onClick = {
-                    prefetchData?.let { homebaseImageLoader.prefetchFullPayload(it) }
+                    prefetchData?.let(prefetchImage)
                     onClick()
                 },
             ),

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultEntryCard.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultEntryCard.kt
@@ -45,11 +45,13 @@ import id.homebase.core.image.HomebaseImage
 import id.homebase.resources.vault_pdf_badge
 import id.homebase.resources.vault_upload_failed
 import id.homebase.core.image.HomebaseImageData
+import id.homebase.core.image.HomebaseImageLoader
 import id.homebase.core.image.ImageSize
 import id.homebase.resources.MR
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 
 private val CARD_WIDTH = 100.dp
 private val CARD_HEIGHT = 120.dp
@@ -57,6 +59,7 @@ private val THUMBNAIL_HEIGHT = 88.dp
 private val LABEL_HEIGHT = 32.dp
 private val CARD_CORNER = 12.dp
 
+@OptIn(ExperimentalEncodingApi::class)
 @Composable
 fun VaultEntryCard(
     file: VaultEntry,
@@ -71,6 +74,26 @@ fun VaultEntryCard(
     val description = file.label?.ifBlank { null } ?: file.fileName
     val noteTitle = file.noteDisplayTitle
 
+    // Warm the full image on press so the fullscreen viewer opens sharp instead
+    // of showing the grid tile upscaled while the payload downloads + decodes.
+    val homebaseImageLoader: HomebaseImageLoader = koinInject()
+    val prefetchData: HomebaseImageData? = remember(file.fileId, file.payloadDescriptors) {
+        val descriptor = file.payloadDescriptors.firstOrNull() ?: return@remember null
+        if (descriptor.contentType?.startsWith("image/") != true) return@remember null
+        val ivBytes = descriptor.iv?.let {
+            try { Base64.decode(it) } catch (_: Exception) { null }
+        } ?: return@remember null
+        HomebaseImageData(
+            driveId = file.driveId,
+            fileId = file.fileId,
+            payloadKey = descriptor.key,
+            loadFullPayload = true,
+            lastModified = descriptor.lastModified,
+            isEncrypted = file.isEncrypted,
+            keyHeader = KeyHeader(iv = ivBytes, aesKey = file.keyHeader.aesKey),
+        )
+    }
+
     Column(
         modifier = modifier
             .width(CARD_WIDTH)
@@ -79,7 +102,10 @@ fun VaultEntryCard(
             .background(MaterialTheme.colorScheme.surfaceContainerLow)
             .clickable(
                 onClickLabel = description,
-                onClick = onClick,
+                onClick = {
+                    prefetchData?.let { homebaseImageLoader.prefetchFullPayload(it) }
+                    onClick()
+                },
             ),
     ) {
         // Thumbnail area — top 88dp

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultEntryCard.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultEntryCard.kt
@@ -36,11 +36,11 @@ import androidx.compose.animation.core.tween
 import androidx.compose.runtime.remember
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
-import id.homebase.api.client.KeyHeader
 import id.homebase.chat.services.LocalAttachmentContext
 import id.homebase.chat.services.LocalAttachmentContextStore
 import id.homebase.core.ui.screens.vault.components.fileTypeIcon
 import id.homebase.core.ui.screens.vault.model.VaultEntry
+import id.homebase.core.ui.screens.vault.model.imageDataFor
 import id.homebase.core.image.HomebaseImage
 import id.homebase.resources.vault_pdf_badge
 import id.homebase.resources.vault_upload_failed
@@ -48,8 +48,6 @@ import id.homebase.core.image.HomebaseImageData
 import id.homebase.core.image.ImageSize
 import id.homebase.core.image.rememberFullScreenImagePrefetch
 import id.homebase.resources.MR
-import kotlin.io.encoding.Base64
-import kotlin.io.encoding.ExperimentalEncodingApi
 import org.jetbrains.compose.resources.stringResource
 
 private val CARD_WIDTH = 100.dp
@@ -58,7 +56,6 @@ private val THUMBNAIL_HEIGHT = 88.dp
 private val LABEL_HEIGHT = 32.dp
 private val CARD_CORNER = 12.dp
 
-@OptIn(ExperimentalEncodingApi::class)
 @Composable
 fun VaultEntryCard(
     file: VaultEntry,
@@ -79,18 +76,7 @@ fun VaultEntryCard(
     val prefetchData: HomebaseImageData? = remember(file.fileId, file.payloadDescriptors) {
         val descriptor = file.payloadDescriptors.firstOrNull() ?: return@remember null
         if (descriptor.contentType?.startsWith("image/") != true) return@remember null
-        val ivBytes = descriptor.iv?.let {
-            try { Base64.decode(it) } catch (_: Exception) { null }
-        } ?: return@remember null
-        HomebaseImageData(
-            driveId = file.driveId,
-            fileId = file.fileId,
-            payloadKey = descriptor.key,
-            loadFullPayload = true,
-            lastModified = descriptor.lastModified,
-            isEncrypted = file.isEncrypted,
-            keyHeader = KeyHeader(iv = ivBytes, aesKey = file.keyHeader.aesKey),
-        )
+        file.imageDataFor(descriptor, loadFullPayload = true)
     }
 
     Column(
@@ -257,7 +243,6 @@ fun VaultEntryCard(
     }
 }
 
-@OptIn(ExperimentalEncodingApi::class)
 @Composable
 private fun VaultCardThumbnail(
     file: VaultEntry,
@@ -296,26 +281,19 @@ private fun VaultCardThumbnail(
 
     // 2. Encrypted server thumbnail (image or PDF — same HomebaseImage path)
     val descriptor = file.payloadDescriptors.firstOrNull()
-    val payloadIv = remember(descriptor?.iv) {
-        descriptor?.iv?.let {
-            try { Base64.decode(it) } catch (_: Exception) { null }
-        }
-    }
-    if ((file.isImage || file.isPdf) && descriptor != null && payloadIv != null) {
-        HomebaseImage(
-            imageData = HomebaseImageData(
-                driveId = file.driveId,
-                fileId = file.fileId,
-                payloadKey = descriptor.key,
+    val thumbnailData = remember(descriptor, file.previewThumbnail) {
+        descriptor?.let {
+            file.imageDataFor(
+                it,
+                loadFullPayload = false,
                 previewThumbnail = file.previewThumbnail,
                 requestedSize = ImageSize.THUMB_MEDIUM,
-                isEncrypted = file.isEncrypted,
-                keyHeader = KeyHeader(
-                    iv = payloadIv,
-                    aesKey = file.keyHeader.aesKey,
-                ),
-                lastModified = descriptor.lastModified,
-            ),
+            )
+        }
+    }
+    if ((file.isImage || file.isPdf) && thumbnailData != null) {
+        HomebaseImage(
+            imageData = thumbnailData,
             modifier = Modifier.fillMaxSize(),
             contentScale = ContentScale.Crop,
             contentDescription = description,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultZoomableImage.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultZoomableImage.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalEncodingApi::class)
-
 package id.homebase.core.ui.screens.vault.gallery
 
 import androidx.compose.animation.AnimatedVisibilityScope
@@ -11,21 +9,18 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.drives.files.PayloadDescriptor
 import id.homebase.chat.services.LocalAttachmentContext
 import id.homebase.chat.services.LocalAttachmentContextStore
-import id.homebase.core.image.HomebaseImageData
 import id.homebase.core.media.MediaPendingOverlay
 import id.homebase.core.media.MediaUnavailablePlaceholder
 import id.homebase.core.media.subsample.SubSamplingImageSource
 import id.homebase.core.media.subsample.ZoomableSubSamplingImage
 import id.homebase.core.ui.screens.vault.components.fileTypeIcon
 import id.homebase.core.ui.screens.vault.model.VaultEntry
+import id.homebase.core.ui.screens.vault.model.imageDataFor
 import id.homebase.resources.MR
 import id.homebase.resources.vault_error_image_unavailable
-import kotlin.io.encoding.Base64
-import kotlin.io.encoding.ExperimentalEncodingApi
 import org.jetbrains.compose.resources.stringResource
 
 
@@ -72,24 +67,12 @@ fun VaultZoomableImage(
         MediaPendingOverlay(onTap = onToggleUI)
     } else {
         val remoteSource =
-            remember(file.fileId, descriptor.key, descriptor.iv, descriptor.lastModified) {
-                val payloadIv = descriptor.iv?.let {
-                    try {
-                        Base64.decode(it)
-                    } catch (_: Exception) {
-                        null
-                    }
-                } ?: return@remember null
-                val imageData = HomebaseImageData(
-                    driveId = file.driveId,
-                    fileId = file.fileId,
-                    payloadKey = descriptor.key,
-                    previewThumbnail = previewThumbnail,
+            remember(file.fileId, descriptor.key, descriptor.iv, descriptor.lastModified, previewThumbnail) {
+                val imageData = file.imageDataFor(
+                    descriptor,
                     loadFullPayload = true,
-                    lastModified = descriptor.lastModified,
-                    isEncrypted = file.isEncrypted,
-                    keyHeader = KeyHeader(iv = payloadIv, aesKey = file.keyHeader.aesKey),
-                )
+                    previewThumbnail = previewThumbnail,
+                ) ?: return@remember null
                 SubSamplingImageSource.Remote(imageData)
             }
         if (remoteSource != null) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/model/VaultEntry.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/model/VaultEntry.kt
@@ -10,8 +10,12 @@ import id.homebase.api.client.drives.files.PayloadDescriptor
 import id.homebase.api.client.drives.upload.EmbeddedThumb
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.chat.services.ChatProtocol
+import id.homebase.core.image.HomebaseImageData
+import id.homebase.core.image.ImageSize
 import id.homebase.core.ui.screens.vault.VaultUploadStatus
 import id.homebase.core.util.CONTENT_TYPE_MARKDOWN
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -114,5 +118,37 @@ fun HomebaseFile.toVaultEntry(): VaultEntry? {
         payloadDescriptors = payloads,
         notes = vaultFileContent.notes,
         pdfPageCount = vaultFileContent.pdfPageCount,
+    )
+}
+
+/**
+ * Builds the [HomebaseImageData] for one of this entry's image payloads, or
+ * null if [descriptor] has no decodable IV (e.g. not yet uploaded).
+ *
+ * Single source of truth for the IV decode + [KeyHeader] assembly, so the grid
+ * thumbnail, the press-time prefetch, and the fullscreen viewer all address the
+ * same Coil / byte-cache entry (the key derives from drive/file/payload/
+ * lastModified) and cannot silently drift apart.
+ */
+@OptIn(ExperimentalEncodingApi::class)
+fun VaultEntry.imageDataFor(
+    descriptor: PayloadDescriptor,
+    loadFullPayload: Boolean,
+    previewThumbnail: EmbeddedThumb? = null,
+    requestedSize: ImageSize? = null,
+): HomebaseImageData? {
+    val ivBytes = descriptor.iv?.let {
+        try { Base64.decode(it) } catch (_: Exception) { null }
+    } ?: return null
+    return HomebaseImageData(
+        driveId = driveId,
+        fileId = fileId,
+        payloadKey = descriptor.key,
+        previewThumbnail = previewThumbnail,
+        requestedSize = requestedSize,
+        loadFullPayload = loadFullPayload,
+        isEncrypted = isEncrypted,
+        lastModified = descriptor.lastModified,
+        keyHeader = KeyHeader(iv = ivBytes, aesKey = keyHeader.aesKey),
     )
 }

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/vault/VaultEntryImageDataTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/vault/VaultEntryImageDataTest.kt
@@ -1,0 +1,122 @@
+@file:OptIn(ExperimentalUuidApi::class, ExperimentalEncodingApi::class)
+
+package id.homebase.core.ui.screens.vault
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.drives.files.PayloadDescriptor
+import id.homebase.api.client.drives.upload.EmbeddedThumb
+import id.homebase.api.common.SecureByteArray
+import id.homebase.core.image.ImageSize
+import id.homebase.core.ui.screens.vault.model.VaultEntry
+import id.homebase.core.ui.screens.vault.model.imageDataFor
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Unit tests for [imageDataFor] — the single source of truth that the Vault
+ * grid thumbnail, the press-time prefetch, and the fullscreen viewer all use to
+ * build a [id.homebase.core.image.HomebaseImageData]. Pins the
+ * null-on-missing-IV contract and the identity-field + KeyHeader mapping so the
+ * three call sites cannot drift apart and miss each other's Coil / byte-cache
+ * entries (whose keys derive from drive/file/payload/lastModified).
+ */
+class VaultEntryImageDataTest {
+
+    private val aesKey = SecureByteArray(ByteArray(16) { 7 })
+
+    private fun vaultEntry(
+        driveId: Uuid = Uuid.random(),
+        fileId: Uuid = Uuid.random(),
+        isEncrypted: Boolean = true,
+    ): VaultEntry = VaultEntry(
+        fileId = fileId,
+        uniqueId = fileId,
+        driveId = driveId,
+        fileName = "photo.jpg",
+        contentType = "image/jpeg",
+        sizeBytes = 1024L,
+        createdAt = 1_700_000_000_000L,
+        previewThumbnail = null,
+        keyHeader = KeyHeader(iv = ByteArray(16), aesKey = aesKey),
+        isEncrypted = isEncrypted,
+        versionTag = null,
+    )
+
+    @Test
+    fun `maps identity fields and decodes the iv into the key header`() {
+        val ivBytes = ByteArray(16) { it.toByte() }
+        val entry = vaultEntry()
+        val descriptor = PayloadDescriptor(
+            key = "vlt_pg_00",
+            contentType = "image/jpeg",
+            iv = Base64.encode(ivBytes),
+            lastModified = 42L,
+        )
+
+        val data = assertNotNull(entry.imageDataFor(descriptor, loadFullPayload = true))
+
+        assertEquals(entry.driveId, data.driveId)
+        assertEquals(entry.fileId, data.fileId)
+        assertEquals("vlt_pg_00", data.payloadKey)
+        assertEquals(42L, data.lastModified)
+        assertTrue(data.isEncrypted)
+        assertTrue(data.loadFullPayload)
+        assertTrue(ivBytes contentEquals data.keyHeader.iv)
+        // The entry's AES key is reused as-is (passed through, not rebuilt).
+        assertSame(entry.keyHeader.aesKey, data.keyHeader.aesKey)
+    }
+
+    @Test
+    fun `passes through preview thumbnail and requested size for the thumbnail variant`() {
+        val entry = vaultEntry()
+        val thumb = EmbeddedThumb(
+            pixelWidth = 10,
+            pixelHeight = 10,
+            contentType = "image/jpeg",
+            content = "abc",
+        )
+        val descriptor = PayloadDescriptor(
+            key = "k",
+            contentType = "image/jpeg",
+            iv = Base64.encode(ByteArray(16)),
+        )
+
+        val data = assertNotNull(
+            entry.imageDataFor(
+                descriptor,
+                loadFullPayload = false,
+                previewThumbnail = thumb,
+                requestedSize = ImageSize.THUMB_MEDIUM,
+            )
+        )
+
+        assertFalse(data.loadFullPayload)
+        assertEquals(thumb, data.previewThumbnail)
+        assertEquals(ImageSize.THUMB_MEDIUM, data.requestedSize)
+    }
+
+    @Test
+    fun `returns null when the descriptor has no iv`() {
+        val entry = vaultEntry()
+        val descriptor = PayloadDescriptor(key = "k", contentType = "image/jpeg", iv = null)
+
+        assertNull(entry.imageDataFor(descriptor, loadFullPayload = true))
+    }
+
+    @Test
+    fun `returns null when the iv is not valid base64`() {
+        val entry = vaultEntry()
+        val descriptor = PayloadDescriptor(key = "k", contentType = "image/jpeg", iv = "%%%%")
+
+        assertNull(entry.imageDataFor(descriptor, loadFullPayload = true))
+    }
+}


### PR DESCRIPTION
## Problem

Opening an image in the **Vault gallery** showed a soft, upscaled grid tile that then **snapped** to full resolution — the "low-res tiles → high-res" effect. Chat looked clean by comparison.

## Root cause (confirmed with on-device instrumentation)

- The fullscreen viewer's placeholder resolution = whatever thumbnail the **list/grid last cached**. Vault tiles are `100×88dp` (~275 px); chat's single-image bubble caches ~800 px — which is why chat looked clean and Vault didn't. (`HomebaseImageFetcher` sizes from `options.size`, so the `requestedSize` arg was inert.)
- The full payload was **fetched + decrypted + decoded up to 4× per open**, with no byte cache (`diskCache(null)` is an intentional privacy choice).
- The full image actually downloads in **~150 ms** — *faster* than the thumbnail endpoint (~512 ms). So the residual wasn't a download problem; it was a **CPU-bound ~308 ms JPEG decode** on an older device.

## What changed

**1. `FullPayloadByteCache`** — bounded in-memory LRU of decrypted full-payload bytes with in-flight **request coalescing**. Collapses the 4× redundant fetch+decrypt to **1×** and is the substrate for prefetch. RAM-only by design (matches `diskCache(null)`); cleared from the Storage **"Clear cache"** action **and on logout/account-switch**.

**2. Decoded-bitmap prefetch on press** — `fullScreenImageRequest` pins the base decode to the **window size**; the viewer and the press-time prefetch share that one request → one Coil memory-cache key → a cold open **hits the already-decoded bitmap** instead of decoding the 6 MB JPEG again. `rememberFullScreenImagePrefetch()` encapsulates the loader + context + window so the Vault grid and chat photos share one implementation. Wired into **both** the Vault grid (`VaultEntryCard`) and the **chat fullscreen viewer** (`MediaItem`).

**3. Cross-fade** — the sharp image fades in over the placeholder so any residual decode reads as a focus-pull rather than a pop. Remote-only (local originals have nothing beneath them, so they show at full opacity). `Modifier.blur` is API 31+, so a blur-up isn't available on older devices — a cross-fade is.

> Note on layering: bitmap-prefetch is a Coil-cache operation, so it lives at the Coil layer (an `ImageLoader` extension + the shared request), not on `HomebaseImageLoader` — that class still does all the fetch/decrypt/byte-cache work and the prefetch flows through it via the fetcher. Putting Coil *into* `HomebaseImageLoader` would form a DI cycle (the Coil `ImageLoader` is built from `HomebaseImageFetcher`, which already depends on `HomebaseImageLoader`).

## Measured on device (Redmi Note 5 Pro, API 30)

| | before | after |
|---|---|---|
| payload loads per open | 4× | **1×** |
| **cold** first open → sharp | ~308 ms hard snap | **~37 ms** |
| reopen → sharp | — | **~10 ms** |
| transition | low-res → snap | cross-fade focus-pull |

## Graceful degradation (every network condition)

Instant floor (embedded preview / grid thumb) → screen-res → full, climbing as data arrives. If the prefetch hasn't finished (slow/offline) you never drop below prior behavior; the thumbnail tier still helps on slow networks; offline/pending shows the existing placeholder/error UI.

## Security / resources

- RAM-only, never written to disk; holds strictly less data than the decoded bitmaps Coil already keeps. Cleared on manual clear **and logout** (so an outgoing identity's decrypted bytes don't linger — same rationale as the existing Coil clear).
- Prefetch is **press-triggered only** (not speculative over the whole grid), so it decrypts/decodes only images you're about to open.
- Net CPU/network **down** (4× → 1× decode+fetch); byte budget bounded (48 MB compressed).

## Tests

`FullPayloadByteCacheTest` (commonTest/JVM): cache hit, concurrent coalescing, LRU eviction by byte budget, null-not-cached, failure-retry, oversized-not-retained, clear.

Compiles on JVM / Android / iOS-sim / wasmJs; `homebase-common:jvmTest` green.

## Out of scope (follow-up)

Double-tap **zoom** tile-decode smoothness is a separate subsystem (the subsampling region decoder). This PR already speeds its setup for free (the tiler's `loadFullPayload` now hits the byte cache), but tuning the tile decode itself is a focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
