### PR TITLE
Fix static image previews broken on Desktop/iOS (skia decoder claimed WebP thumbnails)

### DIFF
--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/image/AnimatedSkiaDecoderTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/image/AnimatedSkiaDecoderTest.kt
@@ -80,10 +80,10 @@ class AnimatedSkiaDecoderTest {
         assertFalse(isAnimatableSource(sourceResult(png, mimeType = null)))
     }
 
-    // --- Factory ---
+    // --- Factory: claims only genuinely multi-frame sources ---
 
     @Test
-    fun `factory returns decoder for gif source`() {
+    fun `factory returns decoder for multi-frame gif`() {
         val gif = Base64.decode(ANIMATED_GIF_2_FRAMES)
         assertNotNull(factory.create(sourceResult(gif, "image/gif"), options, imageLoader))
     }
@@ -93,32 +93,43 @@ class AnimatedSkiaDecoderTest {
         assertNull(factory.create(sourceResult(ByteArray(16), "image/jpeg"), options, imageLoader))
     }
 
-    // --- decode(): animated vs static ---
+    @Test
+    fun `factory returns null for single-frame gif so coil falls back to static decoder`() {
+        // A null from create() makes Coil try the next factory (its default static
+        // Skia decoder). A null from decode() would NOT — it fails the load. That
+        // is why the multi-frame gate lives in create(), not decode().
+        val gif = Base64.decode(STATIC_GIF_1_FRAME)
+        assertNull(factory.create(sourceResult(gif, "image/gif"), options, imageLoader))
+    }
+
+    @Test
+    fun `factory returns null for single-frame source claimed via webp mime`() {
+        // Regression guard: WebP preview thumbnails (every image ships one) arrive
+        // with mimeType image/webp, so isAnimatableSource claims them. A static one
+        // must still make create() return null so the default decoder renders it —
+        // otherwise all image previews break on Desktop/iOS (full payloads, which
+        // are JPEG/PNG and never claimed here, kept working — the exact symptom).
+        val staticSingleFrame = Base64.decode(STATIC_GIF_1_FRAME)
+        assertNull(factory.create(sourceResult(staticSingleFrame, "image/webp"), options, imageLoader))
+    }
+
+    @Test
+    fun `factory returns null for empty bytes`() {
+        assertNull(factory.create(sourceResult(ByteArray(0), "image/gif"), options, imageLoader))
+    }
+
+    // --- decode(): the chosen (multi-frame) decoder always returns an image ---
 
     @Test
     fun `decode returns animating image for multi-frame gif`() = runTest {
         val gif = Base64.decode(ANIMATED_GIF_2_FRAMES)
-        val decoder = AnimatedSkiaDecoder(sourceResult(gif, "image/gif").source, options)
-        val result = decoder.decode()
-        assertNotNull(result, "multi-frame GIF should decode")
-        val image = result.image
+        val decoder = factory.create(sourceResult(gif, "image/gif"), options, imageLoader)
+        assertNotNull(decoder, "multi-frame GIF should be claimed by the factory")
+        val image = assertNotNull(decoder.decode()).image
         assertTrue(image is SkiaAnimatedImage, "expected SkiaAnimatedImage, got ${image::class}")
         assertTrue(image.animatable, "2-frame GIF must be animatable")
         assertEquals(2, image.width)
         assertEquals(1, image.height)
-    }
-
-    @Test
-    fun `decode returns null for single-frame gif so coil falls back to static decoder`() = runTest {
-        val gif = Base64.decode(STATIC_GIF_1_FRAME)
-        val decoder = AnimatedSkiaDecoder(sourceResult(gif, "image/gif").source, options)
-        assertNull(decoder.decode(), "single-frame GIF must defer to default Skia decoder")
-    }
-
-    @Test
-    fun `decode returns null for empty bytes`() = runTest {
-        val decoder = AnimatedSkiaDecoder(sourceResult(ByteArray(0), "image/gif").source, options)
-        assertNull(decoder.decode())
     }
 
     // --- frame timeline math (frameForElapsed) ---
@@ -126,8 +137,8 @@ class AnimatedSkiaDecoderTest {
     @Test
     fun `frameForElapsed maps elapsed time across frames and loops`() = runTest {
         val gif = Base64.decode(ANIMATED_GIF_2_FRAMES)
-        val image = AnimatedSkiaDecoder(sourceResult(gif, "image/gif").source, options)
-            .decode()!!.image as SkiaAnimatedImage
+        val decoder = factory.create(sourceResult(gif, "image/gif"), options, imageLoader)!!
+        val image = assertNotNull(decoder.decode()).image as SkiaAnimatedImage
 
         // Frame 0 spans [0,500), frame 1 spans [500,1250); loops forever.
         assertEquals(0, image.frameForElapsed(0))

--- a/homebase-common/src/skiaMain/kotlin/id/homebase/core/image/AnimatedSkiaDecoder.kt
+++ b/homebase-common/src/skiaMain/kotlin/id/homebase/core/image/AnimatedSkiaDecoder.kt
@@ -4,10 +4,8 @@ import co.touchlab.kermit.Logger
 import coil3.ImageLoader
 import coil3.decode.DecodeResult
 import coil3.decode.Decoder
-import coil3.decode.ImageSource
 import coil3.fetch.SourceFetchResult
 import coil3.request.Options
-import okio.use
 import org.jetbrains.skia.Codec
 import org.jetbrains.skia.Data
 
@@ -25,45 +23,39 @@ import org.jetbrains.skia.Data
  * already-decrypted payload bytes Coil hands it and returns an animating
  * [coil3.Image]. It does not fetch, decrypt, or cache anything itself.
  *
- * Single-frame GIFs/WebP return null from [decode] so Coil falls through to its
- * default (static) Skia decoder — the static path is left completely unchanged.
+ * The animated-vs-static decision is made in [Factory.create], not in [decode]:
+ * create() parses the Skia [Codec] up front and returns this decoder ONLY for a
+ * genuinely multi-frame GIF/WebP. Single-frame GIF/WebP — crucially including
+ * the static WebP *preview thumbnail* that every image ships (server thumbnails
+ * are always WebP) — make create() return null, so Coil falls through to its
+ * default (static) Skia decoder.
+ *
+ * Why the check MUST live in create() and not decode(): a null from a
+ * Decoder.Factory.create() makes Coil try the next factory (fall through to the
+ * default decoder); a null from a *chosen* Decoder.decode() does NOT fall
+ * through — Coil treats it as a decode failure and the image breaks. Returning
+ * null from decode() for static WebP thumbnails was exactly that bug — all image
+ * previews broke on Desktop/iOS, while full JPEG/PNG payloads (never claimed
+ * here) kept working.
  */
 class AnimatedSkiaDecoder(
-    private val source: ImageSource,
-    private val options: Options,
+    private val codec: Codec,
 ) : Decoder {
 
-    override suspend fun decode(): DecodeResult? {
-        val bytes = source.source().use { it.readByteArray() }
-        if (bytes.isEmpty()) return null
-
-        val codec = try {
-            Codec.makeFromData(Data.makeFromBytes(bytes))
-        } catch (e: Throwable) {
-            // Not decodable as an animated container — let the default decoder try.
-            Logger.d(tag = TAG) { "Codec.makeFromData failed (${bytes.size} bytes): ${e.message}" }
-            return null
-        }
-
+    override suspend fun decode(): DecodeResult {
+        // codec is guaranteed multi-frame here (Factory.create only returns this
+        // decoder when frameCount > 1). SkiaAnimatedImage takes ownership of the
+        // codec and closes it when it is itself closed.
         val frameCount = codec.frameCount
-        if (frameCount <= 1) {
-            // Static GIF/WebP — defer to Coil's default Skia decoder unchanged.
-            codec.close()
-            return null
-        }
-
         val framesInfo = codec.framesInfo
         val durations = IntArray(frameCount) { i -> framesInfo.getOrNull(i)?.duration ?: 0 }
         val required = IntArray(frameCount) { i ->
             // skiko reports the index of the frame this one composites onto, or a
-            // negative sentinel for a standalone keyframe. Normalize anything
-            // out of range to -1 (keyframe / decode standalone).
+            // negative sentinel for a standalone keyframe. Normalize anything out
+            // of range to -1 (keyframe / decode standalone).
             val r = framesInfo.getOrNull(i)?.requiredFrame ?: -1
             if (r in 0 until frameCount) r else -1
         }
-
-        // codec keeps ownership of the underlying frames; SkiaAnimatedImage owns
-        // codec from here and closes it when it is itself closed.
         val image = SkiaAnimatedImage(
             codec = codec,
             frameDurationsMs = durations,
@@ -81,8 +73,36 @@ class AnimatedSkiaDecoder(
             options: Options,
             imageLoader: ImageLoader,
         ): Decoder? {
+            // Cheap container sniff first — never parse JPEG/PNG/HEIC.
             if (!isAnimatableSource(result)) return null
-            return AnimatedSkiaDecoder(result.source, options)
+
+            // Read the bytes WITHOUT consuming the source (peek), so that if this
+            // turns out to be static we can decline and Coil's default decoder
+            // still has the full source to read.
+            val bytes = try {
+                result.source.source().peek().readByteArray()
+            } catch (e: Throwable) {
+                Logger.d(tag = TAG) { "peek read failed: ${e.message}" }
+                return null
+            }
+            if (bytes.isEmpty()) return null
+
+            val codec = try {
+                Codec.makeFromData(Data.makeFromBytes(bytes))
+            } catch (e: Throwable) {
+                // Not decodable as an animated container — let the default decoder try.
+                Logger.d(tag = TAG) { "Codec.makeFromData failed (${bytes.size} bytes): ${e.message}" }
+                return null
+            }
+
+            // Single-frame GIF/WebP (incl. every static WebP preview thumbnail):
+            // decline so Coil falls through to its default static Skia decoder.
+            // Only genuinely animated sources are claimed by this decoder.
+            if (codec.frameCount <= 1) {
+                codec.close()
+                return null
+            }
+            return AnimatedSkiaDecoder(codec)
         }
     }
 


### PR DESCRIPTION
## Symptom
After the GIF PRs, **all static image previews broke on Desktop and iOS** (chat bubbles + vault grid), while **full-screen payloads worked** and **Android was fine**.

## Root cause
`AnimatedSkiaDecoder` (the skia animated decoder from #666, used on Desktop/iOS/Web) registers a `Decoder.Factory` whose `create()` claims any source `isAnimatableSource` accepts — which returns `true` for **`image/webp`**. **Every server thumbnail is WebP.** For a *static* WebP the decoder's `decode()` returned `null`, on the assumption Coil would fall back to its default decoder.

It does not. **Coil3 only falls through when a `Decoder.Factory.create()` returns null; a `null` from a *chosen* decoder's `decode()` is a decode failure.** So every static WebP preview thumbnail failed to render on the skia targets. Full JPEG/PNG payloads were never claimed (`isAnimatableSource` is false for them), so they kept working; Android uses coil-gif, so it was unaffected — exactly the observed pattern.

## Fix
Move the multi-frame gate into `Factory.create()`: peek the bytes (non-consuming), parse the Skia `Codec`, and return `AnimatedSkiaDecoder` **only when `frameCount > 1`**. Static/undecodable sources make `create()` return null, so Coil correctly falls through to its default static Skia decoder. `decode()` now always returns a non-null `DecodeResult`.

## Verification
- `homebase-common:jvmTest` `AnimatedSkiaDecoderTest` passes, including a new regression guard: a single-frame source claimed via `image/webp` mime → `create()` returns null (the thumbnail case).
- Compiles on JVM (skia); iOS simulator compile confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)