### PR TITLE
Beautiful markdown: mikepenz renderer + richeditor editor (full authoring, drop underline)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -149,6 +149,7 @@ kermit-io = { module = "co.touchlab:kermit-io", version.ref = "kermit" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesystem", version.ref = "okio" }
 richeditor-compose = { module = "com.mohamedrejeb.richeditor:richeditor-compose", version.ref = "richeditorCompose" }
+markdown-renderer = { module = "com.mikepenz:multiplatform-markdown-renderer", version.ref = "markdownRenderer" }
 markdown-renderer-m3 = { module = "com.mikepenz:multiplatform-markdown-renderer-m3", version.ref = "markdownRenderer" }
 markdown-renderer-coil3 = { module = "com.mikepenz:multiplatform-markdown-renderer-coil3", version.ref = "markdownRenderer" }
 jetbrains-markdown = { module = "org.jetbrains:markdown", version = "0.7.3" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,9 +47,14 @@ okio = "3.17.0"
 richeditorCompose = "1.0.0-rc14"
 # Read-only markdown RENDERER (mikepenz). Built on org.jetbrains:markdown:0.7.3
 # (the CommonMark engine richeditor already pulls in — no version conflict).
-# Publishes m3 + coil3 artifacts for android/jvm/iosArm64/iosSimulatorArm64/wasmJs
-# at 0.41.0 (verified on Maven Central). Drives every read-only display site.
-markdownRenderer = "0.41.0"
+# Publishes m3 + coil3 artifacts for android/jvm/iosArm64/iosSimulatorArm64/wasmJs.
+# Pinned to 0.40.2 (NOT 0.41.0): 0.41.0's bytecode references the synthetic
+# `androidx.compose.ui.graphics.painter.Painter.$stable` field, which Compose 1.10
+# removed — so 0.41.0 throws NoSuchFieldError at runtime on our Compose 1.10.3 the
+# moment it renders an inline markdown image (MarkdownInlineImageWithSize). 0.40.2
+# is the newest release whose bytecode carries no removed-field reference (verified
+# via javap), and 0.39.x release notes confirm the 0.39–0.40 line targets CMP 1.10.
+markdownRenderer = "0.40.2"
 sqldelight = "2.3.2"
 sqlcipher = "4.13.0"
 kotlinx-coroutines = "1.10.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,16 @@ junit = "4.13.2"
 kotlin = "2.3.21"
 browser = "1.10.0"
 okio = "3.17.0"
+# richeditorCompose: 1.0.0-rc14 is the newest published build (2026-04-26); no
+# stable release exists, so there is no upgrade target. Kept as the WYSIWYG
+# composer/editor (the only CMP library that does true inline editing on all
+# four targets, incl. wasmJs). Read-only rendering uses mikepenz below.
 richeditorCompose = "1.0.0-rc14"
+# Read-only markdown RENDERER (mikepenz). Built on org.jetbrains:markdown:0.7.3
+# (the CommonMark engine richeditor already pulls in — no version conflict).
+# Publishes m3 + coil3 artifacts for android/jvm/iosArm64/iosSimulatorArm64/wasmJs
+# at 0.41.0 (verified on Maven Central). Drives every read-only display site.
+markdownRenderer = "0.41.0"
 sqldelight = "2.3.2"
 sqlcipher = "4.13.0"
 kotlinx-coroutines = "1.10.2"
@@ -140,6 +149,9 @@ kermit-io = { module = "co.touchlab:kermit-io", version.ref = "kermit" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesystem", version.ref = "okio" }
 richeditor-compose = { module = "com.mohamedrejeb.richeditor:richeditor-compose", version.ref = "richeditorCompose" }
+markdown-renderer-m3 = { module = "com.mikepenz:multiplatform-markdown-renderer-m3", version.ref = "markdownRenderer" }
+markdown-renderer-coil3 = { module = "com.mikepenz:multiplatform-markdown-renderer-coil3", version.ref = "markdownRenderer" }
+jetbrains-markdown = { module = "org.jetbrains:markdown", version = "0.7.3" }
 sqldelight-runtime = { module = "app.cash.sqldelight:runtime", version.ref = "sqldelight" }
 sqldelight-coroutines-extensions = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqldelight" }
 sqldelight-android-driver = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }

--- a/homebase-api/build.gradle.kts
+++ b/homebase-api/build.gradle.kts
@@ -216,6 +216,10 @@ kotlin {
             implementation(libs.kotlinx.immutableCollections)
             implementation(libs.coil3)
             implementation(libs.okio)
+            // CommonMark AST parser for markdownToPlainPreview (MarkdownPlain.kt).
+            // Same engine the chat renderer (mikepenz) and editor (richeditor)
+            // use, so the preview strip grammar mirrors the rendered output.
+            implementation(libs.jetbrains.markdown)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/util/MarkdownPlain.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/util/MarkdownPlain.kt
@@ -6,6 +6,7 @@ import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.ast.getTextInNode
 import org.intellij.markdown.flavours.commonmark.CommonMarkFlavourDescriptor
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import org.intellij.markdown.parser.MarkdownParser
 
 /**
@@ -158,3 +159,70 @@ private val whitespaceRunForPlain = Regex("\\s+")
 
 private fun String.collapseWhitespace(): String =
     replace(whitespaceRunForPlain, " ").trim()
+
+/**
+ * Top-level node types that are safe to render as a single inline [androidx.compose.ui.text.Text]
+ * node — i.e. they do NOT make the body a multi-block layout. A pure inline
+ * message (bold/italic/strike/inline-code/links, no headings/lists/quotes/etc.)
+ * parses to a single [MarkdownElementTypes.PARAGRAPH] under the root, surrounded
+ * only by whitespace/EOL leaf tokens.
+ *
+ * Everything else at the top level (ATX/Setext headings, ordered/unordered
+ * lists, fenced or indented code blocks, block quotes, GFM tables, thematic
+ * breaks, HTML blocks) is a real block element and must go through the block
+ * renderer.
+ */
+private val inlineSafeTopLevelTypes: Set<IElementType> = setOf(
+    MarkdownElementTypes.PARAGRAPH,
+    MarkdownTokenTypes.EOL,
+    MarkdownTokenTypes.WHITE_SPACE,
+)
+
+/**
+ * Returns true when [content] contains any markdown BLOCK element beyond a single
+ * paragraph / inline run.
+ *
+ * Parses with the SAME engine the chat block renderer (mikepenz) sits on — its
+ * default flavour is GFM, so tables and strikethrough are recognised here exactly
+ * as the renderer would. The result drives the renderer's inline-vs-block
+ * decision in `ChatMarkdown`: an inline-only body renders as a single stable
+ * [androidx.compose.ui.text.Text] node (compatible with the bubble's custom
+ * timestamp-tucking Layout), while a body with block elements renders through the
+ * multi-node block `Markdown()` Column (kept OUT of that Layout's
+ * textLayoutResult coupling).
+ *
+ * Block elements detected: ATX/Setext headings, ordered/unordered lists, fenced
+ * or indented code blocks, block quotes, GFM tables, thematic breaks, HTML
+ * blocks — any top-level node that is not a single PARAGRAPH or surrounding
+ * whitespace.
+ *
+ * Defensive: an unparseable body is treated as inline (returns false) so the
+ * decision never crashes the renderer; a malformed body that the parser cannot
+ * structure is no worse than a plain paragraph for the inline path.
+ */
+fun markdownHasBlockElements(content: String): Boolean {
+    if (content.isEmpty()) return false
+
+    val tree = try {
+        MarkdownParser(GFMFlavourDescriptor()).buildMarkdownTreeFromString(content)
+    } catch (_: Throwable) {
+        return false
+    }
+
+    // The root is MARKDOWN_FILE; its direct children are the block-level nodes.
+    // A pure inline message yields a single PARAGRAPH plus whitespace/EOL tokens.
+    // Any other top-level child (a second paragraph, or any heading/list/quote/
+    // code/table/rule/html block) means we must use the block renderer.
+    var paragraphCount = 0
+    for (child in tree.children) {
+        val type = child.type
+        if (type !in inlineSafeTopLevelTypes) return true
+        if (type == MarkdownElementTypes.PARAGRAPH) {
+            paragraphCount++
+            // Two separate paragraphs (a blank line in between) is multi-block:
+            // the single inline Text path cannot reproduce the paragraph gap.
+            if (paragraphCount > 1) return true
+        }
+    }
+    return false
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/util/MarkdownPlain.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/util/MarkdownPlain.kt
@@ -1,0 +1,160 @@
+package id.homebase.api.util
+
+import org.intellij.markdown.IElementType
+import org.intellij.markdown.MarkdownElementTypes
+import org.intellij.markdown.MarkdownTokenTypes
+import org.intellij.markdown.ast.ASTNode
+import org.intellij.markdown.ast.getTextInNode
+import org.intellij.markdown.flavours.commonmark.CommonMarkFlavourDescriptor
+import org.intellij.markdown.parser.MarkdownParser
+
+/**
+ * Convert a markdown body to a single-line plain-text preview.
+ *
+ * This is the ONE strip path the whole app uses for previews/notifications. It
+ * parses the markdown with the same CommonMark engine the chat renderer
+ * (mikepenz) and the editor (richeditor) sit on, then walks the AST collecting
+ * the text the renderer would actually draw — emphasis/heading/quote/list
+ * markers, code fences and link/image URLs are dropped; link and image *alt*
+ * text is kept. The result is whitespace-collapsed to a single line and
+ * truncated on a code-point boundary so emoji and other surrogate pairs are
+ * never split.
+ *
+ * Replaces the two divergent regex strip paths (`ChatMessageSizer.preview` and
+ * `String.stripMarkdownForPreview`) whose `[*_`#>\-]` class mangled legitimate
+ * hyphens/underscores in the middle of plain words and dropped trailing
+ * punctuation.
+ *
+ * @param markdown the raw markdown body.
+ * @param maxCodePoints maximum number of code points to keep.
+ */
+fun markdownToPlainPreview(markdown: String, maxCodePoints: Int): String {
+    if (markdown.isEmpty()) return ""
+
+    val tree = try {
+        MarkdownParser(CommonMarkFlavourDescriptor()).buildMarkdownTreeFromString(markdown)
+    } catch (_: Throwable) {
+        // The CommonMark parser is robust, but never let a preview crash the
+        // caller — fall back to a whitespace-collapsed copy of the raw source.
+        return markdown.collapseWhitespace().truncateToCodePoints(maxCodePoints)
+    }
+
+    val sb = StringBuilder()
+    appendPlainText(tree, markdown, sb)
+    return sb.toString().collapseWhitespace().truncateToCodePoints(maxCodePoints)
+}
+
+/** Markup-only leaf tokens that must never appear in the rendered plain text. */
+private val markupOnlyLeafTokens: Set<IElementType> = setOf(
+    MarkdownTokenTypes.EMPH,                 // * or _
+    MarkdownTokenTypes.BACKTICK,             // ` for inline code
+    MarkdownTokenTypes.ESCAPED_BACKTICKS,
+    MarkdownTokenTypes.LIST_BULLET,          // - / * / + at list start
+    MarkdownTokenTypes.LIST_NUMBER,          // 1. at ordered-list start
+    MarkdownTokenTypes.BLOCK_QUOTE,          // > marker
+    MarkdownTokenTypes.ATX_HEADER,           // # ## ### markers
+    MarkdownTokenTypes.SETEXT_1,
+    MarkdownTokenTypes.SETEXT_2,
+    MarkdownTokenTypes.CODE_FENCE_START,     // ``` open
+    MarkdownTokenTypes.CODE_FENCE_END,       // ``` close
+    MarkdownTokenTypes.FENCE_LANG,           // language tag on a fence
+    MarkdownTokenTypes.HORIZONTAL_RULE,
+)
+
+/** Whitespace-like leaf tokens that collapse to a single space. */
+private val whitespaceLeafTokens: Set<IElementType> = setOf(
+    MarkdownTokenTypes.EOL,
+    MarkdownTokenTypes.WHITE_SPACE,
+    MarkdownTokenTypes.HARD_LINE_BREAK,
+)
+
+/**
+ * Composite link node types: keep only the visible label, drop the URL. NOTE:
+ * IMAGE is intentionally NOT here — an IMAGE node wraps `! INLINE_LINK`, so we
+ * just recurse into it (dropping the `!` marker) and let the inner INLINE_LINK
+ * extract its own label.
+ */
+private val linkLikeNodes: Set<IElementType> = setOf(
+    MarkdownElementTypes.INLINE_LINK,
+    MarkdownElementTypes.FULL_REFERENCE_LINK,
+    MarkdownElementTypes.SHORT_REFERENCE_LINK,
+)
+
+/** Node subtrees to drop entirely (URLs, titles, link definitions). */
+private val dropSubtreeNodes: Set<IElementType> = setOf(
+    MarkdownElementTypes.LINK_DESTINATION,
+    MarkdownElementTypes.LINK_TITLE,
+    MarkdownElementTypes.LINK_DEFINITION,
+)
+
+/**
+ * Depth-first walk that appends the visible text of [node] to [out].
+ *
+ * Strategy is a *denylist*, not an allowlist: every leaf contributes its literal
+ * text unless it is a known markup-only marker. This keeps ordinary punctuation
+ * (`!`, `.`, `,`, parentheses in prose) intact — an allowlist silently dropped
+ * trailing `!` and broke "Hello there!" previews. Link/image nodes recurse only
+ * into their label; their destination/title subtrees are skipped.
+ */
+private fun appendPlainText(node: ASTNode, source: String, out: StringBuilder) {
+    val type = node.type
+
+    if (type in dropSubtreeNodes) return
+
+    if (type == MarkdownElementTypes.IMAGE) {
+        // IMAGE wraps `! INLINE_LINK`. Drop the bang marker, recurse the rest
+        // (the inner INLINE_LINK extracts its label, the URL is dropped there).
+        for (child in node.children) {
+            if (child.type == MarkdownTokenTypes.EXCLAMATION_MARK) continue
+            appendPlainText(child, source, out)
+        }
+        return
+    }
+
+    if (type in linkLikeNodes) {
+        // Keep the label only. For inline links the label lives under LINK_TEXT;
+        // for reference links / images the same. Recurse into LINK_TEXT children,
+        // and if there is none (short reference link) fall back to LINK_LABEL.
+        val label = node.children.firstOrNull { it.type == MarkdownElementTypes.LINK_TEXT }
+            ?: node.children.firstOrNull { it.type == MarkdownElementTypes.LINK_LABEL }
+        if (label != null) {
+            appendLinkLabel(label, source, out)
+        }
+        return
+    }
+
+    val children = node.children
+    if (children.isEmpty()) {
+        when (type) {
+            in markupOnlyLeafTokens -> return
+            in whitespaceLeafTokens -> out.append(' ')
+            // LINK_LABEL/LINK_TEXT brackets are handled by appendLinkLabel; any
+            // stray bracket tokens reaching here are literal text, keep them.
+            else -> out.append(node.getTextInNode(source))
+        }
+        return
+    }
+
+    for (child in children) {
+        appendPlainText(child, source, out)
+    }
+}
+
+/**
+ * Append the visible text of a LINK_TEXT / LINK_LABEL node, stripping the
+ * surrounding `[` `]` bracket tokens but keeping the inner text (which may itself
+ * contain emphasis we further strip via the normal walk).
+ */
+private fun appendLinkLabel(label: ASTNode, source: String, out: StringBuilder) {
+    for (child in label.children) {
+        when (child.type) {
+            MarkdownTokenTypes.LBRACKET, MarkdownTokenTypes.RBRACKET -> Unit
+            else -> appendPlainText(child, source, out)
+        }
+    }
+}
+
+private val whitespaceRunForPlain = Regex("\\s+")
+
+private fun String.collapseWhitespace(): String =
+    replace(whitespaceRunForPlain, " ").trim()

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/util/StringExtensions.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/util/StringExtensions.kt
@@ -54,16 +54,17 @@ fun String.sanitizePreviewText(): String =
 
 private const val NOTE_PREVIEW_MAX_LENGTH = 200
 
+/**
+ * One-line plain-text preview of a markdown body, capped at
+ * [NOTE_PREVIEW_MAX_LENGTH] code points, or null if the body has no visible
+ * text. Delegates to the shared [markdownToPlainPreview] AST walk so the
+ * grammar mirrors the renderer exactly (the old regex `[*_~`>]` class stripped
+ * legitimate hyphens/underscores from the middle of plain words).
+ */
 fun String.stripMarkdownForPreview(): String? {
-    val plain = this
-        .replace(Regex("^#{1,6}\\s+", RegexOption.MULTILINE), "")
-        .replace(Regex("[*_~`>]"), "")
-        .replace(Regex("!\\[([^]]*)]\\([^)]*\\)"), "$1")
-        .replace(Regex("\\[([^]]*)]\\([^)]*\\)"), "$1")
-        .replace(Regex("\\s+"), " ")
-        .trim()
+    val plain = markdownToPlainPreview(this, NOTE_PREVIEW_MAX_LENGTH)
     if (plain.isEmpty()) return null
-    return plain.truncateToCodePoints(NOTE_PREVIEW_MAX_LENGTH)
+    return plain
 }
 
 // Truncate a string to maxVisibleCharacters (be sure UTF characters aren't chopped in the middle)

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/util/MarkdownHasBlockElementsTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/util/MarkdownHasBlockElementsTest.kt
@@ -1,0 +1,100 @@
+package id.homebase.api.util
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Drives the inline-vs-block decision in `ChatMarkdown`. Inline-only bodies must
+ * stay on the single-Text path (so they remain compatible with the message
+ * bubble's timestamp-tucking custom Layout); anything with a real block element
+ * must route to the block renderer.
+ */
+class MarkdownHasBlockElementsTest {
+
+    @Test
+    fun inlineEmphasisLinkAndCode_isNotBlock() {
+        assertFalse(markdownHasBlockElements("**hi** [x](u) `c`"))
+    }
+
+    @Test
+    fun plainText_isNotBlock() {
+        assertFalse(markdownHasBlockElements("just a normal message, no markdown"))
+    }
+
+    @Test
+    fun emptyAndBlank_isNotBlock() {
+        assertFalse(markdownHasBlockElements(""))
+        assertFalse(markdownHasBlockElements("   "))
+    }
+
+    @Test
+    fun strikethroughAndItalic_isNotBlock() {
+        // GFM strikethrough + italic are inline spans, not blocks.
+        assertFalse(markdownHasBlockElements("~~gone~~ and _slanted_"))
+    }
+
+    @Test
+    fun softWrappedSingleParagraph_isNotBlock() {
+        // A single paragraph that happens to wrap across source lines (single
+        // newlines, no blank line) is still one paragraph.
+        assertFalse(markdownHasBlockElements("line one\nline two\nline three"))
+    }
+
+    @Test
+    fun atxHeading_isBlock() {
+        assertTrue(markdownHasBlockElements("# H"))
+    }
+
+    @Test
+    fun setextHeading_isBlock() {
+        assertTrue(markdownHasBlockElements("Title\n====="))
+    }
+
+    @Test
+    fun unorderedList_isBlock() {
+        assertTrue(markdownHasBlockElements("- a"))
+    }
+
+    @Test
+    fun orderedList_isBlock() {
+        assertTrue(markdownHasBlockElements("1. first\n2. second"))
+    }
+
+    @Test
+    fun blockQuote_isBlock() {
+        assertTrue(markdownHasBlockElements(">q"))
+    }
+
+    @Test
+    fun fencedCodeBlock_isBlock() {
+        assertTrue(markdownHasBlockElements("```\ncode line\n```"))
+    }
+
+    @Test
+    fun indentedCodeBlock_isBlock() {
+        assertTrue(markdownHasBlockElements("    indented code"))
+    }
+
+    @Test
+    fun thematicBreak_isBlock() {
+        assertTrue(markdownHasBlockElements("---"))
+    }
+
+    @Test
+    fun gfmTable_isBlock() {
+        val table = buildString {
+            append("| a | b |\n")
+            append("| - | - |\n")
+            append("| 1 | 2 |\n")
+        }
+        assertTrue(markdownHasBlockElements(table))
+    }
+
+    @Test
+    fun twoParagraphs_isBlock() {
+        // A blank line between paragraphs creates a paragraph gap the single
+        // inline Text path cannot reproduce — treat it as block.
+        assertTrue(markdownHasBlockElements("first para\n\nsecond para"))
+    }
+}

--- a/homebase-chat/build.gradle.kts
+++ b/homebase-chat/build.gradle.kts
@@ -76,6 +76,11 @@ kotlin {
             implementation(libs.coil3.compose)
             implementation(libs.coil3.network)
             implementation(libs.richeditor.compose)
+            // mikepenz read-only markdown renderer (m3 styling + in-markdown
+            // images via the existing Coil3 loader). m3/coil3 ship commonMain +
+            // android/jvm/ios/wasmJs, so no per-target block is needed.
+            implementation(libs.markdown.renderer.m3)
+            implementation(libs.markdown.renderer.coil3)
             implementation(libs.filekit.core)
             implementation(libs.filekit.dialogs.compose)
         }

--- a/homebase-chat/build.gradle.kts
+++ b/homebase-chat/build.gradle.kts
@@ -79,6 +79,17 @@ kotlin {
             // mikepenz read-only markdown renderer (m3 styling + in-markdown
             // images via the existing Coil3 loader). m3/coil3 ship commonMain +
             // android/jvm/ios/wasmJs, so no per-target block is needed.
+            //
+            // The CORE artifact is declared explicitly because MarkdownRenderer.kt
+            // imports com.mikepenz.markdown.annotator.{annotatorSettings,
+            // buildMarkdownAnnotatedString}, which live in the core module — a
+            // first-order use, not merely a transitive of m3/coil3. Without this
+            // line the core only reached the compile classpath transitively; the
+            // Desktop distributable (which consumes homebase-chat via a repackaged
+            // platform JAR in desktopApp, see homebase-core below) dropped it at
+            // runtime → NoClassDefFoundError com/mikepenz/markdown/annotator/
+            // AnnotatorSettingsKt at first render.
+            implementation(libs.markdown.renderer)
             implementation(libs.markdown.renderer.m3)
             implementation(libs.markdown.renderer.coil3)
             implementation(libs.filekit.core)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/chat/ChatMessageSizer.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/chat/ChatMessageSizer.kt
@@ -1,7 +1,7 @@
 package id.homebase.chat.services.chat
 
 import id.homebase.api.serialization.OdinSystemSerializer
-import id.homebase.api.util.truncateToCodePoints
+import id.homebase.api.util.markdownToPlainPreview
 import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.MessageAppData
 import kotlinx.serialization.Serializable
@@ -24,14 +24,10 @@ object ChatMessageSizer {
         return OdinSystemSerializer.serialize(payload).encodeToByteArray()
     }
 
-    fun preview(markdown: String): String {
-        val plain =
-            markdown
-                .replace(Regex("[*_`#>\\-]"), "")
-                .replace("\n", " ")
-
-        return plain.truncateToCodePoints(400)
-    }
+    fun preview(markdown: String): String =
+        // Shared AST strip — mirrors the renderer's grammar and, unlike the old
+        // `[*_`#>\-]` regex, leaves mid-word hyphens/underscores intact.
+        markdownToPlainPreview(markdown, maxCodePoints = 400)
 }
 
 @Serializable

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationItem.kt
@@ -34,8 +34,8 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.mohamedrejeb.richeditor.model.RichTextState
 import id.homebase.api.common.OdinId
+import id.homebase.api.util.markdownToPlainPreview
 import id.homebase.chat.data.ConversationState
 import id.homebase.chat.data.ConversationUiModel
 import id.homebase.chat.services.convo.EnrichedConversationUiModel
@@ -43,7 +43,6 @@ import id.homebase.chat.services.convo.OneOnOneConnectionStatus
 import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.ConversationAvatar
 import id.homebase.core.ui.theme.HomebaseTheme
-import id.homebase.core.util.applyDefaultStyling
 import id.homebase.core.util.formatTimestamp
 import id.homebase.core.util.ifTrue
 import id.homebase.resources.MR
@@ -335,19 +334,18 @@ fun ConversationMessagePreview(
         }
 
         if (text.isNotEmpty()) {
-            // IMPORTANT: RichTextState MUST be wrapped in remember(text).
-            // Without remember, a new RichTextState() is created on every recomposition and
-            // setMarkdown() modifies internal Compose MutableState during composition. This
-            // triggers another recomposition, which creates another RichTextState, which calls
-            // setMarkdown again — causing an infinite recomposition loop that pins the GPU at
-            // ~15-16% (one full core) permanently. The loop is invisible in logs because it
-            // happens purely in the Compose rendering layer with no app-level side effects.
-            val textState = remember(text) {
-                RichTextState().applyDefaultStyling().also { it.setMarkdown(text) }
+            // A conversation-list row is a single line, so render the stripped
+            // plain-text preview rather than the block markdown renderer — a
+            // heading/list/quote would otherwise blow up the one-liner. The
+            // strip is the same AST walk the renderer and previews share, and it
+            // sidesteps the old RichTextState infinite-recomposition footgun
+            // entirely (no Compose MutableState is mutated during composition).
+            val previewText = remember(text) {
+                markdownToPlainPreview(text, maxCodePoints = 200)
             }
 
             Text(
-                text = textState.annotatedString,
+                text = previewText,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(
                     alpha = if (isDeleted) 0.5f else 1f

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
@@ -412,6 +412,11 @@ fun ConversationListPane(
                                     listItem = listItem,
                                     selectedConversationId = selectedConversationId,
                                     iconOnlyMode = iconOnlyMode,
+                                    // Live search text drives the highlight in
+                                    // message-search rows; empty when not searching.
+                                    searchQuery = if (uiState.isSearchActive)
+                                        searchTextState.text.toString()
+                                    else "",
                                     onUiAction = onUiAction,
                                     onConversationSelected = onConversationSelected,
                                 )
@@ -477,6 +482,7 @@ fun ConversationLisContentItem(
     listItem: ConversationListContentModel,
     selectedConversationId: Uuid?,
     iconOnlyMode: Boolean,
+    searchQuery: String,
     onUiAction: (ConversationListUiAction) -> Unit,
     onConversationSelected: (conversationId: Uuid) -> Unit,
 ) {
@@ -552,6 +558,7 @@ fun ConversationLisContentItem(
             MessageSearchItem(
                 memberName = listItem.message.displayName,
                 message = listItem.message.content,
+                searchQuery = searchQuery,
                 contactOdinId = listItem.message.originalAuthor,
                 timestamp = listItem.message.userDate,
                 onClick = {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenMediaViewer.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenMediaViewer.kt
@@ -51,9 +51,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
-import com.mohamedrejeb.richeditor.model.RichTextState
-import com.mohamedrejeb.richeditor.ui.material3.RichText
 import id.homebase.api.client.KeyHeader
 import id.homebase.chat.conversationlist.FullScreenOverlay
 import id.homebase.chat.services.LocalAttachmentContextStore
@@ -66,7 +63,6 @@ import id.homebase.core.media.MediaRailItem
 import id.homebase.core.media.MediaUnavailablePlaceholder
 import id.homebase.core.media.subsample.SubSamplingImageSource
 import id.homebase.core.media.subsample.ZoomableSubSamplingImage
-import id.homebase.core.util.applyDefaultStyling
 import id.homebase.core.util.formatTimestamp
 import id.homebase.resources.MR
 import id.homebase.resources.chat_image_unavailable
@@ -79,7 +75,7 @@ import org.koin.compose.koinInject
 import kotlin.io.encoding.Base64
 import kotlin.uuid.Uuid
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalRichTextApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FullScreenMediaViewer(
     modifier: Modifier = Modifier,
@@ -107,11 +103,6 @@ fun FullScreenMediaViewer(
     }
 
     val currentPayloadKey = data.payloads.getOrNull(pagerState.currentPage)?.key ?: data.selectedPayloadKey
-
-    // See ConversationItem.kt ConversationMessagePreview for why remember is required here
-    val textState = remember(data.content) {
-        RichTextState().applyDefaultStyling().also { it.setMarkdown(data.content) }
-    }
 
     BoxWithConstraints(
         modifier = modifier
@@ -284,9 +275,10 @@ fun FullScreenMediaViewer(
                     .padding(16.dp)
             ) {
                 if (data.content.isNotBlank()) {
-                    RichText(
-                        state = textState,
+                    ChatMarkdown(
+                        content = data.content,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        style = MaterialTheme.typography.bodyLarge,
                         modifier = Modifier
                             .fillMaxWidth()
                             .heightIn(max = maxCaptionHeight)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MarkdownRenderer.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MarkdownRenderer.kt
@@ -1,6 +1,7 @@
 package id.homebase.chat.widget
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
@@ -23,6 +24,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
+import androidx.compose.ui.unit.sp
 import com.mikepenz.markdown.annotator.annotatorSettings
 import com.mikepenz.markdown.annotator.buildMarkdownAnnotatedString
 import com.mikepenz.markdown.coil3.Coil3ImageTransformerImpl
@@ -240,14 +243,18 @@ fun ChatMarkdown(
         dividerColor = color.copy(alpha = DIVIDER_ALPHA),
     )
     val typography = markdownTypography(
-        // Headings: scaled down from mikepenz's display* defaults so they fit a
-        // chat bubble while staying on the M3 typography scale.
-        h1 = MaterialTheme.typography.headlineSmall,
-        h2 = MaterialTheme.typography.titleLarge,
-        h3 = MaterialTheme.typography.titleMedium,
-        h4 = MaterialTheme.typography.titleSmall,
-        h5 = MaterialTheme.typography.labelLarge,
-        h6 = MaterialTheme.typography.labelMedium,
+        // Heading ladder. The M3 title/headline scale is too compressed to give a
+        // legible six-level hierarchy inside a chat bubble (titleLarge 22 → titleMedium
+        // 16 is a cliff, headlineSmall 24 → titleLarge 22 barely steps), so each level
+        // is a weighted, bubble-coloured step scaled off the body [style] instead. h1–h3
+        // bold for a clear top hierarchy; h4–h6 semibold. Sizes scale with the base body
+        // size so they track the chat type scale rather than being absolute.
+        h1 = style.bubbleHeading(color, scale = 1.5f, weight = FontWeight.Bold),
+        h2 = style.bubbleHeading(color, scale = 1.3f, weight = FontWeight.Bold),
+        h3 = style.bubbleHeading(color, scale = 1.15f, weight = FontWeight.Bold),
+        h4 = style.bubbleHeading(color, scale = 1.05f, weight = FontWeight.SemiBold),
+        h5 = style.bubbleHeading(color, scale = 1.0f, weight = FontWeight.SemiBold),
+        h6 = style.bubbleHeading(color, scale = 0.95f, weight = FontWeight.SemiBold),
         text = style,
         paragraph = style,
         ordered = style,
@@ -279,14 +286,27 @@ fun ChatMarkdown(
         // Default is fillMaxSize(); a chat bubble must wrap its content.
         modifier = modifier.wrapContentSize(),
         dimens = markdownDimens(
-            blockQuoteThickness = 3.dp,
-            codeBackgroundCornerSize = 8.dp,
+            // A slightly thicker quote bar reads as a deliberate accent (Notion-style)
+            // rather than a hairline.
+            blockQuoteThickness = 4.dp,
+            codeBackgroundCornerSize = 10.dp,
             dividerThickness = 1.dp,
         ),
         padding = markdownPadding(
-            block = 4.dp,
+            // Vertical rhythm between blocks — the single biggest lever on the
+            // "document" feel. 8.dp gives paragraphs/headings/lists room to breathe
+            // without ballooning the bubble.
+            block = 8.dp,
             list = 4.dp,
-            listIndent = 12.dp,
+            // Space between consecutive list items so multi-item lists don't read as
+            // one dense run.
+            listItemBottom = 4.dp,
+            // Wider indent so nested bullets/numbers clearly step in (was a cramped 12).
+            listIndent = 20.dp,
+            // Generous internal padding so fenced code looks like a real code card.
+            codeBlock = PaddingValues(horizontal = 12.dp, vertical = 10.dp),
+            // Offset the quote text from its accent bar.
+            blockQuoteText = PaddingValues(start = 12.dp, top = 2.dp, bottom = 2.dp),
         ),
         imageTransformer = Coil3ImageTransformerImpl,
         // Custom code components: same default body, but the container is a [color]
@@ -324,6 +344,25 @@ private const val FENCED_CODE_BORDER_ALPHA = 0.25f
 
 /** Divider (`---`) tint — stronger than the code fills so the rule stays visible. */
 private const val DIVIDER_ALPHA = 0.3f
+
+/**
+ * One rung of the bubble heading ladder: the body [this] style re-weighted to [weight]
+ * and recoloured to the bubble content [color], with its font size multiplied by [scale]
+ * (line height derived at 1.3× for headline-tight leading). Scaled off the body style —
+ * not a fixed M3 role — because the M3 type scale has no clean six-level heading ladder
+ * that stays chat-bubble-appropriate; scaling keeps the headings tracking the body type
+ * size. Falls back to a 16sp base if the body size is unspecified.
+ */
+private fun TextStyle.bubbleHeading(color: Color, scale: Float, weight: FontWeight): TextStyle {
+    val baseSp = if (fontSize.isSpecified) fontSize.value else 16f
+    val sizeSp = baseSp * scale
+    return copy(
+        color = color,
+        fontWeight = weight,
+        fontSize = sizeSp.sp,
+        lineHeight = (sizeSp * 1.3f).sp,
+    )
+}
 
 /**
  * Fenced/code-block container for a chat bubble: a faint [color] tint with a subtle

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MarkdownRenderer.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MarkdownRenderer.kt
@@ -9,22 +9,23 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.mikepenz.markdown.annotator.annotatorSettings
 import com.mikepenz.markdown.annotator.buildMarkdownAnnotatedString
 import com.mikepenz.markdown.coil3.Coil3ImageTransformerImpl
 import com.mikepenz.markdown.compose.Markdown
-import com.mikepenz.markdown.compose.components.markdownComponents
-import com.mikepenz.markdown.compose.elements.MarkdownText
 import com.mikepenz.markdown.m3.markdownColor
 import com.mikepenz.markdown.m3.markdownTypography
 import com.mikepenz.markdown.model.markdownDimens
 import com.mikepenz.markdown.model.markdownPadding
+import id.homebase.api.util.markdownHasBlockElements
 import id.homebase.api.util.markdownToPlainPreview
 
 /**
@@ -52,15 +53,40 @@ import id.homebase.api.util.markdownToPlainPreview
  * surface the match is what matters, so dropping inline emphasis there is the
  * correct trade-off, and the two styling worlds now share one [AnnotatedString].
  *
- * ### Layout integration
- * [onTextLayout] is invoked with the [TextLayoutResult] of the body's last
- * rendered paragraph, which is what the bubble's custom Layout needs to tuck the
- * timestamp onto the final line. [maxLines] / [overflow] are honoured on the
- * highlighted single-Text path and exposed so the read-more (Task F) cap merges
- * cleanly; the block renderer cannot apply one global line cap across
- * heterogeneous blocks, so the two 1-line preview sites (conversation list,
- * search row) strip to plain via [markdownToPlainPreview] and use a plain [Text]
- * rather than this block renderer.
+ * ### Layout integration — inline vs block
+ * The bubble's custom Layout (in `MessageBubbleRaw`) tucks the timestamp onto the
+ * last text line by reading the body's [TextLayoutResult] *during its own measure
+ * pass* and force-remeasuring siblings to converge the bubble width. That coupling
+ * is only safe for a SINGLE, STABLE text node. The mikepenz block `Markdown()`
+ * Column is a multi-node, interactive (link/hover) subtree that re-fires layout on
+ * Desktop hover — re-measuring it from inside the parent's layout pass throws
+ * `IllegalStateException: layout state is not idle before measure starts`.
+ *
+ * So this renderer has three shapes:
+ *
+ *  1. **Search active** → one highlighted plain [Text] (single stable node).
+ *  2. **Inline-only body** (no block elements: bold/italic/strike/inline-code/
+ *     links only) → one styled [Text] built from mikepenz
+ *     [buildMarkdownAnnotatedString] + [annotatorSettings]. Links are native
+ *     Compose [androidx.compose.ui.text.LinkAnnotation]s, handled by the Text
+ *     itself — no custom `pointerInput` reading a layout result, so no
+ *     reentrancy. This path reports [onTextLayout] and is the one the bubble's
+ *     custom Layout wraps for the last-line timestamp tuck.
+ *  3. **Block body** (heading/list/quote/code/table/rule/html) → the full
+ *     mikepenz block [Markdown] Column. It deliberately does NOT report
+ *     [onTextLayout]; the caller must place it OUTSIDE the timestamp-tucking
+ *     Layout (`MessageBubbleRaw` routes block bodies to a plain Column with the
+ *     timestamp below). The block path cannot apply one global line cap across
+ *     heterogeneous blocks, so the two 1-line preview sites (conversation list,
+ *     search row) strip to plain via [markdownToPlainPreview] rather than using
+ *     this renderer.
+ *
+ * Use [markdownHasBlockElements] to decide between (2) and (3) — the SAME helper
+ * the caller uses to choose the layout container — so the rendering shape and the
+ * container never disagree.
+ *
+ * [maxLines] / [overflow] are honoured on the single-Text paths (1 and 2) and
+ * exposed so the read-more (Task F) cap merges cleanly.
  */
 @Composable
 fun ChatMarkdown(
@@ -101,7 +127,70 @@ fun ChatMarkdown(
         return
     }
 
-    // Default path: full mikepenz block renderer, M3-styled.
+    // Inline-only path: no block elements, so the whole body is one paragraph of
+    // inline spans. Render it as a SINGLE [Text] over the annotated string mikepenz
+    // would have produced for that paragraph — bold/italic/strike/inline-code/links
+    // included. Links ride as native Compose LinkAnnotations (emitted by
+    // buildMarkdownAnnotatedString via annotatorSettings' linkInteractionListener,
+    // which opens the URL through LocalUriHandler), so a plain Text handles taps
+    // without any pointerInput reading the layout result. This single stable node
+    // is what keeps the bubble's last-line timestamp tuck reentrancy-free.
+    if (!markdownHasBlockElements(content)) {
+        // mikepenz's String overload parses (default GFM flavour, matching the
+        // block Markdown() below), finds the single paragraph/inline run, and
+        // applies the base style's SpanStyle — producing exactly the inline
+        // styling the block path's paragraph would, including the LinkAnnotations
+        // that make a plain Text handle taps natively.
+        //
+        // We build annotatorSettings explicitly rather than via the no-arg
+        // annotatorSettings() default: that default reads LocalMarkdownTypography /
+        // LocalMarkdownColors / LocalReferenceLinkHandler, which mikepenz only
+        // provides INSIDE its Markdown() composable and which `error(...)` when
+        // absent. Here we are outside Markdown(), so we supply the same M3 link
+        // and inline-code styling the block path uses, no reference handler, and
+        // let the default linkInteractionListener open URLs via LocalUriHandler.
+        //
+        // CRITICAL: pass ONLY `style` to TextLinkStyles — no hovered/focused/
+        // pressed variant. Compose's TextLinkScope registers a hover-keyed
+        // StyleAnnotation only to swap between those variants; with a single style
+        // the re-applied AnnotatedString is structurally identical on hover, so
+        // TextAnnotatedStringNode.updateText short-circuits (textChanged=false) and
+        // `onTextLayout` does NOT re-fire on Desktop hover. That is what keeps this
+        // single Text node stable inside the bubble's timestamp-tucking Layout
+        // (same cursor-only hover behaviour the old richeditor renderer had). A
+        // hovered/pressed variant here would mutate the text on hover, re-fire
+        // onTextLayout mid-measure, and resurrect the reentrancy crash.
+        val linkSpanStyle = TextLinkStyles(
+            style = style.copy(
+                fontWeight = FontWeight.Bold,
+                textDecoration = TextDecoration.Underline,
+            ).toSpanStyle(),
+        )
+        val inlineCodeStyle = style.copy(fontFamily = FontFamily.Monospace).toSpanStyle()
+            .copy(background = MaterialTheme.colorScheme.surfaceVariant)
+        val annotated = content.buildMarkdownAnnotatedString(
+            style = style,
+            annotatorSettings = annotatorSettings(
+                linkTextSpanStyle = linkSpanStyle,
+                codeSpanStyle = inlineCodeStyle,
+                referenceLinkHandler = null,
+            ),
+        )
+        Text(
+            text = annotated,
+            modifier = modifier,
+            color = color,
+            style = style,
+            maxLines = maxLines,
+            overflow = overflow,
+            onTextLayout = onTextLayout,
+        )
+        return
+    }
+
+    // Block path: full mikepenz block renderer, M3-styled. Deliberately does NOT
+    // report onTextLayout — the caller must keep this multi-node Column out of the
+    // bubble's timestamp-tucking custom Layout.
     val colors = markdownColor(
         text = color,
         // Inline code chip + fenced code container background.
@@ -145,30 +234,10 @@ fun ChatMarkdown(
             listIndent = 12.dp,
         ),
         imageTransformer = Coil3ImageTransformerImpl,
-        // Custom paragraph component so we can surface the body's last text
-        // layout to the caller (bubble timestamp-fit math). Mirrors mikepenz's
-        // own MarkdownParagraph but uses the MarkdownText overload that reports
-        // onTextLayout.
-        components = markdownComponents(
-            paragraph = { model ->
-                val settings = annotatorSettings()
-                val styled = buildAnnotatedString {
-                    pushStyle(typography.paragraph.toSpanStyle())
-                    buildMarkdownAnnotatedString(
-                        content = model.content,
-                        node = model.node,
-                        annotatorSettings = settings,
-                    )
-                    pop()
-                }
-                MarkdownText(
-                    content = styled,
-                    node = model.node,
-                    style = typography.paragraph,
-                    onTextLayout = { result, _ -> onTextLayout(result) },
-                    sourceContent = model.content,
-                )
-            },
-        ),
+        // No custom paragraph component: the block path intentionally does NOT
+        // surface onTextLayout. mikepenz's default MarkdownParagraph applies the
+        // same `typography.paragraph` styling, and keeping the block subtree free
+        // of the timestamp-tuck callback is what removes it from the bubble's
+        // reentrant custom-Layout coupling on Desktop hover.
     )
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MarkdownRenderer.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MarkdownRenderer.kt
@@ -1,6 +1,12 @@
 package id.homebase.chat.widget
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -20,7 +26,14 @@ import androidx.compose.ui.unit.dp
 import com.mikepenz.markdown.annotator.annotatorSettings
 import com.mikepenz.markdown.annotator.buildMarkdownAnnotatedString
 import com.mikepenz.markdown.coil3.Coil3ImageTransformerImpl
+import com.mikepenz.markdown.compose.LocalMarkdownPadding
 import com.mikepenz.markdown.compose.Markdown
+import com.mikepenz.markdown.compose.components.markdownComponents
+import com.mikepenz.markdown.compose.elements.MarkdownCodeBackground
+import com.mikepenz.markdown.compose.elements.MarkdownCodeBlock
+import com.mikepenz.markdown.compose.elements.MarkdownCodeFence
+import com.mikepenz.markdown.compose.elements.material.MarkdownBasicText
+import com.mikepenz.markdown.m3.elements.MarkdownCheckBox
 import com.mikepenz.markdown.m3.markdownColor
 import com.mikepenz.markdown.m3.markdownTypography
 import com.mikepenz.markdown.model.markdownDimens
@@ -31,12 +44,27 @@ import id.homebase.api.util.markdownToPlainPreview
 /**
  * THE single read-only markdown renderer for chat.
  *
- * Wraps mikepenz [Markdown] with M3-only styling: inline code as a monospace
- * chip on `surfaceVariant`, fenced code in a styled container, blockquotes with
- * an accent bar, headings on the M3 typography scale, and list spacing. Every
- * read-only block-display site (message bubble body, full-screen caption)
- * renders through here, so there is exactly one place styling and parser
- * behaviour live.
+ * Wraps mikepenz [Markdown] with M3-only styling. Every read-only
+ * block-display site (message bubble body, full-screen caption) renders
+ * through here, so there is exactly one place styling and parser behaviour
+ * live.
+ *
+ * ### Bubble-aware decorations
+ * A chat bubble is NOT the surface — a SENT bubble paints `primary` (blue) and
+ * passes a light [color] (white) as the body content colour, while a RECEIVED
+ * bubble paints `surface` and passes a dark [color]. Every markdown decoration
+ * is therefore derived from [color] (the bubble's content colour), not from
+ * fixed surface roles like `surfaceVariant` / `outlineVariant`: those read fine
+ * on a received bubble but produce a light-grey, low-contrast chip on the blue
+ * sent bubble. The derived tints — inline-code/fenced-code backgrounds, divider,
+ * blockquote bar, code text, links — all stay readable on BOTH bubbles because
+ * they're alpha-blended onto, or equal to, the bubble's own content colour.
+ *
+ * Links in particular do NOT use a fixed `MaterialTheme.colorScheme.primary`:
+ * that hue vanishes against the primary-coloured sent bubble. Instead a link is
+ * the bubble [color] itself, bold + underlined — guaranteed-contrast on both
+ * bubbles (it equals the content colour the rest of the body uses), with the
+ * underline carrying the affordance that the hue no longer can.
  *
  * Parser robustness: mikepenz renders through `org.jetbrains:markdown`
  * (CommonMark), which is why the old richeditor `setMarkdown` try/catch +
@@ -160,14 +188,22 @@ fun ChatMarkdown(
         // (same cursor-only hover behaviour the old richeditor renderer had). A
         // hovered/pressed variant here would mutate the text on hover, re-fire
         // onTextLayout mid-measure, and resurrect the reentrancy crash.
+        // Same bubble-aware link + inline-code styling the block path uses, so the
+        // single-Text inline render is pixel-equivalent to the block render for the
+        // same inline content. Link = bubble [color], bold + underlined (readable on
+        // sent AND received bubbles; see kdoc). Inline code = monospace [color] text
+        // on a faint [color] tint chip.
         val linkSpanStyle = TextLinkStyles(
             style = style.copy(
+                color = color,
                 fontWeight = FontWeight.Bold,
                 textDecoration = TextDecoration.Underline,
             ).toSpanStyle(),
         )
-        val inlineCodeStyle = style.copy(fontFamily = FontFamily.Monospace).toSpanStyle()
-            .copy(background = MaterialTheme.colorScheme.surfaceVariant)
+        val inlineCodeStyle = style.copy(
+            color = color,
+            fontFamily = FontFamily.Monospace,
+        ).toSpanStyle().copy(background = color.copy(alpha = INLINE_CODE_BG_ALPHA))
         val annotated = content.buildMarkdownAnnotatedString(
             style = style,
             annotatorSettings = annotatorSettings(
@@ -191,12 +227,17 @@ fun ChatMarkdown(
     // Block path: full mikepenz block renderer, M3-styled. Deliberately does NOT
     // report onTextLayout — the caller must keep this multi-node Column out of the
     // bubble's timestamp-tucking custom Layout.
+    //
+    // All decorations derive from the bubble [color] (see kdoc), not surface roles:
+    //  - inlineCodeBackground: faint [color] tint behind inline-code chips.
+    //  - codeBackground: faint [color] tint behind fenced-code containers (the
+    //    custom codeFence/codeBlock components below add a [color] border on top).
+    //  - dividerColor: a stronger [color] tint for `---` rules.
     val colors = markdownColor(
         text = color,
-        // Inline code chip + fenced code container background.
-        codeBackground = MaterialTheme.colorScheme.surfaceVariant,
-        inlineCodeBackground = MaterialTheme.colorScheme.surfaceVariant,
-        dividerColor = MaterialTheme.colorScheme.outlineVariant,
+        codeBackground = color.copy(alpha = FENCED_CODE_BG_ALPHA),
+        inlineCodeBackground = color.copy(alpha = INLINE_CODE_BG_ALPHA),
+        dividerColor = color.copy(alpha = DIVIDER_ALPHA),
     )
     val typography = markdownTypography(
         // Headings: scaled down from mikepenz's display* defaults so they fit a
@@ -212,9 +253,23 @@ fun ChatMarkdown(
         ordered = style,
         bullet = style,
         list = style,
-        code = style.copy(fontFamily = FontFamily.Monospace),
-        inlineCode = style.copy(fontFamily = FontFamily.Monospace),
-        quote = style.copy(fontStyle = FontStyle.Italic),
+        // code/inlineCode carry an explicit `color = color` so the monospace glyphs
+        // are the bubble content colour (not the surface onBackground default the
+        // mikepenz typography would otherwise fall back to on the chip tint).
+        code = style.copy(color = color, fontFamily = FontFamily.Monospace),
+        inlineCode = style.copy(color = color, fontFamily = FontFamily.Monospace),
+        // quote `color = color` drives BOTH the blockquote text and the accent bar:
+        // MarkdownBlockQuote draws the bar with style.color when specified.
+        quote = style.copy(color = color, fontStyle = FontStyle.Italic),
+        // Links: bubble [color], bold + underlined — readable on sent AND received
+        // bubbles (it equals the content colour), matching the inline path.
+        textLink = TextLinkStyles(
+            style = style.copy(
+                color = color,
+                fontWeight = FontWeight.Bold,
+                textDecoration = TextDecoration.Underline,
+            ).toSpanStyle(),
+        ),
     )
 
     Markdown(
@@ -234,10 +289,75 @@ fun ChatMarkdown(
             listIndent = 12.dp,
         ),
         imageTransformer = Coil3ImageTransformerImpl,
-        // No custom paragraph component: the block path intentionally does NOT
-        // surface onTextLayout. mikepenz's default MarkdownParagraph applies the
-        // same `typography.paragraph` styling, and keeping the block subtree free
-        // of the timestamp-tuck callback is what removes it from the bubble's
-        // reentrant custom-Layout coupling on Desktop hover.
+        // Custom code components: same default body, but the container is a [color]
+        // tint with a subtle [color] border so the fenced block reads as a distinct
+        // surface on both bubbles. Keep the M3 checkbox (the Markdown() default
+        // overrides only `checkbox`; supplying our own components map drops that, so
+        // re-supply it). No custom paragraph component: the block path intentionally
+        // does NOT surface onTextLayout — keeping the block subtree free of the
+        // timestamp-tuck callback removes it from the bubble's reentrant custom-Layout
+        // coupling on Desktop hover.
+        components = markdownComponents(
+            checkbox = { MarkdownCheckBox(it.content, it.node, it.typography.text) },
+            codeFence = {
+                MarkdownCodeFence(it.content, it.node, style = it.typography.code) { code, language, codeStyle ->
+                    BubbleCodeContainer(code = code, language = language, style = codeStyle, color = color)
+                }
+            },
+            codeBlock = {
+                MarkdownCodeBlock(it.content, it.node, style = it.typography.code) { code, language, codeStyle ->
+                    BubbleCodeContainer(code = code, language = language, style = codeStyle, color = color)
+                }
+            },
+        ),
     )
+}
+
+/** Faint tint behind an inline-code chip, alpha-blended onto the bubble content colour. */
+private const val INLINE_CODE_BG_ALPHA = 0.15f
+
+/** Slightly softer tint behind a fenced-code container (it also carries a border). */
+private const val FENCED_CODE_BG_ALPHA = 0.12f
+
+/** Border around a fenced-code container — a touch stronger than its fill. */
+private const val FENCED_CODE_BORDER_ALPHA = 0.25f
+
+/** Divider (`---`) tint — stronger than the code fills so the rule stays visible. */
+private const val DIVIDER_ALPHA = 0.3f
+
+/**
+ * Fenced/code-block container for a chat bubble: a faint [color] tint with a subtle
+ * [color] border, both alpha-blended onto the bubble content colour so the block
+ * reads as a distinct surface on BOTH a sent (primary) and received (surface) bubble.
+ * Mirrors mikepenz's own private `MarkdownCode` body (rounded [MarkdownCodeBackground]
+ * + horizontally-scrollable monospace text) but swaps the surface-role fill for the
+ * bubble-relative tint and adds the border.
+ */
+@Composable
+private fun BubbleCodeContainer(
+    code: String,
+    language: String?,
+    style: TextStyle,
+    color: Color,
+) {
+    val codeBlockPadding = LocalMarkdownPadding.current.codeBlock
+    MarkdownCodeBackground(
+        color = color.copy(alpha = FENCED_CODE_BG_ALPHA),
+        shape = RoundedCornerShape(8.dp),
+        border = BorderStroke(1.dp, color.copy(alpha = FENCED_CODE_BORDER_ALPHA)),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        language = language,
+        code = code,
+    ) {
+        MarkdownBasicText(
+            text = AnnotatedString(code),
+            style = style,
+            color = color,
+            modifier = Modifier
+                .horizontalScroll(rememberScrollState())
+                .padding(codeBlockPadding),
+        )
+    }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MarkdownRenderer.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MarkdownRenderer.kt
@@ -1,0 +1,174 @@
+package id.homebase.chat.widget
+
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.mikepenz.markdown.annotator.annotatorSettings
+import com.mikepenz.markdown.annotator.buildMarkdownAnnotatedString
+import com.mikepenz.markdown.coil3.Coil3ImageTransformerImpl
+import com.mikepenz.markdown.compose.Markdown
+import com.mikepenz.markdown.compose.components.markdownComponents
+import com.mikepenz.markdown.compose.elements.MarkdownText
+import com.mikepenz.markdown.m3.markdownColor
+import com.mikepenz.markdown.m3.markdownTypography
+import com.mikepenz.markdown.model.markdownDimens
+import com.mikepenz.markdown.model.markdownPadding
+import id.homebase.api.util.markdownToPlainPreview
+
+/**
+ * THE single read-only markdown renderer for chat.
+ *
+ * Wraps mikepenz [Markdown] with M3-only styling: inline code as a monospace
+ * chip on `surfaceVariant`, fenced code in a styled container, blockquotes with
+ * an accent bar, headings on the M3 typography scale, and list spacing. Every
+ * read-only block-display site (message bubble body, full-screen caption)
+ * renders through here, so there is exactly one place styling and parser
+ * behaviour live.
+ *
+ * Parser robustness: mikepenz renders through `org.jetbrains:markdown`
+ * (CommonMark), which is why the old richeditor `setMarkdown` try/catch +
+ * `fixProblematicMarkdownText` workaround is retired — the documented
+ * "space after a blank line" crash does not occur with this parser.
+ *
+ * ### Search highlight
+ * When [searchQuery] is non-empty and matches the body, we render a single
+ * highlighted plain-text [Text] built from the markdown's rendered plain form
+ * (via [markdownToPlainPreview]). The highlight offsets are therefore computed
+ * against *exactly* the string being drawn, which structurally removes the
+ * stale-offset `String.subSequence` crash the old separate fork hit when
+ * richeditor reassembled its annotated string to a different length. On a search
+ * surface the match is what matters, so dropping inline emphasis there is the
+ * correct trade-off, and the two styling worlds now share one [AnnotatedString].
+ *
+ * ### Layout integration
+ * [onTextLayout] is invoked with the [TextLayoutResult] of the body's last
+ * rendered paragraph, which is what the bubble's custom Layout needs to tuck the
+ * timestamp onto the final line. [maxLines] / [overflow] are honoured on the
+ * highlighted single-Text path and exposed so the read-more (Task F) cap merges
+ * cleanly; the block renderer cannot apply one global line cap across
+ * heterogeneous blocks, so the two 1-line preview sites (conversation list,
+ * search row) strip to plain via [markdownToPlainPreview] and use a plain [Text]
+ * rather than this block renderer.
+ */
+@Composable
+fun ChatMarkdown(
+    content: String,
+    modifier: Modifier = Modifier,
+    color: Color = LocalContentColor.current,
+    style: TextStyle = MaterialTheme.typography.bodyLarge,
+    searchQuery: String? = null,
+    isCurrentSearchResult: Boolean = false,
+    maxLines: Int = Int.MAX_VALUE,
+    overflow: TextOverflow = TextOverflow.Clip,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+) {
+    // Search-active path: render the rendered-plain form with highlight folded
+    // in. One AnnotatedString, drawn as-is — offsets can never go stale.
+    val query = searchQuery?.takeIf { it.isNotEmpty() }
+    if (query != null) {
+        val plain = markdownToPlainPreview(content, maxCodePoints = Int.MAX_VALUE)
+        val highlightColor =
+            if (isCurrentSearchResult)
+                MaterialTheme.colorScheme.tertiary.copy(alpha = 0.55f)
+            else
+                MaterialTheme.colorScheme.secondary.copy(alpha = 0.35f)
+        val highlighted = buildSearchHighlightedText(
+            plain = plain,
+            searchQuery = query,
+            highlightColor = highlightColor,
+        )
+        Text(
+            text = highlighted ?: AnnotatedString(plain),
+            modifier = modifier,
+            color = color,
+            style = style,
+            maxLines = maxLines,
+            overflow = overflow,
+            onTextLayout = onTextLayout,
+        )
+        return
+    }
+
+    // Default path: full mikepenz block renderer, M3-styled.
+    val colors = markdownColor(
+        text = color,
+        // Inline code chip + fenced code container background.
+        codeBackground = MaterialTheme.colorScheme.surfaceVariant,
+        inlineCodeBackground = MaterialTheme.colorScheme.surfaceVariant,
+        dividerColor = MaterialTheme.colorScheme.outlineVariant,
+    )
+    val typography = markdownTypography(
+        // Headings: scaled down from mikepenz's display* defaults so they fit a
+        // chat bubble while staying on the M3 typography scale.
+        h1 = MaterialTheme.typography.headlineSmall,
+        h2 = MaterialTheme.typography.titleLarge,
+        h3 = MaterialTheme.typography.titleMedium,
+        h4 = MaterialTheme.typography.titleSmall,
+        h5 = MaterialTheme.typography.labelLarge,
+        h6 = MaterialTheme.typography.labelMedium,
+        text = style,
+        paragraph = style,
+        ordered = style,
+        bullet = style,
+        list = style,
+        code = style.copy(fontFamily = FontFamily.Monospace),
+        inlineCode = style.copy(fontFamily = FontFamily.Monospace),
+        quote = style.copy(fontStyle = FontStyle.Italic),
+    )
+
+    Markdown(
+        content = content,
+        colors = colors,
+        typography = typography,
+        // Default is fillMaxSize(); a chat bubble must wrap its content.
+        modifier = modifier.wrapContentSize(),
+        dimens = markdownDimens(
+            blockQuoteThickness = 3.dp,
+            codeBackgroundCornerSize = 8.dp,
+            dividerThickness = 1.dp,
+        ),
+        padding = markdownPadding(
+            block = 4.dp,
+            list = 4.dp,
+            listIndent = 12.dp,
+        ),
+        imageTransformer = Coil3ImageTransformerImpl,
+        // Custom paragraph component so we can surface the body's last text
+        // layout to the caller (bubble timestamp-fit math). Mirrors mikepenz's
+        // own MarkdownParagraph but uses the MarkdownText overload that reports
+        // onTextLayout.
+        components = markdownComponents(
+            paragraph = { model ->
+                val settings = annotatorSettings()
+                val styled = buildAnnotatedString {
+                    pushStyle(typography.paragraph.toSpanStyle())
+                    buildMarkdownAnnotatedString(
+                        content = model.content,
+                        node = model.node,
+                        annotatorSettings = settings,
+                    )
+                    pop()
+                }
+                MarkdownText(
+                    content = styled,
+                    node = model.node,
+                    style = typography.paragraph,
+                    onTextLayout = { result, _ -> onTextLayout(result) },
+                    sourceContent = model.content,
+                )
+            },
+        ),
+    )
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -49,9 +49,6 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
-import com.mohamedrejeb.richeditor.model.RichTextState
-import com.mohamedrejeb.richeditor.ui.material3.RichText
 import id.homebase.api.client.drives.files.PayloadDescriptor
 import id.homebase.chat.conversationlist.DecryptedFileKey
 import id.homebase.chat.conversationlist.MessageClusterPosition
@@ -63,12 +60,8 @@ import id.homebase.chat.groodle.GroodleBubble
 import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.content.MessageContent
 import id.homebase.core.config.chatTargetDrive
-import id.homebase.core.ui.theme.DarkColors
 import id.homebase.core.ui.theme.Dimens
 import id.homebase.core.ui.theme.HomebaseTheme
-import id.homebase.core.ui.theme.LightColors
-import id.homebase.core.util.applyDefaultStyling
-import id.homebase.core.util.applyMarkDownContent
 import id.homebase.core.util.formatMessageTimestamp
 import id.homebase.core.util.ifTrue
 import id.homebase.core.util.isEmojiContentOnly
@@ -106,7 +99,6 @@ import kotlin.uuid.Uuid
  * @param sharedTransitionScope The shared transition scope for animations.
  * @param animatedVisibilityScope The animated visibility scope for animations.
  */
-@OptIn(ExperimentalRichTextApi::class)
 @Composable
 fun MessageBubbleRaw(
     modifier: Modifier = Modifier,
@@ -246,30 +238,11 @@ fun MessageBubbleRaw(
         else MaterialTheme.colorScheme.onSurface
 
     val deletedText = stringResource(MR.string.chat_message_deleted)
-    val textState =
-        remember(message.isDeleted, message.content) {
-            RichTextState()
-                .applyDefaultStyling(linkColor = if (sentByYou) DarkColors.Primary else LightColors.Primary)
-                .applyMarkDownContent(if (message.isDeleted) deletedText else message.content)
-        }
-    // When a search query is active we render a plain AnnotatedString instead of RichText,
-    // so that the string the highlight offsets are computed against is exactly the string
-    // being drawn. RichTextState can reassemble its annotatedString to a different length
-    // at layout time (markdown tokens), which would leave stale SpanStyle ranges and crash
-    // String.subSequence during draw.
-    val highlightedText: AnnotatedString? =
-        remember(message.isDeleted, message.content, searchQuery, isCurrentSearchResult) {
-            if (message.isDeleted) return@remember null
-            val highlightColor = if (isCurrentSearchResult)
-                Color(0xFFFF8C00).copy(alpha = 0.6f)
-            else
-                Color(0xFFFFEB3B).copy(alpha = 0.5f)
-            buildSearchHighlightedText(
-                plain = message.content,
-                searchQuery = searchQuery,
-                highlightColor = highlightColor,
-            )
-        }
+    // Body markdown rendered (and search-highlighted) by the single ChatMarkdown
+    // renderer below — no RichTextState round-trip, no separate highlight fork.
+    val bodyText = if (message.isDeleted) deletedText else message.content
+    // A search query never applies to the system "deleted" placeholder.
+    val effectiveSearchQuery = if (message.isDeleted) "" else searchQuery
 
     val big = Dimens.Message.cornerRadius
     val small = Dimens.Message.cornerCollapseRadius
@@ -473,19 +446,14 @@ fun MessageBubbleRaw(
                                         style = MaterialTheme.typography.displaySmall,
                                         color = contentColor
                                     )
-                                } else if (highlightedText != null) {
-                                    Text(
-                                        text = highlightedText,
-                                        onTextLayout = { textLayoutResult = it },
-                                        style = MaterialTheme.typography.bodyLarge,
-                                        color = contentColor
-                                    )
                                 } else {
-                                    RichText(
-                                        state = textState,
-                                        onTextLayout = { textLayoutResult = it },
+                                    ChatMarkdown(
+                                        content = bodyText,
+                                        color = contentColor,
                                         style = MaterialTheme.typography.bodyLarge,
-                                        color = contentColor
+                                        searchQuery = effectiveSearchQuery,
+                                        isCurrentSearchResult = isCurrentSearchResult,
+                                        onTextLayout = { textLayoutResult = it },
                                     )
                                 }
                             }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import id.homebase.api.client.drives.files.PayloadDescriptor
+import id.homebase.api.util.markdownHasBlockElements
 import id.homebase.chat.conversationlist.DecryptedFileKey
 import id.homebase.chat.conversationlist.MessageClusterPosition
 import id.homebase.chat.conversationlist.UploadStatus
@@ -244,6 +245,24 @@ fun MessageBubbleRaw(
     // A search query never applies to the system "deleted" placeholder.
     val effectiveSearchQuery = if (message.isDeleted) "" else searchQuery
 
+    // When the body contains markdown BLOCK elements (headings, lists, quotes,
+    // code blocks, tables, rules), ChatMarkdown renders the multi-node mikepenz
+    // block Column. That Column re-fires layout on Desktop hover (links/hover),
+    // and the timestamp-tucking custom Layout below reads a freshly-written
+    // textLayoutResult during its own measure pass and force-remeasures children —
+    // re-measuring the block Column from inside that pass throws
+    // "layout state is not idle before measure starts". So a block body is routed
+    // to a plain Column (timestamp placed below as a normal element) instead of
+    // the custom Layout. Emoji-only, search, and the "deleted" placeholder always
+    // render as a single stable Text, so they keep the custom Layout's last-line
+    // timestamp tuck.
+    val bodyIsBlock = remember(bodyText, emojiOnly, effectiveSearchQuery, message.isDeleted) {
+        !message.isDeleted &&
+            !emojiOnly &&
+            effectiveSearchQuery.isEmpty() &&
+            markdownHasBlockElements(bodyText)
+    }
+
     val big = Dimens.Message.cornerRadius
     val small = Dimens.Message.cornerCollapseRadius
     val shape = remember(sentByYou, clusterPosition, mediaOnly) {
@@ -378,6 +397,119 @@ fun MessageBubbleRaw(
                     layout(width, replyPlaceable.height + mediaPlaceable.height) {
                         replyPlaceable.placeRelative(0, 0)
                         mediaPlaceable.placeRelative(0, replyPlaceable.height)
+                    }
+                }
+            } else if (bodyIsBlock) {
+                // BLOCK body path: the multi-node mikepenz block Markdown() Column
+                // is interactive (links/hover) and re-fires layout on Desktop
+                // hover. It must NOT be a child of the timestamp-tucking custom
+                // Layout (which reads textLayoutResult mid-measure and
+                // force-remeasures siblings) — that combination throws
+                // "layout state is not idle before measure starts". So we stack
+                // the same children in a plain Column and place the timestamp
+                // below as a normal element. ChatMarkdown's block path reports no
+                // textLayoutResult, so there is no last-line tuck to lose here:
+                // this is exactly the below-placement the custom Layout already
+                // falls back to when textLayoutResult is null.
+                Column(modifier = Modifier.wrapContentWidth()) {
+                    authorName?.let {
+                        Text(
+                            text = it,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = authorColor ?: contentColor,
+                            modifier = Modifier.padding(
+                                start = 12.dp,
+                                top = 8.dp,
+                                end = 12.dp,
+                                bottom = 4.dp,
+                            ),
+                            maxLines = 1,
+                        )
+                    }
+                    message.messageAppData.replyPreview?.let { reply ->
+                        InlineReplyPreview(
+                            replyPreview = reply,
+                            sentByYou = sentByYou,
+                            onClick = { onClickMessageId(reply.replyUniqueId) },
+                            replyMessage = replyMessages[reply.replyUniqueId],
+                            driveId = chatTargetDrive.alias,
+                        )
+                    }
+                    if (hasMedia) {
+                        MediaMessage(
+                            payloads = filteredPayloads.toPersistentList(),
+                            decryptedFiles = decryptedFiles,
+                            fileId = message.fileId,
+                            driveId = chatTargetDrive.alias,
+                            previewThumbnail = message.previewThumbnail,
+                            onMediaClick = onMediaClick,
+                            keyHeader = message.keyHeader,
+                            shape = if (authorName == null && message.messageAppData.replyPreview == null) RoundedCornerShape(
+                                topStart = Dimens.Message.cornerRadius,
+                                topEnd = Dimens.Message.cornerRadius
+                            ) else RoundedCornerShape(0.dp),
+                            onMediaLongPress = { _, _ -> handleLongClick() },
+                            onRequestDecryptedFile = onRequestDecryptedFile,
+                            sharedTransitionScope = sharedTransitionScope,
+                            animatedVisibilityScope = animatedVisibilityScope,
+                            messageId = message.id,
+                            downloadingFiles = downloadingFiles,
+                            uploadStatus = uploadStatus,
+                        )
+                    }
+                    Row(
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp),
+                    ) {
+                        // No onTextLayout: the block renderer reports none, and the
+                        // timestamp is placed below as its own row (next).
+                        ChatMarkdown(
+                            content = bodyText,
+                            color = contentColor,
+                            style = MaterialTheme.typography.bodyLarge,
+                            searchQuery = effectiveSearchQuery,
+                            isCurrentSearchResult = isCurrentSearchResult,
+                        )
+                    }
+                    if (message.hasMore && onShowMoreClick != null) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable(onClick = onShowMoreClick)
+                        ) {
+                            Text(
+                                text = stringResource(MR.string.show_more),
+                                style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Bold),
+                                color = contentColor,
+                                modifier = Modifier.padding(
+                                    start = 12.dp,
+                                    end = 12.dp,
+                                    top = 4.dp,
+                                    bottom = 6.dp,
+                                ),
+                            )
+                        }
+                    }
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(start = 8.dp, end = 12.dp, bottom = 8.dp),
+                        verticalAlignment = Alignment.Bottom,
+                        horizontalArrangement = Arrangement.End,
+                    ) {
+                        Text(
+                            text = messageInfoText,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = contentColor.copy(alpha = 0.7f)
+                        )
+                        if (sentByYou && !message.isDeleted) {
+                            Spacer(modifier = Modifier.width(4.dp))
+                            DeliveryStatus(
+                                isPendingSend = isPendingSend,
+                                deliveryStatus = message.messageAppData.deliveryStatus,
+                                contentColor = contentColor.copy(alpha = 0.7f),
+                                pendingSince = message.userDate,
+                            )
+                        }
                     }
                 }
             } else {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
@@ -37,6 +37,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.automirrored.outlined.FormatIndentIncrease
 import androidx.compose.material.icons.automirrored.outlined.FormatListBulleted
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
@@ -49,11 +50,16 @@ import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.PhotoCamera
 import androidx.compose.material.icons.filled.Videocam
+import androidx.compose.material.icons.outlined.AddLink
+import androidx.compose.material.icons.outlined.Code
 import androidx.compose.material.icons.outlined.FormatBold
 import androidx.compose.material.icons.outlined.FormatItalic
 import androidx.compose.material.icons.outlined.FormatListNumbered
+import androidx.compose.material.icons.outlined.FormatQuote
 import androidx.compose.material.icons.outlined.FormatStrikethrough
-import androidx.compose.material.icons.outlined.FormatUnderlined
+import androidx.compose.material.icons.outlined.Terminal
+import androidx.compose.material.icons.outlined.Title
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -61,7 +67,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -102,6 +110,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
 import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import com.mohamedrejeb.richeditor.model.HeadingStyle
 import com.mohamedrejeb.richeditor.model.RichTextState
 import com.mohamedrejeb.richeditor.ui.material3.RichTextEditor
 import com.mohamedrejeb.richeditor.ui.material3.RichTextEditorDefaults
@@ -129,6 +138,17 @@ import id.homebase.resources.chat_message_hide_keyboard
 import id.homebase.resources.chat_message_microphone
 import id.homebase.resources.chat_message_processing
 import id.homebase.resources.chat_message_record_video
+import id.homebase.resources.chat_markdown_blockquote
+import id.homebase.resources.chat_markdown_code_block
+import id.homebase.resources.chat_markdown_heading
+import id.homebase.resources.chat_markdown_inline_code
+import id.homebase.resources.chat_markdown_link
+import id.homebase.resources.chat_markdown_link_dialog_cancel
+import id.homebase.resources.chat_markdown_link_dialog_insert
+import id.homebase.resources.chat_markdown_link_dialog_text
+import id.homebase.resources.chat_markdown_link_dialog_title
+import id.homebase.resources.chat_markdown_link_dialog_url
+import id.homebase.resources.chat_markdown_nested_list
 import id.homebase.resources.chat_message_take_photo
 import id.homebase.resources.chat_new_message_placeholder
 import id.homebase.resources.chat_send_message_button
@@ -1205,12 +1225,26 @@ fun MessageTextFieldForAttachment(
     }
 }
 
+@OptIn(ExperimentalRichTextApi::class)
 @Composable
 fun RichTextEditorButtons(
     modifier: Modifier = Modifier,
     state: RichTextState,
     enabled: Boolean,
 ) {
+    // Localized a11y labels for the new authoring affordances. Resolved here
+    // (outside the LazyRow item lambdas) so the Konsist no-literal-Text gate is
+    // satisfied and the labels survive into TalkBack/VoiceOver.
+    val headingLabel = stringResource(MR.string.chat_markdown_heading)
+    val blockquoteLabel = stringResource(MR.string.chat_markdown_blockquote)
+    val inlineCodeLabel = stringResource(MR.string.chat_markdown_inline_code)
+    val codeBlockLabel = stringResource(MR.string.chat_markdown_code_block)
+    val linkLabel = stringResource(MR.string.chat_markdown_link)
+    val nestedListLabel = stringResource(MR.string.chat_markdown_nested_list)
+
+    var showLinkDialog by remember { mutableStateOf(false) }
+    val dividerColor = MaterialTheme.colorScheme.outlineVariant
+
     LazyRow(verticalAlignment = Alignment.CenterVertically, modifier = modifier) {
         item {
             RichTextStyleButton(
@@ -1238,20 +1272,10 @@ fun RichTextEditorButtons(
             )
         }
 
-        item {
-            RichTextStyleButton(
-                onClick = {
-                    state.toggleSpanStyle(
-                        SpanStyle(textDecoration = TextDecoration.Underline)
-                    )
-                },
-                enabled = enabled,
-                isSelected = state.currentSpanStyle.textDecoration?.contains(
-                    TextDecoration.Underline
-                ) == true,
-                icon = Icons.Outlined.FormatUnderlined,
-            )
-        }
+        // Underline intentionally dropped: it has no CommonMark representation,
+        // so toMarkdown() would silently lose it and it would not round-trip to
+        // other Homebase clients (which speak markdown on the wire) nor render in
+        // the mikepenz CommonMark renderer.
 
         item {
             RichTextStyleButton(
@@ -1270,7 +1294,79 @@ fun RichTextEditorButtons(
             )
         }
 
-        item { Box(Modifier.height(24.dp).width(1.dp).background(Color(0xFF393B3D))) }
+        // Inline code (re-enabled). Styled by the renderer as a monospace chip.
+        item {
+            RichTextStyleButton(
+                onClick = { state.toggleCodeSpan() },
+                enabled = enabled,
+                isSelected = state.isCodeSpan,
+                icon = Icons.Outlined.Code,
+                contentDescription = inlineCodeLabel,
+            )
+        }
+
+        // Insert a link via dialog (text + URL).
+        item {
+            RichTextStyleButton(
+                onClick = { showLinkDialog = true },
+                enabled = enabled,
+                isSelected = state.isLink,
+                icon = Icons.Outlined.AddLink,
+                contentDescription = linkLabel,
+            )
+        }
+
+        item {
+            Box(
+                Modifier.height(24.dp).width(1.dp).background(dividerColor)
+            )
+        }
+
+        // Heading: cycle Normal -> H1 -> H2 -> Normal (richeditor serialises the
+        // level as a CommonMark ATX prefix `# ` / `## `).
+        item {
+            RichTextStyleButton(
+                onClick = {
+                    val next = when (state.currentHeadingStyle) {
+                        HeadingStyle.Normal -> HeadingStyle.H1
+                        HeadingStyle.H1 -> HeadingStyle.H2
+                        else -> HeadingStyle.Normal
+                    }
+                    state.setHeadingStyle(next)
+                },
+                enabled = enabled,
+                isSelected = state.currentHeadingStyle != HeadingStyle.Normal,
+                icon = Icons.Outlined.Title,
+                contentDescription = headingLabel,
+            )
+        }
+
+        // Blockquote and fenced code block. richeditor has no paragraph-level
+        // toggle for these, so we insert the CommonMark markers at the cursor;
+        // the editor renders them live and toMarkdown() emits them verbatim.
+        item {
+            RichTextStyleButton(
+                onClick = { state.addTextAfterSelection("\n> ") },
+                enabled = enabled,
+                icon = Icons.Outlined.FormatQuote,
+                contentDescription = blockquoteLabel,
+            )
+        }
+
+        item {
+            RichTextStyleButton(
+                onClick = { state.addTextAfterSelection("\n```\n\n```\n") },
+                enabled = enabled,
+                icon = Icons.Outlined.Terminal,
+                contentDescription = codeBlockLabel,
+            )
+        }
+
+        item {
+            Box(
+                Modifier.height(24.dp).width(1.dp).background(dividerColor)
+            )
+        }
 
         item {
             RichTextStyleButton(
@@ -1290,23 +1386,78 @@ fun RichTextEditorButtons(
             )
         }
 
-        //            item {
-        //                Box(
-        //                    Modifier
-        //                        .height(24.dp)
-        //                        .width(1.dp)
-        //                        .background(Color(0xFF393B3D))
-        //                )
-        //            }
-        //            item {
-        //                RichTextStyleButton(
-        //                    onClick = {
-        //                        state.toggleCodeSpan()
-        //                    },
-        //                    isSelected = state.isCodeSpan,
-        //                    icon = Icons.Outlined.Code,
-        //                )
-        //            }
+        // Nested list: increase the indent level of the current list item. Only
+        // meaningful while the cursor sits inside a list.
+        item {
+            RichTextStyleButton(
+                onClick = { state.increaseListLevel() },
+                enabled = enabled && state.isList,
+                icon = Icons.AutoMirrored.Outlined.FormatIndentIncrease,
+                contentDescription = nestedListLabel,
+            )
+        }
     }
+
+    if (showLinkDialog) {
+        MarkdownLinkDialog(
+            initialText = "",
+            onDismiss = { showLinkDialog = false },
+            onConfirm = { text, url ->
+                if (text.isNotBlank() && url.isNotBlank()) {
+                    state.addLink(text = text, url = url)
+                }
+                showLinkDialog = false
+            },
+        )
+    }
+}
+
+/**
+ * Small dialog to insert a markdown link as `[text](url)`. The editor's
+ * [RichTextState.addLink] handles the actual insertion; this only collects the
+ * two fields. All labels come from string resources so the Konsist no-literal
+ * gate is satisfied and the dialog is localizable.
+ */
+@Composable
+private fun MarkdownLinkDialog(
+    initialText: String,
+    onDismiss: () -> Unit,
+    onConfirm: (text: String, url: String) -> Unit,
+) {
+    var text by remember { mutableStateOf(initialText) }
+    var url by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(MR.string.chat_markdown_link_dialog_title)) },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = text,
+                    onValueChange = { text = it },
+                    label = { Text(stringResource(MR.string.chat_markdown_link_dialog_text)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = url,
+                    onValueChange = { url = it },
+                    label = { Text(stringResource(MR.string.chat_markdown_link_dialog_url)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(text, url) }) {
+                Text(stringResource(MR.string.chat_markdown_link_dialog_insert))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(MR.string.chat_markdown_link_dialog_cancel))
+            }
+        },
+    )
 }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageSearchItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageSearchItem.kt
@@ -17,22 +17,18 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
-import com.mohamedrejeb.richeditor.model.RichTextState
-import com.mohamedrejeb.richeditor.ui.material3.RichText
 import id.homebase.api.common.OdinId
+import id.homebase.api.util.markdownToPlainPreview
 import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.ContactAvatar
 import id.homebase.core.avatars.FallbackAvatar
-import id.homebase.core.util.applyDefaultStyling
-import id.homebase.core.util.applyMarkDownContent
 import id.homebase.core.util.formatTimestamp
 import id.homebase.core.util.initials
 import kotlin.time.Instant
 
-@OptIn(ExperimentalRichTextApi::class)
 @Composable
 fun MessageSearchItem(
     memberName: String,
@@ -41,10 +37,21 @@ fun MessageSearchItem(
     timestamp: Instant,
     onClick: () -> Unit,
     onContactClick: (odinId: OdinId) -> Unit,
+    searchQuery: String = "",
 ) {
-    // See ConversationItem.kt ConversationMessagePreview for why remember is required here
-    val textState = remember(message) {
-        RichTextState().applyDefaultStyling().applyMarkDownContent(message)
+    // Search rows are a single line, so strip the markdown to plain text (the
+    // shared AST walk, same grammar the renderer uses) and fold the search
+    // highlight into that plain string. Both styling worlds share one
+    // AnnotatedString, so the highlight offsets are computed against exactly the
+    // string being drawn — the stale-offset crash class cannot occur.
+    val highlightColor = MaterialTheme.colorScheme.secondary.copy(alpha = 0.35f)
+    val previewText = remember(message, searchQuery, highlightColor) {
+        val plain = markdownToPlainPreview(message, maxCodePoints = 200)
+        buildSearchHighlightedText(
+            plain = plain,
+            searchQuery = searchQuery,
+            highlightColor = highlightColor,
+        ) ?: AnnotatedString(plain)
     }
     Row(
         modifier = Modifier
@@ -108,8 +115,8 @@ fun MessageSearchItem(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                RichText(
-                    state = textState,
+                Text(
+                    text = previewText,
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/RichTextStyleButton.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/RichTextStyleButton.kt
@@ -20,6 +20,7 @@ fun RichTextStyleButton(
     tint: Color? = null,
     enabled: Boolean = true,
     isSelected: Boolean = false,
+    contentDescription: String? = null,
 ) {
     IconButton(
         modifier = Modifier
@@ -39,7 +40,7 @@ fun RichTextStyleButton(
     ) {
         Icon(
             icon,
-            contentDescription = icon.name,
+            contentDescription = contentDescription ?: icon.name,
             tint = tint ?: LocalContentColor.current,
             modifier = Modifier
                 .background(

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/services/chat/MarkdownPlainTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/services/chat/MarkdownPlainTest.kt
@@ -1,0 +1,92 @@
+package id.homebase.chat.services.chat
+
+import id.homebase.api.util.markdownToPlainPreview
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the unified markdown -> plain-text preview strip
+ * ([markdownToPlainPreview]). This replaced two divergent regex strip paths
+ * ([id.homebase.chat.services.chat.ChatMessageSizer.preview] and
+ * `String.stripMarkdownForPreview`), and these tests pin the behaviour the old
+ * regex got wrong.
+ */
+class MarkdownPlainTest {
+
+    @Test
+    fun preservesMidWordHyphensAndUnderscores() {
+        // The old ChatMessageSizer regex `[*_`#>\-]` deleted these mid-word,
+        // mangling plain identifiers / phrases. The AST walk must leave them be.
+        val input = "well-being and snake_case_name and co-op deal"
+        val out = markdownToPlainPreview(input, maxCodePoints = 200)
+        assertEquals("well-being and snake_case_name and co-op deal", out)
+    }
+
+    @Test
+    fun stripsHeadingEmphasisCodeAndQuoteMarkers() {
+        val input = "# Heading\n\nSome **bold** and _italic_ and `code` text.\n\n> a quote"
+        val out = markdownToPlainPreview(input, maxCodePoints = 200)
+        assertTrue(!out.contains("#"), "heading marker leaked: $out")
+        assertTrue(!out.contains("**"), "bold marker leaked: $out")
+        assertTrue(!out.contains("`"), "code marker leaked: $out")
+        assertTrue(!out.contains(">"), "quote marker leaked: $out")
+        assertTrue(out.contains("Heading"))
+        assertTrue(out.contains("bold"))
+        assertTrue(out.contains("italic"))
+        assertTrue(out.contains("code"))
+        assertTrue(out.contains("a quote"))
+    }
+
+    @Test
+    fun keepsLinkLabelAndDropsUrl() {
+        val input = "See [the docs](https://example.test/path?q=1) for details"
+        val out = markdownToPlainPreview(input, maxCodePoints = 200)
+        assertTrue(out.contains("the docs"), "link label dropped: $out")
+        assertTrue(!out.contains("https://"), "link URL leaked: $out")
+        assertTrue(!out.contains("example.test"), "link URL leaked: $out")
+    }
+
+    @Test
+    fun keepsImageAltAndDropsUrl() {
+        val input = "Look: ![a red dot](https://img.test/dot.png) nice"
+        val out = markdownToPlainPreview(input, maxCodePoints = 200)
+        assertTrue(out.contains("a red dot"), "image alt dropped: $out")
+        assertTrue(!out.contains("https://"), "image URL leaked: $out")
+        assertTrue(!out.contains(".png"), "image URL leaked: $out")
+    }
+
+    @Test
+    fun collapsesNewlinesToSpaces() {
+        val input = "line one\n\nline two\nline three"
+        val out = markdownToPlainPreview(input, maxCodePoints = 200)
+        assertTrue(!out.contains("\n"), "newline leaked: $out")
+        assertEquals("line one line two line three", out)
+    }
+
+    @Test
+    fun truncatesOnCodePointBoundaryForEmoji() {
+        // Each 😀 is a surrogate pair (2 chars, 1 code point). Asking for 3 code
+        // points must return exactly 3 whole emoji (6 chars), never split a pair.
+        val input = "😀😀😀😀😀"
+        val out = markdownToPlainPreview(input, maxCodePoints = 3)
+        assertEquals(3, out.codePointCountCompat())
+        assertEquals(6, out.length) // 3 surrogate pairs, no lone surrogate
+    }
+
+    @Test
+    fun emptyInputReturnsEmpty() {
+        assertEquals("", markdownToPlainPreview("", maxCodePoints = 200))
+    }
+}
+
+/** Counts Unicode code points, treating surrogate pairs as one. */
+private fun String.codePointCountCompat(): Int {
+    var count = 0
+    var i = 0
+    while (i < length) {
+        i += if (i + 1 < length && this[i].isHighSurrogate() && this[i + 1].isLowSurrogate()) 2 else 1
+        count++
+    }
+    return count
+}

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/MessageSearchItemTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/MessageSearchItemTest.kt
@@ -27,13 +27,13 @@ class MessageSearchItemTest {
         onNodeWithText("Alice").assertExists()
     }
 
-    // Regression: the search-results row used to call setMarkdown() directly,
-    // which throws StringIndexOutOfBoundsException inside the markdown parser
+    // Regression: the search-results row used to call richeditor setMarkdown()
+    // directly, which threw StringIndexOutOfBoundsException inside that parser
     // for certain inputs (see RichTextRenderingTest for the exact input). The
-    // fix routes the call through applyMarkDownContent(), which catches the
-    // parser blow-up and falls back to plain text. This test composes the
-    // widget with that same known-problematic input and asserts composition
-    // does not throw.
+    // row now strips to plain text via the shared CommonMark AST walk
+    // (markdownToPlainPreview) before rendering, so the crash class is gone.
+    // This composes the widget with that same known-problematic input and
+    // asserts composition does not throw.
     @Test
     fun rendersWithoutCrashing_forParserBreakingMarkdown() = runComposeUiTest {
         val problematic = "gg\n\n  gg"

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/RichTextRenderingTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/RichTextRenderingTest.kt
@@ -59,6 +59,26 @@ class RichTextRenderingTest {
      * render through the M3-styled block path without crashing — proving the new
      * authoring element set displays.
      */
+    /**
+     * An inline-only body (emphasis + a link, no block elements) must render
+     * through the single-Text inline path. The link label text is visible and the
+     * URL syntax is gone — the link rides as a native Compose LinkAnnotation in
+     * the annotated string, which a plain Text handles without a custom
+     * pointerInput. This is the path the bubble's last-line timestamp tuck wraps.
+     */
+    @Test
+    fun chatMarkdownRendersInlineLink() = runComposeUiTest {
+        setContent {
+            Box(Modifier.testTag("md")) {
+                ChatMarkdown(content = "see **this** [link](https://example.test) now")
+            }
+        }
+        waitUntil(timeoutMillis = 5_000) {
+            onAllNodesWithText("see this link now").fetchSemanticsNodes().isNotEmpty()
+        }
+        onNodeWithText("see this link now").assertExists()
+    }
+
     @Test
     fun chatMarkdownRendersBlockElements() = runComposeUiTest {
         val body = buildString {

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/RichTextRenderingTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/RichTextRenderingTest.kt
@@ -1,91 +1,80 @@
 package id.homebase.chat.widget
 
-import androidx.compose.runtime.remember
+import androidx.compose.foundation.layout.Box
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
-import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
-import com.mohamedrejeb.richeditor.model.RichTextState
-import com.mohamedrejeb.richeditor.ui.material3.RichText
-import id.homebase.core.ui.theme.LightColors
-import id.homebase.core.util.applyDefaultStyling
-import id.homebase.core.util.applyMarkDownContent
 import kotlin.test.Test
 
+/**
+ * Rendering regressions for the chat markdown RENDERER, now the mikepenz
+ * CommonMark renderer wrapped by [ChatMarkdown] (the read-only display path).
+ * The editor stays on richeditor; these cover the display side only.
+ */
 @OptIn(ExperimentalTestApi::class)
 class RichTextRenderingTest {
 
-    @OptIn(ExperimentalRichTextApi::class)
     @Test
-    fun testRichTextSetMarkdown() = runComposeUiTest {
-        val testContent = "*Bold* _Italic_"
+    fun chatMarkdownRendersBoldAndItalic() = runComposeUiTest {
         setContent {
-            val textState = remember {
-                RichTextState()
-                    .applyDefaultStyling(linkColor = LightColors.Primary)
-                    .also {
-                        it.setMarkdown(testContent)
-                    }
+            Box(Modifier.testTag("md")) {
+                ChatMarkdown(content = "*Bold* _Italic_")
             }
-
-            RichText(
-                state = textState,
-                modifier = Modifier.testTag("richText")
-            )
         }
 
-        onNodeWithTag("richText").assertTextEquals("Bold Italic")
+        // mikepenz parses on a background dispatcher (non-immediate); wait until
+        // the paragraph node materialises, then assert the visible text matches.
+        waitUntil(timeoutMillis = 5_000) {
+            onAllNodesWithText("Bold Italic").fetchSemanticsNodes().isNotEmpty()
+        }
+        onNodeWithText("Bold Italic").assertExists()
     }
 
-    /*
-    RichTextState Markdown parser used to fail for this input hence this test, the issue seems to have been fixed now.
-    The issue seems to be any space in start of line after an empty line
+    /**
+     * The old richeditor `setMarkdown` parser crashed on a space at the start of
+     * a line following an empty line (`gg\n\n  gg`). The mikepenz CommonMark
+     * parser handles it without the `fixProblematicMarkdownText` workaround —
+     * this asserts the swap fixed the crash: the body must render without
+     * throwing.
      */
-    @OptIn(ExperimentalRichTextApi::class)
     @Test
-    fun testRichTextSetMarkdownProblematicCodeShouldNowWork() = runComposeUiTest {
-        val testContent = """gg
-
-  gg"""
+    fun chatMarkdownDoesNotCrashOnSpaceAfterBlankLine() = runComposeUiTest {
+        val testContent = "gg\n\n  gg"
         setContent {
-                val textState = remember {
-                    RichTextState()
-                        .applyDefaultStyling(linkColor = LightColors.Primary)
-                        .also {
-                            it.setMarkdown(testContent)
-                        }
-                }
-
-            RichText(
-                state = textState,
-                modifier = Modifier.testTag("richText")
-            )
+            Box(Modifier.testTag("md")) {
+                ChatMarkdown(content = testContent)
+            }
         }
-        onNodeWithTag("richText").assertTextEquals("gg  gg")
+        // Reaching here means composition + parse completed without an exception.
+        waitForIdle()
+        onNodeWithTag("md").assertExists()
     }
 
-    @OptIn(ExperimentalRichTextApi::class)
+    /**
+     * A body mixing a heading, a blockquote, a fenced code block and a list must
+     * render through the M3-styled block path without crashing — proving the new
+     * authoring element set displays.
+     */
     @Test
-    fun testRichTextSetMarkdownProblematicShouldBehandled() = runComposeUiTest {
-        val testContent = """gg
-
-  gg"""
-        setContent {
-            val textState = remember {
-                RichTextState()
-                    .applyDefaultStyling(linkColor = LightColors.Primary)
-                    .applyMarkDownContent(testContent)
-            }
-
-            RichText(
-                state = textState,
-                modifier = Modifier.testTag("richText")
-            )
+    fun chatMarkdownRendersBlockElements() = runComposeUiTest {
+        val body = buildString {
+            append("# Title\n\n")
+            append("> a quote\n\n")
+            append("```\ncode line\n```\n\n")
+            append("- one\n- two\n")
         }
-
-        onNodeWithTag("richText").assertTextEquals("gg  gg")
+        setContent {
+            Box(Modifier.testTag("md")) {
+                ChatMarkdown(content = body)
+            }
+        }
+        waitUntil(timeoutMillis = 5_000) {
+            onAllNodesWithText("Title").fetchSemanticsNodes().isNotEmpty()
+        }
+        onNodeWithText("Title").assertExists()
     }
 }

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/RichTextRenderingTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/RichTextRenderingTest.kt
@@ -97,4 +97,73 @@ class RichTextRenderingTest {
         }
         onNodeWithText("Title").assertExists()
     }
+
+    /**
+     * Regression guard for the Desktop runtime crash on PR #665:
+     * `NoClassDefFoundError com/mikepenz/markdown/annotator/AnnotatorSettingsKt`.
+     *
+     * The mikepenz CORE module hosts `annotatorSettings` /
+     * `buildMarkdownAnnotatedString`; [ChatMarkdown] imports both. The block path
+     * here drives `annotatorSettings` (inline spans inside the heading/quote/list/
+     * code blocks all flow through the annotator) PLUS the full block renderer. If
+     * the core artifact is ever dropped from a consumer's classpath again, this
+     * body throws on first render and the test fails.
+     *
+     * NOTE (honest scope): this test resolves homebase-chat's deps NORMALLY, so the
+     * core is on its classpath transitively via m3 even without the explicit
+     * dependency — it therefore passes both before and after the build fix and does
+     * NOT reproduce the Desktop-distributable stripping (which is a property of
+     * desktopApp's per-platform-JAR packaging, not of homebase-chat's own
+     * classpath). It guards the renderer's *use* of the annotator API; the
+     * packaging fix is validated by the Desktop app build itself.
+     */
+    @Test
+    fun chatMarkdownRendersFullAnnotatorBlockSurface() = runComposeUiTest {
+        val body = buildString {
+            append("# Heading\n\n")
+            append("**bold** _italic_ `inline code` [link](https://x)\n\n")
+            append("- item one\n- item two\n\n")
+            append("> a quote\n\n")
+            append("```\ncode block\n```")
+        }
+        setContent {
+            Box(Modifier.testTag("md")) {
+                ChatMarkdown(content = body)
+            }
+        }
+        // Reaching idle means the block renderer + annotatorSettings +
+        // buildMarkdownAnnotatedString all loaded and laid out without throwing.
+        waitUntil(timeoutMillis = 5_000) {
+            onAllNodesWithText("Heading").fetchSemanticsNodes().isNotEmpty()
+        }
+        waitForIdle()
+        onNodeWithTag("md").assertExists()
+        onNodeWithText("Heading").assertExists()
+    }
+
+    /**
+     * Inline-only body (no block elements) → the single-Text inline path, which
+     * also calls `buildMarkdownAnnotatedString` + `annotatorSettings` directly (the
+     * other site that touches the mikepenz core annotator class). This is the path
+     * that threw the Desktop `NoClassDefFoundError` first, because it runs the
+     * annotator outside the block `Markdown()` composable. Must compose + lay out
+     * without throwing.
+     *
+     * Asserted structurally (tag still present after idle) rather than on an exact
+     * concatenated string: the goal is "the annotator path renders without an
+     * exception", and the visible-text shape of inline-code + a bare link is an
+     * implementation detail of the renderer that shouldn't make this guard brittle.
+     */
+    @Test
+    fun chatMarkdownRendersInlineAnnotatorSurface() = runComposeUiTest {
+        setContent {
+            Box(Modifier.testTag("md")) {
+                ChatMarkdown(content = "**hi** `x` [l](https://e.test)")
+            }
+        }
+        // If the annotator core class were missing, composition would throw here and
+        // the test would error out before reaching idle.
+        waitForIdle()
+        onNodeWithTag("md").assertExists()
+    }
 }

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/SearchHighlightTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/SearchHighlightTest.kt
@@ -1,6 +1,7 @@
 package id.homebase.chat.widget
 
 import androidx.compose.ui.graphics.Color
+import id.homebase.api.util.markdownToPlainPreview
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -61,5 +62,35 @@ class SearchHighlightTest {
         val result = buildSearchHighlightedText(body, "Mon", color)!!
         val last = result.spanStyles.last()
         assertEquals(body.length, last.end)
+    }
+
+    @Test
+    fun highlightOffsetsValidAgainstRenderedPlainText() {
+        // The new combined styling+highlight path (ChatMarkdown / MessageSearchItem)
+        // computes highlight offsets against the markdown's RENDERED plain form,
+        // not the raw markdown. This proves that for a markdown body the spans
+        // stay inside the rendered plain string — i.e. the stale-offset
+        // subSequence crash class (which fired when the styled string had a
+        // different length than the highlight string) cannot recur, because both
+        // worlds now share one AnnotatedString.
+        val markdownBody = buildString {
+            append("# Heading with Monday\n\n")
+            append("Here is **bold Monday** and `code Monday` and a [Monday link](https://x.test).\n\n")
+            repeat(20) { append("- item Monday number $it\n") }
+        }
+        val plain = markdownToPlainPreview(markdownBody, maxCodePoints = Int.MAX_VALUE)
+        val result = buildSearchHighlightedText(plain, "Monday", color)!!
+
+        // The rendered plain string must not contain markdown syntax markers,
+        // and every produced span must stay within its bounds.
+        assertEquals(plain, result.text)
+        assertTrue(!plain.contains("**"), "bold markers should be stripped: $plain")
+        assertTrue(!plain.contains("`"), "inline-code markers should be stripped")
+        assertTrue(!plain.contains("https://"), "link URL should be stripped")
+        assertTrue(plain.contains("Monday link"), "link label text should survive")
+        for (range in result.spanStyles) {
+            assertTrue(range.end <= plain.length, "end=${range.end} > len=${plain.length}")
+            assertTrue(range.start in 0..range.end)
+        }
     }
 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/MarkdownAnnotatorClasspathTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/MarkdownAnnotatorClasspathTest.kt
@@ -1,0 +1,59 @@
+package id.homebase.chat.widget
+
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import com.mikepenz.markdown.annotator.buildMarkdownAnnotatedString
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Class-level guard for the Desktop runtime crash on PR #665:
+ *
+ *   java.lang.NoClassDefFoundError: com/mikepenz/markdown/annotator/AnnotatorSettingsKt
+ *   Caused by: java.lang.ClassNotFoundException
+ *
+ * The annotator lives in the mikepenz CORE module
+ * (`com.mikepenz:multiplatform-markdown-renderer`). [ChatMarkdown] uses it on
+ * both the inline and block paths. This test asserts the core class is loadable
+ * AND that the annotator code actually executes (returns a non-null
+ * AnnotatedString) on the test runtime classpath.
+ *
+ * Honest scope: homebase-chat's OWN runtime classpath has always resolved the
+ * core transitively (via the m3 artifact) because tests resolve homebase-chat's
+ * dependencies normally. So this test passes both before and after the build
+ * fix — it does NOT reproduce the Desktop-distributable failure, which is caused
+ * by desktopApp consuming homebase-chat via a repackaged per-platform JAR that
+ * strips homebase-chat's external transitive deps. That packaging crash is fixed
+ * by declaring the renderer deps on homebase-core (a module desktopApp consumes
+ * normally) and is validated by building/running the Desktop app. This test is a
+ * cheap, fast tripwire that the annotator class never silently leaves the
+ * compile/test classpath of the renderer's own module.
+ */
+class MarkdownAnnotatorClasspathTest {
+
+    @Test
+    fun annotatorSettingsClassIsLoadable() {
+        // Exact class named in the Desktop crash's `Caused by ClassNotFoundException`.
+        val clazz = Class.forName("com.mikepenz.markdown.annotator.AnnotatorSettingsKt")
+        assertNotNull(clazz, "AnnotatorSettingsKt must be on the runtime classpath")
+    }
+
+    @Test
+    fun buildMarkdownAnnotatedStringExecutesAndReturnsContent() {
+        // Non-composable overload (no Composer param) — exercises the annotator
+        // code path directly from a plain JVM test. If the core artifact were
+        // missing, this call site would throw NoClassDefFoundError at link time.
+        val annotated = "**x** `c` [l](https://e.test)".buildMarkdownAnnotatedString(
+            style = TextStyle.Default,
+            linkTextSpanStyle = SpanStyle(),
+            codeSpanStyle = SpanStyle(),
+        )
+        assertNotNull(annotated, "annotated string must be produced")
+        // The visible text drops markdown syntax: "x c l" (link label kept, URL gone).
+        assertTrue(
+            annotated.text.contains("x") && annotated.text.contains("c") && annotated.text.contains("l"),
+            "annotated text should contain the rendered inline content, was: '${annotated.text}'",
+        )
+    }
+}

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -510,6 +510,19 @@
     <string name="chat_message_emoji">Emoji</string>
     <string name="chat_message_location">Placering</string>
 
+    <!-- Markdown-værktøjslinje (tilgængelighedsetiketter) og link-dialog -->
+    <string name="chat_markdown_heading">Overskrift</string>
+    <string name="chat_markdown_blockquote">Citat</string>
+    <string name="chat_markdown_inline_code">Indlejret kode</string>
+    <string name="chat_markdown_code_block">Kodeblok</string>
+    <string name="chat_markdown_link">Indsæt link</string>
+    <string name="chat_markdown_nested_list">Indryk liste</string>
+    <string name="chat_markdown_link_dialog_title">Indsæt link</string>
+    <string name="chat_markdown_link_dialog_text">Tekst</string>
+    <string name="chat_markdown_link_dialog_url">URL</string>
+    <string name="chat_markdown_link_dialog_insert">Indsæt</string>
+    <string name="chat_markdown_link_dialog_cancel">Annullér</string>
+
     <!-- Block / Report -->
     <string name="chat_message_block">Blokér</string>
     <string name="chat_message_report">Rapportér</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -802,6 +802,20 @@
     <string name="chat_message_file_type_icon">File type icon</string>
     <string name="chat_message_microphone">Microphone</string>
     <string name="chat_message_emoji">Emoji</string>
+
+    <!-- Markdown composer toolbar (accessibility labels) and link dialog -->
+    <string name="chat_markdown_heading">Heading</string>
+    <string name="chat_markdown_blockquote">Block quote</string>
+    <string name="chat_markdown_inline_code">Inline code</string>
+    <string name="chat_markdown_code_block">Code block</string>
+    <string name="chat_markdown_link">Insert link</string>
+    <string name="chat_markdown_nested_list">Indent list</string>
+    <string name="chat_markdown_link_dialog_title">Insert link</string>
+    <string name="chat_markdown_link_dialog_text">Text</string>
+    <string name="chat_markdown_link_dialog_url">URL</string>
+    <string name="chat_markdown_link_dialog_insert">Insert</string>
+    <string name="chat_markdown_link_dialog_cancel">Cancel</string>
+
     <string name="chat_reactions_title">Reactions</string>
     <string name="chat_reactions_all">All</string>
     <string name="chat_reactions_tap_to_remove">Tap to remove</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/util/RichTextExtensions.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/util/RichTextExtensions.kt
@@ -54,6 +54,18 @@ fun RichTextState.applyDefaultStyling(
     }
 }
 
+/**
+ * Loads existing markdown INTO a richeditor [RichTextState] (the WYSIWYG editor).
+ *
+ * Read-only display no longer goes through here — chat bubbles, captions, the
+ * conversation-list preview and the search row now render with the mikepenz
+ * CommonMark renderer (`ChatMarkdown`), which does not need this try/catch +
+ * [fixProblematicMarkdownText] safety net. The one remaining caller is the
+ * editor-load path: seeding the composer / the Vault note editor with a
+ * previously-saved markdown body, where richeditor's `setMarkdown` still has the
+ * documented "space after a blank line" fragility. Keep this wrapper for that
+ * path; it is not dead code.
+ */
 fun RichTextState.applyMarkDownContent(
     content: String,
 ): RichTextState {

--- a/homebase-core/build.gradle.kts
+++ b/homebase-core/build.gradle.kts
@@ -100,6 +100,21 @@ kotlin {
             implementation(libs.koin.compose.viewmodel)
             implementation(libs.multiplatform.settings)
             implementation(libs.richeditor.compose)
+            // mikepenz markdown renderer — declared here, not only in homebase-chat
+            // (its actual home), for the SAME reason richeditor is duplicated above:
+            // desktopApp consumes homebase-chat via a repackaged per-platform JAR
+            // (desktopApp/build.gradle.kts `jvmJarMacosArm64` etc.) that carries only
+            // homebase-chat's own classes and STRIPS its external transitive deps.
+            // So the renderer's core/m3/coil3 artifacts never reach the Desktop
+            // runtime through homebase-chat. homebase-core, by contrast, is consumed
+            // by desktopApp as a normal JVM project dependency with full metadata, so
+            // listing them here puts them on the Desktop classpath and fixes the
+            // NoClassDefFoundError com/mikepenz/markdown/annotator/AnnotatorSettingsKt
+            // at first markdown render. (Android/iOS/Web were always fine — they
+            // consume homebase-chat normally and got these transitively.)
+            implementation(libs.markdown.renderer)
+            implementation(libs.markdown.renderer.m3)
+            implementation(libs.markdown.renderer.coil3)
             implementation(libs.filekit.dialogs.compose)
         }
         nativeMain.dependencies {


### PR DESCRIPTION
## Root cause / goal

The chat app used `com.mohamedrejeb.richeditor:richeditor-compose:1.0.0-rc14`
for **both** editing and read-only display of markdown bodies. Using it as a
renderer is the source of the in-tree fragility the spec flagged:

- `applyMarkDownContent` wraps `setMarkdown` in a try/catch plus a hand-rolled
  `fixProblematicMarkdownText` workaround (documented "space after a blank
  line" crash).
- An infinite-recomposition footgun in the conversation list (`RichTextState`
  mutates Compose state during composition unless `remember(text)`-wrapped).
- Search-highlight could not coexist with markdown styling, so a **separate**
  plain-`AnnotatedString` fork was used while searching — and it crashed
  `String.subSequence` when the styled string and the highlight string had
  different lengths.
- Two divergent markdown→plain strip paths whose `[*_`#>\-]` regex mangled
  mid-word hyphens/underscores and dropped trailing punctuation.

Goal: a beautiful, professional editor **and** renderer ("like TipTap"). In CMP
there is no single library that is a true TipTap at all four targets, so this
ships a **hybrid**: keep richeditor as the WYSIWYG **editor** (the only CMP
inline editor that works on wasmJs/iOS), and adopt **mikepenz
multiplatform-markdown-renderer (m3 + coil3) 0.41.0** as the robust read-only
**renderer**. Both speak CommonMark, so the markdown wire string round-trips
between them and to other Homebase clients.

## Change per file

**Dependencies**
- `gradle/libs.versions.toml`: `markdownRenderer = "0.41.0"`; aliases
  `markdown-renderer-m3`, `markdown-renderer-coil3`, and `jetbrains-markdown`
  (0.7.3, the CommonMark engine — same version richeditor & mikepenz use, no
  conflict). richeditor kept at rc14 (newest; no stable exists).
- `homebase-chat/build.gradle.kts`: add the two mikepenz deps to commonMain.
- `homebase-api/build.gradle.kts`: add `org.jetbrains:markdown` for the strip
  helper.

**Renderer**
- **NEW `homebase-chat/.../widget/MarkdownRenderer.kt`** — single
  `ChatMarkdown(content, color, style, searchQuery, isCurrentSearchResult,
  maxLines, overflow, onTextLayout, modifier)` wrapping mikepenz `Markdown(...)`
  with `markdownColor()/markdownTypography()/markdownDimens()` using only M3
  roles (inline code = monospace `surfaceVariant` chip; fenced code container;
  blockquote accent bar; headings on the M3 type scale; list spacing). A custom
  `paragraph` component surfaces the last text layout via `onTextLayout` for the
  bubble's timestamp-fit math. **Search-highlight is folded in here**: when a
  query is active, it renders the markdown's *rendered plain* form with
  highlight spans, so offsets are computed against exactly the drawn string —
  the stale-offset `subSequence` crash class is structurally impossible.
- `MessageBubbleRaw.kt` — body renders through `ChatMarkdown`; deleted the
  `RichTextState`/`applyMarkDownContent` block and the separate `highlightedText`
  fork. Emoji-only branch and the show-more slot untouched.
- `FullScreenMediaViewer.kt` — caption renders through `ChatMarkdown`.
- `ConversationItem.kt` (list preview) and `MessageSearchItem.kt` (search row)
  are 1-line sites → strip to plain via `markdownToPlainPreview` + plain `Text`
  (the block renderer would blow up a one-liner with headings/lists). The search
  row folds highlight into that plain string. The search query is threaded from
  `ConversationListPane.kt`.

**Composer (`MessageInputBar.kt`)**
- Re-enabled inline code; added heading (cycles Normal→H1→H2), blockquote,
  fenced code block, a link-insert dialog, and a nested-list (indent) button.
  Each new button has a `stringResource` content description.
- **Dropped the underline button** — underline has no CommonMark form, so
  `toMarkdown()` (the wire string) would silently lose it and it would not
  round-trip to other Homebase clients or render in mikepenz.
- Replaced the hardcoded `Color(0xFF393B3D)` toolbar dividers with
  `MaterialTheme.colorScheme.outlineVariant`.
- `RichTextStyleButton.kt` gains an optional localized `contentDescription`.

**Unified strip path**
- **NEW `homebase-api/.../util/MarkdownPlain.kt`** —
  `markdownToPlainPreview(markdown, maxCodePoints)` parses with CommonMark and
  walks the AST (denylist of markup tokens, keep link/image alt, collapse
  whitespace, `truncateToCodePoints`). `ChatMessageSizer.preview(400)` and
  `String.stripMarkdownForPreview()` now delegate to it.

**RichTextExtensions.kt**
- `applyMarkDownContent` + `fixProblematicMarkdownText` **KEPT** — they remain
  the editor-load path for the Vault note editor (`VaultNoteEditorScreen` seeds
  the `RichTextState` editor from a saved markdown body, which still needs the
  `setMarkdown` safety net). Only the renderer-side callers were removed.
  `applyDefaultStyling` stays (the editor uses it). *(This deviates from the
  plan's "remove applyMarkDownContent": it has a live editor caller, so removal
  would break the Vault note editor.)*

## Compile results — all four targets pass

| Target | Task | Result |
|---|---|---|
| JVM/Desktop | `:homebase-chat:compileKotlinJvm` | ✅ |
| Android | `:homebase-chat:compileAndroidMain` | ✅ |
| iOS (sim arm64) | `:homebase-chat:compileKotlinIosSimulatorArm64` | ✅ |
| Web (wasmJs) | `:homebase-chat:compileKotlinWasmJs` | ✅ |

`homebase-api` (the new `org.jetbrains:markdown` dep) and `homebase-core`
(Vault note editor path) also compile on these targets. **mikepenz m3 + coil3
resolve on wasmJs and iOS** — the decisive dependency gate.

## Tests (JVM, all green)

- **NEW `MarkdownPlainTest`** (7): mid-word `-`/`_` preserved, `#`/`*`/`` ` ``/`>`
  stripped, link + image alt kept, newlines collapsed, code-point-safe emoji
  truncation, empty input.
- `RichTextRenderingTest` repointed to `ChatMarkdown`: bold/italic renders, the
  `gg\n\n  gg` space-after-blank-line input renders **without crashing** (proves
  the parser swap fixed the documented crash), and a heading+quote+code+list
  body renders.
- `SearchHighlightTest`: keeps the 4 existing invariants and adds a combined
  styling+highlight case proving highlight offsets stay valid against the
  rendered plain text.
- `MessageSearchItemTest` / `ConversationMessagePreviewTest` still pass against
  the new strip path; the Konsist `ArchitectureTest` (no-literal-`Text` gate)
  passes with the new strings.

## Cross-platform + wire-compat notes

- Render path is 100% commonMain; mikepenz and richeditor both sit in commonMain
  with no expect/actual.
- **Wire format unchanged**: the message body stays a markdown string
  (`MessageAppData` v≥1; legacy RichText JSON for v==null via the untouched
  `getPlainTextFromRichText`). Dropping underline is what keeps the markdown
  round-trip to other Homebase clients clean.
- New strings added to **both** `values/strings.xml` and `values-da/strings.xml`.

## Task F merge awareness

Task F (PR #662, branch `collapse-long-message-body-read-more`) adds a read-more
cap (`maxLines` + `hasVisualOverflow` + inline expander) to `MessageBubbleRaw`'s
body render. This PR branches off `main` **without** F. `ChatMarkdown` already
exposes `maxLines` / `overflow` / `onTextLayout`, so F integrates cleanly at the
bubble body render at merge time — note this overlap when merging the two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
