### PR TITLE
fix(attachment-editor): hide rich-text formatting toolbar on mobile

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
@@ -1141,18 +1141,24 @@ fun MessageTextFieldForAttachment(
     modifier: Modifier = Modifier,
     state: RichTextState,
     onSmileyClick: () -> Unit,
-    onSendMessage: () -> Unit
+    onSendMessage: () -> Unit,
+    // Mirror the chat composer: the rich-text formatting toolbar is desktop/web-only.
+    // On mobile (Android/iOS) the caption editor hides it. Injectable so both branches
+    // are unit-testable without a device.
+    showFormattingToolbar: Boolean = isDesktopOrWeb(),
 ) {
     var hasSent by remember { mutableStateOf(false) }
     val isKeyboardVisible by keyboardAsState()
     val keyboardController = LocalSoftwareKeyboardController.current
 
     Column(modifier = modifier) {
-        RichTextEditorButtons(
-            modifier = Modifier.fillMaxWidth(),
-            state = state,
-            enabled = true,
-        )
+        if (showFormattingToolbar) {
+            RichTextEditorButtons(
+                modifier = Modifier.fillMaxWidth().testTag("attachment_formatting_toolbar"),
+                state = state,
+                enabled = true,
+            )
+        }
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/AttachmentToolbarVisibilityTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/AttachmentToolbarVisibilityTest.kt
@@ -1,0 +1,50 @@
+package id.homebase.chat.widget
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.runComposeUiTest
+import com.mohamedrejeb.richeditor.model.rememberRichTextState
+import id.homebase.core.ui.theme.HomebaseTheme
+import kotlin.test.Test
+
+/**
+ * The fullscreen attachment editor's caption field must hide its rich-text
+ * formatting toolbar on mobile (mirroring the chat composer, which gates the same
+ * toolbar behind isDesktopOrWeb()). Driven by the [showFormattingToolbar] flag so
+ * both branches are testable without a device.
+ */
+@OptIn(ExperimentalTestApi::class)
+class AttachmentToolbarVisibilityTest {
+
+    @Test
+    fun toolbarHiddenWhenFlagFalse() = runComposeUiTest {
+        setContent {
+            HomebaseTheme {
+                MessageTextFieldForAttachment(
+                    state = rememberRichTextState(),
+                    onSmileyClick = {},
+                    onSendMessage = {},
+                    showFormattingToolbar = false,
+                )
+            }
+        }
+        waitForIdle()
+        onNodeWithTag("attachment_formatting_toolbar").assertDoesNotExist()
+    }
+
+    @Test
+    fun toolbarShownWhenFlagTrue() = runComposeUiTest {
+        setContent {
+            HomebaseTheme {
+                MessageTextFieldForAttachment(
+                    state = rememberRichTextState(),
+                    onSmileyClick = {},
+                    onSendMessage = {},
+                    showFormattingToolbar = true,
+                )
+            }
+        }
+        waitForIdle()
+        onNodeWithTag("attachment_formatting_toolbar").assertExists()
+    }
+}


### PR DESCRIPTION
## What

The fullscreen attachment **caption editor** showed the rich-text formatting toolbar (bold / italic / strikethrough / inline-code / link / heading / blockquote / code-block / list) on **mobile**, unlike the chat composer which already gates the same `RichTextEditorButtons` behind `isDesktopOrWeb()`.

This gates `MessageTextFieldForAttachment`'s toolbar behind a new `showFormattingToolbar` flag defaulting to `isDesktopOrWeb()` — so **mobile (Android/iOS) hides it** and **desktop/web keep it**, mirroring the chat composer exactly.

The crop / draw / remove-background / sticker / download **edit-tools row is untouched** (deliberately out of scope).

## Tests

- `AttachmentToolbarVisibilityTest` — toolbar hidden when the flag is false, shown when true (both branches covered without a device, via the injectable flag + a `testTag`).
- Android + iOS (`compileKotlinIosSimulatorArm64`) compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)