### PR TITLE
Fix remote inline GIF render in chat bubbles (Android)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenMediaViewer.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenMediaViewer.kt
@@ -334,6 +334,10 @@ fun FullScreenMediaViewer(
                                 payloadKey = payload.key,
                                 previewThumbnail = payload.previewThumbnail?.toEmbeddedThumb(),
                                 lastModified = payload.lastModified,
+                                // Real payload type so a GIF rail thumbnail loads
+                                // the animated original instead of a never-generated
+                                // server thumbnail (its preview thumb is WebP).
+                                payloadContentType = payload.contentType,
                                 keyHeader = KeyHeader(
                                     iv = railIv,
                                     aesKey = data.keyHeader.aesKey

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
@@ -270,7 +270,7 @@ fun MediaItem(
                 // Remember the image data to avoid creating a new instance on every recomposition,
                 // which would cause Coil to restart the image loading pipeline and cause flickering.
                 val imageData =
-                    remember(driveId, fileId, payload.key, payload.lastModified, imageSize) {
+                    remember(driveId, fileId, payload.key, payload.lastModified, imageSize, contentType) {
                         val payloadIv = payload.iv?.let { Base64.decode(it) } ?: return@remember null
                         HomebaseImageData(
                             driveId = driveId,
@@ -281,6 +281,11 @@ fun MediaItem(
                             requestedSize = imageSize,
                             lastModified = payload.lastModified,
                             isEncrypted = true,
+                            // Pass the real payload content type so the loader
+                            // recognises a GIF (whose preview thumb is WebP) and
+                            // loads the animated original inline instead of a
+                            // non-existent server thumbnail. See HomebaseImageData.
+                            payloadContentType = contentType,
                             keyHeader = KeyHeader(iv = payloadIv, aesKey = keyHeader.aesKey)
                         )
                     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -947,6 +947,10 @@ fun InlineReplyPreview(
                 ?: replyPreview.previewThumbnail,
             requestedSize = ImageSize.THUMB_SMALL,
             isEncrypted = true,
+            // Real payload type so a GIF reply preview loads the animated
+            // original instead of a never-generated server thumbnail (its
+            // preview thumb is WebP).
+            payloadContentType = firstVisualPayload.contentType,
             keyHeader = KeyHeader(iv = payloadIv, aesKey = replyMessage.keyHeader.aesKey),
         )
     }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageData.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageData.kt
@@ -28,6 +28,16 @@ data class HomebaseImageData(
     val lastModified: Long? = null,
     /** Local pending file (for images being uploaded/sent) */
     val pendingFileUri: String? = null,
+    /**
+     * Content type of the actual payload (e.g. "image/gif"), as declared on the
+     * file/payload descriptor. This is distinct from [contentTypeHint], which
+     * reflects the embedded preview thumbnail's content type — and that is
+     * always "image/webp" even for GIFs (the sender ships a tiny WebP preview,
+     * never a GIF thumbnail). The loader needs the real payload type to
+     * recognise thumbless formats (GIF) and load the animated original instead
+     * of requesting a server thumbnail that was never generated.
+     */
+    val payloadContentType: String? = null,
     /** KeyHeader for decryption of the payload */
     val keyHeader: KeyHeader,
 ) {
@@ -52,6 +62,17 @@ data class HomebaseImageData(
     /** Content type hint from preview thumbnail */
     val contentTypeHint: String?
         get() = previewThumbnail?.contentType
+
+    /**
+     * Best-known content type of the underlying payload, used to decide how to
+     * load the image (thumbnail vs. full animated original). Prefers the real
+     * [payloadContentType] from the descriptor and falls back to the preview
+     * thumbnail's type. Callers that only have a preview thumbnail keep their
+     * existing behaviour; callers that know the payload type (e.g. an inline
+     * GIF in a chat bubble) get the correct thumbless treatment.
+     */
+    val effectiveContentType: String?
+        get() = payloadContentType ?: contentTypeHint
 }
 
 /** Represents image dimensions */

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
@@ -115,8 +115,12 @@ class HomebaseImageLoader(
             return fileOperationsProvider.loadPendingFile(data)
         }
 
-        // Skip thumbnail fetch for SVG/GIF (load full payload instead)
-        if (data.contentTypeHint in THUMBLESS_CONTENT_TYPES) {
+        // Skip thumbnail fetch for GIF (load the animated original instead).
+        // Use effectiveContentType — for a GIF the previewThumbnail is a tiny
+        // WebP, so contentTypeHint alone is "image/webp" and would wrongly try
+        // to fetch a server thumbnail that was never generated (N=0 thumbs for
+        // GIFs), surfacing as a NotFoundException / error triangle.
+        if (data.effectiveContentType in THUMBLESS_CONTENT_TYPES) {
             return loadFullPayload(data, retryConfig)
         }
 

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/image/HomebaseImageLoaderTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/image/HomebaseImageLoaderTest.kt
@@ -74,6 +74,63 @@ class HomebaseImageLoaderTest {
     }
 
     @Test
+    fun `effectiveContentType prefers payloadContentType over preview thumbnail`() {
+        // A GIF ships a tiny WebP preview, so contentTypeHint is "image/webp".
+        // effectiveContentType must surface the real payload type ("image/gif")
+        // so the loader takes the thumbless / full-payload branch and the
+        // animated original renders inline (instead of a NotFoundException from
+        // a server thumbnail that was never generated for a GIF).
+        val gif = HomebaseImageData(
+            driveId = Uuid.random(),
+            fileId = Uuid.random(),
+            payloadKey = "key",
+            keyHeader = KeyHeader.newRandom16(),
+            payloadContentType = "image/gif",
+            previewThumbnail = EmbeddedThumb(
+                pixelWidth = 20,
+                pixelHeight = 20,
+                contentType = "image/webp",
+                content = "base64data"
+            )
+        )
+        assertEquals("image/gif", gif.effectiveContentType)
+        assertTrue(gif.effectiveContentType in HomebaseImageLoader.THUMBLESS_CONTENT_TYPES)
+        // contentTypeHint is unchanged — still the preview thumbnail's type.
+        assertEquals("image/webp", gif.contentTypeHint)
+    }
+
+    @Test
+    fun `effectiveContentType falls back to preview thumbnail when payload type absent`() {
+        val data = HomebaseImageData(
+            driveId = Uuid.random(),
+            fileId = Uuid.random(),
+            payloadKey = "key",
+            keyHeader = KeyHeader.newRandom16(),
+            previewThumbnail = EmbeddedThumb(
+                pixelWidth = 20,
+                pixelHeight = 20,
+                contentType = "image/webp",
+                content = "base64data"
+            )
+        )
+        assertEquals("image/webp", data.effectiveContentType)
+        // A regular raster image is NOT thumbless, so it keeps the server-
+        // thumbnail path — no regression for JPEG/PNG/WebP.
+        assertTrue(data.effectiveContentType !in HomebaseImageLoader.THUMBLESS_CONTENT_TYPES)
+    }
+
+    @Test
+    fun `effectiveContentType is null when neither payload type nor preview present`() {
+        val data = HomebaseImageData(
+            driveId = Uuid.random(),
+            fileId = Uuid.random(),
+            payloadKey = "key",
+            keyHeader = KeyHeader.newRandom16()
+        )
+        assertNull(data.effectiveContentType)
+    }
+
+    @Test
     fun `ImageSize presets are correctly defined`() {
         assertEquals(320, ImageSize.THUMB_SMALL.pixelWidth)
         assertEquals(640, ImageSize.THUMB_MEDIUM.pixelWidth)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/model/VaultEntry.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/model/VaultEntry.kt
@@ -149,6 +149,10 @@ fun VaultEntry.imageDataFor(
         loadFullPayload = loadFullPayload,
         isEncrypted = isEncrypted,
         lastModified = descriptor.lastModified,
+        // Carry the real payload type so the loader recognises thumbless
+        // formats (GIF) and loads the animated original even for the grid
+        // thumbnail request, where the preview thumb's type is WebP.
+        payloadContentType = descriptor.contentType,
         keyHeader = KeyHeader(iv = ivBytes, aesKey = keyHeader.aesKey),
     )
 }

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/vault/VaultEntryImageDataTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/vault/VaultEntryImageDataTest.kt
@@ -119,4 +119,24 @@ class VaultEntryImageDataTest {
 
         assertNull(entry.imageDataFor(descriptor, loadFullPayload = true))
     }
+
+    @Test
+    fun `threads the descriptor content type as the payload content type`() {
+        // A GIF's preview thumbnail is a tiny WebP, so the only way the loader
+        // can tell it is a thumbless format is the real payload content type
+        // carried here. Without it the grid thumbnail request would chase a
+        // server thumbnail that was never generated for a GIF (NotFound).
+        val entry = vaultEntry()
+        val descriptor = PayloadDescriptor(
+            key = "vlt_pg_00",
+            contentType = "image/gif",
+            iv = Base64.encode(ByteArray(16)),
+        )
+
+        val data = assertNotNull(entry.imageDataFor(descriptor, loadFullPayload = false))
+
+        assertEquals("image/gif", data.payloadContentType)
+        // effectiveContentType prefers the payload type over the (absent) preview.
+        assertEquals("image/gif", data.effectiveContentType)
+    }
 }


### PR DESCRIPTION
## Problem

Animated GIFs render fine on upload and while the local file is present, and fine in the full-screen viewer, but an **inline chat-bubble GIF loaded from REMOTE** showed a Coil error (blurred placeholder + ⚠️ triangle) on Android. Desktop/iOS (skiko) were unaffected.

## Captured evidence (device: Redmi Note 5 Pro, `id.homebase.feed.debug`)

The on-device Kermit log showed the failure firing on every view of the affected conversation:

```
2026-06-06T17:34:18.942Z Warn: (HomebaseImageLoader) Non-retriable exception:
  thumb load failed drive=9ff813af-… file=b8dce919-… key=chat_web0
  size=948x451 lastMod=1780763822954 cause=NotFoundException
```

22 such `thumb load failed … cause=NotFoundException` entries for the same GIF payload (`key=chat_web0`), repeating across the day (16:43 → 17:34). The same file's upload had succeeded earlier (`DriveOutboxUploader uploadNewFile: success … fileId=b8dce919-…`), confirming the upload-then-remote pattern: fine on upload, error on the later remote thumbnail fetch.

## Root cause (confirmed)

A GIF ships a tiny **WebP** preview thumbnail and **zero** server thumbnails (`ThumbnailGenerator`: GIF branch sets `EmbeddedThumb.contentType = "image/webp"` and returns `emptyList()` for additional thumbnails — N=0). On the receiver, `HomebaseImageData.contentTypeHint` reads the preview thumb's type, so it is `"image/webp"`, not `"image/gif"`.

`HomebaseImageLoader.loadThumbnail` decided whether to bypass the server-thumbnail fetch via `contentTypeHint in THUMBLESS_CONTENT_TYPES` (`{"image/gif"}`). For a GIF this was `false` → it called `getThumbBytesDecrypted` → the server has no thumbnail for a GIF → `NotFoundException` → error triangle. (Full-screen worked because it sets `loadFullPayload = true`, skipping `loadThumbnail` entirely.)

## Fix

Carry the **real payload content type** alongside the preview-thumb type and use it for the thumbless decision:

- `HomebaseImageData`: new `payloadContentType` field + computed `effectiveContentType = payloadContentType ?: contentTypeHint`. Non-GIF callers that only set a preview thumb keep their existing behaviour (fallback to `contentTypeHint`), so JPEG/PNG/WebP/SVG paths are unchanged.
- `HomebaseImageLoader.loadThumbnail`: THUMBLESS check now uses `effectiveContentType`. For a GIF this is `"image/gif"` → takes the `loadFullPayload` branch → the animated original renders inline; the fetcher returns the payload's real `image/gif` mime to Coil's GIF decoder.
- Threaded `payloadContentType` at the call sites that build a thumbnail-bound `HomebaseImageData` for content that can be a GIF: `MediaItem` (inline chat bubble — the reported bug), `VaultEntry.imageDataFor` (vault grid / single source of truth), `FullScreenMediaViewer` gallery rail thumbnail, and `InlineReplyPreview` (reply to a GIF).

Dependency-free change (the Android GIF decoder was already registered in #663).

## Tests

- `HomebaseImageLoaderTest` (homebase-common jvmTest, 12 tests): `effectiveContentType` prefers `payloadContentType` over the WebP preview and is in `THUMBLESS_CONTENT_TYPES`; falls back to `contentTypeHint` (and a raster stays non-thumbless, no regression); null when neither is set.
- `VaultEntryImageDataTest` (homebase-core jvmTest, 5 tests): `imageDataFor` threads the descriptor's `contentType` as `payloadContentType`.

## Verification

- Compile-checked the touched modules (`homebase-common`, `homebase-chat`, `homebase-core`) on **JVM**, **Android** (`compileAndroidMain`), and **iOS** (`compileKotlinIosSimulatorArm64`) — all BUILD SUCCESSFUL.
- `homebase-chat:jvmTest` + `homebase-common:jvmTest` (incl. the Konsist `ArchitectureTest`) pass.
- **Device:** built + installed this branch as `id.homebase.feed.debug` on the Redmi Note 5 Pro, re-opened the conversation that previously errored. **Zero** new `HomebaseImageLoader` NotFound errors after install, and the inline GIF **animates** in the bubble (consecutive screencaps show distinct GIF frames) with no error triangle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)