### PR TITLE
Reply preview: mirror link-preview truncation (1 line mobile, 2 desktop)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -1003,6 +1003,13 @@ fun InlineReplyPreview(
     )
     val showContentIcon = shouldShowContentIcon(hasThumb, contentLabel?.text)
 
+    // Mirror the link-preview / Signal QuoteView bounded-block pattern: the body
+    // is already capped at 80 codepoints on the header (payload-free), so this is
+    // a pure presentational choice. Desktop has the horizontal room for a second
+    // line; on mobile we keep a single line to stay compact. The author name stays
+    // single-line on every platform.
+    val replyPreviewMaxLines = if (isDesktop()) 2 else 1
+
     Row(
         modifier = Modifier
             .height(IntrinsicSize.Min)
@@ -1054,7 +1061,7 @@ fun InlineReplyPreview(
                             text = displayMessage,
                             style = MaterialTheme.typography.bodySmall,
                             color = contentColor.copy(alpha = 0.7f),
-                            maxLines = 1,
+                            maxLines = replyPreviewMaxLines,
                             overflow = TextOverflow.Ellipsis,
                         )
                     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -1045,7 +1045,11 @@ fun InlineReplyPreview(
                 )
                 if (displayMessage.isNotEmpty()) {
                     Spacer(modifier = Modifier.height(2.dp))
-                    Row(verticalAlignment = Alignment.CenterVertically) {
+                    // Top-align: with the 2-line desktop body the leading
+                    // content icon must sit against the first text line, not
+                    // center against the whole block. Single-line mobile is
+                    // unaffected (Top == Center for one line).
+                    Row(verticalAlignment = Alignment.Top) {
                         if (showContentIcon) {
                             contentLabel?.icon?.let { icon ->
                                 Icon(


### PR DESCRIPTION
## Root cause
`InlineReplyPreview` (homebase-chat/.../widget/MessageBubble.kt) hardcoded the reply body `Text` to `maxLines = 1` with no platform branch. The reply body is already capped at 80 codepoints on the message header (`MessageActionsHandler.toReplyPreview()` -> `truncateToCodePoints(80)`) and is payload-free, so the single-line cap was the only thing limiting how much of that already-short preview the desktop layout could show.

## The fix
Make the body `Text` `maxLines` platform-responsive, mirroring the two in-tree reference patterns:
- Link preview (`LinkPreviewTextContent`: bounded `maxLines` + ellipsis)
- Signal `QuoteView` (`maxLines = 2` + end-ellipsis, no char cap)

```kotlin
val replyPreviewMaxLines = if (isDesktop()) 2 else 1
```

Desktop (which has the horizontal room) gets 2 lines; mobile stays single-line and compact. `overflow = TextOverflow.Ellipsis` and `style = MaterialTheme.typography.bodySmall` are unchanged. The author-name `Text` stays `maxLines = 1` on every platform.

This is a pure presentational change. No wire-format, message app-data schema, model, or 80-codepoint send-time cap change. No new user-facing strings (nothing to add to `strings.xml` / `values-da/strings.xml`). `isDesktop()` was already imported from `id.homebase.core.util`.

## What I verified
- `./gradlew :homebase-chat:compileKotlinJvm` -> BUILD SUCCESSFUL.
- Media-only reply path (`MessageBubbleRaw.kt` custom `Layout`): it positions the media with `mediaPlaceable.placeRelative(0, replyPlaceable.height)` and reports total height as `replyPlaceable.height + mediaPlaceable.height`. There is no fixed-height assumption, so when the reply wraps to two lines on desktop the `replyPlaceable` measures taller and the layout grows correctly. No change needed there.
- Outer `Row` uses `Modifier.height(IntrinsicSize.Min)`; the reply body column reports a taller intrinsic height for the 2-line case, so the bubble grows as expected.

## Cross-platform notes
- Mobile (Android/iOS): unchanged behavior (1 line).
- Desktop (JVM): up to 2 lines + ellipsis.
- Web (wasmJs): `isDesktop()` returns false there, so it falls into the 1-line branch — same as mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)