### PR TITLE
feat(community): peer-hosted collaborative drive transport (Part 1)

### DIFF
--- a/COMMUNITY_PART1_TRANSPORT.md
+++ b/COMMUNITY_PART1_TRANSPORT.md
@@ -1,0 +1,125 @@
+# Community — Part 1: Peer-hosted Drive Transport (chat-kmp)
+
+> **This is a self-contained infrastructure task. It builds NO Community feature.** It teaches
+> chat-kmp to sync, query, websocket, and write to a drive hosted on **another identity's** host, and
+> proves it against a real, already-existing community. The actual Community feature is Part 2
+> (`COMMUNITY_PART2_FEATURE.md`) and must not be started until this passes the validation gate below.
+
+## Goal
+
+A "community" (the Slack-like feature we'll build in Part 2) lives as a single **collaborative drive on
+its creator's identity**. Every member syncs that *one remote drive* into their local client and gets
+live updates over a websocket bound to the owner's host. There is one physical copy of the data (on the
+owner), not a per-member copy.
+
+chat-kmp today cannot do this: **every** sync/query/websocket/upload targets the logged-in user's own
+host (`creds.domain`). This task adds the missing capability — a drive whose **owning identity ≠ me** —
+as a reusable, feature-agnostic addition to `homebase-api` (+ drive registry/config).
+
+> **JS source of truth.** The finished web implementation is a **sibling checkout** at `../odin-js/`
+> (relative to this `chat-kmp/` repo root). Every `*.ts` file cited below is under
+> `../odin-js/packages/apps/community-app/src/` (providers, hooks/community), and the SDK they call
+> (`uploadFileOverPeer`, `queryBatchOverPeer`, `getContentFromHeaderOverPeer`, peer notify) lives in
+> `../odin-js/packages/libs/js-lib/`. When this doc is thin on a detail, read the original there.
+
+## Why it's needed — what's missing (verified against `homebase-api`)
+
+| Capability | Today in chat-kmp | Needed |
+|---|---|---|
+| **Sync** | `DriveSync`/`DriveSyncManager.mountDrive` bind `identityId` = active creds; one host only (`sync/DriveSync.kt`, `DriveSyncManager.kt:287-347`) | Sync a drive whose **owning identity ≠ me** into the local DB, keyed by owning identity |
+| **Query** | `DriveQueryProvider.queryBatch` always hits `creds.domain` `/drives/$id/files/query-batch`. `PeerDriveQueryProvider` only has `fileExistsBy…` (healing) | A real `queryBatchOverPeer(ownerOdinId, drive, …)` → `/peer/$owner/drives/$id/files/query-batch` for catch-up |
+| **WebSocket** | `OdinWebSocketClient` connects `wss://${creds.domain}/…`, single host, drive list from own registry (`OdinWebSocketClient.kt:241,260,810`) | A **peer subscription** to the owner's host for the community drive (peer-subscription endpoint, or a second WS connection per owner host) |
+| **Upload/write** | `TransitOptions.remoteTargetDrive` field exists but has **no consumers**; `DriveUploadProvider.uploadFile` always posts to `creds.domain` | Honour `remoteTargetDrive` so a write lands on the owner's drive over peer |
+| **Drive registry/config** | `LabeledDrive`/`TargetDrive` carry no owning identity; `DriveRegistry` reads only the user's own Chat drive | Track drives as `(ownerOdinId, TargetDrive)` and mount them for sync/WS |
+
+## Decision: local mirror (DECIDED)
+
+Land the remote drive's files in the **local SQLDelight DB**, tagged with the owning identity — exactly
+as own drives are stored. This keeps every future Stream/Service reading the local DB unchanged, and
+gives offline support for free.
+
+Concrete surface:
+- `DriveMainIndex` rows keyed/tagged by **owning identity** so a member's own drives and each remote
+  community drive coexist without collision. (Implementation detail to settle in code: add an
+  owning-identity column vs. repurpose the existing `identityId` column to mean "owner of this drive."
+  Check the SQLDelight schema + `QueryBatch`/`DriveSync` call sites and pick the lower-impact option.)
+- `DriveSync` / `DriveSyncManager.mountDrive` take an owning-identity/host parameter.
+- The sync pull uses `queryBatchOverPeer` against the owner instead of the local-host query.
+- Incoming peer-websocket events feed the **same** `EventBus` / `BackendEvent.DataEvent.BatchReceived`
+  pipeline the existing Streams already consume — no new event plumbing.
+
+> Rejected alternative — *live peer-query (JS parity)*: query the owner's host on demand with no local
+> mirror. Smaller DB change, but breaks the "everything reads local DB" assumption, loses offline, and
+> would be community-specific. Not chosen.
+
+## Fail-soft resilience (key requirement)
+
+Unlike your own host, a community owner's host can be **offline or slow**, and that must never degrade
+your own drives or other communities. Good news: `DriveSyncManager` already isolates failure per drive —
+each drive is its own `DriveSync`; an `Aborted` result only reschedules that one drive
+(`DriveSyncManager.kt:106-122`), a `403` only unmounts that one drive (`:123-128`), and `mountDrive`
+splits "register in-memory (always succeeds)" from "kick the network sync" (`:287-347`), so mounting a
+currently-unreachable owner is fine.
+
+What still needs hardening for remote drives:
+- **Backoff, not a 1s hammer.** The abort path retries on a flat `delay(1000L)` loop (`:114-122`); an
+  offline owner would be polled forever every second. Give remote drives exponential backoff + a ceiling.
+- **Don't pollute the global sync state.** A remote failure currently flips the aggregate `syncState`
+  and emits `SyncAllStopped(Failure)` (`:61-83`) — one offline community would make the whole app read
+  "sync failed." Exclude remote/community drives from the global indicator; surface their health as a
+  per-community status.
+- **Don't barrier on remote drives.** `syncAll()` does `jobs.joinAll()` (`:214-217`); ensure the HTTP
+  client has a real timeout, and consider not awaiting remote drives in the aggregate so one unreachable
+  owner can't stall the round.
+- **Tolerate access revocation.** An owner who removes your drive grant should unmount that community
+  cleanly (reuse the `PermissionDenied`/`unmountDrive` path, `:123-128`/`:354-363`) without error spam.
+
+## The drive you're connecting to (JS mechanics, for the test target)
+
+To validate, point the new transport at a **real, existing community** that the JS web app
+(`odin-js/packages/apps/community-app/`) created. The relevant mechanics to interoperate with:
+
+- **Drive identity & type.** Each community is its own drive: `TargetDrive { alias = communityId,
+  type = '63db75f1-e999-40b2-a321-41ebffa5e363' }`, hosted on the community creator's identity
+  (`getTargetDriveFromCommunityId`, `CommunityDefinitionProvider.ts`).
+- **It's a collaborative drive.** Created with `attributes: { IsCollaborativeChannel: 'true' }`,
+  `allowSubscriptions: true`, permissions `Read+Write+React+Comment`; members are granted access via a
+  circle (`hooks/community/useCommunity.ts`, `useCommunityMemberUpdater.ts`). For the test you just need
+  to be a member (in the owner's community circle) of an existing community.
+- **Messages to look for.** `fileType 7020`, `groupId = channelId`, content embedded in header or in the
+  `comm_web…` payload (`CommunityMessageProvider.ts`). The default "general" channel id is
+  `7d64f4e4-f8e2-4c3b-bc4b-48bbb86e8f9a`.
+- **Read path JS uses (mirror it).** `queryBatchOverPeer(ownerOdinId, communityDrive, …)` +
+  `getContentFromHeaderOverPeer(...)`.
+- **Live path JS uses (mirror it).** A websocket subscriber bound to the **owner's** host watching the
+  community drive for `['fileAdded','fileModified','fileDeleted','statisticsChanged']`
+  (`useCommunityPeerWebsocket.ts`); push armed via
+  `POST notify/peer/subscriptions/push-notification { identity: ownerOdinId, subscriptionId: communityId }`
+  (`PeerNotificationSubscriber.ts`).
+- **Write path JS uses (mirror it).** A non-owner writes straight to the owner's drive over peer:
+  `uploadFileOverPeer(TransitInstructionSet { remoteTargetDrive = communityDrive, recipients:
+  [ownerOdinId], … })`.
+
+> Reading these JS wire constants is a **test affordance only** — the simplest way to exercise the
+> transport against real, already-populated data. Part 2's feature is greenfield and chooses its own
+> file-types/models; do **not** treat any of these constants as a long-term interop contract.
+
+## Validation gate (all three must pass before Part 2)
+
+With a member identity that belongs to an existing JS community owned by a connected identity:
+
+1. **Sync in.** Mount the owner's community drive → its existing messages land in the local DB and are
+   queryable like any own-drive file.
+2. **Live updates.** Owner posts a message in the JS web client → the KMP client receives it live over
+   the peer websocket and it appears in the local DB, no restart.
+3. **Write out.** KMP writes a (raw) message file to the owner's drive over peer → it appears in the JS
+   web client.
+
+Plus the fail-soft checks: with the owner's host unreachable, the app's own drives keep syncing, the
+global sync indicator does **not** read "failed", and retries back off rather than hammer.
+
+## When this passes
+
+Hand off to **`COMMUNITY_PART2_FEATURE.md`**, which builds the actual Community feature on top of this
+transport. From Part 2's perspective the community drive then behaves like any local drive — the only
+difference is that it's owner-hosted, which this layer has made transparent.

--- a/COMMUNITY_PART1_V2_BACKEND_PORT.md
+++ b/COMMUNITY_PART1_V2_BACKEND_PORT.md
@@ -1,0 +1,181 @@
+# Community Part 1 — V2 Backend Port (odin-core)
+
+> **Handoff spec for a fresh session working in `..\odin-core\`.** It defines the V2 server routes
+> the chat-kmp client needs so a member can sync / query / write / live-subscribe to a **community
+> drive hosted on another identity** (the community owner). The client side (chat-kmp, branch
+> `generic-video-compressor`) is already written against the V2 shapes below; this doc is the
+> server contract it expects. The equivalent logic already exists as **V1 transit** endpoints
+> (what the odin-js web app uses) — the task is to expose V2 routes that wrap that logic.
+
+## Why this exists
+
+A community is one collaborative drive on its creator's identity; members sync that single remote
+drive. chat-kmp is a **pure V2 client** (`https://{host}/api/v2/...`, `Authorization: Bearer` CAT +
+shared-secret body/response encryption). The over-peer operations it needs do **not** exist as V2
+routes yet — only as V1 `/transit/...` routes (used by odin-js). The V1 smoke test from chat-kmp
+returned **404** because chat-kmp can't reasonably reach V1 (different base + browser-cookie auth
+model). So: add the V2 routes.
+
+## The pattern to follow (already proven on V2)
+
+chat-kmp already calls one over-peer V2 route successfully today:
+
+```
+GET /api/v2/peer/{odinId}/drives/{driveId}/files/by-uid/{uniqueId}/exists
+GET /api/v2/peer/{odinId}/drives/{driveId}/files/by-gtid/{globalTransitId}/exists
+```
+
+(see chat-kmp `homebase-api/.../client/peer/PeerDriveQueryProvider.kt`). This proves the V2 server
+has a **peer-drive controller mounted at `/api/v2/peer/{odinId}/drives/{driveId}/...`**, it accepts
+chat-kmp's bearer CAT + shared-secret, and it returns headers **re-encrypted to the caller's own
+shared secret**. **All new routes below extend that same controller family** and delegate to the
+existing peer/transit services — they are thin V2 wrappers, not new logic.
+
+> **In odin-core, locate:** (1) the controller serving the `…/by-uid/{uid}/exists` route above
+> (that's the V2 peer-drive controller to extend), and (2) the V1 `/transit/query/batch`,
+> `/transit/sender/files/send`, and `/notify/peer/*` handlers (the existing logic to delegate to).
+> The V2 routes map path params → the existing service calls.
+
+---
+
+## MVP routes (required for the Part 1 validation gate)
+
+### 1. Query over peer (READ) — highest priority
+
+```
+POST /api/v2/peer/{odinId}/drives/{driveId}/files/query-batch
+```
+
+- **Auth/encryption:** identical to the existing `…/exists` route (bearer CAT + shared-secret
+  envelope). Request body and response are shared-secret encrypted (`{iv,data}`).
+- **Request body** (decrypted) = chat-kmp `QueryBatchRequest`:
+  ```jsonc
+  {
+    "queryParams": { /* FileQueryParams: fileType?, dataType?, groupId?, tagsMatchAtLeastOne?, ... — NO targetDrive (it's in the path) */ },
+    "resultOptionsRequest": { "cursorState": null, "maxRecords": 10, "includeMetadataHeader": true, "includeTransferHistory": false, "ordering": "OldestFirst", "sorting": "AnyChangeDate" }
+  }
+  ```
+- **Response** (encrypted to the **caller's** shared secret) = chat-kmp `QueryBatchResponse`:
+  ```jsonc
+  {
+    "name": null, "invalidDrive": false, "queryTime": 0, "includeMetadataHeader": true,
+    "cursorState": "…", "hasMoreRows": false,
+    "searchResults": [ { "fileId", "fileState", "fileSystemType", "sharedSecretEncryptedKeyHeader", "fileMetadata", "serverMetadata", "priority", "fileByteCount" } ]
+  }
+  ```
+  Each `sharedSecretEncryptedKeyHeader` must be re-encrypted to the **caller's** shared secret (so
+  the member can decrypt) — exactly what the V1 transit query and the V2 exists-check already do.
+- **V1 logic to wrap:** `/transit/query/batch` (odin-js `PeerDriveQueryService.ts`), whose body is
+  `{ queryParams: {…, targetDrive}, resultOptionsRequest, odinId }`. The V2 version takes `odinId`
+  and `targetDrive`(=driveId) from the **path** instead of the body.
+- **Client call site (no change needed):** `DriveQueryProvider.queryBatch(driveId, request, ownerOdinId)`.
+
+### 2. Write over peer (member → owner's drive) (WRITE)
+
+```
+POST /api/v2/peer/{odinId}/drives/{driveId}/files        (multipart/form-data)
+```
+
+- Mirrors the own-host create `POST /api/v2/drives/{driveId}/files`, but the target drive is hosted
+  on `{odinId}`, so the server performs the **transit send** to the owner and returns the result.
+- **Multipart parts** (identical to own-host create):
+  - `instructions` — JSON `UploadInstructionSet` (`storageOptions?`, `transitOptions?`, `transferIv`, `manifest`)
+  - `metadata` — shared-secret-encrypted `UploadFileDescriptor` (`{encryptedKeyHeader, fileMetadata}`)
+  - `payload` / `thumbnail` — streamed (encrypted with the file key header)
+- **Response:** the create result (`fileId`/`globalTransitId`/`newVersionTag`, and per-recipient
+  `recipientStatus`). Throw/encode failure if the owner rejects.
+- **V1 logic to wrap:** `/transit/sender/files/send` (odin-js `PeerFileUploader.ts`), whose
+  `TransitInstructionSet` carries `recipients=[owner]` + `remoteTargetDrive`. In V2 both are implicit
+  from the path, so the controller injects `recipients=[{odinId}]`, `remoteTargetDrive={driveId}` and
+  delegates to the existing transit-send service.
+- **Client follow-up (simplification):** once this exists, chat-kmp drops its `TransitInstructionSet`
+  /`TransitUploadResult` layer and routes the existing `DriveUploadProvider.uploadFile` at this URL —
+  a one-line change. (The current `PeerDriveUploadProvider` is a placeholder for the V1 shape.)
+
+### 3. Live updates over peer (WEBSOCKET) — most design latitude
+
+The member needs `fileAdded / fileModified / fileDeleted / statisticsChanged` for the community
+drive, live. **Two designs — please pick (A) is strongly preferred:**
+
+**(A) Broker peer drives on the member's own V2 socket (preferred).**
+Extend the existing V2 notify hub (`wss://{member}/api/v2/notify/ws-token`) so its
+`establishConnectionRequest` can include **owner-hosted drives**, and the member's host relays the
+owner's drive events to the member. One connection, no peer token, no second host.
+- Client impact: chat-kmp **deletes** `PeerWebSocketClient`/`PeerWebSocketManager` and just adds the
+  community drive (tagged with owner) to the existing `OdinWebSocketClient` subscription. Simplest.
+- Requires: a way to express `(ownerOdinId, targetDrive)` in the establish payload, and the hub
+  brokering the owner subscription server-side.
+
+**(B) Direct peer socket (V1 parity, fallback).** Keep the V1 model but on V2:
+```
+POST /api/v2/notify/peer/token              { identity }  ->  { authenticationToken64, sharedSecret }
+wss://{owner}/api/v2/notify/peer/ws          (auth via the token; establish wrapper carries clientAuthToken64)
+```
+- Client impact: chat-kmp keeps `PeerWebSocketClient` and just points its two route constants here
+  (`PEER_WS_PATH`, token route). This is what the client has wired today.
+- **V1 logic to wrap:** odin-js `WebsocketProviderOverPeer.ts` (token + `notify/peer/ws`).
+
+Also (both designs), for closed-app push:
+```
+POST /api/v2/notify/peer/subscriptions/push-notification   { identity, subscriptionId }
+```
+(V1: `PeerNotificationSubscriber.ts`). Client: `PeerNotificationProvider.subscribeToPeerNotifications`.
+
+---
+
+## Follow-up routes (Part 2 / media — not needed for the gate, list for completeness)
+
+Same `/api/v2/peer/{odinId}/drives/{driveId}/...` family, wrapping the V1 transit equivalents:
+
+| V2 route | V1 equiv (odin-js) | For |
+|---|---|---|
+| `GET …/files/{fileId}/header` | `/transit/query/header` | header fetch |
+| `GET …/files/{fileId}/payload?key=` (range) | `/transit/query/payload` | media payload |
+| `GET …/files/{fileId}/thumb?key=&width=&height=` | `/transit/query/thumb` | thumbnails |
+| `POST …/files/senddeleterequest` (or DELETE) | `/transit/sender/files/senddeleterequest` | delete over peer |
+| `POST /api/v2/peer/drives/metadata/type` | `/transit/query/metadata/type` | discover community drives by type |
+
+---
+
+## Auth & encryption (must match the existing V2 peer route)
+
+- **Auth:** bearer CAT (`Authorization: Bearer {clientAccessToken}`), same handler as
+  `…/by-uid/{uid}/exists`. Do **not** require the browser-cookie model the V1 routes use — chat-kmp
+  has no cookie.
+- **Request encryption:** body is shared-secret AES envelope `{iv, data}` (POST/PUT/PATCH);
+  the V2 framework already decrypts this for the exists-check — reuse it.
+- **Response encryption:** encrypt to the **caller's** shared secret; set `X-SSE: 1`. Re-encrypt all
+  `sharedSecretEncryptedKeyHeader`s to the caller (the member must decrypt with their own SS, since
+  they don't hold the owner's drive key).
+- **Permissions:** the member is granted access via the owner's community circle
+  (Read+Write+React+Comment on a collaborative drive). A non-member must get **403** (not 404) so the
+  client can distinguish "not allowed" from "wrong route".
+
+## Validation (against chat-kmp's built-in smoke test)
+
+chat-kmp already has a Developer-Menu action **"Query community (peer)"** (logs under `PeerSmokeTest`)
+that calls route #1. After deploying the V2 query route:
+1. In chat-kmp desktop, log in as a community member, Developer Menu → **Query community (peer)**.
+2. Expect `PeerSmokeTest OK got N file(s); fileType breakdown={7020=…,7015=…,7010=…}` (7020 messages,
+   7015 channels, 7010 community def). A 403 means the member isn't in the owner's circle; a 404 means
+   the route still isn't matched.
+3. Then exercise mount (sync-in to local DB + live), and write-out, as the gate requires
+   (`COMMUNITY_PART1_TRANSPORT.md`).
+
+## Client route constants to confirm after the BE lands
+
+| Client file | Constant / call | Set to |
+|---|---|---|
+| `DriveQueryProvider.queryBatch` | path when `ownerOdinId != null` | `/peer/{owner}/drives/{id}/files/query-batch` (already matches #1) |
+| `PeerDriveUploadProvider` → replace with `DriveUploadProvider` over-peer | `TRANSIT_SEND_PATH` | `/peer/{owner}/drives/{id}/files` (#2) |
+| `PeerWebSocketClient` | `PEER_WS_PATH` + token route | per WS design chosen (#3) — or delete if (A) |
+
+## odin-js reference files (the V1 logic to port)
+
+Under `..\odin-js\packages\libs\js-lib\src\peer\`:
+- `peerData/Query/PeerDriveQueryService.ts` — `/transit/query/batch`
+- `peerData/Upload/PeerFileUploader.ts` — `/transit/sender/files/send`
+- `peerData/File/PeerFileProvider.ts` — `/transit/query/{header,payload,thumb}`
+- `WebsocketData/WebsocketProviderOverPeer.ts` — `/notify/peer/token`, `notify/peer/ws`
+- `..\odin-js\packages\apps\community-app\src\providers\PeerNotificationSubscriber.ts` — push subscription
+- Core transport: `core/DotYouClient.ts` (base + interceptors), `core/InterceptionEncryptionUtil.ts`

--- a/COMMUNITY_PART2_FEATURE.md
+++ b/COMMUNITY_PART2_FEATURE.md
@@ -1,0 +1,270 @@
+# Community — Part 2: Greenfield Feature (chat-kmp)
+
+> **Prerequisite: Part 1 (`COMMUNITY_PART1_TRANSPORT.md`) is done and has passed its validation gate.**
+> That means a drive hosted on another identity (the community owner) can already be synced into the
+> local DB, subscribed to over a peer websocket, queried, and written to over peer — and it fails soft if
+> the owner is offline. From here on, **treat the community drive as if it were a normal local drive**;
+> the only difference (owner-hosted) has been made transparent by Part 1.
+
+This doc distills Homebase **Community** (a Slack-like, multi-channel, multi-member messenger), finished
+as a web app in the **sibling checkout** `../odin-js/` (relative to this `chat-kmp/` repo root), and maps
+it onto chat-kmp's patterns. The **Moments** add-on is your proven template throughout.
+
+> **JS source of truth.** This doc summarizes; it does not reproduce every field, edge case, or screen.
+> When a section here is incomplete, read the original under `../odin-js/`:
+> - data + wire format → `../odin-js/packages/apps/community-app/src/providers/`
+> - use-cases / domain logic → `../odin-js/packages/apps/community-app/src/hooks/community/`
+> - screens / routing → `../odin-js/packages/apps/community-app/src/{app,templates/Community}/`
+> - shared SDK (`@homebase-id/js-lib`) → `../odin-js/packages/libs/js-lib/`
+>
+> All `*.ts` / `use*` paths cited below are relative to that tree.
+
+## Ground rules
+
+- **Greenfield port.** Reuse Community's *semantics*, not its wire format. Pick KMP-native file-types,
+  IDs, and models that fit chat-kmp conventions (a `CommunityProtocol`, mirroring `MomentsProtocol`).
+- **Reuse chat-kmp infrastructure; don't port the JS sync/caching.** The JS app's react-query caches,
+  `useCommunityInboxProcessor`, `useCommunityPeerWebsocket`, `useCommunityWebsocket`, optimistic-update
+  bookkeeping, and version-conflict retry loops are all provided by chat-kmp's DriveSync + EventBus +
+  SQLDelight + Stream/Service pattern (Part 1 extended these to the owner-hosted drive). Copy what
+  Chat/Moments do.
+- **Ignore rendering & editor.** Chat bubbles, the RTE/markdown editor, media rendering, link previews —
+  reuse chat-kmp's existing widgets and editor. Do **not** port the JS components or RTE customizations.
+- **MVP-core first.** Communities list → channels → messages (text + media) → threads/replies →
+  reactions → per-channel unread. Defer: member status, per-channel drafts, pinned messages,
+  saved-for-later, collaborative editing, DMs.
+
+## Distribution model (recap — already solved by Part 1)
+
+The community is an **owner-owned collaborative drive** (one per community, on its creator's identity).
+Members sync that remote drive locally and websocket to it; one physical copy, no mesh fan-out. **This
+does not change the feature design below at all** — channels, messages, threads, reactions, read-state
+are identical regardless of where the drive is hosted. Writes target the community drive: the owner
+writes locally, a member writes over peer (Part 1's `remoteTargetDrive` path). Per-user private state
+(read-state, drafts) stays on the member's **own** drive, never the shared community drive.
+
+---
+
+## Part A — Community domain model (extracted from JS, verified against source)
+
+> Constants/types below are the JS wire format, read from
+> `odin-js/packages/apps/community-app/src/providers/`. In the greenfield KMP port you keep the *shapes
+> and relationships* but assign your own KMP file-type numbers in `CommunityProtocol`.
+
+### A.1 Entities & relationships
+
+```
+Community (definition)            one per community the user belongs to
+  └─ Channel                      many per community  (+ a hard-coded "general" channel)
+       └─ Message                 many per channel
+            └─ Thread reply       many per message    (a Message with parent = message)
+            └─ Reaction           emoji, aggregated on the message header
+  └─ Member status                one per member  (emoji + text presence)        [DEFER]
+  └─ (per-user, local) Metadata   read-state, pins, saved msgs, notif flag       [DEFER most]
+  └─ (per-user, local) Drafts     RichText draft per channel/thread              [DEFER]
+```
+
+### A.2 The types (JS source of truth)
+
+`CommunityDefinitionProvider.ts`
+```ts
+COMMUNITY_DRIVE_TYPE = '63db75f1-e999-40b2-a321-41ebffa5e363'  // each community = its own drive
+COMMUNITY_FILE_TYPE  = 7010
+interface CommunityDefinition { title: string; members: string[]; acl: AccessControlList }
+```
+
+`CommunityProvider.ts` (channels)
+```ts
+COMMUNITY_CHANNEL_FILE_TYPE  = 7015
+COMMUNITY_DEFAULT_GENERAL_ID = '7d64f4e4-f8e2-4c3b-bc4b-48bbb86e8f9a'  // synthetic, never persisted
+interface CommunityChannel { title: string; description: string }
+// stored with groupId = communityId, uniqueId = toGuidId(title)
+```
+
+`CommunityMessageProvider.ts` (messages + threads)
+```ts
+COMMUNITY_MESSAGE_FILE_TYPE = 7020
+COMMUNITY_MESSAGE_PAYLOAD_KEY = 'comm_web'      // media payload key prefix
+COMMUNITY_LINKS_PAYLOAD_KEY   = 'comm_links'    // link-preview payload
+COMMUNITY_PINNED_TAG          = toGuidId('pinned-message')
+MESSAGE_CHARACTERS_LIMIT      = 1600            // embed-in-header vs payload threshold
+BACKEDUP_PAYLOAD_KEY          = 'bckp_key'      // collaborative-edit backup [DEFER]
+CommunityDeletedArchivalStaus = 2              // soft-delete marker
+
+enum CommunityDeliveryStatus { Sending = 15, Sent = 20, Failed = 50 }
+
+interface CommunityMessage {
+  message: RichText | undefined;     // body (rich text)
+  deliveryStatus: CommunityDeliveryStatus;
+  channelId: string;
+  threadId?: string;
+  isEdited?: boolean;
+  lastEditedBy?: string;
+  isCollaborative?: boolean;         // [DEFER]
+  collaborators?: string[];          // [DEFER]
+}
+```
+- **Channel message:** `groupId = channelId`, `tags = [channelId]`, `fileSystemType = 'Standard'`.
+- **Thread reply:** `fileSystemType = 'Comment'`, `referencedFile.globalTransitId = parentMessageId`;
+  threads are **not a separate entity** — a thread is just the set of replies referencing a parent.
+
+`CommunityStatusProvider.ts`  *(DEFER)*
+```ts
+COMMUNITY_STATUS_FILE_TYPE = 7030
+interface CommunityStatus { emoji?: string; status?: string; validTill?: number }
+// uniqueId = toGuidId(odinId) → one presence file per member
+```
+
+Per-user **local** state — JS keeps these on a private "local app" drive, owner-only ACL. *(mostly DEFER)*
+```ts
+// CommunityMetadataProvider.ts
+COMMUNITY_METADATA_FILE_TYPE = 7011
+interface CommunityMetadata {
+  lastReadTime: number; threadsLastReadTime: number;
+  channelLastReadTime: Record<string, number>;       // ← MVP needs this (unread badges)
+  pinnedChannels: string[]; savedMessages: {...}[]; notifiationsEnabled?: boolean;
+  odinId: string; communityId: string;
+}
+// CommunityDraftsProvider.ts                          [DEFER]
+COMMUNITY_DRAFTS_FILE_TYPE = 7017
+interface Draft { message: RichText; updatedAt: number }
+interface CommunityDrafts { drafts?: Record<channelOrThreadId, Draft>; ... }
+```
+
+### A.3 Reactions
+
+Reactions are **not** separate files. They live aggregated in the message header's `reactionPreview`
+(emoji → count), and the current user's own reactions come from a per-user mirror. **chat-kmp already
+does exactly this** for chat & moments (`fileMetadata.reactionPreview` + `fileMetadata.localAppData.localReactions`
+maintained by `OptimisticWriter`). → Reuse wholesale; design nothing new.
+
+---
+
+## Part B — Feature inventory → KMP mapping
+
+**"Reuse"** = chat-kmp already has it; **"New"** = build it (following the cited template).
+
+| Feature (JS hook) | Domain behaviour | KMP target |
+|---|---|---|
+| Communities list (`useCommunities`) | enumerate communities the user is in | **New** `CommunityStream` (cold-load `CommunityDefinition` files + EventBus). Template: `MomentsFeedService` |
+| Community CRUD (`useCommunity`) | create collaborative drive + circle, rename, set ACL, invite link | **New** `CommunityService.create/update`. Owner: create the collaborative drive (`IsCollaborativeChannel`, `allowSubscriptions`) + circle grant. Template: `ConversationService` group create |
+| Channels (`useCommunityChannels`, `useCommunityChannel`) | list / create / rename / delete; synthetic "general" | **New** channel files (`groupId = communityId`) on the **community drive** (owner: local; member: over peer). Template: Moments group files (`MomentGroupService`) |
+| Channels w/ recent msg (`useCommunityChannelsWithRecentMessages`) | last message per channel for the sidebar | **Reuse** — derive from `ChatMessageStream`-style per-group last message |
+| Messages (`useCommunityMessages`, `useCommunityMessage`) | paginated history; send text+media; edit; delete (soft) | **Reuse** `ChatMessageSenderService` + `ChatMessageStream` pattern, scoped by `groupId = channelId`; storage target = the community drive |
+| Media / attachments | images, video, files with thumbnails | **Reuse** `MessageAttachmentBuilder` + `PayloadBundleEncryptor` (payload keys `comm_0000…`) |
+| Threads / replies (`useCommunityThreads`) | replies referencing a parent message; participants; per-thread view | **Reuse Moments comments** shape: `groupId = parentMessageId`. See `MomentCommentsService` |
+| Reactions (`useCommunityReaction`) | emoji add/remove, aggregated counts, own-reactions | **Reuse** `reactionPreview` + `localAppData.localReactions` (no new code) |
+| Read-state (`useMarkCommunityAsRead`, `channelLastReadTime`) | per-channel last-read → unread badges | **New-thin**: a per-user marker on a **private own drive** — never the shared community drive |
+| Realtime (`useLiveCommunityProcessor`, `*Websocket`) | inbox backlog + live push from the owner's host | **Reuse EventBus/Stream pattern** (Part 1 wired the peer sync + peer websocket into `BatchReceived`/`DriveEvent.Stopped`). **Do not port the JS react-query/inbox-processor code.** |
+| Notifications (`useCommunityNotifications`) | push on new message via owner host | **Adapt** — arm a peer push-subscription against the owner; writes set `useAppNotification` + `PushNotificationOptions` like Moments |
+| Status / drafts / pins / saved / collab-edit / DMs | presence, drafts, etc. | **DEFER** — extra file types + local state; post-MVP |
+
+### Navigation graph (from JS `src/app` + `templates/Community`)
+- Communities list / new-community
+- Community shell → channel list (sidebar) + selected channel
+- Channel view: message list + composer (defer pins/info)
+- Thread view: parent message + replies + composer
+- Activity / threads / later / pins overview screens — **defer**
+- Notification deep-link → message
+
+---
+
+## Part C — How to build it (the Moments blueprint, grounded in real files)
+
+chat-kmp already shipped one complete add-on app — **Moments** — and documents the recipe in
+`ADDING_ADDON_APPS.md` (~50 KB, 10 steps) and `ADDING_TYPED_MESSAGE_KIND.md`. Community follows the same
+skeleton. Reference these **real** files:
+
+- `homebase-core/.../moments/services/MomentsProtocol.kt` — file-type constants pattern
+- `homebase-core/.../moments/services/MomentsPostSenderService.kt` — send/update/comment via
+  `OutboxSync.tryEnqueue|replaceEnqueue`, `OptimisticWriter.writeNewFile|writeUpdate|removeOptimisticFile`,
+  `PayloadBundleEncryptor.encryptBundle`, `MessageAttachmentBuilder.build`, two-phase optimistic send
+- `homebase-core/.../moments/services/MomentsFeedService.kt` — the **Stream** template: cold-load via
+  `QueryBatch(identityId).queryBatchAsync(filetypesAnyOf=…)`, then EventBus over `BatchReceived` (live),
+  `DriveEvent.Stopped(totalCount>0)` (silent bulk catch-up re-load), `OptimisticRollback`, `SessionEnded`
+  reset; in-memory `byId` map → sorted `StateFlow`; soft-delete handling
+- `homebase-core/.../moments/services/MomentCommentsService.kt` — **thread/reply** template
+- `homebase-common/.../moments/MomentsPreferences.kt` — activation + icon-visibility flags
+- `homebase-core/.../ui/screens/moments/` — onboarding/permission/feed/detail/compose screens
+- chat reuse targets: `homebase-chat/services/convo/ConversationService.kt`,
+  `homebase-chat/services/ChatMessageSenderService.kt`, `homebase-chat/services/ChatMessageStream.kt`,
+  `homebase-chat/services/builder/MessageAttachmentBuilder.kt`, `homebase-chat/services/PayloadBundleEncryptor.kt`,
+  `homebase-chat/services/outbox/OptimisticWriter.kt`; infra `homebase-api/.../sync/database/OutboxSync`,
+  `homebase-api/.../client/eventbus/EventBus`, `homebase-api/.../sync/database/DatabaseManager`
+
+### Step list (mirrors `ADDING_ADDON_APPS.md`)
+1. **Drive = one collaborative drive per community, hosted on its creator's identity** (not a single
+   labeled drive like Moments). A member belongs to communities owned by *different* identities, so the
+   drive is `(ownerOdinId, TargetDrive{alias = communityId, type = CommunityDriveType})`. Mount it via
+   Part 1's owner-aware registry/sync. Owner creates the drive collaboratively (`IsCollaborativeChannel`,
+   `allowSubscriptions`, `Read+Write+React+Comment`) plus a circle to grant members.
+2. **Protocol** — `community/services/CommunityProtocol.kt` with KMP-native file types
+   (`CommunityDefinition`, `Channel`, `ChannelMessage`, later `MemberStatus`), version constants, AppId.
+3. **Content models** — `@Serializable` `CommunityContent`, `ChannelContent`, `ChannelMessageContent`
+   (body reuses chat-kmp message content / `MessageContent` machinery; don't invent a body format).
+4. **Scoping convention** (all on the community drive):
+   - Community def: `fileType = CommunityDefinition`, `uniqueId = communityId`
+   - Channel: `fileType = Channel`, `groupId = communityId`, `uniqueId = channelId`
+   - Channel message: `fileType = ChannelMessage`, `groupId = channelId`, `uniqueId = messageId`
+   - Thread reply: `fileType = ChannelMessage`, `groupId = parentMessageId` (Moments-comment style)
+   - Reactions: embedded `reactionPreview` + `localReactions` (no file)
+   - Per-user read-state/drafts: **NOT** on the community drive — private own drive.
+5. **Services** (three-service pattern):
+   - `CommunityStream` (communities + channels live view) — template `MomentsFeedService`
+   - `ChannelMessageStream` (messages per channel, paged) — template `ChatMessageStream`
+   - `CommunityService` (community/channel CRUD) + `ChannelMessageSenderService` (send/edit/delete/reply,
+     media) — templates `ConversationService` + `ChatMessageSenderService` + `MomentsPostSenderService`
+6. **Preferences** `CommunityPreferences` (activation, icon visibility) — template `MomentsPreferences`.
+7. **DI** — register singletons + `reset()`/`start()` on `onPostAuthenticated` (logout safety!).
+8. **Navigation + screens** — routes for list / channel / thread; **reuse chat composer, message bubbles,
+   attachment sheet, media widgets, RTE/markdown editor**. Build only Community-specific chrome (channel
+   sidebar, community switcher).
+9. **Notifications** — `TransitOptions.useAppNotification` + `PushNotificationOptions` (Moments currently
+   sends under `ChatProtocol.ChatAppId`; decide whether Community gets its own AppId).
+10. **Typed system messages** *(optional, post-MVP)* — "channel created / member joined / topic changed"
+    via `ADDING_TYPED_MESSAGE_KIND.md`.
+
+### Hard-won gotchas to carry over (from the Moments files/docs)
+- **`DriveEvent.Stopped(totalCount>0)` re-cold-load.** Bulk `DriveSync.performSync` is *silent* (no
+  per-file `BatchReceived`). Without the Stopped branch, mounting a drive at runtime writes rows to the
+  DB but the in-memory list stays empty until restart. Copy the Moments handling.
+- **Read recipients/parents from the local DB**, not the server
+  (`dbm.driveMainIndex.selectHomebaseFileByUnique`). A transient network blip on a server GET otherwise
+  turns into a lost message. Applies to resolving thread-reply recipients.
+- **Reset every user-scoped singleton on logout** or user B sees user A's communities (Koin singletons
+  outlive the session).
+- **Two-phase optimistic send** (placeholder row → background build/encrypt/enqueue/finalize) for snappy
+  UI on media messages — see `MomentsPostSenderService.postMomentAsync`.
+
+---
+
+## One-paragraph kickoff prompt
+
+> You are implementing **Community** (a Slack-like multi-channel messenger) inside the chat-kmp project,
+> **after** the peer-hosted-drive transport (`COMMUNITY_PART1_TRANSPORT.md`) already exists and is proven —
+> so treat the community drive as a normal local drive. Read this doc, `ADDING_ADDON_APPS.md`, and the
+> **Moments** add-on (`homebase-core/.../moments/`) — Moments is your template; take it apart for
+> reference. Community is a **greenfield** port: reuse the *semantics* here with KMP-native
+> file-types/models, and reuse chat-kmp's sync/attachment/editor/message-bubble infrastructure — **do not**
+> port the JS app's react-query caches, websocket handlers, or inbox processor. Each community is an
+> **owner-owned collaborative drive** (one per community, on its creator's identity). Build **MVP-core
+> first**: communities list → channels → text+media messages → threads/replies (Moments-comment shape:
+> `groupId = parentMessageId`) → reactions (reuse `reactionPreview` + `localReactions`) → per-channel
+> unread (on a private own drive). Defer: member status, drafts, pins, saved-for-later, collaborative
+> editing, DMs.
+
+---
+
+## Verification
+
+- **Build:** `./gradlew :homebase-core:compileKotlin…` (see `CLAUDE.md` for per-target build/run) after
+  each service lands.
+- **Realtime smoke test:** owner + member on two devices; owner creates community/channel, posts a
+  message → member sees it live via the peer-drive sync (`DriveEvent.Stopped` / `BatchReceived`).
+- **Member-write test:** member posts a message / thread reply → it lands on the owner's drive and the
+  owner (and other members) receive it.
+- **Thread test:** reply to a message (`groupId = parentMessageId`) → shows under the parent
+  (Moments-comment parity).
+- **Reaction test:** add/remove emoji → count + own-reaction state survive a re-sync.
+- **Logout test:** log in as a second user → no leakage of the first user's communities (singleton
+  `reset()`).

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/query/DriveQueryProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/query/DriveQueryProvider.kt
@@ -2,6 +2,7 @@ package id.homebase.api.client.drives.query
 
 import id.homebase.api.client.OdinApiProviderBase
 import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.common.OdinId
 import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.api.client.drives.QueryBatchRequest
 import id.homebase.api.client.drives.QueryBatchResponse
@@ -43,18 +44,35 @@ class DriveQueryProvider(
         return deserialize(response.body)
     }
 
+    /**
+     * Query a batch of files from a drive.
+     *
+     * @param ownerOdinId when null (the default) the query targets the logged-in user's own host
+     *   (`creds.domain`) at `/drives/$driveId/files/query-batch`. When set, the query is brokered
+     *   over peer to the drive's owning identity at
+     *   `/peer/$ownerOdinId/drives/$driveId/files/query-batch` — the user's own host proxies the
+     *   call server-side and returns headers re-encrypted under the caller's own shared secret, so
+     *   the response decode path is identical. Mirrors the `/peer/$peer/…` broker convention already
+     *   used by [id.homebase.api.client.peer.PeerDriveQueryProvider].
+     */
     suspend fun queryBatch(
         driveId: Uuid,
         request: QueryBatchRequest,
+        ownerOdinId: OdinId? = null,
     ): QueryBatchResponse {
 
         ValidationUtil.requireValidUuid(driveId, "driveId")
 
         val creds = requireCreds()
-        val url = apiUrl(
-            creds.domain,
+        val path = if (ownerOdinId == null) {
             "/drives/$driveId/files/query-batch"
-        )
+        } else {
+            // Over-peer query-batch is a DRIVE-level route (no /files segment, unlike the per-file
+            // peer routes /files/{fileId}/header etc.). Verified against the V2 backend: this returns
+            // 403 unauthenticated (route exists) whereas /files/query-batch returns 404.
+            "/peer/$ownerOdinId/drives/$driveId/query-batch"
+        }
+        val url = apiUrl(creds.domain, path)
 
         val jsonRequest = OdinSystemSerializer.serialize(request)
 
@@ -67,14 +85,26 @@ class DriveQueryProvider(
 
         throwForFailure(apiResponse)
 
-        val internal = deserialize<QueryBatchResponseInternalRaw>(apiResponse.body)
+        return mapQueryBatchResponse(apiResponse.body, creds.secret)
+    }
+
+    /**
+     * Decode a query-batch response body into a [QueryBatchResponse], salvaging individually
+     * corrupt file metadata rather than failing the whole batch. Shared by the own-host and
+     * over-peer query paths — both receive headers encrypted under the caller's [secret].
+     */
+    private suspend fun mapQueryBatchResponse(
+        body: String,
+        secret: SecureByteArray,
+    ): QueryBatchResponse {
+        val internal = deserialize<QueryBatchResponseInternalRaw>(body)
 
         if (internal.invalidDrive) {
             return QueryBatchResponse.fromInvalidDrive(internal.name ?: "")
         }
 
         val files = internal.searchResults.map { serverFileJson ->
-            createServerFileWithSafeMetadata(serverFileJson, creds.secret)
+            createServerFileWithSafeMetadata(serverFileJson, secret)
         }
 
         return QueryBatchResponse(
@@ -111,7 +141,7 @@ class DriveQueryProvider(
             fileSystemType = serverFileWithRawMetadata.fileSystemType,
             sharedSecretEncryptedKeyHeader = serverFileWithRawMetadata.sharedSecretEncryptedKeyHeader,
             fileMetadata = fileMetadata,
-            serverMetadata = serverFileWithRawMetadata.serverMetadata,
+            serverMetadata = serverFileWithRawMetadata.serverMetadata ?: ServerMetadata(),
             priority = serverFileWithRawMetadata.priority,
             fileByteCount = serverFileWithRawMetadata.fileByteCount
         )
@@ -159,7 +189,10 @@ data class ServerFileWithRawMetadata(
     val fileSystemType: FileSystemType,
     val sharedSecretEncryptedKeyHeader: EncryptedKeyHeader,
     val fileMetadata: JsonObject, // This is the key difference - keep it as JsonObject
-    val serverMetadata: ServerMetadata,
+    // Over peer the broker returns serverMetadata=null (it's the owner's private server-side
+    // bookkeeping; a member doesn't receive it). Nullable + default so the peer query decodes —
+    // createServerFileWithSafeMetadata substitutes an empty ServerMetadata() downstream.
+    val serverMetadata: ServerMetadata? = null,
     val priority: Int = 0,
     val fileByteCount: Long = 0
 )

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/upload/DriveUploadProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/upload/DriveUploadProvider.kt
@@ -467,31 +467,9 @@ class DriveUploadProvider(
         metadata: UploadFileMetadata,
         sharedSecret: ByteArray,
         transferIv: ByteArray
-    ): ByteArray {
-        // Encrypt the key header using shared secret and transferIv (matches TypeScript
-        // encryptKeyHeader)
-        val sharedSecretEncryptedKeyHeader =
-            EncryptedKeyHeader.encryptKeyHeaderAes(
-                keyHeader ?: KeyHeader.empty(),
-                transferIv,
-                SecureByteArray(sharedSecret)
-            )
-
-        // Create the file descriptor
-        val descriptor =
-            UploadFileDescriptor(
-                encryptedKeyHeader = sharedSecretEncryptedKeyHeader,
-                fileMetadata = metadata
-            )
-
-        // Serialize to JSON (matches TypeScript jsonStringify64)
-        val descriptorJson = OdinSystemSerializer.json.encodeToString(descriptor)
-        val descriptorBytes = descriptorJson.encodeToByteArray()
-
-        // Encrypt the entire descriptor with sharedSecret using transferIv (matches TypeScript
-        // encryptWithSharedSecret)
-        return AesCbc.encrypt(descriptorBytes, sharedSecret, transferIv)
-    }
+    ): ByteArray =
+        // Shared with the over-peer transit-send path — see UploadDescriptorBuilder.kt.
+        buildSharedSecretEncryptedUploadDescriptor(keyHeader, metadata, sharedSecret, transferIv)
 
     /**
      * Builds an encrypted descriptor (UploadFileDescriptor encrypted with sharedSecret). Matches

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/upload/FormDataExtensions.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/upload/FormDataExtensions.kt
@@ -94,6 +94,30 @@ fun buildUploadFormData(
     )
 }
 
+/**
+ * Builds the multipart body for an over-peer transit send. Identical wire layout to
+ * [buildUploadFormData] (instructions + encrypted metadata + streamed payloads/thumbnails); only the
+ * `instructions` part differs — a [TransitInstructionSet] instead of an [UploadInstructionSet].
+ */
+fun buildTransitFormData(
+    instructionSet: TransitInstructionSet,
+    sharedSecretEncryptedDescriptor: ByteArray? = null,
+    payloads: List<PayloadFile>? = null,
+    thumbnails: List<ThumbnailFile>? = null,
+    fileOperationsProvider: FileOperationsProvider,
+): MultiPartFormDataContent {
+
+    val runtimePayloads =
+        payloads?.map { it.toRuntime { path -> fileOperationsProvider.openFileInput(path) } }
+
+    return buildFormDataInternal(
+        instructionSet = instructionSet,
+        sharedSecretEncryptedDescriptor = sharedSecretEncryptedDescriptor,
+        payloads = runtimePayloads,
+        thumbnails = thumbnails
+    )
+}
+
 suspend fun calculateUploadSize(
     payloads: List<PayloadFile>?,
     thumbnails: List<ThumbnailFile>?,

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/upload/TransitInstructionSet.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/upload/TransitInstructionSet.kt
@@ -1,0 +1,74 @@
+package id.homebase.api.client.drives.upload
+
+import id.homebase.api.client.drives.TargetDrive
+import id.homebase.api.common.OdinId
+import id.homebase.api.prototype.lib.serialization.Base64ByteArraySerializer
+import id.homebase.api.serialization.UuidSerializer
+import kotlinx.serialization.Serializable
+import kotlin.uuid.Uuid
+
+/**
+ * Instruction set for an **over-peer** file send: a non-owner writing a file straight onto another
+ * identity's drive (a community owner's collaborative drive). Mirrors the JS `TransitInstructionSet`
+ * (`js-lib/.../peer/peerData/PeerTypes.ts`). Unlike [UploadInstructionSet] there is no local
+ * `storageOptions`/`driveId` — the target is the remote [remoteTargetDrive] on the [recipients]'
+ * host(s); the user's own host brokers the send (transit/outbox).
+ */
+@Serializable
+data class TransitInstructionSet(
+    @Serializable(with = Base64ByteArraySerializer::class) val transferIv: ByteArray,
+    val manifest: UploadManifest,
+    /** Owner-hosted drive the file lands on (the community drive). */
+    val remoteTargetDrive: TargetDrive,
+    /** Identities to deliver to — for a community write this is the single owner. */
+    val recipients: List<OdinId>,
+    /** When set, overwrites the existing remote file with this globalTransitId (edit path). */
+    @Serializable(with = UuidSerializer::class) val overwriteGlobalTransitFileId: Uuid? = null,
+    val schedule: ScheduleOptions? = null,
+    val priority: PriorityOptions? = null,
+    /** `"metadataOnly"` to send only the header (no payloads). */
+    val storageIntent: String? = null,
+    val notificationOptions: PushNotificationOptions? = null,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        other as TransitInstructionSet
+        if (!transferIv.contentEquals(other.transferIv)) return false
+        if (manifest != other.manifest) return false
+        if (remoteTargetDrive != other.remoteTargetDrive) return false
+        if (recipients != other.recipients) return false
+        if (overwriteGlobalTransitFileId != other.overwriteGlobalTransitFileId) return false
+        if (schedule != other.schedule) return false
+        if (priority != other.priority) return false
+        if (storageIntent != other.storageIntent) return false
+        if (notificationOptions != other.notificationOptions) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = transferIv.contentHashCode()
+        result = 31 * result + manifest.hashCode()
+        result = 31 * result + remoteTargetDrive.hashCode()
+        result = 31 * result + recipients.hashCode()
+        result = 31 * result + (overwriteGlobalTransitFileId?.hashCode() ?: 0)
+        result = 31 * result + (schedule?.hashCode() ?: 0)
+        result = 31 * result + (priority?.hashCode() ?: 0)
+        result = 31 * result + (storageIntent?.hashCode() ?: 0)
+        result = 31 * result + (notificationOptions?.hashCode() ?: 0)
+        return result
+    }
+}
+
+/** Server response to an over-peer send. Mirrors the JS `TransitUploadResult`. */
+@Serializable
+data class TransitUploadResult(
+    val recipientStatus: Map<String, TransferUploadStatus> = emptyMap(),
+    val remoteGlobalTransitIdFileIdentifier: RemoteGlobalTransitIdFileIdentifier? = null,
+)
+
+@Serializable
+data class RemoteGlobalTransitIdFileIdentifier(
+    @Serializable(with = UuidSerializer::class) val globalTransitId: Uuid,
+    val targetDrive: TargetDrive,
+)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/upload/UploadDescriptorBuilder.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/upload/UploadDescriptorBuilder.kt
@@ -1,0 +1,42 @@
+package id.homebase.api.client.drives.upload
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.common.SecureByteArray
+import id.homebase.api.crypto.AesCbc
+import id.homebase.api.crypto.EncryptedKeyHeader
+import id.homebase.api.serialization.OdinSystemSerializer
+
+/**
+ * Builds the shared-secret-encrypted upload descriptor (the `metadata` multipart part) shared by the
+ * own-host upload path ([DriveUploadProvider.uploadFile]) and the over-peer transit-send path
+ * ([id.homebase.api.client.peer.PeerDriveUploadProvider.uploadFileOverPeer]). Both wire shapes are
+ * identical: the per-file [keyHeader] is encrypted with the caller's [sharedSecret] under
+ * [transferIv], wrapped in an [UploadFileDescriptor] alongside the (already content-encrypted)
+ * [metadata], and the whole descriptor is then AES-CBC encrypted with the same shared secret + IV.
+ *
+ * Matches the TypeScript `buildDescriptor` helper.
+ */
+internal suspend fun buildSharedSecretEncryptedUploadDescriptor(
+    keyHeader: KeyHeader?,
+    metadata: UploadFileMetadata,
+    sharedSecret: ByteArray,
+    transferIv: ByteArray,
+): ByteArray {
+    val sharedSecretEncryptedKeyHeader =
+        EncryptedKeyHeader.encryptKeyHeaderAes(
+            keyHeader ?: KeyHeader.empty(),
+            transferIv,
+            SecureByteArray(sharedSecret),
+        )
+
+    val descriptor =
+        UploadFileDescriptor(
+            encryptedKeyHeader = sharedSecretEncryptedKeyHeader,
+            fileMetadata = metadata,
+        )
+
+    val descriptorJson = OdinSystemSerializer.json.encodeToString(descriptor)
+    val descriptorBytes = descriptorJson.encodeToByteArray()
+
+    return AesCbc.encrypt(descriptorBytes, sharedSecret, transferIv)
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerDriveUploadProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerDriveUploadProvider.kt
@@ -1,0 +1,139 @@
+package id.homebase.api.client.peer
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.client.OdinApiProviderBase
+import id.homebase.api.client.UploadProgress
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.upload.TransferUploadStatus
+import id.homebase.api.client.drives.upload.TransitInstructionSet
+import id.homebase.api.client.drives.upload.TransitUploadResult
+import id.homebase.api.client.drives.upload.UploadFileRequest
+import id.homebase.api.client.drives.upload.UploadManifest
+import id.homebase.api.client.drives.upload.buildSharedSecretEncryptedUploadDescriptor
+import id.homebase.api.client.drives.upload.buildTransitFormData
+import id.homebase.api.client.drives.upload.calculateUploadSize
+import id.homebase.api.crypto.ByteArrayUtil
+import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.serialization.OdinSystemSerializer
+import io.ktor.client.HttpClient
+
+/**
+ * Writes a file straight onto a **peer's** drive (a community owner's collaborative drive) over
+ * transit. Mirrors the JS `uploadFileOverPeer` (`js-lib/.../peer/peerData/Upload/PeerFileUploader.ts`).
+ *
+ * The user's OWN host (`creds.domain`) brokers the send: the request is posted to the local host,
+ * which forwards the encrypted file to the [TransitInstructionSet.recipients] (the owner) and lands
+ * it on [TransitInstructionSet.remoteTargetDrive]. Descriptor/payload encryption is identical to the
+ * own-host upload path — the caller pre-encrypts `metadata.appData.content` and we encrypt the
+ * descriptor with the caller's own shared secret (see [buildSharedSecretEncryptedUploadDescriptor]).
+ *
+ * This is what honours the previously-unused [id.homebase.api.client.drives.upload.TransitOptions.remoteTargetDrive].
+ */
+class PeerDriveUploadProvider(
+    httpClient: HttpClient,
+    credentialsManager: CredentialsManager,
+    private val fileOperationsProvider: FileOperationsProvider,
+) : OdinApiProviderBase(httpClient, credentialsManager) {
+
+    /**
+     * Send [request]'s file to the owner-hosted drive. [request.transitOptions] must carry a non-null
+     * `remoteTargetDrive` and at least one recipient (the owner). Returns the transit result, or null
+     * if the broker rejected the request; throws if any recipient is reported `EnqueuedFailed`.
+     */
+    suspend fun uploadFileOverPeer(
+        request: UploadFileRequest,
+        onProgress: UploadProgress? = null,
+    ): TransitUploadResult? {
+        val transit = request.transitOptions
+        val remoteTargetDrive = requireNotNull(transit?.remoteTargetDrive) {
+            "uploadFileOverPeer requires transitOptions.remoteTargetDrive"
+        }
+        val recipients = transit?.recipients
+        require(!recipients.isNullOrEmpty()) {
+            "uploadFileOverPeer requires at least one recipient (the drive owner)"
+        }
+
+        val creds = requireCreds()
+        val sharedSecret = creds.secret.unsafeBytes
+
+        val transferIv = ByteArrayUtil.getRndByteArray(16)
+        val sharedSecretEncryptedDescriptor = buildSharedSecretEncryptedUploadDescriptor(
+            request.keyHeader,
+            request.metadata,
+            sharedSecret,
+            transferIv = transferIv,
+        )
+
+        val instructions = TransitInstructionSet(
+            transferIv = transferIv,
+            manifest = UploadManifest.build(
+                request.payloads,
+                request.thumbnails,
+                generatePayloadIv = request.metadata.isEncrypted,
+            ),
+            remoteTargetDrive = remoteTargetDrive,
+            recipients = recipients,
+            schedule = transit.schedule,
+            priority = transit.priority,
+            notificationOptions = if (transit.useAppNotification == true) transit.appNotificationOptions else null,
+        )
+
+        val data = buildTransitFormData(
+            instructionSet = instructions,
+            sharedSecretEncryptedDescriptor = sharedSecretEncryptedDescriptor,
+            payloads = request.payloads,
+            thumbnails = request.thumbnails,
+            fileOperationsProvider = fileOperationsProvider,
+        )
+
+        val totalUploadSize = calculateUploadSize(
+            request.payloads,
+            request.thumbnails,
+            sharedSecretEncryptedDescriptor,
+            fileOperationsProvider,
+        )
+        val wrappedProgress = onProgress?.let { progress ->
+            suspend { sent: Long, _: Long? -> progress(sent, totalUploadSize) }
+        }
+
+        // V2 over-peer send is a per-drive route carrying owner + driveId in the path; the multipart
+        // body is the same V1 transit bundle (TransitInstructionSet with remoteTargetDrive +
+        // recipients, then metadata, then payload/thumbnail parts).
+        val owner = recipients.first()
+        val url = apiUrl(creds.domain, "/peer/$owner/drives/${remoteTargetDrive.alias}/files/send")
+        Logger.i(tag = TAG) {
+            "uploadFileOverPeer: POST $url recipients=${recipients.map { it.domainName }} " +
+                "remoteDrive=$remoteTargetDrive"
+        }
+
+        val response = plainPostMultipart(
+            url = url,
+            token = creds.accessToken,
+            formData = data,
+            onProgress = wrappedProgress,
+        )
+
+        if (response.status !in 200..299) {
+            Logger.w(tag = TAG) { "uploadFileOverPeer: FAIL status=${response.status} body=${response.body.take(300)}" }
+            throwForFailure(response)
+            return null
+        }
+
+        val result: TransitUploadResult = OdinSystemSerializer.deserialize(response.body)
+
+        val failed = result.recipientStatus.filterValues { it == TransferUploadStatus.EnqueuedFailed }
+        if (failed.isNotEmpty()) {
+            throw IllegalStateException("uploadFileOverPeer: recipients failed to enqueue: ${failed.keys}")
+        }
+
+        Logger.i(tag = TAG) {
+            "uploadFileOverPeer: OK gtid=${result.remoteGlobalTransitIdFileIdentifier?.globalTransitId} " +
+                "status=${result.recipientStatus}"
+        }
+        return result
+    }
+
+    companion object {
+        private const val TAG = "PeerDriveUpload"
+    }
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerNotificationProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerNotificationProvider.kt
@@ -1,0 +1,93 @@
+package id.homebase.api.client.peer
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.client.OdinApiProviderBase
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.common.OdinId
+import id.homebase.api.serialization.OdinSystemSerializer
+import io.ktor.client.HttpClient
+import kotlin.uuid.Uuid
+import kotlinx.serialization.Serializable
+
+@Serializable
+private data class PeerTokenRequest(val identity: OdinId)
+
+/**
+ * Auth material for connecting a websocket directly to a peer's (owner's) host. `sharedSecret` is
+ * base64 — the bytes are used to encrypt/decrypt the peer websocket frames.
+ */
+@Serializable
+data class PeerTokenResponse(
+    val authenticationToken64: String,
+    val sharedSecret: String,
+)
+
+@Serializable
+private data class PeerPushSubscriptionRequest(
+    val identity: OdinId,
+    val subscriptionId: Uuid,
+)
+
+/**
+ * Talks to the user's OWN host for the two peer-notification primitives that the live community
+ * websocket needs. Mirrors the JS `getOrFetchPeerToken` (`WebsocketProviderOverPeer.ts`) and
+ * `SubscribeToPeerNotifications` (`community-app/providers/PeerNotificationSubscriber.ts`).
+ */
+class PeerNotificationProvider(
+    httpClient: HttpClient,
+    credentialsManager: CredentialsManager,
+) : OdinApiProviderBase(httpClient, credentialsManager) {
+
+    /**
+     * Exchange (via the user's own host) for a short-lived auth token + shared secret that authorise
+     * a direct websocket to [ownerOdinId]'s host. The result should be cached per owner by the
+     * caller and re-fetched on `authenticationError`.
+     */
+    suspend fun getPeerToken(ownerOdinId: OdinId): PeerTokenResponse? {
+        val creds = requireCreds()
+        val url = apiUrl(creds.domain, "/peer/notify/token")
+        val body = OdinSystemSerializer.serialize(PeerTokenRequest(ownerOdinId))
+        val response = encryptedPostJson(
+            url = url,
+            token = creds.accessToken,
+            jsonBody = body,
+            secret = creds.secret,
+        )
+        if (response.status !in 200..299) {
+            Logger.w(tag = TAG) {
+                "getPeerToken: FAIL owner=${ownerOdinId.domainName} status=${response.status}"
+            }
+            return null
+        }
+        return deserialize(response.body)
+    }
+
+    /**
+     * Arm a closed-app push subscription on the user's own host so the owner's host pushes a
+     * notification when the community ([subscriptionId] = communityId) changes. Returns true on 2xx.
+     */
+    suspend fun subscribeToPeerNotifications(ownerOdinId: OdinId, subscriptionId: Uuid): Boolean {
+        val creds = requireCreds()
+        val url = apiUrl(creds.domain, "/peer/notify/subscriptions/push-notification")
+        val body = OdinSystemSerializer.serialize(
+            PeerPushSubscriptionRequest(identity = ownerOdinId, subscriptionId = subscriptionId)
+        )
+        val response = encryptedPostJson(
+            url = url,
+            token = creds.accessToken,
+            jsonBody = body,
+            secret = creds.secret,
+        )
+        val ok = response.status in 200..299
+        if (!ok) {
+            Logger.w(tag = TAG) {
+                "subscribeToPeerNotifications: FAIL owner=${ownerOdinId.domainName} sub=$subscriptionId status=${response.status}"
+            }
+        }
+        return ok
+    }
+
+    companion object {
+        private const val TAG = "PeerNotify"
+    }
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerWebSocketClient.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerWebSocketClient.kt
@@ -1,0 +1,341 @@
+package id.homebase.api.client.peer
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.client.SharedSecretEncryptedPayload
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.TargetDrive
+import id.homebase.api.client.eventbus.BackendEvent
+import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.client.websockets.ClientDriveNotification
+import id.homebase.api.client.websockets.ClientNotificationPayload
+import id.homebase.api.client.websockets.ClientNotificationType
+import id.homebase.api.client.websockets.EstablishConnectionRequest
+import id.homebase.api.client.websockets.InboxItemReceivedNotification
+import id.homebase.api.client.websockets.ProcessInboxPayload
+import id.homebase.api.client.websockets.WebSocketClientNotificationPayload
+import id.homebase.api.client.websockets.WebSocketPingSupervisor
+import id.homebase.api.client.websockets.WebSocketState
+import id.homebase.api.client.websockets.WebsocketCommand
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.SecureByteArray
+import id.homebase.api.crypto.AesCbc
+import id.homebase.api.crypto.ByteArrayUtil
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.sync.DriveWebSocketUpsertWorker
+import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.toBase64
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.plugins.websocket.webSocket
+import io.ktor.websocket.Frame
+import io.ktor.websocket.close
+import io.ktor.websocket.readText
+import kotlin.concurrent.Volatile
+import kotlin.io.encoding.Base64
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.Serializable
+
+/** Establish envelope for a peer websocket — carries the guest client-auth token alongside the
+ *  shared-secret-encrypted command. Mirrors the JS `EstablishConnectionOverPeer` wrapper. */
+@Serializable
+private data class PeerEstablishEnvelope(
+    val sharedSecretEncryptedOptions: SharedSecretEncryptedPayload,
+    val clientAuthToken64: String,
+)
+
+/**
+ * A websocket bound to a **peer's** host (a community owner) — the live counterpart to the
+ * over-peer query/upload broker paths. One instance per owner host. Mirrors the JS
+ * `WebsocketProviderOverPeer.ts`:
+ *
+ *  1. exchange a peer token via [PeerNotificationProvider.getPeerToken] (auth token + shared secret),
+ *  2. connect directly to `wss://$ownerOdinId/.../notify/peer/ws` with the token,
+ *  3. `establishConnectionRequest` for the community [drives],
+ *  4. decrypt incoming `fileAdded/fileModified/fileDeleted/statisticsChanged` headers with the PEER
+ *     shared secret and feed them to a per-drive [DriveWebSocketUpsertWorker] keyed by the LOCAL
+ *     user's identity → `BatchReceived` → the same Stream/Service pipeline own drives use.
+ *
+ * Reuses [DriveWebSocketUpsertWorker] and [WebSocketPingSupervisor] wholesale; only the host,
+ * auth, and establish-envelope differ from [id.homebase.api.client.websockets.OdinWebSocketClient].
+ */
+class PeerWebSocketClient(
+    private val ownerOdinId: OdinId,
+    private val drives: List<TargetDrive>,
+    private val credentialsManager: CredentialsManager,
+    private val peerNotificationProvider: PeerNotificationProvider,
+    private val scope: CoroutineScope,
+    private val eventBus: EventBus,
+    private val databaseManager: DatabaseManager,
+) {
+    private var reconnectDelayMs = 1_000L
+    private val maxReconnectDelayMs = 30_000L
+    private var closed = false
+
+    private val client = HttpClient { install(WebSockets) }
+
+    // Per-drive upsert workers, keyed by drive alias. Lazily created on the first file event.
+    private val wsUpsertWorkers = mutableMapOf<Uuid, DriveWebSocketUpsertWorker>()
+    private val wsUpsertWorkersMutex = Mutex()
+
+    // Peer auth material (refetched on authenticationError / reconnect). null until first connect.
+    private var authToken64: String? = null
+    private var peerSharedSecret: ByteArray? = null
+
+    private val _connectionState = MutableStateFlow<WebSocketState>(WebSocketState.Disconnected)
+    val connectionState: StateFlow<WebSocketState> = _connectionState.asStateFlow()
+
+    private var connectionJob: Job? = null
+    private var session: DefaultClientWebSocketSession? = null
+
+    @Volatile private var handshakeDone = false
+
+    private val pingSupervisor = WebSocketPingSupervisor(
+        scope = scope,
+        sessionProvider = { session },
+        encrypt = { encryptCommand(it) },
+        onOnline = { },
+        onOffline = { handleDisconnected() },
+    )
+
+    fun start() {
+        if (connectionJob?.isActive == true) return
+        connectionJob = scope.launch {
+            while (!closed) {
+                try {
+                    connectOnce()
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Logger.w(throwable = e, tag = TAG) {
+                        "peer WS[$ownerOdinId] connect failed: ${e.message}"
+                    }
+                }
+                if (closed) break
+                Logger.w(tag = TAG) { "peer WS[$ownerOdinId] disconnected, retry in ${reconnectDelayMs}ms" }
+                delay(reconnectDelayMs)
+                reconnectDelayMs = (reconnectDelayMs * 2).coerceAtMost(maxReconnectDelayMs)
+            }
+        }
+    }
+
+    private suspend fun handleDisconnected() {
+        if (closed) return
+        eventBus.emit(BackendEvent.ConnectionOffline)
+        connectionJob?.cancel()
+        start()
+    }
+
+    private suspend fun connectOnce() {
+        // Peer token (cached on the instance; refetched after an authentication error clears it).
+        if (authToken64 == null || peerSharedSecret == null) {
+            val token = peerNotificationProvider.getPeerToken(ownerOdinId) ?: run {
+                Logger.w(tag = TAG) { "peer WS[$ownerOdinId] preauth failed — no token" }
+                return
+            }
+            authToken64 = token.authenticationToken64
+            peerSharedSecret = Base64.decode(token.sharedSecret)
+        }
+        val token64 = authToken64 ?: return
+        val ss = peerSharedSecret ?: return
+
+        _connectionState.value = WebSocketState.Connecting
+        val wsUrl = "wss://$ownerOdinId$PEER_WS_PATH"
+        Logger.i(tag = TAG) { "peer WS[$ownerOdinId] connecting to $wsUrl (drives=${drives.size})" }
+
+        client.webSocket(
+            urlString = wsUrl,
+            request = {
+                // Guest client-auth token carried in the SUB32 header (JS parity). The exact v2 peer
+                // WS auth scheme must be confirmed against the server (see plan "Open items").
+                headers.append("SUB32", token64)
+            },
+        ) {
+            session = this
+            _connectionState.value = WebSocketState.Connected
+            handshakeDone = false
+            establishConnectionRequest(ss, token64)
+
+            val handshakeTimeoutJob = scope.launch {
+                delay(10_000L)
+                if (!handshakeDone) {
+                    Logger.w(tag = TAG) { "peer WS[$ownerOdinId] handshake timeout — closing" }
+                    session?.close()
+                }
+            }
+
+            try {
+                for (frame in incoming) {
+                    when (frame) {
+                        is Frame.Text -> handleTextFrame(frame, ss)
+                        is Frame.Close -> break
+                        else -> Unit
+                    }
+                }
+            } finally {
+                handshakeTimeoutJob.cancel()
+                session = null
+                pingSupervisor.stop()
+                if (_connectionState.value !is WebSocketState.Error) {
+                    _connectionState.value = WebSocketState.Disconnected
+                }
+            }
+        }
+    }
+
+    private suspend fun handleTextFrame(frame: Frame.Text, ss: ByteArray) {
+        try {
+            val decryptedJson = decryptData(frame.readText(), ss)
+            val notification = OdinSystemSerializer
+                .deserialize<ClientNotificationPayload>(decryptedJson) ?: return
+            dispatchNotification(notification, ss)
+        } catch (e: Exception) {
+            Logger.e(e) { "peer WS[$ownerOdinId] error handling frame" }
+        }
+    }
+
+    private suspend fun dispatchNotification(notification: ClientNotificationPayload, ss: ByteArray) {
+        when (notification.notificationType) {
+            ClientNotificationType.deviceHandshakeSuccess -> {
+                Logger.i(tag = TAG) { "peer WS[$ownerOdinId] handshake success" }
+                handshakeDone = true
+                reconnectDelayMs = 1_000L
+                pingSupervisor.notifySessionReconnected()
+                pingSupervisor.start()
+                eventBus.emit(BackendEvent.ConnectionOnline)
+            }
+            ClientNotificationType.pong -> pingSupervisor.notifyPongReceived()
+            ClientNotificationType.authenticationError -> {
+                Logger.w(tag = TAG) { "peer WS[$ownerOdinId] auth error — invalidating token" }
+                // Drop the cached token so the next connect re-fetches it, then force a reconnect.
+                authToken64 = null
+                peerSharedSecret = null
+                session?.close()
+            }
+            ClientNotificationType.inboxItemReceived -> handleProcessInbox(notification)
+            ClientNotificationType.fileAdded,
+            ClientNotificationType.fileDeleted,
+            ClientNotificationType.fileModified,
+            ClientNotificationType.statisticsChanged -> handleFileEvent(notification, ss)
+            else -> Unit
+        }
+    }
+
+    private suspend fun handleFileEvent(notification: ClientNotificationPayload, ss: ByteArray) {
+        val fileNotification =
+            OdinSystemSerializer.deserialize<ClientDriveNotification>(notification.data)
+        val driveId = fileNotification.targetDrive?.alias ?: return
+        val header = fileNotification.header ?: run {
+            Logger.i(tag = TAG) {
+                "peer WS[$ownerOdinId] file event drive=$driveId with no header " +
+                    "(type=${notification.notificationType}) — next syncAll will catch up"
+            }
+            return
+        }
+
+        val worker = getOrCreateWorker(driveId) ?: return
+        try {
+            val file = header.asHomebaseFile(SecureByteArray(ss))
+            worker.submit(file)
+        } catch (e: Exception) {
+            Logger.w(e) {
+                "peer WS[$ownerOdinId] pure-push failed drive=$driveId — next syncAll will catch up"
+            }
+        }
+    }
+
+    private suspend fun handleProcessInbox(notification: ClientNotificationPayload) {
+        val n = OdinSystemSerializer.deserialize<InboxItemReceivedNotification>(notification.data)
+        notifyCommand("processInbox", ProcessInboxPayload(targetDrive = n.targetDrive, batchSize = 100))
+    }
+
+    private suspend fun getOrCreateWorker(driveId: Uuid): DriveWebSocketUpsertWorker? {
+        if (closed) return null
+        val identityId = credentialsManager.getActiveCredentials()?.getIdentityId() ?: return null
+        return wsUpsertWorkersMutex.withLock {
+            wsUpsertWorkers[driveId] ?: DriveWebSocketUpsertWorker(
+                identityId = identityId,
+                driveId = driveId,
+                databaseManager = databaseManager,
+                eventBus = eventBus,
+                scope = scope,
+            ).also { wsUpsertWorkers[driveId] = it }
+        }
+    }
+
+    private suspend fun establishConnectionRequest(ss: ByteArray, token64: String) {
+        val command = WebsocketCommand(
+            command = "establishConnectionRequest",
+            data = OdinSystemSerializer.serialize(EstablishConnectionRequest(drives = drives)),
+        )
+        val envelope = PeerEstablishEnvelope(
+            sharedSecretEncryptedOptions = encryptCommand(command, ss),
+            clientAuthToken64 = token64,
+        )
+        session?.send(Frame.Text(OdinSystemSerializer.serialize(envelope)))
+    }
+
+    private suspend fun notifyCommand(command: String, payload: Any) {
+        val ss = peerSharedSecret ?: return
+        val cmd = WebsocketCommand(command = command, data = OdinSystemSerializer.serialize(payload))
+        val encrypted = encryptCommand(cmd, ss)
+        session?.send(Frame.Text(OdinSystemSerializer.serialize(encrypted)))
+    }
+
+    /** Encrypt a command with the peer shared secret; used by the ping supervisor. */
+    private suspend fun encryptCommand(command: WebsocketCommand): SharedSecretEncryptedPayload =
+        encryptCommand(command, peerSharedSecret ?: ByteArray(0))
+
+    private suspend fun encryptCommand(command: WebsocketCommand, ss: ByteArray): SharedSecretEncryptedPayload {
+        val iv = ByteArrayUtil.getRndByteArray(16)
+        val json = OdinSystemSerializer.serialize(command)
+        val encrypted = AesCbc.encrypt(json.encodeToByteArray(), ss, iv)
+        return SharedSecretEncryptedPayload(iv = iv.toBase64(), data = encrypted.toBase64())
+    }
+
+    private suspend fun decryptData(text: String, ss: ByteArray): String {
+        val envelope = OdinSystemSerializer.deserialize<WebSocketClientNotificationPayload>(text)
+        if (!envelope.isEncrypted) return envelope.payload
+        val encryptedPayload =
+            OdinSystemSerializer.deserialize<SharedSecretEncryptedPayload>(envelope.payload)
+        val iv = Base64.decode(encryptedPayload.iv)
+        val encryptedData = Base64.decode(encryptedPayload.data)
+        return AesCbc.decrypt(encryptedData, ss, iv).decodeToString()
+    }
+
+    /** Close this peer connection and release all per-drive workers. */
+    fun close() {
+        Logger.i(tag = TAG) { "peer WS[$ownerOdinId] close()" }
+        closed = true
+        pingSupervisor.stop()
+        session = null
+        connectionJob?.cancel()
+        connectionJob = null
+        val workers = wsUpsertWorkers.values.toList()
+        wsUpsertWorkers.clear()
+        workers.forEach { it.cancel() }
+        _connectionState.value = WebSocketState.Disconnected
+        client.close()
+    }
+
+    companion object {
+        private const val TAG = "PeerWebSocket"
+
+        // Direct peer-WS route on the owner's host (V2 backend spec).
+        // NOTE: the V2 backend authenticates this socket IN-BAND via the first
+        // `SocketAuthenticationPackage` message, NOT the SUB32 header + establish-wrapper model this
+        // client currently sends. The path is correct; the handshake auth still needs to be reworked
+        // to send the SocketAuthenticationPackage before live updates will connect.
+        private const val PEER_WS_PATH = "/api/v2/peer/notify/ws-token"
+    }
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerWebSocketManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerWebSocketManager.kt
@@ -1,0 +1,96 @@
+package id.homebase.api.client.peer
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.TargetDrive
+import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.common.OdinId
+import id.homebase.api.sync.database.DatabaseManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Owns one [PeerWebSocketClient] per community-owner host. A member can belong to communities owned
+ * by different identities, so live updates require a separate websocket per owner host (the existing
+ * single-host [id.homebase.api.client.websockets.OdinWebSocketClient] is bound to `creds.domain`).
+ *
+ * Lifecycle is driven by the drive mount path (mount on subscribe, unmount on revoke) and must be
+ * [reset] on logout so a second user never inherits the first user's peer connections.
+ */
+class PeerWebSocketManager(
+    private val credentialsManager: CredentialsManager,
+    private val peerNotificationProvider: PeerNotificationProvider,
+    private val eventBus: EventBus,
+    private val databaseManager: DatabaseManager,
+    // Own SupervisorJob scope (like DriveRegistry) so a peer-connection crash is isolated and the
+    // manager doesn't have to thread the AuthConnectionCoordinator scope through DI.
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+) {
+    private val mutex = Mutex()
+
+    // One connection per owner host, plus the set of community drives subscribed on it. Adding a
+    // drive for an owner that already has a connection rebuilds the client with the union so a
+    // single establishConnectionRequest covers all that owner's communities.
+    private data class OwnerConnection(
+        val client: PeerWebSocketClient,
+        val drives: Set<TargetDrive>,
+    )
+
+    private val connections = mutableMapOf<OdinId, OwnerConnection>()
+
+    /** Subscribe to [drive] on [ownerOdinId]'s host, starting (or extending) that owner's websocket. */
+    suspend fun mount(ownerOdinId: OdinId, drive: TargetDrive) = mutex.withLock {
+        val existing = connections[ownerOdinId]
+        val drives = (existing?.drives ?: emptySet()) + drive
+        if (existing != null && drive in existing.drives) {
+            Logger.d(tag = TAG) { "mount: $ownerOdinId already subscribed to ${drive.alias}" }
+            return@withLock
+        }
+        existing?.client?.close()
+        val client = newClient(ownerOdinId, drives.toList())
+        connections[ownerOdinId] = OwnerConnection(client, drives)
+        Logger.i(tag = TAG) { "mount: $ownerOdinId now watching ${drives.size} drive(s)" }
+        client.start()
+    }
+
+    /** Stop watching [drive] on [ownerOdinId]; closes the owner's websocket when its last drive goes. */
+    suspend fun unmount(ownerOdinId: OdinId, drive: TargetDrive) = mutex.withLock {
+        val existing = connections[ownerOdinId] ?: return@withLock
+        existing.client.close()
+        val remaining = existing.drives - drive
+        if (remaining.isEmpty()) {
+            connections.remove(ownerOdinId)
+            Logger.i(tag = TAG) { "unmount: $ownerOdinId — no drives left, connection closed" }
+        } else {
+            val client = newClient(ownerOdinId, remaining.toList())
+            connections[ownerOdinId] = OwnerConnection(client, remaining)
+            client.start()
+            Logger.i(tag = TAG) { "unmount: $ownerOdinId — ${remaining.size} drive(s) remain" }
+        }
+    }
+
+    /** Close every peer connection. Call on logout (user-scoped singleton hygiene). */
+    suspend fun reset() = mutex.withLock {
+        connections.values.forEach { it.client.close() }
+        connections.clear()
+        Logger.i(tag = TAG) { "reset: all peer connections closed" }
+    }
+
+    private fun newClient(ownerOdinId: OdinId, drives: List<TargetDrive>) =
+        PeerWebSocketClient(
+            ownerOdinId = ownerOdinId,
+            drives = drives,
+            credentialsManager = credentialsManager,
+            peerNotificationProvider = peerNotificationProvider,
+            scope = scope,
+            eventBus = eventBus,
+            databaseManager = databaseManager,
+        )
+
+    companion object {
+        private const val TAG = "PeerWebSocket"
+    }
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
@@ -22,6 +22,9 @@ import id.homebase.api.client.link.LinkPreviewProvider
 import id.homebase.api.client.location.LocationPreviewProvider
 import id.homebase.api.client.notifications.PushNotificationApi
 import id.homebase.api.client.peer.PeerDriveQueryProvider
+import id.homebase.api.client.peer.PeerDriveUploadProvider
+import id.homebase.api.client.peer.PeerNotificationProvider
+import id.homebase.api.client.peer.PeerWebSocketManager
 import id.homebase.api.client.profile.PublicProfileProvider
 import id.homebase.api.client.profile.PublicProfileProviderCached
 import id.homebase.api.client.upgrade.IdentityUpgradeProvider
@@ -88,6 +91,18 @@ val apiModule = module {
 
     factoryOf(::ConnectionNetworkProvider)
     factoryOf(::PeerDriveQueryProvider)
+    factoryOf(::PeerDriveUploadProvider)
+    factoryOf(::PeerNotificationProvider)
+    // Single: one set of peer (owner-hosted) websocket connections per app session; reset on logout
+    // via AuthConnectionCoordinator.disconnect(). Uses its own internal scope (default ctor arg).
+    single {
+        PeerWebSocketManager(
+            credentialsManager = get(),
+            peerNotificationProvider = get(),
+            eventBus = get(),
+            databaseManager = get(),
+        )
+    }
     factoryOf(::ConnectionRequestProvider)
     factoryOf(::ConnectionIntroductionProvider) bind IntroductionSender::class
     factoryOf(::IdentityUpgradeProvider)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveStatus.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveStatus.kt
@@ -1,12 +1,23 @@
 package id.homebase.api.sync
 
+import id.homebase.api.common.OdinId
 import kotlin.uuid.Uuid
 
 data class DriveStatus(
     val driveId: Uuid,
     val label: String,
     val state: DriveState,
-)
+    /**
+     * Owning identity of this drive when it is hosted on a **peer** (a community owner), or null
+     * for the logged-in user's own drives. Lets the fail-soft logic treat remote drives differently:
+     * they are excluded from the global [SyncState] aggregate and retry with exponential backoff so a
+     * single offline owner can never make the whole app read "sync failed" (see DriveSyncManager).
+     */
+    val ownerOdinId: OdinId? = null,
+) {
+    /** True when this drive is hosted on a peer (owner-hosted), false for own drives. */
+    val isRemote: Boolean get() = ownerOdinId != null
+}
 
 sealed interface DriveState {
     data object Initialized                          : DriveState
@@ -22,10 +33,19 @@ sealed interface SyncState {
     data object Failed    : SyncState  // One or more Failed; rest Completed/Initialized
 }
 
-fun computeSyncState(statuses: Map<Uuid, DriveStatus>): SyncState = when {
-    statuses.isEmpty()                                                -> SyncState.Idle
-    statuses.values.any { it.state is DriveState.Synchronizing }     -> SyncState.Syncing
-    statuses.values.any { it.state is DriveState.Failed }            -> SyncState.Failed
-    statuses.values.all { it.state is DriveState.Completed }         -> SyncState.Completed
-    else                                                              -> SyncState.Idle
+/**
+ * Aggregate sync state for the global sync indicator. **Remote (owner-hosted) drives are excluded**
+ * — a community whose owner is offline/slow must never flip the whole app to [SyncState.Failed] or
+ * stall it on [SyncState.Syncing]. Per-community health is surfaced separately by reading that
+ * drive's own [DriveStatus]. The aggregate therefore reflects only the user's own drives.
+ */
+fun computeSyncState(statuses: Map<Uuid, DriveStatus>): SyncState {
+    val own = statuses.values.filterNot { it.isRemote }
+    return when {
+        own.isEmpty()                                       -> SyncState.Idle
+        own.any { it.state is DriveState.Synchronizing }    -> SyncState.Syncing
+        own.any { it.state is DriveState.Failed }           -> SyncState.Failed
+        own.all { it.state is DriveState.Completed }        -> SyncState.Completed
+        else                                                -> SyncState.Idle
+    }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
@@ -12,6 +12,7 @@ import id.homebase.api.client.drives.query.FileQueryParams
 import id.homebase.api.client.drives.query.QueryBatchCursor
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.common.OdinId
 import id.homebase.api.sync.database.CursorStorage
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.MainIndexMetaHelpers
@@ -37,6 +38,11 @@ class DriveSync(
     scope: CoroutineScope? = null,
     expectFreshCursor: Boolean = false,
     private val policy: DriveSyncPolicy = DriveSyncPolicy(),
+    // Owning identity when this drive is hosted on a peer (a community owner); null for the
+    // logged-in user's own drives. When set, the sync pull is brokered over peer (queryBatch routes
+    // to /peer/$ownerOdinId/...). Rows still land under the local-user [identityId] — the community
+    // driveId is a globally-unique GUID so it can never collide with own-drive rows.
+    private val ownerOdinId: OdinId? = null,
 ) {
     // Background work is Network and DB bound, so using IO
     private val scope = scope ?: supervisedScope("drive-sync")
@@ -172,7 +178,7 @@ class DriveSync(
             val durationMs = measureTimedValue {
                 try {
                     killroy.value = false // Atomic
-                    queryBatchResponse = driveQueryProvider.queryBatch(driveId, request)
+                    queryBatchResponse = driveQueryProvider.queryBatch(driveId, request, ownerOdinId)
 
                     if (queryBatchResponse.cursorState != null)
                         cursor = QueryBatchCursor.fromJson(queryBatchResponse.cursorState)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
@@ -5,9 +5,11 @@ import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.drives.query.DriveQueryProvider
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.common.OdinId
 import id.homebase.api.sync.database.DatabaseManager
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -49,6 +51,12 @@ class DriveSyncManager(
     // guarantee needed for non-mutex readers (syncDrive, pause, clearStorage).
     private var driveSyncs: Map<Uuid, DriveSync> = emptyMap()
     private val driveSyncsMutex = Mutex()
+
+    // Per-remote-drive consecutive-failure counter driving the exponential retry backoff. Only the
+    // single eventBus-collector coroutine touches this (read+write in the Stopped handler), so a
+    // plain map is safe without a lock. Reset to 0 (entry removed) on a Completed round or unmount.
+    private val remoteRetryAttempts = mutableMapOf<Uuid, Int>()
+
     @kotlin.concurrent.Volatile private var _isRunning = false
 
     /**
@@ -110,18 +118,36 @@ class DriveSyncManager(
                         }
                     }
                     is BackendEvent.DriveEvent.Stopped -> when (val r = event.result) {
-                        is BackendEvent.DriveResult.Completed -> updateState(event.driveId) {
-                            it.copy(state = DriveState.Completed(totalCount = event.totalCount))
+                        is BackendEvent.DriveResult.Completed -> {
+                            // A clean round resets the remote backoff ladder — the owner is reachable
+                            // again, so the next failure should start from the floor, not the ceiling.
+                            remoteRetryAttempts.remove(event.driveId)
+                            updateState(event.driveId) {
+                                it.copy(state = DriveState.Completed(totalCount = event.totalCount))
+                            }
                         }
                         is BackendEvent.DriveResult.Aborted -> {
                             updateState(event.driveId) {
                                 it.copy(state = DriveState.Failed(r.errorMessage))
                             }
+                            // Remote (owner-hosted) drives back off exponentially so an offline owner
+                            // is not polled every second forever; own drives keep the flat 1s retry.
+                            // Reads/writes of remoteRetryAttempts are confined to this single-collector
+                            // coroutine, so the plain map needs no extra lock.
+                            val isRemote = _driveStatuses.value[event.driveId]?.isRemote == true
+                            val delayMs = if (isRemote) {
+                                val attempt = (remoteRetryAttempts[event.driveId] ?: 0) + 1
+                                remoteRetryAttempts[event.driveId] = attempt
+                                nextRemoteBackoffMs(attempt)
+                            } else {
+                                1000L
+                            }
                             Logger.w(tag = "DriveSync") {
-                                "drive ${event.driveId} failed: ${r.errorMessage}, scheduling retry in 1s"
+                                "drive ${event.driveId} failed: ${r.errorMessage}, scheduling retry in ${delayMs}ms" +
+                                    if (isRemote) " (remote, attempt ${remoteRetryAttempts[event.driveId]})" else ""
                             }
                             scope.launch {
-                                delay(1000L)
+                                delay(delayMs)
                                 Logger.i(tag = "DriveSync") { "retrying drive ${event.driveId}" }
                                 driveSyncsMutex.withLock { driveSyncs[event.driveId] }?.sync()
                             }
@@ -137,6 +163,18 @@ class DriveSyncManager(
                 }
             }
         }
+    }
+
+    /**
+     * Exponential backoff (capped) for a remote drive's nth consecutive failed sync round: 1s, 2s,
+     * 4s, … up to [REMOTE_RETRY_CEILING_MS]. [attempt] is 1-based.
+     */
+    private fun nextRemoteBackoffMs(attempt: Int): Long {
+        // shl on a 1-based attempt: attempt 1 -> 1s, 2 -> 2s, 3 -> 4s … Guard the shift so a long
+        // outage can't overflow into a negative/huge delay before the coerce clamps it.
+        val exp = (attempt - 1).coerceIn(0, 16)
+        val raw = REMOTE_RETRY_BASE_MS shl exp
+        return raw.coerceIn(REMOTE_RETRY_BASE_MS, REMOTE_RETRY_CEILING_MS)
     }
 
     private fun updateState(driveId: Uuid, transform: (DriveStatus) -> DriveStatus) {
@@ -217,9 +255,16 @@ class DriveSyncManager(
             }
             return
         }
-        val snapshot = driveSyncsMutex.withLock { driveSyncs.values.toList() }
-        val jobs = snapshot.mapNotNull { it.sync() }
-        jobs.joinAll()
+        val snapshot = driveSyncsMutex.withLock { driveSyncs.toList() }
+        // Kick every drive, but only barrier on the user's OWN drives. A remote (owner-hosted) drive
+        // whose owner is offline/slow must not stall the aggregate round via joinAll — its sync is
+        // launched fire-and-forget and reconciled independently through the Stopped/backoff path.
+        val ownJobs = mutableListOf<Job>()
+        for ((driveId, sync) in snapshot) {
+            val job = sync.sync() ?: continue
+            if (_driveStatuses.value[driveId]?.isRemote != true) ownJobs.add(job)
+        }
+        ownJobs.joinAll()
     }
 
     suspend fun syncAllFailed() {
@@ -290,7 +335,7 @@ class DriveSyncManager(
      *   calls (e.g. from a ViewModel reacting to driveStatuses) must NOT cause
      *   a reconnect, or they will tear down an in-flight WS handshake.
      */
-    suspend fun mountDrive(driveId: Uuid, label: String): Boolean {
+    suspend fun mountDrive(driveId: Uuid, label: String, ownerOdinId: OdinId? = null): Boolean {
         // getActiveCredentials() instead of requireActiveCredentials() — a logout
         // race during add-on activation should be a deferred mount, not a crash.
         val identityId = credentialsManager.getActiveCredentials()?.getIdentityId() ?: run {
@@ -328,6 +373,7 @@ class DriveSyncManager(
                     scope = scope,
                     expectFreshCursor = freshLogin,
                     policy = driveSyncPolicies[driveId] ?: DriveSyncPolicy(),
+                    ownerOdinId = ownerOdinId,
                 )
             } catch (e: CancellationException) {
                 // Don't swallow cancellation — let the caller's scope tear down cleanly.
@@ -345,7 +391,9 @@ class DriveSyncManager(
             }
             newSync
         }
-        _driveStatuses.update { it + (driveId to DriveStatus(driveId, label, DriveState.Initialized)) }
+        _driveStatuses.update {
+            it + (driveId to DriveStatus(driveId, label, DriveState.Initialized, ownerOdinId = ownerOdinId))
+        }
 
         // Defer the network kick if the manager isn't running yet — start()'s
         // catch-up loop will pick it up when isRunning flips true.
@@ -365,6 +413,7 @@ class DriveSyncManager(
             s
         } ?: return
         sync.cancel()
+        remoteRetryAttempts.remove(driveId)
         _driveStatuses.update { it - driveId }
         Logger.i(tag = "DriveSync") { "unmountDrive($driveId)" }
     }
@@ -392,5 +441,12 @@ class DriveSyncManager(
 
         // Signal the next start() that any cursor it finds is a bug.
         expectFreshCursors = true
+    }
+
+    companion object {
+        /** Floor of the remote-drive retry backoff (first failure waits this long). */
+        private const val REMOTE_RETRY_BASE_MS = 1_000L
+        /** Ceiling of the remote-drive retry backoff — an offline owner is polled at most this often. */
+        private const val REMOTE_RETRY_CEILING_MS = 60_000L
     }
 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -4,9 +4,12 @@ import androidx.compose.runtime.Immutable
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.auth.OwnerSessionRepository
+import id.homebase.api.client.drives.TargetDrive
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.client.peer.PeerWebSocketManager
 import id.homebase.api.client.websockets.OdinWebSocketClient
+import id.homebase.api.common.OdinId
 import id.homebase.api.sync.DriveSyncManager
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.OutboxSync
@@ -31,6 +34,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.withLock
 import kotlin.concurrent.Volatile
 import kotlin.uuid.Uuid
 
@@ -44,6 +48,7 @@ class AuthConnectionCoordinator(
     private val databaseManager: DatabaseManager,
     private val driveRegistry: DriveRegistry,
     private val securityContextProvider: SecurityContextProvider,
+    private val peerWebSocketManager: PeerWebSocketManager,
     private val onPostAuthenticated: () -> Unit = {},
     /**
      * Initial value of [headless]. True only on platforms that can cold-wake the
@@ -68,6 +73,12 @@ class AuthConnectionCoordinator(
         }
     )
     private var wsClient: OdinWebSocketClient? = null
+
+    // Peer (owner-hosted) drives mounted this session, alias -> (owner, drive). Lets [unmountDrive]
+    // tear down the right per-owner peer websocket given only a driveId. Guarded by [peerOwnersMutex]
+    // because mounts arrive from both the Authenticated branch and the registry observer coroutine.
+    private val peerDriveOwners = mutableMapOf<Uuid, Pair<OdinId, TargetDrive>>()
+    private val peerOwnersMutex = kotlinx.coroutines.sync.Mutex()
 
     // Coalesces bursts of mountDrive/unmountDrive calls into a single WebSocket reconnect.
     // [OdinWebSocketClient] freezes its drive-subscription list at construction time, so we
@@ -194,8 +205,9 @@ class AuthConnectionCoordinator(
                 // Pre-mount the granted optional drives so they're in driveSyncs when
                 // onConnected fires start() + syncAll(). mountDrive() defers the network kick
                 // while isRunning is false; syncAll() picks them up alongside the mandatory drives.
+                // ownerOdinId is set for owner-hosted (peer/community) drives, null for own drives.
                 for (drive in initialDrives.retainGrantedDrives()) {
-                    driveSyncManager.mountDrive(drive.drive.alias, drive.label)
+                    driveSyncManager.mountDrive(drive.drive.alias, drive.label, drive.ownerOdinId)
                 }
                 logLifecycleSnapshot("drives mounted")
 
@@ -214,6 +226,9 @@ class AuthConnectionCoordinator(
                 }
 
                 connect(extraDrives = initialDrives)
+                // Owner-hosted (peer) drives don't ride the own-host WebSocket — open a per-owner
+                // peer websocket for each so live community updates arrive over the owner's host.
+                startPeerConnections(initialDrives)
                 // Observe cross-device registry changes. We seed the diff baseline with the
                 // bootstrap result so the chat-drive sync that later writes the same file
                 // into the local index doesn't trigger a spurious onMount for drives that
@@ -285,6 +300,7 @@ class AuthConnectionCoordinator(
         scope.launch {
             onPostAuthenticated()
             connect(extraDrives = drives)
+            startPeerConnections(drives)
             driveRegistry.start(
                 onMount = { drive -> mountDrive(drive, persist = false) },
                 onUnmount = { driveId -> unmountDrive(driveId, persist = false) },
@@ -372,7 +388,10 @@ class AuthConnectionCoordinator(
                 scope = scope,
                 eventBus = eventBus,
                 databaseManager = databaseManager,
-                drives = (mandatorySyncDrives + optionalDrives).map { it.drive },
+                // Own-host WebSocket subscribes to own drives only. Peer (owner-hosted) drives get
+                // their own per-owner connection via [startPeerConnections] / [PeerWebSocketManager].
+                drives = (mandatorySyncDrives + optionalDrives.filter { it.ownerOdinId == null })
+                    .map { it.drive },
                 // Fires asynchronously once the server handshake has completed.
                 // We mark the connection state and then run post-connect setup in a
                 // background coroutine:
@@ -459,7 +478,8 @@ class AuthConnectionCoordinator(
      */
     suspend fun mountDrive(drive: LabeledDrive, persist: Boolean = true) {
         if (persist) driveRegistry.addDrive(drive)
-        val newlyMounted = driveSyncManager.mountDrive(drive.drive.alias, drive.label)
+        val owner = drive.ownerOdinId
+        val newlyMounted = driveSyncManager.mountDrive(drive.drive.alias, drive.label, owner)
         if (!newlyMounted) {
             // Redundant mount — drive was already in DSM. Skipping the refresh
             // trigger is critical: refreshWsSubscription.trigger() would close
@@ -473,7 +493,38 @@ class AuthConnectionCoordinator(
             }
             return
         }
-        refreshWsSubscription.trigger()
+        if (owner != null) {
+            // Peer drive: open/extend the per-owner peer websocket instead of reconnecting the
+            // own-host socket (the community drive isn't hosted on creds.domain).
+            peerOwnersMutex.withLock { peerDriveOwners[drive.drive.alias] = owner to drive.drive }
+            peerWebSocketManager.mount(owner, drive.drive)
+        } else {
+            refreshWsSubscription.trigger()
+        }
+    }
+
+    /**
+     * Mount a community drive hosted on another identity ([ownerOdinId]) directly. Part 1 transport
+     * affordance for exercising the validation gate against a real existing community before the
+     * Part 2 feature (and its registry entries) exists. Defaults to `persist = false` so it doesn't
+     * write the cross-device registry.
+     */
+    suspend fun mountPeerDrive(
+        ownerOdinId: OdinId,
+        communityDrive: TargetDrive,
+        label: String,
+        persist: Boolean = false,
+    ) {
+        mountDrive(LabeledDrive(communityDrive, label, ownerOdinId), persist = persist)
+    }
+
+    /** Open a peer websocket for every owner-hosted drive in [drives]. No-op for own drives. */
+    private suspend fun startPeerConnections(drives: List<LabeledDrive>) {
+        for (drive in drives) {
+            val owner = drive.ownerOdinId ?: continue
+            peerOwnersMutex.withLock { peerDriveOwners[drive.drive.alias] = owner to drive.drive }
+            peerWebSocketManager.mount(owner, drive.drive)
+        }
     }
 
     /**
@@ -491,7 +542,13 @@ class AuthConnectionCoordinator(
     suspend fun unmountDrive(driveId: Uuid, persist: Boolean = true) {
         if (persist) driveRegistry.removeDrive(driveId)
         driveSyncManager.unmountDrive(driveId)
-        refreshWsSubscription.trigger()
+        val peer = peerOwnersMutex.withLock { peerDriveOwners.remove(driveId) }
+        if (peer != null) {
+            // Peer drive: tear down its per-owner websocket rather than reconnecting the own-host one.
+            peerWebSocketManager.unmount(peer.first, peer.second)
+        } else {
+            refreshWsSubscription.trigger()
+        }
     }
 
     // Close the current WebSocket and open a new one. [connect] reads the DriveRegistry
@@ -512,6 +569,10 @@ class AuthConnectionCoordinator(
         }
         refreshWsSubscription.cancel()
         driveRegistry.stop()
+        // Close every per-owner peer websocket so a second login doesn't inherit the first user's
+        // community connections.
+        peerWebSocketManager.reset()
+        peerOwnersMutex.withLock { peerDriveOwners.clear() }
         outboxSync.setOnline(false)
         // Keep isConnecting = true so the next login cycle correctly starts in
         // StartupState.Loading.  While logged out the auth state is Unauthenticated,

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/config/AppConfig.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/config/AppConfig.kt
@@ -2,6 +2,7 @@ package id.homebase.core.config
 
 import id.homebase.api.client.drives.SystemDriveConstants
 import id.homebase.api.client.drives.TargetDrive
+import id.homebase.api.common.OdinId
 import id.homebase.api.crypto.Md5
 import id.homebase.api.youauth.AppPermissionType
 import id.homebase.api.youauth.DrivePermission
@@ -10,8 +11,21 @@ import id.homebase.api.youauth.TargetDriveAccessRequest
 import kotlin.uuid.Uuid
 import kotlinx.serialization.Serializable
 
+/**
+ * A drive the app mounts for sync, paired with a human-readable label.
+ *
+ * @param ownerOdinId the **owning identity** when this drive is hosted on a peer (a community
+ *   owner's collaborative drive); null for the logged-in user's own drives. When set, the drive is
+ *   synced/queried/written over peer and gets a per-owner peer websocket instead of riding the
+ *   user's own-host websocket. Nullable with a default so existing serialized registry files (which
+ *   predate this field) still parse as own drives.
+ */
 @Serializable
-data class LabeledDrive(val drive: TargetDrive, val label: String)
+data class LabeledDrive(
+    val drive: TargetDrive,
+    val label: String,
+    val ownerOdinId: OdinId? = null,
+)
 
 /**
  * Central app configuration for authentication, permissions, and drives. Used by both

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -301,6 +301,7 @@ val appModule = module {
             databaseManager = get(),
             driveRegistry = get(),
             securityContextProvider = get(),
+            peerWebSocketManager = get(),
             // Start headless only where the OS can cold-wake us in the background
             // (Android/iOS). Desktop/Web report false → start in foreground mode so
             // a missing promoteToForeground() can't hang the app on "syncing".


### PR DESCRIPTION
Client-side transport for talking to a **drive owned by another identity** (a community owner) — the foundation for Communities, where every member syncs one owner-hosted collaborative drive instead of a per-member copy. Feature-agnostic additions to `homebase-api`; **builds no Community feature yet**.

Pairs with **odin-core PR #1540** (the V2 peer routes).

## What's in it

**Over-peer operations** (brokered through the user's own host, `creds.domain`):
- **Query** — `DriveQueryProvider.queryBatch(driveId, request, ownerOdinId)` → `POST /api/v2/peer/{owner}/drives/{id}/query-batch`
- **Write** — `PeerDriveUploadProvider.uploadFileOverPeer(...)` honours the previously-unused `TransitOptions.remoteTargetDrive` → `.../files/send`
- **Live** — `PeerWebSocketClient` / `PeerWebSocketManager` (one connection per owner host) + `PeerNotificationProvider` (peer token + push subscription)
- **Sync** — `DriveSync` / `DriveSyncManager.mountDrive` gain an owning identity; owner-hosted rows land in the local DB under the **local** `identityId` (the community `driveId` is a globally-unique GUID, so no collision — no schema change)

**Fail-soft for remote drives** (`DriveSyncManager` / `DriveStatus`): excluded from the global sync indicator, **exponential backoff** instead of the flat 1s retry, and not awaited in the `syncAll()` barrier — one offline community can't make the whole app read "sync failed".

**Wiring**: `LabeledDrive.ownerOdinId`; `AuthConnectionCoordinator` mounts peer drives over the per-owner peer websocket (the own-host WS stays own-drives-only) and resets them on logout; DI in `ApiModule`/`AppModule`.

## Validation
End-to-end against a real community: **write-out** and **ws-token** confirmed; **query** confirmed against one community. One server-side detail remains on a second test community (a `400` on the owner's perimeter — tracked, not a client bug).

## Docs included
- `COMMUNITY_PART1_TRANSPORT.md` — the transport spec
- `COMMUNITY_PART1_V2_BACKEND_PORT.md` — the BE contract (what odin-core implemented)
- `COMMUNITY_PART2_FEATURE.md` — the next phase (the actual Community feature)

## Notes
- Compiles on JVM (`homebase-api`/`-common`/`-core`). The desktop startup-crash fix went out separately as #638.
- Live-updates websocket auth handshake (in-band `SocketAuthenticationPackage`) is the remaining piece before live sync; query + write are the proven pillars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)