### PR TITLE
feat(sync): per-drive fresh-sync policy (sync-back window + initial queries)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
@@ -37,6 +37,7 @@ class DriveSync(
     private val eventBus: EventBus,
     scope: CoroutineScope? = null,
     expectFreshCursor: Boolean = false,
+    private val policy: DriveSyncPolicy = DriveSyncPolicy(),
 ) {
     // Background work is Network and DB bound, so using IO
     private val scope = scope ?: CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -125,6 +126,29 @@ class DriveSync(
         var pendingDbJob: Deferred<Unit>? = null
 
         eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
+
+        // Snapshot fresh-sync state BEFORE the windowed loop below mutates `cursor`.
+        // Fresh = first login or a discarded stale cursor (loadCursor returned null).
+        // Both policy knobs gate on this; re-reading the field later would be wrong
+        // because the first windowed batch overwrites `cursor`.
+        val isFreshSync = cursor == null
+        if (isFreshSync) {
+            // (a) Custom initial queries (e.g. the chat conversation list). These
+            //     persist NO cursor, so an interruption simply re-runs them on the
+            //     next fresh sync. totalCount carries forward so the windowed
+            //     Progress counts continue upward (DriveSyncManager's monotonic
+            //     `>= current.count` guard would otherwise swallow the first one).
+            totalCount = runInitialQueries(startCount = totalCount)
+
+            // (b) Seed the windowed crawl floor. fromStartPoint sets paging.time
+            //     only; OldestFirst makes the first page return rows changed after
+            //     the floor. Subsequent pages advance via the response cursorState.
+            policy.fullSyncWindow?.let { window ->
+                val floor = UnixTimeUtc().addMilliseconds(-window.inWholeMilliseconds)
+                cursor = QueryBatchCursor.fromStartPoint(floor)
+                Logger.i("DriveSync: fresh sync on $driveId seeded window floor=${floor.milliseconds}")
+            }
+        }
 
         var retryCount = 0
         val maxRetries = 3
@@ -269,5 +293,69 @@ class DriveSync(
             Logger.e("Sync failed due to DB error: ${e.message}")
             eventBus.emit(BackendEvent.DriveEvent.Stopped(driveId, totalCount, BackendEvent.DriveResult.Aborted(e.message ?: "DB upsert failed")))
         }
+    }
+
+    /**
+     * Runs each [DriveSyncPolicy.initialQueries] entry to completion (full
+     * pagination) at the start of a fresh sync, upserting results with
+     * `cursor = null` so the drive's persisted CursorStorage position is never
+     * touched. Returns the running total so the windowed crawl's Progress counts
+     * continue from here. Uses the same OldestFirst / AnyChangeDate ordering as the
+     * main crawl, paginating with a LOCAL cursor that's never saved.
+     *
+     * Best-effort: a query failure is logged and we fall through to the windowed
+     * crawl rather than aborting the whole round — a conversation-list hiccup must
+     * not block message sync. The next fresh sync re-runs these (idempotent
+     * upserts), so nothing is lost.
+     */
+    private suspend fun runInitialQueries(startCount: Int): Int {
+        if (policy.initialQueries.isEmpty()) return startCount
+        var runningTotal = startCount
+
+        for (queryParams in policy.initialQueries) {
+            var initialCursor: QueryBatchCursor? = null
+            while (true) {
+                val request = QueryBatchRequest(
+                    queryParams = queryParams,
+                    resultOptionsRequest = QueryBatchResultOptionsRequest(
+                        maxRecords = batchSize,
+                        includeMetadataHeader = true,
+                        cursorState = initialCursor?.toJson(),
+                        includeTransferHistory = true,
+                        ordering = QueryBatchSortOrder.OldestFirst,
+                        sorting = QueryBatchSortField.AnyChangeDate
+                    )
+                )
+
+                val response = try {
+                    killroy.value = false // Atomic
+                    driveQueryProvider.queryBatch(driveId, request)
+                } catch (e: Exception) {
+                    Logger.w("DriveSync: initial query on $driveId failed, continuing to windowed crawl: ${e.message}")
+                    return runningTotal
+                }
+
+                if (response.cursorState != null)
+                    initialCursor = QueryBatchCursor.fromJson(response.cursorState)
+
+                val results = response.searchResults
+                if (results.isNotEmpty()) {
+                    // cursor = null: do NOT clobber the windowed drive cursor —
+                    // performBaseUpsert persists any non-null cursor to CursorStorage.
+                    fileHeaderProcessor.baseUpsertEntryZapZap(
+                        identityId = identityId,
+                        driveId = driveId,
+                        fileHeaders = results,
+                        cursor = null
+                    )
+                    runningTotal += results.size
+                    eventBus.emit(BackendEvent.DriveEvent.Progress(driveId, runningTotal))
+                }
+
+                if (!response.hasMoreRows) break
+            }
+        }
+        Logger.i("DriveSync: initial queries done on $driveId, $runningTotal records")
+        return runningTotal
     }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
@@ -37,6 +37,12 @@ class DriveSyncManager(
     // valid (before the WebSocket handshake), so these drives appear in [driveStatuses]
     // independently of WS state.
     private val mandatoryDrives: Map<Uuid, String>,
+    // Per-drive fresh-sync overrides (sync-back window + initial queries), keyed by
+    // drive alias — same key space as [mandatoryDrives]. An absent key means the
+    // default policy (sync everything, no initial query). Assembled in
+    // homebase-core's AppModule where chat-specific fileTypes are visible; this layer
+    // stays drive-agnostic.
+    private val driveSyncPolicies: Map<Uuid, DriveSyncPolicy> = emptyMap(),
 ) {
     // Immutable map reference — always replaced, never mutated in-place, preventing CME.
     // All writes are serialized via driveSyncsMutex, which provides the happens-before
@@ -321,6 +327,7 @@ class DriveSyncManager(
                     eventBus = eventBus,
                     scope = scope,
                     expectFreshCursor = freshLogin,
+                    policy = driveSyncPolicies[driveId] ?: DriveSyncPolicy(),
                 )
             } catch (e: CancellationException) {
                 // Don't swallow cancellation — let the caller's scope tear down cleanly.

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncPolicy.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncPolicy.kt
@@ -1,0 +1,26 @@
+package id.homebase.api.sync
+
+import id.homebase.api.client.drives.query.FileQueryParams
+import kotlin.time.Duration
+
+/**
+ * Per-drive overrides for the FRESH-sync path (first login, or a discarded stale
+ * cursor — i.e. `cursor == null` when [DriveSync.performSync] starts). Both fields
+ * are inert on incremental syncs, where the saved cursor is resumed unchanged.
+ *
+ * @param fullSyncWindow How far back to crawl on a fresh sync. `null` (default) =
+ *   sync everything, the historical behavior. Applied by seeding the QueryBatch
+ *   paging cursor to `now - fullSyncWindow` before the main crawl loop; with the
+ *   crawl's `OldestFirst` / `AnyChangeDate` ordering the server then returns only
+ *   rows changed after that floor.
+ * @param initialQueries Custom queries run once, fully paginated, at the START of a
+ *   fresh sync — BEFORE the windowed crawl. Their results are upserted with
+ *   `cursor = null` so they NEVER advance the drive's persisted CursorStorage
+ *   position. The chat drive uses one entry (`fileType = [ConversationFileType]`)
+ *   to pull the complete conversation-file list even though messages are windowed
+ *   to [fullSyncWindow]. Empty (default) = no initial query.
+ */
+data class DriveSyncPolicy(
+    val fullSyncWindow: Duration? = null,
+    val initialQueries: List<FileQueryParams> = emptyList(),
+)

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncTest.kt
@@ -1,17 +1,26 @@
 package id.homebase.api.sync
 
+import id.homebase.api.client.CryptoHelper
 import id.homebase.api.client.auth.ApiCredentials
 import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.QueryBatchRequest
 import id.homebase.api.client.drives.query.DriveQueryProvider
+import id.homebase.api.client.drives.query.FileQueryParams
+import id.homebase.api.client.drives.query.QueryBatchCursor
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.common.OdinId
 import id.homebase.api.common.SecureByteArray
+import id.homebase.api.common.time.UnixTimeUtc
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.sync.database.CursorStorage
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.createInMemoryDatabase
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
+import io.ktor.client.request.HttpRequestData
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
@@ -19,12 +28,21 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.days
 import kotlin.uuid.Uuid
+
+private const val CONVERSATION_FILE_TYPE = 8888
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DriveSyncTest {
+
+    // All credentials in this test use a 16-byte zero shared secret; the MockEngine
+    // decrypts captured request bodies with it to inspect the QueryBatchRequest.
+    private val sharedSecret = ByteArray(16)
 
     private suspend fun buildSync(
         db: DatabaseManager,
@@ -32,13 +50,14 @@ class DriveSyncTest {
         eventBus: EventBus,
         scope: kotlinx.coroutines.CoroutineScope,
         driveId: Uuid,
+        policy: DriveSyncPolicy = DriveSyncPolicy(),
     ): DriveSync {
         val credentialsManager = CredentialsManager()
         credentialsManager.setActiveCredentials(
             ApiCredentials.create(
                 domain = OdinId("test.homebase.id"),
                 clientAccessToken = "fake-token",
-                sharedSecret = SecureByteArray(ByteArray(16))
+                sharedSecret = SecureByteArray(sharedSecret.copyOf())
             )
         )
         val httpClient = HttpClient(mockEngine)
@@ -50,7 +69,28 @@ class DriveSyncTest {
             databaseManager = db,
             eventBus = eventBus,
             scope = scope,
+            policy = policy,
         )
+    }
+
+    /** Decrypts a captured query-batch request body and parses it. */
+    private suspend fun parseRequest(request: HttpRequestData): QueryBatchRequest {
+        val envelope = request.body.toByteArray().decodeToString()
+        val json = CryptoHelper.decryptContentAsString(envelope, sharedSecret)
+        return OdinSystemSerializer.deserialize(json)
+    }
+
+    /** Plaintext query-batch response with no rows. Not an {iv,data} envelope, so the
+     *  client returns it as-is without attempting decryption. */
+    private fun emptyOkBody(): String =
+        """{"name":null,"invalidDrive":false,"queryTime":0,"includeMetadataHeader":false,""" +
+            """"cursorState":null,"searchResults":[],"hasMoreRows":false}"""
+
+    /** Same, but advertises another page and echoes [cursorState] so the caller paginates. */
+    private fun morePagesOkBody(cursorState: String): String {
+        val escaped = cursorState.replace("\\", "\\\\").replace("\"", "\\\"")
+        return """{"name":null,"invalidDrive":false,"queryTime":0,"includeMetadataHeader":false,""" +
+            """"cursorState":"$escaped","searchResults":[],"hasMoreRows":true}"""
     }
 
     @Test
@@ -117,6 +157,247 @@ class DriveSyncTest {
                 "A retry sync must not be triggered after 403 Forbidden"
             )
             collector.cancel()
+        }
+        db.close()
+    }
+
+    private fun chatPolicy() = DriveSyncPolicy(
+        fullSyncWindow = 60.days,
+        initialQueries = listOf(FileQueryParams(fileType = listOf(CONVERSATION_FILE_TYPE))),
+    )
+
+    private fun isConversationQuery(req: QueryBatchRequest) =
+        req.queryParams.fileType?.contains(CONVERSATION_FILE_TYPE) == true
+
+    private fun isWindowedCrawl(req: QueryBatchRequest) = req.queryParams.fileType == null
+
+    @Test
+    fun freshSyncRunsInitialQueryBeforeWindowedCrawl() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val driveId = Uuid.random()
+            val requests = mutableListOf<QueryBatchRequest>()
+            val mockEngine = MockEngine { request ->
+                requests.add(parseRequest(request))
+                respond(emptyOkBody(), HttpStatusCode.OK)
+            }
+            val sync = buildSync(db, mockEngine, eventBus, backgroundScope, driveId, chatPolicy())
+
+            val events = mutableListOf<BackendEvent>()
+            val collector = launch { eventBus.events.collect { events.add(it) } }
+
+            sync.sync()?.join()
+            runCurrent()
+
+            val firstConvIdx = requests.indexOfFirst { isConversationQuery(it) }
+            val firstWindowIdx = requests.indexOfFirst { isWindowedCrawl(it) }
+            assertTrue(firstConvIdx >= 0, "Expected a conversation-list (fileType=[8888]) query")
+            assertTrue(firstWindowIdx >= 0, "Expected a windowed (no fileType) crawl")
+            assertTrue(
+                firstConvIdx < firstWindowIdx,
+                "Conversation query must run BEFORE the windowed crawl (conv@$firstConvIdx, window@$firstWindowIdx)"
+            )
+            // The conversation query must not carry a cursor — it crawls from the start.
+            assertEquals(null, requests[firstConvIdx].resultOptionsRequest.cursorState)
+            assertTrue(
+                events.any {
+                    it is BackendEvent.DriveEvent.Stopped &&
+                        it.result is BackendEvent.DriveResult.Completed
+                },
+                "Expected a single Completed stop"
+            )
+            collector.cancel()
+        }
+        db.close()
+    }
+
+    @Test
+    fun freshSyncSeedsWindowCursorToSixtyDaysAgo() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val driveId = Uuid.random()
+            val requests = mutableListOf<QueryBatchRequest>()
+            val mockEngine = MockEngine { request ->
+                requests.add(parseRequest(request))
+                respond(emptyOkBody(), HttpStatusCode.OK)
+            }
+            val sync = buildSync(db, mockEngine, eventBus, backgroundScope, driveId, chatPolicy())
+
+            sync.sync()?.join()
+            runCurrent()
+
+            val windowed = requests.firstOrNull { isWindowedCrawl(it) }
+            assertNotNull(windowed, "Expected a windowed crawl request")
+            val cursorState = windowed.resultOptionsRequest.cursorState
+            assertNotNull(cursorState, "Windowed crawl must carry a seeded cursor")
+            val pagingTime = QueryBatchCursor.fromJson(cursorState).paging?.time?.milliseconds
+            assertNotNull(pagingTime, "Seeded cursor must have a paging time")
+            val expected = UnixTimeUtc().addDays(-60).milliseconds
+            // Wall-clock based; allow a few seconds of slack for test execution.
+            assertTrue(
+                kotlin.math.abs(pagingTime - expected) < 10_000,
+                "Window floor should be ~60 days ago (got $pagingTime, expected ~$expected)"
+            )
+        }
+        db.close()
+    }
+
+    @Test
+    fun initialQueryPaginatesAndDoesNotLeakCursorIntoWindowedCrawl() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val driveId = Uuid.random()
+            // A cursor the conversation query "advances" to on page 1; the windowed
+            // crawl must NOT resume from it — it must use the 60-day seed instead.
+            val leakedCursor = QueryBatchCursor.fromStartPoint(UnixTimeUtc(123_456L)).toJson()
+            val requests = mutableListOf<QueryBatchRequest>()
+            val mockEngine = MockEngine { request ->
+                val req = parseRequest(request)
+                requests.add(req)
+                when {
+                    // Conversation query: first page advertises another page, second ends.
+                    isConversationQuery(req) && req.resultOptionsRequest.cursorState == null ->
+                        respond(morePagesOkBody(leakedCursor), HttpStatusCode.OK)
+                    else -> respond(emptyOkBody(), HttpStatusCode.OK)
+                }
+            }
+            val sync = buildSync(db, mockEngine, eventBus, backgroundScope, driveId, chatPolicy())
+
+            sync.sync()?.join()
+            runCurrent()
+
+            val convRequests = requests.filter { isConversationQuery(it) }
+            assertTrue(convRequests.size >= 2, "Conversation query should have paginated (>=2 requests)")
+            assertEquals(
+                leakedCursor,
+                convRequests[1].resultOptionsRequest.cursorState,
+                "Second conversation page should carry the echoed cursor"
+            )
+            // The windowed crawl must use the 60-day seed, NOT the conversation query's cursor.
+            val windowed = requests.first { isWindowedCrawl(it) }
+            val windowPaging = QueryBatchCursor.fromJson(windowed.resultOptionsRequest.cursorState!!)
+                .paging!!.time.milliseconds
+            assertTrue(
+                windowPaging != 123_456L,
+                "Windowed crawl leaked the conversation query's cursor"
+            )
+            val expected = UnixTimeUtc().addDays(-60).milliseconds
+            assertTrue(
+                kotlin.math.abs(windowPaging - expected) < 10_000,
+                "Windowed crawl should use the 60-day seed"
+            )
+            // And nothing was persisted to the drive cursor (all responses were empty).
+            assertEquals(null, CursorStorage(db, driveId).loadCursor())
+        }
+        db.close()
+    }
+
+    @Test
+    fun incrementalSyncSkipsInitialQueryAndWindowSeed() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val driveId = Uuid.random()
+            // Pre-existing cursor => NOT a fresh sync.
+            val savedCursor = QueryBatchCursor.fromStartPoint(UnixTimeUtc(999_999L))
+            CursorStorage(db, driveId).saveCursor(savedCursor)
+
+            val requests = mutableListOf<QueryBatchRequest>()
+            val mockEngine = MockEngine { request ->
+                requests.add(parseRequest(request))
+                respond(emptyOkBody(), HttpStatusCode.OK)
+            }
+            val sync = buildSync(db, mockEngine, eventBus, backgroundScope, driveId, chatPolicy())
+
+            sync.sync()?.join()
+            runCurrent()
+
+            assertFalse(
+                requests.any { isConversationQuery(it) },
+                "Incremental sync must not run the initial conversation query"
+            )
+            assertEquals(1, requests.size, "Incremental sync issues a single resume query")
+            val pagingTime = QueryBatchCursor.fromJson(requests[0].resultOptionsRequest.cursorState!!)
+                .paging!!.time.milliseconds
+            assertEquals(
+                999_999L, pagingTime,
+                "Incremental sync must resume from the saved cursor, not a 60-day window"
+            )
+        }
+        db.close()
+    }
+
+    @Test
+    fun initialQueryFailureFallsThroughToWindowedCrawl() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val driveId = Uuid.random()
+            val requests = mutableListOf<QueryBatchRequest>()
+            val mockEngine = MockEngine { request ->
+                val req = parseRequest(request)
+                requests.add(req)
+                if (isConversationQuery(req)) {
+                    respond("boom", HttpStatusCode.InternalServerError)
+                } else {
+                    respond(emptyOkBody(), HttpStatusCode.OK)
+                }
+            }
+            val sync = buildSync(db, mockEngine, eventBus, backgroundScope, driveId, chatPolicy())
+
+            val events = mutableListOf<BackendEvent>()
+            val collector = launch { eventBus.events.collect { events.add(it) } }
+
+            sync.sync()?.join()
+            runCurrent()
+
+            assertTrue(requests.any { isConversationQuery(it) }, "Conversation query should have been attempted")
+            assertTrue(requests.any { isWindowedCrawl(it) }, "Windowed crawl must still run after a failed initial query")
+            assertTrue(
+                events.any {
+                    it is BackendEvent.DriveEvent.Stopped &&
+                        it.result is BackendEvent.DriveResult.Completed
+                },
+                "Round should complete despite the initial-query failure"
+            )
+            assertFalse(
+                events.any {
+                    it is BackendEvent.DriveEvent.Stopped &&
+                        it.result is BackendEvent.DriveResult.Aborted
+                },
+                "A best-effort initial-query failure must not abort the round"
+            )
+            collector.cancel()
+        }
+        db.close()
+    }
+
+    @Test
+    fun noPolicyBehavesAsBefore() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val driveId = Uuid.random()
+            val requests = mutableListOf<QueryBatchRequest>()
+            val mockEngine = MockEngine { request ->
+                requests.add(parseRequest(request))
+                respond(emptyOkBody(), HttpStatusCode.OK)
+            }
+            // Default policy — no window, no initial query.
+            val sync = buildSync(db, mockEngine, eventBus, backgroundScope, driveId)
+
+            sync.sync()?.join()
+            runCurrent()
+
+            assertFalse(requests.any { isConversationQuery(it) }, "No policy => no conversation query")
+            assertEquals(1, requests.size, "No policy => a single unfiltered crawl")
+            assertEquals(
+                null, requests[0].resultOptionsRequest.cursorState,
+                "No policy => no window cursor seed (fresh sync starts at null)"
+            )
         }
         db.close()
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -192,6 +192,28 @@ val appModule = module {
         DriveSyncManager(
             get(), get(), get(), get(), get(),
             mandatoryDrives = mandatorySyncDrives.associate { it.drive.alias to it.label },
+            // Per-drive fresh-sync policy (sync-back window + custom initial queries) is
+            // wired and tested, but no drive opts in yet — chat behaves like every other
+            // drive (sync everything). Part 2 re-enables the chat policy below together
+            // with the "load older messages when scrolling to the top" feature; until
+            // then a fresh login would only see the last N days, which is confusing
+            // without that scroll-to-load path. Diagnostics confirmed the window itself
+            // is correct (cursor: zero duplicates / no floor breaches at 7/30/60 days).
+            //
+            // To re-enable, add the imports
+            //   id.homebase.api.client.drives.SystemDriveConstants
+            //   id.homebase.api.client.drives.query.FileQueryParams
+            //   id.homebase.api.sync.DriveSyncPolicy
+            //   kotlin.time.Duration.Companion.days
+            // and pass:
+            // driveSyncPolicies = mapOf(
+            //     SystemDriveConstants.chatDrive.alias to DriveSyncPolicy(
+            //         fullSyncWindow = 30.days,
+            //         initialQueries = listOf(
+            //             FileQueryParams(fileType = listOf(ChatProtocol.ConversationFileType)),
+            //         ),
+            //     ),
+            // ),
         )
     }
 


### PR DESCRIPTION
## What

Adds `DriveSyncPolicy` — per-drive, fresh-sync-only knobs on the sync engine:

1. **`fullSyncWindow: Duration?`** — on a fresh sync (`cursor == null`), seed the QueryBatch paging cursor to `now - window` so the crawl only pulls files changed within the window. `null` = sync everything (unchanged default).
2. **`initialQueries: List<FileQueryParams>`** — 0..n queries run once at the start of a fresh sync, fully paginated, upserted with `cursor = null` so they never persist the drive cursor. Intended use: pull the full chat conversation-file list up front even when messages are windowed.

Both are inert on incremental syncs.

## Scope: infrastructure only

**No drive opts in yet.** The chat policy (30-day window + fetch-all-conversations query) is wired and **commented out** in `AppModule`, ready to enable in **part 2** alongside *load older messages when scrolling to the top*. Enabling the window without that scroll-to-load path would make a fresh login confusingly show only recent history.

## Why this is safe to merge now

- Runtime behavior is **unchanged** — `driveSyncPolicies` defaults to `emptyMap()`, so every drive still syncs everything exactly as before.
- The mechanism was validated on a live account via temporary diagnostics (since removed). Across 7/30/60-day windows the cursor returned **zero duplicate fileIds** and **never breached the seeded floor**. The higher-than-expected 60-day count traced to a **server-side bulk write** that re-stamped `modified` on ~6k old messages in April (ancient-dominated spikes on specific days) — real upstream data, not a sync bug.

## Changes

- `DriveSyncPolicy` (new) in `homebase-api`.
- `DriveSync`: snapshot `isFreshSync` before the loop mutates `cursor`; run `initialQueries` first (best-effort — a failure falls through to the windowed crawl), then seed the paging cursor.
- `DriveSyncManager`: new `driveSyncPolicies` map next to `mandatoryDrives`, threaded into each `DriveSync`.
- `AppModule`: chat policy commented out with re-enable instructions.

## Tests

6 new `DriveSyncTest` cases (request-side — they decrypt the captured query bodies): initial-query-before-windowed ordering, the window cursor seed, no cursor leak from initial → windowed, incremental skip, best-effort failure fallthrough, and a no-policy regression guard. JVM/Android/wasmJs all compile.

## Follow-up (part 2)

Uncomment the chat policy and wire conversation scroll-to-top → `query-batch` for older records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)