### PR TITLE
feat(sticker): Material Symbols icons for the Stickers tab and add tile

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ExpressionSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ExpressionSheet.kt
@@ -12,8 +12,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.StickyNote2
-import androidx.compose.material.icons.automirrored.outlined.StickyNote2
 import androidx.compose.material.icons.filled.EmojiEmotions
 import androidx.compose.material.icons.filled.GifBox
 import androidx.compose.material.icons.outlined.EmojiEmotions
@@ -37,6 +35,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.chat.conversationlist.ConversationListUiAction
 import id.homebase.chat.services.sticker.SavedSticker
 import id.homebase.chat.services.sticker.StickerStream
+import id.homebase.core.ui.assets.HomebaseIcons
+import id.homebase.core.ui.assets.StickerFilled
+import id.homebase.core.ui.assets.StickerOutlined
 import id.homebase.core.util.detectContentTypeFromExtensionOrHint
 import id.homebase.core.widget.EmojiSelection
 import id.homebase.resources.MR
@@ -105,7 +106,7 @@ fun ExpressionSheet(
 /**
  * Centered icon tab row. The active tab is tinted with the primary color and uses the
  * filled icon variant; inactive tabs use the outlined variant. Emoji = a smiley, Stickers =
- * a sticky-note glyph (distinct from the emoji face), Gifs = a GIF box (reserved tab).
+ * the Material Symbols sticker glyph, Gifs = a GIF box (reserved tab).
  */
 @Composable
 private fun ExpressionTabRow(
@@ -127,7 +128,7 @@ private fun ExpressionTabRow(
                         ExpressionTab.Emoji ->
                             if (isSel) Icons.Filled.EmojiEmotions else Icons.Outlined.EmojiEmotions
                         ExpressionTab.Stickers ->
-                            if (isSel) Icons.AutoMirrored.Filled.StickyNote2 else Icons.AutoMirrored.Outlined.StickyNote2
+                            if (isSel) HomebaseIcons.StickerFilled else HomebaseIcons.StickerOutlined
                         ExpressionTab.Gifs ->
                             if (isSel) Icons.Filled.GifBox else Icons.Outlined.GifBox
                     },

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/StickerTray.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/StickerTray.kt
@@ -14,8 +14,6 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -30,6 +28,8 @@ import androidx.compose.ui.unit.dp
 import id.homebase.chat.services.sticker.SavedSticker
 import id.homebase.chat.services.sticker.toImageData
 import id.homebase.core.image.HomebaseImage
+import id.homebase.core.ui.assets.HomebaseIcons
+import id.homebase.core.ui.assets.StickerAdd
 import id.homebase.resources.MR
 import id.homebase.resources.cd_import_sticker
 import id.homebase.resources.cd_sticker_thumbnail
@@ -78,7 +78,7 @@ fun StickerTray(
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(
-                    imageVector = Icons.Default.Add,
+                    imageVector = HomebaseIcons.StickerAdd,
                     contentDescription = importDescription,
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.sizeIn(maxWidth = 32.dp, maxHeight = 32.dp),

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/assets/StickerAdd.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/assets/StickerAdd.kt
@@ -1,0 +1,112 @@
+package id.homebase.core.ui.assets
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+/**
+ * Material Symbols "sticker_add" (Outlined family, weight 400, FILL 1). The add-a-sticker
+ * tray tile's call-to-action glyph; filled so it reads as a strong affordance at small size
+ * against the colourful saved-sticker thumbnails beside it.
+ */
+public val HomebaseIcons.StickerAdd: ImageVector
+    get() {
+        if (_stickerAdd != null) {
+            return _stickerAdd!!
+        }
+        _stickerAdd =
+            ImageVector.Builder(
+                name = "StickerAdd",
+                defaultWidth = 24.dp,
+                defaultHeight = 24.dp,
+                viewportWidth = 24f,
+                viewportHeight = 24f,
+                autoMirror = true,
+            )
+                .apply {
+                    path(
+                        fill = SolidColor(Color.Black),
+                        fillAlpha = 1f,
+                        stroke = null,
+                        strokeAlpha = 1f,
+                        strokeLineWidth = 1f,
+                        strokeLineCap = StrokeCap.Butt,
+                        strokeLineJoin = StrokeJoin.Bevel,
+                        strokeLineMiter = 1f,
+                        pathFillType = PathFillType.NonZero,
+                    ) {
+                        moveTo(19f, 7f)
+                        verticalLineTo(5f)
+                        horizontalLineTo(17f)
+                        verticalLineTo(3f)
+                        horizontalLineToRelative(2f)
+                        verticalLineTo(1f)
+                        horizontalLineToRelative(2f)
+                        verticalLineTo(3f)
+                        horizontalLineToRelative(2f)
+                        verticalLineTo(5f)
+                        horizontalLineTo(21f)
+                        verticalLineTo(7f)
+                        horizontalLineTo(19f)
+                        close()
+                        moveTo(13.35f, 9.5f)
+                        lineTo(16f, 8.75f)
+                        quadTo(16.13f, 8.05f, 15.66f, 7.52f)
+                        reflectiveQuadTo(14.5f, 7f)
+                        quadTo(13.88f, 7f, 13.44f, 7.44f)
+                        reflectiveQuadTo(13f, 8.5f)
+                        quadToRelative(0f, 0.27f, 0.1f, 0.52f)
+                        reflectiveQuadTo(13.35f, 9.5f)
+                        close()
+                        moveToRelative(-6f, 1.75f)
+                        lineTo(10f, 10.5f)
+                        quadTo(10.1f, 9.8f, 9.65f, 9.27f)
+                        reflectiveQuadTo(8.5f, 8.75f)
+                        quadToRelative(-0.63f, 0f, -1.06f, 0.44f)
+                        reflectiveQuadTo(7f, 10.25f)
+                        quadToRelative(0f, 0.27f, 0.1f, 0.52f)
+                        reflectiveQuadToRelative(0.25f, 0.48f)
+                        close()
+                        moveTo(11.5f, 15f)
+                        quadToRelative(1.73f, 0f, 3f, -1.13f)
+                        quadTo(15.78f, 12.75f, 16f, 11.05f)
+                        lineTo(8f, 13.3f)
+                        quadToRelative(0.65f, 0.8f, 1.55f, 1.25f)
+                        reflectiveQuadTo(11.5f, 15f)
+                        close()
+                        moveTo(15f, 19f)
+                        lineToRelative(4f, -4f)
+                        horizontalLineTo(17f)
+                        quadToRelative(-0.82f, 0f, -1.41f, 0.59f)
+                        reflectiveQuadTo(15f, 17f)
+                        verticalLineToRelative(2f)
+                        close()
+                        moveToRelative(1f, 2f)
+                        horizontalLineTo(5f)
+                        quadTo(4.18f, 21f, 3.59f, 20.41f)
+                        reflectiveQuadTo(3f, 19f)
+                        verticalLineTo(5f)
+                        quadTo(3f, 4.17f, 3.59f, 3.59f)
+                        reflectiveQuadTo(5f, 3f)
+                        horizontalLineTo(15.1f)
+                        quadTo(15.05f, 3.25f, 15.03f, 3.49f)
+                        reflectiveQuadTo(15f, 4f)
+                        quadToRelative(0f, 2.07f, 1.46f, 3.54f)
+                        reflectiveQuadTo(20f, 9f)
+                        quadToRelative(0.28f, 0f, 0.51f, -0.03f)
+                        reflectiveQuadTo(21f, 8.9f)
+                        verticalLineTo(16f)
+                        lineToRelative(-5f, 5f)
+                        close()
+                    }
+                }
+                .build()
+        return _stickerAdd!!
+    }
+
+private var _stickerAdd: ImageVector? = null

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/assets/StickerFilled.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/assets/StickerFilled.kt
@@ -1,0 +1,94 @@
+package id.homebase.core.ui.assets
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+/**
+ * Material Symbols "sticker" (Outlined family, weight 400, FILL 1). The active Stickers-tab
+ * glyph; the inactive state uses [StickerOutlined], mirroring the Emoji/GIFs tabs'
+ * filled-when-active pattern.
+ */
+public val HomebaseIcons.StickerFilled: ImageVector
+    get() {
+        if (_stickerFilled != null) {
+            return _stickerFilled!!
+        }
+        _stickerFilled =
+            ImageVector.Builder(
+                name = "StickerFilled",
+                defaultWidth = 24.dp,
+                defaultHeight = 24.dp,
+                viewportWidth = 24f,
+                viewportHeight = 24f,
+                autoMirror = true,
+            )
+                .apply {
+                    path(
+                        fill = SolidColor(Color.Black),
+                        fillAlpha = 1f,
+                        stroke = null,
+                        strokeAlpha = 1f,
+                        strokeLineWidth = 1f,
+                        strokeLineCap = StrokeCap.Butt,
+                        strokeLineJoin = StrokeJoin.Bevel,
+                        strokeLineMiter = 1f,
+                        pathFillType = PathFillType.NonZero,
+                    ) {
+                        moveTo(5f, 21f)
+                        quadTo(4.18f, 21f, 3.59f, 20.41f)
+                        reflectiveQuadTo(3f, 19f)
+                        verticalLineTo(5f)
+                        quadTo(3f, 4.17f, 3.59f, 3.59f)
+                        reflectiveQuadTo(5f, 3f)
+                        horizontalLineTo(19f)
+                        quadToRelative(0.83f, 0f, 1.41f, 0.59f)
+                        reflectiveQuadTo(21f, 5f)
+                        verticalLineTo(16f)
+                        lineToRelative(-5f, 5f)
+                        horizontalLineTo(5f)
+                        close()
+                        moveTo(13.35f, 9.5f)
+                        lineTo(16f, 8.75f)
+                        quadTo(16.13f, 8.05f, 15.66f, 7.52f)
+                        reflectiveQuadTo(14.5f, 7f)
+                        quadTo(13.88f, 7f, 13.44f, 7.44f)
+                        reflectiveQuadTo(13f, 8.5f)
+                        quadToRelative(0f, 0.27f, 0.1f, 0.52f)
+                        reflectiveQuadTo(13.35f, 9.5f)
+                        close()
+                        moveToRelative(-6f, 1.75f)
+                        lineTo(10f, 10.5f)
+                        quadTo(10.1f, 9.8f, 9.65f, 9.27f)
+                        reflectiveQuadTo(8.5f, 8.75f)
+                        quadToRelative(-0.63f, 0f, -1.06f, 0.44f)
+                        reflectiveQuadTo(7f, 10.25f)
+                        quadToRelative(0f, 0.27f, 0.1f, 0.52f)
+                        reflectiveQuadToRelative(0.25f, 0.48f)
+                        close()
+                        moveTo(11.5f, 15f)
+                        quadToRelative(1.73f, 0f, 3f, -1.13f)
+                        quadTo(15.78f, 12.75f, 16f, 11.05f)
+                        lineTo(8f, 13.3f)
+                        quadToRelative(0.65f, 0.8f, 1.55f, 1.25f)
+                        reflectiveQuadTo(11.5f, 15f)
+                        close()
+                        moveTo(15f, 19f)
+                        lineToRelative(4f, -4f)
+                        horizontalLineTo(17f)
+                        quadToRelative(-0.82f, 0f, -1.41f, 0.59f)
+                        reflectiveQuadTo(15f, 17f)
+                        verticalLineToRelative(2f)
+                        close()
+                    }
+                }
+                .build()
+        return _stickerFilled!!
+    }
+
+private var _stickerFilled: ImageVector? = null

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/assets/StickerOutlined.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/assets/StickerOutlined.kt
@@ -1,0 +1,106 @@
+package id.homebase.core.ui.assets
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+/**
+ * Material Symbols "sticker" (Outlined, weight 400, FILL 0). The inactive Stickers-tab
+ * glyph; the active state uses the filled [StickerFilled] twin, mirroring the Emoji/GIFs
+ * tabs' filled-when-active pattern.
+ */
+public val HomebaseIcons.StickerOutlined: ImageVector
+    get() {
+        if (_stickerOutlined != null) {
+            return _stickerOutlined!!
+        }
+        _stickerOutlined =
+            ImageVector.Builder(
+                name = "StickerOutlined",
+                defaultWidth = 24.dp,
+                defaultHeight = 24.dp,
+                viewportWidth = 24f,
+                viewportHeight = 24f,
+                autoMirror = true,
+            )
+                .apply {
+                    path(
+                        fill = SolidColor(Color.Black),
+                        fillAlpha = 1f,
+                        stroke = null,
+                        strokeAlpha = 1f,
+                        strokeLineWidth = 1f,
+                        strokeLineCap = StrokeCap.Butt,
+                        strokeLineJoin = StrokeJoin.Bevel,
+                        strokeLineMiter = 1f,
+                        pathFillType = PathFillType.NonZero,
+                    ) {
+                        moveTo(11.5f, 15f)
+                        quadToRelative(1.73f, 0f, 3f, -1.13f)
+                        quadTo(15.78f, 12.75f, 16f, 11.05f)
+                        lineTo(8f, 13.3f)
+                        quadToRelative(0.65f, 0.8f, 1.55f, 1.25f)
+                        reflectiveQuadTo(11.5f, 15f)
+                        close()
+                        moveTo(7.35f, 11.25f)
+                        lineTo(10f, 10.5f)
+                        quadTo(10.1f, 9.8f, 9.65f, 9.27f)
+                        reflectiveQuadTo(8.5f, 8.75f)
+                        quadToRelative(-0.63f, 0f, -1.06f, 0.44f)
+                        reflectiveQuadTo(7f, 10.25f)
+                        quadToRelative(0f, 0.27f, 0.1f, 0.52f)
+                        reflectiveQuadToRelative(0.25f, 0.48f)
+                        close()
+                        moveToRelative(6f, -1.75f)
+                        lineTo(16f, 8.75f)
+                        quadTo(16.13f, 8.05f, 15.66f, 7.52f)
+                        reflectiveQuadTo(14.5f, 7f)
+                        quadTo(13.88f, 7f, 13.44f, 7.44f)
+                        reflectiveQuadTo(13f, 8.5f)
+                        quadToRelative(0f, 0.27f, 0.1f, 0.52f)
+                        reflectiveQuadTo(13.35f, 9.5f)
+                        close()
+                        moveTo(16f, 21f)
+                        horizontalLineTo(5f)
+                        quadTo(4.18f, 21f, 3.59f, 20.41f)
+                        reflectiveQuadTo(3f, 19f)
+                        verticalLineTo(5f)
+                        quadTo(3f, 4.17f, 3.59f, 3.59f)
+                        reflectiveQuadTo(5f, 3f)
+                        horizontalLineTo(19f)
+                        quadToRelative(0.83f, 0f, 1.41f, 0.59f)
+                        reflectiveQuadTo(21f, 5f)
+                        verticalLineTo(16f)
+                        lineToRelative(-5f, 5f)
+                        close()
+                        moveTo(15f, 19f)
+                        verticalLineTo(17f)
+                        quadToRelative(0f, -0.82f, 0.59f, -1.41f)
+                        reflectiveQuadTo(17f, 15f)
+                        horizontalLineToRelative(2f)
+                        verticalLineTo(5f)
+                        horizontalLineTo(5f)
+                        verticalLineTo(19f)
+                        horizontalLineTo(15f)
+                        close()
+                        moveToRelative(0f, 0f)
+                        close()
+                        moveTo(5f, 19f)
+                        verticalLineTo(5f)
+                        verticalLineTo(15f)
+                        quadToRelative(0f, 0f, 0f, 0.59f)
+                        reflectiveQuadTo(5f, 17f)
+                        verticalLineToRelative(2f)
+                        close()
+                    }
+                }
+                .build()
+        return _stickerOutlined!!
+    }
+
+private var _stickerOutlined: ImageVector? = null


### PR DESCRIPTION
## What

Swaps the placeholder icons in the sticker UI for proper **Material Symbols** glyphs, vendored as `HomebaseIcons` assets (same convention as `MessageForward`, `Pdf`, etc.).

| Site | Before | After |
|---|---|---|
| Stickers expression tab | `Icons.AutoMirrored.*.StickyNote2` (sticky-note stand-in) | `HomebaseIcons.StickerFilled` (active) / `StickerOutlined` (inactive) |
| Add-sticker tray tile | `Icons.Default.Add` (generic `+`) | `HomebaseIcons.StickerAdd` (filled `sticker_add`) |

## Design decisions

- **Weight 400 / opsz 24 / grade 0**, Outlined family — matches the visual weight of the classic Material Icons it sits beside (`EmojiEmotions`, `GifBox`); heavier would stand out from its neighbours.
- **Filled-when-active, outlined-when-inactive** on the tab — exact parity with the Emoji and GIFs tabs' existing toggle, so selection feedback is consistent across the row.
- **Filled `sticker_add`** on the add tile — it's a single-state call-to-action (replacing a filled `+`); a solid glyph reads as a stronger affordance and stays legible at 32 dp against the colourful saved-sticker thumbnails.
- `autoMirror = true` on all three (preserves the prior `StickyNote2` RTL behaviour).

## Verification

- `:homebase-common:compileKotlinJvm :homebase-chat:compileKotlinJvm :homebase-chat:compileAndroidMain` — BUILD SUCCESSFUL
- `:homebase-common:jvmTest :homebase-chat:jvmTest` — green (Konsist architecture check + sticker tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)