### PR TITLE
Share into "New Moment" (Android + iOS)

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
@@ -160,6 +160,16 @@ class MainActivity : AppCompatActivity() {
                 return
             }
 
+            // Share-into-"New Moment" deep link: homebase-fchat://moment-compose
+            // The share flow already seeded MomentCreateFlowState with the chosen
+            // media; this only steers the nav stack into the composer.
+            if (data.host == "moment-compose") {
+                Logger.i(tag = "MainActivity") { "Deep link: navigating to moment compose" }
+                notificationService.navigateToMomentCompose()
+                intent.data = null
+                return
+            }
+
             // Owner-console "Extend Permissions" return URL.
             // Path: homebase-fchat://permission-callback?status=[canceled|...]
             if (data.host == "permission-callback") {

--- a/androidApp/src/main/kotlin/id/homebase/feed/share/SharePickerScreen.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/SharePickerScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
@@ -65,6 +66,8 @@ import id.homebase.resources.groups
 import id.homebase.resources.number_of_members
 import id.homebase.resources.recents
 import id.homebase.resources.sending_to_conversations
+import id.homebase.resources.share_picker_new_moment
+import id.homebase.resources.share_picker_new_moment_subtitle
 import id.homebase.resources.share_picker_next
 import id.homebase.resources.share_picker_send
 import id.homebase.resources.share_to
@@ -84,7 +87,8 @@ fun SharePickerScreen(
     sharedContent: SharedContent,
     hasFiles: Boolean,
     isSending: Boolean,
-    onSendToConversations: (Set<Uuid>) -> Unit,
+    showNewMomentOption: Boolean,
+    onTargetSelected: (ShareTarget) -> Unit,
     onCancel: () -> Unit,
 ) {
     val conversationsData by conversationStream.conversations.collectAsStateWithLifecycle()
@@ -186,7 +190,7 @@ fun SharePickerScreen(
                 ShareSendBar(
                     count = selectedIds.size,
                     buttonText = if (hasFiles) stringResource(MR.string.share_picker_next) else stringResource(MR.string.share_picker_send),
-                    onSend = { onSendToConversations(selectedIds) },
+                    onSend = { onTargetSelected(ShareTarget.Conversations(selectedIds)) },
                 )
             }
         },
@@ -212,6 +216,15 @@ fun SharePickerScreen(
             )
 
             HorizontalDivider()
+
+            // A "New Moment" destination sits above the conversation list (only
+            // when files are present and Moments is activated). It's an action,
+            // not a selectable checkbox row, so it dispatches immediately rather
+            // than joining the multi-select set.
+            if (showNewMomentOption && !isSending && conversationsData.dataReady) {
+                NewMomentRow(onClick = { onTargetSelected(ShareTarget.NewMoment) })
+                HorizontalDivider()
+            }
 
             if (isSending) {
                 Box(
@@ -347,6 +360,46 @@ private fun ShareSendBar(
             FilledTonalButton(onClick = onSend) {
                 Text(buttonText)
             }
+        }
+    }
+}
+
+@Composable
+private fun NewMomentRow(onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 28.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .background(MaterialTheme.colorScheme.primaryContainer, CircleShape),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.AutoAwesome,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                modifier = Modifier.size(24.dp),
+            )
+        }
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(MR.string.share_picker_new_moment),
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                text = stringResource(MR.string.share_picker_new_moment_subtitle),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
@@ -40,6 +40,8 @@ import id.homebase.chat.services.convo.ConversationStream
 import id.homebase.chat.services.convo.contact.ContactService
 import id.homebase.chat.widget.FullScreenAttachmentEditor
 import id.homebase.core.auth.AuthConnectionCoordinator
+import id.homebase.core.moments.MomentsPreferences
+import id.homebase.core.moments.services.MomentCreateFlowState
 import id.homebase.core.settings.ThemeState
 import id.homebase.core.settings.UserPreferences
 import id.homebase.core.ui.theme.HomebaseTheme
@@ -81,6 +83,8 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
     private val fileOperationsProvider: FileOperationsProvider by inject()
     private val userPreferences: UserPreferences by inject()
     private val authConnectionCoordinator: AuthConnectionCoordinator by inject()
+    private val momentCreateFlowState: MomentCreateFlowState by inject()
+    private val momentsPreferences: MomentsPreferences by inject()
 
     private var isSending by mutableStateOf(false)
     private var isProcessing by mutableStateOf(false)
@@ -221,29 +225,16 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
                             sharedContent = sharedContent,
                             hasFiles = sharedContent.hasFiles,
                             isSending = isSending,
-                            onSendToConversations = { conversationIds ->
-                                Logger.d(tag = COLD_TAG) {
-                                    "picker.onSendToConversations: count=${conversationIds.size} hasFiles=${sharedContent.hasFiles}"
-                                }
-                                if (sharedContent.hasFiles) {
-                                    // Show overlay while converting files
-                                    isProcessing = true
-                                    lifecycleScope.launch {
-                                        val attachments = withContext(Dispatchers.IO) {
-                                            convertToAttachmentFiles(sharedContent.files)
-                                        }
-                                        val title = resolveConversationTitle(conversationIds)
-                                        editorAttachments = attachments
-                                        isProcessing = false
-                                        screenState = ShareScreenState.Previewing(
-                                            selectedConversationIds = conversationIds,
-                                            attachments = attachments,
-                                            conversationTitle = title,
-                                        )
-                                    }
-                                } else {
-                                    // Text-only: send directly as before
-                                    sendToMultipleConversations(conversationIds, sharedContent)
+                            // Moments need media — only offer "New Moment" when the
+                            // share carries files and the feature is activated.
+                            showNewMomentOption = sharedContent.hasFiles &&
+                                momentsPreferences.activated.value,
+                            onTargetSelected = { target ->
+                                when (target) {
+                                    is ShareTarget.Conversations ->
+                                        onConversationsPicked(target.ids, sharedContent)
+                                    ShareTarget.NewMoment ->
+                                        startNewMoment(sharedContent)
                                 }
                             },
                             onCancel = { finish() },
@@ -312,6 +303,68 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
                 }
                 } // Box
             }
+        }
+    }
+
+    /**
+     * Terminal dispatch for the [ShareTarget.Conversations] branch. Files go
+     * through the in-activity preview/caption editor; text-only sends directly.
+     */
+    private fun onConversationsPicked(conversationIds: Set<Uuid>, content: SharedContent) {
+        Logger.d(tag = COLD_TAG) {
+            "onConversationsPicked: count=${conversationIds.size} hasFiles=${content.hasFiles}"
+        }
+        if (content.hasFiles) {
+            // Show overlay while converting files
+            isProcessing = true
+            lifecycleScope.launch {
+                val attachments = withContext(Dispatchers.IO) {
+                    convertToAttachmentFiles(content.files)
+                }
+                val title = resolveConversationTitle(conversationIds)
+                editorAttachments = attachments
+                isProcessing = false
+                screenState = ShareScreenState.Previewing(
+                    selectedConversationIds = conversationIds,
+                    attachments = attachments,
+                    conversationTitle = title,
+                )
+            }
+        } else {
+            // Text-only: send directly as before
+            sendToMultipleConversations(conversationIds, content)
+        }
+    }
+
+    /**
+     * Terminal dispatch for the [ShareTarget.NewMoment] branch. Reuses the same
+     * `convertToAttachmentFiles` step the chat path uses, seeds the moments
+     * composer draft ([MomentCreateFlowState] is a process-wide Koin singleton
+     * that [MomentComposeViewModel] reads on init), then hands off to
+     * `Route.MomentCompose` in the main app. The moments composer is the editor
+     * here — trim/crop/description/audience all live there — so there's no
+     * in-activity preview step on this path.
+     */
+    private fun startNewMoment(content: SharedContent) {
+        if (!content.hasFiles) {
+            finish()
+            return
+        }
+        isProcessing = true
+        lifecycleScope.launch {
+            val attachments = withContext(Dispatchers.IO) {
+                convertToAttachmentFiles(content.files)
+            }
+            momentCreateFlowState.setDraft(
+                MomentCreateFlowState.Draft(
+                    attachments = attachments,
+                    description = content.text ?: "",
+                )
+            )
+            Logger.d(tag = COLD_TAG) { "startNewMoment: seeded draft with ${attachments.size} attachments" }
+            // The moments composer owns the temp files now; don't reap share_temp.
+            startActivity(openMomentComposeIntent())
+            finish()
         }
     }
 
@@ -449,6 +502,19 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
             data = "homebase-fchat://conversation/$conversationId".toUri()
             flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
             putExtra(ShareShortcutPublisher.EXTRA_FROM_SHARE_SHORTCUT, true)
+        }
+
+    /**
+     * Re-opens [MainActivity] on the moments composer. The draft has already
+     * been seeded into [MomentCreateFlowState]; MainActivity.handleIntent reads
+     * this `homebase-fchat://moment-compose` deep link and emits the
+     * OpenMomentCompose navigation event that AppNavHost routes to
+     * `Route.MomentCompose`.
+     */
+    internal fun openMomentComposeIntent(): Intent =
+        Intent(this, MainActivity::class.java).apply {
+            data = "homebase-fchat://moment-compose".toUri()
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
         }
 
     private fun extractDirectShareConversationId(): String? {

--- a/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
@@ -189,6 +189,7 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
         Logger.d(tag = COLD_TAG) { "initShareFlow: reached setContent (picker path)" }
         setContent {
             val prefState by userPreferences.preferenceState.collectAsStateWithLifecycle()
+            val momentsActivated by momentsPreferences.activated.collectAsStateWithLifecycle()
             val isDarkTheme = if (prefState.theme == ThemeState.System) isSystemInDarkTheme()
             else prefState.theme == ThemeState.Dark
 
@@ -228,7 +229,7 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
                             // Moments need media — only offer "New Moment" when the
                             // share carries files and the feature is activated.
                             showNewMomentOption = sharedContent.hasFiles &&
-                                momentsPreferences.activated.value,
+                                momentsActivated,
                             onTargetSelected = { target ->
                                 when (target) {
                                     is ShareTarget.Conversations ->

--- a/androidApp/src/main/kotlin/id/homebase/feed/share/ShareTarget.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/ShareTarget.kt
@@ -1,0 +1,19 @@
+package id.homebase.feed.share
+
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Where the user chose to send the shared content. The picker emits one of
+ * these; [ShareReceiverActivity] branches on it exactly once so the capture →
+ * convert → caption steps stay shared and only the terminal dispatch diverges.
+ *
+ * - [Conversations] runs the chat send path ([ChatMessageSenderService]).
+ * - [NewMoment] seeds the moments composer draft and hands off to
+ *   `Route.MomentCompose`, reusing the same media-upload pipeline downstream.
+ */
+@OptIn(ExperimentalUuidApi::class)
+sealed interface ShareTarget {
+    data class Conversations(val ids: Set<Uuid>) : ShareTarget
+    data object NewMoment : ShareTarget
+}

--- a/androidApp/src/test/kotlin/id/homebase/feed/share/ShareReceiverActivityIntentTest.kt
+++ b/androidApp/src/test/kotlin/id/homebase/feed/share/ShareReceiverActivityIntentTest.kt
@@ -87,4 +87,26 @@ class ShareReceiverActivityIntentTest {
             "Re-opening MainActivity must not spawn a duplicate (SINGLE_TOP).",
         )
     }
+
+    @Test
+    fun `openMomentComposeIntent targets MainActivity with the moment-compose deep link`() {
+        val intent = activity.openMomentComposeIntent()
+
+        assertEquals(
+            MainActivity::class.java.name,
+            intent.component?.className,
+            "The New-Moment hand-off intent must land in MainActivity.",
+        )
+        assertEquals(
+            "homebase-fchat://moment-compose",
+            intent.data?.toString(),
+            "MainActivity.handleIntent() matches host == \"moment-compose\" to steer the " +
+                "nav stack into the composer; the deep link must encode exactly that.",
+        )
+        assertTrue(
+            intent.flags and Intent.FLAG_ACTIVITY_CLEAR_TOP != 0 &&
+                intent.flags and Intent.FLAG_ACTIVITY_SINGLE_TOP != 0,
+            "Re-opening MainActivity must reuse the existing task (CLEAR_TOP|SINGLE_TOP).",
+        )
+    }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -24,6 +24,7 @@ import id.homebase.core.config.chatTargetDrive
 import id.homebase.core.image.HomebaseImageLoader
 import id.homebase.core.image.ImageSize
 import id.homebase.core.share.ShareCacheStorage
+import id.homebase.core.moments.MomentsPreferences
 import id.homebase.core.share.ShareConversationCacheWriter
 import id.homebase.core.share.ShareableConversation
 import kotlinx.coroutines.CoroutineScope
@@ -67,6 +68,7 @@ class ConversationStream(
     private val cacheStorage: ShareCacheStorage,
     private val optimisticWriter: OptimisticWriter,
     private val outboxSync: OutboxSync,
+    private val momentsPreferences: MomentsPreferences,
 ) : ConversationLoader, ConversationParticipantLookup {
 
     private val chatDrive = chatTargetDrive.alias
@@ -1458,7 +1460,7 @@ class ConversationStream(
                 )
             }
             _shareableConversations.value = shareable
-            shareCacheWriter.updateCache(shareable, domain)
+            shareCacheWriter.updateCache(shareable, domain, momentsPreferences.activated.value)
 
             // Pre-cache group avatar images for the iOS share extension
             for (convo in conversations) {

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/util/FileUtilities.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/util/FileUtilities.android.kt
@@ -69,7 +69,10 @@ actual fun getUriHandler(): FileSystemHandler {
                 TODO("Not yet implemented")
             }
 
-            override fun shareFile(file: Path, onError: (Throwable) -> Unit) {
+            override fun shareFile(file: Path, onError: (Throwable) -> Unit) =
+                shareFile(file, text = null, onError = onError)
+
+            override fun shareFile(file: Path, text: String?, onError: (Throwable) -> Unit) {
                 try {
                     val javaFile = File(file.toString())
                     val authority = "${context.packageName}.fileprovider"
@@ -79,6 +82,10 @@ actual fun getUriHandler(): FileSystemHandler {
                     val intent = Intent(Intent.ACTION_SEND).apply {
                         type = mimeType
                         putExtra(Intent.EXTRA_STREAM, uri)
+                        // Caption travels as EXTRA_TEXT. Many gallery/social
+                        // targets drop it on image shares, but messaging/email
+                        // targets honor it — best-effort by design.
+                        if (!text.isNullOrBlank()) putExtra(Intent.EXTRA_TEXT, text)
                         addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                     }

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -634,4 +634,8 @@
     <string name="feed_error_retry">Prøv igen</string>
     <string name="feed_loading">Indlæser feed…</string>
 
+    <!-- Moments push notifications -->
+    <string name="moments_push_new_post">Et øjeblik er blevet delt med dig…</string>
+    <string name="moments_push_new_comment">Kommenterede på et øjeblik, du er en del af</string>
+
 </resources>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -336,6 +336,8 @@
     <string name="moments_settings_show_icon">Show Moments icon in bottom bar</string>
     <string name="moments_create_action">Create a new moment</string>
     <string name="moments_post_open">Open moment</string>
+    <string name="moments_push_new_post">A moment has been shared with you...</string>
+    <string name="moments_push_new_comment">Commented on a moment you\'re in</string>
     <string name="moments_view_menu">Change view</string>
     <string name="moments_view_timeline">Timeline</string>
     <string name="moments_view_album">Album</string>
@@ -364,6 +366,7 @@
     <string name="moments_detail_menu_more">More options</string>
     <string name="moments_detail_menu_delete">Delete</string>
     <string name="moments_detail_menu_save_current">Save current</string>
+    <string name="moments_detail_menu_share">Share</string>
     <string name="moments_detail_menu_info">Info</string>
     <string name="moments_detail_menu_add_people">Add people</string>
     <string name="moments_add_people_title">Add people</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -646,6 +646,8 @@
     <string name="chat_message_record_video">Record video</string>
     <string name="share_picker_next">Next</string>
     <string name="share_picker_send">Send</string>
+    <string name="share_picker_new_moment">New Moment</string>
+    <string name="share_picker_new_moment_subtitle">Share to your Moments</string>
     <string name="chat_message_emoji_options">Emoji options</string>
     <string name="chat_message_edited">Edited</string>
     <string name="chat_message_deleted">🚫 This message was deleted</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationNavigationEvent.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationNavigationEvent.kt
@@ -24,4 +24,12 @@ sealed class NotificationNavigationEvent {
         val momentId: String,
         val openComments: Boolean = false,
     ) : NotificationNavigationEvent()
+
+    /**
+     * Open the moments composer (`Route.MomentCompose`). Emitted when the user
+     * shares media into "New Moment" from the OS share sheet: the share flow
+     * has already seeded [MomentCreateFlowState] with the chosen attachments, so
+     * this event only steers the back stack into the composer.
+     */
+    data object OpenMomentCompose : NotificationNavigationEvent()
 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
@@ -645,6 +645,11 @@ class NotificationService(
         )
     }
 
+    /** Navigate to the moments composer (used for the "New Moment" share deep link). */
+    fun navigateToMomentCompose() {
+        _navigationEvents.trySend(NotificationNavigationEvent.OpenMomentCompose)
+    }
+
     /** Displays a rich notification using platform-specific APIs. */
     private fun showRichNotification(data: RichNotificationData) {
         try {

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/share/ShareConversationCacheWriter.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/share/ShareConversationCacheWriter.kt
@@ -12,12 +12,17 @@ class ShareConversationCacheWriter(
 ) {
     private val json = Json { ignoreUnknownKeys = true }
 
-    fun updateCache(conversations: List<ShareableConversation>, userDomain: String) {
+    fun updateCache(
+        conversations: List<ShareableConversation>,
+        userDomain: String,
+        momentsActivated: Boolean,
+    ) {
         try {
             val data = ShareConversationCacheData(
                 conversations = conversations.sortedByDescending { it.lastMessageTimestamp },
                 updatedAt = kotlin.time.Clock.System.now().toEpochMilliseconds(),
                 userDomain = userDomain,
+                momentsActivated = momentsActivated,
             )
             val encoded = json.encodeToString(data)
             cacheStorage.writeConversationCache(encoded)

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/share/ShareableConversation.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/share/ShareableConversation.kt
@@ -27,4 +27,9 @@ data class ShareConversationCacheData(
     val conversations: List<ShareableConversation>,
     val updatedAt: Long,
     val userDomain: String,
+    // Whether the Moments feature is activated for this user. The iOS share
+    // extension reads this to decide whether to offer "New Moment" as a share
+    // destination (it can't reach the main app's DB). Defaults false so older
+    // caches deserialize cleanly.
+    val momentsActivated: Boolean = false,
 )

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/util/FileUtilities.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/util/FileUtilities.kt
@@ -12,6 +12,17 @@ interface FileSystemHandler {
     fun openFile(file: Path, showChooser: Boolean, onError: (Throwable) -> Unit = {})
     fun openFileBrowser(file: Path, onError: (Throwable) -> Unit = {})
     fun shareFile(file: Path, onError: (Throwable) -> Unit = {})
+
+    /**
+     * Share a file alongside a caption (e.g. a Moment's media + its
+     * description). Single-file + text is the one multi-part share the OS
+     * delivers reliably across target apps. Defaults to a file-only share so
+     * platforms that don't carry text (Desktop/Web) degrade gracefully; Android
+     * and iOS override to attach [text] when it's non-blank.
+     */
+    fun shareFile(file: Path, text: String?, onError: (Throwable) -> Unit = {}) =
+        shareFile(file, onError)
+
     fun shareText(text: String, onError: (Throwable) -> Unit = {})
     fun openAppStore(onError: (Throwable) -> Unit = {})
 

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/FileUtilities.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/FileUtilities.native.kt
@@ -1,26 +1,37 @@
 package id.homebase.core.util
 
 import androidx.compose.runtime.Composable
+import co.touchlab.kermit.Logger
+import id.homebase.api.lib.image.ImageFormatDetector
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.ObjCObjectVar
+import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
+import kotlinx.cinterop.usePinned
 import kotlinx.cinterop.value
 import kotlinx.io.files.Path
+import platform.Foundation.NSData
 import platform.Foundation.NSDocumentDirectory
 import platform.Foundation.NSError
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSSearchPathForDirectoriesInDomains
 import platform.Foundation.NSURL
 import platform.Foundation.NSUserDomainMask
+import platform.Foundation.dataWithContentsOfURL
 import platform.Photos.PHAccessLevelAddOnly
 import platform.Photos.PHAssetChangeRequest
+import platform.Photos.PHAssetCreationRequest
+import platform.Photos.PHAssetResourceTypePhoto
 import platform.Photos.PHAuthorizationStatusAuthorized
 import platform.Photos.PHAuthorizationStatusLimited
 import platform.Photos.PHPhotoLibrary
 import platform.UIKit.UIActivityViewController
 import platform.UIKit.UIApplication
+import platform.UIKit.UIImage
+import platform.UIKit.UIImageJPEGRepresentation
+import platform.posix.memcpy
 
 @Composable
 actual fun getUriHandler(): FileSystemHandler {
@@ -178,6 +189,7 @@ actual fun getUriHandler(): FileSystemHandler {
             }
         }
 
+        @OptIn(ExperimentalForeignApi::class)
         private fun saveToPhotoLibrary(
             fileUrl: NSURL,
             isVideo: Boolean,
@@ -185,12 +197,31 @@ actual fun getUriHandler(): FileSystemHandler {
             onError: (Throwable) -> Unit,
         ) {
             val scoped = fileUrl.startAccessingSecurityScopedResource()
+
+            // Some image formats this platform serves (notably WebP, also AVIF)
+            // can be *displayed* by iOS but are rejected by the Photos library on
+            // import with PHPhotosError 3302 (invalidResource) — the cause of the
+            // "couldn't save photo" failures. UIImage can still decode them, so
+            // re-encode such files to JPEG and add them as raw photo-resource
+            // data. JPEG/PNG/GIF/HEIC import losslessly via the original file URL.
+            val reencodedJpeg: NSData? = if (isVideo) null else jpegForUnsupportedPhotoFormat(fileUrl)
+
             PHPhotoLibrary.sharedPhotoLibrary().performChanges(
                 changeBlock = {
-                    if (isVideo) {
-                        PHAssetChangeRequest.creationRequestForAssetFromVideoAtFileURL(fileUrl)
-                    } else {
-                        PHAssetChangeRequest.creationRequestForAssetFromImageAtFileURL(fileUrl)
+                    when {
+                        isVideo ->
+                            PHAssetChangeRequest.creationRequestForAssetFromVideoAtFileURL(fileUrl)
+
+                        reencodedJpeg != null ->
+                            PHAssetCreationRequest.creationRequestForAsset()
+                                .addResourceWithType(
+                                    type = PHAssetResourceTypePhoto,
+                                    data = reencodedJpeg,
+                                    options = null,
+                                )
+
+                        else ->
+                            PHAssetChangeRequest.creationRequestForAssetFromImageAtFileURL(fileUrl)
                     }
                 },
                 completionHandler = { success, error ->
@@ -202,6 +233,50 @@ actual fun getUriHandler(): FileSystemHandler {
                     }
                 },
             )
+        }
+
+        /**
+         * If [fileUrl] points to an image in a format the Photos library can't
+         * import (WebP/AVIF/BMP/unknown — anything other than JPEG/PNG/GIF/HEIC),
+         * decode it with UIImage and return JPEG bytes suitable for
+         * [PHAssetCreationRequest.addResourceWithType]. Returns null for formats
+         * Photos accepts directly (so the original bytes are preserved) or when
+         * the file can't be read/decoded (so Photos still gets to try the
+         * original and surface its own error).
+         */
+        @OptIn(ExperimentalForeignApi::class)
+        private fun jpegForUnsupportedPhotoFormat(fileUrl: NSURL): NSData? {
+            val data = NSData.dataWithContentsOfURL(fileUrl) ?: return null
+            val format = ImageFormatDetector.detectFormat(data.headerBytes(16))
+            val importsDirectly = format in setOf(
+                "image/jpeg", "image/png", "image/gif", "image/heic", "image/heif",
+            )
+            if (importsDirectly) return null
+
+            Logger.d(tag = "FileUtilities") {
+                "saveToPhotoLibrary: re-encoding $format to JPEG (Photos cannot import it directly)"
+            }
+            val uiImage = UIImage.imageWithData(data)
+            if (uiImage == null) {
+                Logger.w(tag = "FileUtilities") {
+                    "saveToPhotoLibrary: UIImage could not decode $format; letting Photos try the original"
+                }
+                return null
+            }
+            return UIImageJPEGRepresentation(uiImage, 0.95)
+        }
+
+        /** Copy up to [count] leading bytes of this [NSData] into a [ByteArray]. */
+        @OptIn(ExperimentalForeignApi::class)
+        private fun NSData.headerBytes(count: Int): ByteArray {
+            val n = minOf(count.toULong(), length).toInt()
+            val out = ByteArray(n)
+            if (n > 0) {
+                out.usePinned { pinned ->
+                    memcpy(pinned.addressOf(0), bytes, n.toULong())
+                }
+            }
+            return out
         }
 
         override fun shareText(text: String, onError: (Throwable) -> Unit) {

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/FileUtilities.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/FileUtilities.native.kt
@@ -68,7 +68,11 @@ actual fun getUriHandler(): FileSystemHandler {
         }
 
         @OptIn(ExperimentalForeignApi::class)
-        override fun shareFile(file: Path, onError: (Throwable) -> Unit) {
+        override fun shareFile(file: Path, onError: (Throwable) -> Unit) =
+            shareFile(file, text = null, onError = onError)
+
+        @OptIn(ExperimentalForeignApi::class)
+        override fun shareFile(file: Path, text: String?, onError: (Throwable) -> Unit) {
             try {
                 val filePath = file.toString()
                 if (!NSFileManager.defaultManager.fileExistsAtPath(filePath)) {
@@ -76,8 +80,16 @@ actual fun getUriHandler(): FileSystemHandler {
                     return
                 }
                 val fileUrl = NSURL.fileURLWithPath(filePath)
+                // The caption rides as a second activity item; each share target
+                // decides whether to use it. Photos/Messages combine file + text
+                // cleanly; others may ignore the string.
+                val activityItems = if (!text.isNullOrBlank()) {
+                    listOf(fileUrl, text)
+                } else {
+                    listOf(fileUrl)
+                }
                 val activityVC = UIActivityViewController(
-                    activityItems = listOf(fileUrl), applicationActivities = null
+                    activityItems = activityItems, applicationActivities = null
                 )
                 activityVC.completionWithItemsHandler =
                     { _, _, _, error ->

--- a/homebase-core/src/androidMain/kotlin/id/homebase/core/share/ShareHandlerRegistration.android.kt
+++ b/homebase-core/src/androidMain/kotlin/id/homebase/core/share/ShareHandlerRegistration.android.kt
@@ -7,3 +7,11 @@ actual fun registerShareHandler(handler: (conversationId: String) -> Unit) {
 actual fun unregisterShareHandler() {
     // No-op
 }
+
+actual fun registerMomentShareHandler(handler: () -> Unit) {
+    // No-op on Android — sharing into a new moment is handled in-process by ShareReceiverActivity
+}
+
+actual fun unregisterMomentShareHandler() {
+    // No-op
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentsPostSenderService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentsPostSenderService.kt
@@ -37,7 +37,11 @@ import id.homebase.chat.services.builder.AttachmentInput
 import id.homebase.chat.services.builder.MessageAttachmentBuilder
 import id.homebase.chat.services.outbox.OptimisticWriter
 import id.homebase.core.config.momentsLabeledDrive
+import id.homebase.core.localization.TranslationUtil
 import id.homebase.core.notifications.MOMENT_COMMENT_TAG_SENTINEL
+import id.homebase.resources.MR
+import id.homebase.resources.moments_push_new_comment
+import id.homebase.resources.moments_push_new_post
 import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.CoroutineScope
@@ -356,7 +360,7 @@ class MomentsPostSenderService(
                         typeId = momentUniqueId.toString(),
                         tagId = momentUniqueId.toString(),
                         silent = false,
-                        unEncryptedMessage = "New moment posted",
+                        unEncryptedMessage = TranslationUtil.getString(MR.string.moments_push_new_post),
                     ),
                 ),
                 payloads = encrypted.payloads,
@@ -996,7 +1000,7 @@ class MomentsPostSenderService(
                     typeId = momentId.toString(),
                     tagId = MOMENT_COMMENT_TAG_SENTINEL,
                     silent = false,
-                    unEncryptedMessage = "New comment",
+                    unEncryptedMessage = TranslationUtil.getString(MR.string.moments_push_new_comment),
                 ),
             ),
             payloads = encrypted.payloads,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/share/ShareHandlerRegistration.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/share/ShareHandlerRegistration.kt
@@ -8,3 +8,13 @@ expect fun registerShareHandler(handler: (conversationId: String) -> Unit)
 
 /** Clears the share handler registration. */
 expect fun unregisterShareHandler()
+
+/**
+ * Registers a "New Moment" share handler on platforms that support it (iOS).
+ * Invoked when the share extension hands a media share off to the moments
+ * composer. No-op on Android/Desktop/Web where sharing is handled in-process.
+ */
+expect fun registerMomentShareHandler(handler: () -> Unit)
+
+/** Clears the moment share handler registration. */
+expect fun unregisterMomentShareHandler()

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/share/SharedMediaAttachment.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/share/SharedMediaAttachment.kt
@@ -1,0 +1,29 @@
+package id.homebase.core.share
+
+import id.homebase.chat.conversationlist.AttachmentPendingFile
+import id.homebase.core.clipboard.platformFileFromPath
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Wrap a shared media file (already copied to a readable path) as the editor's
+ * per-attachment model, chosen by MIME prefix.
+ *
+ * Shared by the share-into-chat and share-into-"New Moment" hand-offs so both
+ * platforms produce identical attachments for the chat composer and the moments
+ * composer. The bare image/video metadata (EXIF, video poster/duration) is
+ * backfilled later by whichever editor consumes the attachment — see
+ * `MomentComposeViewModel`'s init backfill and `AttachmentHandler`.
+ */
+@OptIn(ExperimentalUuidApi::class)
+fun sharedMediaAttachment(path: String, mimeType: String): AttachmentPendingFile {
+    val file = platformFileFromPath(path)
+    return when {
+        mimeType.startsWith("image/") ->
+            AttachmentPendingFile.FileImage(Uuid.random(), file)
+        mimeType.startsWith("video/") ->
+            AttachmentPendingFile.FileVideo(Uuid.random(), file, thumbnailBytes = null)
+        else ->
+            AttachmentPendingFile.File(Uuid.random(), file)
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -374,6 +374,30 @@ fun AppNavHost(
                     }
                     TextRenderingHelper.nudge()
                 }
+
+                is NotificationNavigationEvent.OpenMomentCompose -> {
+                    Logger.i(tag = "AppNavHost") {
+                        "OpenMomentCompose received: activated=${momentsPreferences.activated.value}"
+                    }
+                    // The share flow seeded MomentCreateFlowState before launching
+                    // us; MomentComposeViewModel reads that draft on init. Gate on
+                    // Moments being activated (the share picker only offers "New
+                    // Moment" when it is) and mirror the OpenMoment back-stack
+                    // handling: push Moments first so back-press from the composer
+                    // lands on the feed, then open the composer.
+                    if (momentsPreferences.activated.value) {
+                        navController.currentBackStack.firstContaining {
+                            it.destination.hasRoute(Route.ChatList::class)
+                        }
+                        navController.navigate(Route.Moments) {
+                            popUpTo(Route.ChatList) { saveState = true }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
+                        navController.navigate(Route.MomentCompose)
+                    }
+                    TextRenderingHelper.nudge()
+                }
             }
         }
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppViewModel.kt
@@ -17,8 +17,12 @@ import id.homebase.core.notifications.NotificationService
 import id.homebase.core.notifications.RichNotificationData
 import id.homebase.core.permission.registerPermissionCallbackHandler
 import id.homebase.core.permission.unregisterPermissionCallbackHandler
+import id.homebase.core.moments.services.MomentCreateFlowState
 import id.homebase.core.share.ShareContentProcessor
+import id.homebase.core.share.registerMomentShareHandler
 import id.homebase.core.share.registerShareHandler
+import id.homebase.core.share.sharedMediaAttachment
+import id.homebase.core.share.unregisterMomentShareHandler
 import id.homebase.core.share.unregisterShareHandler
 import id.homebase.core.updater.UpdateAppManager
 import id.homebase.core.upgrade.PendingUpgradeManager
@@ -46,6 +50,7 @@ class AppViewModel(
     private val updateAppManager: UpdateAppManager,
     private val eventBus: EventBus,
     private val pendingUpgradeManager: PendingUpgradeManager,
+    private val momentCreateFlowState: MomentCreateFlowState,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(AppUiState())
     val uiState: StateFlow<AppUiState> = _uiState.asStateFlow()
@@ -63,6 +68,7 @@ class AppViewModel(
     init {
         collectNotificationEvents()
         registerShareHandler { conversationId -> handleShareIntent(conversationId) }
+        registerMomentShareHandler { handleMomentShareIntent() }
         registerPermissionCallbackHandler { canceled ->
             viewModelScope.launch {
                 eventBus.emit(
@@ -91,6 +97,7 @@ class AppViewModel(
     override fun onCleared() {
         super.onCleared()
         unregisterShareHandler()
+        unregisterMomentShareHandler()
         unregisterPermissionCallbackHandler()
         unregisterDataUpgradeCallbackHandler()
     }
@@ -195,6 +202,37 @@ class AppViewModel(
         } else {
             Logger.w(tag = "AppViewModel") { "No pending shared content found for conversation: $conversationId" }
         }
+    }
+
+    /**
+     * Called when the app receives a "New Moment" share (iOS: via the
+     * `homebase-share://moment` URL scheme). Reads the media the share extension
+     * staged in the App Group, seeds the moments composer draft (the same
+     * [MomentCreateFlowState] the Android share path seeds), and navigates to
+     * the composer via [NotificationNavigationEvent.OpenMomentCompose].
+     *
+     * Deliberately does NOT call [ShareContentProcessor.cleanup] — that deletes
+     * the staged files, which the composer/upload still needs. As on Android,
+     * the composer owns the files from here; the next share overwrites the
+     * staging area.
+     */
+    fun handleMomentShareIntent() {
+        val descriptor = shareContentProcessor.readPendingContent()
+        if (descriptor == null || descriptor.fileNames.isEmpty()) {
+            Logger.w(tag = "AppViewModel") { "Moment share: no pending media to compose" }
+            return
+        }
+        val attachments = descriptor.fileNames.zip(descriptor.mimeTypes).map { (name, mime) ->
+            sharedMediaAttachment(shareContentProcessor.resolveFilePath(name), mime)
+        }
+        Logger.i(tag = "AppViewModel") { "Moment share: seeding draft with ${attachments.size} attachments" }
+        momentCreateFlowState.setDraft(
+            MomentCreateFlowState.Draft(
+                attachments = attachments,
+                description = descriptor.text ?: "",
+            )
+        )
+        _navigationEvents.trySend(NotificationNavigationEvent.OpenMomentCompose)
     }
 
     private fun listenForConnectionRequests() {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentComposeViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentComposeViewModel.kt
@@ -47,6 +47,27 @@ class MomentComposeViewModel(
     private val _events = MutableSharedFlow<MomentComposeUiEvent>(extraBufferCapacity = 4)
     val events: SharedFlow<MomentComposeUiEvent> = _events.asSharedFlow()
 
+    init {
+        // Attachments restored from a draft can arrive without the metadata the
+        // gallery-pick path extracts via AttachmentsAdded — notably the
+        // share-into-"New Moment" hand-off, whose attachments are built bare by
+        // the share flow's convertToAttachmentFiles. Backfill EXIF (capture
+        // date, camera, GPS) and video poster/duration so the photo-info chip,
+        // the derived moment date, and the trim scrubber behave the same as a
+        // normally-composed moment. The null guards make this a no-op for
+        // back-nav drafts that already carry their metadata.
+        _uiState.value.attachments.forEach { f ->
+            when (f) {
+                is AttachmentPendingFile.FileImage ->
+                    if (f.metadata == null) extractImageMetadata(f.attachmentId, f.file.toString())
+                is AttachmentPendingFile.FileVideo ->
+                    if (f.thumbnailBytes == null || f.durationMs == null)
+                        extractVideoMetadata(f.attachmentId, f.file.toString())
+                else -> Unit
+            }
+        }
+    }
+
     /**
      * Rebuild the compose state from any draft left behind by a previous
      * Continue → Audience hop, so back-nav from the audience picker lands the

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
@@ -173,6 +173,7 @@ import id.homebase.resources.moments_detail_menu_delete
 import id.homebase.resources.moments_detail_menu_info
 import id.homebase.resources.moments_detail_menu_more
 import id.homebase.resources.moments_detail_menu_save_current
+import id.homebase.resources.moments_detail_menu_share
 import id.homebase.resources.moments_detail_description_hint
 import id.homebase.resources.moments_detail_description_save
 import id.homebase.resources.moments_detail_edit_description
@@ -517,7 +518,7 @@ fun MomentDetailPane(
             when (event) {
                 is MomentDetailUiEvent.MomentDeleted -> onNavigateBack?.invoke()
                 is MomentDetailUiEvent.ShareFileReady ->
-                    fileSystemHandler.shareFile(Path(event.filePath))
+                    fileSystemHandler.shareFile(Path(event.filePath), event.caption)
                 // "Save current": the VM has finished decrypting (+ remuxing)
                 // the visible payload to a cache file; hand it to the platform
                 // save-to-device flow and confirm with a snackbar. Reuses the
@@ -820,6 +821,9 @@ private fun DetailContent(
 private fun MomentOverflowMenu(
     isDeleting: Boolean,
     isSaving: Boolean,
+    isSharing: Boolean,
+    showShare: Boolean,
+    onShareClick: () -> Unit,
     showSave: Boolean,
     onSaveClick: () -> Unit,
     showInfo: Boolean,
@@ -830,11 +834,11 @@ private fun MomentOverflowMenu(
     iconTint: Color = Color.Unspecified,
 ) {
     var expanded by remember { mutableStateOf(false) }
-    // While a delete OR a save is in flight the icon is swapped for a spinner.
-    // Same shape as the per-comment delete indicator: tells the user
-    // "something is happening" — for save, that covers the decrypt/remux of
-    // the visible payload before the device-gallery write fires.
-    val busy = isDeleting || isSaving
+    // While a delete, save, OR share is in flight the icon is swapped for a
+    // spinner. Same shape as the per-comment delete indicator: tells the user
+    // "something is happening" — for save/share, that covers the decrypt/remux
+    // of the visible payload before the device-gallery write / share sheet fires.
+    val busy = isDeleting || isSaving || isSharing
     Box {
         IconButton(onClick = { expanded = true }, enabled = !busy) {
             if (busy) {
@@ -857,6 +861,15 @@ private fun MomentOverflowMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
         ) {
+            if (showShare) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(MR.string.moments_detail_menu_share)) },
+                    onClick = {
+                        expanded = false
+                        onShareClick()
+                    },
+                )
+            }
             if (showSave) {
                 DropdownMenuItem(
                     text = { Text(stringResource(MR.string.moments_detail_menu_save_current)) },
@@ -1221,6 +1234,15 @@ private fun MomentMediaScaffold(
                         MomentOverflowMenu(
                             isDeleting = uiState.isDeleting,
                             isSaving = uiState.isSavingMedia,
+                            isSharing = uiState.isSharingMedia,
+                            // Hidden on description-only moments — nothing on
+                            // screen to share. Shares the visible item + caption.
+                            showShare = visiblePayloadKey != null,
+                            onShareClick = {
+                                visiblePayloadKey?.let {
+                                    onAction(MomentDetailUiAction.ShareMedia(it))
+                                }
+                            },
                             // Hidden on description-only moments — nothing on
                             // screen to save.
                             showSave = visiblePayloadKey != null,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailUiState.kt
@@ -95,6 +95,13 @@ data class MomentDetailUiState(
     val isSavingMedia: Boolean = false,
 
     /**
+     * True while the "Share" flow is decrypting (and, for HLS video, remuxing)
+     * the visible payload into the share_outbound dir before the OS share sheet
+     * opens. Drives the same overflow-menu spinner as [isSavingMedia].
+     */
+    val isSharingMedia: Boolean = false,
+
+    /**
      * Comment ids whose delete is currently in flight. The comment row reads
      * this to disable its Edit/Delete buttons and show a small spinner while
      * the optimistic write + outbox enqueue is running. Entries are removed
@@ -387,10 +394,15 @@ sealed interface MomentDetailUiEvent {
     data class CommentDeleteFailed(val message: String?) : MomentDetailUiEvent
 
     /**
-     * Decrypted payload is written to [filePath] under the share_outbound sweep
-     * dir; the screen should hand the path to the platform share sheet.
+     * Decrypted (and, for HLS, remuxed) payload is written to [filePath] under
+     * the share_outbound sweep dir; the screen hands it to the platform share
+     * sheet. [caption] is the moment's description, attached so single-file +
+     * text shares carry the words alongside the media (best-effort per target).
      */
-    data class ShareFileReady(val filePath: String) : MomentDetailUiEvent
+    data class ShareFileReady(
+        val filePath: String,
+        val caption: String?,
+    ) : MomentDetailUiEvent
     data class ShareFailed(val message: String?) : MomentDetailUiEvent
 
     /**

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailViewModel.kt
@@ -104,6 +104,7 @@ class MomentDetailViewModel(
         val showDeleteDialog: Boolean = false,
         val isDeletingMoment: Boolean = false,
         val isSavingMedia: Boolean = false,
+        val isSharingMedia: Boolean = false,
         val deletingCommentIds: Set<Uuid> = emptySet(),
         val deleteCommentDialogTarget: Uuid? = null,
         val sharedWithExpanded: Boolean = false,
@@ -222,6 +223,7 @@ class MomentDetailViewModel(
             showDeleteDialog = local.showDeleteDialog,
             isDeleting = local.isDeletingMoment,
             isSavingMedia = local.isSavingMedia,
+            isSharingMedia = local.isSharingMedia,
             deletingCommentIds = local.deletingCommentIds,
             deleteCommentDialogTarget = local.deleteCommentDialogTarget,
             sharedWith = momentBundle.sharedWith,
@@ -657,14 +659,21 @@ class MomentDetailViewModel(
     }
 
     /**
-     * Decrypt the selected payload and write a cleartext copy into the
-     * share_outbound sweep dir, then surface the path so the screen can hand
-     * it to the platform share sheet. Mirrors `MediaDownloadHandler.handleShareMedia`
-     * on the chat side — same KeyHeader assembly and same sequestered temp
-     * dir so the cleartext copy is reaped by the cold-start + foreground sweepers.
+     * Decrypt the selected payload to a cleartext file and surface it (with the
+     * moment's caption) so the screen can hand it to the platform share sheet.
+     *
+     * Images / progressive video stream into the share_outbound sweep dir, so
+     * the cold-start + foreground sweepers reap the cleartext copy. A segmented
+     * HLS video is first remuxed to a playable MP4 (a raw .ts segment shared
+     * as-is won't open in the target app) — the same path `saveMedia` takes;
+     * that MP4 lands in the cache dir and is reaped by the cache sweeper.
+     *
+     * [isSharingMedia] gates the overflow-menu spinner over the decrypt/remux,
+     * which is the slow part (videos especially) before the sheet opens.
      */
     @OptIn(ExperimentalEncodingApi::class)
     private fun shareMedia(payloadKey: String) {
+        if (_screenLocal.value.isSharingMedia) return
         val moment = uiState.value.moment ?: return
         val payload = moment.payloads.firstOrNull { it.key == payloadKey } ?: return
         val ivString = payload.iv ?: run {
@@ -672,31 +681,59 @@ class MomentDetailViewModel(
             _events.tryEmit(MomentDetailUiEvent.ShareFailed("Payload missing key header"))
             return
         }
+        val keyHeader = KeyHeader(Base64.decode(ivString), moment.keyHeader.aesKey)
+        val caption = moment.description.takeIf { it.isNotBlank() }
+
+        _screenLocal.update { it.copy(isSharingMedia = true) }
         viewModelScope.launch {
             try {
-                val payloadIv = Base64.decode(ivString)
-                val response = driveFileProvider.getPayloadBytesDecrypted(
+                val hlsMetadata = resolveHlsVideoMetadata(
+                    descriptorContent = payload.descriptorContent,
                     driveId = moment.driveId,
                     fileId = moment.fileId,
-                    key = payloadKey,
-                    keyHeader = KeyHeader(payloadIv, moment.keyHeader.aesKey),
+                    keyHeader = keyHeader,
                 )
-                val bytes = response?.bytes
-                if (bytes == null) {
-                    _events.tryEmit(MomentDetailUiEvent.ShareFailed("Could not download file"))
-                    return@launch
+                val sharePath = if (hlsMetadata != null) {
+                    val remuxed = withContext(ioDispatcher) {
+                        downloadAndRemuxHlsToMp4(
+                            driveId = moment.driveId,
+                            fileId = moment.fileId,
+                            payloadKey = payloadKey,
+                            keyHeader = keyHeader,
+                            metadata = hlsMetadata,
+                            suggestedBaseName = payload.filename(),
+                        )
+                    }
+                    if (remuxed == null) {
+                        _events.tryEmit(MomentDetailUiEvent.ShareFailed("Could not convert video"))
+                        return@launch
+                    }
+                    remuxed.first
+                } else {
+                    val bytes = driveFileProvider.getPayloadBytesDecrypted(
+                        driveId = moment.driveId,
+                        fileId = moment.fileId,
+                        key = payloadKey,
+                        keyHeader = keyHeader,
+                    )?.bytes
+                    if (bytes == null) {
+                        _events.tryEmit(MomentDetailUiEvent.ShareFailed("Could not download file"))
+                        return@launch
+                    }
+                    val extension = payload.contentType?.let { extensionForMimeType(it) }
+                        ?: payload.contentType?.substringAfter("/")
+                        ?: "bin"
+                    fileOperationsProvider.writeBytesToShareOutboundFile(
+                        bytes = bytes,
+                        suffix = ".$extension",
+                    )
                 }
-                val extension = payload.contentType?.let { extensionForMimeType(it) }
-                    ?: payload.contentType?.substringAfter("/")
-                    ?: "bin"
-                val tempPath = fileOperationsProvider.writeBytesToShareOutboundFile(
-                    bytes = bytes,
-                    suffix = ".$extension",
-                )
-                _events.tryEmit(MomentDetailUiEvent.ShareFileReady(tempPath))
+                _events.tryEmit(MomentDetailUiEvent.ShareFileReady(sharePath, caption))
             } catch (t: Throwable) {
                 Logger.e(throwable = t, tag = TAG) { "shareMedia failed: ${t.message}" }
                 _events.tryEmit(MomentDetailUiEvent.ShareFailed(t.message))
+            } finally {
+                _screenLocal.update { it.copy(isSharingMedia = false) }
             }
         }
     }

--- a/homebase-core/src/jvmMain/kotlin/id/homebase/core/share/ShareHandlerRegistration.jvm.kt
+++ b/homebase-core/src/jvmMain/kotlin/id/homebase/core/share/ShareHandlerRegistration.jvm.kt
@@ -7,3 +7,11 @@ actual fun registerShareHandler(handler: (conversationId: String) -> Unit) {
 actual fun unregisterShareHandler() {
     // No-op
 }
+
+actual fun registerMomentShareHandler(handler: () -> Unit) {
+    // No-op on Desktop
+}
+
+actual fun unregisterMomentShareHandler() {
+    // No-op
+}

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/share/ShareHandlerBridge.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/share/ShareHandlerBridge.kt
@@ -11,6 +11,7 @@ import id.homebase.core.share.ShareHandlerBridge.setHandler
  */
 object ShareHandlerBridge {
     private var handler: ((String) -> Unit)? = null
+    private var momentHandler: (() -> Unit)? = null
 
     /** Called from AppViewModel to register the share handler. */
     fun setHandler(handler: (conversationId: String) -> Unit) {
@@ -24,8 +25,26 @@ object ShareHandlerBridge {
             ?: Logger.w(tag = "ShareHandlerBridge") { "No handler registered for share intent" }
     }
 
-    /** Clear handler when AppViewModel is cleared. */
+    /** Called from AppViewModel to register the "New Moment" share handler. */
+    fun setMomentHandler(handler: () -> Unit) {
+        this.momentHandler = handler
+    }
+
+    /**
+     * Called from Swift when the app opens via `homebase-share://moment`. The
+     * extension has already written the shared media descriptor to the App
+     * Group; the handler reads it, seeds the moments composer draft, and
+     * navigates there.
+     */
+    fun handleIncomingMomentShare() {
+        Logger.i(tag = "ShareHandlerBridge") { "Incoming share for a new moment" }
+        this.momentHandler?.invoke()
+            ?: Logger.w(tag = "ShareHandlerBridge") { "No handler registered for moment share intent" }
+    }
+
+    /** Clear handlers when AppViewModel is cleared. */
     fun clearHandler() {
         handler = null
+        momentHandler = null
     }
 }

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/share/ShareHandlerRegistration.native.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/share/ShareHandlerRegistration.native.kt
@@ -7,3 +7,11 @@ actual fun registerShareHandler(handler: (conversationId: String) -> Unit) {
 actual fun unregisterShareHandler() {
     ShareHandlerBridge.clearHandler()
 }
+
+actual fun registerMomentShareHandler(handler: () -> Unit) {
+    ShareHandlerBridge.setMomentHandler(handler)
+}
+
+actual fun unregisterMomentShareHandler() {
+    // Cleared together with the conversation handler in ShareHandlerBridge.clearHandler().
+}

--- a/homebase-core/src/wasmJsMain/kotlin/id/homebase/core/share/ShareHandlerRegistration.web.kt
+++ b/homebase-core/src/wasmJsMain/kotlin/id/homebase/core/share/ShareHandlerRegistration.web.kt
@@ -7,3 +7,11 @@ actual fun registerShareHandler(handler: (conversationId: String) -> Unit) {
 actual fun unregisterShareHandler() {
     // No-op
 }
+
+actual fun registerMomentShareHandler(handler: () -> Unit) {
+    // No-op on Web
+}
+
+actual fun unregisterMomentShareHandler() {
+    // No-op
+}

--- a/iosApp/ShareExtension/ShareConversationCacheReader.swift
+++ b/iosApp/ShareExtension/ShareConversationCacheReader.swift
@@ -16,6 +16,8 @@ struct ShareConversationCacheSwift: Codable {
     let conversations: [ShareableConversationSwift]
     let updatedAt: Int64
     let userDomain: String
+    /// Optional so caches written before this field existed still decode.
+    let momentsActivated: Bool?
 }
 
 /// Reads the conversation cache from the App Group container.
@@ -25,25 +27,25 @@ struct ShareConversationCacheReader {
     static let appGroupId = Bundle.main.infoDictionary?["AppGroupIdentifier"] as? String ?? "group.id.homebase.feed"
     static let cacheFileName = "share_conversation_cache.json"
 
-    static func load() -> (conversations: [ShareableConversationSwift], updatedAt: Date?) {
+    static func load() -> (conversations: [ShareableConversationSwift], updatedAt: Date?, momentsActivated: Bool) {
         guard let containerURL = FileManager.default
             .containerURL(forSecurityApplicationGroupIdentifier: appGroupId)
         else {
-            return ([], nil)
+            return ([], nil, false)
         }
 
         let cacheURL = containerURL.appendingPathComponent(cacheFileName)
 
         guard let data = try? Data(contentsOf: cacheURL) else {
-            return ([], nil)
+            return ([], nil, false)
         }
 
         guard let cache = try? JSONDecoder().decode(ShareConversationCacheSwift.self, from: data)
         else {
-            return ([], nil)
+            return ([], nil, false)
         }
 
         let date = Date(timeIntervalSince1970: TimeInterval(cache.updatedAt) / 1000.0)
-        return (cache.conversations, date)
+        return (cache.conversations, date, cache.momentsActivated ?? false)
     }
 }

--- a/iosApp/ShareExtension/SharePickerView.swift
+++ b/iosApp/ShareExtension/SharePickerView.swift
@@ -8,7 +8,10 @@ private let recentsCount = 5
 /// Supports multi-select — user taps conversations to toggle selection, then taps Send.
 struct SharePickerView: View {
     let conversations: [ShareableConversationSwift]
+    /// Whether to offer "New Moment" as a destination (media present + Moments activated).
+    var showMomentOption: Bool = false
     let onSelect: ([String]) -> Void
+    var onSelectMoment: () -> Void = {}
     let onCancel: () -> Void
 
     @State private var searchText = ""
@@ -50,6 +53,73 @@ struct SharePickerView: View {
 
     var body: some View {
         NavigationView {
+            VStack(spacing: 0) {
+                if showMomentOption {
+                    newMomentButton
+                    Divider()
+                }
+
+                conversationContent
+            }
+            .navigationTitle("Share to...")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel", action: onCancel)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(action: { onSelect(Array(selectedIds)) }) {
+                        if selectedIds.count > 1 {
+                            Text("Send (\(selectedIds.count))")
+                        } else {
+                            Text("Send")
+                        }
+                    }
+                    .fontWeight(.semibold)
+                    .disabled(selectedIds.isEmpty)
+                }
+            }
+            .searchable(text: $searchText, prompt: "Search conversations...")
+        }
+    }
+
+    /// "New Moment" destination row, shown above the conversation list when the
+    /// share carries media and Moments is activated. Mirrors the Android picker.
+    private var newMomentButton: some View {
+        Button(action: onSelectMoment) {
+            HStack(spacing: 12) {
+                ZStack {
+                    Circle().fill(Color.accentColor.opacity(0.15))
+                    Image(systemName: "sparkles")
+                        .foregroundColor(.accentColor)
+                        .imageScale(.large)
+                }
+                .frame(width: 40, height: 40)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("New Moment")
+                        .font(.body)
+                        .fontWeight(.medium)
+                    Text("Share to your Moments")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .foregroundColor(Color(UIColor.tertiaryLabel))
+                    .imageScale(.small)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private var conversationContent: some View {
             Group {
                 if conversations.isEmpty {
                     emptyState
@@ -97,26 +167,6 @@ struct SharePickerView: View {
                     }
                 }
             }
-            .navigationTitle("Share to...")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel", action: onCancel)
-                }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button(action: { onSelect(Array(selectedIds)) }) {
-                        if selectedIds.count > 1 {
-                            Text("Send (\(selectedIds.count))")
-                        } else {
-                            Text("Send")
-                        }
-                    }
-                    .fontWeight(.semibold)
-                    .disabled(selectedIds.isEmpty)
-                }
-            }
-            .searchable(text: $searchText, prompt: "Search conversations...")
-        }
     }
 
     private func conversationButton(_ conversation: ShareableConversationSwift) -> some View {

--- a/iosApp/ShareExtension/ShareViewController.swift
+++ b/iosApp/ShareExtension/ShareViewController.swift
@@ -26,13 +26,21 @@ class ShareViewController: UIViewController {
         }
 
         // 3. Load conversation cache from App Group
-        let (conversations, _) = ShareConversationCacheReader.load()
+        let (conversations, _, momentsActivated) = ShareConversationCacheReader.load()
+
+        // "New Moment" needs media and an activated Moments feature — mirror the
+        // Android picker's gating.
+        let hasMedia = extensionContext.map { SharedContentSaver.hasMedia(in: $0) } ?? false
 
         // 4. Present SwiftUI picker
         let pickerView = SharePickerView(
             conversations: conversations,
+            showMomentOption: momentsActivated && hasMedia,
             onSelect: { [weak self] conversationIds in
                 self?.handleSelection(conversationIds: conversationIds)
+            },
+            onSelectMoment: { [weak self] in
+                self?.handleMomentSelection()
             },
             onCancel: { [weak self] in
                 self?.cancelExtension()
@@ -87,6 +95,40 @@ class ShareViewController: UIViewController {
                 )
             }
         }
+    }
+
+    /// Stage the shared media for a new moment, then hand off to the main app's
+    /// moments composer. Unlike the conversation path there's no target to pick —
+    /// the composer (audience, trim, description) lives in the main app.
+    private func handleMomentSelection() {
+        guard let extensionContext = extensionContext else {
+            cancelExtension()
+            return
+        }
+
+        SharedContentSaver.save(
+            extensionContext: extensionContext,
+            conversationId: SharedContentSaver.momentTargetId
+        ) { [weak self] success in
+            if success {
+                self?.openMainAppForMoment()
+            } else {
+                self?.showError(
+                    title: "Error",
+                    message: "Failed to prepare shared content."
+                )
+            }
+        }
+    }
+
+    /// Open the main app's moments composer via URL scheme.
+    private func openMainAppForMoment() {
+        guard let url = URL(string: "homebase-share://moment") else {
+            cancelExtension()
+            return
+        }
+        openURL(url)
+        extensionContext?.completeRequest(returningItems: nil, completionHandler: nil)
     }
 
     /// Open the main app via URL scheme to complete the send.

--- a/iosApp/ShareExtension/SharedContentSaver.swift
+++ b/iosApp/ShareExtension/SharedContentSaver.swift
@@ -9,6 +9,28 @@ struct SharedContentSaver {
     static let sharedContentFile = "shared_content.json"
     static let sharedFilesDir = "shared_files"
 
+    /// Sentinel `targetConversationId` for a "New Moment" share. The main app's
+    /// moment hand-off ignores the target (the `homebase-share://moment` URL is
+    /// what disambiguates), but the descriptor field is non-optional, so we
+    /// stamp this rather than a real conversation id.
+    static let momentTargetId = "__moment__"
+
+    /// Synchronously reports whether the share carries at least one image or
+    /// video. Used to gate the "New Moment" option, which requires media.
+    static func hasMedia(in extensionContext: NSExtensionContext) -> Bool {
+        guard let inputItems = extensionContext.inputItems as? [NSExtensionItem] else { return false }
+        for item in inputItems {
+            guard let attachments = item.attachments else { continue }
+            for provider in attachments {
+                if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier) ||
+                   provider.hasItemConformingToTypeIdentifier(UTType.movie.identifier) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
     /// Content descriptor mirroring KMP SharedContentDescriptor.
     struct ContentDescriptor: Codable {
         let contentType: String

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -195,7 +195,11 @@ struct iOSApp: App {
     private func handleIncomingURL(_ url: URL) {
         switch url.scheme {
         case "homebase-share":
-            handleShareURL(url)
+            if url.host == "moment" {
+                ShareHandlerBridge.shared.handleIncomingMomentShare()
+            } else {
+                handleShareURL(url)
+            }
         case "homebase-fchat":
             switch url.host {
             case "permission-callback":


### PR DESCRIPTION
## What

Adds **Moments** as a destination in the OS share sheet → Homebase flow. Media shared from another app can now be composed into a new moment, reusing the existing media-upload pipeline rather than duplicating it.

**Flow:** Share sheet → Homebase → tap **New Moment** → the shared photos/videos seed the moments composer (trim/crop/description/audience all live there) → post through the existing `MomentsPostSenderService`.

## How

Both platforms converge on one seam: shared files become `AttachmentPendingFile`, the composer draft (`MomentCreateFlowState`) is seeded, and the app navigates to `Route.MomentCompose` via a new `OpenMomentCompose` navigation event. Only the terminal dispatch diverges from the chat-share path — the `media → payload → encrypt → outbox` core stays single-sourced.

- **Android** — a `ShareTarget` sealed type (`Conversations` / `NewMoment`) lets `ShareReceiverActivity` branch exactly once; `SharePickerScreen` gains a gated **New Moment** row (shown only when the share has media and Moments is activated).
- **iOS** — the Swift share extension stages media in the App Group and opens `homebase-share://moment`; `AppViewModel.handleMomentShareIntent` reads the descriptor, seeds the draft, and routes. A `momentsActivated` flag was added to the app-group conversation cache so the extension can gate the option the same way Android does (the extension can't reach the main app's DB).
- **`MomentComposeViewModel`** now backfills EXIF / video poster+duration for draft-restored attachments, so shared media gets the same capture-date and trim treatment as gallery-picked media.

## Notable decisions

- **No duplicated upload code.** `MessageAttachmentBuilder` / `PayloadBundleEncryptor` / `OptimisticWriter` / outbox are reused as-is; the only new shared conversion logic is `sharedMediaAttachment(path, mime)`.
- **File cleanup** is deliberately skipped on the moment hand-off (it would delete the staged files the composer still needs) — same "editor owns the files now" stance as the existing chat-share files path.

## Validation

| Check | Result |
|---|---|
| KMP compile — JVM (common/chat/core) | ✅ |
| KMP compile — iOS (`compileKotlinIosSimulatorArm64`) | ✅ |
| KMP framework link (`linkDebugFrameworkIosSimulatorArm64`) | ✅ confirms `handleIncomingMomentShare` is exported |
| KMP tests — core/chat/common `jvmTest` | ✅ |
| Swift `ShareExtension` target (xcodebuild) | ✅ BUILD SUCCEEDED |
| Android intent test for the new deep link | ✅ added |

**Caveat:** a full xcodebuild of the *main app* target wasn't run — its "Compile Kotlin Framework" Xcode script phase fails in this headless environment (a pre-existing tooling/signing issue, no build config was touched). The one main-app Swift edit is a host/scheme branch calling the already-exported `handleIncomingMomentShare`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)