### PR TITLE
feat(ios): shake-triggered blank-text recovery experiment (+ drop base64 from link-preview log)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/link/LinkPreviewProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/link/LinkPreviewProvider.kt
@@ -27,7 +27,9 @@ class LinkPreviewProvider(
             secret = creds.secret,
             queryString = "url=${standardisedUrl}"
         )
-        Logger.d("getLinkPreview: $response")
+        // Don't log the full response — link-preview bodies embed base64 image data-URIs that
+        // can be 100KB+ each and bloat homebase.log. Log status + headers + body length only.
+        Logger.d { "getLinkPreview: status=${response.status} headers=${response.headers} bodyLen=${response.body.length}" }
 
         if (response.status == 404) {
             return null

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/diagnostics/TextRecovery.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/diagnostics/TextRecovery.kt
@@ -1,0 +1,24 @@
+package id.homebase.core.diagnostics
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+
+/**
+ * Forced-recomposition lever for the iOS blank-text recovery experiment.
+ *
+ * `App()` reads [epoch] inside a `key(...)` wrapping the UI tree; bumping it disposes and recomposes
+ * the whole subtree, so every `Text` re-shapes and re-issues its glyph draws from scratch. Combined
+ * with a Skia cache purge, that is the recovery we test when the user shakes the device during a
+ * blank screen (see the iOS `onBlankTextShake`). The `navController` is remembered ABOVE the `key`,
+ * so navigation state survives the recomposition.
+ *
+ * Bump only from the main thread (it writes Compose snapshot state) — the iOS shake handler runs on
+ * main. No-op on platforms that never bump it (the bug is iOS-only).
+ */
+object TextRecovery {
+    val epoch: MutableState<Int> = mutableStateOf(0)
+
+    fun forceRecompose() {
+        epoch.value = epoch.value + 1
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/App.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/App.kt
@@ -5,6 +5,8 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import id.homebase.core.diagnostics.TextRecovery
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
@@ -33,11 +35,16 @@ fun App(
     val isDarkTheme = if (prefState.theme == ThemeState.System) isSystemInDarkTheme() else if (prefState.theme == ThemeState.Dark) true else false
 
     HomebaseTheme(darkTheme = isDarkTheme) {
-        AppNavHost(
-            viewModel = koinInject(),
-            navController = navController,
-            youAuthFlowManager = youAuthFlowManager
-        )
+        // key(TextRecovery.epoch) — the iOS blank-text recovery (shake) bumps this to force a full
+        // re-composition of the UI tree so every Text re-shapes and re-rasterizes its glyphs. The
+        // navController is remembered above, so navigation state survives. No-op when never bumped.
+        key(TextRecovery.epoch.value) {
+            AppNavHost(
+                viewModel = koinInject(),
+                navController = navController,
+                youAuthFlowManager = youAuthFlowManager
+            )
+        }
         LaunchedEffect(navController) { onNavHostReady(navController) }
     }
 }

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/diagnostics/IosGpuTextDiagnostics.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/diagnostics/IosGpuTextDiagnostics.kt
@@ -2,6 +2,9 @@ package id.homebase.core.diagnostics
 
 import co.touchlab.kermit.Logger
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.jetbrains.skia.Graphics
 import platform.Foundation.NSDate
 import platform.Foundation.NSNotificationCenter
@@ -98,4 +101,37 @@ fun installGpuTextDiagnostics() {
 
     Logger.i(tag = GpuTextDiagnostics.TAG) { "installed (probe + lifecycle observers attached)" }
     GpuTextDiagnostics.log(GpuTextDiagnostics.Event.ColdStart)
+}
+
+/**
+ * iOS blank-text recovery EXPERIMENT — called from Swift (`ContentView`) when the user shakes the
+ * device during a blank screen. Because every label is unreadable during the bug, a physical shake
+ * is the only reliable trigger.
+ *
+ * It (1) logs the font-cache state to homebase.log BEFORE, (2) attempts a recovery — purge Skia's
+ * CPU strike cache + GPU resource/atlas pages, then force a full re-composition so every `Text`
+ * re-shapes and re-rasterizes against a clean atlas — and (3) logs the font-cache state again ~1.5s
+ * later. The before/after `fontCacheCount` tells us whether the recovery worked (climbs to ~80 = text
+ * rendered; stays ~0 = glyphs still aren't rasterizing, pointing upstream of the GPU).
+ *
+ * The CAMetalLayer fields come from Swift (Kotlin can't read Compose's Metal view) so the GPU-surface
+ * state (device present? drawable size?) also lands in the shareable homebase.log. Runs on main.
+ */
+fun onBlankTextShake(
+    metalLayerCount: Int,
+    metalDevicePresent: Boolean,
+    drawableWidth: Double,
+    drawableHeight: Double,
+) {
+    val metal = "metal[count=$metalLayerCount device=$metalDevicePresent " +
+        "drawable=${drawableWidth.toInt()}x${drawableHeight.toInt()}]"
+    GpuTextDiagnostics.log(GpuTextDiagnostics.Event.ManualCapture, note = "shake/before $metal")
+
+    runCatching { Graphics.purgeAllCaches() }
+    TextRecovery.forceRecompose()
+
+    MainScope().launch {
+        delay(1500)
+        GpuTextDiagnostics.log(GpuTextDiagnostics.Event.ManualCapture, note = "shake/after purge+recompose")
+    }
 }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -36,11 +36,14 @@ struct ContentView: View {
             }
         }
         .onAppear {
-            os_log("onAppear fired — scheduling cold-start Metal nudge (150ms)", log: textRenderLog, type: .info)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                os_log("Cold-start nudge firing at 150ms", log: textRenderLog, type: .info)
-                nudgeMetalLayer(trigger: "onAppear")
-            }
+            os_log("onAppear fired", log: textRenderLog, type: .info)
+            // DISABLED for the blank-text recovery experiment — the cold-start 150ms Metal nudge is a
+            // bare setNeedsDisplay (replays cached blobs) that hasn't reliably fixed the bug and would
+            // confound attribution of the shake-triggered purge+recompose recovery. Re-enable to restore.
+            // DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            //     os_log("Cold-start nudge firing at 150ms", log: textRenderLog, type: .info)
+            //     nudgeMetalLayer(trigger: "onAppear")
+            // }
         }
         .onChange(of: scenePhase) { _, newPhase in
             os_log("scenePhase changed to %{public}@", log: textRenderLog, type: .info, String(describing: newPhase))
@@ -55,21 +58,23 @@ struct ContentView: View {
                 withAnimation(.easeOut(duration: 0.15)) {
                     showPrivacyOverlay = false
                 }
-                nudgeMetalLayer(trigger: "scenePhase→active")
+                // DISABLED for the experiment (see onAppear): the foreground nudge would mask the blank
+                // and confound the shake recovery. nudgeMetalLayer(trigger: "scenePhase→active")
             default:
                 break
             }
         }
         .onChange(of: colorScheme) { _, newScheme in
             os_log("colorScheme changed to %{public}@", log: textRenderLog, type: .info, String(describing: newScheme))
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                nudgeMetalLayer(trigger: "colorScheme→\(newScheme)")
-            }
+            // DISABLED for the experiment (see onAppear):
+            // DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            //     nudgeMetalLayer(trigger: "colorScheme→\(newScheme)")
+            // }
         }
         .onReceive(NotificationCenter.default.publisher(for: .deviceDidShake)) { _ in
-            // Manual blank-text marker: log only (no recovery), so the user can shake when text is
-            // missing and we can find the exact moment in the logs. See logBlankTextMarker.
-            logBlankTextMarker(trigger: "user-shake")
+            // Blank-text recovery experiment: log cache state, purge Skia caches + force a full
+            // re-composition, then log again ~1.5s later. See captureAndRecoverOnShake.
+            captureAndRecoverOnShake()
         }
     }
 }

--- a/iosApp/iosApp/TextRenderingNudge.swift
+++ b/iosApp/iosApp/TextRenderingNudge.swift
@@ -76,38 +76,46 @@ extension UIWindow {
     }
 }
 
-/// Log a blank-text marker. When the intermittent iOS blank-text bug strikes, every label is
-/// unreadable so the user can't tap an on-screen control — but a physical shake works regardless.
-/// On shake we LOG ONLY (no recovery, no Kotlin bridge): a loud marker plus the read-only state of
-/// every CAMetalLayer-backed Skiko view (device present? drawableSize?), so the moment can be lined
-/// up against the automatic `GpuTextDiag` entries in homebase.log. Distinct from `nudgeMetalLayer`,
-/// which calls `setNeedsDisplay` to attempt a fix.
-func logBlankTextMarker(trigger: String) {
-    os_log("[%{public}@] BLANK-TEXT MARKER — user reported missing text", log: textRenderLog, type: .error, trigger)
-    guard let view = MainViewControllerRef.shared.instance?.view else {
-        os_log("[%{public}@] marker: MainViewControllerRef.instance is nil", log: textRenderLog, type: .fault, trigger)
-        return
-    }
-    view.layoutIfNeeded()
+/// Blank-text recovery EXPERIMENT, fired by a device shake. When the bug strikes every label is
+/// unreadable, so the user can't tap an on-screen control — a physical shake works regardless.
+///
+/// We read the (read-only) CAMetalLayer state from the view hierarchy and hand it to Kotlin
+/// `onBlankTextShake`, which logs the font-cache state to homebase.log BEFORE, attempts a recovery
+/// (purge Skia caches + force a full Compose re-composition so glyphs re-rasterize), and logs the
+/// font-cache state again ~1.5s later. The before/after counts tell us whether the recovery worked.
+/// Passing the CAMetalLayer fields means the GPU-surface state lands in the shareable homebase.log
+/// too (Kotlin can't read Compose's Metal view).
+func captureAndRecoverOnShake() {
+    os_log("BLANK-TEXT shake — capturing state + attempting recovery", log: textRenderLog, type: .error)
+
     var count = 0
-    logMetalLayerState(in: view, trigger: trigger, count: &count)
-    if count == 0 {
-        os_log("[%{public}@] marker: NO CAMetalLayer view found in hierarchy", log: textRenderLog, type: .error, trigger)
+    var devicePresent = false
+    var drawableW = 0.0
+    var drawableH = 0.0
+    if let view = MainViewControllerRef.shared.instance?.view {
+        view.layoutIfNeeded()
+        collectMetalState(in: view, count: &count, devicePresent: &devicePresent, drawableW: &drawableW, drawableH: &drawableH)
+    } else {
+        os_log("shake: MainViewControllerRef.instance is nil", log: textRenderLog, type: .fault)
     }
+
+    IosGpuTextDiagnosticsKt.onBlankTextShake(
+        metalLayerCount: Int32(count),
+        metalDevicePresent: devicePresent,
+        drawableWidth: drawableW,
+        drawableHeight: drawableH
+    )
 }
 
-/// Read-only walk: logs CAMetalLayer state without touching it (no `setNeedsDisplay`).
-private func logMetalLayerState(in view: UIView, trigger: String, count: inout Int) {
+/// Read-only walk: collect CAMetalLayer state without touching it (no `setNeedsDisplay`).
+private func collectMetalState(in view: UIView, count: inout Int, devicePresent: inout Bool, drawableW: inout Double, drawableH: inout Double) {
     if let metalLayer = view.layer as? CAMetalLayer {
         count += 1
-        os_log("[%{public}@] marker CAMetalLayer: type=%{public}@, device=%{public}@, drawableSize=%.0fx%.0f, framebufferOnly=%{public}@",
-               log: textRenderLog, type: .info, trigger,
-               String(describing: type(of: view)),
-               String(describing: metalLayer.device != nil),
-               metalLayer.drawableSize.width, metalLayer.drawableSize.height,
-               String(describing: metalLayer.framebufferOnly))
+        if metalLayer.device != nil { devicePresent = true }
+        drawableW = Double(metalLayer.drawableSize.width)
+        drawableH = Double(metalLayer.drawableSize.height)
     }
     for subview in view.subviews {
-        logMetalLayerState(in: subview, trigger: trigger, count: &count)
+        collectMetalState(in: subview, count: &count, devicePresent: &devicePresent, drawableW: &drawableW, drawableH: &drawableH)
     }
 }


### PR DESCRIPTION
## Why

We confirmed a real blank-text occurrence in the field (`homebase.log`, 2026-06-08 11:55 UTC): the app was fully live (drive sync, websocket, 21 conversations flowing) but the skiko font strike cache was nearly empty (`fontCacheCount=4` vs. 70–166 in healthy sessions) — i.e. text glyphs were barely being rasterized. The user shook the device, but the marker went to `os_log` (unretrievable) and never captured the font cache. Two gaps to close: **make the shake retrievable + make it do more than log.**

## What this does

Turns the shake from a passive marker into a **logged recovery experiment**, routed into `homebase.log`.

On shake (`captureAndRecoverOnShake` → Kotlin `onBlankTextShake`):
1. **Log BEFORE** → `homebase.log`: font-cache counts + CAMetalLayer state (device present? drawable size?), the GPU-surface signal the previous os_log-only path couldn't share.
2. **Recover**: `Graphics.purgeAllCaches()` (drop Skia's CPU strike cache + GPU resource/atlas pages) + `TextRecovery.forceRecompose()` (a `key()` bump in `App()` → full re-composition so every `Text` re-shapes and re-rasterizes). `navController` is remembered above the `key`, so navigation survives.
3. **Log AFTER (~1.5 s)** → `homebase.log`: font-cache counts again.

**The payoff:** next blank → shake → the before/after `fontCacheCount` is decisive:
- climbs to ~80 + text reappears → purge+recompose is a **working fix** (caches were stale); we then wire it to fire automatically on foreground-after-idle.
- stays ~0 + still blank → glyphs genuinely aren't rasterizing → the bug is **upstream of the GPU** (strings/typeface), which redirects the whole investigation.

Either way it's a decisive answer, on demand, instead of another passive log line.

## Also in this PR

- **Disabled the existing Metal nudges** (cold-start 150 ms `onAppear`, `scenePhase→active`, `colorScheme`) — bare `setNeedsDisplay` that replays cached blobs, unproven, and would confound the experiment's attribution. Commented, trivially restored.
- **Dropped base64 from the link-preview log**: `LinkPreviewProvider` logged the full response, embedding base64 image data-URIs (100 KB+ lines bloating `homebase.log`). Now logs status + headers + body length.

## Verification

- Common code: `:homebase-common:jvmTest` (GpuTextDiagnosticsTest) green; JVM + common-metadata compiles clean for api/common/core.
- The `nativeMain` `onBlankTextShake` (skiko purge, coroutine delay) + the Swift wiring are validated by **CI (iosArm64 / Xcode build)** — they can't be compiled on the Linux dev host.

## Trade-off

`key()` re-composition flashes and resets transient UI state — acceptable because it only fires on a deliberate shake during a blank screen; zero impact on normal use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
