### PR TITLE
Message Info: honest headline for recipient-level delivery failure

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoScreen.kt
@@ -44,6 +44,7 @@ import id.homebase.common.util.formatBytes
 import id.homebase.chat.services.ChatDeliveryStatus
 import id.homebase.chat.widget.ReceivedMessageBubbleDisplayOnly
 import id.homebase.chat.widget.SentMessageBubbleDisplayOnly
+import id.homebase.chat.widget.deliveryFailureTint
 import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.PublicAvatar
 import id.homebase.core.clipboard.clipEntryOf
@@ -59,6 +60,8 @@ import id.homebase.resources.label_received
 import id.homebase.resources.copy_message_id
 import id.homebase.resources.label_message_id
 import id.homebase.resources.label_sent
+import id.homebase.resources.error_delivery_failed
+import id.homebase.resources.msg_status_delivery_details_unavailable
 import id.homebase.resources.msg_status_failed_to_send
 import id.homebase.resources.msg_status_sending
 import id.homebase.resources.msg_status_sent
@@ -209,12 +212,35 @@ fun MessageInfoUi(
                             Text(
                                 text = stringResource(MR.string.msg_status_failed_to_send),
                                 style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.error,
+                                color = deliveryFailureTint(),
+                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
+                            )
+                        }
+
+                        OutgoingSendState.DeliveryFailed -> {
+                            Text(
+                                text = stringResource(MR.string.error_delivery_failed),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = deliveryFailureTint(),
                                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
                             )
                         }
 
                         null -> {}
+                    }
+
+                    // A failed message must never show a bare failure headline
+                    // with silently-missing reasons: when the per-recipient
+                    // transfer history couldn't load, say so.
+                    val sendFailed = uiState.sendState == OutgoingSendState.Failed ||
+                        uiState.sendState == OutgoingSendState.DeliveryFailed
+                    if (sendFailed && uiState.transferHistoryFailed) {
+                        Text(
+                            text = stringResource(MR.string.msg_status_delivery_details_unavailable),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp),
+                        )
                     }
 
                     if (uiState.canRetry) {
@@ -428,7 +454,7 @@ private fun RecipientRow(recipient: RecipientStatusUiModel, modifier: Modifier =
                 Text(
                     text = errorText,
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.error,
+                    color = deliveryFailureTint(),
                 )
             }
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoUiState.kt
@@ -22,8 +22,11 @@ data class ReactionUiModel(
 
 /** High-level send status for an *outgoing* (own) message, shown as the single
  *  status row in Message Info. Null for inbound messages (which keep the
- *  sender-sent / we-received rows instead). */
-enum class OutgoingSendState { Sending, Sent, Failed }
+ *  sender-sent / we-received rows instead). [Failed] is a local send failure
+ *  (the file never settled on our server); [DeliveryFailed] is recipient-level
+ *  (the file settled, but ≥1 recipient transfer failed) — distinct wording and
+ *  no retry, matching the bubble's orange failed indicator. */
+enum class OutgoingSendState { Sending, Sent, Failed, DeliveryFailed }
 
 /** What a (future, currently stubbed) retry would do, derived from whether the
  *  file already exists on the server: [Create] = re-upload a never-landed file;
@@ -76,6 +79,9 @@ data class MessageInfoUiState(
     val isServerCheckLoading: Boolean = false,
     /** Status row for own messages; null for inbound. */
     val sendState: OutgoingSendState? = null,
+    /** True when the transfer-history load threw — distinguishes "no
+     *  recipients" from "couldn't load the per-recipient delivery details". */
+    val transferHistoryFailed: Boolean = false,
     /** Intent a retry would carry; null when no retry is offered. */
     val retryMode: RetryMode? = null,
     /** Whether to surface the Retry affordance (currently a no-op stub). */
@@ -94,8 +100,9 @@ data class SendStatusResult(
 )
 
 /**
- * Pure mapping of (own/inbound, local tag state, server presence) → what the
- * Message Info screen shows. See the scenario matrix in the plan.
+ * Pure mapping of (own/inbound, local tag state, delivery state, server
+ * presence) → what the Message Info screen shows. See the scenario matrix in
+ * the plan.
  *
  * - Inbound → no status row (keeps the legacy sent/received rows), no retry.
  * - Failed send (`isFailedSend`) → Failed + retry. Retry intent is Create when
@@ -103,12 +110,20 @@ data class SendStatusResult(
  * - Pending send (`isPendingSend`) → Sent if the server already has it
  *   (the pending tag just hasn't cleared — e.g. opened info too fast),
  *   otherwise Sending. No retry while still in the outbox.
- * - Settled → Sent.
+ * - Settled + `deliveryFailed` → DeliveryFailed: our upload landed but ≥1
+ *   recipient transfer failed (the bubble's orange state). No retry — a
+ *   redistribution is not an outbox re-enqueue.
+ * - Settled otherwise → Sent.
+ *
+ * The local tags win over `deliveryFailed`: they describe whether *our* upload
+ * settled, and an optimistic/pending file has no transfer history anyway
+ * (`MessageAppData.deliveryStatus` defaults to Sent).
  */
 fun deriveSendStatus(
     isOwnMessage: Boolean,
     isPendingSend: Boolean,
     isFailedSend: Boolean,
+    deliveryFailed: Boolean,
     serverPresence: ServerPresence,
 ): SendStatusResult = when {
     !isOwnMessage -> SendStatusResult(null, null, false)
@@ -122,5 +137,6 @@ fun deriveSendStatus(
         ServerPresence.Absent, ServerPresence.Unknown ->
             SendStatusResult(OutgoingSendState.Sending, null, false)
     }
+    deliveryFailed -> SendStatusResult(OutgoingSendState.DeliveryFailed, null, false)
     else -> SendStatusResult(OutgoingSendState.Sent, null, false)
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoViewModel.kt
@@ -8,6 +8,7 @@ import co.touchlab.kermit.Logger
 import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.common.OdinId
+import id.homebase.chat.services.ChatDeliveryStatus
 import id.homebase.chat.services.ChatMessageActionService
 import id.homebase.chat.services.ChatMessageStream
 import id.homebase.chat.services.toChatDeliveryStatus
@@ -84,10 +85,16 @@ class MessageInfoViewModel(
                             it.copy(
                                 recipients = recipients,
                                 isTransferHistoryLoading = false,
+                                transferHistoryFailed = false,
                             )
                         }
                     } catch (e: Exception) {
-                        _uiState.update { it.copy(isTransferHistoryLoading = false) }
+                        _uiState.update {
+                            it.copy(
+                                isTransferHistoryLoading = false,
+                                transferHistoryFailed = true,
+                            )
+                        }
                     }
                 }
 
@@ -140,6 +147,7 @@ class MessageInfoViewModel(
                 isOwnMessage = isOwn,
                 isPendingSend = message.isPendingSend,
                 isFailedSend = message.isFailedSend,
+                deliveryFailed = message.messageAppData.deliveryStatus == ChatDeliveryStatus.Failed.value,
                 serverPresence = state.serverPresence,
             )
             state.copy(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/DeliveryFailureTint.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/DeliveryFailureTint.kt
@@ -1,0 +1,13 @@
+package id.homebase.chat.widget
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import id.homebase.core.ui.theme.HomebaseTheme
+
+/**
+ * The one source of truth for the delivery-failure accent ("orange"). The
+ * bubble's status icon, Message Info's failure headlines, and per-recipient
+ * error details all read this, so they can never drift apart again.
+ */
+@Composable
+fun deliveryFailureTint(): Color = HomebaseTheme.extendedColors.warning

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -827,7 +827,7 @@ fun DeliveryStatus(
     contentColor: Color,
     pendingSince: Instant? = null,
 ) {
-    val warning = HomebaseTheme.extendedColors.warning
+    val warning = deliveryFailureTint()
     if (isPendingSend) {
         val stale = pendingSince != null && rememberPendingStale(pendingSince)
         Icon(

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/messageinfo/DeriveSendStatusTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/messageinfo/DeriveSendStatusTest.kt
@@ -17,15 +17,18 @@ class DeriveSendStatusTest {
     @Test
     fun inbound_neverShowsStatusOrRetry() {
         for (presence in ServerPresence.entries) {
-            val r = deriveSendStatus(
-                isOwnMessage = false,
-                isPendingSend = false,
-                isFailedSend = false,
-                serverPresence = presence,
-            )
-            assertNull(r.sendState, "inbound should have no status row")
-            assertNull(r.retryMode)
-            assertFalse(r.canRetry)
+            for (deliveryFailed in listOf(false, true)) {
+                val r = deriveSendStatus(
+                    isOwnMessage = false,
+                    isPendingSend = false,
+                    isFailedSend = false,
+                    deliveryFailed = deliveryFailed,
+                    serverPresence = presence,
+                )
+                assertNull(r.sendState, "inbound should have no status row")
+                assertNull(r.retryMode)
+                assertFalse(r.canRetry)
+            }
         }
     }
 
@@ -37,6 +40,7 @@ class DeriveSendStatusTest {
             isOwnMessage = true,
             isPendingSend = false,
             isFailedSend = true,
+            deliveryFailed = false,
             serverPresence = ServerPresence.Absent,
         )
         assertEquals(OutgoingSendState.Failed, r.sendState)
@@ -50,6 +54,7 @@ class DeriveSendStatusTest {
             isOwnMessage = true,
             isPendingSend = false,
             isFailedSend = true,
+            deliveryFailed = false,
             serverPresence = ServerPresence.Present,
         )
         assertEquals(OutgoingSendState.Failed, r.sendState)
@@ -63,6 +68,7 @@ class DeriveSendStatusTest {
             isOwnMessage = true,
             isPendingSend = false,
             isFailedSend = true,
+            deliveryFailed = false,
             serverPresence = ServerPresence.Unknown,
         )
         assertEquals(OutgoingSendState.Failed, r.sendState)
@@ -78,6 +84,7 @@ class DeriveSendStatusTest {
             isOwnMessage = true,
             isPendingSend = true,
             isFailedSend = false,
+            deliveryFailed = false,
             serverPresence = ServerPresence.Present,
         )
         assertEquals(OutgoingSendState.Sent, r.sendState)
@@ -91,6 +98,7 @@ class DeriveSendStatusTest {
             isOwnMessage = true,
             isPendingSend = true,
             isFailedSend = false,
+            deliveryFailed = false,
             serverPresence = ServerPresence.Absent,
         )
         assertEquals(OutgoingSendState.Sending, r.sendState)
@@ -103,6 +111,7 @@ class DeriveSendStatusTest {
             isOwnMessage = true,
             isPendingSend = true,
             isFailedSend = false,
+            deliveryFailed = false,
             serverPresence = ServerPresence.Unknown,
         )
         assertEquals(OutgoingSendState.Sending, r.sendState)
@@ -117,11 +126,58 @@ class DeriveSendStatusTest {
             isOwnMessage = true,
             isPendingSend = false,
             isFailedSend = false,
+            deliveryFailed = false,
             serverPresence = ServerPresence.Unknown,
         )
         assertEquals(OutgoingSendState.Sent, r.sendState)
         assertFalse(r.canRetry)
         assertNull(r.retryMode)
+    }
+
+    // --- Settled + recipient-level failure: DeliveryFailed, no retry -------
+
+    @Test
+    fun settled_deliveryFailed_isDeliveryFailedNoRetry() {
+        for (presence in ServerPresence.entries) {
+            val r = deriveSendStatus(
+                isOwnMessage = true,
+                isPendingSend = false,
+                isFailedSend = false,
+                deliveryFailed = true,
+                serverPresence = presence,
+            )
+            assertEquals(OutgoingSendState.DeliveryFailed, r.sendState)
+            assertNull(r.retryMode)
+            assertFalse(r.canRetry)
+        }
+    }
+
+    // --- Local tags win over recipient-level delivery state ----------------
+
+    @Test
+    fun failedSend_winsOverDeliveryFailed() {
+        val r = deriveSendStatus(
+            isOwnMessage = true,
+            isPendingSend = false,
+            isFailedSend = true,
+            deliveryFailed = true,
+            serverPresence = ServerPresence.Absent,
+        )
+        assertEquals(OutgoingSendState.Failed, r.sendState)
+        assertTrue(r.canRetry)
+    }
+
+    @Test
+    fun pending_winsOverDeliveryFailed() {
+        val r = deriveSendStatus(
+            isOwnMessage = true,
+            isPendingSend = true,
+            isFailedSend = false,
+            deliveryFailed = true,
+            serverPresence = ServerPresence.Absent,
+        )
+        assertEquals(OutgoingSendState.Sending, r.sendState)
+        assertFalse(r.canRetry)
     }
 
     // --- Failed wins over pending if both tags somehow present -------------
@@ -132,6 +188,7 @@ class DeriveSendStatusTest {
             isOwnMessage = true,
             isPendingSend = true,
             isFailedSend = true,
+            deliveryFailed = false,
             serverPresence = ServerPresence.Absent,
         )
         assertEquals(OutgoingSendState.Failed, r.sendState)

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -71,6 +71,7 @@
     <string name="msg_status_sending">Sender…</string>
     <string name="msg_status_sent">Sendt: %1$s</string>
     <string name="msg_status_failed_to_send">Kunne ikke sendes</string>
+    <string name="msg_status_delivery_details_unavailable">Leveringsdetaljer kunne ikke indlæses</string>
     <string name="action_retry">Prøv igen</string>
     <string name="label_edited">Redigeret: %1$s</string>
     <string name="label_size">Størrelse: %1$s</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="msg_status_sending">Sending…</string>
     <string name="msg_status_sent">Sent: %1$s</string>
     <string name="msg_status_failed_to_send">Failed to send</string>
+    <string name="msg_status_delivery_details_unavailable">Couldn’t load delivery details</string>
     <string name="action_retry">Retry</string>
     <string name="label_edited">Edited: %1$s</string>
     <string name="label_size">Size: %1$s</string>


### PR DESCRIPTION
## Problem

For an own message that settled on our server but failed to reach a recipient, the chat bubble and the Message Info screen contradicted each other:

- The **bubble** derives its indicator from `MessageMapper.getDeliveryStatus()`, which folds `transferSummary.totalFailed > 0` into `ChatDeliveryStatus.Failed` and renders an orange (`extendedColors.warning`) `ErrorOutline` icon.
- The **Message Info headline** (`deriveSendStatus`) only consulted the local outbox tags `isPendingSend` / `isFailedSend`, so this case fell through to the settled branch and read **"Sent: \<date\>"** — directly contradicting the failed bubble.

Two adjacent inconsistencies made this worse:

- **Color drift:** Message Info colored its failure texts `colorScheme.error` (red) while the bubble used `extendedColors.warning` (orange); there was no shared source for the failure accent.
- **Silent reason loss:** when the transfer-history fetch threw, the ViewModel just cleared the loading flag — the per-recipient failure reasons vanished with no explanation.

## Changes

**New `DeliveryFailed` headline state** — `deriveSendStatus` takes a `deliveryFailed` flag, fed from `messageAppData.deliveryStatus == ChatDeliveryStatus.Failed` (the same recipient-level signal the bubble uses). Settled + deliveryFailed now shows **"Delivery failed"** (reuses the already-translated `error_delivery_failed` resource), with wording deliberately distinct from the local **"Failed to send"**:

- `Failed` (local, `isFailedSend`): the file never settled on our server → Retry offered (Create/Update by server presence), unchanged.
- `DeliveryFailed` (recipient-level): the file is on our server, ≥1 recipient transfer failed → no Retry, since a redistribution is not an outbox re-enqueue. Per-recipient reasons below explain who failed and why.

Precedence stays `!own > isFailedSend > isPendingSend > deliveryFailed > Sent` — the local tags describe whether *our* upload settled and must win; a pending optimistic file has no transfer history anyway.

**One source of truth for the failure "orange"** — new `deliveryFailureTint()` (`widget/DeliveryFailureTint.kt`) returns `HomebaseTheme.extendedColors.warning` and is now read by:
- the bubble's `DeliveryStatus` icon (and therefore `ConversationItem` / `StickerMessage`, which reuse it),
- both Message Info headline failure states (previously red `colorScheme.error`),
- the per-recipient error-detail lines (previously red).

**Failure reason survives a transfer-history load failure** — the catch now sets a `transferHistoryFailed` flag instead of failing silently, and the screen shows a muted *"Couldn't load delivery details"* line (new `msg_status_delivery_details_unavailable` string, en + da) under any failure headline, so a failed message never shows a bare headline with its reasons section silently missing.

## Tests

`DeriveSendStatusTest` matrix extended: settled + deliveryFailed → `DeliveryFailed` with no retry across all server presences; `isFailedSend` and pending both win over `deliveryFailed`; inbound stays row-less even with `deliveryFailed`.

Verified: `homebase-chat:jvmTest` + `homebase-common:jvmTest` (incl. Konsist `ArchitectureTest`) green; compiles on `compileKotlinJvm`, `compileAndroidMain`, `compileKotlinWasmJs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)