### PR TITLE
Show 'Sticker' label in the conversation tile for sticker messages

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageContentLabel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageContentLabel.kt
@@ -6,9 +6,11 @@ import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.PhotoLibrary
+import androidx.compose.material.icons.automirrored.filled.StickyNote2
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
+import id.homebase.api.client.drives.files.DescriptorContent
 import id.homebase.api.client.drives.files.PayloadDescriptor
 import id.homebase.chat.services.ChatProtocol
 import id.homebase.resources.MR
@@ -20,6 +22,7 @@ import id.homebase.resources.chat_message_link
 import id.homebase.resources.chat_message_location
 import id.homebase.resources.chat_message_multiple_media
 import id.homebase.resources.chat_message_video
+import id.homebase.resources.chat_preview_sticker
 import org.jetbrains.compose.resources.stringResource
 
 /**
@@ -62,6 +65,15 @@ fun messageContentLabel(
 
     if (firstPayload != null) {
         return when {
+            // A solo transparent cut-out image carries DescriptorContent.ImageFile(isSticker=true).
+            // hasMultiplePayloads is already false here, so this is the single-payload case the
+            // sticker bubble (MediaMessage) recognises — surface "Sticker" instead of "Image".
+            firstPayload.contentType?.startsWith("image/") == true &&
+                (firstPayload.descriptorInfo() as? DescriptorContent.ImageFile)?.isSticker == true ->
+                ContentLabel(
+                    text = stringResource(MR.string.chat_preview_sticker),
+                    icon = Icons.AutoMirrored.Filled.StickyNote2
+                )
             firstPayload.contentType?.startsWith("image/") == true -> ContentLabel(
                 text = stringResource(MR.string.chat_message_image),
                 icon = Icons.Default.Image

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -446,6 +446,7 @@
     <string name="chat_message_deleted">🚫 Denne besked blev slettet</string>
 
     <string name="chat_message_image">Billede</string>
+    <string name="chat_preview_sticker">Klistermærke</string>
     <string name="chat_message_link">Link</string>
     <string name="chat_message_video">Video</string>
     <string name="chat_message_audio">Lyd</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -651,6 +651,7 @@
     <string name="chat_message_deleted">🚫 This message was deleted</string>
 
     <string name="chat_message_image">Image</string>
+    <string name="chat_preview_sticker">Sticker</string>
     <string name="chat_message_link">Link</string>
     <string name="chat_message_video">Video</string>
     <string name="chat_message_audio">Audio</string>


### PR DESCRIPTION
## Mechanism

The conversation-list tile's last-message preview is **computed live**, not from a denormalized stored string. `ConversationItem.kt` calls the shared `messageContentLabel(...)` Composable (`MessageContentLabel.kt`), passing `enrichedData.conversation.lastMessageFirstPayload` — the actual `PayloadDescriptor?` of the last message's first payload (populated in `ConversationUiModel`/`ConversationStream`/`ConversationMessageBump` from `msg.payloads?.firstOrNull()`). Because the real descriptor is in hand, `isSticker` is reachable at label time; nothing needs to be re-derived from stored text.

`messageContentLabel` is a **shared helper** used by three call sites — `ConversationItem` (tile), `ReplyPreviewBar` (reply input preview), and `MessageBubble` (reply quote) — so fixing it once makes the label consistent everywhere.

## The change

In `messageContentLabel`, the solo-image branch now first checks for a sticker. `hasMultiplePayloads` is already `false` at that point, so this matches the same single-image-payload condition `MediaMessage` uses to render the sticker bubble:

```kotlin
firstPayload.contentType?.startsWith("image/") == true &&
    (firstPayload.descriptorInfo() as? DescriptorContent.ImageFile)?.isSticker == true
```

When true, the label is `chat_preview_sticker` ("Sticker") with an `Icons.AutoMirrored.Filled.StickyNote2` icon. Ordinary images/photos/videos/audio/links/locations are unchanged. Detection reuses the existing `DescriptorContent.ImageFile.isSticker` check — no new detection logic, **no wire-format change**.

New string `chat_preview_sticker` added to `homebase-common` `values/strings.xml` (`Sticker`) and `values-da/strings.xml` (`Klistermærke`). All user-facing text goes through `stringResource`.

## Cross-platform

Compiled clean on all four targets:
- `:homebase-chat:compileKotlinJvm` ✅
- `:homebase-chat:compileAndroidMain` ✅
- `:homebase-chat:compileKotlinIosSimulatorArm64` ✅
- `:homebase-chat:compileKotlinWasmJs` ✅

## Tests

No unit test added: `messageContentLabel` is a `@Composable` whose output is a `stringResource`, so it isn't unit-testable on JVM without a UI test harness. Behavior verified by reusing the already-tested sticker-detection idiom (`MediaMessage`, `PayloadDescriptorImageTest`, `MessageAttachmentBuilderStickerTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)