### PR TITLE
Sticker support: render transparent images cut-out via an explicit per-image flag

### DIFF
--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/image/ImageUtil.android.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/image/ImageUtil.android.kt
@@ -292,6 +292,59 @@ actual object ImageUtils {
         return ImageSize(options.outWidth, options.outHeight)
     }
 
+    actual fun hasNonOpaquePixels(srcBytes: ByteArray): Boolean {
+        var bitmap: Bitmap? = null
+        return try {
+            val options = BitmapFactory.Options().apply {
+                inPreferredConfig = Bitmap.Config.ARGB_8888
+            }
+            bitmap = BitmapFactory.decodeByteArray(srcBytes, 0, srcBytes.size, options)
+                ?: return false
+            // Fast path: the bitmap has no alpha channel at all → fully opaque.
+            if (!bitmap.hasAlpha()) return false
+
+            val w = bitmap.width
+            val h = bitmap.height
+            if (w <= 0 || h <= 0) return false
+
+            // Coarse grid (≤ ~ALPHA_PROBE_MAX_SAMPLES) so a huge image stays cheap.
+            val cols = minOf(w, ALPHA_PROBE_GRID)
+            val rows = minOf(h, ALPHA_PROBE_GRID)
+            for (gy in 0 until rows) {
+                val y = (gy.toLong() * (h - 1) / maxOf(1, rows - 1)).toInt()
+                for (gx in 0 until cols) {
+                    val x = (gx.toLong() * (w - 1) / maxOf(1, cols - 1)).toInt()
+                    if ((bitmap.getPixel(x, y) ushr 24) < ALPHA_OPAQUE_THRESHOLD) return true
+                }
+            }
+            // Always include the 4 corners + centre — where cut-out stickers
+            // carry their transparency — in case the grid stepped over them.
+            val probes = intArrayOf(
+                bitmap.getPixel(0, 0),
+                bitmap.getPixel(w - 1, 0),
+                bitmap.getPixel(0, h - 1),
+                bitmap.getPixel(w - 1, h - 1),
+                bitmap.getPixel(w / 2, h / 2),
+            )
+            probes.any { (it ushr 24) < ALPHA_OPAQUE_THRESHOLD }
+        } catch (e: Exception) {
+            Logger.w(throwable = e, tag = "hasNonOpaquePixels") { "Android alpha probe failed" }
+            false
+        } finally {
+            bitmap?.recycle()
+        }
+    }
+
+    /**
+     * Alpha below this counts as non-opaque. 250 (not 255) tolerates the
+     * compression fringe that WebP/PNG lossy re-encode adds to near-opaque
+     * photos, so an ordinary photo isn't misdetected as a transparent sticker.
+     */
+    private const val ALPHA_OPAQUE_THRESHOLD: Int = 250
+
+    /** Grid side length → ALPHA_PROBE_GRID² ≤ ~4096 samples regardless of image size. */
+    private const val ALPHA_PROBE_GRID: Int = 64
+
     @RequiresApi(Build.VERSION_CODES.R)
     actual fun warpAffine(
         srcBytes: ByteArray,

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/PayloadDescriptor.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/PayloadDescriptor.kt
@@ -79,9 +79,15 @@ data class PayloadDescriptor(
                 // or corrupt descriptor never throws at render and never strips a photo's
                 // backdrop (opaque is the safe default). Mirrors the audio/video
                 // parse-failure contract above.
-                if (descriptorContent.isBlank()) {
-                    DescriptorContent.ImageFile(isSticker = false)
-                } else {
+                //
+                // Single-payload link-preview (chat_links) and location-preview (chat_loc)
+                // bubbles ALSO carry an image/* contentType but store a JSON *array* in
+                // descriptorContent — not an {"isSticker":...} object. Only attempt the
+                // ImageFile deserialize when the content actually looks like a JSON object,
+                // so the expected blank/array case is silent (no redundant parse, no warning
+                // log on the recomposition hot path) while genuine "looks like an object but
+                // failed to parse" corruption is still logged.
+                if (descriptorContent.trimStart().startsWith("{")) {
                     try {
                         OdinSystemSerializer.deserialize<DescriptorContent.ImageFile>(
                             descriptorContent
@@ -90,6 +96,8 @@ data class PayloadDescriptor(
                         Logger.w("PayloadFile.descriptorInfo", e)
                         DescriptorContent.ImageFile(isSticker = false)
                     }
+                } else {
+                    DescriptorContent.ImageFile(isSticker = false)
                 }
             }
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/PayloadDescriptor.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/PayloadDescriptor.kt
@@ -72,6 +72,27 @@ data class PayloadDescriptor(
                 }
             }
 
+            contentType?.startsWith("image/") == true -> {
+                // Image payloads historically wrote descriptorContent = "" (no info).
+                // We now optionally store a tiny {"isSticker":true} object here. Blank /
+                // legacy / malformed all fall back to a non-sticker ImageFile so an older
+                // or corrupt descriptor never throws at render and never strips a photo's
+                // backdrop (opaque is the safe default). Mirrors the audio/video
+                // parse-failure contract above.
+                if (descriptorContent.isBlank()) {
+                    DescriptorContent.ImageFile(isSticker = false)
+                } else {
+                    try {
+                        OdinSystemSerializer.deserialize<DescriptorContent.ImageFile>(
+                            descriptorContent
+                        )
+                    } catch (e: Exception) {
+                        Logger.w("PayloadFile.descriptorInfo", e)
+                        DescriptorContent.ImageFile(isSticker = false)
+                    }
+                }
+            }
+
             else -> DescriptorContent.File(name = descriptorContent)
         }
     }
@@ -81,6 +102,7 @@ data class PayloadDescriptor(
             is DescriptorContent.AudioFile -> info.name
             DescriptorContent.Empty -> null
             is DescriptorContent.File -> info.name
+            is DescriptorContent.ImageFile -> null
             is DescriptorContent.NoteFile -> null
             is DescriptorContent.VideoFile -> null
         }
@@ -93,6 +115,16 @@ sealed interface DescriptorContent {
     data class NoteFile(val preview: String?) : DescriptorContent
     @Serializable
     data class AudioFile(val name: String?, val lengthSeconds: Int) : DescriptorContent
+
+    /**
+     * Per-image descriptor. Rides on the payload's [PayloadDescriptor.descriptorContent]
+     * slot (which image payloads otherwise leave blank). [isSticker] marks a transparent
+     * cut-out image that should render without the opaque bubble backdrop/clip. Additive
+     * and backward-compatible: a blank or legacy descriptor parses to `ImageFile(false)`.
+     */
+    @Serializable
+    data class ImageFile(val isSticker: Boolean = false) : DescriptorContent
+
     /** Surfaces the bits of a video's [VideoMetadata] that the UI cares about. */
     data class VideoFile(
         val durationMs: Long?,
@@ -110,6 +142,11 @@ sealed interface DescriptorContent {
     companion object {
         fun descriptorContentFromAudioFile(name: String, lengthSeconds: Int): String {
             return OdinSystemSerializer.serialize(AudioFile(name, lengthSeconds))
+        }
+
+        /** Serialize an [ImageFile] descriptor (e.g. `{"isSticker":true}`) for the wire. */
+        fun descriptorContentFromImage(isSticker: Boolean): String {
+            return OdinSystemSerializer.serialize(ImageFile(isSticker))
         }
     }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/image/ImageUtil.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/image/ImageUtil.kt
@@ -65,6 +65,22 @@ expect object ImageUtils {
     fun getNaturalSize(srcBytes: ByteArray): ImageSize
 
     /**
+     * Decode [srcBytes] and report whether ANY sampled pixel is non-opaque
+     * (alpha below an opaque threshold). Used to auto-detect sticker / cut-out
+     * images at send time so the bubble can drop its opaque backdrop.
+     *
+     * Callers MUST pre-gate by format — only call this for formats that can
+     * carry alpha (PNG / WebP) — to keep it cheap and avoid decoding JPEGs.
+     *
+     * Sampling is coarse (a bounded grid plus the four corners + centre, where
+     * cut-out stickers carry their transparency) so a huge image stays fast; a
+     * single transparent corner is therefore reliably detected. The probe is
+     * defensive: on ANY decode failure it returns `false` (opaque) so we never
+     * accidentally strip a real photo's backdrop.
+     */
+    fun hasNonOpaquePixels(srcBytes: ByteArray): Boolean
+
+    /**
      * Apply an arbitrary affine transform to [srcBytes] and rasterize the
      * result into a new image of [outputWidth] x [outputHeight] pixels.
      *

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/files/PayloadDescriptorImageTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/files/PayloadDescriptorImageTest.kt
@@ -64,6 +64,24 @@ class PayloadDescriptorImageTest {
     }
 
     @Test
+    fun jsonArrayDescriptor_isNonSticker_noThrow() {
+        // Single-payload link-preview (chat_links) and location-preview (chat_loc) bubbles
+        // share the image/* contentType but store a JSON *array* (not an {"isSticker":...}
+        // object) in descriptorContent. That must parse to a non-sticker ImageFile WITHOUT
+        // attempting the object deserialize and WITHOUT logging a warning, since the array
+        // shape is expected — not corruption. (Smoke test: the array shape doesn't throw.)
+        val info = imageDescriptor("""[{"url":"https://example.com","title":"Hi"}]""")
+            .descriptorInfo()
+        assertTrue(info is DescriptorContent.ImageFile, "Expected ImageFile, got $info")
+        assertFalse(info.isSticker)
+
+        // Leading whitespace before the array bracket is still treated as a non-object.
+        val padded = imageDescriptor("""   [{"url":"https://example.com"}]""").descriptorInfo()
+        assertTrue(padded is DescriptorContent.ImageFile, "Expected ImageFile, got $padded")
+        assertFalse(padded.isSticker)
+    }
+
+    @Test
     fun unknownKeysInDescriptor_areIgnored() {
         // Forward-compat: a future client might add fields; ignoreUnknownKeys keeps us parsing.
         val info = imageDescriptor("""{"isSticker":true,"futureField":42}""").descriptorInfo()

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/files/PayloadDescriptorImageTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/files/PayloadDescriptorImageTest.kt
@@ -1,0 +1,81 @@
+package id.homebase.api.client.drives.files
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Pins the per-image sticker descriptor that rides on `PayloadDescriptor.descriptorContent`.
+ * The bubble reads this flag to decide whether to drop its opaque backdrop. The contract is
+ * additive and backward-compatible: a blank, null, or malformed descriptor must yield a
+ * non-sticker [DescriptorContent.ImageFile] (never throw, never accidentally cut out a photo),
+ * and `filename()` must return null for an image so the download name still falls back to the
+ * payload key.
+ */
+class PayloadDescriptorImageTest {
+
+    private fun imageDescriptor(descriptorContent: String?): PayloadDescriptor =
+        PayloadDescriptor(
+            key = "chat_web0",
+            contentType = "image/png",
+            descriptorContent = descriptorContent,
+        )
+
+    @Test
+    fun stickerDescriptor_roundTrips_true() {
+        val serialized = DescriptorContent.descriptorContentFromImage(isSticker = true)
+        val info = imageDescriptor(serialized).descriptorInfo()
+        assertTrue(info is DescriptorContent.ImageFile, "Expected ImageFile, got $info")
+        assertTrue(info.isSticker, "Expected isSticker=true")
+    }
+
+    @Test
+    fun nonStickerDescriptor_roundTrips_false() {
+        val serialized = DescriptorContent.descriptorContentFromImage(isSticker = false)
+        val info = imageDescriptor(serialized).descriptorInfo()
+        assertTrue(info is DescriptorContent.ImageFile)
+        assertFalse(info.isSticker)
+    }
+
+    @Test
+    fun blankDescriptor_isNonSticker() {
+        // Legacy image payloads wrote descriptorContent = "".
+        val info = imageDescriptor("").descriptorInfo()
+        assertTrue(info is DescriptorContent.ImageFile, "Expected ImageFile, got $info")
+        assertFalse(info.isSticker)
+    }
+
+    @Test
+    fun nullDescriptor_isEmpty() {
+        // null short-circuits to Empty at the top of descriptorInfo() (unchanged behaviour);
+        // the image branch only runs for a present descriptor.
+        val info = imageDescriptor(null).descriptorInfo()
+        assertEquals(DescriptorContent.Empty, info)
+    }
+
+    @Test
+    fun malformedDescriptor_isNonSticker_noThrow() {
+        // A corrupt descriptor must not crash the bubble — opaque is the safe default.
+        val info = imageDescriptor("{not valid json").descriptorInfo()
+        assertTrue(info is DescriptorContent.ImageFile, "Expected ImageFile, got $info")
+        assertFalse(info.isSticker)
+    }
+
+    @Test
+    fun unknownKeysInDescriptor_areIgnored() {
+        // Forward-compat: a future client might add fields; ignoreUnknownKeys keeps us parsing.
+        val info = imageDescriptor("""{"isSticker":true,"futureField":42}""").descriptorInfo()
+        assertTrue(info is DescriptorContent.ImageFile)
+        assertTrue(info.isSticker)
+    }
+
+    @Test
+    fun imageFilename_isNull_soDownloadNameFallsBackToPayloadKey() {
+        // The sticker descriptor is NOT a filename — filename() must return null so
+        // MediaDownloadHandler keeps falling back to payload.key (legacy "" behaviour).
+        assertNull(imageDescriptor(DescriptorContent.descriptorContentFromImage(true)).filename())
+        assertNull(imageDescriptor("").filename())
+    }
+}

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/files/PayloadDescriptorVideoTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/files/PayloadDescriptorVideoTest.kt
@@ -126,15 +126,17 @@ class PayloadDescriptorVideoTest {
 
     @Test
     fun nonVideoDescriptor_isUnaffected() {
-        // Make sure the new VideoFile branch only fires when contentType matches.
-        val imageDescriptor = PayloadDescriptor(
+        // Make sure the typed branches (video/image/audio) only fire when
+        // contentType matches — a generic file content type falls through to
+        // DescriptorContent.File carrying the download filename.
+        val fileDescriptor = PayloadDescriptor(
             key = "chat_web0",
-            contentType = "image/jpeg",
-            descriptorContent = "filename.jpg",
+            contentType = "application/pdf",
+            descriptorContent = "filename.pdf",
         )
 
-        val info = imageDescriptor.descriptorInfo()
+        val info = fileDescriptor.descriptorInfo()
         assertTrue(info is DescriptorContent.File)
-        assertEquals("filename.jpg", info.name)
+        assertEquals("filename.pdf", info.name)
     }
 }

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/image/HasNonOpaquePixelsTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/image/HasNonOpaquePixelsTest.kt
@@ -1,0 +1,109 @@
+package id.homebase.api.image
+
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.ColorAlphaType
+import org.jetbrains.skia.ColorInfo
+import org.jetbrains.skia.ColorSpace
+import org.jetbrains.skia.ColorType
+import org.jetbrains.skia.EncodedImageFormat
+import org.jetbrains.skia.ImageInfo
+import org.jetbrains.skia.Image
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the alpha probe that drives sticker auto-detection. Runs the skiaMain actual
+ * (which backs Desktop/iOS/Web) on the JVM. The contract: report `true` only when a
+ * sampled pixel is genuinely non-opaque, `false` for fully opaque images, and `false`
+ * (never throw) on undecodable bytes — opaque is the safe default so we never strip a
+ * real photo's backdrop.
+ */
+class HasNonOpaquePixelsTest {
+
+    /** Encode a w×h BGRA buffer (alpha provided per pixel) as a PNG. */
+    private fun pngWithAlpha(w: Int, h: Int, alphaAt: (x: Int, y: Int) -> Int): ByteArray {
+        val info = ImageInfo(
+            colorInfo = ColorInfo(ColorType.BGRA_8888, ColorAlphaType.UNPREMUL, ColorSpace.sRGB),
+            width = w,
+            height = h,
+        )
+        val rowBytes = w * 4
+        val bytes = ByteArray(w * h * 4)
+        for (y in 0 until h) {
+            for (x in 0 until w) {
+                val i = (y * w + x) * 4
+                bytes[i] = 0       // B
+                bytes[i + 1] = 0   // G
+                bytes[i + 2] = (0xFF).toByte() // R
+                bytes[i + 3] = (alphaAt(x, y) and 0xFF).toByte() // A
+            }
+        }
+        val image = Image.makeRaster(info, bytes, rowBytes)
+        val data = image.encodeToData(EncodedImageFormat.PNG)
+            ?: error("Failed to encode test PNG")
+        return data.bytes
+    }
+
+    @Test
+    fun opaquePng_isReportedOpaque() {
+        val bytes = pngWithAlpha(64, 64) { _, _ -> 0xFF }
+        assertFalse(ImageUtils.hasNonOpaquePixels(bytes), "Fully-opaque PNG must report false")
+    }
+
+    @Test
+    fun fullyTransparentPng_isReportedNonOpaque() {
+        val bytes = pngWithAlpha(64, 64) { _, _ -> 0x00 }
+        assertTrue(ImageUtils.hasNonOpaquePixels(bytes), "Transparent PNG must report true")
+    }
+
+    @Test
+    fun pngWithOneTransparentCorner_isReportedNonOpaque() {
+        // A cut-out sticker often carries transparency only at the corners — the
+        // corner-probe guarantees we catch it even if the coarse grid steps over it.
+        val bytes = pngWithAlpha(200, 200) { x, y ->
+            if (x == 0 && y == 0) 0x00 else 0xFF
+        }
+        assertTrue(
+            ImageUtils.hasNonOpaquePixels(bytes),
+            "A single transparent corner must be detected",
+        )
+    }
+
+    @Test
+    fun nearOpaqueFringe_belowThreshold_isReportedOpaque() {
+        // alpha 252 (> 250 threshold) models WebP/PNG compression fringe on a near-opaque
+        // photo — it must NOT be misdetected as a sticker.
+        val bytes = pngWithAlpha(64, 64) { _, _ -> 252 }
+        assertFalse(
+            ImageUtils.hasNonOpaquePixels(bytes),
+            "Near-opaque fringe (alpha 252) must stay below the non-opaque threshold",
+        )
+    }
+
+    @Test
+    fun opaqueJpeg_isReportedOpaque() {
+        val bytes = ImageTestHelper.loadImage("red-leaf.jpg")
+        assertFalse(ImageUtils.hasNonOpaquePixels(bytes), "Opaque JPEG must report false")
+    }
+
+    @Test
+    fun realTransparentPngFixture_isReportedNonOpaque() {
+        val bytes = ImageTestHelper.loadImage("shirt_transparent.png")
+        assertTrue(
+            ImageUtils.hasNonOpaquePixels(bytes),
+            "A real cut-out PNG fixture must report true",
+        )
+    }
+
+    @Test
+    fun corruptBytes_returnFalse_noThrow() {
+        val bytes = ByteArray(128) { it.toByte() }
+        assertFalse(ImageUtils.hasNonOpaquePixels(bytes), "Corrupt bytes must report false, not throw")
+    }
+
+    @Test
+    fun emptyBytes_returnFalse_noThrow() {
+        assertFalse(ImageUtils.hasNonOpaquePixels(ByteArray(0)))
+    }
+}

--- a/homebase-api/src/skiaMain/kotlin/id/homebase/api/image/ImageUtil.skia.kt
+++ b/homebase-api/src/skiaMain/kotlin/id/homebase/api/image/ImageUtil.skia.kt
@@ -229,6 +229,71 @@ actual object ImageUtils {
         return ImageSize(img.width, img.height)
     }
 
+    actual fun hasNonOpaquePixels(srcBytes: ByteArray): Boolean {
+        return try {
+            val image = decodeImage(srcBytes)
+            // Fast path: the decoded image declares itself fully opaque.
+            if (image.imageInfo.colorInfo.alphaType == ColorAlphaType.OPAQUE) return false
+
+            val w = image.width
+            val h = image.height
+            if (w <= 0 || h <= 0) return false
+
+            // Read every pixel into a BGRA_8888 buffer (alpha = high byte at
+            // offset 3 of each 4-byte pixel) — same layout the blur path uses.
+            val info = ImageInfo(
+                colorInfo = ColorInfo(ColorType.BGRA_8888, ColorAlphaType.UNPREMUL, ColorSpace.sRGB),
+                width = w,
+                height = h,
+            )
+            val rowBytes = w * 4
+            val bitmap = SkiaBitmap()
+            if (!bitmap.allocPixels(info)) return false
+            try {
+                if (!image.readPixels(bitmap)) return false
+                val bytes = bitmap.readPixels(info, rowBytes, 0, 0) ?: return false
+
+                // Coarse grid (≤ ~ALPHA_PROBE_GRID² samples) so a huge image stays cheap.
+                val cols = minOf(w, ALPHA_PROBE_GRID)
+                val rows = minOf(h, ALPHA_PROBE_GRID)
+                for (gy in 0 until rows) {
+                    val y = (gy.toLong() * (h - 1) / maxOf(1, rows - 1)).toInt()
+                    for (gx in 0 until cols) {
+                        val x = (gx.toLong() * (w - 1) / maxOf(1, cols - 1)).toInt()
+                        val alpha = bytes[(y * w + x) * 4 + 3].toInt() and 0xFF
+                        if (alpha < ALPHA_OPAQUE_THRESHOLD) return true
+                    }
+                }
+                // Always include the 4 corners + centre — where cut-out stickers
+                // carry their transparency — in case the grid stepped over them.
+                val corners = listOf(
+                    0 to 0,
+                    (w - 1) to 0,
+                    0 to (h - 1),
+                    (w - 1) to (h - 1),
+                    (w / 2) to (h / 2),
+                )
+                corners.any { (x, y) ->
+                    (bytes[(y * w + x) * 4 + 3].toInt() and 0xFF) < ALPHA_OPAQUE_THRESHOLD
+                }
+            } finally {
+                bitmap.close()
+            }
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    /**
+     * Alpha below this counts as non-opaque. 250 (not 255) tolerates the
+     * compression fringe that WebP/PNG re-encode adds to near-opaque photos,
+     * so an ordinary photo isn't misdetected as a transparent sticker.
+     */
+    private const val ALPHA_OPAQUE_THRESHOLD: Int = 250
+
+    /** Grid side length → ALPHA_PROBE_GRID² ≤ ~4096 samples regardless of image size. */
+    private const val ALPHA_PROBE_GRID: Int = 64
+
     actual fun warpAffine(
         srcBytes: ByteArray,
         matrix9: FloatArray,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/AttachmentInput.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/AttachmentInput.kt
@@ -15,4 +15,11 @@ data class AttachmentInput(
      * compress INPUT so the original is read in JS (no Kotlin copy / base64). Null on native.
      */
     val inputBlobUrl: String? = null,
+    /**
+     * Image-only: force this attachment to be sent as a sticker (transparent cut-out
+     * render), skipping the automatic alpha probe. v1 leaves this `false` and relies on
+     * auto-detection; the future manual "Send as sticker" toggle flips this without any
+     * further change to the attachment builder.
+     */
+    val forceSticker: Boolean = false,
 )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilder.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilder.kt
@@ -3,6 +3,8 @@ package id.homebase.chat.services.builder
 import id.homebase.api.client.drives.files.DescriptorContent
 import id.homebase.api.client.drives.files.PayloadFile
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.image.ImageUtils
+import id.homebase.api.lib.image.ImageFormatDetector
 import id.homebase.chat.services.PayloadBundle
 
 object MessageAttachmentBuilder {
@@ -37,6 +39,26 @@ object MessageAttachmentBuilder {
                                 fileOperationsProvider,
                             )
 
+                        // Sticker auto-detect: a transparent cut-out image renders
+                        // without the opaque bubble backdrop. Detect on the ORIGINAL
+                        // source bytes (the generator already read them — no second
+                        // read), gated to alpha-capable formats (PNG/WebP). forceSticker
+                        // (future manual toggle) bypasses detection. We store a tiny
+                        // {"isSticker":true} descriptor only when transparent; ordinary
+                        // photos keep the legacy "" so nothing changes for them.
+                        val isSticker = attachment.forceSticker ||
+                            run {
+                                val format = ImageFormatDetector.detectFormat(thumbs.sourceBytes)
+                                (format == "image/png" || format == "image/webp") &&
+                                    ImageUtils.hasNonOpaquePixels(thumbs.sourceBytes)
+                            }
+                        val descriptorContent =
+                            if (isSticker) {
+                                DescriptorContent.descriptorContentFromImage(isSticker = true)
+                            } else {
+                                ""
+                            }
+
                         PayloadBundle(
                             payloads =
                                 listOf(
@@ -45,7 +67,7 @@ object MessageAttachmentBuilder {
                                         filePath = attachment.filePath,
                                         contentType = attachment.contentType,
                                         previewThumbnail = thumbs.preview,
-                                        descriptorContent = ""
+                                        descriptorContent = descriptorContent
                                     )
                                 ),
                             thumbnails = thumbs.thumbnails,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/MessageThumbnailGenerator.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/MessageThumbnailGenerator.kt
@@ -16,7 +16,8 @@ object MessageThumbnailGenerator {
 
         return ThumbnailResult(
             preview = tinyThumb,
-            thumbnails = thumbnails
+            thumbnails = thumbnails,
+            sourceBytes = bytes
         )
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/ThumbnailResult.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/ThumbnailResult.kt
@@ -6,5 +6,29 @@ import id.homebase.api.client.drives.upload.EmbeddedThumb
 // Small shared result type
 data class ThumbnailResult(
     val preview: EmbeddedThumb?,
-    val thumbnails: List<ThumbnailFile>
-)
+    val thumbnails: List<ThumbnailFile>,
+    /**
+     * The ORIGINAL (pre-thumbnail) source bytes the generator already read.
+     * Threaded out so the attachment builder can run a sticker/alpha probe on
+     * the source — not the re-encoded thumbnail (lossy re-encode adds an alpha
+     * fringe) — without a second file read.
+     */
+    val sourceBytes: ByteArray
+) {
+    // ByteArray uses identity equals/hashCode by default, which would make two
+    // structurally-equal results unequal. Override so the data class stays sane.
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ThumbnailResult) return false
+        return preview == other.preview &&
+            thumbnails == other.thumbnails &&
+            sourceBytes.contentEquals(other.sourceBytes)
+    }
+
+    override fun hashCode(): Int {
+        var result = preview?.hashCode() ?: 0
+        result = 31 * result + thumbnails.hashCode()
+        result = 31 * result + sourceBytes.contentHashCode()
+        return result
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenMediaViewer.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenMediaViewer.kt
@@ -114,6 +114,11 @@ fun FullScreenMediaViewer(
     }
 
     BoxWithConstraints(
+        // Deliberate divergence from the chat bubble: the bubble renders stickers
+        // transparently (no backdrop), but the full-screen viewer keeps a solid
+        // surface backdrop for all media — including stickers — so a maximised
+        // cut-out image sits on a clean, predictable surface rather than whatever
+        // is behind the viewer.
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.surface)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
@@ -107,6 +107,7 @@ fun MediaItem(
     keyHeader: KeyHeader,
     imageSize: ImageSize? = ImageSize.THUMB_MEDIUM,
     preserveAspectRatio: Boolean = false,
+    isSticker: Boolean = false,
     onClick: (() -> Unit)? = null,
     onLongPress: ((Offset) -> Unit)? = null,
     onRequestDecryptedFile: (() -> Unit)? = null,
@@ -143,8 +144,9 @@ fun MediaItem(
             }
         }
 
-    // Base modifier with shape clip
-    val baseModifier = modifier.clip(shape)
+    // Base modifier with shape clip. Stickers skip the rounded-card clip so the
+    // transparent cut-out shows the chat surface through; ordinary media keeps it.
+    val baseModifier = if (isSticker) modifier else modifier.clip(shape)
 
     // Apply aspect ratio only if needed and available.
     // Note: For aspect ratio to work for "fitting inside", we typically want fillMaxWidth()

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
 import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.drives.files.DescriptorContent
 import id.homebase.api.client.drives.files.PayloadDescriptor
 import id.homebase.api.client.drives.upload.EmbeddedThumb
 import id.homebase.api.video.VideoProcessingPhase
@@ -85,10 +86,21 @@ fun MediaMessage(
 ) {
     if (payloads.isEmpty()) return
 
+    // A sticker is always a solo, transparent image. Multi-image bundles keep the
+    // opaque letterbox fill (a transparent image inside a grid still letterboxes).
+    val isSticker = payloads.size == 1 &&
+        (payloads[0].descriptorInfo() as? DescriptorContent.ImageFile)?.isSticker == true
+
     Box(modifier = Modifier.animateContentSize()) {
         when (payloads.size) {
             1 -> {
-                val widthModifier = modifier.background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                // Stickers drop the opaque surface fill so transparent pixels show the
+                // chat surface through; ordinary photos keep it as a loading/letterbox backdrop.
+                val widthModifier = if (isSticker) {
+                    modifier
+                } else {
+                    modifier.background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                }
                 MediaItem(
                     payload = payloads[0],
                     fileId = fileId,
@@ -103,6 +115,7 @@ fun MediaMessage(
                     ),
                     imageSize = ImageSize.THUMB_MEDIUM,
                     preserveAspectRatio = preserveAspectRatio,
+                    isSticker = isSticker,
                     onClick = { onMediaClick?.invoke(payloads[0]) },
                     onLongPress = { offset -> onMediaLongPress?.invoke(payloads[0], offset) },
                     onRequestDecryptedFile = if (onRequestDecryptedFile != null) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -88,8 +89,12 @@ fun MediaMessage(
 
     // A sticker is always a solo, transparent image. Multi-image bundles keep the
     // opaque letterbox fill (a transparent image inside a grid still letterboxes).
-    val isSticker = payloads.size == 1 &&
-        (payloads[0].descriptorInfo() as? DescriptorContent.ImageFile)?.isSticker == true
+    // Remembered on the payload list so the descriptor parse runs once per change
+    // rather than on every recomposition.
+    val isSticker = remember(payloads) {
+        payloads.size == 1 &&
+            (payloads[0].descriptorInfo() as? DescriptorContent.ImageFile)?.isSticker == true
+    }
 
     Box(modifier = Modifier.animateContentSize()) {
         when (payloads.size) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.Layout
@@ -52,6 +53,7 @@ import androidx.compose.ui.unit.sp
 import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
 import com.mohamedrejeb.richeditor.model.RichTextState
 import com.mohamedrejeb.richeditor.ui.material3.RichText
+import id.homebase.api.client.drives.files.DescriptorContent
 import id.homebase.api.client.drives.files.PayloadDescriptor
 import id.homebase.chat.conversationlist.DecryptedFileKey
 import id.homebase.chat.conversationlist.MessageClusterPosition
@@ -293,9 +295,19 @@ fun MessageBubbleRaw(
         }
     }
 
+    // A media-only sticker message must float directly on the chat wallpaper, so its
+    // transparent pixels show the background — not the bubble fill. Detect it the same
+    // way MediaMessage does (solo, transparent image payload) and, when true, drop the
+    // outer Surface fill/shape/elevation entirely. Non-sticker bubbles are unaffected.
+    val isSticker = remember(filteredPayloads) {
+        filteredPayloads?.size == 1 &&
+            (filteredPayloads[0].descriptorInfo() as? DescriptorContent.ImageFile)?.isSticker == true
+    }
+    val isStickerBubble = isSticker && mediaOnly
+
     Surface(
         modifier = modifier
-            .clip(shape)
+            .ifTrue(!isStickerBubble) { Modifier.clip(shape) }
             .ifTrue(isMobile()) {
                 Modifier.combinedClickable(
                     onClick = {},
@@ -308,8 +320,8 @@ fun MessageBubbleRaw(
                 scaleX = scaleAnim.value
                 scaleY = scaleAnim.value
             },
-        shape = shape,
-        color = backgroundColor,
+        shape = if (isStickerBubble) RectangleShape else shape,
+        color = if (isStickerBubble) Color.Transparent else backgroundColor,
     ) {
         Box {
             // Overlay Box that captures all long clicks

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -238,12 +238,26 @@ fun MessageBubbleRaw(
     val mediaOnly = remember { !message.content.hasContent() && hasMedia && message.messageAppData.replyPreview == null }
     val replyMediaOnly = remember { !message.content.hasContent() && hasMedia && message.messageAppData.replyPreview != null }
     val emojiOnly = remember { message.content.isEmojiContentOnly() && !hasMedia }
+
+    // A media-only sticker message must float directly on the chat wallpaper, so its
+    // transparent pixels show the background — not the bubble fill. Detect it the same
+    // way MediaMessage does (solo, transparent image payload) and, when true, drop the
+    // outer Surface fill/shape/elevation entirely and render it like an emoji-only
+    // message (see StickerMessage). Non-sticker bubbles are unaffected.
+    val isSticker = remember(filteredPayloads) {
+        filteredPayloads?.size == 1 &&
+            (filteredPayloads[0].descriptorInfo() as? DescriptorContent.ImageFile)?.isSticker == true
+    }
+    val isStickerBubble = isSticker && mediaOnly
+
     val backgroundColor =
         if (emojiOnly) Color.Unspecified
         else if (sentByYou) HomebaseTheme.extendedColors.bubbleSentSurface
         else MaterialTheme.colorScheme.surfaceContainerHigh
+    // Stickers float on the wallpaper like emoji-only, so their tucked timestamp uses the
+    // same wallpaper-readable onSurface color rather than a sent-bubble tint.
     val contentColor =
-        if (emojiOnly) MaterialTheme.colorScheme.onSurface
+        if (emojiOnly || isStickerBubble) MaterialTheme.colorScheme.onSurface
         else if (sentByYou) HomebaseTheme.extendedColors.bubbleSentOnSurface
         else MaterialTheme.colorScheme.onSurface
 
@@ -295,16 +309,6 @@ fun MessageBubbleRaw(
         }
     }
 
-    // A media-only sticker message must float directly on the chat wallpaper, so its
-    // transparent pixels show the background — not the bubble fill. Detect it the same
-    // way MediaMessage does (solo, transparent image payload) and, when true, drop the
-    // outer Surface fill/shape/elevation entirely. Non-sticker bubbles are unaffected.
-    val isSticker = remember(filteredPayloads) {
-        filteredPayloads?.size == 1 &&
-            (filteredPayloads[0].descriptorInfo() as? DescriptorContent.ImageFile)?.isSticker == true
-    }
-    val isStickerBubble = isSticker && mediaOnly
-
     Surface(
         modifier = modifier
             .ifTrue(!isStickerBubble) { Modifier.clip(shape) }
@@ -337,7 +341,35 @@ fun MessageBubbleRaw(
                 )
             }
 
-            if (mediaOnly && !message.isDeleted) {
+            if (isStickerBubble && !message.isDeleted) {
+                // Stickers render exactly like emoji-only messages: a bare image floating
+                // on the wallpaper with a tucked, scrim-free timestamp. This deliberately
+                // bypasses MediaMessage's media chrome and MediaTimestampOverlay's gray
+                // scrim — see StickerMessage. Non-sticker media-only messages fall through
+                // to the unchanged path below.
+                StickerMessage(
+                    payloads = filteredPayloads?.toPersistentList() ?: persistentListOf(),
+                    decryptedFiles = decryptedFiles,
+                    keyHeader = message.keyHeader,
+                    driveId = chatTargetDrive.alias,
+                    fileId = message.fileId,
+                    messageId = message.id,
+                    previewThumbnail = message.previewThumbnail,
+                    messageInfoText = messageInfoText,
+                    sentByYou = sentByYou,
+                    isPendingSend = isPendingSend,
+                    deliveryStatus = message.messageAppData.deliveryStatus,
+                    contentColor = contentColor,
+                    pendingSince = message.userDate,
+                    onMediaClick = onMediaClick,
+                    onMediaLongPress = { handleLongClick() },
+                    onRequestDecryptedFile = onRequestDecryptedFile,
+                    sharedTransitionScope = sharedTransitionScope,
+                    animatedVisibilityScope = animatedVisibilityScope,
+                    downloadingFiles = downloadingFiles,
+                    uploadStatus = uploadStatus,
+                )
+            } else if (mediaOnly && !message.isDeleted) {
                 Box(modifier = Modifier.wrapContentWidth()) {
                     MediaMessage(
                         payloads = filteredPayloads?.toPersistentList() ?: persistentListOf(),

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/StickerMessage.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/StickerMessage.kt
@@ -1,0 +1,146 @@
+package id.homebase.chat.widget
+
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.unit.dp
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.drives.files.PayloadDescriptor
+import id.homebase.api.client.drives.upload.EmbeddedThumb
+import id.homebase.chat.conversationlist.DecryptedFileKey
+import id.homebase.chat.conversationlist.UploadStatus
+import id.homebase.core.image.ImageSize
+import id.homebase.core.ui.theme.Dimens
+import kotlinx.collections.immutable.ImmutableMap
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * Renders a sticker message exactly like an emoji-only message: a bare image floating
+ * directly on the chat wallpaper, with NO bubble surface, NO background fill, NO media
+ * chrome, and NO timestamp scrim.
+ *
+ * This is the sticker analogue of the emoji-only branch in [MessageBubbleRaw]. The
+ * single transparent image is loaded through the SAME encrypted-image path
+ * [MediaMessage]/[MediaItem] use (so the existing sticker-aware [MediaItem] already
+ * drops the rounded clip and the opaque letterbox fill), but it is constrained to
+ * [Dimens.Sticker.maxSize] with [androidx.compose.ui.layout.ContentScale.Fit].
+ *
+ * The timestamp + delivery status are tucked under the bottom-end corner of the image
+ * via the same custom [Layout] idiom the emoji-only bubble uses for its `infoPlaceable`
+ * — a subtle `labelSmall` row drawn with `contentColor.copy(alpha = 0.7f)`. There is no
+ * [androidx.compose.foundation.background] anywhere in this component; in particular it
+ * deliberately does NOT use `MediaTimestampOverlay`, which paints a `Color.Black` 0.6
+ * gradient scrim over the bottom of the media.
+ *
+ * @param payloads The message payloads; the solo sticker image payload is rendered.
+ * @param messageInfoText Preformatted timestamp (optionally prefixed with "edited").
+ */
+@Composable
+fun StickerMessage(
+    payloads: List<PayloadDescriptor>,
+    decryptedFiles: ImmutableMap<DecryptedFileKey, String>,
+    keyHeader: KeyHeader,
+    driveId: Uuid,
+    fileId: Uuid,
+    messageId: Uuid,
+    previewThumbnail: EmbeddedThumb?,
+    messageInfoText: String,
+    sentByYou: Boolean,
+    isPendingSend: Boolean,
+    deliveryStatus: Int,
+    contentColor: Color,
+    pendingSince: Instant?,
+    onMediaClick: (PayloadDescriptor) -> Unit,
+    onMediaLongPress: () -> Unit,
+    onRequestDecryptedFile: ((PayloadDescriptor) -> Unit)?,
+    sharedTransitionScope: SharedTransitionScope?,
+    animatedVisibilityScope: AnimatedVisibilityScope?,
+    downloadingFiles: Set<String>,
+    uploadStatus: UploadStatus? = null,
+    modifier: Modifier = Modifier,
+) {
+    if (payloads.isEmpty()) return
+    val payload = payloads[0]
+
+    Layout(
+        modifier = modifier,
+        content = {
+            // The bare sticker image. isSticker = true makes MediaItem drop the rounded
+            // clip; we pass no background-bearing modifier, so transparent pixels show the
+            // chat wallpaper through. ContentScale.Fit + a max-size sizeIn keeps it within
+            // the sticker budget while preserving aspect ratio.
+            MediaItem(
+                payload = payload,
+                fileId = fileId,
+                driveId = driveId,
+                previewThumbnail = previewThumbnail
+                    ?: payload.previewThumbnail?.toEmbeddedThumb(),
+                decryptedFiles = decryptedFiles,
+                keyHeader = keyHeader,
+                modifier = Modifier.sizeIn(maxWidth = Dimens.Sticker.maxSize, maxHeight = Dimens.Sticker.maxSize),
+                imageSize = ImageSize.THUMB_MEDIUM,
+                preserveAspectRatio = true,
+                isSticker = true,
+                onClick = { onMediaClick(payload) },
+                onLongPress = { onMediaLongPress() },
+                onRequestDecryptedFile = if (onRequestDecryptedFile != null) {
+                    { onRequestDecryptedFile(payload) }
+                } else {
+                    null
+                },
+                sharedTransitionScope = sharedTransitionScope,
+                animatedVisibilityScope = animatedVisibilityScope,
+                isDownloading = downloadingFiles.contains("${messageId}_${payload.key}"),
+                messageId = messageId,
+                isUploading = uploadStatus != null,
+            )
+
+            // Subtle timestamp + delivery status — identical styling to the emoji-only
+            // footer (labelSmall, contentColor @ 0.7 alpha), no scrim, no background.
+            Row(verticalAlignment = Alignment.Bottom) {
+                Text(
+                    text = messageInfoText,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = contentColor.copy(alpha = 0.7f),
+                )
+                if (sentByYou) {
+                    Spacer(modifier = Modifier.width(4.dp))
+                    DeliveryStatus(
+                        isPendingSend = isPendingSend,
+                        deliveryStatus = deliveryStatus,
+                        contentColor = contentColor.copy(alpha = 0.7f),
+                        pendingSince = pendingSince,
+                    )
+                }
+            }
+        },
+    ) { measurables, constraints ->
+        val imagePlaceable = measurables[0].measure(constraints)
+        // The info row is never wider than the sticker; clamp so it can't expand the bubble.
+        val infoPlaceable = measurables[1].measure(
+            constraints.copy(minWidth = 0, maxWidth = imagePlaceable.width)
+        )
+
+        val gap = 4.dp.roundToPx()
+        val width = imagePlaceable.width
+        val height = imagePlaceable.height + gap + infoPlaceable.height
+
+        layout(width, height) {
+            imagePlaceable.placeRelative(0, 0)
+            // Tuck the timestamp under the bottom-end corner of the sticker.
+            val infoX = (width - infoPlaceable.width).coerceAtLeast(0)
+            infoPlaceable.placeRelative(infoX, imagePlaceable.height + gap)
+        }
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilderStickerTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilderStickerTest.kt
@@ -1,0 +1,155 @@
+package id.homebase.chat.services.builder
+
+import id.homebase.api.client.drives.files.DescriptorContent
+import id.homebase.api.file.FileOperationsProvider
+import io.ktor.client.request.forms.InputProvider
+import org.jetbrains.skia.ColorAlphaType
+import org.jetbrains.skia.ColorInfo
+import org.jetbrains.skia.ColorSpace
+import org.jetbrains.skia.ColorType
+import org.jetbrains.skia.EncodedImageFormat
+import org.jetbrains.skia.Image
+import org.jetbrains.skia.ImageInfo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Pins the sticker auto-detection in MessageAttachmentBuilder's image branch:
+ * a transparent PNG produces a {"isSticker":true} descriptor, an opaque JPEG keeps
+ * the legacy "" descriptor, and forceSticker overrides detection. This is the
+ * send-side half of the sticker feature (the render-side reads descriptorInfo()).
+ */
+class MessageAttachmentBuilderStickerTest {
+
+    /** Encode a w×h image, alpha provided per pixel, in the given format. */
+    private fun encode(
+        w: Int,
+        h: Int,
+        format: EncodedImageFormat,
+        alphaAt: (x: Int, y: Int) -> Int,
+    ): ByteArray {
+        val info = ImageInfo(
+            colorInfo = ColorInfo(ColorType.BGRA_8888, ColorAlphaType.UNPREMUL, ColorSpace.sRGB),
+            width = w,
+            height = h,
+        )
+        val rowBytes = w * 4
+        val bytes = ByteArray(w * h * 4)
+        for (y in 0 until h) {
+            for (x in 0 until w) {
+                val i = (y * w + x) * 4
+                bytes[i] = 0                        // B
+                bytes[i + 1] = (0x80).toByte()      // G
+                bytes[i + 2] = (0xFF).toByte()      // R
+                bytes[i + 3] = (alphaAt(x, y) and 0xFF).toByte() // A
+            }
+        }
+        val image = Image.makeRaster(info, bytes, rowBytes)
+        return image.encodeToData(format)?.bytes ?: error("encode failed")
+    }
+
+    private fun transparentPng(): ByteArray =
+        encode(64, 64, EncodedImageFormat.PNG) { x, y -> if (x < 8 && y < 8) 0x00 else 0xFF }
+
+    private fun opaqueJpeg(): ByteArray =
+        encode(64, 64, EncodedImageFormat.JPEG) { _, _ -> 0xFF }
+
+    /** Returns the bytes registered at [filePath]; thumbnail generation reads them. */
+    private fun fakeFsServing(filePath: String, bytes: ByteArray) =
+        object : FileOperationsProvider {
+            override fun getCacheDirectory(): String = "/tmp/test-cache"
+            override fun openFileInput(path: String): InputProvider = fail("openFileInput")
+            override suspend fun readFileBytes(path: String): ByteArray {
+                assertEquals(filePath, path)
+                return bytes
+            }
+            override fun deleteTempFile(path: String): Boolean = false
+            override fun getFileSize(path: String): Long = bytes.size.toLong()
+            override suspend fun writeBytesToTempFile(
+                bytes: ByteArray, prefix: String, suffix: String,
+            ): String = fail("writeBytesToTempFile")
+            override suspend fun writeBytesToShareOutboundFile(
+                bytes: ByteArray, suffix: String,
+            ): String = fail("writeBytesToShareOutboundFile")
+            override suspend fun writeStream(path: String, data: Flow<ByteArray>) =
+                fail<Unit>("writeStream")
+            private fun <T> fail(name: String): T =
+                throw UnsupportedOperationException("$name should not be called from this test")
+        }
+
+    private fun stickerOf(descriptorContent: String?): Boolean? {
+        // Reconstruct the descriptor as a receiver would and read the flag back.
+        val info = id.homebase.api.client.drives.files.PayloadDescriptor(
+            key = "chat_web0",
+            contentType = "image/png",
+            descriptorContent = descriptorContent,
+        ).descriptorInfo()
+        return (info as? DescriptorContent.ImageFile)?.isSticker
+    }
+
+    @Test
+    fun transparentPng_setsStickerDescriptor() = runTest {
+        val path = "/tmp/cutout.png"
+        val bundle = MessageAttachmentBuilder.buildSingle(
+            attachment = AttachmentInput(filePath = path, contentType = "image/png"),
+            fileOperationsProvider = fakeFsServing(path, transparentPng()),
+            payloadKey = "chat_web0",
+        )
+        val payload = bundle.payloads.single()
+        assertEquals(true, stickerOf(payload.descriptorContent))
+    }
+
+    @Test
+    fun opaqueJpeg_keepsEmptyDescriptor() = runTest {
+        val path = "/tmp/photo.jpg"
+        val bundle = MessageAttachmentBuilder.buildSingle(
+            attachment = AttachmentInput(filePath = path, contentType = "image/jpeg"),
+            fileOperationsProvider = fakeFsServing(path, opaqueJpeg()),
+            payloadKey = "chat_web0",
+        )
+        val payload = bundle.payloads.single()
+        // Legacy empty descriptor → non-sticker; nothing changes for ordinary photos.
+        assertEquals("", payload.descriptorContent)
+        assertEquals(false, stickerOf(payload.descriptorContent))
+    }
+
+    @Test
+    fun forceSticker_overridesDetection_onOpaqueImage() = runTest {
+        val path = "/tmp/opaque.png"
+        val bundle = MessageAttachmentBuilder.buildSingle(
+            attachment = AttachmentInput(
+                filePath = path,
+                contentType = "image/png",
+                forceSticker = true,
+            ),
+            fileOperationsProvider = fakeFsServing(
+                path,
+                encode(32, 32, EncodedImageFormat.PNG) { _, _ -> 0xFF },
+            ),
+            payloadKey = "chat_web0",
+        )
+        val payload = bundle.payloads.single()
+        assertEquals(true, stickerOf(payload.descriptorContent))
+    }
+
+    @Test
+    fun transparentPng_descriptorParsesAsStickerImageFile() = runTest {
+        // End-to-end: the descriptor written at send must round-trip to ImageFile(isSticker=true).
+        val path = "/tmp/cutout2.png"
+        val bundle = MessageAttachmentBuilder.buildSingle(
+            attachment = AttachmentInput(filePath = path, contentType = "image/png"),
+            fileOperationsProvider = fakeFsServing(path, transparentPng()),
+            payloadKey = "chat_web0",
+        )
+        val descriptor = id.homebase.api.client.drives.files.PayloadDescriptor(
+            key = "chat_web0",
+            contentType = "image/png",
+            descriptorContent = bundle.payloads.single().descriptorContent,
+        )
+        val info = descriptor.descriptorInfo()
+        assertTrue(info is DescriptorContent.ImageFile && info.isSticker)
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/theme/Dimens.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/theme/Dimens.kt
@@ -166,6 +166,11 @@ object Dimens {
         val pageItemWidth = 72.dp
         val previewStickerSize = 96.dp
         val previewGutterSize = 16.dp
+
+        // Max edge of a sticker rendered in a chat bubble. Comparable to the emoji-only
+        // big glyph size (and well under Signal's 512 logical-px sticker) so the bare
+        // image floats on the wallpaper without dominating the column.
+        val maxSize = 160.dp
     }
 
     // Tooltip


### PR DESCRIPTION
## Goal / root cause

Transparent PNG/WebP cut-outs ("stickers") used to render with an opaque `surfaceContainerHigh` card behind them plus a rounded-card clip, so with the default `ContentScale.Fit` the transparency was flattened onto the bubble surface and they never looked cut out. Alpha is already preserved end-to-end on every platform (ARGB_8888 / N32Premul); the only defect was the render-side backdrop.

This adds an **explicit per-image sticker flag** — a real stored flag, not content-type inference at render — auto-detected at send time, and drops the backdrop + clip for solo stickers in the bubble.

## Change per file

**Storage (additive, backward-compatible, no wire break)**
- `PayloadDescriptor.kt` — new `@Serializable DescriptorContent.ImageFile(isSticker: Boolean = false)`, parsed in `descriptorInfo()` for `image/*` content type. Blank / null / legacy / malformed JSON all fall back to `ImageFile(false)` (try/catch, never throws — mirrors the audio/video parse-failure contract). `filename()` returns `null` for `ImageFile` so the download name still falls back to `payload.key` exactly as it did for the legacy `""` case. New `descriptorContentFromImage(isSticker)` companion helper. **No `MessageAppData` version bump, no message-body change** — this rides entirely on the per-payload descriptor slot that image payloads otherwise leave `""`.

**Detection (send-side)**
- `ImageUtil.kt` — new `expect ImageUtils.hasNonOpaquePixels(srcBytes): Boolean`.
- `ImageUtil.android.kt` — Android actual: `BitmapFactory` ARGB_8888, `Bitmap.hasAlpha()` fast-path then a coarse grid (≤ ~4096 samples) + the 4 corners + centre; `getPixel` alpha scan; try/catch → false; recycles the bitmap.
- `ImageUtil.skia.kt` — skiaMain actual (covers **Desktop + iOS + Web**): `alphaType == OPAQUE` fast-path then BGRA `readPixels` coarse-grid alpha-byte scan; try/catch → false.
- Threshold **alpha < 250** (not 255) to avoid false positives from WebP/PNG compression fringe on near-opaque photos.
- `MessageThumbnailGenerator.kt` / `ThumbnailResult.kt` — thread the original source bytes out of the generator (it already reads them) so the probe runs on the **pre-thumbnail** bytes with **no second file read**.
- `MessageAttachmentBuilder.kt` — in the image branch, gate to `image/png` + `image/webp` via `ImageFormatDetector`, run the probe, and write `{"isSticker":true}` only when transparent (or `AttachmentInput.forceSticker` is set). Opaque photos keep `""`.
- `AttachmentInput.kt` — new `forceSticker: Boolean = false` hook for a later manual "Send as sticker" toggle (v1 is auto-detect only).

**Render (100% commonMain, one path for all platforms)**
- `MediaMessage.kt` — `isSticker = payloads.size == 1 && (payloads[0].descriptorInfo() as? ImageFile)?.isSticker == true`; drops the `surfaceContainerHigh` background for the solo-image branch only (multi-image grids keep the letterbox fill); passes `isSticker` to `MediaItem`.
- `MediaItem.kt` — `isSticker: Boolean = false` param; applies `.clip(shape)` only when `!isSticker`; keeps `ContentScale.Fit`.
- `FullScreenMediaViewer.kt` — no functional change; added a comment noting the deliberate divergence (bubble = transparent, full-screen = solid surface backdrop).
- `PendingMessageBubble.kt` — unchanged; the optimistic placeholder keeps the normal fill for v1 (covered by the upload overlay, brief lifetime).

## Compile results (all targets)

| Target | homebase-api | homebase-chat |
|---|---|---|
| JVM (`compileKotlinJvm`) | PASS | PASS |
| Android (`compileAndroidMain`) | PASS | PASS |
| iOS (`compileKotlinIosSimulatorArm64`) | PASS | PASS |
| Web (`compileKotlinWasmJs`) | PASS | PASS |

The `expect`/`actual` alpha probe resolves on all four targets (two actuals only: androidMain + skiaMain).

## Tests

JVM (`homebase-api:jvmTest` + `homebase-chat:jvmTest`), all green:
- **PayloadDescriptor round-trip** — `ImageFile(true)` round-trips; blank / null / malformed all → `isSticker=false` with no throw; unknown keys ignored; `filename()` == null for image descriptors.
- **hasNonOpaquePixels** (skiaMain actual on JVM) — opaque PNG → false, fully-transparent → true, single transparent corner → true, alpha-252 fringe → false, opaque JPEG → false, real `shirt_transparent.png` fixture → true, corrupt/empty bytes → false (no throw).
- **MessageAttachmentBuilder** — transparent PNG → sticker descriptor, opaque JPEG → `""`, `forceSticker=true` on an opaque image → sticker; descriptor round-trips to `ImageFile(isSticker=true)`.
- Konsist `ArchitectureTest` passes (no new user-facing strings).

## Cross-platform + wire-compat notes

- Render change is 100% commonMain — identical on Android/iOS/Desktop/Web. The only per-platform code is the alpha probe (androidMain + skiaMain).
- **No wire break**: additive per-payload descriptor field; older clients ignore `descriptorContent` for images and a blank/legacy descriptor parses to `isSticker=false`. `MessageAppData.version` and the markdown/RichText body contract are untouched.
- Behaviour change worth calling out: `descriptorInfo()` for an `image/*` payload now returns `ImageFile` instead of `File`. Production never wrote a filename to an image descriptor (image payloads always wrote `""`), and `filename()` still returns `null` → download name falls back to `payload.key`. One existing test that asserted the old `image/jpeg`→`File("filename.jpg")` shape was retargeted to `application/pdf` to preserve its "generic file branch is unaffected" intent.
- Manual cross-platform smoke (recommended post-merge): send a cut-out transparent PNG and confirm no grey card behind it on Android + Desktop + iOS + wasmJs; confirm an ordinary photo still shows the letterbox backdrop; tap to full-screen and confirm the solid surface backdrop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)