### PR TITLE
Fix Android share shortcut showing "nothing to share" on launcher tap

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
@@ -146,8 +146,11 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
 
         // Check for direct share target (user tapped a conversation shortcut in the share sheet).
         // Try multiple detection mechanisms since Android behavior varies by version:
-        // 1. intent.data URI (set via shortcut's setIntents)
-        // 2. EXTRA_SHORTCUT_ID (set by ChooserActivity on API 29+)
+        // 1. intent.data URI — defensive fallback for any send intent that carries the
+        //    homebase-fchat://conversation/{id} URI directly.
+        // 2. EXTRA_SHORTCUT_ID (set by ChooserActivity on API 29+) — the primary Direct
+        //    Share mechanism; the conversation shortcut no longer launches this activity
+        //    itself (it opens MainActivity), so Direct Share relies on this.
         val directShareConvoId = extractDirectShareConversationId()
         Logger.d(tag = COLD_TAG) { "initShareFlow: directShareConvoId=$directShareConvoId" }
         if (directShareConvoId != null) {

--- a/androidApp/src/main/kotlin/id/homebase/feed/share/ShareShortcutPublisher.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/ShareShortcutPublisher.kt
@@ -73,18 +73,17 @@ class ShareShortcutPublisher(
             .setIcon(icon)
             .build()
 
-        // Share intent: receive shared content and route to the conversation
-        val shareIntent = Intent(Intent.ACTION_SEND).apply {
-            component = ComponentName(context, ShareReceiverActivity::class.java)
-            data = "homebase-fchat://conversation/${conversation.id}".toUri()
-            type = "*/*"
-        }
-
-        // Main intent: open the conversation directly when tapped from launcher long-press,
-        // and also runs underneath the shareIntent on Direct Share so the user lands on the
-        // conversation after sending. The EXTRA lets MainActivity tag the resulting
-        // OpenConversation event as Source.ShareIntent so AppNavHost routes via
-        // selectConversationOnChatList instead of the PendingNotificationTap path.
+        // Launch intent: open the conversation directly when the shortcut is tapped from
+        // the launcher long-press. This is the ONLY use of the shortcut's own intent — a
+        // launcher tap starts it via startActivities() semantics. Direct Share does NOT use
+        // it: the share sheet routes shared content to ShareReceiverActivity via the
+        // <share-target> entry in share_shortcuts.xml plus EXTRA_SHORTCUT_ID, and the
+        // receiver itself startActivity()s back into the conversation after sending. So
+        // this must NOT be an ACTION_SEND into ShareReceiverActivity — a launcher tap has
+        // no shared content, which would show "nothing to share" and finish.
+        // The EXTRA lets MainActivity tag the resulting OpenConversation event as
+        // Source.ShareIntent so AppNavHost routes via selectConversationOnChatList instead
+        // of the PendingNotificationTap path.
         val mainIntent = Intent(Intent.ACTION_VIEW).apply {
             component = ComponentName(context, MainActivity::class.java)
             data = "homebase-fchat://conversation/${conversation.id}".toUri()
@@ -103,7 +102,7 @@ class ShareShortcutPublisher(
             .setShortLabel(label)
             .setLongLabel(label)
             .setIcon(icon)
-            .setIntents(arrayOf(mainIntent, shareIntent))
+            .setIntent(mainIntent)
             .setLongLived(true)
             .setIsConversation()
             .setRank(rank)

--- a/androidApp/src/test/kotlin/id/homebase/feed/share/ShareShortcutPublisherTest.kt
+++ b/androidApp/src/test/kotlin/id/homebase/feed/share/ShareShortcutPublisherTest.kt
@@ -7,6 +7,7 @@ import androidx.core.graphics.createBitmap
 import androidx.core.graphics.drawable.IconCompat
 import androidx.test.core.app.ApplicationProvider
 import id.homebase.core.share.ShareableConversation
+import id.homebase.feed.MainActivity
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -111,6 +112,42 @@ class ShareShortcutPublisherTest {
                 "AppNavHost falls into the NotificationTap branch (which expects a " +
                 "PendingNotificationTap singleton) and navigation dead-ends — " +
                 "see homebase.log: popBackStack(ChatList)=false at 13:04:34.",
+        )
+    }
+
+    @Test
+    fun `launcher tap opens the conversation, not the empty share receiver`() = runTest {
+        // Reproduces: long-press the app icon, tap a recent contact. The app opens the
+        // conversation but ALSO flashes a "nothing to share" toast.
+        //
+        // Root cause: ShortcutInfoCompat.setIntents(Intent[]) follows startActivities()
+        // back-stack semantics — the LAST intent is the activity launched on top, the
+        // rest sit beneath it. A launcher long-press tap launches that top intent. If it
+        // is the ACTION_SEND intent into ShareReceiverActivity, there is no shared content
+        // (the user came from the launcher, not a share sheet), so the receiver shows
+        // "nothing to share" and finishes — while MainActivity beneath it reveals the
+        // conversation. Direct Share is routed by <share-target> + EXTRA_SHORTCUT_ID and
+        // does NOT use setIntents, so the share intent here is pure harm.
+        val publisher = newPublisher()
+        ShortcutManagerCompat.removeAllDynamicShortcuts(context)
+
+        publisher.updateShortcuts(
+            listOf(convo(id = "11111111-1111-1111-1111-111111111111", displayName = "Alice"))
+        )
+
+        val shortcut = ShortcutManagerCompat.getDynamicShortcuts(context).single()
+        val launched = shortcut.intents.last()
+        assertEquals(
+            Intent.ACTION_VIEW,
+            launched.action,
+            "Launcher tap launches the last intent; it must open the conversation " +
+                "(ACTION_VIEW), not trigger the share receiver (ACTION_SEND).",
+        )
+        assertEquals(
+            MainActivity::class.java.name,
+            launched.component?.className,
+            "Launcher tap must land in MainActivity (conversation), never in " +
+                "ShareReceiverActivity — which would show \"nothing to share\".",
         )
     }
 

--- a/androidApp/src/test/kotlin/id/homebase/feed/share/ShareShortcutPublisherTest.kt
+++ b/androidApp/src/test/kotlin/id/homebase/feed/share/ShareShortcutPublisherTest.kt
@@ -149,6 +149,11 @@ class ShareShortcutPublisherTest {
             "Launcher tap must land in MainActivity (conversation), never in " +
                 "ShareReceiverActivity — which would show \"nothing to share\".",
         )
+        assertTrue(
+            shortcut.intents.none { it.action == Intent.ACTION_SEND },
+            "The shortcut must carry NO ACTION_SEND intent — re-adding one (even beneath " +
+                "the launch intent in the back stack) reintroduces the \"nothing to share\" bug.",
+        )
     }
 
     @Test


### PR DESCRIPTION
## Problem

Long-press the app icon → tap a recent contact. The conversation opens, but a spurious **"nothing to share"** toast flashes at the same time.

## Root cause

The dynamic shortcut was published with two intents:

```kotlin
.setIntents(arrayOf(mainIntent, shareIntent))
```

`ShortcutInfoCompat.setIntents()` follows `Context.startActivities()` back-stack semantics — the **last** intent is the activity launched on top, the rest sit beneath it. A launcher long-press tap starts that top intent, which was `shareIntent` (`ACTION_SEND` → `ShareReceiverActivity`). From a launcher tap there is no shared content, so `SharedContentExtractor.extract()` returns empty → the receiver shows `share_nothing_to_share` and `finish()`es, revealing `mainIntent` (the conversation) underneath.

Direct Share does **not** use the shortcut's own intents — it routes shared content to `ShareReceiverActivity` via the `<share-target>` entry in `share_shortcuts.xml` plus `EXTRA_SHORTCUT_ID`, and the receiver itself `startActivity()`s back into the conversation after a send. So `shareIntent` in `setIntents` served no purpose and was the sole cause of the bug.

## Fix

Publish only the conversation intent:

```kotlin
.setIntent(mainIntent)
```

A launcher tap now opens the conversation directly with no toast. Direct Share is unaffected.

## Tests

Added a regression test (`launcher tap opens the conversation, not the empty share receiver`) asserting the launched (last) intent is an `ACTION_VIEW` into `MainActivity`, not `ACTION_SEND` into `ShareReceiverActivity`.

- RED before the fix: failed on the `ACTION_VIEW` assertion (last intent was `ACTION_SEND`).
- GREEN after: `ShareShortcutPublisherTest` → 4 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)