### PR TITLE
Honest upload % via payload-relative socket send-buffer cap

### DIFF
--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/client/UploadHttpClientFactory.android.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/client/UploadHttpClientFactory.android.kt
@@ -1,0 +1,53 @@
+package id.homebase.api.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import java.net.InetAddress
+import java.net.Socket
+import javax.net.SocketFactory
+
+/**
+ * Delegating [SocketFactory] that caps each socket's `SO_SNDBUF` to [sendBufferBytes].
+ *
+ * OkHttp opens connections via the no-arg [createSocket] (an *unconnected* socket it then
+ * connects), so setting the send buffer there applies **pre-connect** — required to influence
+ * TCP window-scaling negotiation, and it disables Linux send-buffer autotuning for that socket
+ * (which is exactly what forces the backpressure that makes Ktor's `onUpload` track the wire).
+ * The connected overloads are delegated and set defensively even though OkHttp doesn't use them.
+ *
+ * `setSendBufferSize` is a hint the kernel clamps to `net.core.wmem_max` (>= 4 MiB on Android),
+ * so the [UploadHttpClientPool] range (64 KiB..2 MiB) is honored.
+ */
+private class SndBufSocketFactory(
+    private val sendBufferBytes: Int,
+    private val delegate: SocketFactory = SocketFactory.getDefault(),
+) : SocketFactory() {
+
+    private fun Socket.capped(): Socket = apply {
+        runCatching { sendBufferSize = sendBufferBytes }
+    }
+
+    override fun createSocket(): Socket = delegate.createSocket().capped()
+
+    override fun createSocket(host: String?, port: Int): Socket =
+        delegate.createSocket(host, port).capped()
+
+    override fun createSocket(host: String?, port: Int, localHost: InetAddress?, localPort: Int): Socket =
+        delegate.createSocket(host, port, localHost, localPort).capped()
+
+    override fun createSocket(host: InetAddress?, port: Int): Socket =
+        delegate.createSocket(host, port).capped()
+
+    override fun createSocket(address: InetAddress?, port: Int, localAddress: InetAddress?, localPort: Int): Socket =
+        delegate.createSocket(address, port, localAddress, localPort).capped()
+}
+
+actual fun createUploadHttpClient(sendBufferBytes: Int): HttpClient =
+    HttpClient(OkHttp) {
+        applyOdinDefaults()
+        engine {
+            config {
+                socketFactory(SndBufSocketFactory(sendBufferBytes))
+            }
+        }
+    }

--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/client/UploadHttpClientFactory.android.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/client/UploadHttpClientFactory.android.kt
@@ -1,5 +1,6 @@
 package id.homebase.api.client
 
+import co.touchlab.kermit.Logger
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import java.net.InetAddress
@@ -24,7 +25,18 @@ private class SndBufSocketFactory(
 ) : SocketFactory() {
 
     private fun Socket.capped(): Socket = apply {
-        runCatching { sendBufferSize = sendBufferBytes }
+        // Log requested vs. actually-applied SO_SNDBUF so we can confirm the cap took effect.
+        // Linux typically reports back ~2x the requested value (kernel bookkeeping); what matters
+        // is that it's near our request and NOT the multi-MB autotuned default. If onUpload still
+        // reaches 100% fast while this is small, the bytes genuinely left the wire fast → the
+        // remaining wait is server-side.
+        val applied = runCatching {
+            sendBufferSize = sendBufferBytes
+            sendBufferSize
+        }.getOrElse { -1 }
+        Logger.i(tag = "UploadSndBuf") {
+            "createSocket: requested=$sendBufferBytes appliedSendBuffer=$applied"
+        }
     }
 
     override fun createSocket(): Socket = delegate.createSocket().capped()

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/HttpClientProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/HttpClientProvider.kt
@@ -3,6 +3,7 @@ package id.homebase.api.client
 import co.touchlab.kermit.Logger
 import id.homebase.api.serialization.OdinSystemSerializer
 import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.api.createClientPlugin
 import io.ktor.client.plugins.compression.ContentEncoding
@@ -26,25 +27,40 @@ internal val HttpBreadcrumbPlugin = createClientPlugin("HttpBreadcrumb") {
     }
 }
 
+/**
+ * The shared plugin/config block applied to every Odin HTTP client — the default
+ * client built by [HttpClientProvider.create] and the per-tier upload clients built by
+ * [createUploadHttpClient]. Extracted so upload clients are byte-for-byte plugin-identical
+ * to the shared one; the only thing upload clients add on top is a capped socket send buffer
+ * (Android/OkHttp only), which is engine config, not a plugin.
+ *
+ * Note: [ContentEncoding] here is response-side (Accept-Encoding + response decode). It does
+ * NOT compress request bodies unless `compress()` is called explicitly, which the multipart
+ * upload path never does — so upload byte math stays exact.
+ */
+internal fun HttpClientConfig<*>.applyOdinDefaults() {
+    install(HttpBreadcrumbPlugin)
+
+    install(ContentNegotiation) {
+        json(OdinSystemSerializer.json)
+    }
+
+    install(ContentEncoding) {
+        gzip(quality = 1.0f)
+        deflate(quality = 0.9f)
+    }
+
+    install(HttpTimeout) {
+        requestTimeoutMillis = 5 * 60_000   // 5 minutes
+        connectTimeoutMillis = 30_000        // 30 seconds
+        socketTimeoutMillis = 5 * 60_000     // 5 minutes
+    }
+}
+
 object HttpClientProvider {
     fun create(): HttpClient {
         return HttpClient {
-            install(HttpBreadcrumbPlugin)
-
-            install(ContentNegotiation) {
-                json(OdinSystemSerializer.json)
-            }
-
-            install(ContentEncoding) {
-                gzip(quality = 1.0f)
-                deflate(quality = 0.9f)
-            }
-
-            install(HttpTimeout) {
-                requestTimeoutMillis = 5 * 60_000   // 5 minutes
-                connectTimeoutMillis = 30_000        // 30 seconds
-                socketTimeoutMillis = 5 * 60_000     // 5 minutes
-            }
+            applyOdinDefaults()
         }
     }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/OdinApiProviderBase.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/OdinApiProviderBase.kt
@@ -228,13 +228,16 @@ abstract class OdinApiProviderBase(
         url: String,
         token: String,
         formData: MultiPartFormDataContent,
-        onProgress: UploadProgress? = null
+        onProgress: UploadProgress? = null,
+        // The send-buffer-capped upload client for this payload's tier (see UploadHttpClientPool).
+        // Defaults to the shared client so non-upload callers are unaffected.
+        client: HttpClient = httpClient
     ): ApiResponse {
         requireHostInUrl(url)
 
         return request(
             {
-                httpClient.post(url) {
+                client.post(url) {
                     bearerAuth(token)
                     setBody(formData)
 
@@ -251,13 +254,14 @@ abstract class OdinApiProviderBase(
         url: String,
         token: String,
         formData: MultiPartFormDataContent,
-        onProgress: UploadProgress? = null
+        onProgress: UploadProgress? = null,
+        client: HttpClient = httpClient
     ): ApiResponse {
         requireHostInUrl(url)
 
         return request(
             {
-                httpClient.patch(url) {
+                client.patch(url) {
                     bearerAuth(token)
                     setBody(formData)
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/UploadHttpClientFactory.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/UploadHttpClientFactory.kt
@@ -1,0 +1,24 @@
+package id.homebase.api.client
+
+import io.ktor.client.HttpClient
+
+/**
+ * Builds an HTTP client whose TCP socket send buffer (`SO_SNDBUF`) is capped to
+ * [sendBufferBytes], used only for the multipart drive-upload path.
+ *
+ * ## Why
+ * A curated image often fits entirely inside the OS TCP send buffer (Android `tcp_wmem`
+ * autotunes to several MB), so Ktor's `onUpload` — which counts bytes *accepted into the
+ * socket*, not bytes on the wire — reports 100% the instant the kernel swallows the payload.
+ * The upload then drains over the wire with no further progress, surfacing as a long
+ * "Finalizing…" spinner. Capping `SO_SNDBUF` below the payload forces TCP backpressure so
+ * `onUpload` tracks the wire and the percentage climbs honestly. See
+ * [id.homebase.api.client.UploadHttpClientPool] for the per-payload sizing.
+ *
+ * ## Platform support (honest)
+ * - **Android (OkHttp):** real — a delegating `SocketFactory` sets `setSendBufferSize` pre-connect.
+ * - **iOS (Darwin), Desktop (CIO), Web (Js):** no-op cap. NSURLSession/CIO/fetch expose no
+ *   `SO_SNDBUF` lever, so these return a client identical to the shared one; [sendBufferBytes]
+ *   is ignored. (Darwin's `didSendBodyData` is often already more wire-accurate.)
+ */
+expect fun createUploadHttpClient(sendBufferBytes: Int): HttpClient

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/UploadHttpClientPool.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/UploadHttpClientPool.kt
@@ -1,0 +1,56 @@
+package id.homebase.api.client
+
+import io.ktor.client.HttpClient
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Lazily-built, cached pool of [createUploadHttpClient] instances bucketed by send-buffer tier.
+ *
+ * The OkHttp `SocketFactory` is fixed at client-build time and runs on OkHttp's own threads, so a
+ * single client cannot vary `SO_SNDBUF` per request (a caller [ThreadLocal] wouldn't propagate, and
+ * concurrent uploads would race a shared value). Instead we keep one client per buffer tier — each
+ * with its own connection pool, so every socket inside it was created by that tier's factory. This
+ * is deterministic and concurrency-safe.
+ *
+ * Sizing: target = `totalUploadSize / 12`, clamped to `[64 KiB, 2 MiB]`, rounded **up** to the
+ * nearest power-of-two tier. `/12` yields ~12 wire-paced `onUpload` steps; the 2 MiB ceiling stays
+ * above the bandwidth-delay product of typical mobile/Wi-Fi links so large uploads aren't
+ * over-throttled; the 64 KiB floor bounds the throughput penalty for tiny payloads (which finish
+ * sub-second anyway). Only the multipart upload path uses this — all other requests keep the shared
+ * client.
+ */
+class UploadHttpClientPool {
+    private val mutex = Mutex()
+    private val clientsByTier = mutableMapOf<Int, HttpClient>()
+
+    /** The send-buffer tier (bytes) that [clientFor] would use for [totalUploadSize]. */
+    fun bufferBytesFor(totalUploadSize: Long): Int = tierFor(totalUploadSize)
+
+    /** Returns the cached upload client for [totalUploadSize]'s tier, building it on first use. */
+    suspend fun clientFor(totalUploadSize: Long): HttpClient {
+        val tier = tierFor(totalUploadSize)
+        return mutex.withLock {
+            clientsByTier.getOrPut(tier) { createUploadHttpClient(tier) }
+        }
+    }
+
+    companion object {
+        private const val MIN_BUFFER = 64 * 1024          // 64 KiB
+        private const val MAX_BUFFER = 2 * 1024 * 1024    // 2 MiB
+
+        private val TIERS = intArrayOf(
+            64 * 1024,        // 64 KiB
+            128 * 1024,       // 128 KiB
+            256 * 1024,       // 256 KiB
+            512 * 1024,       // 512 KiB
+            1024 * 1024,      // 1 MiB
+            2 * 1024 * 1024,  // 2 MiB
+        )
+
+        internal fun tierFor(totalUploadSize: Long): Int {
+            val target = (totalUploadSize / 12).coerceIn(MIN_BUFFER.toLong(), MAX_BUFFER.toLong())
+            return TIERS.firstOrNull { it.toLong() >= target } ?: MAX_BUFFER
+        }
+    }
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/upload/DriveUploadProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/upload/DriveUploadProvider.kt
@@ -5,6 +5,7 @@ import id.homebase.api.client.ApiResponse
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.OdinApiProviderBase
 import id.homebase.api.client.OdinClientErrorCode
+import id.homebase.api.client.UploadHttpClientPool
 import id.homebase.api.client.OdinErrorResponse
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.drives.FileSystemType
@@ -23,6 +24,7 @@ import io.ktor.client.request.forms.MultiPartFormDataContent
 import kotlinx.serialization.Serializable
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.time.TimeSource
 import kotlin.uuid.Uuid
 
 @Serializable
@@ -89,6 +91,7 @@ class DriveUploadProvider(
     httpClient: HttpClient,
     credentialsManager: CredentialsManager,
     private val fileOperationsProvider: FileOperationsProvider,
+    private val uploadClientPool: UploadHttpClientPool,
 ) : OdinApiProviderBase(httpClient, credentialsManager) {
 
     companion object {
@@ -142,18 +145,37 @@ class DriveUploadProvider(
             fileOperationsProvider
         )
 
-        val wrappedProgress = onProgress?.let { progress ->
-            suspend { sent: Long, _: Long? ->
-                progress(sent, totalUploadSize)
+        // Timing breakdown so a repro proves where the upload spends its time:
+        // handoffMs = until onUpload reports the last byte accepted into the (now capped) socket
+        // buffer; waitMs = handoff → server response = the "Finalizing" tail (wire drain + ack).
+        val bufferBytes = uploadClientPool.bufferBytesFor(totalUploadSize)
+        val start = TimeSource.Monotonic.markNow()
+        var handoffMs: Long? = null
+
+        val wrappedProgress: UploadProgress = { sent: Long, _: Long? ->
+            if (handoffMs == null && totalUploadSize > 0 && sent >= totalUploadSize) {
+                handoffMs = start.elapsedNow().inWholeMilliseconds
             }
+            onProgress?.invoke(sent, totalUploadSize)
         }
 
         val result =
             pureUpload(
                 request.driveId, data, request.fileSystemType,
                 wrappedProgress,
-                onVersionConflict
+                onVersionConflict,
+                uploadSizeBytes = totalUploadSize,
             )
+
+        val totalMs = start.elapsedNow().inWholeMilliseconds
+        val handoff = handoffMs ?: totalMs
+        val waitMs = (totalMs - handoff).coerceAtLeast(0)
+        val throughputKBps = if (totalMs > 0) totalUploadSize * 1000 / totalMs / 1024 else 0
+        Logger.i(tag = TAG) {
+            "(UploadTiming) uniqueId=${request.metadata.appData.uniqueId} bytes=$totalUploadSize " +
+                "bufferBytes=$bufferBytes payloads=${request.payloads.size} thumbs=${request.thumbnails.size} " +
+                "handoffMs=$handoff waitMs=$waitMs totalMs=$totalMs throughputKBps=$throughputKBps"
+        }
 
         if (result != null) {
             cleanupPayloadTempFiles(request.payloads)
@@ -203,7 +225,10 @@ class DriveUploadProvider(
         }
 
         val path = "/drives/${request.driveId}/files/${request.fileId}"
-        val result = pureUpdate(data, path, wrappedProgress, onVersionConflict)
+        val result = pureUpdate(
+            data, path, wrappedProgress, onVersionConflict,
+            uploadSizeBytes = totalUploadSize,
+        )
 
         if (result != null) {
             cleanupPayloadTempFiles(request.payloads)
@@ -267,9 +292,27 @@ class DriveUploadProvider(
                 fileOperationsProvider = fileOperationsProvider,
             )
 
+        val totalUploadSize = calculateUploadSize(
+            request.payloads,
+            request.thumbnails,
+            sharedSecretEncryptedDescriptor,
+            fileOperationsProvider
+        )
+
+        // Report progress against the true total (engine total can be unknown for chunked
+        // multipart) and pick the send-buffer-capped client for honest wire-paced progress.
+        val wrappedProgress = onProgress?.let { progress ->
+            suspend { sent: Long, _: Long? ->
+                progress(sent, totalUploadSize)
+            }
+        }
+
         val path = "/drives/${request.driveId}/files/by-uid/${request.uniqueId}"
 
-        val result = pureUpdate(data, path, onProgress, onVersionConflict)
+        val result = pureUpdate(
+            data, path, wrappedProgress, onVersionConflict,
+            uploadSizeBytes = totalUploadSize,
+        )
 
         if (result != null) {
             cleanupPayloadTempFiles(request.payloads)
@@ -380,7 +423,10 @@ class DriveUploadProvider(
         data: MultiPartFormDataContent,
         fileSystemType: FileSystemType? = null,
         onProgress: UploadProgress? = null,
-        onVersionConflict: (suspend () -> CreateFileResult?)? = null
+        onVersionConflict: (suspend () -> CreateFileResult?)? = null,
+        // Total payload+thumbnail+descriptor byte size, used to pick a send-buffer-capped
+        // upload client so onUpload progress tracks the wire instead of the socket buffer.
+        uploadSizeBytes: Long = 0L,
     ): CreateFileResult? {
 
         val credentials = requireCreds()
@@ -415,7 +461,8 @@ class DriveUploadProvider(
                 url = url,
                 token = credentials.accessToken,
                 formData = data,
-                onProgress = onProgress
+                onProgress = onProgress,
+                client = uploadClientPool.clientFor(uploadSizeBytes)
             )
 
         if (response.status in 200..299) {
@@ -431,7 +478,8 @@ class DriveUploadProvider(
         data: MultiPartFormDataContent,
         path: String,
         onProgress: UploadProgress? = null,
-        onVersionConflict: (suspend () -> UpdateFileResult?)? = null
+        onVersionConflict: (suspend () -> UpdateFileResult?)? = null,
+        uploadSizeBytes: Long = 0L,
     ): UpdateFileResult? {
         val credentials = requireCreds()
 
@@ -441,7 +489,8 @@ class DriveUploadProvider(
                 url = url,
                 token = credentials.accessToken,
                 formData = data,
-                onProgress = onProgress
+                onProgress = onProgress,
+                client = uploadClientPool.clientFor(uploadSizeBytes)
             )
 
         if (response.status in 200..299) {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
@@ -2,6 +2,7 @@ package id.homebase.api.di
 
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.HttpClientProvider
+import id.homebase.api.client.UploadHttpClientPool
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.api.client.connections.ConnectionIntroductionProvider
@@ -56,6 +57,10 @@ val apiModule = module {
 
     // this creates the HttpClient
     single { HttpClientProvider.create() }
+
+    // Pool of send-buffer-capped HTTP clients (one per size tier) used only by the multipart
+    // drive-upload path so onUpload progress tracks the wire instead of the socket buffer.
+    single { UploadHttpClientPool() }
 
     // Constructed via the lambda DSL (not singleOf) so Kotlin's default values for
     // the compressor/probe params are honored — Koin's constructor DSL would instead

--- a/homebase-api/src/jvmMain/kotlin/id/homebase/api/client/UploadHttpClientFactory.jvm.kt
+++ b/homebase-api/src/jvmMain/kotlin/id/homebase/api/client/UploadHttpClientFactory.jvm.kt
@@ -1,0 +1,14 @@
+package id.homebase.api.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+
+/**
+ * Desktop (CIO) exposes no supported socket send-buffer config, so this is an honest no-op cap:
+ * [sendBufferBytes] is ignored and the client is identical to the shared one. Revisit only if
+ * desktop upload-progress honesty becomes a priority.
+ */
+actual fun createUploadHttpClient(sendBufferBytes: Int): HttpClient =
+    HttpClient(CIO) {
+        applyOdinDefaults()
+    }

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/client/UploadHttpClientFactory.native.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/client/UploadHttpClientFactory.native.kt
@@ -1,0 +1,15 @@
+package id.homebase.api.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.darwin.Darwin
+
+/**
+ * iOS (Darwin/NSURLSession) exposes no `SO_SNDBUF` lever, so this is an honest no-op cap:
+ * [sendBufferBytes] is ignored and the client is identical to the shared one. Darwin's
+ * `onUpload` (driven by `didSendBodyData`) is often already more wire-accurate than OkHttp's
+ * socket-fill count; measure before pursuing any iOS-specific work.
+ */
+actual fun createUploadHttpClient(sendBufferBytes: Int): HttpClient =
+    HttpClient(Darwin) {
+        applyOdinDefaults()
+    }

--- a/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/client/UploadHttpClientFactory.web.kt
+++ b/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/client/UploadHttpClientFactory.web.kt
@@ -1,0 +1,14 @@
+package id.homebase.api.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.js.Js
+
+/**
+ * Web (Js/browser fetch) cannot report upload progress at all and exposes no `SO_SNDBUF` lever,
+ * so this is an honest no-op cap: [sendBufferBytes] is ignored and the client is identical to the
+ * shared one. Real web upload progress would require an XMLHttpRequest path (deferred).
+ */
+actual fun createUploadHttpClient(sendBufferBytes: Int): HttpClient =
+    HttpClient(Js) {
+        applyOdinDefaults()
+    }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
@@ -2,6 +2,7 @@ package id.homebase.chat.services
 
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.UploadHttpClientPool
 import id.homebase.api.client.auth.ApiCredentials
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.drives.HomebaseFile
@@ -191,6 +192,7 @@ class ChatMessageActionServiceTestFixture(
                     httpClient,
                     credentialsManager,
                     NoopFileOperationsProvider(),
+                    UploadHttpClientPool(),
                 ),
                 fileProvider = fileProvider,
                 operationsProvider = DriveFileOperationsProvider(httpClient, credentialsManager),


### PR DESCRIPTION
## Problem

Sending a photo in chat shows the upload % race to 100% almost instantly, then a **"Finalizing…" spinner that hangs 10–50 s**. Diagnosed from `homebase.log`: every slow upload (8–51 s) is a media send (`payloads ≥ 1`); every text send (`payloads = 0`) is < 1 s.

**Root cause:** Ktor *streams* the multipart body (a large video shows a wire-paced % climb), but a curated image fits entirely inside the OS TCP send buffer (Android `tcp_wmem` autotunes to several MB). Ktor's `onUpload` counts bytes *accepted into the socket*, not bytes on the wire — so for a buffer-sized payload it reports 100% the instant the kernel swallows it, and the real transmission happens during "Finalizing". (If it were server-side, the video would hang at "Finalizing" too — it doesn't.)

## Fix

Cap `SO_SNDBUF` **below the payload size** so TCP backpressure forces `onUpload` to track the wire. The cap is relative to payload size so large uploads aren't over-throttled. **Only the multipart drive-upload path** uses the capped client; every other request keeps the shared client untouched. No compression (payloads are curated), and "Finalizing" is kept (it's genuinely one step — awaiting the POST response).

### What changed
- **`UploadHttpClientPool`** — one cached `HttpClient` per power-of-two tier `{64K…2M}`; `buffer = (totalUploadSize / 12).coerceIn(64 KiB, 2 MiB)`. `/12` → ~12 wire-paced steps; the 2 MiB ceiling stays above the bandwidth-delay product of typical mobile/Wi-Fi links; the 64 KiB floor bounds the penalty for tiny payloads. Tiering (vs. per-request sizing) is required because the OkHttp `SocketFactory` is fixed at client-build time and runs on OkHttp's own threads.
- **`createUploadHttpClient` (expect/actual)** — Android (OkHttp) installs a delegating `SocketFactory` that calls `setSendBufferSize` **pre-connect** (required to influence TCP window scaling; also disables Linux autotuning). Darwin/CIO/Js are **honest no-ops** (no `SO_SNDBUF` lever).
- **`HttpClientProvider`** — extracted `applyOdinDefaults()` so upload clients are plugin-identical to the shared one.
- **`OdinApiProviderBase`** — `plainPostMultipart`/`plainPatchMultipart` take an optional `client` (defaults to the shared client → non-upload callers unaffected).
- **`DriveUploadProvider`** — threads the already-computed `totalUploadSize` into `pureUpload`/`pureUpdate` to select the tier. **Fixes `updateFileByUniqueId`**, which previously neither computed the size nor reported progress against the true total. Adds a `(UploadTiming)` log line (`bytes/bufferBytes/handoffMs/waitMs/throughputKBps`).
- **`ApiModule`** — `single { UploadHttpClientPool() }`.

## Platform support (honest)
| Platform | Engine | Status |
|---|---|---|
| **Android** | OkHttp | ✅ real `SO_SNDBUF` cap |
| iOS | Darwin/NSURLSession | ⚪ no-op — NSURLSession exposes no send-buffer control; `didSendBodyData` may already be more wire-accurate. **Measure first** via the timing log. |
| Desktop | CIO | ⚪ no-op — no supported lever |
| Web | Js/fetch | ⚪ no-op — fetch can't report upload progress (would need XHR) |

## Testing
- Compiles on JVM, Android, wasmJs (iOS skipped on a Linux host).
- `homebase-api` + `homebase-chat` JVM test suites pass.

### How to verify on-device (Android)
Send a photo, then:
```
adb shell run-as id.homebase.feed.dev cat files/logs/homebase.log | grep "(UploadTiming)"
```
Before: `handoffMs` tiny, `waitMs` huge. After: `handoffMs` ≈ real transfer time, `waitMs` small. Throttle to ~1 Mbps and the chat % should climb in steps instead of snapping to 100% then hanging.

## Regression notes
- The cap trades peak throughput for honesty; the 2 MiB max tier bounds this — raise it if fast-link upload times regress.
- Cross-tier sends reopen TCP+TLS (sequential outbox, acceptable); the shared client's connection reuse is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)