### PR TITLE
Background-remover sticker tool (Android ML Kit + iOS Vision)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -72,6 +72,7 @@ playPublisher = "4.0.0"
 buildconfig = "6.0.9"
 play-app-update = "2.1.0"
 play-services-location = "21.3.0"
+mlkit-subject-segmentation = "16.0.0-beta1"
 metadataExtractor = "2.19.0"
 
 [libraries]
@@ -196,6 +197,7 @@ composenativewebview = { module = "io.github.kdroidfilter:composewebview", versi
 conveyor-control = { module = "dev.hydraulic.conveyor:conveyor-control", version.ref = "conveyorControl" }
 play-app-update = { module = "com.google.android.play:app-update-ktx", version.ref = "play-app-update" }
 play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "play-services-location" }
+mlkit-subject-segmentation = { module = "com.google.android.gms:play-services-mlkit-subject-segmentation", version.ref = "mlkit-subject-segmentation" }
 metadata-extractor = { module = "com.drewnoakes:metadata-extractor", version.ref = "metadataExtractor" }
 nucleus-notification-common = { module = "io.github.kdroidfilter:nucleus.notification-common", version.ref = "nucleus" }
 nucleus-notification-windows = { module = "io.github.kdroidfilter:nucleus.notification-windows", version.ref = "nucleus" }

--- a/homebase-chat/build.gradle.kts
+++ b/homebase-chat/build.gradle.kts
@@ -86,6 +86,9 @@ kotlin {
             implementation(libs.androidx.media3.ui)
             implementation(libs.androidx.ui.tooling)
             implementation(libs.play.services.location)
+            // On-device subject segmentation for the "Remove background" sticker tool.
+            // Model is downloaded via Google Play services (not bundled) → ~0 APK cost.
+            implementation(libs.mlkit.subject.segmentation)
         }
         appleMain.dependencies {
             implementation(libs.ktor.client.darwin)

--- a/homebase-chat/src/androidMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.android.kt
+++ b/homebase-chat/src/androidMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.android.kt
@@ -1,0 +1,88 @@
+package id.homebase.chat.services.image
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import co.touchlab.kermit.Logger
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GoogleApiAvailability
+import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.segmentation.subject.SubjectSegmentation
+import com.google.mlkit.vision.segmentation.subject.SubjectSegmentationResult
+import com.google.mlkit.vision.segmentation.subject.SubjectSegmenterOptions
+import id.homebase.api.ActivityProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import java.io.ByteArrayOutputStream
+import kotlin.coroutines.resume
+
+private const val TAG = "BackgroundRemover"
+
+/**
+ * Android implementation: ML Kit Subject Segmentation (on-device, model downloaded
+ * via Google Play services — not bundled, so ~0 APK cost). The segmenter's
+ * `foregroundBitmap` is already an alpha-cut ARGB bitmap; we PNG-encode it so the
+ * transparency survives into the send pipeline.
+ *
+ * Returns null (soft fail, caller keeps the original) when:
+ *  - Google Play services / the segmentation model isn't available,
+ *  - the model hasn't been downloaded yet (process() fails),
+ *  - the source can't be decoded,
+ *  - or no foreground subject was detected.
+ */
+actual suspend fun removeBackground(srcBytes: ByteArray): ByteArray? = withContext(Dispatchers.Default) {
+    if (!isBackgroundRemovalSupported()) return@withContext null
+
+    val source = runCatching {
+        BitmapFactory.decodeByteArray(srcBytes, 0, srcBytes.size)
+    }.getOrNull()
+    if (source == null) {
+        Logger.w(tag = TAG) { "Android: could not decode source bytes for background removal" }
+        return@withContext null
+    }
+
+    val options = SubjectSegmenterOptions.Builder()
+        .enableForegroundBitmap()
+        .build()
+    val segmenter = SubjectSegmentation.getClient(options)
+
+    try {
+        val result = suspendCancellableCoroutine<SubjectSegmentationResult?> { cont ->
+            segmenter.process(InputImage.fromBitmap(source, 0))
+                .addOnSuccessListener { res -> cont.resume(res) }
+                .addOnFailureListener { e ->
+                    // The common path here is "model not downloaded yet" (the model
+                    // downloads in the background on first use). Treat as soft-null.
+                    Logger.w(tag = TAG) { "Android: subject segmentation failed: ${e.message}" }
+                    cont.resume(null)
+                }
+        } ?: return@withContext null
+
+        val foreground: Bitmap = result.foregroundBitmap ?: run {
+            Logger.d(tag = TAG) { "Android: no foreground subject found" }
+            return@withContext null
+        }
+
+        ByteArrayOutputStream().use { out ->
+            foreground.compress(Bitmap.CompressFormat.PNG, 100, out)
+            out.toByteArray()
+        }
+    } catch (e: Exception) {
+        Logger.w(tag = TAG) { "Android: background removal threw: ${e.message}" }
+        null
+    } finally {
+        segmenter.close()
+    }
+}
+
+/**
+ * Supported when Google Play services is present — the Subject Segmentation model
+ * rides on GMS and is unavailable on GMS-less devices. We don't probe model
+ * download state here (that would require a network/IPC round-trip); a missing
+ * model simply surfaces later as a null from [removeBackground].
+ */
+actual fun isBackgroundRemovalSupported(): Boolean = runCatching {
+    val context = ActivityProvider.requireApplicationContext()
+    GoogleApiAvailability.getInstance()
+        .isGooglePlayServicesAvailable(context) == ConnectionResult.SUCCESS
+}.getOrDefault(false)

--- a/homebase-chat/src/androidMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.android.kt
+++ b/homebase-chat/src/androidMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.android.kt
@@ -19,6 +19,14 @@ import kotlin.coroutines.resume
 private const val TAG = "BackgroundRemover"
 
 /**
+ * Cap (px, longest edge) on the bitmap fed to ML Kit. A 12-MP frame would otherwise
+ * decode into a ~48 MB ARGB bitmap which, alongside ML Kit's own foreground bitmap,
+ * risks OOM on low-RAM devices; 2048px still yields a high-quality mask for a <=512px
+ * sticker.
+ */
+private const val MAX_SEGMENT_INPUT_DIM = 2048
+
+/**
  * Android implementation: ML Kit Subject Segmentation (on-device, model downloaded
  * via Google Play services — not bundled, so ~0 APK cost). The segmenter's
  * `foregroundBitmap` is already an alpha-cut ARGB bitmap; we PNG-encode it so the
@@ -34,7 +42,7 @@ actual suspend fun removeBackground(srcBytes: ByteArray): ByteArray? = withConte
     if (!isBackgroundRemovalSupported()) return@withContext null
 
     val source = runCatching {
-        BitmapFactory.decodeByteArray(srcBytes, 0, srcBytes.size)
+        decodeBoundedBitmap(srcBytes, MAX_SEGMENT_INPUT_DIM)
     }.getOrNull()
     if (source == null) {
         Logger.w(tag = TAG) { "Android: could not decode source bytes for background removal" }
@@ -86,3 +94,25 @@ actual fun isBackgroundRemovalSupported(): Boolean = runCatching {
     GoogleApiAvailability.getInstance()
         .isGooglePlayServicesAvailable(context) == ConnectionResult.SUCCESS
 }.getOrDefault(false)
+
+/**
+ * Decode [srcBytes] with an `inSampleSize` cap so the segmenter input stays within
+ * [maxDim] on its longest edge. `inSampleSize` only powers-of-two downsamples at decode
+ * time and does NOT apply EXIF rotation — matching the previous raw `decodeByteArray`,
+ * so the cut-out's orientation is unchanged. ARGB_8888 preserves the alpha channel ML
+ * Kit fills into the foreground bitmap.
+ */
+private fun decodeBoundedBitmap(srcBytes: ByteArray, maxDim: Int): Bitmap? {
+    val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    BitmapFactory.decodeByteArray(srcBytes, 0, srcBytes.size, bounds)
+    val longest = maxOf(bounds.outWidth, bounds.outHeight)
+    var sample = 1
+    while (longest > 0 && longest / sample > maxDim) {
+        sample *= 2
+    }
+    val options = BitmapFactory.Options().apply {
+        inSampleSize = sample
+        inPreferredConfig = Bitmap.Config.ARGB_8888
+    }
+    return BitmapFactory.decodeByteArray(srcBytes, 0, srcBytes.size, options)
+}

--- a/homebase-chat/src/androidMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.android.kt
+++ b/homebase-chat/src/androidMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.android.kt
@@ -5,11 +5,17 @@ import android.graphics.BitmapFactory
 import co.touchlab.kermit.Logger
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
+import com.google.android.gms.common.moduleinstall.InstallStatusListener
+import com.google.android.gms.common.moduleinstall.ModuleInstall
+import com.google.android.gms.common.moduleinstall.ModuleInstallRequest
+import com.google.android.gms.common.moduleinstall.ModuleInstallStatusUpdate
 import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.segmentation.subject.SubjectSegmentation
 import com.google.mlkit.vision.segmentation.subject.SubjectSegmentationResult
+import com.google.mlkit.vision.segmentation.subject.SubjectSegmenter
 import com.google.mlkit.vision.segmentation.subject.SubjectSegmenterOptions
 import id.homebase.api.ActivityProvider
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
@@ -26,15 +32,27 @@ private const val TAG = "BackgroundRemover"
  */
 private const val MAX_SEGMENT_INPUT_DIM = 2048
 
+private fun segmenterOptions(): SubjectSegmenterOptions =
+    SubjectSegmenterOptions.Builder()
+        .enableForegroundBitmap()
+        .build()
+
 /**
  * Android implementation: ML Kit Subject Segmentation (on-device, model downloaded
  * via Google Play services — not bundled, so ~0 APK cost). The segmenter's
  * `foregroundBitmap` is already an alpha-cut ARGB bitmap; we PNG-encode it so the
  * transparency survives into the send pipeline.
  *
+ * The model is an optional Play-services module that is NOT in the APK — first use has
+ * to download it. We [ensureSegmentationModuleInstalled] (suspending until the download
+ * finishes) BEFORE process(), so the first attempt waits for the model instead of
+ * one-shot failing with "Waiting for the subject segmentation optional module to be
+ * downloaded." [warmUpBackgroundRemoval] can pre-warm it earlier so that wait is
+ * usually instant.
+ *
  * Returns null (soft fail, caller keeps the original) when:
- *  - Google Play services / the segmentation model isn't available,
- *  - the model hasn't been downloaded yet (process() fails),
+ *  - Google Play services isn't available,
+ *  - the model can't be installed (download failed / declined),
  *  - the source can't be decoded,
  *  - or no foreground subject was detected.
  */
@@ -49,20 +67,22 @@ actual suspend fun removeBackground(srcBytes: ByteArray): ByteArray? = withConte
         return@withContext null
     }
 
-    val options = SubjectSegmenterOptions.Builder()
-        .enableForegroundBitmap()
-        .build()
-    val segmenter = SubjectSegmentation.getClient(options)
+    val segmenter = SubjectSegmentation.getClient(segmenterOptions())
 
     try {
+        // The model isn't bundled — make sure Play services has downloaded it (waiting
+        // on the download if this is the first use) before we hand it an image.
+        if (!ensureSegmentationModuleInstalled(segmenter)) {
+            Logger.w(tag = TAG) { "Android: segmentation model unavailable (install failed/declined)" }
+            return@withContext null
+        }
+
         val result = suspendCancellableCoroutine<SubjectSegmentationResult?> { cont ->
             segmenter.process(InputImage.fromBitmap(source, 0))
-                .addOnSuccessListener { res -> cont.resume(res) }
+                .addOnSuccessListener { res -> if (cont.isActive) cont.resume(res) }
                 .addOnFailureListener { e ->
-                    // The common path here is "model not downloaded yet" (the model
-                    // downloads in the background on first use). Treat as soft-null.
                     Logger.w(tag = TAG) { "Android: subject segmentation failed: ${e.message}" }
-                    cont.resume(null)
+                    if (cont.isActive) cont.resume(null)
                 }
         } ?: return@withContext null
 
@@ -75,6 +95,10 @@ actual suspend fun removeBackground(srcBytes: ByteArray): ByteArray? = withConte
             foreground.compress(Bitmap.CompressFormat.PNG, 100, out)
             out.toByteArray()
         }
+    } catch (e: CancellationException) {
+        // Editor closed / coroutine cancelled mid-segmentation — let structured
+        // concurrency tear this down; never swallow it as a soft "failed" result.
+        throw e
     } catch (e: Exception) {
         Logger.w(tag = TAG) { "Android: background removal threw: ${e.message}" }
         null
@@ -94,6 +118,103 @@ actual fun isBackgroundRemovalSupported(): Boolean = runCatching {
     GoogleApiAvailability.getInstance()
         .isGooglePlayServicesAvailable(context) == ConnectionResult.SUCCESS
 }.getOrDefault(false)
+
+/**
+ * Best-effort proactive download: when an image editor opens, ask Play services to
+ * *deferred-install* the Subject Segmentation module (it fetches when the device is
+ * idle and on unmetered Wi-Fi — no UI, no guarantee it finishes before the user taps).
+ * The on-tap path still installs-and-waits, so this only shortens the common case.
+ * Fire-and-forget and idempotent; never throws.
+ */
+actual fun warmUpBackgroundRemoval() {
+    if (!isBackgroundRemovalSupported()) return
+    runCatching {
+        val context = ActivityProvider.requireApplicationContext()
+        val segmenter = SubjectSegmentation.getClient(segmenterOptions())
+        ModuleInstall.getClient(context)
+            .deferredInstall(segmenter)
+            .addOnFailureListener { e ->
+                Logger.d(tag = TAG) { "Android: deferred segmentation install not scheduled: ${e.message}" }
+            }
+        // The deferred request is already enqueued with Play services; the local handle
+        // isn't needed past scheduling, so release its native pipeline.
+        segmenter.close()
+    }.onFailure {
+        Logger.d(tag = TAG) { "Android: warmUpBackgroundRemoval skipped: ${it.message}" }
+    }
+}
+
+/**
+ * Make sure the ML Kit Subject Segmentation optional module is installed, downloading
+ * it (and suspending until it finishes) if necessary. Returns true once the model is
+ * present, false if Play services can't provide it.
+ *
+ * The model rides on Play services and is NOT in the APK; without this gate the first
+ * process() call fails with "...optional module to be downloaded. Please wait." We turn
+ * that one-shot failure into a wait (the editor shows a spinner meanwhile).
+ *
+ * Key subtlety: the Task from installModules() resolves when the request is ACCEPTED,
+ * not when the download FINISHES — so completion is observed via the
+ * [InstallStatusListener] reaching a terminal state. [invokeOnCancellation] unregisters
+ * the listener so a coroutine cancelled mid-download (editor closed) doesn't leak it.
+ */
+private suspend fun ensureSegmentationModuleInstalled(segmenter: SubjectSegmenter): Boolean {
+    val context = ActivityProvider.requireApplicationContext()
+    val client = ModuleInstall.getClient(context)
+
+    // Fast path: already installed (every call after the first) — skip the install request.
+    val alreadyInstalled = suspendCancellableCoroutine<Boolean> { cont ->
+        client.areModulesAvailable(segmenter)
+            .addOnSuccessListener { response -> if (cont.isActive) cont.resume(response.areModulesAvailable()) }
+            .addOnFailureListener { e ->
+                Logger.w(tag = TAG) { "Android: areModulesAvailable failed: ${e.message}" }
+                if (cont.isActive) cont.resume(false)
+            }
+    }
+    if (alreadyInstalled) return true
+
+    return suspendCancellableCoroutine { cont ->
+        lateinit var listener: InstallStatusListener
+        listener = InstallStatusListener { update ->
+            when (update.installState) {
+                ModuleInstallStatusUpdate.InstallState.STATE_COMPLETED -> {
+                    client.unregisterListener(listener)
+                    if (cont.isActive) cont.resume(true)
+                }
+
+                ModuleInstallStatusUpdate.InstallState.STATE_FAILED,
+                ModuleInstallStatusUpdate.InstallState.STATE_CANCELED -> {
+                    client.unregisterListener(listener)
+                    if (cont.isActive) cont.resume(false)
+                }
+
+                else -> Unit // PENDING / DOWNLOADING / DOWNLOADED / INSTALLING — keep waiting.
+            }
+        }
+
+        val request = ModuleInstallRequest.newBuilder()
+            .addApi(segmenter)
+            .setListener(listener)
+            .build()
+
+        client.installModules(request)
+            .addOnSuccessListener { response ->
+                // Rare race: it became installed between the availability check and now.
+                // No status updates will fire in that case, so resolve from the response.
+                if (response.areModulesAlreadyInstalled() && cont.isActive) {
+                    client.unregisterListener(listener)
+                    cont.resume(true)
+                }
+            }
+            .addOnFailureListener { e ->
+                Logger.w(tag = TAG) { "Android: module install request failed: ${e.message}" }
+                client.unregisterListener(listener)
+                if (cont.isActive) cont.resume(false)
+            }
+
+        cont.invokeOnCancellation { client.unregisterListener(listener) }
+    }
+}
 
 /**
  * Decode [srcBytes] with an `inSampleSize` cap so the segmenter input stays within

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentHandler.kt
@@ -14,6 +14,7 @@ import id.homebase.core.localization.TranslationUtil
 import id.homebase.core.util.detectContentTypeFromExtensionOrHint
 import id.homebase.chat.services.image.StickerImageProcessor
 import id.homebase.chat.services.image.removeBackground
+import id.homebase.chat.services.image.warmUpBackgroundRemoval
 import id.homebase.imageeditor.ui.CropResultBus
 import id.homebase.imageeditor.ui.DrawResultBus
 import id.homebase.resources.MR
@@ -165,6 +166,11 @@ internal class AttachmentHandler(
                     )
                 }
 
+                // Image editor is open — pre-warm the background-removal model so the
+                // first "Remove background" tap is usually instant (Android-only; no-op
+                // elsewhere and when no image was attached).
+                maybeWarmUpBackgroundRemoval(newFiles)
+
                 // Editor is now visible — extract thumbnails in the background and
                 // patch the pending FileVideo entries when they complete.
                 newFiles.forEach { f ->
@@ -228,6 +234,10 @@ internal class AttachmentHandler(
                         fullScreenOverlay = newOverlay,
                     )
                 }
+
+                // Image editor is open — pre-warm the background-removal model (no-op
+                // when no image was attached or the platform is unsupported).
+                maybeWarmUpBackgroundRemoval(newFiles)
 
                 // Editor visible — kick off thumbnail extraction in parallel.
                 newFiles.zip(action.files).forEach { (pending, gallery) ->
@@ -325,6 +335,9 @@ internal class AttachmentHandler(
                 messagesUiState.update {
                     it.copy(fullScreenOverlay = newOverlay)
                 }
+
+                // A pasted image is always image-like — pre-warm the background-removal model.
+                maybeWarmUpBackgroundRemoval(listOf(newFile))
             } catch (e: Exception) {
                 Logger.e("Failed to attach clipboard image", e)
                 sendEvent(ShowErrorMessage("Failed to paste image: ${e.message}"))
@@ -466,6 +479,22 @@ internal class AttachmentHandler(
                 sendEvent(ShowErrorMessage("Failed to apply drawing: ${e.message}"))
             }
         }
+    }
+
+    /**
+     * Best-effort: when an image editor opens on a device that supports background
+     * removal, ask the platform to pre-download the segmentation model (Android's ML
+     * Kit optional module) so the first [handleRemoveBackground] tap usually finds it
+     * ready instead of triggering — and briefly failing on — the download then. No-op
+     * on platforms without an optional model, and when nothing image-like was attached.
+     */
+    private fun maybeWarmUpBackgroundRemoval(files: List<AttachmentPendingFile>) {
+        // Support is re-checked inside warmUpBackgroundRemoval() (a no-op on platforms
+        // without an optional model), so here we only gate on having an image.
+        val hasImage = files.any {
+            it is AttachmentPendingFile.FileImage || it is AttachmentPendingFile.Gallery
+        }
+        if (hasImage) warmUpBackgroundRemoval()
     }
 
     /**

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentHandler.kt
@@ -12,6 +12,7 @@ import id.homebase.core.audio.AudioWaveFormGenerator
 import id.homebase.core.clipboard.platformFileFromPath
 import id.homebase.core.localization.TranslationUtil
 import id.homebase.core.util.detectContentTypeFromExtensionOrHint
+import id.homebase.chat.services.image.StickerImageProcessor
 import id.homebase.chat.services.image.removeBackground
 import id.homebase.imageeditor.ui.CropResultBus
 import id.homebase.imageeditor.ui.DrawResultBus
@@ -482,9 +483,18 @@ internal class AttachmentHandler(
      */
     fun handleRemoveBackground(action: ConversationListUiAction.RemoveBackgroundAttachment) {
         scope.launch {
+            val overlay = messagesUiState.value.fullScreenOverlay as? FullScreenOverlay.AttachmentData
+            // Idempotency guard: the wand is disabled while running, but a rapid double-tap
+            // could still launch twice within the same frame. scope is the Main dispatcher,
+            // so this check-then-mark prefix runs before the first suspension point — the
+            // second launch sees the id already in-flight and bails, avoiding a redundant
+            // parallel segmentation and an orphaned temp file.
+            if (overlay == null || action.attachmentId in overlay.processingAttachmentIds) {
+                return@launch
+            }
+            setBackgroundRemovalInProgress(action.attachmentId, inProgress = true)
             try {
-                val overlay = messagesUiState.value.fullScreenOverlay as? FullScreenOverlay.AttachmentData
-                val attachment = overlay?.attachments?.firstOrNull {
+                val attachment = overlay.attachments.firstOrNull {
                     it.attachmentId == action.attachmentId
                 }
                 val sourcePath = when (attachment) {
@@ -506,8 +516,15 @@ internal class AttachmentHandler(
                     return@launch
                 }
 
+                // The segmenter returns a full-resolution lossless PNG. The send path
+                // uploads images byte-for-byte (no resize — see MessageAttachmentBuilder),
+                // so persist a sticker-sized (<=512px) PNG instead: alpha-perfect at a
+                // fraction of the bytes. Falls back to the original cut-out on any
+                // re-encode failure so it can never block sending.
+                val stickerBytes = StickerImageProcessor.downscaleCutOut(cutOutBytes)
+
                 val tempPath = fileOperationsProvider.writeBytesToTempFile(
-                    cutOutBytes,
+                    stickerBytes,
                     "cutout_image",
                     ".png",
                 )
@@ -524,10 +541,30 @@ internal class AttachmentHandler(
                 messagesUiState.update {
                     it.copy(fullScreenOverlay = current.copy(attachments = newAttachments))
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Logger.e("RemoveBackground failed", e)
                 sendEvent(ShowErrorMessage(TranslationUtil.getString(MR.string.chat_remove_background_failed)))
+            } finally {
+                setBackgroundRemovalInProgress(action.attachmentId, inProgress = false)
             }
+        }
+    }
+
+    /**
+     * Toggle the editor's per-attachment "background removal in progress" marker, which
+     * drives the wand-button spinner in
+     * [id.homebase.chat.widget.FullScreenAttachmentEditor]. No-ops if the attachment
+     * overlay is no longer open (e.g. the user dismissed it mid-run).
+     */
+    private fun setBackgroundRemovalInProgress(attachmentId: Uuid, inProgress: Boolean) {
+        messagesUiState.update { state ->
+            val overlay = state.fullScreenOverlay as? FullScreenOverlay.AttachmentData
+                ?: return@update state
+            val ids = if (inProgress) overlay.processingAttachmentIds + attachmentId
+            else overlay.processingAttachmentIds - attachmentId
+            state.copy(fullScreenOverlay = overlay.copy(processingAttachmentIds = ids))
         }
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentHandler.kt
@@ -11,11 +11,13 @@ import id.homebase.core.audio.AudioWaveFormGenerator
 import id.homebase.core.clipboard.platformFileFromPath
 import id.homebase.core.localization.TranslationUtil
 import id.homebase.core.util.detectContentTypeFromExtensionOrHint
+import id.homebase.chat.services.image.removeBackground
 import id.homebase.imageeditor.ui.CropResultBus
 import id.homebase.imageeditor.ui.DrawResultBus
 import id.homebase.resources.MR
 import id.homebase.resources.chat_attach_file_failed
 import id.homebase.resources.chat_message_audio_recording_help
+import id.homebase.resources.chat_remove_background_failed
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.mimeType
 import io.github.vinceglb.filekit.name
@@ -450,6 +452,70 @@ internal class AttachmentHandler(
             } catch (e: Exception) {
                 Logger.e("ApplyDrawResult failed", e)
                 sendEvent(ShowErrorMessage("Failed to apply drawing: ${e.message}"))
+            }
+        }
+    }
+
+    /**
+     * Remove the background from the current image attachment via on-device
+     * segmentation, then swap it for a transparent-PNG cut-out tagged as a sticker.
+     *
+     * Same swap shape as [handleApplyCropResult] but the bytes come from
+     * [removeBackground] (run off the main thread by the platform actual) instead
+     * of an editor result bus. The result is written as a `.png` temp so the
+     * alpha survives, and `forceSticker = true` is carried on the swapped image so
+     * the send path tags it a sticker even if a downstream re-encode flattens
+     * fringe alpha. On a null result (unsupported platform, no subject, or model
+     * unavailable) the original attachment is left untouched and a soft error is
+     * surfaced.
+     */
+    fun handleRemoveBackground(action: ConversationListUiAction.RemoveBackgroundAttachment) {
+        scope.launch {
+            try {
+                val overlay = messagesUiState.value.fullScreenOverlay as? FullScreenOverlay.AttachmentData
+                val attachment = overlay?.attachments?.firstOrNull {
+                    it.attachmentId == action.attachmentId
+                }
+                val sourcePath = when (attachment) {
+                    is AttachmentPendingFile.FileImage -> attachment.file.toString()
+                    is AttachmentPendingFile.Gallery -> attachment.image.file.toString()
+                    else -> null
+                }
+                if (sourcePath == null) {
+                    sendEvent(ShowErrorMessage(TranslationUtil.getString(MR.string.chat_remove_background_failed)))
+                    return@launch
+                }
+
+                val srcBytes = fileOperationsProvider.readFileBytes(sourcePath)
+                val cutOutBytes = removeBackground(srcBytes)
+                if (cutOutBytes == null) {
+                    // Soft fail: no confident subject, model not available, or
+                    // unsupported platform. Leave the original image in place.
+                    sendEvent(ShowErrorMessage(TranslationUtil.getString(MR.string.chat_remove_background_failed)))
+                    return@launch
+                }
+
+                val tempPath = fileOperationsProvider.writeBytesToTempFile(
+                    cutOutBytes,
+                    "cutout_image",
+                    ".png",
+                )
+                val newFile = AttachmentPendingFile.FileImage(
+                    id = action.attachmentId,
+                    file = id.homebase.core.clipboard.platformFileFromPath(tempPath),
+                    forceSticker = true,
+                )
+                val current = messagesUiState.value.fullScreenOverlay
+                if (current !is FullScreenOverlay.AttachmentData) return@launch
+                val newAttachments = current.attachments.map { existing ->
+                    if (existing.attachmentId == action.attachmentId) newFile else existing
+                }
+                messagesUiState.update {
+                    it.copy(fullScreenOverlay = current.copy(attachments = newAttachments))
+                }
+            } catch (e: Exception) {
+                Logger.e("RemoveBackground failed", e)
+                sendEvent(ShowErrorMessage(TranslationUtil.getString(MR.string.chat_remove_background_failed)))
             }
         }
     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
@@ -259,6 +259,16 @@ sealed interface ConversationListUiAction {
         val paintedBytes: ByteArray,
     ) : ConversationListUiAction
 
+    /**
+     * User tapped the "Remove background" tool on an image attachment. The handler
+     * runs on-device segmentation off the main thread and, on success, swaps the
+     * attachment for a transparent-PNG cut-out tagged as a sticker.
+     */
+    data class RemoveBackgroundAttachment(
+        val conversationId: Uuid,
+        val attachmentId: Uuid,
+    ) : ConversationListUiAction
+
     /** Inline trim scrubber moved — store the chosen range, or null to clear. */
     data class ApplyTrimResult(
         val conversationId: Uuid,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -266,6 +266,15 @@ sealed interface FullScreenOverlay {
         val conversationTitle: String,
         val conversationId: Uuid,
         val attachments: List<AttachmentPendingFile>,
+        /**
+         * Attachment ids whose background removal is currently running. The editor's
+         * "Remove background" tool shows a spinner and disables itself for these, so the
+         * multi-hundred-ms (first call: model download / warm-up) on-device segmentation
+         * pass doesn't read as a dead button. Keyed by id so the spinner follows the
+         * specific image across pager swipes. Added/removed (in a `finally`) by
+         * [AttachmentHandler.handleRemoveBackground].
+         */
+        val processingAttachmentIds: Set<Uuid> = emptySet(),
     ) : FullScreenOverlay
 
     @Immutable

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -280,12 +280,19 @@ sealed class AttachmentPendingFile(val attachmentId: Uuid) {
      * @param includeLocation Per-image opt-in for embedding GPS coordinates in the
      *   eventual post. Date / camera / dimensions always travel when known —
      *   only the privacy-sensitive bit is gated. Defaults false.
+     * @param forceSticker Per-image opt-in to send as a sticker (transparent
+     *   cut-out render), threaded into [id.homebase.chat.services.builder.AttachmentInput.forceSticker]
+     *   at send time so it skips the auto alpha probe. Set true by the
+     *   background-remover tool so intent survives a re-encode that flattens
+     *   fringe alpha; also the carrier for the manual "Send as sticker" toggle.
+     *   Defaults false.
      */
     data class FileImage(
         val id: Uuid,
         val file: PlatformFile,
         val metadata: ImageMetadata? = null,
         val includeLocation: Boolean = false,
+        val forceSticker: Boolean = false,
     ) : AttachmentPendingFile(id)
     data class FileVideo(
         val id: Uuid,
@@ -300,7 +307,12 @@ sealed class AttachmentPendingFile(val attachmentId: Uuid) {
         val playablePath: String? = null,
     ) : AttachmentPendingFile(id)
     data class File(val id: Uuid, val file: PlatformFile) : AttachmentPendingFile(id)
-    data class Gallery(val id: Uuid, val image: GalleryImage) : AttachmentPendingFile(id)
+    data class Gallery(
+        val id: Uuid,
+        val image: GalleryImage,
+        /** See [FileImage.forceSticker]. */
+        val forceSticker: Boolean = false,
+    ) : AttachmentPendingFile(id)
     data class Audio(val id: Uuid, val audioFile: PlatformFile, val waveformFile: PlatformFile?, val lengthSeconds: Int) : AttachmentPendingFile(id)
 }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -976,6 +976,8 @@ class ConversationListViewModel(
 
             is ConversationListUiAction.ApplyDrawResult -> attachmentHandler.handleApplyDrawResult(action)
 
+            is ConversationListUiAction.RemoveBackgroundAttachment -> attachmentHandler.handleRemoveBackground(action)
+
             is ConversationListUiAction.ApplyTrimResult -> attachmentHandler.handleApplyTrimResult(action)
 
             is ConversationListUiAction.ShowRecordingHelp -> attachmentHandler.handleShowRecordingHelp()

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -659,6 +659,7 @@ internal class MessageActionsHandler(
                                 filePath = filePath,
                                 contentType = contentType,
                                 displayName = attachment.file.name,
+                                forceSticker = attachment.forceSticker,
                             )
                         )
                     }
@@ -704,6 +705,7 @@ internal class MessageActionsHandler(
                                 filePath = filePath,
                                 contentType = contentType,
                                 displayName = attachment.image.fileName,
+                                forceSticker = attachment.forceSticker,
                             )
                         )
                     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.kt
@@ -38,3 +38,21 @@ expect suspend fun removeBackground(srcBytes: ByteArray): ByteArray?
  * engine is structurally unavailable here.
  */
 expect fun isBackgroundRemovalSupported(): Boolean
+
+/**
+ * Best-effort proactive download of the on-device segmentation model, so the first
+ * [removeBackground] call usually finds it already present instead of having to
+ * download it then (which makes that first attempt soft-fail while the model arrives).
+ *
+ * Android only: asks Google Play services to *deferred-install* the ML Kit Subject
+ * Segmentation optional module — it downloads when the device is idle and on unmetered
+ * Wi-Fi, with no progress UI and no guarantee it has finished by the time the user
+ * taps. The on-tap path ([removeBackground]) still installs-and-waits if this hasn't
+ * completed, so this is purely a latency optimization. A no-op on every other target:
+ * iOS Vision is built into the OS (nothing to download), and Desktop/Web are
+ * unsupported.
+ *
+ * Fire-and-forget and idempotent — safe to call each time an image editor opens.
+ * Returns immediately and never throws.
+ */
+expect fun warmUpBackgroundRemoval()

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.kt
@@ -1,0 +1,40 @@
+package id.homebase.chat.services.image
+
+/**
+ * On-device subject / foreground segmentation: turn a photo into a transparent
+ * cut-out so it can be sent as a sticker (PR #664's isSticker / forceSticker path).
+ *
+ * This is a STANDALONE expect/actual rather than a method on `ImageUtils` on
+ * purpose. `ImageUtils` is a shared Skia-backed object (one actual covers
+ * Desktop/iOS/Web via `skiaMain`), but a background remover needs three genuinely
+ * different native engines that the Skia sharing structurally forbids:
+ *
+ *  - Android  → ML Kit Subject Segmentation (Play-services on-device model).
+ *  - iOS      → Vision `VNGenerateForegroundInstanceMaskRequest` (Neural Engine).
+ *  - JVM/Web  → unsupported in v1 (`return null`).
+ *
+ * Each platform places its own `actual` in `androidMain` / `nativeMain` /
+ * `jvmMain` / `wasmJsMain` (NOT a shared source set).
+ *
+ * @return a transparent PNG (alpha-cut foreground) on success, or `null` when:
+ *   - the platform is unsupported (Desktop/Web, iOS Simulator / no Neural Engine),
+ *   - the on-device model isn't available yet (ML Kit model not downloaded, no GMS),
+ *   - or no confident foreground subject was found.
+ * `null` is a soft outcome — callers leave the original image untouched and
+ * surface a "no subject found" message; it never throws for these cases.
+ *
+ * Suspends so each platform can run the segmenter off the main thread.
+ */
+expect suspend fun removeBackground(srcBytes: ByteArray): ByteArray?
+
+/**
+ * Whether [removeBackground] can plausibly produce a cut-out on this platform/device.
+ *
+ * The attachment editor calls this to decide whether to show the "Remove
+ * background" tool at all, so unsupported platforms (Desktop/Web, iOS Simulator)
+ * present no dead control. It is a fast, side-effect-free capability probe — a
+ * `true` result does NOT guarantee a subject will be found in a given image
+ * (that still returns `null` from [removeBackground]); a `false` result means the
+ * engine is structurally unavailable here.
+ */
+expect fun isBackgroundRemovalSupported(): Boolean

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/image/StickerImageProcessor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/image/StickerImageProcessor.kt
@@ -1,0 +1,61 @@
+package id.homebase.chat.services.image
+
+import id.homebase.api.image.ImageFormat
+import id.homebase.api.image.ImageUtils
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Sizing/encoding for the background-remover sticker pipeline.
+ *
+ * Kept separate from [removeBackground] (the platform segmenter) and from the editor
+ * handler so the pure `ByteArray -> ByteArray` transform is unit-testable on JVM — the
+ * JVM target of `homebase-api` is backed by Skia [ImageUtils], so the resize/encode runs
+ * for real in `jvmTest`.
+ */
+object StickerImageProcessor {
+
+    /**
+     * Max edge (px) of the persisted/uploaded cut-out. The chat render-side caps a
+     * sticker at `Dimens.Sticker.maxSize` (160.dp ≈ ≤480px even at 3x density), so 512
+     * gives crisp 2× display headroom while staying a tiny fraction of a full-resolution
+     * camera frame. The send path uploads images BYTE-FOR-BYTE (see
+     * [id.homebase.chat.services.builder.MessageAttachmentBuilder]), so this directly
+     * bounds upload/storage/download cost. Mirrors the 512px sticker convention used by
+     * Signal / WhatsApp / Telegram.
+     */
+    const val STICKER_MAX_DIM = 512
+
+    // PNG is lossless so quality is a no-op for the encoder, but the API requires it.
+    private const val STICKER_PNG_QUALITY = 100
+
+    /**
+     * Downscale the segmenter's full-resolution cut-out to a `<= [STICKER_MAX_DIM]`px
+     * **lossless PNG** (alpha preserved) for upload.
+     *
+     * PNG, not WebP: the Android [ImageUtils] WebP branch is `WEBP_LOSSY` and gated to
+     * API 30+, but `minSdk` is 28 — WebP output would `NoSuchFieldError`-crash on API
+     * 28/29. PNG encodes on every API level and keeps cut-out edges alpha-perfect.
+     *
+     * Never upscales (an already-small cut-out is just re-encoded). Defensive: returns
+     * the original [cutOutBytes] unchanged if the re-encode fails or yields nothing, so a
+     * resize hiccup can never block sending the cut-out. CPU-bound, so it hops to
+     * [Dispatchers.Default].
+     */
+    suspend fun downscaleCutOut(cutOutBytes: ByteArray): ByteArray =
+        withContext(Dispatchers.Default) {
+            // runCatching catches Throwable, so a resize failure — or, hypothetically, an
+            // API-gated encoder on an old device — degrades to the original cut-out instead
+            // of crashing. It wraps only the synchronous resize (not a suspension point), so
+            // it cannot swallow CancellationException; cancellation propagates via withContext.
+            runCatching {
+                ImageUtils.resizePreserveAspect(
+                    srcBytes = cutOutBytes,
+                    maxWidth = STICKER_MAX_DIM,
+                    maxHeight = STICKER_MAX_DIM,
+                    outputFormat = ImageFormat.PNG,
+                    quality = STICKER_PNG_QUALITY,
+                ).bytes.takeIf { it.isNotEmpty() }
+            }.getOrNull() ?: cutOutBytes
+        }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
@@ -355,6 +355,14 @@ fun ConversationMessagesPane(
                                     )
                                 )
                             },
+                            onRemoveBackground = { conversationId, attachmentId ->
+                                onUiAction(
+                                    id.homebase.chat.conversationlist.ConversationListUiAction.RemoveBackgroundAttachment(
+                                        conversationId,
+                                        attachmentId,
+                                    )
+                                )
+                            },
                             onTrimChange = { conversationId, attachmentId, startMs, endMs ->
                                 onUiAction(
                                     id.homebase.chat.conversationlist.ConversationListUiAction.ApplyTrimResult(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenAttachmentEditor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenAttachmentEditor.kt
@@ -37,6 +37,7 @@ import androidx.compose.material.icons.filled.PhotoCamera
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.PlayCircle
 import androidx.compose.material.icons.filled.UploadFile
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledIconToggleButton
 import androidx.compose.material3.Icon
@@ -58,6 +59,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import coil3.ImageLoader
 import coil3.compose.AsyncImage
@@ -82,6 +85,7 @@ import id.homebase.resources.cd_video_thumbnail
 import id.homebase.resources.chat_message_add_gallery_image
 import id.homebase.resources.chat_message_remove_gallery_image
 import id.homebase.resources.chat_remove_background
+import id.homebase.resources.chat_removing_background
 import id.homebase.resources.crop
 import id.homebase.resources.draw
 import id.homebase.resources.menu_back
@@ -542,16 +546,33 @@ fun FullScreenAttachmentEditor(
                 // Background remover — hidden on platforms where the on-device
                 // segmenter is unavailable (Desktop/Web) so there's no dead control.
                 if (backgroundRemovalSupported) {
+                    // Per-attachment so the spinner follows this image across pager swipes.
+                    val isRemovingBackground =
+                        currentAttachment.attachmentId in data.processingAttachmentIds
                     IconButton(
                         onClick = { onRemoveBackground(data.conversationId, currentAttachment.attachmentId) },
+                        enabled = !isRemovingBackground,
                         colors = IconButtonDefaults.iconButtonColors(
                             containerColor = MaterialTheme.colorScheme.surfaceContainerHighest
                         )
                     ) {
-                        Icon(
-                            imageVector = Icons.Default.AutoFixHigh,
-                            contentDescription = stringResource(MR.string.chat_remove_background),
-                        )
+                        if (isRemovingBackground) {
+                            // First call can take ~1s (model download / warm-up); a spinner
+                            // keeps the wand from reading as a dead button.
+                            val removingDescription =
+                                stringResource(MR.string.chat_removing_background)
+                            CircularProgressIndicator(
+                                modifier = Modifier
+                                    .size(20.dp)
+                                    .semantics { contentDescription = removingDescription },
+                                strokeWidth = 2.dp,
+                            )
+                        } else {
+                            Icon(
+                                imageVector = Icons.Default.AutoFixHigh,
+                                contentDescription = stringResource(MR.string.chat_remove_background),
+                            )
+                        }
                     }
                 }
                 // Send-as-sticker: render this image as a bare transparent cut-out

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenAttachmentEditor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenAttachmentEditor.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.filled.Crop
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Draw
+import androidx.compose.material.icons.filled.AutoFixHigh
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PhotoCamera
 import androidx.compose.material.icons.filled.PlayArrow
@@ -63,6 +64,7 @@ import id.homebase.api.video.IndexedFrame
 import id.homebase.api.video.VideoThumbnailService
 import id.homebase.chat.conversationlist.AttachmentPendingFile
 import id.homebase.chat.conversationlist.FullScreenOverlay
+import id.homebase.chat.services.image.isBackgroundRemovalSupported
 import id.homebase.chat.widget.video.TrimDurationLabel
 import id.homebase.chat.widget.video.TrimmableVideoPlayerSurface
 import id.homebase.chat.widget.video.VideoTrimScrubber
@@ -76,6 +78,7 @@ import id.homebase.resources.cd_send_to
 import id.homebase.resources.cd_video_thumbnail
 import id.homebase.resources.chat_message_add_gallery_image
 import id.homebase.resources.chat_message_remove_gallery_image
+import id.homebase.resources.chat_remove_background
 import id.homebase.resources.crop
 import id.homebase.resources.draw
 import id.homebase.resources.menu_back
@@ -103,6 +106,7 @@ fun FullScreenAttachmentEditor(
     onDismiss: () -> Unit,
     onCropImage: (conversationId: Uuid, attachmentId: Uuid) -> Unit = { _, _ -> },
     onDrawImage: (conversationId: Uuid, attachmentId: Uuid) -> Unit = { _, _ -> },
+    onRemoveBackground: (conversationId: Uuid, attachmentId: Uuid) -> Unit = { _, _ -> },
     onTrimChange: (conversationId: Uuid, attachmentId: Uuid, startMs: Long?, endMs: Long?) -> Unit = { _, _, _, _ -> },
 ) {
     val isFileMode = data.attachments.all { it is AttachmentPendingFile.File }
@@ -495,6 +499,10 @@ fun FullScreenAttachmentEditor(
         // attachment — crop (image only), download. Future tools (filters,
         // markup) would join this row.
         val currentAttachment = data.attachments.getOrNull(pagerState.currentPage)
+        // Capability probe is a cheap, constant per-platform check (GMS present on
+        // Android, true on iOS, false on Desktop/Web); hold it so the tool button
+        // shows no dead control where removeBackground always returns null.
+        val backgroundRemovalSupported = remember { isBackgroundRemovalSupported() }
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -526,6 +534,21 @@ fun FullScreenAttachmentEditor(
                         imageVector = Icons.Default.Draw,
                         contentDescription = stringResource(MR.string.draw),
                     )
+                }
+                // Background remover — hidden on platforms where the on-device
+                // segmenter is unavailable (Desktop/Web) so there's no dead control.
+                if (backgroundRemovalSupported) {
+                    IconButton(
+                        onClick = { onRemoveBackground(data.conversationId, currentAttachment.attachmentId) },
+                        colors = IconButtonDefaults.iconButtonColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest
+                        )
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.AutoFixHigh,
+                            contentDescription = stringResource(MR.string.chat_remove_background),
+                        )
+                    }
                 }
             }
             if (currentAttachment != null) {

--- a/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.jvm.kt
+++ b/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.jvm.kt
@@ -8,3 +8,8 @@ package id.homebase.chat.services.image
 actual suspend fun removeBackground(srcBytes: ByteArray): ByteArray? = null
 
 actual fun isBackgroundRemovalSupported(): Boolean = false
+
+/** No-op: Desktop has no segmenter, so there is no model to pre-download. */
+actual fun warmUpBackgroundRemoval() {
+    // Nothing to warm up on Desktop.
+}

--- a/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.jvm.kt
+++ b/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.jvm.kt
@@ -1,0 +1,10 @@
+package id.homebase.chat.services.image
+
+/**
+ * Desktop (JVM): background removal is deferred for v1 (no OS segmenter; bundling
+ * an ONNX model would bloat the distributable). Returns null so common code
+ * compiles and the editor hides the tool on Desktop.
+ */
+actual suspend fun removeBackground(srcBytes: ByteArray): ByteArray? = null
+
+actual fun isBackgroundRemovalSupported(): Boolean = false

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/image/BackgroundRemoverTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/image/BackgroundRemoverTest.kt
@@ -1,0 +1,68 @@
+package id.homebase.chat.services.image
+
+import id.homebase.chat.conversationlist.AttachmentPendingFile
+import id.homebase.core.gallery.GalleryImage
+import io.github.vinceglb.filekit.PlatformFile
+import kotlinx.coroutines.test.runTest
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * Pins the background-remover contract on the JVM (Desktop) leg and the shared
+ * `forceSticker` carrier wiring.
+ *
+ * Desktop/Web are deferred in v1: the actual must return null and report
+ * unsupported so the editor hides the tool — common code still compiles.
+ * The Android (ML Kit) and iOS (Vision) success paths are device-only and are
+ * covered by instrumented / XCTest device tests, not here.
+ */
+class BackgroundRemoverTest {
+
+    @Test
+    fun jvm_removeBackground_returnsNull_deferredPlatform() = runTest {
+        // Even with plausible PNG-ish bytes, the Desktop actual is a deferred no-op.
+        val bytes = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47)
+        assertNull(removeBackground(bytes), "Desktop background removal must be a soft no-op (null)")
+    }
+
+    @Test
+    fun jvm_isBackgroundRemovalSupported_isFalse() {
+        assertFalse(
+            isBackgroundRemovalSupported(),
+            "Desktop has no on-device segmenter; the editor must hide the tool",
+        )
+    }
+
+    @Test
+    fun fileImage_forceSticker_defaultsFalse_andCarries() {
+        val id = Uuid.random()
+        val file = PlatformFile(File("/tmp/x.png"))
+        assertFalse(AttachmentPendingFile.FileImage(id = id, file = file).forceSticker)
+        assertTrue(
+            AttachmentPendingFile.FileImage(id = id, file = file, forceSticker = true).forceSticker,
+        )
+    }
+
+    @Test
+    fun gallery_forceSticker_defaultsFalse_andCarries() {
+        val id = Uuid.random()
+        val image = GalleryImage(
+            id = "g1",
+            file = PlatformFile(File("/tmp/x.png")),
+            dateAdded = 0L,
+            mimeType = "image/png",
+            fileName = "x.png",
+            galleryName = "Camera",
+        )
+        assertFalse(AttachmentPendingFile.Gallery(id = id, image = image).forceSticker)
+        assertEquals(
+            true,
+            AttachmentPendingFile.Gallery(id = id, image = image, forceSticker = true).forceSticker,
+        )
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/image/StickerImageProcessorTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/image/StickerImageProcessorTest.kt
@@ -1,0 +1,82 @@
+package id.homebase.chat.services.image
+
+import id.homebase.api.image.ImageUtils
+import id.homebase.api.lib.image.ImageFormatDetector
+import kotlinx.coroutines.test.runTest
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Exercises the cut-out sizing/encoding on the JVM, where [ImageUtils] is the real
+ * Skia backend — so the resize, the alpha preservation, and the PNG output are all
+ * verified for real rather than mocked.
+ */
+class StickerImageProcessorTest {
+
+    @Test
+    fun downscaleCutOut_largeTransparentPng_cappedAtStickerMax_keepsAlphaAndStaysPng() = runTest {
+        val src = transparentPng(1500, 1000)
+
+        val out = StickerImageProcessor.downscaleCutOut(src)
+
+        val size = ImageUtils.getNaturalSize(out)
+        assertTrue(
+            size.pixelWidth <= StickerImageProcessor.STICKER_MAX_DIM &&
+                size.pixelHeight <= StickerImageProcessor.STICKER_MAX_DIM,
+            "cut-out must be capped at ${StickerImageProcessor.STICKER_MAX_DIM}px, was ${size.pixelWidth}x${size.pixelHeight}",
+        )
+        // Long edge maps exactly to the cap; aspect is preserved (1500x1000 -> 512x341).
+        assertEquals(StickerImageProcessor.STICKER_MAX_DIM, size.pixelWidth)
+        assertEquals(
+            "image/png",
+            ImageFormatDetector.detectFormat(out),
+            "must stay PNG — the Android ImageUtils WebP branch crashes on API 28/29",
+        )
+        assertTrue(
+            ImageUtils.hasNonOpaquePixels(out),
+            "transparency must survive the downscale or the sticker loses its cut-out",
+        )
+        assertTrue(out.size < src.size, "the 512px cut-out should be smaller than the 1500px source")
+    }
+
+    @Test
+    fun downscaleCutOut_smallImage_isNotUpscaled_andKeepsAlpha() = runTest {
+        val src = transparentPng(300, 200)
+
+        val out = StickerImageProcessor.downscaleCutOut(src)
+
+        val size = ImageUtils.getNaturalSize(out)
+        assertEquals(300, size.pixelWidth, "must not upscale an already-small cut-out")
+        assertEquals(200, size.pixelHeight)
+        assertTrue(ImageUtils.hasNonOpaquePixels(out))
+    }
+
+    @Test
+    fun downscaleCutOut_undecodableBytes_fallsBackToInputUnchanged() = runTest {
+        val junk = byteArrayOf(1, 2, 3, 4, 5)
+
+        assertContentEquals(
+            junk,
+            StickerImageProcessor.downscaleCutOut(junk),
+            "a re-encode failure must fall back to the original bytes, never block sending",
+        )
+    }
+
+    /** A PNG with a fully transparent canvas and one opaque blob — content + alpha. */
+    private fun transparentPng(width: Int, height: Int): ByteArray {
+        val img = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+        val g = img.createGraphics()
+        g.color = Color(220, 40, 40, 255)
+        g.fillOval(width / 4, height / 4, width / 2, height / 2)
+        g.dispose()
+        val out = ByteArrayOutputStream()
+        ImageIO.write(img, "png", out)
+        return out.toByteArray()
+    }
+}

--- a/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.native.kt
+++ b/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.native.kt
@@ -1,0 +1,132 @@
+@file:OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+
+package id.homebase.chat.services.image
+
+import co.touchlab.kermit.Logger
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.usePinned
+import kotlinx.cinterop.value
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import platform.CoreImage.CIContext
+import platform.CoreImage.CIImage
+import platform.CoreImage.createCGImage
+import platform.Foundation.NSData
+import platform.Foundation.NSError
+import platform.Foundation.create
+import platform.UIKit.UIImage
+import platform.UIKit.UIImagePNGRepresentation
+import platform.Vision.VNGenerateForegroundInstanceMaskRequest
+import platform.Vision.VNImageRequestHandler
+import platform.Vision.VNInstanceMaskObservation
+import platform.posix.memcpy
+
+private const val TAG = "BackgroundRemover"
+
+/**
+ * iOS implementation: Vision `VNGenerateForegroundInstanceMaskRequest` (iOS 17+,
+ * class-agnostic foreground instance mask; the app targets iOS 18.2 so the
+ * availability is fully covered).
+ *
+ * Pipeline: bytes → UIImage → CGImage → VNImageRequestHandler →
+ * VNInstanceMaskObservation.generateMaskedImageOfInstances → CVPixelBuffer →
+ * CIImage → CGImage → UIImage → PNG (alpha preserved).
+ *
+ * HARD CAVEAT: the foreground-instance segmenter runs on the Neural Engine and is
+ * a no-op on the Simulator / CPU-only devices — it surfaces here as an empty
+ * observation list, which we map to null. Requires physical-device testing.
+ *
+ * Returns null (soft fail) when the source can't be decoded, the request errors,
+ * or no confident subject instance is found.
+ */
+actual suspend fun removeBackground(srcBytes: ByteArray): ByteArray? = withContext(Dispatchers.Default) {
+    if (srcBytes.isEmpty()) return@withContext null
+
+    val nsData: NSData = srcBytes.usePinned { pinned ->
+        NSData.create(bytes = pinned.addressOf(0), length = srcBytes.size.toULong())
+    }
+    val uiImage = UIImage.imageWithData(nsData) ?: run {
+        Logger.w(tag = TAG) { "iOS: could not decode source bytes" }
+        return@withContext null
+    }
+    val cgImage = uiImage.CGImage ?: run {
+        Logger.w(tag = TAG) { "iOS: UIImage has no CGImage backing" }
+        return@withContext null
+    }
+
+    try {
+        val request = VNGenerateForegroundInstanceMaskRequest()
+        val handler = VNImageRequestHandler(cGImage = cgImage, options = emptyMap<Any?, Any?>())
+
+        val performed = memScoped {
+            val errVar = alloc<kotlinx.cinterop.ObjCObjectVar<NSError?>>()
+            val ok = handler.performRequests(listOf(request), errVar.ptr)
+            if (!ok) {
+                Logger.w(tag = TAG) { "iOS: performRequests failed: ${errVar.value?.localizedDescription}" }
+            }
+            ok
+        }
+        if (!performed) return@withContext null
+
+        val observation = (request.results?.firstOrNull() as? VNInstanceMaskObservation) ?: run {
+            // Empty on Simulator / no confident subject.
+            Logger.d(tag = TAG) { "iOS: no foreground instance mask observation" }
+            return@withContext null
+        }
+
+        val maskedPixelBuffer = memScoped {
+            val errVar = alloc<kotlinx.cinterop.ObjCObjectVar<NSError?>>()
+            val buffer = observation.generateMaskedImageOfInstances(
+                instances = observation.allInstances,
+                fromRequestHandler = handler,
+                croppedToInstancesExtent = false,
+                error = errVar.ptr,
+            )
+            if (buffer == null) {
+                Logger.w(tag = TAG) { "iOS: generateMaskedImageOfInstances failed: ${errVar.value?.localizedDescription}" }
+            }
+            buffer
+        } ?: return@withContext null
+
+        // CVPixelBuffer (BGRA with alpha) → CIImage → CGImage → UIImage → PNG.
+        val ciImage = CIImage.imageWithCVPixelBuffer(maskedPixelBuffer)
+        val ciContext = CIContext.context()
+        val outCgImage = ciContext.createCGImage(ciImage, fromRect = ciImage.extent)
+            ?: run {
+                Logger.w(tag = TAG) { "iOS: could not rasterize masked CIImage" }
+                return@withContext null
+            }
+        val outImage = UIImage.imageWithCGImage(outCgImage)
+        val png = UIImagePNGRepresentation(outImage) ?: run {
+            Logger.w(tag = TAG) { "iOS: PNG encode of cut-out failed" }
+            return@withContext null
+        }
+        png.toByteArray()
+    } catch (e: Exception) {
+        Logger.w(tag = TAG) { "iOS: background removal threw: ${e.message}" }
+        null
+    }
+}
+
+/**
+ * Capability probe. The Vision foreground-instance segmenter exists from iOS 17+
+ * (the app targets 18.2, so the class is always linkable) but only produces a
+ * result on the Neural Engine — it yields nothing on the Simulator. We report
+ * `true` here (the API is present); a device without a confident result still
+ * degrades to a null from [removeBackground].
+ */
+actual fun isBackgroundRemovalSupported(): Boolean = true
+
+@OptIn(ExperimentalForeignApi::class)
+private fun NSData.toByteArray(): ByteArray {
+    val size = length.toInt()
+    if (size == 0) return ByteArray(0)
+    val out = ByteArray(size)
+    out.usePinned { pinned -> memcpy(pinned.addressOf(0), this.bytes, length) }
+    return out
+}

--- a/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.native.kt
+++ b/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.native.kt
@@ -41,6 +41,14 @@ private const val TAG = "BackgroundRemover"
  * a no-op on the Simulator / CPU-only devices — it surfaces here as an empty
  * observation list, which we map to null. Requires physical-device testing.
  *
+ * NOTE (deliberate platform asymmetry): unlike the Android actual — which caps the
+ * segmenter input via `inSampleSize` to bound peak memory on low-RAM devices — iOS feeds
+ * the full-resolution CGImage to Vision. iOS gives apps generous memory and we target
+ * modern devices (18.2), so the transient full-res bitmap is acceptable here; the
+ * uploaded cut-out is still downscaled to a sticker size by the shared
+ * [id.homebase.chat.services.image.StickerImageProcessor]. Add ImageIO thumbnail
+ * decoding here if a low-RAM iOS OOM ever shows up in the field.
+ *
  * Returns null (soft fail) when the source can't be decoded, the request errors,
  * or no confident subject instance is found.
  */

--- a/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.native.kt
+++ b/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.native.kt
@@ -130,6 +130,15 @@ actual suspend fun removeBackground(srcBytes: ByteArray): ByteArray? = withConte
  */
 actual fun isBackgroundRemovalSupported(): Boolean = true
 
+/**
+ * No-op on iOS: the Vision foreground-instance segmenter is part of the OS, so there
+ * is no optional model to pre-download (unlike Android's ML Kit module that rides on
+ * Google Play services).
+ */
+actual fun warmUpBackgroundRemoval() {
+    // Nothing to warm up — Vision ships with the OS.
+}
+
 @OptIn(ExperimentalForeignApi::class)
 private fun NSData.toByteArray(): ByteArray {
     val size = length.toInt()

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.wasmJs.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.wasmJs.kt
@@ -1,0 +1,9 @@
+package id.homebase.chat.services.image
+
+/**
+ * Web (wasmJs): background removal is deferred for v1 (the web target is partial /
+ * disabled). Returns null so common code compiles and the editor hides the tool.
+ */
+actual suspend fun removeBackground(srcBytes: ByteArray): ByteArray? = null
+
+actual fun isBackgroundRemovalSupported(): Boolean = false

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.wasmJs.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/services/image/BackgroundRemover.wasmJs.kt
@@ -7,3 +7,8 @@ package id.homebase.chat.services.image
 actual suspend fun removeBackground(srcBytes: ByteArray): ByteArray? = null
 
 actual fun isBackgroundRemovalSupported(): Boolean = false
+
+/** No-op: the web target is unsupported, so there is no model to pre-download. */
+actual fun warmUpBackgroundRemoval() {
+    // Nothing to warm up on Web.
+}

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -553,6 +553,7 @@
     <string name="draw">Tegn</string>
     <string name="chat_remove_background">Fjern baggrund</string>
     <string name="chat_remove_background_failed">Kunne ikke fjerne baggrunden</string>
+    <string name="chat_removing_background">Fjerner baggrund…</string>
     <string name="send_as_sticker">Send som klistermærke</string>
     <string name="cd_send_as_sticker">Skift send som klistermærke</string>
     <string name="trim_start_handle">Beskær start</string>

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -536,6 +536,8 @@
 
     <string name="crop">Beskær</string>
     <string name="draw">Tegn</string>
+    <string name="chat_remove_background">Fjern baggrund</string>
+    <string name="chat_remove_background_failed">Kunne ikke fjerne baggrunden</string>
     <string name="trim_start_handle">Beskær start</string>
     <string name="trim_end_handle">Beskær slut</string>
     <string name="trim_position">Afspilningsposition</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -995,6 +995,8 @@
     <string name="pending_attachment_many">%1$d attachments</string>
     <string name="crop">Crop</string>
     <string name="draw">Draw</string>
+    <string name="chat_remove_background">Remove background</string>
+    <string name="chat_remove_background_failed">Couldn\'t remove the background</string>
     <string name="trim_start_handle">Trim start</string>
     <string name="trim_end_handle">Trim end</string>
     <string name="trim_position">Playback position</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1018,6 +1018,7 @@
     <string name="draw">Draw</string>
     <string name="chat_remove_background">Remove background</string>
     <string name="chat_remove_background_failed">Couldn\'t remove the background</string>
+    <string name="chat_removing_background">Removing background…</string>
     <string name="send_as_sticker">Send as sticker</string>
     <string name="cd_send_as_sticker">Toggle send as sticker</string>
     <string name="trim_start_handle">Trim start</string>


### PR DESCRIPTION
## What

Adds a one-tap **Remove background** tool to the chat full-screen attachment editor that turns a photo into a transparent-PNG cut-out and routes it through PR #664's sticker path. v1 ships on **Android + iOS only**; Desktop and Web are deferred (like GIF).

## How — the expect/actual seam

A standalone `expect suspend fun removeBackground(srcBytes: ByteArray): ByteArray?` in `homebase-chat` commonMain, returning a transparent PNG or `null`. It is **not** a method on `ImageUtils`: that object is shared across Desktop/iOS/Web via a single Skia actual and structurally cannot host three different native engines.

| Target | Actual |
|--------|--------|
| `androidMain` | ML Kit Subject Segmentation (`play-services-mlkit-subject-segmentation:16.0.0-beta1`) — on-device, model downloaded via Play services (~0 APK cost). Returns `null` when GMS / the model isn't available, or no subject is found. |
| `nativeMain` (iOS) | Vision `VNGenerateForegroundInstanceMaskRequest` via the bundled Kotlin/Native `platform.Vision` binding (no cinterop `.def` needed). Neural-Engine only → returns `null` on the Simulator / no confident subject. iOS 17+ (app targets 18.2). |
| `jvmMain`, `wasmJsMain` | `return null` (deferred). |

A companion `expect fun isBackgroundRemovalSupported()` gates the editor IconButton so **Desktop/Web show no dead control**.

## Pipeline

`onRemoveBackground(conversationId, attachmentId)` → `AttachmentHandler.handleRemoveBackground`: reads the source bytes, runs `removeBackground` off the main thread, writes the result as a **`.png`** temp (alpha must survive), swaps the `FileImage` in place (same shape as `handleApplyCropResult`), and sets **`forceSticker = true`** so it is tagged a sticker even if a re-encode flattens fringe alpha. A `null` result leaves the original untouched and surfaces a soft "couldn't remove the background" message.

## Shared foundation (overlaps the send-as-sticker toggle PR)

Adds `forceSticker: Boolean = false` to `AttachmentPendingFile.FileImage` **and** `Gallery`, and threads it into the two image `AttachmentInput(...)` constructions at send time. This overlaps the toggle PR and resolves as a trivial merge conflict.

## Tests / verification

- New `BackgroundRemoverTest` (jvmTest): pins the Desktop deferred-`null` contract (`removeBackground` returns null, `isBackgroundRemovalSupported() == false`) and the `forceSticker` carrier defaults/wiring.
- Konsist `ArchitectureTest` green (new button label / snackbar via `stringResource`, added to `values/` and `values-da/`).
- Compiles on all four targets: `:homebase-chat:compileKotlinJvm`, `:compileAndroidMain`, `:compileKotlinIosSimulatorArm64`, `:compileKotlinWasmJs`. Full `:homebase-chat:jvmTest` green.

## Risks / follow-ups

- **iOS needs physical-device testing.** Vision's foreground-instance segmenter is a no-op on the Simulator (Neural Engine); the code degrades to `null` there but the success path is unverified until run on a device.
- Android ML Kit dep is **beta** (`16.0.0-beta1`) and depends on Google Play services + a one-time background model download; first use before the model lands returns `null` (soft fail).
- Quality is best-effort (hair/fine edges); no manual brush refinement in v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)