### PR TITLE
Share into Homebase now switches to the target conversation

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
@@ -345,13 +345,7 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
                 Toast.makeText(this@ShareReceiverActivity, countLabel, Toast.LENGTH_SHORT).show()
 
                 // Open the first conversation in the main app
-                val firstId = conversationIds.first()
-                val mainIntent =
-                    Intent(this@ShareReceiverActivity, MainActivity::class.java).apply {
-                        data = "homebase-fchat://conversation/${firstId}".toUri()
-                        flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
-                    }
-                startActivity(mainIntent)
+                startActivity(openConversationIntent(conversationIds.first()))
                 finish()
             } catch (e: Exception) {
                 Logger.e(tag = "ShareReceiver") { "Failed to send: ${e.message}" }
@@ -392,12 +386,7 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
                 Toast.makeText(this@ShareReceiverActivity, getString(R.string.share_sent), Toast.LENGTH_SHORT).show()
 
                 // Open conversation in main app
-                val mainIntent =
-                    Intent(this@ShareReceiverActivity, MainActivity::class.java).apply {
-                        data = "homebase-fchat://conversation/${conversationId}".toUri()
-                        flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
-                    }
-                startActivity(mainIntent)
+                startActivity(openConversationIntent(conversationId))
                 finish()
             } catch (e: Exception) {
                 Logger.e(tag = "ShareReceiver") { "Failed to send: ${e.message}" }
@@ -442,6 +431,25 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
     private fun cleanupTempFiles() {
         safeDeleteRecursively(cacheDir.absolutePath, "share_temp")
     }
+
+    /**
+     * Builds the Intent that re-opens [MainActivity] on the just-shared-to conversation.
+     *
+     * The [ShareShortcutPublisher.EXTRA_FROM_SHARE_SHORTCUT] extra is what makes
+     * MainActivity.handleIntent() classify this deep link as
+     * `OpenConversation.Source.ShareIntent` instead of `Source.NotificationTap`. The
+     * ShareIntent source routes through AppNavHost's `selectConversationOnChatList`, which
+     * actually opens the conversation; the NotificationTap source resolves via a
+     * PendingNotificationTap that needs a messageId a share never has, so without the extra
+     * the deep link dead-ends and the conversation never opens. Centralized here so all
+     * three send paths (text-only single, text-only multi, edited files) stay in sync.
+     */
+    internal fun openConversationIntent(conversationId: Uuid): Intent =
+        Intent(this, MainActivity::class.java).apply {
+            data = "homebase-fchat://conversation/$conversationId".toUri()
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            putExtra(ShareShortcutPublisher.EXTRA_FROM_SHARE_SHORTCUT, true)
+        }
 
     private fun extractDirectShareConversationId(): String? {
         // Method 1: Check intent data URI (homebase-fchat://conversation/{uuid})
@@ -552,12 +560,8 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
 
                 // Navigate immediately — don't wait for sends to complete
                 val firstId = conversationIds.first()
-                val mainIntent = Intent(this@ShareReceiverActivity, MainActivity::class.java).apply {
-                    data = "homebase-fchat://conversation/${firstId}".toUri()
-                    flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
-                }
                 Logger.d(tag = COLD_TAG) { "sendEditedFiles: launching MainActivity for convo=$firstId then finish()" }
-                startActivity(mainIntent)
+                startActivity(openConversationIntent(firstId))
 
                 // Fire sends in background scope that survives the activity finish.
                 // Safe because MainActivity starts before finish(), keeping the process alive.

--- a/androidApp/src/test/kotlin/id/homebase/feed/share/ShareReceiverActivityIntentTest.kt
+++ b/androidApp/src/test/kotlin/id/homebase/feed/share/ShareReceiverActivityIntentTest.kt
@@ -1,0 +1,90 @@
+package id.homebase.feed.share
+
+import android.app.Application
+import android.content.Intent
+import id.homebase.feed.MainActivity
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Guards the regression where sharing into Homebase sent the message but never switched
+ * to the conversation.
+ *
+ * The three send paths in [ShareReceiverActivity] (text-only single, text-only multi,
+ * edited files) all re-open [MainActivity] on the target conversation. That deep link is
+ * only routed to the conversation if it carries
+ * [ShareShortcutPublisher.EXTRA_FROM_SHARE_SHORTCUT] == true — MainActivity.handleIntent()
+ * uses that extra to pick `OpenConversation.Source.ShareIntent` (which AppNavHost routes via
+ * selectConversationOnChatList) over `Source.NotificationTap` (which expects a
+ * PendingNotificationTap/messageId a share never has, so it dead-ends). All three paths now
+ * funnel through [ShareReceiverActivity.openConversationIntent]; this test pins that helper.
+ */
+@OptIn(ExperimentalUuidApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class ShareReceiverActivityIntentTest {
+
+    // buildActivity(...).get() returns the activity WITHOUT running onCreate(), so the
+    // lazy Koin `by inject()` services are never resolved — openConversationIntent only
+    // needs the Activity's Context, nothing injected.
+    private val activity: ShareReceiverActivity
+        get() = Robolectric.buildActivity(ShareReceiverActivity::class.java).get()
+
+    @Test
+    fun `openConversationIntent carries EXTRA_FROM_SHARE_SHORTCUT so it routes as ShareIntent`() {
+        val conversationId = Uuid.parse("11111111-1111-1111-1111-111111111111")
+
+        val intent = activity.openConversationIntent(conversationId)
+
+        assertTrue(
+            intent.getBooleanExtra(ShareShortcutPublisher.EXTRA_FROM_SHARE_SHORTCUT, false),
+            "After sending, the intent re-opening MainActivity must carry " +
+                "EXTRA_FROM_SHARE_SHORTCUT so MainActivity.handleIntent() classifies it as " +
+                "OpenConversation.Source.ShareIntent. Without it the deep link falls into the " +
+                "NotificationTap branch (which needs a messageId a share lacks) and the " +
+                "conversation never opens.",
+        )
+    }
+
+    @Test
+    fun `openConversationIntent targets MainActivity with the conversation deep link`() {
+        val conversationId = Uuid.parse("22222222-2222-2222-2222-222222222222")
+
+        val intent = activity.openConversationIntent(conversationId)
+
+        assertEquals(
+            MainActivity::class.java.name,
+            intent.component?.className,
+            "The post-share intent must land in MainActivity, not the share receiver.",
+        )
+        assertEquals(
+            "homebase-fchat://conversation/$conversationId",
+            intent.data?.toString(),
+            "The deep link must encode the just-shared-to conversation id so the app " +
+                "switches to it.",
+        )
+    }
+
+    @Test
+    fun `openConversationIntent sets CLEAR_TOP and SINGLE_TOP flags`() {
+        val conversationId = Uuid.parse("33333333-3333-3333-3333-333333333333")
+
+        val intent = activity.openConversationIntent(conversationId)
+
+        assertTrue(
+            intent.flags and Intent.FLAG_ACTIVITY_CLEAR_TOP != 0,
+            "Re-opening MainActivity must reuse the existing task (CLEAR_TOP).",
+        )
+        assertTrue(
+            intent.flags and Intent.FLAG_ACTIVITY_SINGLE_TOP != 0,
+            "Re-opening MainActivity must not spawn a duplicate (SINGLE_TOP).",
+        )
+    }
+}


### PR DESCRIPTION
## Root cause

After sharing content into a conversation, `ShareReceiverActivity` re-opens `MainActivity` on a `homebase-fchat://conversation/{id}` deep link to switch to that chat. Three send paths built that intent inline:

- `sendToMultipleConversations` (text-only, multi-select)
- `sendSharedContent` (text-only, single / direct-share target)
- `sendEditedFiles` (file attachments via the editor)

Each set `data` + `FLAG_ACTIVITY_CLEAR_TOP | FLAG_ACTIVITY_SINGLE_TOP`, but **none** set `ShareShortcutPublisher.EXTRA_FROM_SHARE_SHORTCUT`.

`MainActivity.handleIntent()` uses that extra to choose the deep-link source:

```kotlin
val source = if (fromShareShortcut)
    OpenConversation.Source.ShareIntent
else
    OpenConversation.Source.NotificationTap
```

Without the extra, the share deep link was classified as `Source.NotificationTap`, which resolves via a `PendingNotificationTap` that requires a `messageId` a share never has — so the navigation dead-ended and the conversation never opened. `Source.ShareIntent` is the source `AppNavHost` routes through `selectConversationOnChatList` to actually open the conversation.

## The fix

Extract a single private helper in `ShareReceiverActivity`:

```kotlin
internal fun openConversationIntent(conversationId: Uuid): Intent
```

It builds the URI + the two flags + `putExtra(EXTRA_FROM_SHARE_SHORTCUT, true)` once, and all three send paths now call it. This reuses the **existing** `Source.ShareIntent` routing that the launcher share shortcut already relies on — `MainActivity` / `NotificationService` / `AppNavHost` are untouched.

## Cross-platform notes

Android-only. iOS already does the equivalent: `AppViewModel.handleShareIntent` emits `Source.ShareIntent`. Desktop/Web have no share-receiver entry point.

## Verified

- `./gradlew :androidApp:testDebugUnitTest --tests "id.homebase.feed.share.ShareReceiverActivityIntentTest"` — 3 tests pass (compiles `:androidApp:compileDebugKotlin` as part of the run, BUILD SUCCESSFUL).
- New Robolectric test `ShareReceiverActivityIntentTest` asserts the helper's intent carries `EXTRA_FROM_SHARE_SHORTCUT == true`, targets `MainActivity` with `homebase-fchat://conversation/{id}` data, and keeps `CLEAR_TOP`/`SINGLE_TOP`. It mirrors the existing `ShareShortcutPublisherTest` Robolectric setup and builds the activity via `Robolectric.buildActivity(...).get()` so no Koin graph is needed (the helper only uses the Activity `Context`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)