### PR TITLE
Remove grabThumbnail from FFmpegUtils expect; delete dead android/web actuals

### DIFF
--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/video/FFmpegUtils.android.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/video/FFmpegUtils.android.kt
@@ -78,26 +78,11 @@ actual object FFmpegUtils {
         return UUID.nameUUIDFromBytes("${file.name}_${file.length()}".toByteArray()).toString()
     }
 
-    actual suspend fun grabThumbnail(inputPath: String): String? =
-        withContext(Dispatchers.IO) {
-            val context = ActivityProvider.requireApplicationContext()
-            val uniqueId = getUniqueId(inputPath)
-            val outputFile = File(context.cacheDir, "thumb-$uniqueId.jpg")
-            if (outputFile.exists() && outputFile.length() > 0L) {
-                return@withContext outputFile.absolutePath
-            }
-
-            // Delegate to the platform-native poster-frame extractor. Same
-            // MediaMetadataRetriever + content-resolver fallbacks that the
-            // scrubber preview uses; works for both file paths and content://
-            // URIs, and avoids the FFmpegKit JNI surface entirely (the v7
-            // upgrade aborted on HLS-remuxed MP4 inputs here, see homebase.log
-            // tombstone from 2026-05-17).
-            val bytes = VideoThumbnailService.extractPosterFrame(inputPath)
-                ?: return@withContext null
-            outputFile.writeBytes(bytes)
-            outputFile.absolutePath
-        }
+    // No `grabThumbnail` actual: Android's thumbnail decoder is MediaMetadataRetriever-backed
+    // (platformFfmpegDecoder() == null), so nothing on this platform needs the ffmpeg poster
+    // helper. Poster frames go through VideoThumbnailService.extractPosterFrame. grabThumbnail
+    // is no longer in the FFmpegUtils expect — it survives only as a JVM/native-internal helper
+    // for the two platforms whose thumbnail decoder is ffmpeg-backed.
 
     actual suspend fun getRotationFromFile(filePath: String): Int =
         withContext(Dispatchers.IO) {

--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/video/FFmpegUtils.android.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/video/FFmpegUtils.android.kt
@@ -78,11 +78,17 @@ actual object FFmpegUtils {
         return UUID.nameUUIDFromBytes("${file.name}_${file.length()}".toByteArray()).toString()
     }
 
-    // No `grabThumbnail` actual: Android's thumbnail decoder is MediaMetadataRetriever-backed
-    // (platformFfmpegDecoder() == null), so nothing on this platform needs the ffmpeg poster
-    // helper. Poster frames go through VideoThumbnailService.extractPosterFrame. grabThumbnail
-    // is no longer in the FFmpegUtils expect — it survives only as a JVM/native-internal helper
-    // for the two platforms whose thumbnail decoder is ffmpeg-backed.
+    // No `grabThumbnail` actual: Android's thumbnail decoder is *currently*
+    // MediaMetadataRetriever-backed (platformFfmpegDecoder() == null), so nothing on this
+    // platform calls the ffmpeg poster helper today, and grabThumbnail is no longer in the
+    // FFmpegUtils expect. Poster frames go through VideoThumbnailService.extractPosterFrame.
+    //
+    // An Android ffmpeg fallback is still possible: add a VideoDecoder that drives FFmpegKit
+    // (directly, as the compressVideo path below already does, or via a re-added Android-internal
+    // grabThumbnail mirroring the JVM/native helpers) and return it from platformFfmpegDecoder().
+    // If you do, that decoder MUST serialize its ffmpeg_execute against compress/segment: Android's
+    // FFmpegKit is the same non-reentrant engine that SIGSEGV'd on iOS when two sessions overlapped
+    // (PR #644). Today the MediaMetadataRetriever path is the only reason Android can't hit that.
 
     actual suspend fun getRotationFromFile(filePath: String): Int =
         withContext(Dispatchers.IO) {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/FFmpegUtils.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/FFmpegUtils.kt
@@ -21,8 +21,6 @@ data class VideoTrackInfo(
 expect object FFmpegUtils {
     fun getUniqueId(filePath: String): String
 
-    suspend fun grabThumbnail(inputPath: String): String?
-
     suspend fun getRotationFromFile(filePath: String): Int
 
     /**

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/LowLevelFfmpegApi.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/LowLevelFfmpegApi.kt
@@ -12,8 +12,8 @@ package id.homebase.api.video
  * Calling [FFmpegUtils] directly is reserved for:
  * - the seam implementations themselves ([FFmpegVideoCompressor], [FFmpegVideoProber],
  *   and the thumbnail decoders) that delegate to it;
- * - the small set of helpers with no seam equivalent (`grabThumbnail`,
- *   `getRotationFromFile`, `getUniqueId`, `generateHlsKeyInfoFile`);
+ * - the small set of helpers with no seam equivalent (`getRotationFromFile`,
+ *   `getUniqueId`, `generateHlsKeyInfoFile`);
  * - backend integration tests that deliberately exercise the real ffmpeg per platform.
  *
  * Each such site opts in explicitly with `@OptIn(LowLevelFfmpegApi::class)`, so any *new,

--- a/homebase-api/src/jvmMain/java/id/homebase/api/video/FFmpegUtils.jvm.kt
+++ b/homebase-api/src/jvmMain/java/id/homebase/api/video/FFmpegUtils.jvm.kt
@@ -48,7 +48,15 @@ actual object FFmpegUtils {
         return UUID.nameUUIDFromBytes("${file.name}_${file.length()}".toByteArray()).toString()
     }
 
-    actual suspend fun grabThumbnail(inputPath: String): String? =
+    /**
+     * Platform-internal ffmpeg poster-frame helper for the JVM fallback decoder
+     * ([FFmpegSubprocessVideoDecoder]) and its backend coverage test. NOT part of the
+     * [FFmpegUtils] `expect` contract — the cross-platform seam for poster frames is
+     * [VideoThumbnailService.extractPosterFrame]. It survives only on the JVM/native actuals
+     * because those are the two platforms whose thumbnail decoder is ffmpeg-backed. ffmpeg
+     * low-level must never call back up into the `VideoSomething` services.
+     */
+    suspend fun grabThumbnail(inputPath: String): String? =
         withContext(Dispatchers.IO) {
             if (!FFmpegBinaryManager.isAvailable()) {
                 println("FFmpeg binaries not available for this platform")

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/video/FFmpegUtils.native.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/video/FFmpegUtils.native.kt
@@ -66,7 +66,15 @@ actual object FFmpegUtils {
         return "${fileName}_${fileSize}".hashCode().toString()
     }
 
-    actual suspend fun grabThumbnail(inputPath: String): String? =
+    /**
+     * Platform-internal ffmpeg poster-frame helper for the iOS fallback decoder
+     * ([FFmpegKitVideoDecoder]). NOT part of the [FFmpegUtils] `expect` contract — the
+     * cross-platform seam for poster frames is [VideoThumbnailService.extractPosterFrame]. It
+     * survives only on the JVM/native actuals because those are the two platforms whose
+     * thumbnail decoder is ffmpeg-backed. ffmpeg low-level must never call back up into the
+     * `VideoSomething` services.
+     */
+    suspend fun grabThumbnail(inputPath: String): String? =
             withContext(Dispatchers.IO) {
                 val fileManager = NSFileManager.defaultManager
 

--- a/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/video/FFmpegUtils.web.kt
+++ b/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/video/FFmpegUtils.web.kt
@@ -35,18 +35,10 @@ actual object FFmpegUtils {
 
     actual fun getUniqueId(filePath: String): String = filePath
 
-    actual suspend fun grabThumbnail(inputPath: String): String? {
-        val safe = inputPath.substringAfterLast('/').ifBlank { "video" }
-        val thumbPath = "$CACHE_DIR/thumb-$safe.jpg"
-        val existing = thumbPath.toPath()
-        if (systemFileSystem.exists(existing) &&
-            (systemFileSystem.metadataOrNull(existing)?.size ?: 0L) > 0L
-        ) {
-            return thumbPath
-        }
-        val jpeg = VideoThumbnailService.extractPosterFrame(inputPath) ?: return null
-        return writeCacheBytes("thumb-$safe.jpg", jpeg)
-    }
+    // No `grabThumbnail` actual: web poster frames go through VideoThumbnailService
+    // (<video>+<canvas> primary, ffmpeg.wasm fallback). grabThumbnail is no longer in the
+    // FFmpegUtils expect — it survives only as a JVM/native-internal helper for the two
+    // platforms whose thumbnail decoder is ffmpeg-backed.
 
     actual suspend fun getRotationFromFile(filePath: String): Int {
         val bytes = readOkioBytes(filePath) ?: return 0


### PR DESCRIPTION
## Summary

`FFmpegUtils.grabThumbnail` was declared on the `expect object FFmpegUtils`, implying a cross-platform low-level API. In practice it is only called by the **JVM** and **native** ffmpeg-backed fallback decoders (`FFmpegSubprocessVideoDecoder`, `FFmpegKitVideoDecoder`), and always from platform code — never from common.

The **android** and **web** actuals had **no caller at all** and implemented the method by calling **up** into `VideoThumbnailService.extractPosterFrame()` — inverting the intended layering. The whole point of `@LowLevelFfmpegApi` is that the low-level ffmpeg backend is hidden behind the `VideoCompressionService` / `VideoThumbnailService` seams and is only used by those seams and by tests; a low-level helper calling back up into the seam is exactly the inversion that annotation exists to prevent. It was dead, confusing code that costs real time to untangle.

## Changes

- Remove `grabThumbnail` from the `expect object FFmpegUtils` contract.
- **JVM / native:** keep `grabThumbnail` on the actual objects as a plain (non-`expect`) platform-internal helper for their ffmpeg-backed decoders. Added KDoc stating it is *not* part of the expect contract, that the cross-platform seam for poster frames is `VideoThumbnailService.extractPosterFrame`, and that ffmpeg low-level must never call up into the `VideoSomething` services. (An `actual object` may carry members beyond the `expect`, so common code can no longer reach it while the two platforms that need it keep it.)
- **Android / web:** delete the unused, inverting actuals entirely; replace each with a short comment explaining why no actual exists (their thumbnail decoders are MediaMetadataRetriever- / `<canvas>`-backed).
- `LowLevelFfmpegApi`: drop the now-stale claim that `grabThumbnail` has "no seam equivalent" — `extractPosterFrame` *is* its equivalent.

## Behavior

No behavior change. The surviving JVM/native bodies are untouched; common code never called `grabThumbnail`; the deleted android/web actuals had no callers (production or test).

## Verification

- `:homebase-api:compileKotlinJvm`, `:homebase-api:compileAndroidMain`, `:homebase-api:compileKotlinWasmJs` — green
- `:homebase-chat:compileTestKotlinJvm` — green (confirms the JVM test's `FFmpegUtils.grabThumbnail` call still resolves as a non-`expect` member)
- `:homebase-chat:jvmTest --tests *FFmpegPipelineCoverageJvmTest*` — passes (it invokes `grabThumbnail` at runtime)
- ⚠️ iOS/native **not** compiled locally — this Linux host can't cross-compile the `ffmpegkit` cinterop. The native change is only dropping the `actual` keyword + adding KDoc; **the CI iOS build is the real check here.**

## Context

Spun out of an analysis of #644 (the iOS concurrent-FFmpegKit crash). This is the orthogonal layering cleanup that analysis surfaced; it does not touch the concurrency behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)