### PR TITLE
Coalesce an edit into a still-pending create (don't strand the message)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
@@ -48,6 +48,19 @@ private fun uploadTypeName(t: Long): String = when (t) {
 
 private fun Outbox.uploadTypeLabel(): String = "${uploadTypeName(uploadType)}($uploadType)"
 
+/**
+ * True when enqueuing [incomingUploadType] over an existing pending
+ * [existingUploadType] would strand a not-yet-sent create. An `UpdateFile`
+ * must not replace a pending `UploadNewFile`: the two share
+ * `(driveId, uniqueId)`, so the replace deletes the create that never reached
+ * the server, and the update then fails permanently ("Could not find file with
+ * uniqueId") — losing the message. The caller must instead re-enqueue the edit
+ * AS a create (see `ChatMessageSenderService.updateMessage`). Pure + testable.
+ */
+internal fun wouldStrandPendingCreate(existingUploadType: Long?, incomingUploadType: Long): Boolean =
+    incomingUploadType == DriveOutboxUploader.UpdateFile &&
+        existingUploadType == DriveOutboxUploader.UploadNewFile
+
 class OutboxSync(
     private val databaseManager: DatabaseManager,
     private val uploader: OutboxUploader,
@@ -419,6 +432,47 @@ class OutboxSync(
         return enqueued
     }
 
+    /** Replace any pending row for this message with a fresh create. Used to
+     *  coalesce an edit into a still-queued (not-yet-sent) create so the edit
+     *  doesn't downgrade it to an UpdateFile and strand it. */
+    public suspend fun replaceEnqueue(
+        request: UploadFileRequest,
+        priority: Long = 100,
+        dependencyUniqueId: Uuid? = null,
+        sendNow: Boolean = true
+    ): Boolean {
+        val enqueued = replaceEnqueue(
+            driveId = request.driveId,
+            uniqueId = request.metadata.appData.uniqueId
+                ?: error("unique id required to place in outbox"),
+            dependencyUniqueId = dependencyUniqueId,
+            priority = priority,
+            uploadType = DriveOutboxUploader.UploadNewFile,
+            json = OdinSystemSerializer.serialize(request)
+        )
+
+        if (enqueued && sendNow) {
+            scope.launch { send() }
+        }
+
+        return enqueued
+    }
+
+    /** Upload type of the pending row for (driveId, uniqueId), or null if none
+     *  is queued. Lets a caller branch on create-vs-update before enqueuing. */
+    public suspend fun pendingUploadType(driveId: Uuid, uniqueId: Uuid): Long? =
+        databaseManager.outbox.selectByDriveAndUnique(driveId, uniqueId)?.uploadType
+
+    /** The pending row deserialized as an [UploadFileRequest], or null when there
+     *  is no pending row or it isn't an `UploadNewFile`. Lets an edit amend a
+     *  still-queued create in place — preserving its media payloads — rather than
+     *  replacing it with an update the server can't apply. */
+    public suspend fun pendingUploadFileRequest(driveId: Uuid, uniqueId: Uuid): UploadFileRequest? {
+        val row = databaseManager.outbox.selectByDriveAndUnique(driveId, uniqueId) ?: return null
+        if (row.uploadType != DriveOutboxUploader.UploadNewFile) return null
+        return OdinSystemSerializer.deserialize<UploadFileRequest>(row.json.decodeToString())
+    }
+
     public suspend fun tryEnqueue(
         request: UpdateLocalMetadataTagsOutboxRequest,
         driveId: Uuid,
@@ -548,6 +602,18 @@ class OutboxSync(
         uploadType: Long,
         json: String
     ): Boolean {
+        // Defense in depth: never silently downgrade a pending create to an
+        // update. Chat's edit path coalesces into a create before reaching here
+        // (see ChatMessageSenderService.updateMessage); this guard ensures no
+        // current or future caller can strand a not-yet-sent message instead.
+        val existing = databaseManager.outbox.selectByDriveAndUnique(driveId, uniqueId)
+        if (wouldStrandPendingCreate(existing?.uploadType, uploadType)) {
+            Logger.w(
+                "OutboxSync: refusing to replace a pending UploadNewFile with an UpdateFile " +
+                    "for uniqueId=$uniqueId — would strand the un-sent create."
+            )
+            return false
+        }
         databaseManager.outbox.deleteBy(driveId, uniqueId)
         return tryEnqueue(driveId, uniqueId, dependencyUniqueId, priority, uploadType, json)
     }

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/WouldStrandPendingCreateTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/WouldStrandPendingCreateTest.kt
@@ -1,0 +1,48 @@
+package id.homebase.api.sync.database
+
+import id.homebase.api.client.drives.files.DriveOutboxUploader
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The outbox guard predicate: an UpdateFile must never silently replace a
+ * pending UploadNewFile (they share (driveId, uniqueId), so the replace would
+ * delete the un-sent create and the update would then fail "Could not find
+ * file" — losing the message). See [wouldStrandPendingCreate].
+ */
+class WouldStrandPendingCreateTest {
+
+    private val create = DriveOutboxUploader.UploadNewFile
+    private val update = DriveOutboxUploader.UpdateFile
+    private val delete = DriveOutboxUploader.DeleteFile
+
+    @Test
+    fun update_over_pending_create_isStranding() {
+        assertTrue(wouldStrandPendingCreate(existingUploadType = create, incomingUploadType = update))
+    }
+
+    @Test
+    fun create_over_pending_create_isFine() {
+        // Coalescing an edit re-enqueues AS a create — must be allowed.
+        assertFalse(wouldStrandPendingCreate(existingUploadType = create, incomingUploadType = create))
+    }
+
+    @Test
+    fun update_over_pending_update_isFine() {
+        // The file already exists on the server; replacing one edit with another is fine.
+        assertFalse(wouldStrandPendingCreate(existingUploadType = update, incomingUploadType = update))
+    }
+
+    @Test
+    fun update_with_no_pending_row_isFine() {
+        assertFalse(wouldStrandPendingCreate(existingUploadType = null, incomingUploadType = update))
+    }
+
+    @Test
+    fun nonUpdate_incoming_isNeverStranding() {
+        // Only an incoming UpdateFile can strand a create; deletes etc. don't.
+        assertFalse(wouldStrandPendingCreate(existingUploadType = create, incomingUploadType = delete))
+        assertFalse(wouldStrandPendingCreate(existingUploadType = create, incomingUploadType = create))
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
@@ -396,6 +396,62 @@ class ChatMessageSenderService(
         val recipients = conversationStream.getRecipients(msg.conversationId)
         val isLocalOnly = recipients.isEmpty() // self-conversation: no distribution
 
+        // If the original create is still queued (never reached the server),
+        // editing must keep it a *create*. Downgrading to an UpdateFile would
+        // delete the pending create (they share uniqueId) and then fail
+        // permanently with "Could not find file" — losing the message. Amend
+        // the queued create in place, preserving its media payloads.
+        val pendingCreate = outboxSync.pendingUploadFileRequest(chatDrive, messageId)
+        if (pendingCreate != null) {
+            val createKey = pendingCreate.keyHeader
+            // First delivery: the recipient never saw a prior version, so this
+            // is not an "edit" — don't stamp isEdited.
+            val createMessageData = msg.messageAppData.copy(
+                deliveryStatus = ChatDeliveryStatus.Sending.value,
+                message = JsonPrimitive(content),
+                isEdited = false
+            )
+            val createBuilt = buildMessageContentAndBundle(
+                preVersionedMessageData = createMessageData,
+                payloadBundle = null,
+                fileOperationsProvider = fileOperationsProvider
+            )
+            val createMetadata = UploadFileMetadata(
+                allowDistribution = !isLocalOnly,
+                isEncrypted = true,
+                // No versionTag — this is a create, not an update.
+                appData = UploadAppFileMetaData(
+                    uniqueId = messageId,
+                    groupId = msg.conversationId,
+                    fileType = ChatProtocol.MessageFileType,
+                    dataType = 0,
+                    userDate = msg.userDate.toEpochMilliseconds(),
+                    content = createBuilt.headerContent,
+                    previewThumbnail = msg.previewThumbnail
+                )
+            )
+            // Re-encrypt the (possibly new) text-overflow payload with the same
+            // aesKey the create's media payloads already use, so everything in
+            // the amended request stays decryptable with one keyHeader.
+            val encryptedOverflow = createBuilt.payloadBundle?.let {
+                payloadBundleEncryptionService.encryptBundle(messageId, it, createKey.aesKey, scope)
+            }?.payloads ?: emptyList()
+            val amended = amendPendingCreate(
+                existingCreate = pendingCreate,
+                encryptedMetadata = createMetadata.encryptContent(createKey),
+                encryptedOverflowPayloads = encryptedOverflow
+            )
+            val enqueued = outboxSync.replaceEnqueue(amended, priority = 1, dependencyUniqueId = null)
+            if (!enqueued) error("Failed to update chat message")
+            optimisticWriter.writeUpdate(
+                driveId = chatDrive,
+                keyHeader = createKey,
+                unecryptedMetadata = createMetadata
+            )
+            Logger.d(tag = TAG) { "updateMessage: coalesced edit into still-pending create uniqueId=$messageId" }
+            return UpdateMessageResult(uniqueId = messageId)
+        }
+
         val messageData = msg.messageAppData.copy(
             deliveryStatus = ChatDeliveryStatus.Sending.value,
             message = JsonPrimitive(content),

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/EditCoalesce.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/EditCoalesce.kt
@@ -1,0 +1,35 @@
+package id.homebase.chat.services
+
+import id.homebase.api.client.drives.files.PayloadFile
+import id.homebase.api.client.drives.upload.UploadFileMetadata
+import id.homebase.api.client.drives.upload.UploadFileRequest
+
+/**
+ * Rebuild a still-pending create so it carries an edit's new content while
+ * preserving the original message's media payloads.
+ *
+ * Why this exists: editing a message whose create hasn't reached the server
+ * must keep it a *create* — downgrading to an `UpdateFile` would strand it
+ * ("Could not find file with uniqueId"); see
+ * `OutboxSync.wouldStrandPendingCreate`. But a create is a *full snapshot*
+ * (unlike an update, which is a delta that leaves untouched payloads alone), so
+ * we must carry forward the original media payloads. We swap only:
+ *
+ *  - the header [encryptedMetadata] (the edited text), and
+ *  - the text-overflow payload (`ChatProtocol.DefaultPayloadKey`) — replaced by
+ *    [encryptedOverflowPayloads] (empty when the edited text fits in the header).
+ *
+ * Everything else on the queued create — `transitOptions` (recipients +
+ * notification), `thumbnails`, `keyHeader`, media payloads — is preserved via
+ * `copy`. Pure + unit-testable (the encryption is done by the caller).
+ */
+internal fun amendPendingCreate(
+    existingCreate: UploadFileRequest,
+    encryptedMetadata: UploadFileMetadata,
+    encryptedOverflowPayloads: List<PayloadFile>,
+): UploadFileRequest =
+    existingCreate.copy(
+        metadata = encryptedMetadata,
+        payloads = existingCreate.payloads.filterNot { it.key == ChatProtocol.DefaultPayloadKey } +
+            encryptedOverflowPayloads,
+    )

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/services/AmendPendingCreateTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/services/AmendPendingCreateTest.kt
@@ -1,0 +1,104 @@
+package id.homebase.chat.services
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.drives.files.PayloadFile
+import id.homebase.api.client.drives.upload.UploadAppFileMetaData
+import id.homebase.api.client.drives.upload.UploadFileMetadata
+import id.homebase.api.client.drives.upload.UploadFileRequest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.uuid.Uuid
+
+/**
+ * [amendPendingCreate] is what keeps an edit-while-pending from dropping media.
+ * A create is a full snapshot, so when we fold an edit into a still-queued
+ * create we must keep the original media payloads and swap only the header +
+ * the text-overflow payload (DefaultPayloadKey).
+ */
+class AmendPendingCreateTest {
+
+    private val mediaKey = "chat_web0"
+    private val overflowKey = ChatProtocol.DefaultPayloadKey
+
+    private fun payload(key: String) = PayloadFile(key = key, filePath = "/tmp/$key.enc")
+
+    private fun meta(content: String) = UploadFileMetadata(
+        allowDistribution = true,
+        isEncrypted = true,
+        appData = UploadAppFileMetaData(uniqueId = Uuid.random(), content = content),
+    )
+
+    private fun create(payloads: List<PayloadFile>): UploadFileRequest {
+        val key = KeyHeader.newRandom16()
+        return UploadFileRequest(
+            driveId = Uuid.random(),
+            keyHeader = key,
+            metadata = meta("old header"),
+            payloads = payloads,
+            thumbnails = emptyList(),
+            transitOptions = null,
+        )
+    }
+
+    @Test
+    fun keepsMedia_replacesOverflow() {
+        val media = payload(mediaKey)
+        val existing = create(listOf(media, payload(overflowKey)))   // media + old overflow
+        val newMeta = meta("new header")
+        val newOverflow = payload(overflowKey)
+
+        val result = amendPendingCreate(existing, newMeta, listOf(newOverflow))
+
+        // media survives; the old overflow is dropped; the new overflow is appended.
+        assertEquals(listOf(media, newOverflow), result.payloads)
+        // header swapped to the edited content.
+        assertSame(newMeta, result.metadata)
+    }
+
+    @Test
+    fun shortEdit_dropsOverflow_keepsMedia() {
+        val media = payload(mediaKey)
+        val existing = create(listOf(media, payload(overflowKey)))
+
+        // Edited text now fits in the header → no overflow payload.
+        val result = amendPendingCreate(existing, meta("short"), emptyList())
+
+        assertEquals(listOf(media), result.payloads)
+    }
+
+    @Test
+    fun textOnly_swapsOverflowOnly() {
+        val existing = create(listOf(payload(overflowKey)))           // no media
+        val newOverflow = payload(overflowKey)
+
+        val result = amendPendingCreate(existing, meta("new"), listOf(newOverflow))
+
+        assertEquals(listOf(newOverflow), result.payloads)
+    }
+
+    @Test
+    fun preservesEnvelope() {
+        val existing = create(listOf(payload(mediaKey)))
+
+        val result = amendPendingCreate(existing, meta("new"), emptyList())
+
+        // keyHeader, thumbnails, driveId, transitOptions are carried through untouched.
+        assertSame(existing.keyHeader, result.keyHeader)
+        assertEquals(existing.driveId, result.driveId)
+        assertEquals(existing.thumbnails, result.thumbnails)
+        assertEquals(existing.transitOptions, result.transitOptions)
+    }
+
+    @Test
+    fun multipleMediaPreserved_inOrder() {
+        val m0 = payload("chat_web0")
+        val m1 = payload("chat_web1")
+        val existing = create(listOf(m0, m1, payload(overflowKey)))
+        val newOverflow = payload(overflowKey)
+
+        val result = amendPendingCreate(existing, meta("new"), listOf(newOverflow))
+
+        assertEquals(listOf(m0, m1, newOverflow), result.payloads)
+    }
+}


### PR DESCRIPTION
## Problem

Editing a message *before its original send reached the server* lost the message (it went orange **!** and never delivered). This is the "I sent a message to Andrea, edited it, and it went orange" bug.

Mechanism: a send queues a **create** (`UploadNewFile`); an edit queues an **update** (`UpdateFile`). Both share the same `uniqueId`, and the outbox is `UNIQUE(driveId, uniqueId)`. The edit path uses `replaceEnqueue`, which **deletes the still-queued create** and inserts an update. The create never runs → the server has no such file → the update fails permanently (`400 "Could not find file with uniqueId"`) → the message is dropped.

## Fix

When you edit a message whose create is **still pending**, keep it a **create** carrying the edited text instead of downgrading to an update:

- **`ChatMessageSenderService.updateMessage`** checks the queued op (`outboxSync.pendingUploadFileRequest`). If a create is pending, it **amends that create in place** — swaps the header and re-encrypts the text overflow with the same key, **preserving media payloads** (`amendPendingCreate`) — and re-enqueues as a create. Marked `isEdited = false` (first delivery; the recipient never saw a prior version). Robust in the race: if the original create lands first, the new create hits `ExistingFileWithUniqueId` and the existing `retryAsUpdate` converts it.
- **`OutboxSync` guard** (`wouldStrandPendingCreate`): `replaceEnqueue` refuses to silently replace a pending `UploadNewFile` with an `UpdateFile` — defense in depth so no future caller can strand a not-yet-sent message.
- New `OutboxSync.pendingUploadType` / `pendingUploadFileRequest` + `OutboxWrapper.selectByDriveAndUnique` + a `replaceEnqueue(UploadFileRequest)` overload.

## Tests

- `WouldStrandPendingCreateTest` — the guard truth table.
- `AmendPendingCreateTest` — media payloads preserved, text overflow swapped, envelope (keyHeader/thumbnails/transitOptions/driveId) preserved, multi-media order.

## Verification

- JVM + Android + WasmJs compile; `homebase-api` + `homebase-chat` `jvmTest` green.
- Manual: airplane mode → send → edit 1–3× → restore network → delivers as one message with the final text, no orange **!**.

## Note for sequencing

Adds the same `selectByDriveAndUnique` outbox query as PR #694 (delete-cancels-pending). Whoever merges second resolves a trivial identical overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)