### PR TITLE
feat(moments): declutter feed/detail — FAB lift, drop lock, move code…

### DIFF
--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -362,6 +362,7 @@
     <string name="moments_detail_menu_more">More options</string>
     <string name="moments_detail_menu_delete">Delete</string>
     <string name="moments_detail_menu_save_current">Save current</string>
+    <string name="moments_detail_menu_info">Info</string>
     <string name="moments_detail_menu_add_people">Add people</string>
     <string name="moments_add_people_title">Add people</string>
     <string name="moments_add_people_confirm">Add</string>
@@ -1054,7 +1055,7 @@
     <string name="dev_menu_trigger_test_crash">Trigger test crash</string>
     <string name="dev_menu_trigger_test_crash_description">Intentionally crashes the app right now to verify crash reporting. The app will close immediately — reopen it afterward to let the crash report upload to Crashlytics.</string>
     <string name="dev_menu_crash_confirm_title">Crash the app?</string>
-    <string name="dev_menu_crash_confirm_message">This will intentionally crash the app immediately to test Crashlytics. You\'ll need to reopen the app afterward.</string>
+    <string name="dev_menu_crash_confirm_message">This will intentionally crash the app immediately to test Crashlytics. You'll need to reopen the app afterward.</string>
     <string name="dev_menu_crash_confirm_action">Crash now</string>
 
     <!-- Video debug info overlay (long-press the MP4/HLS tag) -->
@@ -1070,6 +1071,12 @@
     <string name="video_info_unknown">—</string>
     <string name="video_info_yes">Yes</string>
     <string name="video_info_no">No</string>
+
+    <!-- Image info overlay (shown from the moment overflow "Info" menu item) -->
+    <string name="image_info_title">Image info</string>
+    <string name="image_info_type">Type: %1$s</string>
+    <string name="image_info_dimensions">Dimensions: %1$s (approx.)</string>
+    <string name="image_info_date">Date: %1$s</string>
 
     <!-- Defragmenter issue labels -->
     <string name="defragmenter_issue_legacy_user_date">Legacy userDate=0</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/common/widget/ImageInfoOverlay.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/common/widget/ImageInfoOverlay.kt
@@ -1,0 +1,94 @@
+package id.homebase.common.widget
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import id.homebase.api.client.drives.files.PayloadDescriptor
+import id.homebase.common.util.formatBytes
+import id.homebase.core.util.formateDateTime
+import id.homebase.resources.MR
+import id.homebase.resources.image_info_date
+import id.homebase.resources.image_info_dimensions
+import id.homebase.resources.image_info_title
+import id.homebase.resources.image_info_type
+import id.homebase.resources.video_info_size
+import id.homebase.resources.video_info_unknown
+import kotlin.time.Instant
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Info panel for an image payload, mirroring [VideoInfoOverlay]. Shown from the
+ * moment overflow "Info" menu item when the on-screen item is an image.
+ *
+ * Unlike video, images carry no rich [id.homebase.api.client.drives.files.DescriptorContent]
+ * (there is no `ImageFile`), so the values come straight off the
+ * [PayloadDescriptor]: content type, size, and last-modified date. The original
+ * pixel dimensions aren't stored, so the resolution line is derived from the
+ * largest stored thumbnail and explicitly labelled approximate; it's omitted
+ * entirely when no thumbnail dimensions are available.
+ */
+@Composable
+fun ImageInfoOverlay(
+    payload: PayloadDescriptor,
+    modifier: Modifier = Modifier,
+) {
+    val unknown = stringResource(MR.string.video_info_unknown)
+
+    val typeVal = payload.contentType
+        ?.substringAfterLast('/')
+        ?.uppercase()
+        ?: unknown
+    val sizeVal = payload.bytesWritten?.takeIf { it > 0 }?.let { formatBytes(it) } ?: unknown
+    val dateVal = payload.lastModified
+        ?.let { formateDateTime(Instant.fromEpochMilliseconds(it)) }
+        ?: unknown
+
+    // Best-effort resolution: the largest thumbnail we have. Not the original
+    // image's true pixel size, hence the "(approx.)" label on the string.
+    val largestThumb = payload.thumbnails
+        ?.filter { (it.pixelWidth ?: 0) > 0 && (it.pixelHeight ?: 0) > 0 }
+        ?.maxByOrNull { (it.pixelWidth ?: 0) * (it.pixelHeight ?: 0) }
+    val dimensionsVal = largestThumb?.let { "${it.pixelWidth}×${it.pixelHeight}" }
+
+    val lines = buildList {
+        add(stringResource(MR.string.image_info_type, typeVal))
+        if (dimensionsVal != null) {
+            add(stringResource(MR.string.image_info_dimensions, dimensionsVal))
+        }
+        add(stringResource(MR.string.video_info_size, sizeVal))
+        add(stringResource(MR.string.image_info_date, dateVal))
+    }
+    val title = stringResource(MR.string.image_info_title)
+    val body = lines.joinToString("\n")
+
+    Box(
+        modifier = modifier.background(Color.Black.copy(alpha = 0.78f)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Text(
+                text = title,
+                color = Color.White,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = body,
+                color = Color.White,
+                fontSize = 11.sp,
+            )
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
@@ -98,6 +99,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
@@ -107,6 +109,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import co.touchlab.kermit.Logger
 import coil3.compose.AsyncImage
+import id.homebase.api.client.drives.files.DescriptorContent
 import id.homebase.api.common.OdinId
 import id.homebase.chat.conversationlist.FullScreenOverlay
 import id.homebase.chat.services.ChatDeliveryStatus
@@ -122,6 +125,8 @@ import id.homebase.core.moments.services.MomentCommentItem
 import id.homebase.core.moments.services.MomentFeedItem
 import id.homebase.core.moments.services.MomentsFeedService
 import id.homebase.core.moments.services.MomentsVideoSession
+import id.homebase.common.widget.ImageInfoOverlay
+import id.homebase.common.widget.VideoInfoOverlay
 import id.homebase.core.ui.screens.moments.widget.MomentDatePill
 import id.homebase.core.ui.screens.moments.widget.MomentInlineVideoTile
 import id.homebase.core.ui.screens.moments.widget.MomentMediaItem
@@ -156,6 +161,7 @@ import id.homebase.resources.moments_detail_comments_section
 import id.homebase.resources.moments_detail_delete_comment_dialog_title
 import id.homebase.resources.moments_detail_delete_dialog_title
 import id.homebase.resources.moments_detail_menu_delete
+import id.homebase.resources.moments_detail_menu_info
 import id.homebase.resources.moments_detail_menu_more
 import id.homebase.resources.moments_detail_menu_save_current
 import id.homebase.resources.moments_detail_description_hint
@@ -633,6 +639,12 @@ private fun DetailContent(
     // moments (nothing to save → the menu item hides).
     var visiblePayloadKey by remember { mutableStateOf<String?>(null) }
 
+    // Toggled by the overflow "Info" item — shows a technical-info panel over
+    // the media for the payload currently on screen (video → codec panel,
+    // image → image-info panel). Replaces the old long-press-the-badge debug
+    // affordance that used to live on the MP4/HLS tag.
+    var showCurrentInfo by remember { mutableStateOf(false) }
+
     Scaffold(
         // Black so the letterbox bars around a Fit-scaled image or video
         // read as part of the cinematic surface rather than the surface
@@ -691,6 +703,10 @@ private fun DetailContent(
                                     onAction(MomentDetailUiAction.SaveMedia(it))
                                 }
                             },
+                            // Same condition as Save — there's an on-screen
+                            // payload to describe. Opens the info overlay below.
+                            showInfo = visiblePayloadKey != null,
+                            onInfoClick = { showCurrentInfo = true },
                             // Author-only: only the original author can widen
                             // the audience of a moment.
                             showAddPeople = uiState.isMine,
@@ -734,21 +750,61 @@ private fun DetailContent(
                 if (uiState.isLoading) CircularProgressIndicator(color = Color.White)
             }
         } else {
-            MomentDetailContent(
-                uiState = uiState,
-                moment = moment,
-                initialPayloadKey = uiState.initialPayloadKey,
-                onAction = onAction,
-                onOpenComments = { showCommentsSheet = true },
-                onVisiblePayloadChanged = { visiblePayloadKey = it },
-                commentsOpen = commentsShrinkActive,
-                sharedTransitionScope = sharedTransitionScope,
-                animatedVisibilityScope = animatedVisibilityScope,
-                isActivePage = isActivePage,
+            Box(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(contentPadding),
-            )
+            ) {
+                MomentDetailContent(
+                    uiState = uiState,
+                    moment = moment,
+                    initialPayloadKey = uiState.initialPayloadKey,
+                    onAction = onAction,
+                    onOpenComments = { showCommentsSheet = true },
+                    onVisiblePayloadChanged = { visiblePayloadKey = it },
+                    commentsOpen = commentsShrinkActive,
+                    sharedTransitionScope = sharedTransitionScope,
+                    animatedVisibilityScope = animatedVisibilityScope,
+                    isActivePage = isActivePage,
+                    modifier = Modifier.fillMaxSize(),
+                )
+                // Technical-info overlay for the on-screen payload, opened from
+                // the overflow "Info" item. Looks up the current payload by the
+                // key the inner pager reports up, then routes to the video codec
+                // panel or the image-info panel. Tap anywhere to dismiss.
+                val infoPayload = remember(showCurrentInfo, visiblePayloadKey, moment.payloads) {
+                    if (!showCurrentInfo) null
+                    else visiblePayloadKey?.let { key ->
+                        moment.payloads.firstOrNull { it.keyEquals(key) }
+                    }
+                }
+                if (infoPayload != null) {
+                    val dismissModifier = Modifier
+                        .matchParentSize()
+                        .pointerInput(Unit) {
+                            detectTapGestures(
+                                onTap = { showCurrentInfo = false },
+                                onLongPress = { showCurrentInfo = false },
+                            )
+                        }
+                    val isVideo = infoPayload.contentType?.startsWith("video/") == true ||
+                        infoPayload.contentType == "application/vnd.apple.mpegurl"
+                    if (isVideo) {
+                        val videoDescriptor =
+                            infoPayload.descriptorInfo() as? DescriptorContent.VideoFile
+                        VideoInfoOverlay(
+                            descriptor = videoDescriptor,
+                            isHls = videoDescriptor?.isSegmented == true,
+                            modifier = dismissModifier,
+                        )
+                    } else {
+                        ImageInfoOverlay(
+                            payload = infoPayload,
+                            modifier = dismissModifier,
+                        )
+                    }
+                }
+            }
         }
     }
 
@@ -838,6 +894,8 @@ private fun MomentOverflowMenu(
     isSaving: Boolean,
     showSave: Boolean,
     onSaveClick: () -> Unit,
+    showInfo: Boolean,
+    onInfoClick: () -> Unit,
     showAddPeople: Boolean,
     onAddPeopleClick: () -> Unit,
     onDeleteClick: () -> Unit,
@@ -877,6 +935,15 @@ private fun MomentOverflowMenu(
                     onClick = {
                         expanded = false
                         onSaveClick()
+                    },
+                )
+            }
+            if (showInfo) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(MR.string.moments_detail_menu_info)) },
+                    onClick = {
+                        expanded = false
+                        onInfoClick()
                     },
                 )
             }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.outlined.AutoAwesome
-import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.PhotoAlbum
 import androidx.compose.material.icons.outlined.Slideshow
 import androidx.compose.material.icons.outlined.ViewAgenda
@@ -275,7 +274,12 @@ private fun CompactMomentsLayout(
             )
         },
         floatingActionButton = {
-            FloatingActionButton(onClick = onCreateMoment) {
+            FloatingActionButton(
+                onClick = onCreateMoment,
+                // Lifted off the bottom edge a touch so it doesn't sit on top
+                // of whatever's at the bottom of the content under it.
+                modifier = Modifier.padding(bottom = 16.dp),
+            ) {
                 Icon(
                     imageVector = Icons.Default.Add,
                     contentDescription = stringResource(MR.string.moments_create_action),
@@ -377,7 +381,12 @@ private fun WideMomentsLayout(
                 )
             },
             floatingActionButton = {
-                FloatingActionButton(onClick = onCreateMoment) {
+                FloatingActionButton(
+                    onClick = onCreateMoment,
+                    // Lifted off the bottom edge a touch so it doesn't sit on
+                    // top of whatever's at the bottom of the content under it.
+                    modifier = Modifier.padding(bottom = 16.dp),
+                ) {
                     Icon(
                         imageVector = Icons.Default.Add,
                         contentDescription = stringResource(MR.string.moments_create_action),
@@ -439,7 +448,12 @@ private fun WideMomentsLayout(
                 )
             },
             floatingActionButton = {
-                FloatingActionButton(onClick = onCreateMoment) {
+                FloatingActionButton(
+                    onClick = onCreateMoment,
+                    // Lifted off the bottom edge a touch so it doesn't sit on
+                    // top of whatever's at the bottom of the content under it.
+                    modifier = Modifier.padding(bottom = 16.dp),
+                ) {
                     Icon(
                         imageVector = Icons.Default.Add,
                         contentDescription = stringResource(MR.string.moments_create_action),
@@ -1237,28 +1251,6 @@ private fun MomentPostCard(
             }
         }
 
-        // Bottom-right: lock indicator for a private moment (no recipients) —
-        // absence implies shared, which is the common case. On a video moment
-        // the duration chip now also sits bottom-right (see
-        // MomentInlineVideoTile), so lift the lock above it; images have no
-        // duration chip and keep the snug 8.dp corner inset.
-        if (moment.isPrivate(selfOdinId)) {
-            val hasVideo = moment.payloads.any { p ->
-                p.contentType?.startsWith("video/") == true ||
-                    p.contentType == "application/vnd.apple.mpegurl"
-            }
-            Box(
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .padding(end = 8.dp, bottom = if (hasVideo) 36.dp else 8.dp),
-            ) {
-                IndicatorBadge(
-                    imageVector = Icons.Outlined.Lock,
-                    contentDescription = stringResource(MR.string.moments_feed_indicator_private),
-                )
-            }
-        }
-
         // Floating-emoji overlay: pops + fades in when a double/triple-tap
         // lands a reaction, then fades back out via [floatingEmojiHideJob].
         // Sits centered on the card so the user sees clear confirmation that
@@ -1530,27 +1522,6 @@ private fun MomentsViewModeMenuItem(
         },
         onClick = onClick,
     )
-}
-
-@Composable
-private fun IndicatorBadge(
-    imageVector: ImageVector,
-    contentDescription: String? = null,
-) {
-    Box(
-        modifier = Modifier
-            .size(28.dp)
-            .clip(CircleShape)
-            .background(Color.Black.copy(alpha = 0.45f)),
-        contentAlignment = Alignment.Center,
-    ) {
-        Icon(
-            imageVector = imageVector,
-            contentDescription = contentDescription,
-            tint = Color.White,
-            modifier = Modifier.size(16.dp),
-        )
-    }
 }
 
 internal const val HeartEmoji = "❤️"

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentInlineVideoTile.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentInlineVideoTile.kt
@@ -58,7 +58,6 @@ import id.homebase.api.video.VideoPlayerData
 import id.homebase.chat.conversationlist.FullScreenOverlay
 import id.homebase.chat.services.LocalAttachmentContext
 import id.homebase.chat.widget.video.VideoPlayerSurface
-import id.homebase.common.widget.VideoInfoOverlay
 import id.homebase.core.image.HomebaseImage
 import id.homebase.core.moments.services.MomentsVideoSession
 import org.koin.compose.koinInject
@@ -213,11 +212,6 @@ fun MomentInlineVideoTile(
     }
 
     val isButtonOnly = tapMode == MomentVideoTapMode.ButtonOnly
-
-    // Hidden debug overlay: long-press the MP4/HLS badge to toggle the codec-info
-    // panel; long-press again (or tap) to dismiss. Reachable while the tile is
-    // idle (the badge is hidden during playback).
-    var showVideoInfo by remember(fileId, payload.key) { mutableStateOf(false) }
 
     // Effective crop-to-fill decision for both the player surface and the
     // thumbnail underlay. Preserves the prior behaviour — inline tiles
@@ -603,23 +597,6 @@ fun MomentInlineVideoTile(
                     tint = Color.White.copy(alpha = 0.85f),
                 )
             }
-            // Top-right: codec badge. Moved off the top-left so the feed card's
-            // author avatar can own that corner; long-press still opens the
-            // video-info overlay.
-            Text(
-                text = if (isHls) "HLS" else "MP4",
-                color = Color.White,
-                fontSize = 9.sp,
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .background(Color.Black.copy(alpha = 0.5f), RoundedCornerShape(2.dp))
-                    .padding(horizontal = 3.dp, vertical = 1.dp)
-                    .pointerInput(Unit) {
-                        detectTapGestures(
-                            onLongPress = { showVideoInfo = !showVideoInfo },
-                        )
-                    },
-            )
             // Bottom-right: duration. Moved off the bottom-left so the feed
             // card's capture-date pill can own that corner.
             if (displayDurationMs != null) {
@@ -637,21 +614,6 @@ fun MomentInlineVideoTile(
                         .padding(horizontal = 6.dp, vertical = 2.dp),
                 )
             }
-        }
-
-        if (showVideoInfo && !isUploading) {
-            VideoInfoOverlay(
-                descriptor = videoDescriptor,
-                isHls = isHls,
-                modifier = Modifier
-                    .matchParentSize()
-                    .pointerInput(Unit) {
-                        detectTapGestures(
-                            onTap = { showVideoInfo = false },
-                            onLongPress = { showVideoInfo = false },
-                        )
-                    },
-            )
         }
 
         // Preload progress only meaningful while idle; once the user has

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaItem.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaItem.kt
@@ -56,7 +56,6 @@ import id.homebase.chat.services.builder.LocationPreviewDescriptor
 import id.homebase.chat.widget.DocumentMediaItem
 import id.homebase.chat.widget.LinkPreviewCard
 import id.homebase.chat.widget.LocationPreviewCard
-import id.homebase.common.widget.VideoInfoOverlay
 import id.homebase.core.HomebaseConstants
 import id.homebase.core.image.HomebaseImage
 import id.homebase.core.image.HomebaseImageData
@@ -301,12 +300,8 @@ fun MomentMediaItem(
                 val videoDescriptor = remember(payload.descriptorContent) {
                     payload.descriptorInfo() as? DescriptorContent.VideoFile
                 }
-                val isHls = videoDescriptor?.isSegmented == true
                 var isPreloading by remember(fileId, payload.key) { mutableStateOf(false) }
                 var preloadProgress by remember(fileId, payload.key) { mutableFloatStateOf(0f) }
-                // Hidden debug overlay: long-press the MP4/HLS tag to toggle the
-                // codec-info panel; long-press again (or tap) to dismiss.
-                var showVideoInfo by remember(fileId, payload.key) { mutableStateOf(false) }
                 if (!isUploading) {
                     VideoPreloadEffect(
                         data = videoPlayerData,
@@ -382,20 +377,6 @@ fun MomentMediaItem(
                                 .align(Alignment.Center),
                             tint = Color.White.copy(alpha = 0.85f)
                         )
-                        Text(
-                            text = if (isHls) "HLS" else "MP4",
-                            color = Color.White,
-                            fontSize = 9.sp,
-                            modifier = Modifier
-                                .align(Alignment.TopStart)
-                                .background(Color.Black.copy(alpha = 0.5f), RoundedCornerShape(2.dp))
-                                .padding(horizontal = 3.dp, vertical = 1.dp)
-                                .pointerInput(Unit) {
-                                    detectTapGestures(
-                                        onLongPress = { showVideoInfo = !showVideoInfo },
-                                    )
-                                },
-                        )
                         if (displayDurationMs != null) {
                             Text(
                                 text = formatDurationLabel(displayDurationMs),
@@ -411,20 +392,6 @@ fun MomentMediaItem(
                                     .padding(horizontal = 6.dp, vertical = 2.dp),
                             )
                         }
-                    }
-                    if (showVideoInfo && !isUploading) {
-                        VideoInfoOverlay(
-                            descriptor = videoDescriptor,
-                            isHls = isHls,
-                            modifier = Modifier
-                                .matchParentSize()
-                                .pointerInput(Unit) {
-                                    detectTapGestures(
-                                        onTap = { showVideoInfo = false },
-                                        onLongPress = { showVideoInfo = false },
-                                    )
-                                },
-                        )
                     }
                     if (isPreloading && !isUploading) {
                         Box(


### PR DESCRIPTION
…c info to menu

- Lift the create-moment FAB off the bottom edge (16dp) across all three view modes so it stops covering content beneath it.
- Remove the private-moment lock badge from feed cards (and its now-orphaned IndicatorBadge helper).
- Replace the hidden long-press MP4/HLS codec badge on feed tiles and the detail viewer with a context-aware "Info" item in the detail overflow menu: it shows VideoInfoOverlay for a video or a new ImageInfoOverlay for an image, acting on the payload currently on screen. ImageInfoOverlay reports type, approximate dimensions (largest thumbnail), size, and date — images carry no rich descriptor, so resolution is best-effort and labelled approx.