### PR TITLE
Cancel the queued send when deleting a not-yet-sent message

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxWrapper.kt
@@ -44,6 +44,13 @@ class OutboxWrapper(
             delegate.selectCheckedOut(checkOutStamp).executeAsOneOrNull()
         }
 
+    /** The single pending row for (driveId, uniqueId), or null if nothing is
+     *  queued. Outbox is UNIQUE(driveId, uniqueId), so there is at most one. */
+    suspend fun selectByDriveAndUnique(driveId: Uuid, uniqueId: Uuid): Outbox? =
+        databaseManager.readValue("outbox.selectByDriveAndUnique") {
+            delegate.selectByDriveAndUnique(driveId, uniqueId).executeAsOneOrNull()
+        }
+
     suspend fun count(): Long =
         databaseManager.readValue("outbox.count") { delegate.count().executeAsOne() }
 

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/Outbox.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/Outbox.sq
@@ -89,6 +89,13 @@ DELETE FROM Outbox
 WHERE driveId = ? AND uniqueId = ?;
 
 
+-- Select the (single, by UNIQUE(driveId,uniqueId)) pending row for a message.
+-- Lets a caller tell a queued create apart from a queued edit before deleting.
+selectByDriveAndUnique:
+SELECT rowId,driveId,uniqueId,dependencyUniqueId,priority,lastAttempt,nextRunTime,checkOutCount,checkOutStamp,uploadType,json,files
+FROM Outbox
+WHERE driveId = ? AND uniqueId = ?;
+
 -- Select checked out item
 selectCheckedOut:
 SELECT rowId,driveId,uniqueId,dependencyUniqueId,priority,lastAttempt,nextRunTime,checkOutCount,checkOutStamp,uploadType,json,files

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
@@ -5,6 +5,7 @@ import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.client.drives.files.DeleteLocalFilesByFileIdRequest
+import id.homebase.api.client.drives.files.DriveOutboxUploader
 import id.homebase.api.client.drives.files.SendReadReceiptByFileIdsOutboxRequest
 import id.homebase.api.client.drives.files.reactions.DriveFileGroupReactionProvider
 import id.homebase.api.client.drives.files.reactions.ToggleReactionOutboxRequest
@@ -271,6 +272,26 @@ class ChatMessageActionService(
         deleteForEveryone: Boolean
     ) {
         val msg = messageLookup.getMessage(messageId) ?: return
+
+        // What's queued for this message decides whether the server even knows
+        // about it. A pending *create* (UploadNewFile) means it never reached the
+        // server; a pending *edit* (UpdateFile) means it did. We can't use
+        // msg.isPendingSend for this — an edit re-stamps isPendingSendTag, so a
+        // sent-then-edited message looks "pending" yet still needs a server delete.
+        val pendingUploadType =
+            dbm.outbox.selectByDriveAndUnique(chatDrive, messageId)?.uploadType
+
+        if (pendingUploadType == DriveOutboxUploader.UploadNewFile) {
+            // Never reached the server: cancel the queued send and drop it
+            // locally. No server delete — recipients never received it, and there
+            // is no remote file to remove. (Narrow race: if the send confirms
+            // between the lookup and here, removeOptimisticFile self-guards on
+            // isPendingSendTag and no-ops; a second delete then takes the path
+            // below.)
+            optimisticWriter.removeOptimisticFile(chatDrive, messageId)
+            return
+        }
+
         val conversation = conversationService.getConversation(msg.conversationId) ?: return
         // msg.fileId is already populated by messageLookup.getMessage above —
         // an extra requireFileId(messageId) here would issue a second
@@ -286,6 +307,11 @@ class ChatMessageActionService(
         } else {
             null
         }
+
+        // Cancel any queued *edit* before deleting — its content is moot, and
+        // leaving it would race the delete against the server. No-op when nothing
+        // is queued (a normally-sent message).
+        dbm.outbox.deleteBy(chatDrive, messageId)
 
         val original = optimisticWriter.writeDelete(chatDrive, messageId)
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -947,8 +947,8 @@ class ConversationService(
         } catch (t: Throwable) {
             audit.threw("step2RemoveSelf", t)
             audit.info("ROLLBACK: removing optimistic status message and its outbox row")
+            // removeOptimisticFile now also cancels the queued outbox send.
             optimisticWriter.removeOptimisticFile(chatDrive, messageId)
-            dbm.outbox.deleteBy(chatDrive, messageId)
             audit.finish("ABORTED at STEP 2 — rolled back step 1 message; leave did NOT complete")
             throw t
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
@@ -422,8 +422,16 @@ class OptimisticWriter(
         }
     }
 
-    /** Removes an optimistic file from the local DB. Call when the send fails so the
-     *  pending message is not left stranded in the conversation list. */
+    /**
+     * Removes a still-pending optimistic file from the local DB **and cancels its
+     * queued outbox send**. Call when a pending message must not ship — a failed
+     * send rollback, or the user deleting a message before it left the device.
+     *
+     * The local file and its outbox row share the same uniqueId; dropping the
+     * file without cancelling the row would still upload the message we just
+     * removed (the "deleted message still gets sent" bug). Only acts while the
+     * file is still pending (`isPendingSendTag`) — a no-op once the send confirms.
+     */
     suspend fun removeOptimisticFile(driveId: Uuid, uniqueId: Uuid) {
         val credentials = credentialsManager.requireActiveCredentials()
 
@@ -438,6 +446,11 @@ class OptimisticWriter(
         if (!isPending) return
 
         try {
+            // Cancel the queued send FIRST. The create/edit row is keyed by this
+            // uniqueId; leaving it would re-upload the file we're about to drop.
+            // Ordered before the local delete so a failure can't leave a message
+            // that's gone locally but still queued to send.
+            dbm.outbox.deleteBy(driveId, uniqueId)
             fileProcessor.deleteEntryDriveMainIndex(
                 identityId = credentials.getIdentityId(),
                 driveId = driveId,

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
@@ -406,6 +406,7 @@ class ChatMessageActionServiceTestFixture(
         userDateMs: Long = 100L,
         id: Uuid = Uuid.random(),
         fileId: Uuid = Uuid.random(),
+        isPendingSend: Boolean = false,
     ): Uuid {
         // 1) FakeMessageLookup record (so getMessage(id) returns non-null).
         seedMessage(
@@ -414,7 +415,13 @@ class ChatMessageActionServiceTestFixture(
             userDateMs = userDateMs,
             id = id,
             fileId = fileId,
+            isPendingSend = isPendingSend,
         )
+
+        // A still-pending message carries isPendingSendTag in localAppData (same as
+        // the optimistic send path), so removeOptimisticFile recognises and drops it.
+        val localAppDataJson =
+            if (isPendingSend) """{"tags": ["${ChatProtocol.isPendingSendTag}"]}""" else "null"
 
         // 2) Real DriveMainIndex row keyed by uniqueId=id so requireFileId(id) finds it.
         val now = Clock.System.now().epochSeconds
@@ -449,7 +456,7 @@ class ChatMessageActionServiceTestFixture(
                   "previewThumbnail": null,
                   "archivalStatus": 0
                 },
-                "localAppData": null,
+                "localAppData": $localAppDataJson,
                 "referencedFile": null,
                 "reactionPreview": null,
                 "versionTag": "${Uuid.random()}",

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/DeleteMessageCancelsPendingTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/DeleteMessageCancelsPendingTest.kt
@@ -1,0 +1,96 @@
+package id.homebase.chat.services
+
+import id.homebase.api.client.drives.files.DriveOutboxUploader
+import kotlin.test.Test
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Deleting a chat message must respect what is queued for it:
+ *  - a pending **create** (UploadNewFile, never on the server) → cancel the send,
+ *    drop it locally, and enqueue NO server delete.
+ *  - a pending **edit** (UpdateFile, the message IS on the server) → cancel the
+ *    edit, but STILL delete the message on the server.
+ *
+ * Regression guard for the trap where `isPendingSend` alone can't tell these
+ * apart: an edit re-stamps `isPendingSendTag`, so a sent-then-edited message
+ * looks "pending" yet must still be deleted server-side.
+ */
+class DeleteMessageCancelsPendingTest {
+
+    @Test
+    fun delete_pendingCreate_cancelsSend_andEnqueuesNoServerDelete() = runTest {
+        ChatMessageActionServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val messageId = fixture.seedDeletableMessage(
+                conversationId = Uuid.random(),
+                isPendingSend = true,
+            )
+            // A queued create — the message never reached the server.
+            fixture.dbm.outbox.insert(
+                driveId = fixture.chatDriveId,
+                uniqueId = messageId,
+                dependencyUniqueId = null,
+                priority = 1L,
+                uploadType = DriveOutboxUploader.UploadNewFile,
+                json = "{}".encodeToByteArray(),
+                filePaths = null,
+            )
+
+            service.deleteMessage(messageId, deleteForEveryone = true)
+
+            val rows = fixture.drainOutbox()
+            assertTrue(
+                rows.none { it.uploadType == DriveOutboxUploader.DeleteFile },
+                "a never-sent message must NOT enqueue a server delete",
+            )
+            assertTrue(
+                rows.none { it.uniqueId == messageId },
+                "the queued create must be cancelled",
+            )
+            assertNull(
+                fixture.dbm.driveMainIndex.selectHomebaseFileByUnique(
+                    fixture.testIdentityId, fixture.chatDriveId, messageId,
+                ),
+                "the optimistic local file must be removed",
+            )
+        }
+    }
+
+    @Test
+    fun delete_pendingEdit_cancelsEdit_butStillDeletesOnServer() = runTest {
+        ChatMessageActionServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = fixture.seedOneOnOneConversation(other = "alice.test")
+            val messageId = fixture.seedDeletableMessage(
+                conversationId = convoId,
+                // an edit re-stamped isPendingSendTag, so this "looks" pending…
+                isPendingSend = true,
+            )
+            // …but the message IS on the server: what's queued is an EDIT, not a create.
+            fixture.dbm.outbox.insert(
+                driveId = fixture.chatDriveId,
+                uniqueId = messageId,
+                dependencyUniqueId = null,
+                priority = 1L,
+                uploadType = DriveOutboxUploader.UpdateFile,
+                json = "{}".encodeToByteArray(),
+                filePaths = null,
+            )
+
+            service.deleteMessage(messageId, deleteForEveryone = true)
+
+            val rows = fixture.drainOutbox()
+            assertTrue(
+                rows.none { it.uploadType == DriveOutboxUploader.UpdateFile },
+                "the queued edit must be cancelled",
+            )
+            assertTrue(
+                rows.any { it.uploadType == DriveOutboxUploader.DeleteFile },
+                "a message already on the server must STILL be deleted there",
+            )
+        }
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/outbox/RemoveOptimisticFileCancelsSendTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/outbox/RemoveOptimisticFileCancelsSendTest.kt
@@ -1,0 +1,98 @@
+package id.homebase.chat.services.outbox
+
+import id.homebase.chat.services.ChatMessageSenderServiceTestFixture
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Deleting a message that is still pending in the outbox must also cancel its
+ * queued send — otherwise the "deleted" message still uploads to the server
+ * once the outbox drains. [OptimisticWriter.removeOptimisticFile] is the shared
+ * primitive (used by message delete and leave-group rollback); it must drop the
+ * local file AND its outbox row together.
+ */
+class RemoveOptimisticFileCancelsSendTest {
+
+    @Test
+    fun removeOptimisticFile_cancelsQueuedSend() = runTest {
+        ChatMessageSenderServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val conversationId = fixture.seedConversation(others = listOf("alice.test"))
+            val messageId = Uuid.random()
+
+            service.sendNewMessage(
+                messageUniqueId = messageId,
+                conversationId = conversationId,
+                messageText = "to be deleted before it sends",
+                previousMessageUniqueId = null,
+                payloadBundle = null,
+            )
+
+            // The optimistic file + its queued send both exist.
+            assertNotNull(
+                fixture.dbm.driveMainIndex.selectHomebaseFileByUnique(
+                    fixture.testIdentityId, fixture.chatDriveId, messageId,
+                ),
+                "expected an optimistic file after sendNewMessage",
+            )
+            val outboxBefore = fixture.dbm.outbox.count()
+            assertTrue(outboxBefore >= 1, "expected a queued send row after sendNewMessage")
+
+            // Delete-before-send.
+            fixture.optimisticWriter.removeOptimisticFile(fixture.chatDriveId, messageId)
+
+            assertNull(
+                fixture.dbm.driveMainIndex.selectHomebaseFileByUnique(
+                    fixture.testIdentityId, fixture.chatDriveId, messageId,
+                ),
+                "local file should be removed",
+            )
+            assertEquals(
+                outboxBefore - 1,
+                fixture.dbm.outbox.count(),
+                "removeOptimisticFile must cancel exactly the message's queued send",
+            )
+        }
+    }
+
+    @Test
+    fun removeOptimisticFile_noOpWhenAlreadySent() = runTest {
+        ChatMessageSenderServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val conversationId = fixture.seedConversation(others = listOf("alice.test"))
+            val messageId = Uuid.random()
+
+            service.sendNewMessage(
+                messageUniqueId = messageId,
+                conversationId = conversationId,
+                messageText = "already confirmed",
+                previousMessageUniqueId = null,
+                payloadBundle = null,
+            )
+
+            // Simulate the send confirming: the pending tag is cleared on sync-back.
+            fixture.optimisticWriter.updateLocalTags(fixture.chatDriveId, messageId, emptyList())
+            val outboxBefore = fixture.dbm.outbox.count()
+
+            fixture.optimisticWriter.removeOptimisticFile(fixture.chatDriveId, messageId)
+
+            // Not pending → must NOT delete the file or touch the outbox.
+            assertNotNull(
+                fixture.dbm.driveMainIndex.selectHomebaseFileByUnique(
+                    fixture.testIdentityId, fixture.chatDriveId, messageId,
+                ),
+                "a confirmed (non-pending) message must not be removed",
+            )
+            assertEquals(
+                outboxBefore,
+                fixture.dbm.outbox.count(),
+                "a no-op removal must not touch the outbox",
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Deleting a chat message soft-deleted it locally and enqueued a server `DeleteFile`, but **never removed the message's own pending outbox row**. So a message deleted before it finished sending still uploaded to the server and reached recipients. Even **"delete for me"** on a never-sent message ended up delivered to everyone — you deleted it *before* it sent, yet it sent.

Found while reviewing the failed-send work; same `UNIQUE(driveId, uniqueId)` / outbox-coupling family.

## Why `isPendingSend` isn't enough

There are **two** pending states, and they need opposite outcomes:

| queued op | meaning | correct delete |
|---|---|---|
| `UploadNewFile` | never reached the server | cancel the send, drop locally, **no** server delete |
| `UpdateFile` | message **is** on the server, an edit is queued | cancel the edit, **but still** delete on the server |

`isPendingSend` can't tell them apart — editing a message re-stamps `isPendingSendTag`, so a **sent-then-edited** message looks "pending" yet must still be deleted server-side. (Caught as a follow-up question: *"if I delete right after editing, before the edit uploads, does the message fail to delete?"* — it did.)

## Fix

- **`OutboxWrapper.selectByDriveAndUnique`** (+ `Outbox.sq` query) — read the single pending row for a message, to tell a queued create from a queued edit.
- **`ChatMessageActionService.deleteMessage`** branches on that op type (table above). It cancels any queued edit before the soft-delete + server-delete.
- **`OptimisticWriter.removeOptimisticFile`** now also cancels the queued send (it dropped only the local file before) — making it the single primitive that does *local delete + outbox delete*. `ConversationService.leaveGroup`'s rollback drops its now-redundant explicit `deleteBy`.

## Tests

- `DeleteMessageCancelsPendingTest`
  - **pending create** → send cancelled, **no** server delete enqueued, local file removed.
  - **pending edit** → edit cancelled, **server delete still enqueued** (the regression you'd otherwise hit).
- `RemoveOptimisticFileCancelsSendTest` — the primitive cancels the queued send; no-op once the send has confirmed.
- Existing `ChatMessageActionServiceTest` (delete-for-everyone / delete-for-me) still passes — the normal sent-delete path is unchanged.

## Verification

- JVM + Android + WasmJs compile; `homebase-chat:jvmTest` green (new + existing delete tests).
- Manual: airplane mode → send → delete before it sends → message does **not** appear for the recipient when back online; send → edit offline → delete → recipient's copy **is** removed.

## Note for sequencing

This adds the same `selectByDriveAndUnique` outbox query as the pending-create-coalesce branch (the edit-before-send fix). If both land, it's an identical, trivially-resolved overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)