### PR TITLE
Add animated GIF rendering on Android (Coil coil-gif)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -183,6 +183,7 @@ coil3-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref
 coil3-network = { group = "io.coil-kt.coil3", name = "coil-network-ktor3", version.ref = "coil3" }
 coil3-video = { group = "io.coil-kt.coil3", name = "coil-video", version.ref = "coil3" } # Android only
 coil3-svg = { group = "io.coil-kt.coil3", name = "coil-svg", version.ref = "coil3" }
+coil3-gif = { group = "io.coil-kt.coil3", name = "coil-gif", version.ref = "coil3" }
 zoomimage-compose-coil3 = { group = "io.github.panpf.zoomimage", name = "zoomimage-compose-coil3", version.ref = "zoomimage" }
 androidsvg = { module = "com.caverock:androidsvg-aar", version = "1.4" }
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlinStdlib" }

--- a/homebase-common/build.gradle.kts
+++ b/homebase-common/build.gradle.kts
@@ -121,6 +121,14 @@ kotlin {
             implementation(libs.accompanist.permissions)
             implementation(libs.firebase.crashlytics)
             api(libs.coil3.video)
+            // coil-gif is an Android-only artifact in Coil 3.4.0 (com.android.library,
+            // packaging=aar, no jvm/ios/wasmJs variants — verified against the published
+            // Gradle module metadata and the coil-gif/build.gradle.kts at the 3.4.0 tag).
+            // It supplies coil3.gif.AnimatedImageDecoder / coil3.gif.GifDecoder. There is
+            // NO AnimatedSkiaImageDecoder in Coil 3.4.0 (nor 3.5.0-beta01), so animated GIF
+            // decoding is Android-only at this Coil version; the other targets fall back to
+            // coil-core's static SkiaImageDecoder (first-frame still).
+            api(libs.coil3.gif)
             implementation(libs.kermit.io)
             // kmpnotifier has no wasmJs artifact — must stay off commonMain.
             // `api` so the dep cascades transitively to androidApp (which

--- a/homebase-core/src/androidMain/kotlin/id/homebase/core/di/AppModule.android.kt
+++ b/homebase-core/src/androidMain/kotlin/id/homebase/core/di/AppModule.android.kt
@@ -1,8 +1,11 @@
 package id.homebase.core.di
 
+import android.os.Build
 import co.touchlab.kermit.Logger
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
+import coil3.gif.AnimatedImageDecoder
+import coil3.gif.GifDecoder
 import coil3.memory.MemoryCache
 import coil3.video.VideoFrameDecoder
 import id.homebase.api.file.AndroidFileOperationsProvider
@@ -82,6 +85,15 @@ actual fun platformModule(): Module = module {
                     add(PublicImageFetcher.Factory(get()))
                     add(PlatformFileFetcher.Factory())
                     add(VideoFrameDecoder.Factory())
+                    // Animated GIF decoding. AnimatedImageDecoder uses the platform
+                    // android.graphics.ImageDecoder (API 28+); GifDecoder is the
+                    // pure-Kotlin fallback for API 27 (our minSdk). Both ship in
+                    // coil-gif, which is Android-only at Coil 3.4.0.
+                    if (Build.VERSION.SDK_INT >= 28) {
+                        add(AnimatedImageDecoder.Factory())
+                    } else {
+                        add(GifDecoder.Factory())
+                    }
                 }
             .memoryCache {
                 MemoryCache.Builder()

--- a/homebase-core/src/androidMain/kotlin/id/homebase/core/di/AppModule.android.kt
+++ b/homebase-core/src/androidMain/kotlin/id/homebase/core/di/AppModule.android.kt
@@ -3,6 +3,7 @@ package id.homebase.core.di
 import co.touchlab.kermit.Logger
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
+import coil3.gif.AnimatedImageDecoder
 import coil3.memory.MemoryCache
 import coil3.video.VideoFrameDecoder
 import id.homebase.api.file.AndroidFileOperationsProvider
@@ -82,6 +83,13 @@ actual fun platformModule(): Module = module {
                     add(PublicImageFetcher.Factory(get()))
                     add(PlatformFileFetcher.Factory())
                     add(VideoFrameDecoder.Factory())
+                    // Animated GIF decoding. AnimatedImageDecoder uses the platform
+                    // android.graphics.ImageDecoder, which requires API 28+. Our
+                    // minSdk is 28 (gradle/libs.versions.toml android-minSdk), so the
+                    // <28 GifDecoder fallback would be dead code — we register the
+                    // platform decoder unconditionally. AnimatedImageDecoder ships in
+                    // coil-gif, which is Android-only at Coil 3.4.0.
+                    add(AnimatedImageDecoder.Factory())
                 }
             .memoryCache {
                 MemoryCache.Builder()


### PR DESCRIPTION
## Root cause

The image data path already loads full GIF payloads — `image/gif` is in
`THUMBLESS_CONTENT_TYPES` (`HomebaseImageLoader.kt`) so the whole animated
file reaches Coil. But **no animated decoder was registered on any platform**,
so Coil decoded GIFs with its default static path and rendered a single frame.

## The fix

Register Coil's GIF decoder on **Android**:

1. `gradle/libs.versions.toml` — add a `coil3-gif` alias (Coil `3.4.0`, matching the existing `coil3` version ref).
2. `homebase-common/build.gradle.kts` — add `coil-gif` to **`androidMain`** (see note below on why not `commonMain`).
3. `AppModule.android.kt` — in the `ImageLoader` `components { }` block, register
   `AnimatedImageDecoder.Factory()` **unconditionally**. It uses the platform
   `android.graphics.ImageDecoder`, which requires API 28+. Our effective
   `minSdk` is **28** (`gradle/libs.versions.toml` `android-minSdk = "28"`), so
   the earlier `Build.VERSION.SDK_INT < 28` guard with a `GifDecoder.Factory()`
   fallback was **dead code** and has been removed (along with the now-unused
   `android.os.Build` and `coil3.gif.GifDecoder` imports).

No change to the transport, thumbnail, or `THUMBLESS_CONTENT_TYPES` pipeline.
No new user-facing strings (no Konsist/strings.xml impact).

## Scope: Android-only — coil-gif has no non-Android animated decoder at any Coil version

The earlier hope was that `coil-gif` ships android+jvm+ios+wasmJs (like `coil-svg`)
and that the other targets could register an `AnimatedSkiaImageDecoder.Factory()`.
**That is not the case at any published Coil version.** Verified evidence:

- **Published Gradle module metadata** for `io.coil-kt.coil3:coil-gif` lists **only
  Android variants** (`releaseVariantReleaseApiPublication` /
  `...RuntimePublication` / `...SourcePublication`, `.aar`) — checked at both the
  latest stable `3.4.0` **and** the latest beta `3.5.0-beta01` on Maven Central.
  There is no `coil-gif-jvm`, native, or `wasmJs` publication.
- **Empirical resolve** confirms it: in `:homebase-common`'s `jvmCompileClasspath`,
  `coil-core`, `coil-compose`, and `coil-svg` all resolve their `-jvm` Skiko
  variants, while `coil-gif` does not appear at all (it lives only in `androidMain`).
- **`coil3.gif.AnimatedSkiaImageDecoder` does not exist** in any Coil version. The
  `coil3.gif` package contains only `AnimatedImageDecoder`, `GifDecoder`,
  `MovieDrawable`, `AnimatedTransformation`, `PixelOpacity`. The official
  [GIFs docs](https://coil-kt.github.io/coil/gifs/) state: *"This feature is only
  available on Android."*
- Upstream [coil-kt/coil#2347](https://github.com/coil-kt/coil/issues/2347)
  (animated images on iOS / non-Android) is **still open** and tagged
  *help wanted* — the feature is unimplemented.

Because no non-Android animated decoder exists, registering one on
Desktop/iOS/Web would not compile. `coil-gif` is therefore added to
**androidMain only**, and the desktop/native/web `AppModule`s are intentionally
left untouched.

**Net effect on non-Android targets:** Desktop, iOS, and Web continue to render
the **first frame** of a GIF (via coil-core's static `SkiaImageDecoder`) — same
as before this PR, no regression.

## What would unlock Desktop / iOS / Web

Nothing in this repo's control today. It requires **upstream Coil** to ship a
multiplatform/Skia animated decoder (the work tracked in coil-kt/coil#2347). No
Coil version through `3.5.0-beta01` provides it, and the in-flight Compose /
Skia upgrade (PR #656) does not change this — the missing piece is a Coil
artifact, not a Skia/Compose version. Revisit when Coil publishes a non-Android
`coil-gif` variant or an `AnimatedSkiaImageDecoder`.

## What I verified

- `./gradlew :homebase-core:compileAndroidMain` — **BUILD SUCCESSFUL**.
- `./gradlew :homebase-core:compileKotlinJvm` — **BUILD SUCCESSFUL** (untouched JVM path still compiles).
- Confirmed all `coil-gif` / `coil3.gif.*` references are confined to `androidMain` + build files.

## Cross-platform smoke-test status (UNVERIFIED — needs manual post-merge testing)

- **Android** — the real path here. Animated GIF playback should work on API 28+
  via `AnimatedImageDecoder`. **Smoke-test on a device:** send/receive a GIF and
  confirm it animates inline.
- **Desktop (JVM) / iOS (Skia) / Web (wasm-Skia)** — **no animation in this PR**;
  they render the first frame as before. Confirm there's no visual regression
  (GIFs still show their first frame).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
