### PR TITLE
Quick-gallery multi-select (long-press, numbered send-order badges)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/AttachmentOptions.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/AttachmentOptions.kt
@@ -159,6 +159,10 @@ fun AttachmentGallery(
                 }
             }
         } else {
+            // Gallery strip and confirm control stacked in a Column so the Send-(N)
+            // pill sits in its own row BELOW the 160dp thumbnail strip and never
+            // overlaps (occludes) the leading thumbnails.
+            Column(modifier = Modifier.fillMaxWidth()) {
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -318,16 +322,20 @@ fun AttachmentGallery(
                         }
                     }
                 }
-                // Confirm control: while in multi-select with a non-empty ordered selection,
-                // resolve selectedIds to items (associate by id, ordered by selectedIds) and
-                // hand the batch to the existing send path, then reset.
-                if (multiSelect && selectedIds.isNotEmpty()) {
-                    val byId = galleryItems.associateBy { it.id }
-                    val sendCount = selectedIds.size
+            }
+            // Confirm control: while in multi-select with a non-empty ordered selection,
+            // resolve selectedIds to items (associate by id, ordered by selectedIds) and
+            // hand the batch to the existing send path, then reset. Anchored in its own
+            // row BELOW the 160dp strip so it never covers the thumbnails.
+            if (multiSelect && selectedIds.isNotEmpty()) {
+                val byId = galleryItems.associateBy { it.id }
+                val sendCount = selectedIds.size
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                ) {
                     ElevatedButton(
-                        modifier = Modifier
-                            .align(Alignment.BottomStart)
-                            .padding(16.dp),
                         onClick = {
                             val ordered = selectedIds.mapNotNull { byId[it] }
                             resetSelection()
@@ -339,6 +347,7 @@ fun AttachmentGallery(
                         Text(stringResource(MR.string.chat_gallery_send_count, sendCount))
                     }
                 }
+            }
             }
         }
     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/AttachmentOptions.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/AttachmentOptions.kt
@@ -3,8 +3,10 @@ package id.homebase.chat.widget
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.border
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -19,6 +21,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -30,6 +33,7 @@ import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.PlayCircle
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.UploadFile
+import androidx.compose.material.icons.outlined.Circle
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ElevatedButton
@@ -73,7 +77,10 @@ import id.homebase.resources.chat_message_needs_gallery_permission
 import id.homebase.resources.chat_message_needs_gallery_permission_button_text
 import id.homebase.resources.chat_no_gallery_items
 import id.homebase.resources.cd_gallery_thumbnail
+import id.homebase.resources.cd_not_selected
 import id.homebase.resources.cd_play_video
+import id.homebase.resources.chat_gallery_selection_index
+import id.homebase.resources.chat_gallery_send_count
 import id.homebase.resources.chat_select_more_photos
 import id.homebase.resources.go_to_settings
 import id.homebase.resources.manage
@@ -101,9 +108,14 @@ fun AttachmentOptionsDisplay(
     }
 }
 
+// Mirror Signal: cap a single multi-select batch so we never stage more than the
+// downstream editor / sender is built to handle in one go.
+private const val MaxGallerySelection = 32
+
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun AttachmentGallery(
-    onImageSelected: (GalleryImage) -> Unit,
+    onImagesSelected: (List<GalleryImage>) -> Unit,
 ) {
     if (isMobile()) {
         // Get ImageLoader with HomebaseImageFetcher from Koin DI
@@ -116,6 +128,18 @@ fun AttachmentGallery(
                 galleryCache.refresh()
             }
         )
+
+        // Multi-select state. selectedIds is an ORDERED list keyed on GalleryImage.id —
+        // its position drives the numbered send-order badge (computed at render, never
+        // stored). multiSelect distinguishes the fast single-tap path (tap attaches now)
+        // from the batch path (long-press enters multi-select; tap then toggles).
+        var multiSelect by remember { mutableStateOf(false) }
+        var selectedIds by remember { mutableStateOf(emptyList<String>()) }
+
+        fun resetSelection() {
+            multiSelect = false
+            selectedIds = emptyList()
+        }
 
         if (!galleryPermissionState.hasGalleryPermission && !galleryPermissionState.hasPartialGalleryPermission) {
             Column(
@@ -151,8 +175,51 @@ fun AttachmentGallery(
                     ) {
 
                         items(galleryItems, key = { it.id }) { galleryImage ->
+                            val isSelected = galleryImage.id in selectedIds
+                            // Send-order number, computed at render from list position — never stored.
+                            val selectionNumber = selectedIds.indexOf(galleryImage.id) + 1
                             Box(
-                                contentAlignment = Alignment.Center
+                                contentAlignment = Alignment.Center,
+                                modifier = Modifier
+                                    .size(160.dp)
+                                    .clip(RoundedCornerShape(8.dp))
+                                    .then(
+                                        if (isSelected) {
+                                            Modifier.border(
+                                                width = 2.dp,
+                                                color = MaterialTheme.colorScheme.primary,
+                                                shape = RoundedCornerShape(8.dp)
+                                            )
+                                        } else {
+                                            Modifier
+                                        }
+                                    )
+                                    .combinedClickable(
+                                        onClick = {
+                                            if (multiSelect) {
+                                                // In multi-select, tap toggles membership. Gate adds
+                                                // at the max so a batch never exceeds the cap.
+                                                selectedIds = if (isSelected) {
+                                                    selectedIds - galleryImage.id
+                                                } else if (selectedIds.size < MaxGallerySelection) {
+                                                    selectedIds + galleryImage.id
+                                                } else {
+                                                    selectedIds
+                                                }
+                                            } else {
+                                                // Fast path: first tap attaches immediately.
+                                                onImagesSelected(listOf(galleryImage))
+                                            }
+                                        },
+                                        onLongClick = {
+                                            // Long-press enters multi-select and selects the
+                                            // long-pressed item first.
+                                            if (!multiSelect) {
+                                                multiSelect = true
+                                                selectedIds = listOf(galleryImage.id)
+                                            }
+                                        }
+                                    )
                             ) {
                                 AsyncImage(
                                     imageLoader = imageLoader,
@@ -167,8 +234,7 @@ fun AttachmentGallery(
                                     contentDescription = stringResource(MR.string.cd_gallery_thumbnail),
                                     modifier = Modifier
                                         .size(160.dp)
-                                        .clip(RoundedCornerShape(8.dp))
-                                        .clickable { onImageSelected(galleryImage) },
+                                        .clip(RoundedCornerShape(8.dp)),
                                     contentScale = ContentScale.Crop
                                 )
                                 if (galleryImage.isVideo()) {
@@ -191,6 +257,15 @@ fun AttachmentGallery(
                                                 .padding(horizontal = 6.dp, vertical = 2.dp),
                                         )
                                     }
+                                }
+                                if (multiSelect) {
+                                    SelectionBadge(
+                                        isSelected = isSelected,
+                                        selectionNumber = selectionNumber,
+                                        modifier = Modifier
+                                            .align(Alignment.TopEnd)
+                                            .padding(6.dp)
+                                    )
                                 }
                             }
                         }
@@ -243,8 +318,62 @@ fun AttachmentGallery(
                         }
                     }
                 }
+                // Confirm control: while in multi-select with a non-empty ordered selection,
+                // resolve selectedIds to items (associate by id, ordered by selectedIds) and
+                // hand the batch to the existing send path, then reset.
+                if (multiSelect && selectedIds.isNotEmpty()) {
+                    val byId = galleryItems.associateBy { it.id }
+                    val sendCount = selectedIds.size
+                    ElevatedButton(
+                        modifier = Modifier
+                            .align(Alignment.BottomStart)
+                            .padding(16.dp),
+                        onClick = {
+                            val ordered = selectedIds.mapNotNull { byId[it] }
+                            resetSelection()
+                            if (ordered.isNotEmpty()) {
+                                onImagesSelected(ordered)
+                            }
+                        }
+                    ) {
+                        Text(stringResource(MR.string.chat_gallery_send_count, sendCount))
+                    }
+                }
             }
         }
+    }
+}
+
+@Composable
+private fun SelectionBadge(
+    isSelected: Boolean,
+    selectionNumber: Int,
+    modifier: Modifier = Modifier,
+) {
+    if (isSelected) {
+        Box(
+            modifier = modifier
+                .size(24.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primary),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = stringResource(MR.string.chat_gallery_selection_index, selectionNumber),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onPrimary,
+                textAlign = TextAlign.Center,
+            )
+        }
+    } else {
+        // Unselected affordance — mirrors CreateConversationScreen's selection markers
+        // (CheckCircle when chosen / outlined Circle when not) for accessibility parity.
+        Icon(
+            imageVector = Icons.Outlined.Circle,
+            contentDescription = stringResource(MR.string.cd_not_selected),
+            tint = Color.White.copy(alpha = 0.85f),
+            modifier = modifier.size(24.dp)
+        )
     }
 }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -1568,12 +1568,12 @@ fun ConversationContent(
                     // applies — desktop can host a virtual keyboard, so the floor stays.
                     if (isMobile()) {
                         AttachmentGallery(
-                            onImageSelected = {
+                            onImagesSelected = { images ->
                                 showAttachmentSheet = false
                                 onUiAction(
                                     ConversationListUiAction.AttachGalleryItem(
                                         conversationId = conversation.conversation.id,
-                                        files = listOf(it)
+                                        files = images
                                     )
                                 )
                             },

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -298,6 +298,8 @@
     <string name="chat_next_result">Næste resultat</string>
     <string name="chat_no_gallery_items">Ingen elementer</string>
     <string name="chat_select_more_photos">Vælg flere billeder</string>
+    <string name="chat_gallery_selection_index">%1$d</string>
+    <string name="chat_gallery_send_count">Send (%1$d)</string>
 
     <!-- Conversation new -->
     <string name="chat_new_conversation">Ny samtale</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -480,6 +480,8 @@
     <string name="chat_next_result">Next result</string>
     <string name="chat_no_gallery_items">No items</string>
     <string name="chat_select_more_photos">Select more photos</string>
+    <string name="chat_gallery_selection_index">%1$d</string>
+    <string name="chat_gallery_send_count">Send (%1$d)</string>
 
     <!-- Conversation new -->
     <string name="chat_new_conversation">New conversation</string>


### PR DESCRIPTION
## What & why

The in-chat quick-selection gallery strip (`AttachmentGallery`, mobile-only) only allowed single-select: each thumbnail tap attached exactly one image. This PR adds Signal-style ordered multi-select so a user can stage several photos/videos at once before sending.

This is a **UI-only** change. The whole downstream batch path already existed and is unchanged: `AttachGalleryItem.files` is `List<GalleryImage>`, and `handleAttachGalleryItem` stages a list into the `FullScreenAttachmentEditor` where the user sends. Previously the caller just wrapped a single item in `listOf(it)`.

## The change

- `AttachmentGallery`'s callback changes from `onImageSelected: (GalleryImage) -> Unit` to `onImagesSelected: (List<GalleryImage>) -> Unit`.
- **Interaction (mirrors Signal):**
  - Not in multi-select: a single tap attaches immediately — `onImagesSelected(listOf(item))` — preserving today's fast path.
  - Long-press enters multi-select (`combinedClickable`, `ExperimentalFoundationApi`) and selects the long-pressed item first.
  - While in multi-select, tap toggles membership instead of attaching.
- **Ordered selection:** `selectedIds` is an ORDERED `List<String>` keyed on `GalleryImage.id` (already the LazyRow key). The numbered send-order badge is `selectedIds.indexOf(id) + 1`, computed at render and never stored.
- **Visuals:** selected thumbs get a 2.dp `MaterialTheme.colorScheme.primary` border and a numbered primary-tinted circle badge (top-end); unselected thumbs show an outlined `Icons.Outlined.Circle` marker (`cd_not_selected`) for accessibility parity with `CreateConversationScreen`.
- **Confirm:** a `Send (N)` `ElevatedButton` appears when multi-select is active with a non-empty selection; on confirm it resolves `selectedIds` back to items in selection order (`associateBy { id }` + ordered `mapNotNull`), calls `onImagesSelected(list)`, and resets selection + `multiSelect`.
- **Cap:** a single batch is gated to max 32 items at the toggle.
- **Caller:** `ConversationContent.kt` now forwards the list straight into the existing `ConversationListUiAction.AttachGalleryItem(files = images)` action. `AttachmentHandler` / `UiAction` / send path are untouched.

## Strings

Two new strings added to both `values/strings.xml` and `values-da/strings.xml`, referenced via `stringResource` so the Konsist `ArchitectureTest` stays green (no raw `Text("...")` / `$`-interpolated literals):

- `chat_gallery_selection_index` = `%1$d` (badge number)
- `chat_gallery_send_count` = `Send (%1$d)` / `Send (%1$d)` (DA)

## Verified

- `./gradlew :homebase-chat:compileKotlinJvm` — BUILD SUCCESSFUL.
- Confirmed no raw `Text("...")` literals in the changed file (badge number and send count both go through `stringResource(..., n)`).
- Confirmed `AttachGalleryItem.files` is `List<GalleryImage>`, so the batch flows through the unchanged send path.

## Cross-platform notes

`AttachmentGallery` is gated behind `isMobile()` (Android + iOS only) because it reads the OS photo library via `GalleryCache`. Desktop/Web already multi-pick through FileKit and are not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)