### PR TITLE
Contain & attribute uncaught coroutine network crashes

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -39,6 +39,11 @@ android {
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
+            // Our GlobalCoroutineExceptionHandler is registered via a ServiceLoader
+            // file at this path, which collides with the one kotlinx-coroutines-android
+            // ships (AndroidExceptionPreHandler). Concatenate them so BOTH handlers
+            // survive packaging instead of one silently winning the merge.
+            merges += "META-INF/services/kotlinx.coroutines.CoroutineExceptionHandler"
         }
     }
 

--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -34,3 +34,8 @@
 # Play Core
 -keep class com.google.android.play.core.** { *; }
 -dontwarn com.google.android.play.core.**
+
+# Global coroutine exception handler — instantiated by fully-qualified name via
+# ServiceLoader (META-INF/services/kotlinx.coroutines.CoroutineExceptionHandler),
+# so R8 must neither rename nor strip it.
+-keep class id.homebase.feed.GlobalCoroutineExceptionHandler { *; }

--- a/androidApp/src/main/kotlin/id/homebase/feed/GlobalCoroutineExceptionHandler.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/GlobalCoroutineExceptionHandler.kt
@@ -1,0 +1,59 @@
+package id.homebase.feed
+
+import co.touchlab.kermit.Logger
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import id.homebase.api.coroutines.COROUTINE_CRASH_TAG
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineName
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Global, ServiceLoader-registered catch-all for coroutines launched on a scope
+ * with NO local [CoroutineExceptionHandler] (e.g. a `viewModelScope`, or any
+ * scope we haven't given the shared `loggingExceptionHandler`). kotlinx invokes
+ * every ServiceLoader-registered handler for those cases.
+ *
+ * IMPORTANT: a global handler CANNOT stop the process kill — after it runs,
+ * kotlinx still forwards the exception to the thread's uncaught handler. Its sole
+ * job is to make the otherwise unattributable crash report useful: a suspended
+ * network call's stack is pure `okhttp3` with no app frames, so we stamp
+ * Crashlytics custom keys with the offending coroutine name + thread (set just
+ * before the fatal is recorded, so they land on that report) and log the stack.
+ *
+ * Scopes that carry the shared `loggingExceptionHandler` never reach here — a
+ * handler present in the coroutine's own context short-circuits the global path.
+ *
+ * Wiring: registered via
+ * `META-INF/services/kotlinx.coroutines.CoroutineExceptionHandler` and kept from
+ * R8 by a `-keep` rule in `proguard-rules.pro` (ServiceLoader instantiates it by
+ * fully-qualified name, so it must not be renamed or stripped).
+ */
+class GlobalCoroutineExceptionHandler : CoroutineExceptionHandler {
+    override val key = CoroutineExceptionHandler
+
+    override fun handleException(context: CoroutineContext, exception: Throwable) {
+        val coroutineName = context[CoroutineName]?.name ?: "unnamed"
+        val thread = Thread.currentThread().name
+
+        try {
+            FirebaseCrashlytics.getInstance().apply {
+                setCustomKey("uncaught_coroutine_scope", coroutineName)
+                setCustomKey("uncaught_coroutine_thread", thread)
+            }
+        } catch (_: Throwable) {
+            // Crashlytics not initialized / collection disabled — reporting must
+            // never itself throw out of an exception handler.
+        }
+
+        // Log the stack as TEXT (not via the `throwable` parameter) so this is
+        // not also recorded as a Crashlytics non-fatal by CrashlyticsLogWriter —
+        // the fatal is captured by Firebase's native uncaught handler, and the
+        // custom keys above attribute it. Same rationale as CrashLogger.
+        Logger.e(tag = COROUTINE_CRASH_TAG) {
+            "Uncaught coroutine exception (no local handler) coroutine='$coroutineName' " +
+                "thread='$thread' — process will terminate; custom keys " +
+                "uncaught_coroutine_scope/_thread are stamped on the fatal report.\n" +
+                exception.stackTraceToString()
+        }
+    }
+}

--- a/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
@@ -33,9 +33,7 @@ import id.homebase.core.settings.UserPreferences
 import id.homebase.chat.services.convo.ConversationStream
 import id.homebase.feed.share.ShareShortcutAvatarLoader
 import id.homebase.feed.share.ShareShortcutPublisher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
+import id.homebase.api.coroutines.supervisedScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.io.files.Path
@@ -164,7 +162,7 @@ class MainApplication : Application(), KoinComponent {
         })
     }
 
-    private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val appScope = supervisedScope("android-app")
 
     private fun initShareShortcuts() {
         val conversationStream = get<ConversationStream>()

--- a/androidApp/src/main/resources/META-INF/services/kotlinx.coroutines.CoroutineExceptionHandler
+++ b/androidApp/src/main/resources/META-INF/services/kotlinx.coroutines.CoroutineExceptionHandler
@@ -1,0 +1,1 @@
+id.homebase.feed.GlobalCoroutineExceptionHandler

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/HttpClientProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/HttpClientProvider.kt
@@ -1,15 +1,36 @@
 package id.homebase.api.client
 
+import co.touchlab.kermit.Logger
 import id.homebase.api.serialization.OdinSystemSerializer
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.api.createClientPlugin
 import io.ktor.client.plugins.compression.ContentEncoding
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 
+/**
+ * Emits one Kermit Info line per outbound request (host + path only — the query
+ * string is omitted because it can carry tokens/IDs). The installed
+ * `CrashlyticsLogWriter` mirrors Info logs as Crashlytics breadcrumbs, so the
+ * last few HTTP requests appear in the "Logs" section of any crash report. This
+ * is the attribution we lacked for the `UnknownHostException` crash: a suspended
+ * network call's stack has no app frames, so without this breadcrumb the report
+ * could not say which endpoint/host was in flight.
+ */
+internal val HttpBreadcrumbPlugin = createClientPlugin("HttpBreadcrumb") {
+    onRequest { request, _ ->
+        Logger.i(tag = "HttpIO") {
+            "→ ${request.method.value} ${request.url.host}${request.url.encodedPathSegments.joinToString("/")}"
+        }
+    }
+}
+
 object HttpClientProvider {
     fun create(): HttpClient {
         return HttpClient {
+            install(HttpBreadcrumbPlugin)
+
             install(ContentNegotiation) {
                 json(OdinSystemSerializer.json)
             }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/coroutines/CoroutineExceptionHandlers.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/coroutines/CoroutineExceptionHandlers.kt
@@ -1,0 +1,56 @@
+package id.homebase.api.coroutines
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+
+const val COROUTINE_CRASH_TAG = "CoroutineCrash"
+
+/**
+ * Shared fallback [CoroutineExceptionHandler] for app-created scopes.
+ *
+ * A coroutine that fails on a scope WITHOUT a handler routes its exception to
+ * the thread's uncaught handler and kills the process. The recurring shape of
+ * that crash here is a transient `UnknownHostException` (dropped network /
+ * unreachable identity host) escaping an outbound Ktor call — a condition we
+ * never want to be fatal. This handler turns it into a logged, non-fatal event:
+ * the scope's other children keep running.
+ *
+ * It logs via Kermit WITH the throwable, which — through the installed
+ * `CrashlyticsLogWriter` — both writes the stack to `homebase.log` AND records a
+ * Crashlytics non-fatal. Crucially, the async stack of a suspended network call
+ * has NO app frames (the caller already suspended), so [scopeLabel] and any
+ * [CoroutineName] on the failing coroutine are what actually attribute the
+ * failure to a subsystem in the dashboard. Name your scopes.
+ */
+fun loggingExceptionHandler(scopeLabel: String): CoroutineExceptionHandler =
+    CoroutineExceptionHandler { context, throwable ->
+        val coroutineName = context[CoroutineName]?.name
+        Logger.e(throwable = throwable, tag = COROUTINE_CRASH_TAG) {
+            buildString {
+                append("Uncaught coroutine exception isolated by fallback handler (scope='")
+                append(scopeLabel).append('\'')
+                if (coroutineName != null) append(" coroutine='").append(coroutineName).append('\'')
+                append("). Not fatal — the scope's other children keep running.")
+            }
+        }
+    }
+
+/**
+ * Creates a [CoroutineScope] with the standard app shape: a [SupervisorJob] (one
+ * child's failure doesn't cancel its siblings), a [CoroutineName] for crash
+ * attribution, and the shared [loggingExceptionHandler] so a missing local
+ * handler can't escalate a transient failure into a process kill.
+ *
+ * Prefer this over a bare `CoroutineScope(SupervisorJob() + dispatcher)` for any
+ * long-lived, app-owned background scope.
+ */
+fun supervisedScope(
+    label: String,
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+): CoroutineScope =
+    CoroutineScope(SupervisorJob() + dispatcher + CoroutineName(label) + loggingExceptionHandler(label))

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
@@ -15,12 +15,11 @@ import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.sync.database.CursorStorage
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.MainIndexMetaHelpers
+import id.homebase.api.coroutines.supervisedScope
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -40,7 +39,7 @@ class DriveSync(
     private val policy: DriveSyncPolicy = DriveSyncPolicy(),
 ) {
     // Background work is Network and DB bound, so using IO
-    private val scope = scope ?: CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val scope = scope ?: supervisedScope("drive-sync")
     private var cursor: QueryBatchCursor?
     private val mutex = Mutex()
     private var batchSize = 500 // Balanced starting point

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveWebSocketUpsertWorker.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveWebSocketUpsertWorker.kt
@@ -6,11 +6,10 @@ import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.MainIndexMetaHelpers
+import id.homebase.api.coroutines.supervisedScope
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -55,7 +54,7 @@ class DriveWebSocketUpsertWorker(
     scope: CoroutineScope? = null,
 ) {
     // Network/DB-bound work. Same dispatcher choice as DriveSync.
-    private val scope = scope ?: CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val scope = scope ?: supervisedScope("ws-upsert-worker")
 
     private val mutex = Mutex()
     private var job: Job? = null

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
@@ -20,13 +20,13 @@ import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.coroutines.ioDispatcher
+import id.homebase.api.coroutines.supervisedScope
 import id.homebase.api.crypto.toUtf8ByteArray
 import id.homebase.api.serialization.OdinSystemSerializer
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.sync.*
 import kotlin.uuid.Uuid
 
@@ -55,7 +55,7 @@ class OutboxSync(
     scope: CoroutineScope? = null
 ) {
     // The threads use the DB & Network, so we use the IO dispatcher
-    private val scope = scope ?: CoroutineScope(SupervisorJob() + ioDispatcher)
+    private val scope = scope ?: supervisedScope("outbox-sync", ioDispatcher)
     @kotlin.concurrent.Volatile
     private var isOnline = false
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPreloadService.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPreloadService.kt
@@ -1,8 +1,6 @@
 package id.homebase.api.video
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
+import id.homebase.api.coroutines.supervisedScope
 import kotlinx.coroutines.launch
 
 /**
@@ -17,7 +15,7 @@ import kotlinx.coroutines.launch
 class VideoPreloadService(
     private val videoPreloader: VideoPreloader,
 ) {
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val scope = supervisedScope("video-preload")
 
     /** Schedule a background preload. Returns immediately. Safe to call repeatedly for the
      *  same (fileId, payloadKey) — duplicate in-flight calls serialize on the preloader's mutex,

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/coroutines/CoroutineExceptionHandlersTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/coroutines/CoroutineExceptionHandlersTest.kt
@@ -1,0 +1,133 @@
+package id.homebase.api.coroutines
+
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Severity
+import co.touchlab.kermit.platformLogWriter
+import id.homebase.api.client.HttpBreadcrumbPlugin
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import java.net.UnknownHostException
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * What these tests prove, in plain terms:
+ *
+ *  - A background coroutine that fails with the exact error that crashed the app
+ *    in the wild (`UnknownHostException`, a dropped-network DNS failure) is now
+ *    CONTAINED by [supervisedScope]'s fallback handler instead of killing the
+ *    process — and its sibling coroutines keep running.
+ *  - When it's contained, the failure is LOGGED with the scope name and the
+ *    original throwable, which is the attribution Crashlytics relies on (the
+ *    async stack of a suspended network call has no app frames of its own).
+ *  - The per-request HTTP breadcrumb names the host + path but NEVER the query
+ *    string (which can carry the shared secret / tokens).
+ *
+ * The only part of the crash-handling change NOT covered here is the Android
+ * `ServiceLoader` global handler + R8 packaging — that only proves out in a real
+ * APK and was verified by inspecting the merged `base.jar`.
+ */
+class CoroutineExceptionHandlersTest {
+
+    private val logCollector = CollectingLogWriter()
+
+    @BeforeTest
+    fun setUp() {
+        Logger.setLogWriters(listOf(logCollector))
+    }
+
+    @AfterTest
+    fun tearDown() {
+        // Restore Kermit's global writer — this is process-wide shared state.
+        Logger.setLogWriters(listOf(platformLogWriter()))
+    }
+
+    @Test
+    fun aThrowingChildIsContained_andSiblingsKeepRunning() = runTest {
+        val scope = supervisedScope("test-sync", StandardTestDispatcher(testScheduler))
+
+        var siblingCompleted = false
+        // One child blows up with the real-world crash.
+        scope.launch { throw UnknownHostException("shelly.silberberg.dk") }
+        // A sibling on the SAME scope must still run to completion — proving the
+        // failure was isolated, not propagated to tear the scope (and process) down.
+        scope.launch { siblingCompleted = true }
+
+        advanceUntilIdle()
+
+        assertTrue(siblingCompleted, "a sibling must survive another child's crash")
+        assertTrue(scope.isActive, "the scope must stay alive after an isolated child failure")
+    }
+
+    @Test
+    fun theFallbackHandlerLogsTheThrowableWithScopeName_forCrashlyticsAttribution() = runTest {
+        val scope = supervisedScope("drive-sync", StandardTestDispatcher(testScheduler))
+
+        scope.launch { throw UnknownHostException("shelly.silberberg.dk") }
+        advanceUntilIdle()
+
+        val errors = logCollector.entries.filter {
+            it.severity == Severity.Error && it.tag == COROUTINE_CRASH_TAG
+        }
+        assertEquals(1, errors.size, "exactly one error should be logged for the one failure")
+        val entry = errors.single()
+        // The scope label is the attribution we depend on in the crash report.
+        assertTrue(
+            entry.message.contains("drive-sync"),
+            "the log must name the offending scope; was: ${entry.message}",
+        )
+        // The throwable is attached so CrashlyticsLogWriter records it as a non-fatal
+        // (with a stack) rather than it vanishing into the text log.
+        assertTrue(
+            entry.throwable is UnknownHostException,
+            "the original throwable must be attached; was: ${entry.throwable}",
+        )
+    }
+
+    @Test
+    fun httpBreadcrumbLogsMethodHostAndPath_butNeverTheQueryString() = runTest {
+        val client = HttpClient(MockEngine { respond("ok", HttpStatusCode.OK) }) {
+            install(HttpBreadcrumbPlugin)
+        }
+
+        client.get("https://shelly.silberberg.dk/api/v2/drive/query?ss=SUPERSECRET&token=PII")
+
+        val breadcrumbs = logCollector.entries.filter { it.tag == "HttpIO" }.map { it.message }
+        assertEquals(1, breadcrumbs.size, "one breadcrumb per request")
+        val line = breadcrumbs.single()
+        assertTrue(line.contains("GET"), "method should be present; was: $line")
+        assertTrue(
+            line.contains("shelly.silberberg.dk/api/v2/drive/query"),
+            "host + path should be present; was: $line",
+        )
+        assertFalse(
+            line.contains("SUPERSECRET"),
+            "the query string can carry the shared secret and MUST be stripped; was: $line",
+        )
+        assertFalse(line.contains("token"), "no query params in the breadcrumb; was: $line")
+    }
+}
+
+/** Kermit [LogWriter] that captures entries for assertions. */
+private class CollectingLogWriter : LogWriter() {
+    data class Entry(val severity: Severity, val tag: String, val message: String, val throwable: Throwable?)
+
+    val entries: MutableList<Entry> = mutableListOf()
+
+    override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
+        entries += Entry(severity, tag, message, throwable)
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
@@ -5,14 +5,12 @@ import id.homebase.api.client.NotFoundException
 import id.homebase.api.client.RetryConfig
 import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.client.withRetry
+import id.homebase.api.coroutines.supervisedScope
 import id.homebase.api.file.FileOperationsProvider
 import id.homebase.core.clipboard.platformFileFromPath
 import io.github.vinceglb.filekit.extension
 import io.github.vinceglb.filekit.mimeType
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlin.uuid.Uuid
 
@@ -46,7 +44,7 @@ class HomebaseImageLoader(
     // Durable scope hosting full-payload loads so a cancelled caller (e.g. a
     // prefetch whose grid item left composition) does not abort a load that
     // other callers are awaiting.
-    private val cacheScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val cacheScope = supervisedScope("image-loader")
     private val fullPayloadCache = FullPayloadByteCache(
         maxBytes = MAX_FULL_PAYLOAD_CACHE_BYTES,
         scope = cacheScope,

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/DriveRegistry.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/DriveRegistry.kt
@@ -19,14 +19,13 @@ import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.crypto.ByteArrayUtil
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.coroutines.supervisedScope
 import id.homebase.core.config.LabeledDrive
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -78,11 +77,13 @@ class DriveRegistry(
     private val uploadFile: suspend (UploadFileRequest) -> Unit,
     private val updateFileByUniqueId: suspend (UpdateFileByUniqueIdRequest) -> Unit,
     private val eventBus: EventBus,
-    // Scope for the BatchReceived observer. Defaults to a fresh Default-dispatched scope
-    // with a SupervisorJob, so an observer crash doesn't take down the process. Tests pass
-    // `backgroundScope` from `runTest` so virtual-time helpers (advanceUntilIdle) see the
-    // observer coroutine.
-    private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob()),
+    // Scope for the BatchReceived observer. Defaults to a named, supervised scope whose
+    // fallback CoroutineExceptionHandler keeps an observer crash (e.g. a transient
+    // network error) from taking down the process — the SupervisorJob alone wouldn't
+    // (it only stops siblings cancelling; an uncaught child still reaches the thread's
+    // uncaught handler). Tests pass `backgroundScope` from `runTest` so virtual-time
+    // helpers (advanceUntilIdle) see the observer coroutine.
+    private val scope: CoroutineScope = supervisedScope("drive-registry"),
 ) {
     private val stateMutex = Mutex()
     private var observerJob: Job? = null


### PR DESCRIPTION
## Problem

Crashlytics reported a fatal `java.net.UnknownHostException: Unable to resolve host "…"` — a routine dropped-network / unreachable-identity-host DNS failure on an outbound Ktor call. Two things made it bad:

1. **It was fatal.** The network layer (`OdinApiProviderBase.request()`, `PublicProfileProviderCached.getCached()`) propagates network exceptions to callers by design. When such a call runs in a fire-and-forget coroutine on a scope **without** a `CoroutineExceptionHandler` (a `SupervisorJob` alone does *not* stop this — an uncaught child still reaches the thread's uncaught handler), the process is killed. The app relied on per-caller discipline plus two CEH-protected scopes; a few hand-rolled background scopes slipped through.
2. **The report was unattributable.** A suspended network call's exception stack is pure `okhttp3` with **zero app frames** (the caller already suspended), so the report couldn't say who made the call or to which endpoint.

## What this changes

**Containment (prevents the kill)**
- New shared `loggingExceptionHandler(label)` + `supervisedScope(label, dispatcher)` in `homebase-api/coroutines`. The handler logs the throwable (which, via the existing `CrashlyticsLogWriter`, also records an *attributed* Crashlytics non-fatal) instead of letting it crash.
- Applied to the hand-rolled background scopes that lacked a handler: `MainApplication.appScope`, `DriveSync`, `OutboxSync`, `DriveWebSocketUpsertWorker`, `VideoPreloadService`, `HomebaseImageLoader`, `DriveRegistry`. Each scope is now also `CoroutineName`-tagged for attribution.

**Attribution (makes the next report useful)**
- A one-line Ktor client plugin emits a breadcrumb per request — `→ GET host/path`, **query string stripped** (it can carry the shared secret/tokens). The installed `CrashlyticsLogWriter` mirrors it as a breadcrumb, so the last few in-flight requests show up in every crash report's Logs.
- `GlobalCoroutineExceptionHandler` (Android, ServiceLoader-registered) catches any coroutine on a scope that *still* has no local handler (e.g. a `viewModelScope`) and stamps `uncaught_coroutine_scope` + `uncaught_coroutine_thread` as Crashlytics custom keys before the unavoidable kill. It can't prevent that kill (kotlinx forwards to the thread handler afterward) — its job is purely to attribute it.

### Note on the ServiceLoader file
`kotlinx-coroutines-android` ships a services file at the same path, so I added a `packaging { resources { merges += … } }` rule to concatenate them (verified the merged `base.jar` lists **both** handlers) and a `-keep` rule so R8 doesn't strip our handler.

## Tests

`CoroutineExceptionHandlersTest` (jvmTest, 3 tests, passing):
- a throwing child (real `UnknownHostException`) is contained — its sibling completes and the scope stays alive;
- the fallback handler logs the throwable with the scope name (the attribution we depend on);
- the HTTP breadcrumb logs host + path but **never** the query string.

The only part not unit-testable is the Android ServiceLoader/R8 packaging — that was verified by inspecting the merged jar.

## Risk

Low. Changes are additive (a fallback handler + breadcrumb + custom keys). The converted scopes only changed their *default* scope (the `?: scope` fallback) and gained protection; the sync engine already caught its own network errors, so these handlers are backstops. One deliberate visibility tweak: the breadcrumb plugin is `internal` (was `private`) so it can be tested. Compiles on JVM/Android/wasmJs; `homebase-api` + `homebase-common` JVM test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)