### PR TITLE
fix(ios): configure Firebase before initializeApp so launch crashes are captured

### DIFF
--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -10,12 +10,20 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
   func application(_ application: UIApplication,
                    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
 
+      // Configure Firebase FIRST — before any heavy init. FirebaseApp.configure()
+      // is what arms Crashlytics' signal/Mach/NSException handlers; until it runs,
+      // nothing is captured. initializeApp() below starts Koin, file logging, and a
+      // runBlocking database open/migration, any of which can crash on launch for
+      // some users. Configuring first means those launch crashes get reported
+      // instead of vanishing. (Android gets this ordering for free via Firebase's
+      // auto-init ContentProvider, which runs before Application.onCreate; iOS has
+      // no such hook, so the order here is load-bearing.)
+      FirebaseApp.configure()
+
       // Run Koin, logging, and database init before any UI framework setup.
       // This keeps the main-thread run-loop free between heavy init and the
       // first Compose frame, preventing the iOS text-rendering race condition.
       MainViewControllerKt.initializeApp()
-
-      FirebaseApp.configure() //important
 
       //By default showPushNotification value is true.
       //When set showPushNotification to false foreground push  notification will not be shown.


### PR DESCRIPTION
## Problem

Users report the app **crashes on open and nothing is recorded** in Crashlytics on iOS.

Root cause is ordering in `iOSApp.swift`'s `didFinishLaunchingWithOptions`:

```swift
MainViewControllerKt.initializeApp()   // Koin + file logging + runBlocking DB open/migration
FirebaseApp.configure()                // arms Crashlytics handlers — runs AFTER
```

`FirebaseApp.configure()` is what installs Crashlytics' signal / Mach-exception / `NSException` handlers. `initializeApp()` runs Koin, file logging, and a `runBlocking` database open + migration — all of which can crash on launch for some users. Because the crash-prone init ran **before** the handlers were armed, those launch crashes happened with no reporter installed and vanished — exactly matching the user reports.

## Fix

Move `FirebaseApp.configure()` to the **top** of `didFinishLaunchingWithOptions`, before `initializeApp()`, so the handlers are armed before any heavy init runs.

Android already gets this ordering for free: Firebase's auto-init `ContentProvider` runs before `Application.onCreate`. iOS has no equivalent hook, so the order here is load-bearing.

## Relationship to `b4bae27a`

`b4bae27a` (*record Kotlin/Native crashes on iOS + log-trail bridge + test crash*) made the **content** of iOS crash reports far richer — Kotlin/Native `recordException`, a Kermit breadcrumb/non-fatal log trail, a dev-menu test crash. But it left this ordering untouched, so **launch-time** crashes (the ones during Koin/DB init) are still invisible because the handlers aren't armed yet when they fire. This PR closes that remaining gap; the two are complementary.

This is the one surviving piece of the now-closed #643 (whose bridge-enrichment work was superseded by `b4bae27a`).

## Scope

One file, ~3 effective lines moved. No behavior change to push/notification setup or the Compose text-rendering race the original comment guards (that concerns init running before the first Compose frame, which is unchanged).

## Verification

- [ ] Force a crash during `initializeApp()` on a device **without a debugger attached** (Crashlytics suppresses uploads while debugging), reopen, confirm the report appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)