### PR TITLE
fix(vault): persist per-section horizontal scroll across image open/close

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultContent.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalUuidApi::class)
+
 package id.homebase.core.ui.screens.vault
 
 import androidx.compose.animation.AnimatedVisibilityScope
@@ -19,6 +21,8 @@ import id.homebase.chat.services.LocalAttachmentContextStore
 import id.homebase.core.ui.screens.vault.components.VaultEmptyState
 import id.homebase.core.ui.screens.vault.model.VaultEntry
 import id.homebase.core.ui.screens.vault.model.VaultSection
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 @Composable
 fun VaultContent(
@@ -35,6 +39,11 @@ fun VaultContent(
     onAddSection: () -> Unit,
     modifier: Modifier = Modifier,
     lazyListState: LazyListState = rememberLazyListState(),
+    // Per-section horizontal scroll states, keyed by sectionId and owned by the
+    // caller (VaultScreen) so they outlive this composable being torn down when
+    // the full-screen overlay opens/closes. Default is a throwaway map for
+    // previews/tests, where surviving the overlay swap is irrelevant.
+    sectionRowStates: MutableMap<Uuid, LazyListState> = mutableMapOf(),
     sharedTransitionScope: SharedTransitionScope? = null,
     animatedVisibilityScope: AnimatedVisibilityScope? = null,
 ) {
@@ -63,9 +72,14 @@ fun VaultContent(
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
                 items(sections, key = { it.sectionId }) { section ->
+                    // getOrPut on the hoisted map gives each section a stable row
+                    // state that persists across the overlay open/close. Created
+                    // lazily the first time a section is composed.
+                    val rowState = sectionRowStates.getOrPut(section.sectionId) { LazyListState() }
                     VaultSectionCard(
                         section = section,
                         localAttachmentStore = localAttachmentStore,
+                        rowState = rowState,
                         onEntryClick = { onEntryClick(it) },
                         onAddEntry = { onAddEntry(section) },
                         onMoveUp = { onMoveUp(section) },

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -85,6 +86,7 @@ import io.github.vinceglb.filekit.dialogs.FileKitMode
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher
 import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 import kotlinx.io.files.Path
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
@@ -107,6 +109,16 @@ fun VaultScreen(
     val vaultListState = rememberLazyListState()
     var savedScrollIndex by remember { mutableIntStateOf(0) }
     var savedScrollOffset by remember { mutableIntStateOf(0) }
+
+    // Per-section horizontal scroll positions, hoisted ABOVE the AnimatedContent
+    // (grid <-> gallery) so they survive the grid being disposed while the
+    // full-screen overlay is open. Without this every section's LazyRow resets to
+    // 0 on close, so the tile the close hero must fly back to is at the wrong x —
+    // or not composed at all (a LazyRow only composes visible items) — and the
+    // shared-element transition snaps instead of flying home. Mirrors the
+    // vertical vaultListState hoist above; keyed by sectionId. Stale entries for
+    // deleted sections are harmless (sections are few).
+    val sectionRowStates = remember { mutableMapOf<Uuid, LazyListState>() }
 
     LaunchedEffect(uiState.fullScreenOverlay) {
         if (uiState.fullScreenOverlay != null) {
@@ -314,6 +326,7 @@ fun VaultScreen(
                             onAddSection = { showNewSectionSheet = true },
                             modifier = contentModifier,
                             lazyListState = vaultListState,
+                            sectionRowStates = sectionRowStates,
                             sharedTransitionScope = this@SharedTransitionLayout,
                             animatedVisibilityScope = this@AnimatedContent,
                         )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultSectionCard.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultSectionCard.kt
@@ -7,8 +7,10 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -60,6 +62,9 @@ fun VaultSectionCard(
     onRenameSection: () -> Unit,
     onDeleteSection: () -> Unit,
     modifier: Modifier = Modifier,
+    // Hoisted by the caller so the row's horizontal scroll survives the
+    // full-screen overlay open/close; defaults to a local state for previews.
+    rowState: LazyListState = rememberLazyListState(),
     sharedTransitionScope: SharedTransitionScope? = null,
     animatedVisibilityScope: AnimatedVisibilityScope? = null,
 ) {
@@ -100,6 +105,7 @@ fun VaultSectionCard(
             // Entry cards row
             if (section.entries.isNotEmpty()) {
                 LazyRow(
+                    state = rowState,
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
                     contentPadding = PaddingValues(end = 4.dp),
                 ) {


### PR DESCRIPTION
## Problem

Opening an image in **Vault** isn't as smooth as chat — the shared-element ("hero") transition snaps on the first frame, especially when returning to the grid.

## Root cause

The Vault grid has **two** scroll axes:

- **Vertical** (the column of sections): hoisted as `vaultListState` above the `AnimatedContent` that swaps grid ⇄ gallery, so it survives open/close. ✅
- **Horizontal** (cards within a section — `VaultSectionCard`'s `LazyRow`): used an internal default `rememberLazyListState()` living *inside* the `AnimatedContent` slot. When the overlay opens, that slot is disposed; on close it's rebuilt fresh → **every section's row resets to offset 0.** ❌

The close hero pairs the fullscreen image with its source tile via `sharedBounds(key = "image-<fileId>-<payloadKey>")`. If the row reset to 0, that tile is at the wrong x — or **not composed at all** (a `LazyRow` only composes visible items) — so the hero has no correctly-placed partner and snaps.

chat feels smooth because its single message-list state is already hoisted above the analogous `AnimatedContent`; Vault hoisted the vertical axis but missed the per-section horizontal ones.

## Fix

Hoist each section's horizontal scroll state above the `AnimatedContent`, mirroring the existing vertical hoist:

- **`VaultScreen`** — `val sectionRowStates = remember { mutableMapOf<Uuid, LazyListState>() }`, passed into `VaultContent`.
- **`VaultContent`** — `getOrPut(section.sectionId) { LazyListState() }` gives each section a stable, hoisted row state.
- **`VaultSectionCard`** — `LazyRow(state = rowState, …)` instead of the internal one.

3 files, **+33 lines**, no new dependencies.

## How to verify

1. Vault tab → a section with enough cards to scroll sideways.
2. Scroll the row, open a card that **isn't** the first, then press back.
3. Expected: the row **stays put** and the image **flies home cleanly**. Previously the row reset to the start and the hero snapped.

Compiles on JVM + Android (`:homebase-core:compileKotlinJvm`, `:homebase-core:compileAndroidMain`).

## Out of scope (noticed during testing)

HEIC photos (e.g. `IMG_4344.HEIC`) render **rotated 90°** in the Vault fullscreen viewer — an EXIF-orientation decode issue, unrelated to this transition fix. Will file separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
