### PR TITLE
Animate GIF/WebP on Desktop, iOS & Web (in-house skiko decoder)

### DIFF
--- a/homebase-common/build.gradle.kts
+++ b/homebase-common/build.gradle.kts
@@ -69,6 +69,17 @@ kotlin {
     }
 
     sourceSets {
+        // Shared Skia-backed implementations for the targets that bundle skiko:
+        // Desktop/JVM, iOS/native, and Web/wasmJs. Android is intentionally
+        // excluded — it uses Coil's android.graphics-backed decoders (coil-gif
+        // animates GIFs there via AnimatedImageDecoder; see PR #663). Lets the
+        // in-house animated-GIF/WebP Skia decoder live in one place instead of
+        // three near-identical per-platform copies.
+        val skiaMain by creating { dependsOn(commonMain.get()) }
+        jvmMain.get().dependsOn(skiaMain)
+        nativeMain.get().dependsOn(skiaMain)
+        wasmJsMain.get().dependsOn(skiaMain)
+
         commonMain.dependencies {
             api(project(":homebase-api"))
             api(project(":homebase-notifshared"))

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/AnimatedImageDetection.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/AnimatedImageDetection.kt
@@ -1,0 +1,61 @@
+package id.homebase.core.image
+
+import coil3.fetch.SourceFetchResult
+
+/**
+ * Shared "could this be an animated image?" gate for the in-house Skia
+ * animated decoder (Desktop/JVM, iOS/native, Web/wasmJs).
+ *
+ * This is intentionally a *container* check, not an "is animated" check: it
+ * answers "are these bytes a GIF or WebP whose frames the Skia codec might
+ * animate?". A GIF/WebP with a single frame still passes this gate — the
+ * [AnimatedSkiaDecoder] then asks the Skia codec for the real frame count and
+ * returns null for single-frame images so Coil falls back to its default
+ * (static) Skia decoder. Keeping the cheap container sniff here means the
+ * expensive codec parse only runs for GIF/WebP, never for JPEG/PNG/HEIC.
+ *
+ * Animated GIF and animated WebP are the only animated raster formats Skia's
+ * [org.jetbrains.skia.Codec] exposes multi-frame; APNG is not reliably
+ * multi-frame across skiko versions, so we don't claim PNG here.
+ */
+fun isAnimatableSource(result: SourceFetchResult): Boolean {
+    when (result.mimeType) {
+        "image/gif", "image/webp" -> return true
+        // Any other declared image type is not an animated container we handle.
+        // (mimeType is null only when the fetcher couldn't determine it; fall
+        // through to the magic-byte sniff below.)
+        null -> Unit
+        else -> return false
+    }
+    return try {
+        val peek = result.source.source().peek()
+        val header = ByteArray(HEADER_PEEK_BYTES)
+        val read = peek.read(header)
+        if (read < MIN_HEADER_BYTES) return false
+        isGifHeader(header) || isWebpHeader(header)
+    } catch (_: Exception) {
+        false
+    }
+}
+
+/** GIF magic: "GIF87a" or "GIF89a" — only the first three bytes ("GIF") matter here. */
+private fun isGifHeader(b: ByteArray): Boolean =
+    b.size >= 3 &&
+        b[0] == 0x47.toByte() && // G
+        b[1] == 0x49.toByte() && // I
+        b[2] == 0x46.toByte() //    F
+
+/**
+ * WebP magic: "RIFF" .... "WEBP" — bytes 0..3 == RIFF, bytes 8..11 == WEBP.
+ * Bytes 4..7 are the little-endian RIFF chunk size (skipped).
+ */
+private fun isWebpHeader(b: ByteArray): Boolean =
+    b.size >= 12 &&
+        b[0] == 0x52.toByte() && b[1] == 0x49.toByte() && // RI
+        b[2] == 0x46.toByte() && b[3] == 0x46.toByte() && // FF
+        b[8] == 0x57.toByte() && b[9] == 0x45.toByte() && // WE
+        b[10] == 0x42.toByte() && b[11] == 0x50.toByte() // BP
+
+// Enough to cover the WebP RIFF/WEBP split header (12 bytes); GIF only needs 3.
+private const val HEADER_PEEK_BYTES = 12
+private const val MIN_HEADER_BYTES = 3

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/image/AnimatedSkiaDecoderTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/image/AnimatedSkiaDecoderTest.kt
@@ -1,0 +1,154 @@
+package id.homebase.core.image
+
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.decode.DataSource
+import coil3.decode.ImageSource
+import coil3.fetch.SourceFetchResult
+import coil3.request.Options
+import kotlinx.coroutines.test.runTest
+import okio.Buffer
+import okio.FileSystem
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Exercises the in-house Skia animated decoder on the JVM (its code lives in the
+ * shared skiaMain source set, so jvmMain — and therefore jvmTest — sees it).
+ *
+ * The two fixtures are hand-built minimal GIF89a files:
+ *  - [ANIMATED_GIF_2_FRAMES]: 2x1, two frames (500ms red, 750ms blue), Netscape
+ *    loop-forever block.
+ *  - [STATIC_GIF_1_FRAME]: 2x1, a single frame, no loop block.
+ */
+@OptIn(ExperimentalEncodingApi::class)
+class AnimatedSkiaDecoderTest {
+
+    private val factory = AnimatedSkiaDecoder.Factory()
+    private val options = Options(PlatformContext.INSTANCE)
+    private val imageLoader = ImageLoader.Builder(PlatformContext.INSTANCE).build()
+
+    private fun sourceResult(bytes: ByteArray, mimeType: String? = null): SourceFetchResult {
+        val buffer = Buffer().write(bytes)
+        val source = ImageSource(buffer, FileSystem.SYSTEM)
+        return SourceFetchResult(source, mimeType, DataSource.MEMORY)
+    }
+
+    // --- isAnimatableSource gate ---
+
+    @Test
+    fun `isAnimatableSource true for gif mimeType`() {
+        assertTrue(isAnimatableSource(sourceResult(ByteArray(16), mimeType = "image/gif")))
+    }
+
+    @Test
+    fun `isAnimatableSource true for webp mimeType`() {
+        assertTrue(isAnimatableSource(sourceResult(ByteArray(16), mimeType = "image/webp")))
+    }
+
+    @Test
+    fun `isAnimatableSource true for gif magic bytes with null mimeType`() {
+        val gif = Base64.decode(ANIMATED_GIF_2_FRAMES)
+        assertTrue(isAnimatableSource(sourceResult(gif, mimeType = null)))
+    }
+
+    @Test
+    fun `isAnimatableSource true for webp magic bytes with null mimeType`() {
+        // RIFF????WEBP header (12 bytes) is enough for the container sniff.
+        val webp = byteArrayOf(
+            0x52, 0x49, 0x46, 0x46, // RIFF
+            0x10, 0x00, 0x00, 0x00, // chunk size (ignored)
+            0x57, 0x45, 0x42, 0x50, // WEBP
+        )
+        assertTrue(isAnimatableSource(sourceResult(webp, mimeType = null)))
+    }
+
+    @Test
+    fun `isAnimatableSource false for jpeg mimeType`() {
+        assertFalse(isAnimatableSource(sourceResult(ByteArray(16), mimeType = "image/jpeg")))
+    }
+
+    @Test
+    fun `isAnimatableSource false for png bytes with null mimeType`() {
+        val png = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0, 0, 0, 0)
+        assertFalse(isAnimatableSource(sourceResult(png, mimeType = null)))
+    }
+
+    // --- Factory ---
+
+    @Test
+    fun `factory returns decoder for gif source`() {
+        val gif = Base64.decode(ANIMATED_GIF_2_FRAMES)
+        assertNotNull(factory.create(sourceResult(gif, "image/gif"), options, imageLoader))
+    }
+
+    @Test
+    fun `factory returns null for jpeg source`() {
+        assertNull(factory.create(sourceResult(ByteArray(16), "image/jpeg"), options, imageLoader))
+    }
+
+    // --- decode(): animated vs static ---
+
+    @Test
+    fun `decode returns animating image for multi-frame gif`() = runTest {
+        val gif = Base64.decode(ANIMATED_GIF_2_FRAMES)
+        val decoder = AnimatedSkiaDecoder(sourceResult(gif, "image/gif").source, options)
+        val result = decoder.decode()
+        assertNotNull(result, "multi-frame GIF should decode")
+        val image = result.image
+        assertTrue(image is SkiaAnimatedImage, "expected SkiaAnimatedImage, got ${image::class}")
+        assertTrue(image.animatable, "2-frame GIF must be animatable")
+        assertEquals(2, image.width)
+        assertEquals(1, image.height)
+    }
+
+    @Test
+    fun `decode returns null for single-frame gif so coil falls back to static decoder`() = runTest {
+        val gif = Base64.decode(STATIC_GIF_1_FRAME)
+        val decoder = AnimatedSkiaDecoder(sourceResult(gif, "image/gif").source, options)
+        assertNull(decoder.decode(), "single-frame GIF must defer to default Skia decoder")
+    }
+
+    @Test
+    fun `decode returns null for empty bytes`() = runTest {
+        val decoder = AnimatedSkiaDecoder(sourceResult(ByteArray(0), "image/gif").source, options)
+        assertNull(decoder.decode())
+    }
+
+    // --- frame timeline math (frameForElapsed) ---
+
+    @Test
+    fun `frameForElapsed maps elapsed time across frames and loops`() = runTest {
+        val gif = Base64.decode(ANIMATED_GIF_2_FRAMES)
+        val image = AnimatedSkiaDecoder(sourceResult(gif, "image/gif").source, options)
+            .decode()!!.image as SkiaAnimatedImage
+
+        // Frame 0 spans [0,500), frame 1 spans [500,1250); loops forever.
+        assertEquals(0, image.frameForElapsed(0))
+        assertEquals(0, image.frameForElapsed(499))
+        assertEquals(1, image.frameForElapsed(500))
+        assertEquals(1, image.frameForElapsed(1249))
+        // Loop wrap: 1250ms == start of next loop -> frame 0 again.
+        assertEquals(0, image.frameForElapsed(1250))
+        assertEquals(1, image.frameForElapsed(1750))
+        // Loop-forever GIF never returns null (never "finished").
+        assertNotNull(image.frameForElapsed(10_000))
+    }
+
+    private companion object {
+        // 2x1 GIF89a, 2 frames: 500ms red, 750ms blue, Netscape loop-forever.
+        const val ANIMATED_GIF_2_FRAMES =
+            "R0lGODlhAgABAPAAAP8AAAAA/yH/C05FVFNDQVBFMi4wAwEAAAAh+QQAMgAAACwAAAAAAgABAAAC" +
+                "AgQKACH5BABLAAAALAAAAAACAAEAAAICTAoAOw=="
+
+        // 2x1 GIF89a, single frame (no loop block).
+        const val STATIC_GIF_1_FRAME =
+            "R0lGODlhAgABAPAAAP8AAAAA/yH5BAAAAAAALAAAAAACAAEAAAICBAoAOw=="
+    }
+}

--- a/homebase-common/src/skiaMain/kotlin/id/homebase/core/image/AnimatedSkiaDecoder.kt
+++ b/homebase-common/src/skiaMain/kotlin/id/homebase/core/image/AnimatedSkiaDecoder.kt
@@ -1,0 +1,92 @@
+package id.homebase.core.image
+
+import co.touchlab.kermit.Logger
+import coil3.ImageLoader
+import coil3.decode.DecodeResult
+import coil3.decode.Decoder
+import coil3.decode.ImageSource
+import coil3.fetch.SourceFetchResult
+import coil3.request.Options
+import okio.use
+import org.jetbrains.skia.Codec
+import org.jetbrains.skia.Data
+
+/**
+ * In-house Coil3 [Decoder] that animates multi-frame GIF and WebP via Skia's
+ * [org.jetbrains.skia.Codec] on the non-Android targets (Desktop/JVM,
+ * iOS/native, Web/wasmJs). Coil ships no animated decoder for these targets —
+ * coil-gif's AnimatedImageDecoder is Android-only and there is no
+ * `coil3.gif.AnimatedSkiaImageDecoder` at any version — so we implement it here
+ * using skiko, which all three targets bundle. Android keeps using coil-gif
+ * (PR #663) and is intentionally not wired to this decoder.
+ *
+ * Registered next to [HeicDecoder] in each non-Android AppModule, so it sits in
+ * the existing encrypted Coil pipeline: it decodes the already-fetched,
+ * already-decrypted payload bytes Coil hands it and returns an animating
+ * [coil3.Image]. It does not fetch, decrypt, or cache anything itself.
+ *
+ * Single-frame GIFs/WebP return null from [decode] so Coil falls through to its
+ * default (static) Skia decoder — the static path is left completely unchanged.
+ */
+class AnimatedSkiaDecoder(
+    private val source: ImageSource,
+    private val options: Options,
+) : Decoder {
+
+    override suspend fun decode(): DecodeResult? {
+        val bytes = source.source().use { it.readByteArray() }
+        if (bytes.isEmpty()) return null
+
+        val codec = try {
+            Codec.makeFromData(Data.makeFromBytes(bytes))
+        } catch (e: Throwable) {
+            // Not decodable as an animated container — let the default decoder try.
+            Logger.d(tag = TAG) { "Codec.makeFromData failed (${bytes.size} bytes): ${e.message}" }
+            return null
+        }
+
+        val frameCount = codec.frameCount
+        if (frameCount <= 1) {
+            // Static GIF/WebP — defer to Coil's default Skia decoder unchanged.
+            codec.close()
+            return null
+        }
+
+        val framesInfo = codec.framesInfo
+        val durations = IntArray(frameCount) { i -> framesInfo.getOrNull(i)?.duration ?: 0 }
+        val required = IntArray(frameCount) { i ->
+            // skiko reports the index of the frame this one composites onto, or a
+            // negative sentinel for a standalone keyframe. Normalize anything
+            // out of range to -1 (keyframe / decode standalone).
+            val r = framesInfo.getOrNull(i)?.requiredFrame ?: -1
+            if (r in 0 until frameCount) r else -1
+        }
+
+        // codec keeps ownership of the underlying frames; SkiaAnimatedImage owns
+        // codec from here and closes it when it is itself closed.
+        val image = SkiaAnimatedImage(
+            codec = codec,
+            frameDurationsMs = durations,
+            requiredFrames = required,
+            repetitionCount = codec.repetitionCount,
+        )
+        // The first paint comes from the embedded thumbnail placeholder until the
+        // driver advances; mark not sampled (we decode at native resolution).
+        return DecodeResult(image = image, isSampled = false)
+    }
+
+    class Factory : Decoder.Factory {
+        override fun create(
+            result: SourceFetchResult,
+            options: Options,
+            imageLoader: ImageLoader,
+        ): Decoder? {
+            if (!isAnimatableSource(result)) return null
+            return AnimatedSkiaDecoder(result.source, options)
+        }
+    }
+
+    private companion object {
+        private const val TAG = "AnimatedSkiaDecoder"
+    }
+}

--- a/homebase-common/src/skiaMain/kotlin/id/homebase/core/image/SkiaAnimatedImage.kt
+++ b/homebase-common/src/skiaMain/kotlin/id/homebase/core/image/SkiaAnimatedImage.kt
@@ -1,0 +1,301 @@
+package id.homebase.core.image
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import co.touchlab.kermit.Logger
+import coil3.Image
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.Canvas
+import org.jetbrains.skia.Codec
+import org.jetbrains.skia.Rect
+import kotlin.time.TimeSource
+import org.jetbrains.skia.Image as SkiaImage
+
+/** Monotonic wall-clock in milliseconds — portable across JVM, native, wasmJs. */
+private val timeOrigin = TimeSource.Monotonic.markNow()
+internal fun nowMs(): Long = timeOrigin.elapsedNow().inWholeMilliseconds
+
+/**
+ * A [coil3.Image] that animates a multi-frame GIF/WebP through Skia's
+ * [org.jetbrains.skia.Codec], returned by [AnimatedSkiaDecoder] on the
+ * non-Android targets (Desktop/JVM, iOS/native, Web/wasmJs). Android animates
+ * via Coil's coil-gif AnimatedImageDecoder instead (PR #663).
+ *
+ * How animation reaches the screen without touching HomebaseImage:
+ *
+ * Coil wraps a non-[coil3.BitmapImage] custom [coil3.Image] in its internal
+ * `coil3.compose.ImagePainter`, whose `onDraw(DrawScope)` calls [draw] inside
+ * the Compose draw phase. [draw] reads [displayedFrame], a Compose
+ * [androidx.compose.runtime.MutableIntState]. Because that read happens during
+ * the draw phase, Compose's snapshot observer records it and re-invalidates the
+ * draw whenever the value changes. A shared [SkiaFrameDriver] advances
+ * [displayedFrame] over time off [Dispatchers.Main]; the painter repaints in
+ * lock-step. No second image loader, no re-fetch, no re-decrypt — the decoder
+ * sits in the existing encrypted Coil pipeline, so it inherits decrypt / fetch
+ * / cache / placeholder / sizing for free.
+ *
+ * Cost control:
+ *  - Frames are decoded **on demand** (never all up front). One reused scratch
+ *    bitmap holds the last decoded frame so Skia can composite delta (disposal)
+ *    frames forward; finished frames are snapshotted into a small bounded LRU of
+ *    immutable [SkiaImage]s, so large GIFs never hold every frame at once.
+ *  - The driver only ticks while at least one animated image has [draw]n
+ *    recently (i.e. is on-screen). Items scrolled out of a LazyColumn stop
+ *    drawing, stop renewing their registration, and the driver reaps them and
+ *    parks itself — so off-screen GIFs cost nothing.
+ */
+internal class SkiaAnimatedImage(
+    private val codec: Codec,
+    private val frameDurationsMs: IntArray,
+    private val requiredFrames: IntArray,
+    private val repetitionCount: Int,
+) : Image {
+
+    private val frameWidth: Int = codec.width
+    private val frameHeight: Int = codec.height
+
+    // Cumulative end-time timeline used to map elapsed ms -> frame index.
+    private val frameEndTimesMs: LongArray = LongArray(frameDurationsMs.size).also { arr ->
+        var acc = 0L
+        for (i in frameDurationsMs.indices) {
+            // Skia reports 0 for "as fast as possible" / malformed frames; clamp
+            // to a sane minimum so a bad GIF doesn't spin at thousands of fps.
+            acc += frameDurationsMs[i].coerceAtLeast(MIN_FRAME_DURATION_MS).toLong()
+            arr[i] = acc
+        }
+    }
+    private val totalDurationMs: Long = frameEndTimesMs.lastOrNull() ?: 0L
+    private val frameCount: Int get() = frameDurationsMs.size
+
+    /** Compose-observable index of the frame currently shown. Read in [draw]. */
+    private var displayedFrame by mutableIntStateOf(0)
+
+    // Single scratch bitmap that always holds [lastDecodedFrame]'s pixels so the
+    // codec can composite the next delta frame on top of it.
+    private val scratch: Bitmap = Bitmap().also { it.allocPixels(codec.imageInfo) }
+    private var lastDecodedFrame: Int = -1
+
+    // Bounded cache of decoded immutable frame images. Insertion-ordered
+    // (LinkedHashMap is multiplatform); we evict the oldest entry once over the
+    // cap. Java's removeEldestEntry hook is JVM-only, so eviction is manual to
+    // keep this compiling on native and wasmJs.
+    private val frameCache = LinkedHashMap<Int, SkiaImage>()
+
+    override val size: Long = frameWidth.toLong() * frameHeight.toLong() * 4
+    override val width: Int = frameWidth
+    override val height: Int = frameHeight
+    // Frame content changes over time, so the decoded result is not shareable
+    // (Coil must not treat it as a stable immutable bitmap).
+    override val shareable: Boolean = false
+
+    override fun draw(canvas: Canvas) {
+        // Reading displayedFrame here (draw phase) is what wires Compose
+        // invalidation: SkiaFrameDriver writes it, Compose repaints.
+        val frame = displayedFrame
+        // Renew our "on-screen" lease so the driver keeps ticking us.
+        SkiaFrameDriver.touch(this)
+
+        val image = frameImageOrNull(frame) ?: return
+        canvas.drawImageRect(image, Rect.makeWH(width.toFloat(), height.toFloat()))
+    }
+
+    /** Returns the decoded [SkiaImage] for [frame], decoding+caching on demand. */
+    private fun frameImageOrNull(frame: Int): SkiaImage? {
+        frameCache[frame]?.let { return it }
+        return try {
+            decodeFrame(frame)
+        } catch (e: Throwable) {
+            Logger.e(tag = TAG) { "Frame $frame decode failed: ${e.message}" }
+            null
+        }
+    }
+
+    /**
+     * Decode [frame] into the scratch bitmap, honoring GIF/WebP disposal. The
+     * driver advances frames monotonically (…→wrap to 0), so the scratch normally
+     * already holds the required predecessor and Skia's 3-arg readPixels can
+     * composite the delta. When the scratch is stale (first decode, a seek, or a
+     * loop wrap), we replay forward from the required keyframe so the composite
+     * base is correct. A snapshot of the result is cached as an immutable image.
+     */
+    private fun decodeFrame(frame: Int): SkiaImage {
+        val required = requiredFrames.getOrElse(frame) { -1 }
+        if (required >= 0 && lastDecodedFrame != required) {
+            // Rebuild the composite base: walk from the keyframe up to `required`.
+            replayTo(required)
+        }
+        if (required >= 0 && lastDecodedFrame == required) {
+            codec.readPixels(scratch, frame, required)
+        } else {
+            codec.readPixels(scratch, frame)
+        }
+        lastDecodedFrame = frame
+
+        val snapshot = snapshotScratch()
+        putInCache(frame, snapshot)
+        return snapshot
+    }
+
+    private fun putInCache(frame: Int, image: SkiaImage) {
+        frameCache[frame] = image
+        while (frameCache.size > MAX_CACHED_FRAMES) {
+            val eldestKey = frameCache.keys.firstOrNull() ?: break
+            frameCache.remove(eldestKey)?.close()
+        }
+    }
+
+    /** Decode frames [0..target] forward into the scratch so it holds [target]. */
+    private fun replayTo(target: Int) {
+        var keyframe = target
+        while (keyframe > 0 && requiredFrames.getOrElse(keyframe) { -1 } >= 0) {
+            keyframe = requiredFrames[keyframe]
+        }
+        for (i in keyframe..target) {
+            val req = requiredFrames.getOrElse(i) { -1 }
+            if (req >= 0 && lastDecodedFrame == req) {
+                codec.readPixels(scratch, i, req)
+            } else {
+                codec.readPixels(scratch, i)
+            }
+            lastDecodedFrame = i
+        }
+    }
+
+    /**
+     * Snapshot the current scratch pixels into an immutable [SkiaImage].
+     * [SkiaImage.makeFromBitmap] deep-copies a *mutable* source bitmap (Skia's
+     * Image::MakeFromBitmap), so the returned image is independent of the next
+     * frame's mutation of [scratch].
+     */
+    private fun snapshotScratch(): SkiaImage = SkiaImage.makeFromBitmap(scratch)
+
+    /**
+     * Compute the frame index for [elapsedMs] since playback start, honoring the
+     * loop count. Returns null once a finite-loop animation has completed (so the
+     * driver can stop and the last frame stays painted).
+     */
+    fun frameForElapsed(elapsedMs: Long): Int? {
+        if (totalDurationMs <= 0L || frameCount <= 1) return 0
+        if (repetitionCount >= 0) {
+            // repetitionCount is the number of *extra* loops after the first
+            // play-through (skiko convention), so total plays = repetition + 1.
+            val totalPlayMs = totalDurationMs * (repetitionCount + 1)
+            if (elapsedMs >= totalPlayMs) return null // finished — hold last frame
+        }
+        val intoLoop = elapsedMs % totalDurationMs
+        // Binary search the cumulative end-times for the first frame whose end
+        // time is strictly greater than intoLoop.
+        var lo = 0
+        var hi = frameCount - 1
+        while (lo < hi) {
+            val mid = (lo + hi) ushr 1
+            if (frameEndTimesMs[mid] <= intoLoop) lo = mid + 1 else hi = mid
+        }
+        return lo
+    }
+
+    /** Called by the driver to advance the visible frame; no-op if unchanged. */
+    fun advanceTo(frame: Int) {
+        if (frame != displayedFrame) displayedFrame = frame
+    }
+
+    val animatable: Boolean get() = frameCount > 1 && totalDurationMs > 0L
+
+    private companion object {
+        private const val TAG = "SkiaAnimatedImage"
+
+        // GIFs with a 0ms (or absurdly small) delay should not burn CPU; 20ms ~= 50fps cap.
+        private const val MIN_FRAME_DURATION_MS = 20
+
+        // On-demand frame cache cap per image. Bounds memory for long GIFs while
+        // keeping the recently-shown window warm for smooth looping.
+        private const val MAX_CACHED_FRAMES = 24
+    }
+}
+
+/**
+ * Process-wide clock that advances every on-screen [SkiaAnimatedImage]. A single
+ * coroutine on [Dispatchers.Main] re-evaluates each registered image's displayed
+ * frame on a fixed cadence and parks itself once no image has drawn within
+ * [GRACE_MS]. This bounds list-scroll cost: GIFs scrolled off-screen stop
+ * drawing, stop renewing their lease, and get reaped — so off-screen GIFs cost
+ * nothing.
+ *
+ * Threading: every method runs on the single-threaded [Dispatchers.Main], so the
+ * registration map needs no locking. [touch] is called from the Compose draw
+ * phase (also Main), and the tick loop runs on the same dispatcher.
+ */
+internal object SkiaFrameDriver {
+    private val scope = CoroutineScope(Dispatchers.Main)
+
+    private class Registration(val image: SkiaAnimatedImage, var lastTouchedMs: Long, val startedMs: Long)
+
+    private val registrations = HashMap<SkiaAnimatedImage, Registration>()
+    private var job: Job? = null
+
+    /** Renew an image's on-screen lease (called from its [SkiaAnimatedImage.draw]). */
+    fun touch(image: SkiaAnimatedImage) {
+        if (!image.animatable) return
+        val now = nowMs()
+        val existing = registrations[image]
+        if (existing != null) {
+            existing.lastTouchedMs = now
+        } else {
+            registrations[image] = Registration(image, now, now)
+        }
+        ensureRunning()
+    }
+
+    private fun ensureRunning() {
+        if (job?.isActive == true) return
+        job = scope.launch {
+            while (isActive) {
+                if (!tick()) break
+                delay(TICK_INTERVAL_MS)
+            }
+        }
+    }
+
+    /**
+     * One driver pass: drop stale (off-screen) or finished images, advance live
+     * ones. Returns false (and parks the loop) once nothing is left to animate.
+     */
+    private fun tick(): Boolean {
+        val now = nowMs()
+        val it = registrations.entries.iterator()
+        while (it.hasNext()) {
+            val reg = it.next().value
+            if (now - reg.lastTouchedMs > GRACE_MS) {
+                it.remove()
+                continue
+            }
+            val frame = reg.image.frameForElapsed(now - reg.startedMs)
+            if (frame == null) {
+                // Finished looping — hold last frame, stop ticking this one.
+                it.remove()
+                continue
+            }
+            reg.image.advanceTo(frame)
+        }
+        if (registrations.isEmpty()) {
+            job = null
+            return false
+        }
+        return true
+    }
+
+    // Repaint cadence. We re-evaluate at <=60fps; the per-image timeline decides
+    // which frame to show, so a slow 1fps GIF still only changes pixels once per
+    // second even though we poll faster.
+    private const val TICK_INTERVAL_MS = 16L
+
+    // How long after the last draw before we consider an image off-screen.
+    private const val GRACE_MS = 500L
+}

--- a/homebase-core/src/jvmMain/kotlin/id/homebase/core/di/AppModule.desktop.kt
+++ b/homebase-core/src/jvmMain/kotlin/id/homebase/core/di/AppModule.desktop.kt
@@ -20,6 +20,7 @@ import id.homebase.core.audio.JvmWaveFormGenerator
 import id.homebase.core.gallery.GalleryCache
 import id.homebase.core.gallery.JvmGalleryManager
 import id.homebase.core.gallery.PlatformGalleryManager
+import id.homebase.core.image.AnimatedSkiaDecoder
 import id.homebase.core.image.HeicDecoder
 import id.homebase.core.image.HomebaseImageFetcher
 import id.homebase.core.image.HomebaseImageKeyer
@@ -70,6 +71,9 @@ actual fun platformModule(): Module = module {
                     add(HomebaseImageFetcher.Factory(get(), get()))
                     add(PublicImageFetcher.Factory(get()))
                     add(PlatformFileFetcher.Factory())
+                    // Animates multi-frame GIF/WebP in-house via skiko; static
+                    // images fall through to Coil's default Skia decoder.
+                    add(AnimatedSkiaDecoder.Factory())
                     add(HeicDecoder.Factory())
                 }
                 .diskCache(null)

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/di/AppModule.native.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/di/AppModule.native.kt
@@ -22,6 +22,7 @@ import id.homebase.core.gallery.GalleryCache
 import id.homebase.core.gallery.IOSGalleryLibraryObserver
 import id.homebase.core.gallery.IOSGalleryManager
 import id.homebase.core.gallery.PlatformGalleryManager
+import id.homebase.core.image.AnimatedSkiaDecoder
 import id.homebase.core.image.HeicDecoder
 import id.homebase.core.image.HomebaseImageFetcher
 import id.homebase.core.image.HomebaseImageKeyer
@@ -69,6 +70,9 @@ actual fun platformModule(): Module = module {
                     add(HomebaseImageFetcher.Factory(get(), get()))
                     add(PublicImageFetcher.Factory(get()))
                     add(PlatformFileFetcher.Factory())
+                    // Animates multi-frame GIF/WebP in-house via skiko; static
+                    // images fall through to Coil's default Skia decoder.
+                    add(AnimatedSkiaDecoder.Factory())
                     add(HeicDecoder.Factory())
                 }
                 .diskCache(null)

--- a/homebase-core/src/wasmJsMain/kotlin/id/homebase/core/di/AppModule.web.kt
+++ b/homebase-core/src/wasmJsMain/kotlin/id/homebase/core/di/AppModule.web.kt
@@ -13,6 +13,7 @@ import id.homebase.core.audio.AudioWaveFormGenerator
 import id.homebase.core.audio.getAudioPlayer
 import id.homebase.core.gallery.GalleryCache
 import id.homebase.core.gallery.PlatformGalleryManager
+import id.homebase.core.image.AnimatedSkiaDecoder
 import id.homebase.core.image.HomebaseImageFetcher
 import id.homebase.core.image.HomebaseImageKeyer
 import id.homebase.core.notifications.NoopNotificationBackend
@@ -56,6 +57,9 @@ actual fun platformModule(): Module = module {
                     add(HomebaseImageKeyer())
                     add(HomebaseImageFetcher.Factory(get(), get()))
                     add(PlatformFileFetcher.Factory())
+                    // Animates multi-frame GIF/WebP in-house via skiko; static
+                    // images fall through to Coil's default Skia decoder.
+                    add(AnimatedSkiaDecoder.Factory())
                 }
                 .build()
     }


### PR DESCRIPTION
## Problem

Animated GIFs (and animated WebP) play on Android via Coil's `coil-gif` `AnimatedImageDecoder` (PR #663), but show only their **first frame, frozen** on Desktop (JVM), iOS (native), and Web (wasmJs). Coil ships **no** animated decoder for those targets — `coil-gif` is Android-only, and there is no `coil3.gif.AnimatedSkiaImageDecoder` at any version. So this implements one in-house using **skiko** (`org.jetbrains.skia.Codec`), which JVM/native/wasmJs all bundle.

## Approach: a custom Coil `Decoder` in the shared `skiaMain` source set

`AnimatedSkiaDecoder` is a `coil3.decode.Decoder` registered next to the existing `HeicDecoder` in the three non-Android `AppModule`s. Mirroring `HeicDecoder`'s structure, it lives in a new shared `skiaMain` source set (same pattern as `homebase-api`'s `skiaMain`) so one copy serves Desktop + iOS + Web.

Because it sits **inside the existing encrypted Coil pipeline**, it inherits decrypt/fetch/cache/placeholder/sizing for free:

- The bytes it decodes are the already-fetched, already-decrypted Homebase payload that `HomebaseImageFetcher` hands Coil (GIF already loads the full payload via `THUMBLESS_CONTENT_TYPES`).
- **No** second image loader, **no** re-fetch, **no** re-decrypt — the decoder only decodes bytes Coil gives it.
- It claims GIF/WebP sources (mime or magic bytes), asks the codec for `frameCount`, and returns **null for single-frame** images so static decoding falls through to Coil's default Skia decoder completely unchanged.

### How it animates without touching `HomebaseImage`

Verified against the Coil 3.4.0 bytecode: on non-Android, `coil3.Image.draw(org.jetbrains.skia.Canvas)` is the contract, and Coil wraps a non-`BitmapImage` custom `coil3.Image` in its internal `coil3.compose.ImagePainter`, whose `onDraw(DrawScope)` calls `image.draw(canvas)` **inside the Compose draw phase**.

So `SkiaAnimatedImage.draw()` reads a Compose `MutableIntState` (the current frame). Because that read happens during the draw phase, Compose's snapshot observer records it and re-invalidates the draw when it changes. A shared `SkiaFrameDriver` on `Dispatchers.Main` advances that state on the GIF's **own per-frame timeline**, and the painter repaints in lock-step. This drives animation through the normal `SubcomposeAsyncImage`/`AsyncImagePainter` path — `MediaItem`/`HomebaseImage` are not modified at all.

`shareable = false` keeps the animated image out of Coil's memory cache (verified: `MemoryCacheService` skips caching when `shareable` is false), so frames are never flattened into a stale static snapshot.

## Correctness & cost

- **Animated GIF and animated WebP** both detected (`Codec.frameCount > 1`).
- **Per-frame duration** honored (skiko `framesInfo[i].duration`), with a 20ms floor so a 0ms-delay GIF can't spin at thousands of fps.
- **Disposal / delta frames** composite correctly: frames decode into one reused scratch bitmap and Skia's 3-arg `readPixels(bitmap, frame, requiredFrame)` blends deltas; on a loop wrap or seek we replay forward from the keyframe so the composite base is correct.
- **Decode on demand** — never pre-decode all frames; decoded frames cache in a small bounded LRU (24) so large GIFs don't blow up memory.
- **Bounded list-scroll cost** — the driver only ticks while an image has `draw()`n within a 500ms grace window. GIFs scrolled out of a `LazyColumn` stop drawing, stop renewing their lease, get reaped, and the driver parks itself — so off-screen GIFs cost nothing.
- **Static images unchanged**, transparency preserved (no opaque background fill — respects the B1 sticker work), native resolution.

## Per-target compile results

All green; Android proven untouched:

| Target | `homebase-common` | `homebase-core` |
|---|---|---|
| JVM / Desktop (`compileKotlinJvm`) | PASS | PASS |
| iOS (`compileKotlinIosSimulatorArm64`) | PASS | PASS |
| Web (`compileKotlinWasmJs`) | PASS | PASS |
| Android (`compileAndroidMain`) | PASS | PASS |

## Tests

New JVM unit test `AnimatedSkiaDecoderTest` (runs on CI via `homebase-common:jvmTest`, since `skiaMain` is on the JVM classpath). Uses two hand-built minimal GIF89a fixtures:

- `isAnimatableSource` gate (GIF/WebP by mime + magic bytes; rejects JPEG/PNG).
- Decoder returns an animating `SkiaAnimatedImage` for the 2-frame GIF and **null** for the single-frame GIF (proving the static fall-through).
- `frameForElapsed` timeline math validated against the real codec's reported 500ms/750ms delays, including loop wrap.

## Relation to #663

Complementary and non-overlapping: #663 makes GIFs animate on **Android** via `coil-gif`'s `AnimatedImageDecoder`. This PR makes them animate on **Desktop, iOS, and Web** via the in-house skiko decoder. Android is not wired to this decoder (`skiaMain` excludes Android by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
