### PR TITLE
Retry core: resend a failed message (create or update) from Message Info

### DIFF
--- a/homebase-api/build.gradle.kts
+++ b/homebase-api/build.gradle.kts
@@ -164,6 +164,7 @@ kotlin {
         "id.homebase.api.sync.database.DriveTagIndexTest",
         "id.homebase.api.sync.database.FileStateFilterTest",
         "id.homebase.api.sync.database.MainIndexMetaTest",
+        "id.homebase.api.sync.database.OutboxSetNextRunTimeTest",
         "id.homebase.api.sync.database.OutboxSyncTest",
         "id.homebase.api.sync.database.OutboxTest",
         "id.homebase.api.sync.DriveSyncManagerTest",

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
@@ -480,6 +480,72 @@ class DriveFileProviderCached(
         }
     }
 
+    // =======================================================
+    // -------------------- CACHE SEEDING --------------------
+    // =======================================================
+
+    /**
+     * Seed the payload disk cache with already-encrypted bytes the client
+     * produced locally (e.g. at optimistic send time, before the server has
+     * the file). The bytes must be exactly what the server would return for
+     * `GET payload` — AES-CBC encrypted with the file's [KeyHeader] — so that
+     * [getPayloadBytesRaw]/[getPayloadBytesDecrypted] serve them
+     * transparently. Clears any stale 404 marker for the key so a pre-send
+     * lookup can't shadow the seeded entry.
+     */
+    suspend fun cachePayloadBytesEncrypted(
+            driveId: Uuid,
+            fileId: Uuid,
+            key: String,
+            bytes: ByteArray,
+            contentType: String
+    ) {
+        val cacheKey = buildPayloadCacheKey(driveId, fileId, key, null, null)
+        seedCache(payloadDiskCache, cacheKey, "PayloadIO", bytes, contentType)
+    }
+
+    /**
+     * Thumbnail analog of [cachePayloadBytesEncrypted]. `lastModified` defaults
+     * to null to line up with the read path's default for files that have not
+     * synced back from the server yet.
+     */
+    suspend fun cacheThumbBytesEncrypted(
+            driveId: Uuid,
+            fileId: Uuid,
+            payloadKey: String,
+            width: Int,
+            height: Int,
+            bytes: ByteArray,
+            contentType: String,
+            lastModified: Long? = null
+    ) {
+        val cacheKey = buildThumbCacheKey(driveId, fileId, payloadKey, width, height, lastModified)
+        seedCache(thumbDiskCache, cacheKey, "ThumbIO", bytes, contentType)
+    }
+
+    private suspend fun seedCache(
+            cache: DiskCache,
+            cacheKey: String,
+            logTag: String,
+            bytes: ByteArray,
+            contentType: String
+    ) {
+        writeToDiskCache(
+                cache,
+                cacheKey,
+                logTag,
+                ByteApiResponse(
+                        status = 200,
+                        // The payloadencrypted bit is load-bearing: decrypt-on-read
+                        // consults it to know the cached bytes need AES-CBC.
+                        headers = Headers.build { append("payloadencrypted", "true") },
+                        bytes = bytes,
+                        contentType = contentType
+                )
+        )
+        notFoundCacheMutex.withLock { notFoundCache = notFoundCache - cacheKey }
+    }
+
     // ====================================================
     // -------------------- CACHE KEYS --------------------
     // ====================================================

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveFileProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveFileProvider.kt
@@ -236,6 +236,33 @@ public class DriveFileProvider(
     }
 
     /**
+     * Seed the encrypted payload disk cache with locally-produced bytes — the
+     * exact AES-CBC ciphertext the server would return for this payload. Used
+     * at optimistic send time so a message whose upload later fails permanently
+     * still has retrievable media: [getPayloadBytesEncrypted] checks this cache
+     * before the network. Counterpart write API to [getPayloadBytesEncrypted].
+     */
+    suspend fun cachePayloadBytesEncrypted(
+        driveId: Uuid,
+        fileId: Uuid,
+        key: String,
+        bytes: ByteArray,
+        contentType: String,
+    ) = driveCache.cachePayloadBytesEncrypted(driveId, fileId, key, bytes, contentType)
+
+    /** Thumbnail counterpart to [cachePayloadBytesEncrypted]; pairs with [getThumbBytesEncrypted]. */
+    suspend fun cacheThumbBytesEncrypted(
+        driveId: Uuid,
+        fileId: Uuid,
+        payloadKey: String,
+        width: Int,
+        height: Int,
+        bytes: ByteArray,
+        contentType: String,
+        lastModified: Long? = null,
+    ) = driveCache.cacheThumbBytesEncrypted(driveId, fileId, payloadKey, width, height, bytes, contentType, lastModified)
+
+    /**
      * Fetch the raw (still-encrypted) bytes for a specific byterange of a payload, going through
      * the disk cache. Used by the iOS HLS resource loader, which decrypts each HLS segment as a
      * standalone AES-CBC blob (FFmpeg encrypts each segment independently with PKCS7 padding).

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
@@ -280,9 +280,14 @@ class OutboxSync(
                     e
                 )
 
+                // nextRunTime is a MILLISECONDS epoch — checkout/nextScheduled
+                // compare it against UnixTimeUtc.now().milliseconds. Storing
+                // `.seconds` here (the pre-fix bug) made every backoff deadline
+                // a ~1970s-era value, so failed rows were immediately
+                // re-eligible and the 30s→4h backoff was never enforced.
                 databaseManager.outbox.checkInFailed(
                     outboxRecord.checkOutStamp!!,
-                    UnixTimeUtc.now().addSeconds(n).seconds
+                    UnixTimeUtc.now().addSeconds(n).milliseconds
                 )
 
                 eventBus.emit(
@@ -471,6 +476,46 @@ class OutboxSync(
         val row = databaseManager.outbox.selectByDriveAndUnique(driveId, uniqueId) ?: return null
         if (row.uploadType != DriveOutboxUploader.UploadNewFile) return null
         return OdinSystemSerializer.deserialize<UploadFileRequest>(row.json.decodeToString())
+    }
+
+    /** Display-oriented snapshot of the pending row for (driveId, uniqueId) —
+     *  what Message Info needs to render "still sending, next attempt in ~N min"
+     *  without deserializing the request json. */
+    public data class PendingRowSnapshot(
+        /** Milliseconds epoch of the next attempt (0 / sentinel = "shortly").
+         *  Rows written before the checkInFailed unit fix may carry a
+         *  seconds-epoch value — display code must normalize. */
+        val nextRunTime: Long,
+        val checkOutCount: Long,
+        /** True when an upload worker currently holds the row. */
+        val isCheckedOut: Boolean,
+        val uploadType: Long,
+    )
+
+    public suspend fun pendingRowSnapshot(driveId: Uuid, uniqueId: Uuid): PendingRowSnapshot? {
+        val row = databaseManager.outbox.selectByDriveAndUnique(driveId, uniqueId) ?: return null
+        return PendingRowSnapshot(
+            nextRunTime = row.nextRunTime,
+            checkOutCount = row.checkOutCount,
+            isCheckedOut = row.checkOutStamp != null,
+            uploadType = row.uploadType,
+        )
+    }
+
+    /**
+     * Force a queued (backed-off) row to be eligible immediately and kick the
+     * send loop — the "Try now" button. Returns false when nothing changed:
+     * the row is gone (already sent/dropped) or currently checked out (the
+     * upload is literally running — a harmless no-op either way). A row with
+     * an unresolved dependency gets its time reset but still waits for the
+     * dependency to drain (the checkout SQL's NOT EXISTS guard).
+     */
+    public suspend fun runNow(driveId: Uuid, uniqueId: Uuid): Boolean {
+        val changed = databaseManager.outbox.setNextRunTime(driveId, uniqueId, 0L)
+        if (changed > 0) {
+            scope.launch { send() }
+        }
+        return changed > 0
     }
 
     public suspend fun tryEnqueue(

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxWrapper.kt
@@ -84,8 +84,26 @@ class OutboxWrapper(
         checkOutStamp: Long,
         nextRunTime: Long,
     ): Long {
+        // Named args are load-bearing: the generated query's parameter order is
+        // (nextRunTime, checkOutStamp) — SQL appearance order, both Long. The
+        // original positional call had them SWAPPED, so the WHERE never matched:
+        // failed rows stayed checked out (zombies) until the next app start's
+        // clearCheckedOut, and in-session retry/backoff never actually ran.
         return databaseManager.withWriteValue {
-            delegate.checkInFailed(checkOutStamp, nextRunTime).value
+            delegate.checkInFailed(nextRunTime = nextRunTime, checkOutStamp = checkOutStamp).value
+        }
+    }
+
+    /** Reset a queued row's next-attempt time (ms epoch). Returns the number of
+     *  rows changed: 0 when the row is missing or currently checked out — an
+     *  in-flight row's nextRunTime is owned by [checkInFailed]. */
+    suspend fun setNextRunTime(
+        driveId: Uuid,
+        uniqueId: Uuid,
+        nextRunTime: Long,
+    ): Long {
+        return databaseManager.withWriteValue {
+            delegate.setNextRunTime(nextRunTime = nextRunTime, driveId = driveId, uniqueId = uniqueId).value
         }
     }
 

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/Outbox.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/Outbox.sq
@@ -70,6 +70,14 @@ SET checkOutStamp=NULL,
     nextRunTime=:nextRunTime
 WHERE checkOutStamp=:checkOutStamp;
 
+-- Force a queued row's next attempt (e.g. "Try now" resetting a backed-off
+-- item to run immediately). Guarded on checkOutStamp IS NULL: an in-flight
+-- row's nextRunTime is owned by checkInFailed and must not be raced.
+setNextRunTime:
+UPDATE Outbox
+SET nextRunTime = :nextRunTime
+WHERE driveId = :driveId AND uniqueId = :uniqueId AND checkOutStamp IS NULL;
+
 -- When the app starts, clear all checked out items
 clearCheckedOut:
 UPDATE Outbox

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSetNextRunTimeTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSetNextRunTimeTest.kt
@@ -3,6 +3,7 @@ package id.homebase.api.sync.database
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.common.time.UnixTimeUtc
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
@@ -28,6 +29,7 @@ import kotlin.uuid.Uuid
  *    `.seconds` while `checkout` compares an ms epoch, so even a matching
  *    check-in would have made the row immediately re-eligible.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class OutboxSetNextRunTimeTest {
 
     private suspend fun insertRow(dbm: DatabaseManager, driveId: Uuid, uniqueId: Uuid) {

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSetNextRunTimeTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSetNextRunTimeTest.kt
@@ -1,0 +1,155 @@
+package id.homebase.api.sync.database
+
+import id.homebase.api.client.eventbus.BackendEvent
+import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.common.time.UnixTimeUtc
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * The outbox `setNextRunTime` primitive behind [OutboxSync.runNow] ("Try now"),
+ * plus regressions for the two stacked bugs that meant in-session retry/backoff
+ * never actually ran:
+ *
+ * 1. **Swapped checkInFailed arguments** — the generated query's parameter
+ *    order is (nextRunTime, checkOutStamp); the wrapper passed them positionally
+ *    reversed (both Long, so it compiled). The WHERE never matched: failed rows
+ *    stayed checked out (zombies) until the next app start's `clearCheckedOut`.
+ * 2. **Seconds-vs-ms deadline** — the OutboxSync call site stored
+ *    `.seconds` while `checkout` compares an ms epoch, so even a matching
+ *    check-in would have made the row immediately re-eligible.
+ */
+class OutboxSetNextRunTimeTest {
+
+    private suspend fun insertRow(dbm: DatabaseManager, driveId: Uuid, uniqueId: Uuid) {
+        dbm.outbox.insert(
+            driveId = driveId,
+            uniqueId = uniqueId,
+            dependencyUniqueId = null,
+            priority = 0L,
+            uploadType = 0L,
+            json = byteArrayOf(),
+            filePaths = null,
+        )
+    }
+
+    @Test
+    fun backedOffRowIsNotEligibleUntilItsDeadline() = runTest {
+        DatabaseManager({ createInMemoryDatabase() }).use { dbm ->
+            val driveId = Uuid.random()
+            val uniqueId = Uuid.random()
+            insertRow(dbm, driveId, uniqueId)
+
+            val row = dbm.outbox.checkout()
+            assertNotNull(row)
+            // Check in as failed with a deadline 30s out — a ms epoch.
+            val changed = dbm.outbox.checkInFailed(row.checkOutStamp!!, UnixTimeUtc.now().addSeconds(30).milliseconds)
+
+            assertEquals(
+                1L, changed,
+                "checkInFailed must match the checked-out row — 0 means the " +
+                    "swapped-positional-arguments bug is back (zombie rows)",
+            )
+            assertNull(
+                dbm.outbox.checkout(),
+                "a row backed off into the future must not be eligible for checkout",
+            )
+        }
+    }
+
+    @Test
+    fun setNextRunTimeMakesABackedOffRowImmediatelyEligible() = runTest {
+        DatabaseManager({ createInMemoryDatabase() }).use { dbm ->
+            val driveId = Uuid.random()
+            val uniqueId = Uuid.random()
+            insertRow(dbm, driveId, uniqueId)
+            val row = dbm.outbox.checkout()!!
+            dbm.outbox.checkInFailed(row.checkOutStamp!!, UnixTimeUtc.now().addSeconds(3600).milliseconds)
+            assertNull(dbm.outbox.checkout(), "precondition: row is backed off")
+
+            val changed = dbm.outbox.setNextRunTime(driveId, uniqueId, 0L)
+
+            assertEquals(1L, changed, "exactly the one queued row must be updated")
+            val checkedOut = dbm.outbox.checkout()
+            assertNotNull(checkedOut, "the reset row must be eligible immediately")
+            assertEquals(uniqueId, checkedOut.uniqueId)
+        }
+    }
+
+    @Test
+    fun setNextRunTimeDoesNotTouchACheckedOutRow() = runTest {
+        DatabaseManager({ createInMemoryDatabase() }).use { dbm ->
+            val driveId = Uuid.random()
+            val uniqueId = Uuid.random()
+            insertRow(dbm, driveId, uniqueId)
+            val row = dbm.outbox.checkout()
+            assertNotNull(row, "precondition: row is in flight")
+
+            val changed = dbm.outbox.setNextRunTime(driveId, uniqueId, 0L)
+
+            assertEquals(0L, changed, "an in-flight row's nextRunTime is owned by checkInFailed")
+        }
+    }
+
+    @Test
+    fun setNextRunTimeOnAMissingRowChangesNothing() = runTest {
+        DatabaseManager({ createInMemoryDatabase() }).use { dbm ->
+            assertEquals(0L, dbm.outbox.setNextRunTime(Uuid.random(), Uuid.random(), 0L))
+        }
+    }
+
+    /**
+     * Unit regression THROUGH the send loop: after one failed attempt,
+     * OutboxSync's checkInFailed call site must have stored a future
+     * MILLISECONDS deadline. Pre-fix it stored `.seconds` (~1.7e9), which is
+     * far in the past as an ms epoch — this assertion fails on that code.
+     * Real-dispatcher DB (not runOutboxTest's virtual-time binding) for the
+     * same reason as `OutboxSyncTest.testFailureAndRetry`.
+     */
+    @Test
+    fun failedAttemptStoresAFutureMillisecondsDeadline() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val uploader = TestUploader().apply { shouldFail = true }
+            val sync = OutboxSync(
+                databaseManager = db, uploader = uploader, eventBus = eventBus, scope = backgroundScope,
+            )
+            sync.setOnline(true)
+
+            // checkInFailed runs BEFORE ItemFailed is emitted, so awaiting the
+            // event guarantees the deadline is in the DB.
+            val failedDeferred = async {
+                eventBus.events.filterIsInstance<BackendEvent.OutboxEvent.ItemFailed>().first()
+            }
+            testScheduler.runCurrent()
+
+            val driveId = Uuid.random()
+            val uniqueId = Uuid.random()
+            insertRow(db, driveId, uniqueId)
+
+            sync.send()
+            advanceUntilIdle()
+            failedDeferred.await()
+
+            val row = db.outbox.selectByDriveAndUnique(driveId, uniqueId)
+            assertNotNull(row, "one failed attempt must re-queue, not drop")
+            assertTrue(
+                row.nextRunTime > UnixTimeUtc.now().milliseconds,
+                "backoff deadline must be a FUTURE ms epoch (got ${row.nextRunTime}) — " +
+                    "a seconds-epoch value here means the checkInFailed unit bug is back",
+            )
+            sync.clearCheckout(timeoutMs = 5_000)
+        }
+        db.close()
+    }
+}

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
@@ -31,6 +31,7 @@ import java.nio.file.Path
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
@@ -328,6 +329,68 @@ class DriveFileProviderCachedTest {
             CacheStats.UNAVAILABLE, thumb.sizeBytes,
             "broken thumb cache must be marked unavailable via the sentinel"
         )
+    }
+
+    /**
+     * Seed-on-send round-trip: bytes written via [DriveFileProviderCached.cachePayloadBytesEncrypted]
+     * must be served by the read path with NO network — this is what makes a
+     * never-sent (failed) message's media retrievable for retry. The mock
+     * engine throws on any request to prove the network is never touched.
+     */
+    @Test
+    fun `seeded payload bytes are served from cache without touching the network`() = runTest {
+        nextException = IOException("network must not be reached for a seeded payload")
+        val bytes = ByteArray(64) { it.toByte() }
+
+        provider.cachePayloadBytesEncrypted(driveId, fileId, key, bytes, "image/jpeg")
+        val result = provider.getPayloadBytesRaw(driveId, fileId, key)
+
+        assertEquals(0, requestCount, "seeded read must not hit the network")
+        assertEquals(200, result.status)
+        assertContentEquals(bytes, result.bytes)
+        assertEquals("image/jpeg", result.contentType)
+        assertEquals(
+            "true", result.headers["payloadencrypted"],
+            "the encrypted bit must round-trip — decrypt-on-read depends on it"
+        )
+    }
+
+    @Test
+    fun `seeded thumb bytes are served from cache without touching the network`() = runTest {
+        nextException = IOException("network must not be reached for a seeded thumb")
+        val bytes = ByteArray(32) { (it * 3).toByte() }
+
+        provider.cacheThumbBytesEncrypted(driveId, fileId, key, 100, 100, bytes, "image/webp")
+        val result = provider.getThumbBytesRaw(driveId, fileId, key, 100, 100)
+
+        assertEquals(0, requestCount, "seeded read must not hit the network")
+        assertEquals(200, result.status)
+        assertContentEquals(bytes, result.bytes)
+        assertEquals("true", result.headers["payloadencrypted"])
+    }
+
+    /**
+     * A pre-send 404 lookup (e.g. a bubble probing a payload before the seed
+     * landed) must not shadow the seeded entry: seeding clears the in-memory
+     * notFound marker for the key.
+     */
+    @Test
+    fun `seeding clears a prior 404 marker for the key`() = runTest {
+        nextStatus = HttpStatusCode.NotFound
+        assertFailsWith<NotFoundException> {
+            provider.getPayloadBytesRaw(driveId, fileId, key)
+        }
+        val countAfter404 = requestCount
+
+        val bytes = ByteArray(16) { 0x42 }
+        provider.cachePayloadBytesEncrypted(driveId, fileId, key, bytes, "image/jpeg")
+
+        nextException = IOException("network must not be reached after seeding")
+        val result = provider.getPayloadBytesRaw(driveId, fileId, key)
+
+        assertEquals(countAfter404, requestCount, "read after seeding must not hit the network")
+        assertEquals(200, result.status, "the 404 marker must not shadow the seeded bytes")
+        assertContentEquals(bytes, result.bytes)
     }
 
     /**

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoScreen.kt
@@ -24,9 +24,12 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -87,10 +90,17 @@ fun MessageInfoScreen(
             onNavigateBack()
         }
 
+        // Consumed inside MessageInfoUi, where the snackbar host lives.
+        is MessageInfoUiEvent.RetryFailed -> {}
+
         null -> {}
     }
 
-    MessageInfoUi(uiState = uiState, onUiAction = viewModel::onUiAction)
+    MessageInfoUi(
+        uiState = uiState,
+        onUiAction = viewModel::onUiAction,
+        onEventConsumed = viewModel::eventConsumed,
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -98,10 +108,23 @@ fun MessageInfoScreen(
 fun MessageInfoUi(
     uiState: MessageInfoUiState,
     onUiAction: (MessageInfoUiAction) -> Unit,
+    onEventConsumed: () -> Unit = {},
 ) {
     val scrollState = rememberScrollState()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    val retryFailed = uiState.uiEvent as? MessageInfoUiEvent.RetryFailed
+    val retryFailedText = retryFailed?.let { stringResource(it.messageRes) }
+    LaunchedEffect(retryFailed) {
+        if (retryFailed != null && retryFailedText != null) {
+            // Consume before showing — showSnackbar suspends until dismissal.
+            onEventConsumed()
+            snackbarHostState.showSnackbar(retryFailedText)
+        }
+    }
 
     Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(MR.string.chat_message_info)) },

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoScreen.kt
@@ -64,10 +64,14 @@ import id.homebase.resources.copy_message_id
 import id.homebase.resources.label_message_id
 import id.homebase.resources.label_sent
 import id.homebase.resources.error_delivery_failed
+import id.homebase.resources.action_try_now
+import id.homebase.resources.msg_next_attempt_minutes
+import id.homebase.resources.msg_next_attempt_shortly
 import id.homebase.resources.msg_status_delivery_details_unavailable
 import id.homebase.resources.msg_status_failed_to_send
 import id.homebase.resources.msg_status_sending
 import id.homebase.resources.msg_status_sent
+import id.homebase.resources.msg_still_in_outbox
 import id.homebase.resources.label_size
 import id.homebase.resources.menu_back
 import id.homebase.resources.reactions
@@ -217,6 +221,40 @@ fun MessageInfoUi(
                                     text = stringResource(MR.string.msg_status_sending),
                                     style = MaterialTheme.typography.bodyMedium,
                                 )
+                            }
+                        }
+
+                        OutgoingSendState.Queued -> {
+                            // Still in the outbox: it WILL be sent (after its
+                            // backoff). Honest copy + a Try-now escape hatch
+                            // instead of an indefinite "Sending…" spinner.
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
+                            ) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(16.dp),
+                                    strokeWidth = 2.dp,
+                                )
+                                val minutes = uiState.nextAttemptInMinutes
+                                val attemptText = if (minutes == null || minutes <= 0L) {
+                                    stringResource(MR.string.msg_next_attempt_shortly)
+                                } else {
+                                    stringResource(MR.string.msg_next_attempt_minutes, minutes)
+                                }
+                                Text(
+                                    text = stringResource(MR.string.msg_still_in_outbox, attemptText),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                )
+                            }
+                            if (uiState.canTryNow) {
+                                OutlinedButton(
+                                    onClick = { onUiAction(MessageInfoUiAction.TryNowClicked) },
+                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                                ) {
+                                    Text(stringResource(MR.string.action_try_now))
+                                }
                             }
                         }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoUiAction.kt
@@ -3,4 +3,5 @@ package id.homebase.chat.messageinfo
 sealed interface MessageInfoUiAction {
     data object BackClicked : MessageInfoUiAction
     data object RetryClicked : MessageInfoUiAction
+    data object TryNowClicked : MessageInfoUiAction
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoUiState.kt
@@ -90,6 +90,9 @@ data class MessageInfoUiState(
 
 sealed interface MessageInfoUiEvent {
     object Back : MessageInfoUiEvent
+
+    /** Retry could not be enqueued — surface [messageRes] as a snackbar. */
+    data class RetryFailed(val messageRes: StringResource) : MessageInfoUiEvent
 }
 
 /** Derived send-status fields for the Message Info status row + retry stub. */

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoUiState.kt
@@ -2,6 +2,7 @@ package id.homebase.chat.messageinfo
 
 import androidx.compose.runtime.Immutable
 import id.homebase.api.client.auth.OwnerSession
+import id.homebase.api.sync.database.OutboxSync
 import id.homebase.chat.data.MessageUiModel
 import id.homebase.chat.services.ChatDeliveryStatus
 import kotlin.coroutines.cancellation.CancellationException
@@ -22,11 +23,13 @@ data class ReactionUiModel(
 
 /** High-level send status for an *outgoing* (own) message, shown as the single
  *  status row in Message Info. Null for inbound messages (which keep the
- *  sender-sent / we-received rows instead). [Failed] is a local send failure
- *  (the file never settled on our server); [DeliveryFailed] is recipient-level
- *  (the file settled, but ≥1 recipient transfer failed) — distinct wording and
- *  no retry, matching the bubble's orange failed indicator. */
-enum class OutgoingSendState { Sending, Sent, Failed, DeliveryFailed }
+ *  sender-sent / we-received rows instead). [Queued] means an outbox row still
+ *  exists for the message — it WILL be sent (possibly after a backoff wait), so
+ *  the affordance is "Try now", never "Retry". [Failed] is a local send failure
+ *  (the file never settled on our server, no outbox row left); [DeliveryFailed]
+ *  is recipient-level (the file settled, but ≥1 recipient transfer failed) —
+ *  distinct wording and no retry, matching the bubble's orange failed indicator. */
+enum class OutgoingSendState { Sending, Queued, Sent, Failed, DeliveryFailed }
 
 /** What a (future, currently stubbed) retry would do, derived from whether the
  *  file already exists on the server: [Create] = re-upload a never-landed file;
@@ -75,6 +78,9 @@ data class MessageInfoUiState(
     val isOwnMessage: Boolean = false,
     /** Server-side existence of the message file, keyed by uniqueId. */
     val serverPresence: ServerPresence = ServerPresence.Unknown,
+    /** Pending outbox row for the message (own pending/failed messages only);
+     *  non-null means the send is still queued → Queued state + Try-now. */
+    val outboxRow: OutboxSync.PendingRowSnapshot? = null,
     /** True while the by-uniqueId server existence check is in flight. */
     val isServerCheckLoading: Boolean = false,
     /** Status row for own messages; null for inbound. */
@@ -84,8 +90,13 @@ data class MessageInfoUiState(
     val transferHistoryFailed: Boolean = false,
     /** Intent a retry would carry; null when no retry is offered. */
     val retryMode: RetryMode? = null,
-    /** Whether to surface the Retry affordance (currently a no-op stub). */
+    /** Whether to surface the Retry affordance. */
     val canRetry: Boolean = false,
+    /** Whether to surface the Try-now affordance (Queued message, not in flight). */
+    val canTryNow: Boolean = false,
+    /** Whole minutes until the queued message's next attempt; null = no
+     *  meaningful deadline (fresh row / in-flight) → render "shortly". */
+    val nextAttemptInMinutes: Long? = null,
 )
 
 sealed interface MessageInfoUiEvent {
@@ -142,4 +153,60 @@ fun deriveSendStatus(
     }
     deliveryFailed -> SendStatusResult(OutgoingSendState.DeliveryFailed, null, false)
     else -> SendStatusResult(OutgoingSendState.Sent, null, false)
+}
+
+/** [deriveSendStatus]'s fields plus the outbox-row overlay (Try-now). */
+data class RetryUiState(
+    val sendState: OutgoingSendState?,
+    val retryMode: RetryMode?,
+    val canRetry: Boolean,
+    val canTryNow: Boolean,
+    val nextAttemptInMinutes: Long?,
+)
+
+/** Below this raw `nextRunTime`, the value can't be a current ms-epoch: it's a
+ *  fresh-insert sentinel (0 / 42) or a legacy seconds-epoch row written before
+ *  the checkInFailed unit fix. Either way the row is due "shortly". */
+private const val MIN_PLAUSIBLE_MS_EPOCH = 100_000_000_000L // 2001-09-09 in ms
+
+/**
+ * Layer the outbox-row reality on top of [deriveSendStatus]'s tag/server view.
+ *
+ * An existing outbox row is authoritative "still sending": the queued item WILL
+ * run again (after its backoff), so the screen shows **Queued** with the next
+ * attempt time and a **Try now** button — never Retry (the message is not
+ * failed) and never the bare Sending spinner (which reads as "in flight" when
+ * the item may be hours of backoff away).
+ *
+ * - No row → [base] passes through untouched.
+ * - Row checked out → the upload is literally running: Queued with
+ *   `nextAttemptInMinutes = null` ("sending now"-ish copy) and no Try-now
+ *   (resetting an in-flight row is meaningless; [id.homebase.api.sync.database.OutboxSync.runNow]
+ *   would no-op anyway).
+ * - Row waiting → minutes until [nextRunTimeRaw], floored at 0; raw values
+ *   below [MIN_PLAUSIBLE_MS_EPOCH] (insert sentinels, legacy seconds-epoch
+ *   rows) normalize to "shortly" (null is reserved for checked-out).
+ */
+fun retryUiState(
+    base: SendStatusResult,
+    inOutbox: Boolean,
+    isCheckedOut: Boolean,
+    nextRunTimeRaw: Long?,
+    nowMs: Long,
+): RetryUiState {
+    if (!inOutbox) {
+        return RetryUiState(base.sendState, base.retryMode, base.canRetry, canTryNow = false, nextAttemptInMinutes = null)
+    }
+    val minutes = when {
+        isCheckedOut -> null
+        nextRunTimeRaw == null || nextRunTimeRaw < MIN_PLAUSIBLE_MS_EPOCH -> 0L
+        else -> ((nextRunTimeRaw - nowMs).coerceAtLeast(0L)) / 60_000L
+    }
+    return RetryUiState(
+        sendState = OutgoingSendState.Queued,
+        retryMode = null,
+        canRetry = false,
+        canTryNow = !isCheckedOut,
+        nextAttemptInMinutes = minutes,
+    )
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoViewModel.kt
@@ -8,6 +8,8 @@ import co.touchlab.kermit.Logger
 import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.common.OdinId
+import id.homebase.api.common.time.UnixTimeUtc
+import id.homebase.api.sync.database.OutboxSync
 import id.homebase.chat.services.ChatDeliveryStatus
 import id.homebase.chat.services.ChatMessageActionService
 import id.homebase.chat.services.ChatMessageSenderService
@@ -21,6 +23,7 @@ import id.homebase.core.ui.navigation.Route
 import id.homebase.resources.MR
 import id.homebase.resources.msg_retry_failed
 import id.homebase.resources.msg_retry_media_unavailable
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -37,6 +40,7 @@ class MessageInfoViewModel(
     private val contactService: ContactService,
     private val chatMessageActionService: ChatMessageActionService,
     private val chatMessageSenderService: ChatMessageSenderService,
+    private val outboxSync: OutboxSync,
 ) : ViewModel() {
 
     val messageInfo = savedStateHandle.toRoute<Route.MessageInfo>()
@@ -47,12 +51,16 @@ class MessageInfoViewModel(
     // message (or vice-versa) can't kick it twice.
     private var serverCheckStarted = false
 
+    // Same one-shot guard for the outbox-row read (Queued / Try-now display).
+    private var outboxReadStarted = false
+
     init {
         viewModelScope.launch {
             ownerSessionRepository.user.collect { session ->
                 _uiState.update { it.copy(ownerSession = session) }
                 recomputeSendStatus()
                 startServerCheckIfNeeded()
+                startOutboxReadIfNeeded()
             }
         }
         viewModelScope.launch {
@@ -68,6 +76,7 @@ class MessageInfoViewModel(
                 }
                 recomputeSendStatus()
                 startServerCheckIfNeeded()
+                startOutboxReadIfNeeded()
 
                 // Load transfer history
                 viewModelScope.launch {
@@ -157,13 +166,48 @@ class MessageInfoViewModel(
                 deliveryFailed = message.messageAppData.deliveryStatus == ChatDeliveryStatus.Failed.value,
                 serverPresence = state.serverPresence,
             )
+            // The outbox row (when present) overrides the tag/server view —
+            // a queued item is "still sending", whatever the tags claim.
+            val overlay = retryUiState(
+                base = result,
+                inOutbox = isOwn && state.outboxRow != null,
+                isCheckedOut = state.outboxRow?.isCheckedOut == true,
+                nextRunTimeRaw = state.outboxRow?.nextRunTime,
+                nowMs = UnixTimeUtc.now().milliseconds,
+            )
             state.copy(
                 isOwnMessage = isOwn,
-                sendState = result.sendState,
-                retryMode = result.retryMode,
-                canRetry = result.canRetry,
+                sendState = overlay.sendState,
+                retryMode = overlay.retryMode,
+                canRetry = overlay.canRetry,
+                canTryNow = overlay.canTryNow,
+                nextAttemptInMinutes = overlay.nextAttemptInMinutes,
             )
         }
+    }
+
+    /**
+     * One-shot read of the message's pending outbox row at open (own message
+     * still pending or failed only). A row means the send is queued/backed-off:
+     * the screen shows Queued + "next attempt in ~N min" + Try now instead of
+     * the bare Sending spinner or a Retry that would be a no-op.
+     */
+    private fun startOutboxReadIfNeeded() {
+        if (outboxReadStarted) return
+        val state = _uiState.value
+        val message = state.message ?: return
+        if (!message.isAuthoredBy(state.ownerSession?.odinId)) return
+        if (!message.isPendingSend && !message.isFailedSend) return
+
+        outboxReadStarted = true
+        viewModelScope.launch { refreshOutboxRow() }
+    }
+
+    private suspend fun refreshOutboxRow() {
+        val message = _uiState.value.message ?: return
+        val row = outboxSync.pendingRowSnapshot(chatTargetDrive.alias, message.id)
+        _uiState.update { it.copy(outboxRow = row) }
+        recomputeSendStatus()
     }
 
     /**
@@ -201,6 +245,26 @@ class MessageInfoViewModel(
         when (action) {
             is MessageInfoUiAction.BackClicked -> _uiState.update { it.copy(uiEvent = MessageInfoUiEvent.Back) }
             is MessageInfoUiAction.RetryClicked -> retryFailedSend()
+            is MessageInfoUiAction.TryNowClicked -> tryNow()
+        }
+    }
+
+    /**
+     * Reset the queued item's backoff so it runs immediately
+     * ([OutboxSync.runNow]). Optimistically collapses the wait to "shortly";
+     * one delayed re-read then settles the row's real state (usually gone →
+     * back to the plain tag-derived status). No polling loop — the screen is
+     * a snapshot, not a live monitor.
+     */
+    private fun tryNow() {
+        val state = _uiState.value
+        val message = state.message ?: return
+        if (!state.canTryNow) return
+        _uiState.update { it.copy(canTryNow = false, nextAttemptInMinutes = 0L) }
+        viewModelScope.launch {
+            outboxSync.runNow(chatTargetDrive.alias, message.id)
+            delay(POST_TRY_NOW_REFRESH_MS)
+            refreshOutboxRow()
         }
     }
 
@@ -224,11 +288,12 @@ class MessageInfoViewModel(
                 ResendOutcome.EnqueuedUpdate,
                 ResendOutcome.AlreadyQueued -> {
                     Logger.i { "MessageInfo: retry enqueued ($outcome) uniqueId=${message.id}" }
-                    // Refresh so the swapped tags (failed→pending) drive any later
-                    // recompute instead of the stale Failed snapshot.
+                    // Refresh so the swapped tags (failed→pending) and the fresh
+                    // outbox row drive any later recompute instead of the stale
+                    // Failed snapshot.
                     val refreshed = chatMessageStream.getMessage(message.id)
                     _uiState.update { it.copy(message = refreshed ?: it.message) }
-                    recomputeSendStatus()
+                    refreshOutboxRow()
                 }
 
                 ResendOutcome.UnrecoverableMedia ->
@@ -250,5 +315,11 @@ class MessageInfoViewModel(
 
     fun eventConsumed() {
         _uiState.update { it.copy(uiEvent = null) }
+    }
+
+    private companion object {
+        /** Single post-Try-now settle re-read — long enough for a fast send to
+         *  drain the row, short enough to feel responsive. */
+        const val POST_TRY_NOW_REFRESH_MS = 3_000L
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoViewModel.kt
@@ -10,17 +10,23 @@ import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.common.OdinId
 import id.homebase.chat.services.ChatDeliveryStatus
 import id.homebase.chat.services.ChatMessageActionService
+import id.homebase.chat.services.ChatMessageSenderService
 import id.homebase.chat.services.ChatMessageStream
+import id.homebase.chat.services.ResendOutcome
 import id.homebase.chat.services.toChatDeliveryStatus
 import id.homebase.chat.services.toErrorDetailRes
 import id.homebase.chat.services.convo.contact.ContactService
 import id.homebase.core.config.chatTargetDrive
 import id.homebase.core.ui.navigation.Route
+import id.homebase.resources.MR
+import id.homebase.resources.msg_retry_failed
+import id.homebase.resources.msg_retry_media_unavailable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.StringResource
 import kotlin.uuid.Uuid
 
 class MessageInfoViewModel(
@@ -30,6 +36,7 @@ class MessageInfoViewModel(
     private val driveFileProvider: DriveFileProvider,
     private val contactService: ContactService,
     private val chatMessageActionService: ChatMessageActionService,
+    private val chatMessageSenderService: ChatMessageSenderService,
 ) : ViewModel() {
 
     val messageInfo = savedStateHandle.toRoute<Route.MessageInfo>()
@@ -193,16 +200,52 @@ class MessageInfoViewModel(
     fun onUiAction(action: MessageInfoUiAction) {
         when (action) {
             is MessageInfoUiAction.BackClicked -> _uiState.update { it.copy(uiEvent = MessageInfoUiEvent.Back) }
-            // Stub: Layer 1 will re-enqueue the outbox item. retryMode tells it
-            // whether to re-upload a never-landed file (Create) or re-push an
-            // edit against an existing server file (Update).
-            is MessageInfoUiAction.RetryClicked -> {
-                val state = _uiState.value
-                Logger.i {
-                    "MessageInfo: retry requested (stub) uniqueId=${state.message?.id} retryMode=${state.retryMode}"
+            is MessageInfoUiAction.RetryClicked -> retryFailedSend()
+        }
+    }
+
+    /**
+     * Re-enqueue the failed send via [ChatMessageSenderService.resendMessage]
+     * (create vs update is decided there by a fresh server check). Optimistically
+     * flips the status row to *Sending* and hides the button; on a refused retry
+     * the Failed state is restored from the (unchanged) local tags and the reason
+     * surfaces as a one-time snackbar event.
+     */
+    private fun retryFailedSend() {
+        val state = _uiState.value
+        val message = state.message ?: return
+        if (!state.canRetry) return
+        _uiState.update {
+            it.copy(sendState = OutgoingSendState.Sending, canRetry = false, retryMode = null)
+        }
+        viewModelScope.launch {
+            when (val outcome = chatMessageSenderService.resendMessage(message.id)) {
+                ResendOutcome.EnqueuedCreate,
+                ResendOutcome.EnqueuedUpdate,
+                ResendOutcome.AlreadyQueued -> {
+                    Logger.i { "MessageInfo: retry enqueued ($outcome) uniqueId=${message.id}" }
+                    // Refresh so the swapped tags (failed→pending) drive any later
+                    // recompute instead of the stale Failed snapshot.
+                    val refreshed = chatMessageStream.getMessage(message.id)
+                    _uiState.update { it.copy(message = refreshed ?: it.message) }
+                    recomputeSendStatus()
+                }
+
+                ResendOutcome.UnrecoverableMedia ->
+                    revertRetryWithError(MR.string.msg_retry_media_unavailable)
+
+                is ResendOutcome.Failed -> {
+                    Logger.w(outcome.error) { "MessageInfo: retry failed uniqueId=${message.id}" }
+                    revertRetryWithError(MR.string.msg_retry_failed)
                 }
             }
         }
+    }
+
+    private fun revertRetryWithError(messageRes: StringResource) {
+        // Tags are unchanged (still failed) — recompute restores Failed + canRetry.
+        recomputeSendStatus()
+        _uiState.update { it.copy(uiEvent = MessageInfoUiEvent.RetryFailed(messageRes)) }
     }
 
     fun eventConsumed() {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
@@ -28,6 +28,7 @@ import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.OutboxSync
 import id.homebase.chat.data.ConversationState
+import id.homebase.chat.data.MessageUiModel
 import id.homebase.chat.services.chat.ChatMessageSizer
 import id.homebase.chat.services.convo.ConversationParticipantLookup
 import id.homebase.chat.services.outbox.OptimisticWriter
@@ -330,6 +331,17 @@ class ChatMessageSenderService(
             PayloadDescriptor(
                 key = payload.key,
                 contentType = payload.contentType.ifEmpty { null },
+                thumbnails = encryptedBundle.thumbnails
+                    .filter { it.key == payload.key }
+                    .map {
+                        ThumbnailDescriptor(
+                            pixelWidth = it.pixelWidth,
+                            pixelHeight = it.pixelHeight,
+                            contentType = it.contentType,
+                            content = null,
+                        )
+                    }
+                    .ifEmpty { null },
                 iv = payload.iv?.let { Base64.encode(it) },
                 descriptorContent = payload.descriptorContent,
                 previewThumbnail = payload.previewThumbnail?.let {
@@ -343,7 +355,7 @@ class ChatMessageSenderService(
             )
         }.ifEmpty { null }
         try {
-            optimisticWriter.writeNewFile(
+            val optimisticFileId = optimisticWriter.writeNewFile(
                 driveId = chatDrive,
                 keyHeader = keyHeader,
                 unecryptedMetadata = unecryptedMetadata,
@@ -352,6 +364,7 @@ class ChatMessageSenderService(
                 payloadDescriptors = payloadDescriptors,
             )
             Logger.d(tag = TAG) { "sendMessageInternal: optimistic write complete message=$messageUniqueId" }
+            seedPayloadCache(optimisticFileId, encryptedBundle)
         } catch (e: Exception) {
             Logger.e(throwable = e, tag = TAG) { "sendMessageInternal: optimistic write failed (non-fatal) message=$messageUniqueId" }
         }
@@ -372,6 +385,45 @@ class ChatMessageSenderService(
         }
 
         return SendMessageResult(uniqueId = messageUniqueId)
+    }
+
+    /**
+     * Seed the encrypted payload/thumbnail disk cache with the bytes that just
+     * went into the outbox, keyed under the optimistic fileId. The outbox temp
+     * files are deleted when a permanently-failed row is dropped, so this cache
+     * copy is what makes a failed message's media (and overflow text, which also
+     * rides as a payload) recoverable by [resendMessage]. Best-effort: the cache
+     * is LRU-bounded and a miss only degrades retry to [ResendOutcome.UnrecoverableMedia].
+     */
+    private suspend fun seedPayloadCache(fileId: Uuid, encryptedBundle: PayloadBundle) {
+        for (payload in encryptedBundle.payloads) {
+            try {
+                driveFileProvider.cachePayloadBytesEncrypted(
+                    driveId = chatDrive,
+                    fileId = fileId,
+                    key = payload.key,
+                    bytes = fileOperationsProvider.readFileBytes(payload.filePath),
+                    contentType = payload.contentType,
+                )
+            } catch (e: Exception) {
+                Logger.w(throwable = e, tag = TAG) { "seedPayloadCache: payload seed failed (non-fatal) key=${payload.key} fileId=$fileId" }
+            }
+        }
+        for (thumb in encryptedBundle.thumbnails) {
+            try {
+                driveFileProvider.cacheThumbBytesEncrypted(
+                    driveId = chatDrive,
+                    fileId = fileId,
+                    payloadKey = thumb.key,
+                    width = thumb.pixelWidth,
+                    height = thumb.pixelHeight,
+                    bytes = thumb.thumbnailBytes,
+                    contentType = thumb.contentType,
+                )
+            } catch (e: Exception) {
+                Logger.w(throwable = e, tag = TAG) { "seedPayloadCache: thumb seed failed (non-fatal) key=${thumb.key} ${thumb.pixelWidth}x${thumb.pixelHeight} fileId=$fileId" }
+            }
+        }
     }
 
     suspend fun updateMessage(
@@ -537,6 +589,237 @@ class ChatMessageSenderService(
         }
 
         error("Failed to update chat message")
+    }
+
+    /**
+     * Retries a message whose send permanently failed ([ChatProtocol.isFailedSendTag]).
+     * Decides create-vs-update by asking the server whether the uniqueId exists:
+     *
+     * 1. **Server absent** — the original create never landed: re-enqueue an
+     *    [UploadFileRequest], reusing the file's original [KeyHeader] so the
+     *    recovered pre-encrypted payloads (seeded into the payload cache at
+     *    send time by [seedPayloadCache]) stay decryptable. If any media
+     *    payload's bytes are gone (cache evicted), refuses with
+     *    [ResendOutcome.UnrecoverableMedia] rather than silently sending a
+     *    text-only message.
+     * 2. **Server present** — a later edit's update failed: enqueue an
+     *    [UpdateFileByUniqueIdRequest] stamped with the SERVER's current
+     *    versionTag, re-attaching the payloads fetched back off the drive.
+     *
+     * Deliberately does NOT reuse [sendMessageInternal] — it mints a fresh
+     * [KeyHeader.newRandom16], which would orphan the existing encrypted payloads.
+     *
+     * On success the local tags swap failed→pending ([tagsForRetry]) so the
+     * bubble shows *Sending* again; the outbox outcome then drives the final
+     * state exactly like a first send.
+     *
+     * Known edge: retrying a failed *edit* of an overflow-length (>header) text
+     * resends the full text recovered via [MessageLookup.loadFullMessage]; if
+     * that overflow payload is itself unrecoverable, the header preview is sent.
+     */
+    suspend fun resendMessage(messageId: Uuid): ResendOutcome {
+        val msg = chatMessageStream.getMessage(messageId)
+            ?: return ResendOutcome.Failed(IllegalArgumentException("message not found: $messageId"))
+        val file = chatMessageStream.getMessageFile(messageId)
+            ?: return ResendOutcome.Failed(IllegalArgumentException("message file not found: $messageId"))
+
+        // Safety net — the Retry button isn't shown for a queued message, but if
+        // a row appeared in the meantime the pending send already covers this.
+        if (outboxSync.pendingUploadType(chatDrive, messageId) != null) {
+            Logger.i(tag = TAG) { "resendMessage: uniqueId=$messageId already queued in outbox — no-op" }
+            return ResendOutcome.AlreadyQueued
+        }
+
+        val serverFile = try {
+            driveFileProvider.getFileHeaderByUid(chatDrive, messageId)
+        } catch (e: Exception) {
+            Logger.w(throwable = e, tag = TAG) { "resendMessage: server check failed for uniqueId=$messageId" }
+            return ResendOutcome.Failed(e)
+        }
+
+        // Recover the media payloads as pre-encrypted bytes (seeded cache first,
+        // then the server). The text overflow is excluded — it's rebuilt from
+        // plaintext below.
+        val recovered = resendablePayloads(
+            file = file,
+            driveId = chatDrive,
+            byteSource = driveFileProvider,
+            fileOps = fileOperationsProvider,
+            excludeKeys = setOf(ChatProtocol.DefaultPayloadKey),
+            tempPrefix = "retry",
+            logTag = TAG,
+        )
+        val mediaKeys = file.fileMetadata.payloads.orEmpty()
+            .filterNot { it.keyEquals(ChatProtocol.DefaultPayloadKey) }
+            .map { it.key }
+            .toSet()
+        val recoverability = retryRecoverability(
+            serverPresent = serverFile != null,
+            mediaKeys = mediaKeys,
+            availableMediaKeys = mediaKeys - recovered.unavailableKeys.toSet(),
+        )
+        if (recoverability == RetryRecoverability.UnrecoverableMedia) {
+            Logger.w(tag = TAG) {
+                "resendMessage: uniqueId=$messageId has unrecoverable media (${recovered.unavailableKeys}) — refusing to resend"
+            }
+            return ResendOutcome.UnrecoverableMedia
+        }
+
+        // Rebuild the text header (and overflow payload, if the full text doesn't
+        // fit the header) from the locally readable full text.
+        val hasOverflow = file.fileMetadata.payloads.orEmpty()
+            .any { it.keyEquals(ChatProtocol.DefaultPayloadKey) }
+        val fullText = if (hasOverflow) {
+            chatMessageStream.loadFullMessage(msg.conversationId, messageId)
+                ?: msg.messageAppData.getMessage()
+        } else {
+            msg.messageAppData.getMessage()
+        }
+        val messageData = msg.messageAppData.copy(
+            message = JsonPrimitive(fullText),
+            deliveryStatus = ChatDeliveryStatus.Sending.value,
+        )
+        val built = buildMessageContentAndBundle(
+            preVersionedMessageData = messageData,
+            payloadBundle = null,
+            fileOperationsProvider = fileOperationsProvider,
+        )
+
+        val recipients = conversationStream.getRecipients(msg.conversationId)
+        val isLocalOnly = recipients.isEmpty()
+
+        val enqueueOutcome = try {
+            when (recoverability) {
+                RetryRecoverability.Create -> resendAsCreate(
+                    messageId, msg, file, built, recovered, recipients, isLocalOnly,
+                )
+                RetryRecoverability.Update -> resendAsUpdate(
+                    messageId, msg, file, serverFile!!, built, recovered, recipients, isLocalOnly,
+                )
+                RetryRecoverability.UnrecoverableMedia -> error("unreachable")
+            }
+        } catch (e: Exception) {
+            Logger.e(throwable = e, tag = TAG) { "resendMessage: enqueue failed uniqueId=$messageId" }
+            return ResendOutcome.Failed(e)
+        }
+
+        // Flip the bubble back to *Sending* — the exact inverse of markSendFailed.
+        try {
+            optimisticWriter.updateLocalTags(
+                chatDrive,
+                messageId,
+                tagsForRetry(file.fileMetadata.localAppData?.tags.orEmpty()),
+            )
+        } catch (e: Exception) {
+            Logger.e(throwable = e, tag = TAG) { "resendMessage: tag swap failed (non-fatal) uniqueId=$messageId" }
+        }
+        Logger.i(tag = TAG) { "resendMessage: enqueued $enqueueOutcome uniqueId=$messageId" }
+        return enqueueOutcome
+    }
+
+    private suspend fun resendAsCreate(
+        messageId: Uuid,
+        msg: MessageUiModel,
+        file: HomebaseFile,
+        built: MessageBuildResult,
+        recovered: ResendablePayloads,
+        recipients: List<OdinId>,
+        isLocalOnly: Boolean,
+    ): ResendOutcome {
+        // Re-encrypt the rebuilt text-overflow payload (if any) with the file's
+        // original aesKey so it stays decryptable alongside the recovered media.
+        val encryptedOverflow = built.payloadBundle?.let {
+            payloadBundleEncryptionService.encryptBundle(messageId, it, file.keyHeader.aesKey, scope)
+        }?.payloads ?: emptyList()
+
+        val unecryptedMetadata = UploadFileMetadata(
+            allowDistribution = !isLocalOnly,
+            isEncrypted = true,
+            appData = UploadAppFileMetaData(
+                uniqueId = messageId,
+                groupId = msg.conversationId,
+                fileType = ChatProtocol.MessageFileType,
+                dataType = file.fileMetadata.appData.dataType ?: 0,
+                userDate = msg.userDate.toEpochMilliseconds(),
+                content = built.headerContent,
+                previewThumbnail = msg.previewThumbnail,
+            ),
+        )
+        val request = UploadFileRequest(
+            driveId = chatDrive,
+            keyHeader = file.keyHeader,
+            metadata = unecryptedMetadata.encryptContent(file.keyHeader),
+            transitOptions = TransitOptions(
+                recipients = recipients,
+                sendContents = SendContents.All,
+                useAppNotification = !isLocalOnly,
+                appNotificationOptions = PushNotificationOptions(
+                    appId = ChatProtocol.ChatAppId.toString(),
+                    typeId = msg.conversationId.toString(),
+                    tagId = messageId.toString(),
+                    silent = false,
+                    unEncryptedMessage = "You have a new message",
+                ),
+            ),
+            payloads = recovered.payloads + encryptedOverflow,
+            thumbnails = recovered.thumbnails,
+        )
+        val enqueued = outboxSync.tryEnqueue(request, priority = 1, dependencyUniqueId = null)
+        if (!enqueued) return ResendOutcome.Failed(IllegalStateException("outbox refused the retry create"))
+        return ResendOutcome.EnqueuedCreate
+    }
+
+    private suspend fun resendAsUpdate(
+        messageId: Uuid,
+        msg: MessageUiModel,
+        file: HomebaseFile,
+        serverFile: HomebaseFile,
+        built: MessageBuildResult,
+        recovered: ResendablePayloads,
+        recipients: List<OdinId>,
+        isLocalOnly: Boolean,
+    ): ResendOutcome {
+        // Raw (not pre-encrypted) overflow — the uploader encrypts it with the
+        // manifest-generated iv, exactly like updateMessage's update branch.
+        val overflowPayloads = built.payloadBundle?.payloads ?: emptyList()
+        val toDeletePayloads =
+            if (overflowPayloads.isEmpty())
+                listOf(PayloadDeleteKey(ChatProtocol.DefaultPayloadKey))
+            else
+                emptyList()
+
+        val unecryptedMetadata = UploadFileMetadata(
+            allowDistribution = !isLocalOnly,
+            isEncrypted = true,
+            // The SERVER's current versionTag — the local one is stale (the
+            // failed update bumped nothing server-side).
+            versionTag = serverFile.fileMetadata.versionTag,
+            appData = UploadAppFileMetaData(
+                uniqueId = messageId,
+                groupId = msg.conversationId,
+                fileType = ChatProtocol.MessageFileType,
+                dataType = file.fileMetadata.appData.dataType ?: 0,
+                userDate = msg.userDate.toEpochMilliseconds(),
+                content = built.headerContent,
+                previewThumbnail = msg.previewThumbnail,
+            ),
+        )
+        val request = buildResendUpdateRequest(
+            driveId = chatDrive,
+            messageId = messageId,
+            keyHeader = KeyHeader(
+                iv = ByteArrayUtil.getRndByteArray(16),
+                aesKey = file.keyHeader.aesKey,
+            ),
+            unencryptedMetadata = unecryptedMetadata,
+            recipients = recipients,
+            payloads = recovered.payloads + overflowPayloads,
+            toDeletePayloads = toDeletePayloads,
+            thumbnails = recovered.thumbnails,
+        )
+        val enqueued = outboxSync.replaceEnqueue(request, priority = 1, dependencyUniqueId = null)
+        if (!enqueued) return ResendOutcome.Failed(IllegalStateException("outbox refused the retry update"))
+        return ResendOutcome.EnqueuedUpdate
     }
 
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ResendHelpers.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ResendHelpers.kt
@@ -1,0 +1,116 @@
+package id.homebase.chat.services
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.drives.files.PayloadFile
+import id.homebase.api.client.drives.files.ThumbnailFile
+import id.homebase.api.client.drives.upload.FileUpdateInstructionSet
+import id.homebase.api.client.drives.upload.PayloadDeleteKey
+import id.homebase.api.client.drives.upload.UpdateFileByUniqueIdRequest
+import id.homebase.api.client.drives.upload.UpdateLocale
+import id.homebase.api.client.drives.upload.UpdateManifest
+import id.homebase.api.client.drives.upload.UploadFileMetadata
+import id.homebase.api.common.OdinId
+import id.homebase.api.crypto.ByteArrayUtil
+import kotlin.uuid.Uuid
+
+/**
+ * Outcome of [ChatMessageSenderService.resendMessage] — retrying a message
+ * whose send permanently failed (orange **!** / [ChatProtocol.isFailedSendTag]).
+ */
+sealed interface ResendOutcome {
+    /** Server had no file for the uniqueId — a fresh create was enqueued. */
+    data object EnqueuedCreate : ResendOutcome
+
+    /** Server already has the file (a later edit failed) — an update against the server's versionTag was enqueued. */
+    data object EnqueuedUpdate : ResendOutcome
+
+    /** An outbox row for the message already exists — nothing to do, the queued send covers it. */
+    data object AlreadyQueued : ResendOutcome
+
+    /**
+     * The message has media payloads whose encrypted bytes are gone (payload
+     * cache evicted and not on the server). Nothing was enqueued — resending
+     * without the media would silently turn it into a text-only message.
+     */
+    data object UnrecoverableMedia : ResendOutcome
+
+    /** The retry could not be attempted (message gone, server unreachable, enqueue refused). */
+    data class Failed(val error: Throwable? = null) : ResendOutcome
+}
+
+enum class RetryRecoverability { Create, Update, UnrecoverableMedia }
+
+/**
+ * Pure decision matrix for [ChatMessageSenderService.resendMessage]:
+ * - server has the file → [RetryRecoverability.Update] (payload bytes are
+ *   re-fetchable from the server regardless of the local cache);
+ * - server absent and every media payload's bytes are locally available →
+ *   [RetryRecoverability.Create];
+ * - server absent with any media payload's bytes missing →
+ *   [RetryRecoverability.UnrecoverableMedia] (refuse — no silent text-only send).
+ */
+fun retryRecoverability(
+    serverPresent: Boolean,
+    mediaKeys: Set<String>,
+    availableMediaKeys: Set<String>,
+): RetryRecoverability = when {
+    serverPresent -> RetryRecoverability.Update
+    mediaKeys.all { it in availableMediaKeys } -> RetryRecoverability.Create
+    else -> RetryRecoverability.UnrecoverableMedia
+}
+
+/**
+ * Local-tag swap for a retried message: drop [ChatProtocol.isFailedSendTag],
+ * ensure [ChatProtocol.isPendingSendTag] — the exact inverse of
+ * `ChatMessageStream.markSendFailed`, so the bubble shows *Sending* again.
+ * Idempotent: a list already in the pending state is returned unchanged.
+ */
+fun tagsForRetry(existing: List<Uuid>): List<Uuid> {
+    val withoutFailed = existing.filterNot { it == ChatProtocol.isFailedSendTag }
+    return if (ChatProtocol.isPendingSendTag in withoutFailed) {
+        withoutFailed
+    } else {
+        withoutFailed + ChatProtocol.isPendingSendTag
+    }
+}
+
+/**
+ * Builds the update request for retrying a message the server already has
+ * (a later edit's update failed). Mirrors `ChatMessageSenderService.updateMessage`'s
+ * update branch and `DriveOutboxUploader.retryAsUpdate`:
+ * [unencryptedMetadata] must carry the SERVER's current versionTag (not the
+ * stale local one), and [keyHeader] a fresh iv with the file's original aesKey
+ * so the recovered pre-encrypted payloads stay decryptable.
+ * `generatePayloadIv = true` keeps each pre-encrypted payload's own iv and
+ * mints one only for raw payloads (the rebuilt text overflow).
+ */
+internal suspend fun buildResendUpdateRequest(
+    driveId: Uuid,
+    messageId: Uuid,
+    keyHeader: KeyHeader,
+    unencryptedMetadata: UploadFileMetadata,
+    recipients: List<OdinId>,
+    payloads: List<PayloadFile>,
+    toDeletePayloads: List<PayloadDeleteKey>,
+    thumbnails: List<ThumbnailFile>,
+): UpdateFileByUniqueIdRequest = UpdateFileByUniqueIdRequest(
+    driveId = driveId,
+    uniqueId = messageId,
+    keyHeader = keyHeader,
+    instructions = FileUpdateInstructionSet(
+        transferIv = ByteArrayUtil.getRndByteArray(16),
+        locale = UpdateLocale.Local,
+        recipients = recipients,
+        manifest = UpdateManifest.build(
+            payloads = payloads,
+            toDeletePayloads = toDeletePayloads,
+            thumbnails = thumbnails.ifEmpty { null },
+            generatePayloadIv = true,
+        ),
+        useAppNotification = false,
+        appNotificationOptions = null,
+    ),
+    metadata = unencryptedMetadata.encryptContent(keyHeader),
+    payloads = payloads,
+    thumbnails = thumbnails,
+)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ResendPayloads.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ResendPayloads.kt
@@ -1,0 +1,157 @@
+package id.homebase.chat.services
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.client.drives.files.PayloadFile
+import id.homebase.api.client.drives.files.ResendPayloadByteSource
+import id.homebase.api.client.drives.files.ThumbnailFile
+import id.homebase.api.file.FileOperationsProvider
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.uuid.Uuid
+
+/**
+ * Result of [resendablePayloads]: the payloads/thumbnails that could be
+ * recovered as pre-encrypted [PayloadFile]/[ThumbnailFile]s, plus the keys of
+ * descriptors whose bytes could NOT be recovered (cache-evicted and not on the
+ * server, or missing iv). Callers use [unavailableKeys] to decide whether a
+ * resend is safe — e.g. refuse to retry a media message whose image bytes are
+ * gone rather than silently sending a text-only message.
+ */
+internal data class ResendablePayloads(
+    val payloads: List<PayloadFile>,
+    val thumbnails: List<ThumbnailFile>,
+    val unavailableKeys: List<String>,
+)
+
+/**
+ * Re-reads a file's existing payloads as pre-encrypted [PayloadFile]s so they
+ * can be re-attached to a new upload/update request. For each payload
+ * descriptor the still-encrypted bytes are pulled via [byteSource] (disk cache
+ * first, then the server), dropped into a temp file, and wrapped with
+ * `isPreEncrypted = true` + the descriptor's original IV — the file's
+ * [id.homebase.api.client.KeyHeader.aesKey] must be preserved by the caller so
+ * the bytes decrypt cleanly on the peer side.
+ *
+ * Per-payload thumbnails are re-attached too: an update ships an
+ * AppendOrOverwrite per payload key, which REPLACES the payload AND its
+ * thumbnail set on the server — shipping the payload without its thumbnails
+ * wipes them server-side and every thumb load 404s afterwards. Thumbnail
+ * recovery is best-effort and does not mark the payload unavailable.
+ *
+ * Temp files are written with [FileOperationsProvider.writeBytesToTempFile]
+ * and left for the OS / app cleanup pass to remove once the outbox drains,
+ * mirroring how `MessageAttachmentBuilder` handles attachments.
+ *
+ * Used by the conversation heal-redistribute path and by chat message retry.
+ *
+ * @param excludeKeys descriptor keys to skip entirely (not recovered, not
+ *   reported unavailable) — e.g. the text-overflow payload, which retry
+ *   rebuilds from plaintext instead.
+ */
+internal suspend fun resendablePayloads(
+    file: HomebaseFile,
+    driveId: Uuid,
+    byteSource: ResendPayloadByteSource,
+    fileOps: FileOperationsProvider,
+    excludeKeys: Set<String> = emptySet(),
+    tempPrefix: String = "resend",
+    logTag: String = "Resend",
+): ResendablePayloads {
+    val existing = file.fileMetadata.payloads.orEmpty()
+        .filter { it.key !in excludeKeys }
+    if (existing.isEmpty()) {
+        Logger.d(tag = logTag) {
+            "resendablePayloads: fileId=${file.fileId} has no existing payloads — nothing to re-attach"
+        }
+        return ResendablePayloads(emptyList(), emptyList(), emptyList())
+    }
+
+    val payloads = mutableListOf<PayloadFile>()
+    val thumbnails = mutableListOf<ThumbnailFile>()
+    val unavailableKeys = mutableListOf<String>()
+    for (descriptor in existing) {
+        try {
+            val bytes = byteSource.getPayloadBytesEncrypted(driveId, file.fileId, descriptor.key)
+            if (bytes == null || bytes.isEmpty()) {
+                Logger.w(tag = logTag) {
+                    "resendablePayloads: payload key=${descriptor.key} unavailable — getPayloadBytesEncrypted returned ${if (bytes == null) "null" else "empty"} (fileId=${file.fileId})"
+                }
+                unavailableKeys += descriptor.key
+                continue
+            }
+            val ivBytes = descriptor.iv?.let {
+                @OptIn(ExperimentalEncodingApi::class)
+                Base64.Default.decode(it)
+            }
+            if (ivBytes == null) {
+                Logger.w(tag = logTag) {
+                    "resendablePayloads: payload key=${descriptor.key} unavailable — descriptor has no iv (fileId=${file.fileId})"
+                }
+                unavailableKeys += descriptor.key
+                continue
+            }
+            val tempPath = fileOps.writeBytesToTempFile(
+                bytes = bytes,
+                prefix = "${tempPrefix}_${descriptor.key}_",
+                suffix = ".enc",
+            )
+            payloads += PayloadFile(
+                key = descriptor.key,
+                filePath = tempPath,
+                // Keep the payload's embedded preview thumbnail on the descriptor too.
+                previewThumbnail = descriptor.previewThumbnail?.toEmbeddedThumb(),
+                contentType = descriptor.contentType ?: "",
+                isPreEncrypted = true,
+                iv = ivBytes,
+                descriptorContent = descriptor.descriptorContent,
+            )
+
+            // The thumbnails are encrypted with the SAME payload key + iv, so we
+            // ship the pre-encrypted bytes as-is (no re-encryption needed).
+            var reattachedThumbs = 0
+            for (thumb in descriptor.thumbnails.orEmpty()) {
+                val w = thumb.pixelWidth
+                val h = thumb.pixelHeight
+                if (w == null || h == null) {
+                    Logger.w(tag = logTag) {
+                        "resendablePayloads: skipping thumbnail for key=${descriptor.key} — missing pixel dims (w=$w h=$h fileId=${file.fileId})"
+                    }
+                    continue
+                }
+                val thumbBytes = byteSource.getThumbBytesEncrypted(
+                    driveId = driveId,
+                    fileId = file.fileId,
+                    payloadKey = descriptor.key,
+                    width = w,
+                    height = h,
+                    lastModified = descriptor.lastModified,
+                )
+                if (thumbBytes == null || thumbBytes.isEmpty()) {
+                    Logger.w(tag = logTag) {
+                        "resendablePayloads: skipping thumbnail key=${descriptor.key} ${w}x$h — getThumbBytesEncrypted returned ${if (thumbBytes == null) "null" else "empty"} (fileId=${file.fileId})"
+                    }
+                    continue
+                }
+                thumbnails += ThumbnailFile(
+                    pixelWidth = w,
+                    pixelHeight = h,
+                    thumbnailBytes = thumbBytes,
+                    key = descriptor.key,
+                    contentType = thumb.contentType ?: "image/webp",
+                )
+                reattachedThumbs++
+            }
+
+            Logger.i(tag = logTag) {
+                "resendablePayloads: re-attached payload key=${descriptor.key} bytes=${bytes.size} thumbs=$reattachedThumbs/${descriptor.thumbnails?.size ?: 0} tempPath=$tempPath fileId=${file.fileId}"
+            }
+        } catch (e: Exception) {
+            Logger.w(throwable = e, tag = logTag) {
+                "resendablePayloads: failed to re-attach payload key=${descriptor.key} fileId=${file.fileId}"
+            }
+            unavailableKeys += descriptor.key
+        }
+    }
+    return ResendablePayloads(payloads, thumbnails, unavailableKeys)
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -44,6 +44,7 @@ import id.homebase.chat.services.StatusMessage
 import id.homebase.chat.services.StatusMessageData
 import id.homebase.chat.services.XorIdUtil
 import id.homebase.chat.services.outbox.OptimisticWriter
+import id.homebase.chat.services.resendablePayloads
 import id.homebase.core.config.chatTargetDrive
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -2150,103 +2151,15 @@ class ConversationService(
             }
             return emptyList<PayloadFile>() to emptyList()
         }
-        val existing = file.fileMetadata.payloads.orEmpty()
-        if (existing.isEmpty()) {
-            Logger.d(tag = "HealAudit") {
-                "reuseExistingPayloadsForResend: fileId=${file.fileId} has no existing payloads — nothing to re-attach"
-            }
-            return emptyList<PayloadFile>() to emptyList()
-        }
-
-        val payloads = mutableListOf<PayloadFile>()
-        val thumbnails = mutableListOf<ThumbnailFile>()
-        for (descriptor in existing) {
-            try {
-                val bytes = dfp.getPayloadBytesEncrypted(chatDrive, file.fileId, descriptor.key)
-                if (bytes == null || bytes.isEmpty()) {
-                    Logger.w(tag = "HealAudit") {
-                        "reuseExistingPayloadsForResend: skipping payload key=${descriptor.key} — getPayloadBytesEncrypted returned ${if (bytes == null) "null" else "empty"} (fileId=${file.fileId})"
-                    }
-                    continue
-                }
-                val ivBytes = descriptor.iv?.let {
-                    @OptIn(kotlin.io.encoding.ExperimentalEncodingApi::class)
-                    kotlin.io.encoding.Base64.Default.decode(it)
-                }
-                if (ivBytes == null) {
-                    Logger.w(tag = "HealAudit") {
-                        "reuseExistingPayloadsForResend: skipping payload key=${descriptor.key} — descriptor has no iv (fileId=${file.fileId})"
-                    }
-                    continue
-                }
-                val tempPath = fop.writeBytesToTempFile(
-                    bytes = bytes,
-                    prefix = "heal_${descriptor.key}_",
-                    suffix = ".enc",
-                )
-                payloads += PayloadFile(
-                    key = descriptor.key,
-                    filePath = tempPath,
-                    // Keep the payload's embedded preview thumbnail on the descriptor too.
-                    previewThumbnail = descriptor.previewThumbnail?.toEmbeddedThumb(),
-                    contentType = descriptor.contentType ?: "",
-                    isPreEncrypted = true,
-                    iv = ivBytes,
-                    descriptorContent = descriptor.descriptorContent,
-                )
-
-                // Re-attach the payload's thumbnails. The update ships an
-                // AppendOrOverwrite for this payload key, which REPLACES the
-                // payload AND its thumbnail set on the server. Re-attaching only
-                // the payload bytes (the previous behavior) wiped every
-                // server-side thumbnail, so the avatar loader 404'd on each size
-                // — the warning-triangle-over-tiny-thumb group-image bug. The
-                // thumbnails are encrypted with the SAME payload key + iv, so we
-                // ship the pre-encrypted bytes as-is (no re-encryption needed).
-                var reattachedThumbs = 0
-                for (thumb in descriptor.thumbnails.orEmpty()) {
-                    val w = thumb.pixelWidth
-                    val h = thumb.pixelHeight
-                    if (w == null || h == null) {
-                        Logger.w(tag = "HealAudit") {
-                            "reuseExistingPayloadsForResend: skipping thumbnail for key=${descriptor.key} — missing pixel dims (w=$w h=$h fileId=${file.fileId})"
-                        }
-                        continue
-                    }
-                    val thumbBytes = dfp.getThumbBytesEncrypted(
-                        driveId = chatDrive,
-                        fileId = file.fileId,
-                        payloadKey = descriptor.key,
-                        width = w,
-                        height = h,
-                        lastModified = descriptor.lastModified,
-                    )
-                    if (thumbBytes == null || thumbBytes.isEmpty()) {
-                        Logger.w(tag = "HealAudit") {
-                            "reuseExistingPayloadsForResend: skipping thumbnail key=${descriptor.key} ${w}x$h — getThumbBytesEncrypted returned ${if (thumbBytes == null) "null" else "empty"} (fileId=${file.fileId})"
-                        }
-                        continue
-                    }
-                    thumbnails += ThumbnailFile(
-                        pixelWidth = w,
-                        pixelHeight = h,
-                        thumbnailBytes = thumbBytes,
-                        key = descriptor.key,
-                        contentType = thumb.contentType ?: "image/webp",
-                    )
-                    reattachedThumbs++
-                }
-
-                Logger.i(tag = "HealAudit") {
-                    "reuseExistingPayloadsForResend: re-attached payload key=${descriptor.key} bytes=${bytes.size} thumbs=$reattachedThumbs/${descriptor.thumbnails?.size ?: 0} tempPath=$tempPath fileId=${file.fileId}"
-                }
-            } catch (e: Exception) {
-                Logger.w(throwable = e, tag = "HealAudit") {
-                    "reuseExistingPayloadsForResend: failed to re-attach payload key=${descriptor.key} fileId=${file.fileId}"
-                }
-            }
-        }
-        return payloads to thumbnails
+        val recovered = resendablePayloads(
+            file = file,
+            driveId = chatDrive,
+            byteSource = dfp,
+            fileOps = fop,
+            tempPrefix = "heal",
+            logTag = "HealAudit",
+        )
+        return recovered.payloads to recovered.thumbnails
     }
 
     override suspend fun getConversationHomebaseFile(conversationId: Uuid): HomebaseFile? {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
@@ -60,6 +60,12 @@ class OptimisticWriter(
             reactionToggleLocks.getOrPut(driveId to uniqueId) { Mutex() }
         }
 
+    /**
+     * @param fileId the optimistic (client-minted) fileId for the local record.
+     *   Returned so the send path can key per-file side effects (e.g. seeding
+     *   the payload cache) to the same id the local record carries until the
+     *   server-assigned file syncs back.
+     */
     suspend fun writeNewFile(
         driveId: Uuid,
         keyHeader: KeyHeader,
@@ -67,14 +73,15 @@ class OptimisticWriter(
         originalRecipientCount: Int,
         fileSystemType: FileSystemType,
         payloadDescriptors: List<PayloadDescriptor>? = null,
-    ) {
+        fileId: Uuid = Uuid.random(),
+    ): Uuid {
 
         val credentials = credentialsManager.requireActiveCredentials()
         val domain = credentials.domain
         val created = UnixTimeUtc.now()
 
         val file = HomebaseFile(
-            fileId = Uuid.random(),
+            fileId = fileId,
             driveId = driveId,
             serverFileIsEncrypted = unecryptedMetadata.isEncrypted,
             fileState = FileState.Active,
@@ -137,6 +144,8 @@ class OptimisticWriter(
             Logger.e(throwable = e, tag = TAG) { "Optimistic insert failed for uniqueId=${unecryptedMetadata.appData.uniqueId} groupId=${unecryptedMetadata.appData.groupId}" }
             throw e
         }
+
+        return fileId
     }
 
     /**

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/messageinfo/RetryUiStateTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/messageinfo/RetryUiStateTest.kt
@@ -1,0 +1,109 @@
+package id.homebase.chat.messageinfo
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * [retryUiState] — the outbox-row overlay on top of [deriveSendStatus]. A
+ * pending outbox row is authoritative "still sending": Queued + Try-now wins
+ * over both the Sending spinner and a (theoretically stale) Failed/Retry.
+ */
+class RetryUiStateTest {
+
+    private val nowMs = 1_780_000_000_000L // a current-era ms epoch
+
+    private val failedBase = SendStatusResult(OutgoingSendState.Failed, RetryMode.Create, canRetry = true)
+    private val sendingBase = SendStatusResult(OutgoingSendState.Sending, null, canRetry = false)
+    private val sentBase = SendStatusResult(OutgoingSendState.Sent, null, canRetry = false)
+
+    // ---- no outbox row: base passes through ----
+
+    @Test
+    fun noRowPassesTheBaseThroughUntouched() {
+        for (base in listOf(failedBase, sendingBase, sentBase)) {
+            val result = retryUiState(base, inOutbox = false, isCheckedOut = false, nextRunTimeRaw = null, nowMs = nowMs)
+            assertEquals(base.sendState, result.sendState)
+            assertEquals(base.retryMode, result.retryMode)
+            assertEquals(base.canRetry, result.canRetry)
+            assertFalse(result.canTryNow)
+            assertNull(result.nextAttemptInMinutes)
+        }
+    }
+
+    // ---- row present: Queued is authoritative ----
+
+    @Test
+    fun queuedRowOverridesSendingWithTryNow() {
+        val result = retryUiState(
+            sendingBase, inOutbox = true, isCheckedOut = false,
+            nextRunTimeRaw = nowMs + 10 * 60_000L, nowMs = nowMs,
+        )
+        assertEquals(OutgoingSendState.Queued, result.sendState)
+        assertFalse(result.canRetry)
+        assertTrue(result.canTryNow)
+        assertEquals(10L, result.nextAttemptInMinutes)
+    }
+
+    @Test
+    fun queuedRowSuppressesRetryEvenForAFailedBase() {
+        val result = retryUiState(
+            failedBase, inOutbox = true, isCheckedOut = false,
+            nextRunTimeRaw = nowMs + 60_000L, nowMs = nowMs,
+        )
+        assertEquals(OutgoingSendState.Queued, result.sendState)
+        assertFalse(result.canRetry, "a queued message must never offer Retry")
+        assertNull(result.retryMode)
+        assertTrue(result.canTryNow)
+    }
+
+    @Test
+    fun checkedOutRowShowsNoTryNowAndNoDeadline() {
+        val result = retryUiState(
+            sendingBase, inOutbox = true, isCheckedOut = true,
+            nextRunTimeRaw = nowMs + 60_000L, nowMs = nowMs,
+        )
+        assertEquals(OutgoingSendState.Queued, result.sendState)
+        assertFalse(result.canTryNow, "resetting an in-flight upload is meaningless")
+        assertNull(result.nextAttemptInMinutes)
+    }
+
+    // ---- deadline normalization ----
+
+    @Test
+    fun pastDeadlineFloorsToZeroMinutes() {
+        val result = retryUiState(
+            sendingBase, inOutbox = true, isCheckedOut = false,
+            nextRunTimeRaw = nowMs - 5_000L, nowMs = nowMs,
+        )
+        assertEquals(0L, result.nextAttemptInMinutes)
+    }
+
+    @Test
+    fun insertSentinelsAndLegacySecondsEpochsReadAsShortly() {
+        // 0 and 42 are fresh-insert/clearCheckedOut sentinels; ~1.7e9 is a
+        // legacy seconds-epoch row written before the checkInFailed unit fix.
+        for (raw in listOf(0L, 42L, 1_780_000_000L)) {
+            val result = retryUiState(
+                sendingBase, inOutbox = true, isCheckedOut = false,
+                nextRunTimeRaw = raw, nowMs = nowMs,
+            )
+            assertEquals(
+                0L, result.nextAttemptInMinutes,
+                "raw=$raw must normalize to 'shortly', not a year-count of minutes",
+            )
+            assertTrue(result.canTryNow)
+        }
+    }
+
+    @Test
+    fun subMinuteWaitRoundsDownToShortly() {
+        val result = retryUiState(
+            sendingBase, inOutbox = true, isCheckedOut = false,
+            nextRunTimeRaw = nowMs + 45_000L, nowMs = nowMs,
+        )
+        assertEquals(0L, result.nextAttemptInMinutes)
+    }
+}

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/services/ResendHelpersTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/services/ResendHelpersTest.kt
@@ -1,0 +1,97 @@
+package id.homebase.chat.services
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+
+class ResendHelpersTest {
+
+    // ---- retryRecoverability matrix ----
+
+    @Test
+    fun serverAbsentWithAllMediaAvailableIsCreate() {
+        assertEquals(
+            RetryRecoverability.Create,
+            retryRecoverability(
+                serverPresent = false,
+                mediaKeys = setOf("img_key1", "img_key2"),
+                availableMediaKeys = setOf("img_key1", "img_key2"),
+            ),
+        )
+    }
+
+    @Test
+    fun serverAbsentTextOnlyIsCreate() {
+        assertEquals(
+            RetryRecoverability.Create,
+            retryRecoverability(
+                serverPresent = false,
+                mediaKeys = emptySet(),
+                availableMediaKeys = emptySet(),
+            ),
+        )
+    }
+
+    @Test
+    fun serverAbsentWithEvictedMediaIsUnrecoverable() {
+        assertEquals(
+            RetryRecoverability.UnrecoverableMedia,
+            retryRecoverability(
+                serverPresent = false,
+                mediaKeys = setOf("img_key1", "img_key2"),
+                availableMediaKeys = setOf("img_key1"),
+            ),
+        )
+    }
+
+    @Test
+    fun serverPresentIsAlwaysUpdate() {
+        // Present wins regardless of local availability — bytes re-fetch from the server.
+        assertEquals(
+            RetryRecoverability.Update,
+            retryRecoverability(
+                serverPresent = true,
+                mediaKeys = setOf("img_key1"),
+                availableMediaKeys = emptySet(),
+            ),
+        )
+        assertEquals(
+            RetryRecoverability.Update,
+            retryRecoverability(
+                serverPresent = true,
+                mediaKeys = emptySet(),
+                availableMediaKeys = emptySet(),
+            ),
+        )
+    }
+
+    // ---- tagsForRetry ----
+
+    private val otherTag = Uuid.parse("11111111-2222-3333-4444-555555555555")
+
+    @Test
+    fun failedTagSwapsToPending() {
+        val result = tagsForRetry(listOf(otherTag, ChatProtocol.isFailedSendTag))
+        assertEquals(listOf(otherTag, ChatProtocol.isPendingSendTag), result)
+    }
+
+    @Test
+    fun alreadyPendingIsUnchanged() {
+        val tags = listOf(otherTag, ChatProtocol.isPendingSendTag)
+        assertEquals(tags, tagsForRetry(tags))
+    }
+
+    @Test
+    fun failedAndPendingCollapsesToPendingOnce() {
+        val result = tagsForRetry(
+            listOf(ChatProtocol.isFailedSendTag, ChatProtocol.isPendingSendTag, otherTag),
+        )
+        assertEquals(listOf(ChatProtocol.isPendingSendTag, otherTag), result)
+        assertEquals(1, result.count { it == ChatProtocol.isPendingSendTag })
+    }
+
+    @Test
+    fun emptyTagsGainPending() {
+        assertEquals(listOf(ChatProtocol.isPendingSendTag), tagsForRetry(emptyList()))
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceResendTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceResendTest.kt
@@ -1,0 +1,321 @@
+package id.homebase.chat.services
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.drives.FileSystemType
+import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.client.drives.files.DriveOutboxUploader
+import id.homebase.api.client.drives.files.PayloadDescriptor
+import id.homebase.api.client.drives.files.PayloadFile
+import id.homebase.api.client.drives.files.ThumbnailFile
+import id.homebase.api.client.drives.upload.PayloadDeleteKey
+import id.homebase.api.client.drives.upload.PayloadOperationType
+import id.homebase.api.client.drives.upload.UpdateLocale
+import id.homebase.api.client.drives.upload.UploadAppFileMetaData
+import id.homebase.api.client.drives.upload.UploadFileMetadata
+import id.homebase.api.client.drives.upload.UploadFileRequest
+import id.homebase.api.client.drives.query.QueryBatchCursor
+import id.homebase.api.common.BatchResult
+import id.homebase.api.common.OdinId
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.chat.data.MessageUiModel
+import io.ktor.client.engine.mock.respondError
+import io.ktor.http.HttpStatusCode
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * [ChatMessageSenderService.resendMessage] — retrying a permanently-failed
+ * send. Uses the real in-memory DB + outbox; the by-uid server check is
+ * scripted through the fixture's mock engine (404 = server absent → the retry
+ * must be a create).
+ */
+@OptIn(ExperimentalEncodingApi::class)
+class ChatMessageSenderServiceResendTest {
+
+    /**
+     * [MessageLookup] backed by the fixture's real DriveMainIndex, so the
+     * optimistic write → mark-failed → resend chain reads the same rows
+     * production would. [getMessage] rebuilds the [MessageUiModel] from the
+     * stored plaintext header content (the optimistic write stores the
+     * UNencrypted metadata).
+     */
+    private class DbBackedMessageLookup(
+        private val dbm: DatabaseManager,
+        private val identityId: Uuid,
+        private val chatDriveId: Uuid,
+        private val domain: String,
+    ) : MessageLookup {
+        override suspend fun getMessageFile(messageId: Uuid): HomebaseFile? =
+            dbm.driveMainIndex.selectHomebaseFileByUnique(identityId, chatDriveId, messageId)
+
+        override suspend fun getMessage(messageId: Uuid): MessageUiModel? {
+            val file = getMessageFile(messageId) ?: return null
+            val content = file.fileMetadata.appData.content ?: return null
+            val appData = OdinSystemSerializer.deserialize<MessageAppData>(content)
+            return MessageUiModel(
+                id = messageId,
+                globalTransitId = null,
+                fileId = file.fileId,
+                conversationId = file.fileMetadata.appData.groupId ?: return null,
+                content = appData.getMessage(),
+                userDate = Instant.fromEpochMilliseconds(file.fileMetadata.appData.userDate ?: 0L),
+                modified = null,
+                created = Instant.fromEpochMilliseconds(0L),
+                originalAuthor = OdinId(domain),
+                sender = OdinId(domain),
+                displayName = domain,
+                localReadTimestamp = null,
+                isDeleted = false,
+                isPendingSend = false,
+                versionTag = file.fileMetadata.versionTag ?: Uuid.NIL,
+                messageAppData = appData,
+                reactionPreview = null,
+                previewThumbnail = null,
+                payloads = file.fileMetadata.payloads?.toImmutableList(),
+                keyHeader = file.keyHeader,
+                hasMore = false,
+            )
+        }
+
+        override suspend fun getMessages(messageIds: List<Uuid>, conversationId: Uuid): BatchResult<MessageUiModel> =
+            BatchResult(records = emptyList(), hasMoreRows = false, cursor = QueryBatchCursor())
+
+        override suspend fun loadFullMessage(conversationId: Uuid, messageId: Uuid): String? = null
+
+        override fun findCachedFileId(messageId: Uuid): Uuid? = null
+    }
+
+    private fun ChatMessageSenderServiceTestFixture.dbLookup() = { dbm: DatabaseManager ->
+        DbBackedMessageLookup(dbm, testIdentityId, chatDriveId, testDomain)
+    }
+
+    private suspend fun ChatMessageSenderServiceTestFixture.localTags(messageId: Uuid): List<Uuid> =
+        dbm.driveMainIndex.selectHomebaseFileByUnique(testIdentityId, chatDriveId, messageId)!!
+            .fileMetadata.localAppData?.tags.orEmpty()
+
+    /** Simulate the outbox permanently dropping the message: delete the row + swap to the failed tag. */
+    private suspend fun ChatMessageSenderServiceTestFixture.dropAndMarkFailed(messageId: Uuid) {
+        val drained = drainOutboxInDependencyOrder()
+        assertTrue(drained.any { it.uniqueId == messageId }, "expected the create row in the outbox")
+        optimisticWriter.updateLocalTags(
+            chatDriveId,
+            messageId,
+            localTags(messageId).filterNot { it == ChatProtocol.isPendingSendTag } + ChatProtocol.isFailedSendTag,
+        )
+    }
+
+    @Test
+    fun `failed text send retries as a create with the original keyHeader and tags swap back to pending`() = runTest {
+        ChatMessageSenderServiceTestFixture().use { fixture ->
+            val service = fixture.build(
+                messageLookup = fixture.dbLookup(),
+                engineHandler = { respondError(HttpStatusCode.NotFound) }, // server absent
+            )
+            val conversationId = fixture.seedConversation(others = listOf("bob.test"))
+            val messageId = Uuid.random()
+
+            service.sendNewMessage(messageId, conversationId, "hello", null, null)
+            val originalKeyHeader = fixture.dbm.driveMainIndex
+                .selectHomebaseFileByUnique(fixture.testIdentityId, fixture.chatDriveId, messageId)!!
+                .keyHeader
+            fixture.dropAndMarkFailed(messageId)
+            assertEquals(0, fixture.outboxRowCount(), "drop must leave the outbox empty")
+
+            val outcome = service.resendMessage(messageId)
+
+            assertEquals(ResendOutcome.EnqueuedCreate, outcome)
+            val rows = fixture.drainOutboxInDependencyOrder()
+            assertEquals(1, rows.size)
+            assertEquals(messageId, rows.single().uniqueId)
+            assertEquals(DriveOutboxUploader.UploadNewFile, rows.single().uploadType)
+
+            val request = OdinSystemSerializer.deserialize<UploadFileRequest>(rows.single().json.decodeToString())
+            assertEquals(
+                OdinSystemSerializer.serialize(originalKeyHeader),
+                OdinSystemSerializer.serialize(request.keyHeader),
+                "retry must reuse the original keyHeader — a fresh one would orphan existing payloads",
+            )
+            assertEquals(listOf("bob.test"), request.transitOptions?.recipients?.map { it.domainName })
+
+            val tags = fixture.localTags(messageId)
+            assertTrue(ChatProtocol.isPendingSendTag in tags, "bubble must flip back to Sending")
+            assertFalse(ChatProtocol.isFailedSendTag in tags, "failed tag must clear on retry")
+        }
+    }
+
+    @Test
+    fun `a message still queued in the outbox is not re-enqueued`() = runTest {
+        ChatMessageSenderServiceTestFixture().use { fixture ->
+            val service = fixture.build(
+                messageLookup = fixture.dbLookup(),
+                engineHandler = { respondError(HttpStatusCode.NotFound) },
+            )
+            val conversationId = fixture.seedConversation(others = listOf("bob.test"))
+            val messageId = Uuid.random()
+            service.sendNewMessage(messageId, conversationId, "hello", null, null)
+            val rowsBefore = fixture.outboxRowCount()
+
+            val outcome = service.resendMessage(messageId)
+
+            assertEquals(ResendOutcome.AlreadyQueued, outcome)
+            assertEquals(rowsBefore, fixture.outboxRowCount(), "no extra row may appear")
+        }
+    }
+
+    /**
+     * The graceful-cleanup scenario: a never-sent media message whose payload
+     * bytes are gone (cache evicted, server absent). The retry must refuse —
+     * enqueueing the header alone would silently deliver a text-only message.
+     */
+    @Test
+    fun `unrecoverable media refuses to enqueue anything`() = runTest {
+        ChatMessageSenderServiceTestFixture().use { fixture ->
+            val service = fixture.build(
+                messageLookup = fixture.dbLookup(),
+                engineHandler = { respondError(HttpStatusCode.NotFound) }, // server absent AND payload bytes 404
+            )
+            val conversationId = fixture.seedConversation(others = listOf("bob.test"))
+            val messageId = Uuid.random()
+
+            // Seed the failed media message directly: a file with a media payload
+            // descriptor whose bytes exist nowhere (payload cache empty, server 404s).
+            val appData = MessageAppData(message = JsonPrimitive("look at this pic"))
+            fixture.optimisticWriter.writeNewFile(
+                driveId = fixture.chatDriveId,
+                keyHeader = KeyHeader.newRandom16(),
+                unecryptedMetadata = UploadFileMetadata(
+                    allowDistribution = true,
+                    isEncrypted = true,
+                    appData = UploadAppFileMetaData(
+                        uniqueId = messageId,
+                        groupId = conversationId,
+                        fileType = ChatProtocol.MessageFileType,
+                        userDate = 0L,
+                        content = OdinSystemSerializer.serialize(appData),
+                    ),
+                ),
+                originalRecipientCount = 1,
+                fileSystemType = FileSystemType.Standard,
+                payloadDescriptors = listOf(
+                    PayloadDescriptor(
+                        key = "img_key1",
+                        contentType = "image/jpeg",
+                        iv = Base64.encode(ByteArray(16) { 7 }),
+                    ),
+                ),
+            )
+            fixture.optimisticWriter.updateLocalTags(
+                fixture.chatDriveId, messageId, listOf(ChatProtocol.isFailedSendTag),
+            )
+
+            val outcome = service.resendMessage(messageId)
+
+            assertEquals(ResendOutcome.UnrecoverableMedia, outcome)
+            assertEquals(0, fixture.outboxRowCount(), "nothing may be enqueued — no silent text-only send")
+            assertTrue(
+                ChatProtocol.isFailedSendTag in fixture.localTags(messageId),
+                "the message must stay in the failed state",
+            )
+        }
+    }
+
+    @Test
+    fun `a server error on the presence check fails the retry instead of guessing`() = runTest {
+        ChatMessageSenderServiceTestFixture().use { fixture ->
+            val service = fixture.build(
+                messageLookup = fixture.dbLookup(),
+                engineHandler = { respondError(HttpStatusCode.InternalServerError) },
+            )
+            val conversationId = fixture.seedConversation(others = listOf("bob.test"))
+            val messageId = Uuid.random()
+            service.sendNewMessage(messageId, conversationId, "hello", null, null)
+            fixture.dropAndMarkFailed(messageId)
+
+            val outcome = service.resendMessage(messageId)
+
+            assertTrue(outcome is ResendOutcome.Failed, "got $outcome")
+            assertEquals(0, fixture.outboxRowCount())
+            assertTrue(ChatProtocol.isFailedSendTag in fixture.localTags(messageId))
+        }
+    }
+
+    // ---- update-path request shape (unit level — the server-present E2E needs
+    // an encrypted ServerFile response, which the create-path tests don't) ----
+
+    @Test
+    fun `buildResendUpdateRequest stamps the server versionTag and ships recovered payloads`() = runTest {
+        val driveId = Uuid.random()
+        val messageId = Uuid.random()
+        val serverVersionTag = Uuid.random()
+        val keyHeader = KeyHeader.newRandom16()
+        val recovered = PayloadFile(
+            key = "img_key1",
+            filePath = "/tmp/retry_img_key1_0.enc",
+            contentType = "image/jpeg",
+            isPreEncrypted = true,
+            iv = ByteArray(16) { 9 },
+        )
+        val thumb = ThumbnailFile(
+            pixelWidth = 100,
+            pixelHeight = 100,
+            thumbnailBytes = ByteArray(32),
+            key = "img_key1",
+        )
+
+        val request = buildResendUpdateRequest(
+            driveId = driveId,
+            messageId = messageId,
+            keyHeader = keyHeader,
+            unencryptedMetadata = UploadFileMetadata(
+                allowDistribution = true,
+                isEncrypted = true,
+                versionTag = serverVersionTag,
+                appData = UploadAppFileMetaData(
+                    uniqueId = messageId,
+                    groupId = Uuid.random(),
+                    fileType = ChatProtocol.MessageFileType,
+                    userDate = 0L,
+                    content = "{}",
+                ),
+            ),
+            recipients = listOf(OdinId("bob.test")),
+            payloads = listOf(recovered),
+            toDeletePayloads = listOf(PayloadDeleteKey(ChatProtocol.DefaultPayloadKey)),
+            thumbnails = listOf(thumb),
+        )
+
+        assertEquals(driveId, request.driveId)
+        assertEquals(messageId, request.uniqueId)
+        assertEquals(
+            serverVersionTag, request.metadata.versionTag,
+            "the update must carry the SERVER's current versionTag, not the stale local one",
+        )
+        assertEquals(UpdateLocale.Local, request.instructions.locale)
+        assertEquals(listOf("bob.test"), request.instructions.recipients.map { it.domainName })
+        assertEquals(listOf(recovered), request.payloads)
+        assertEquals(listOf(thumb), request.thumbnails)
+        val descriptors = request.instructions.manifest.payloadDescriptors.orEmpty()
+        val append = descriptors.singleOrNull { it.operationType == PayloadOperationType.AppendOrOverwrite }
+        assertNotNull(append, "the manifest must describe the recovered payload")
+        assertEquals("img_key1", append.payloadKey)
+        assertContentEquals(
+            recovered.iv, append.iv,
+            "the pre-encrypted payload's own iv must be preserved, not regenerated",
+        )
+        val delete = descriptors.singleOrNull { it.operationType == PayloadOperationType.DeletePayload }
+        assertNotNull(delete, "the now-empty overflow must be deleted server-side")
+        assertEquals(ChatProtocol.DefaultPayloadKey, delete.payloadKey)
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceTestFixture.kt
@@ -22,7 +22,10 @@ import id.homebase.chat.services.outbox.OptimisticWriter
 import id.homebase.core.avatars.ConversationAvatarModel
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
 import io.ktor.client.engine.mock.respondError
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.HttpResponseData
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -79,7 +82,20 @@ class ChatMessageSenderServiceTestFixture : AutoCloseable {
     lateinit var optimisticWriter: OptimisticWriter
         private set
 
-    suspend fun build(scope: CoroutineScope = TestScope()): ChatMessageSenderService {
+    /**
+     * @param messageLookup override for tests that need `getMessage`/`getMessageFile`
+     *   to return real data (e.g. the resend tests' DB-backed lookup).
+     * @param engineHandler override for the [MockEngine] backing [DriveFileProvider] —
+     *   the default 500s everything (send-path tests never reach it); resend tests
+     *   script the by-uid server check with it.
+     */
+    suspend fun build(
+        scope: CoroutineScope = TestScope(),
+        messageLookup: ((DatabaseManager) -> MessageLookup)? = null,
+        engineHandler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData = {
+            respondError(HttpStatusCode.InternalServerError)
+        },
+    ): ChatMessageSenderService {
         dbm = createInMemoryDbm()
         credentialsManager = createCredentialsManager(testDomain)
         eventBus = EventBus()
@@ -100,11 +116,9 @@ class ChatMessageSenderServiceTestFixture : AutoCloseable {
             eventBus = eventBus,
         )
 
-        // Real DriveFileProvider with an HTTP client that 500s every request.
-        // The send path doesn't call into it; this is just to satisfy the ctor.
-        val httpClient = HttpClient(MockEngine { _ ->
-            respondError(HttpStatusCode.InternalServerError)
-        })
+        // Real DriveFileProvider with a scriptable mock engine (default: 500s
+        // every request — the send path doesn't call into it).
+        val httpClient = HttpClient(MockEngine { request -> engineHandler(request) })
         val driveCache = DriveFileProviderCached(
             httpClient,
             credentialsManager,
@@ -117,7 +131,7 @@ class ChatMessageSenderServiceTestFixture : AutoCloseable {
             conversationStream = conversationLookup,
             payloadBundleEncryptionService = payloadEncryptor,
             scope = scope,
-            chatMessageStream = FakeMessageLookup(),
+            chatMessageStream = messageLookup?.invoke(dbm) ?: FakeMessageLookup(),
             optimisticWriter = optimisticWriter,
             fileOperationsProvider = SenderNoopFileOperationsProvider(),
             driveFileProvider = driveFileProvider,

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ResendablePayloadsTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ResendablePayloadsTest.kt
@@ -1,0 +1,160 @@
+package id.homebase.chat.services
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.drives.FileState
+import id.homebase.api.client.drives.FileSystemType
+import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.client.drives.ServerMetadata
+import id.homebase.api.client.drives.files.FileMetadata
+import id.homebase.api.client.drives.files.PayloadDescriptor
+import id.homebase.api.client.drives.files.ResendPayloadByteSource
+import id.homebase.api.client.drives.files.ThumbnailDescriptor
+import id.homebase.chat.services.convo.FakeFileOperationsProvider
+import kotlinx.coroutines.test.runTest
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * [resendablePayloads] — the shared payload-recovery helper used by the
+ * conversation heal-redistribute path and chat message retry. Exercises the
+ * recovered/unavailable split that retry's recoverability decision hangs on.
+ */
+@OptIn(ExperimentalEncodingApi::class)
+class ResendablePayloadsTest {
+
+    private val driveId = Uuid.parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    private val iv = ByteArray(16) { it.toByte() }
+    private val fileOps = FakeFileOperationsProvider()
+
+    /** Byte source whose responses are scripted per payload key; null = gone. */
+    private class ScriptedByteSource(
+        private val payloadBytes: Map<String, ByteArray?>,
+        private val thumbBytes: ByteArray? = ByteArray(256) { 2 },
+        private val throwOnKey: String? = null,
+    ) : ResendPayloadByteSource {
+        val payloadRequests = mutableListOf<String>()
+
+        override suspend fun getPayloadBytesEncrypted(driveId: Uuid, fileId: Uuid, key: String): ByteArray? {
+            payloadRequests += key
+            if (key == throwOnKey) throw IllegalStateException("boom for $key")
+            return payloadBytes[key]
+        }
+
+        override suspend fun getThumbBytesEncrypted(
+            driveId: Uuid,
+            fileId: Uuid,
+            payloadKey: String,
+            width: Int,
+            height: Int,
+            lastModified: Long?,
+        ): ByteArray? = thumbBytes
+    }
+
+    private fun fileWith(vararg descriptors: PayloadDescriptor): HomebaseFile = HomebaseFile(
+        fileId = Uuid.random(),
+        driveId = driveId,
+        fileState = FileState.Active,
+        fileSystemType = FileSystemType.Standard,
+        keyHeader = KeyHeader.newRandom16(),
+        fileMetadata = FileMetadata(payloads = descriptors.toList().ifEmpty { null }),
+        serverMetadata = ServerMetadata(),
+    )
+
+    private fun descriptor(
+        key: String,
+        withIv: Boolean = true,
+        thumbs: List<ThumbnailDescriptor>? = null,
+    ) = PayloadDescriptor(
+        key = key,
+        contentType = "image/jpeg",
+        iv = if (withIv) Base64.encode(iv) else null,
+        thumbnails = thumbs,
+    )
+
+    @Test
+    fun `available bytes are recovered as pre-encrypted payloads with iv and thumbnails`() = runTest {
+        val bytes = ByteArray(2048) { 1 }
+        val source = ScriptedByteSource(mapOf("img_key1" to bytes))
+        val file = fileWith(
+            descriptor(
+                "img_key1",
+                thumbs = listOf(ThumbnailDescriptor(pixelWidth = 100, pixelHeight = 100, contentType = "image/webp")),
+            ),
+        )
+
+        val result = resendablePayloads(file, driveId, source, fileOps)
+
+        assertEquals(1, result.payloads.size)
+        val payload = result.payloads.single()
+        assertEquals("img_key1", payload.key)
+        assertTrue(payload.isPreEncrypted, "recovered bytes are already ciphertext")
+        assertContentEquals(iv, payload.iv, "the descriptor's original iv must be carried")
+        assertEquals(1, result.thumbnails.size, "the payload's thumbnail must ship too (AppendOrOverwrite wipes it otherwise)")
+        assertEquals("img_key1", result.thumbnails.single().key)
+        assertTrue(result.unavailableKeys.isEmpty())
+    }
+
+    @Test
+    fun `missing bytes are reported unavailable not silently dropped`() = runTest {
+        val source = ScriptedByteSource(
+            mapOf("img_key1" to ByteArray(64) { 1 }, "img_key2" to null),
+        )
+        val file = fileWith(descriptor("img_key1"), descriptor("img_key2"))
+
+        val result = resendablePayloads(file, driveId, source, fileOps)
+
+        assertEquals(listOf("img_key1"), result.payloads.map { it.key })
+        assertEquals(listOf("img_key2"), result.unavailableKeys)
+    }
+
+    @Test
+    fun `descriptor without iv is unavailable`() = runTest {
+        val source = ScriptedByteSource(mapOf("img_key1" to ByteArray(64) { 1 }))
+        val file = fileWith(descriptor("img_key1", withIv = false))
+
+        val result = resendablePayloads(file, driveId, source, fileOps)
+
+        assertTrue(result.payloads.isEmpty())
+        assertEquals(listOf("img_key1"), result.unavailableKeys)
+    }
+
+    @Test
+    fun `a throwing byte source marks the key unavailable`() = runTest {
+        val source = ScriptedByteSource(
+            mapOf("img_key1" to ByteArray(64) { 1 }),
+            throwOnKey = "img_key1",
+        )
+        val file = fileWith(descriptor("img_key1"))
+
+        val result = resendablePayloads(file, driveId, source, fileOps)
+
+        assertTrue(result.payloads.isEmpty())
+        assertEquals(listOf("img_key1"), result.unavailableKeys)
+    }
+
+    @Test
+    fun `excluded keys are neither recovered nor reported unavailable`() = runTest {
+        val source = ScriptedByteSource(mapOf("img_key1" to ByteArray(64) { 1 }))
+        val file = fileWith(
+            descriptor(ChatProtocol.DefaultPayloadKey),
+            descriptor("img_key1"),
+        )
+
+        val result = resendablePayloads(
+            file, driveId, source, fileOps,
+            excludeKeys = setOf(ChatProtocol.DefaultPayloadKey),
+        )
+
+        assertEquals(listOf("img_key1"), result.payloads.map { it.key })
+        assertTrue(result.unavailableKeys.isEmpty())
+        assertEquals(
+            listOf("img_key1"), source.payloadRequests,
+            "the excluded overflow key must not even be requested",
+        )
+    }
+}

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -75,6 +75,10 @@
     <string name="action_retry">Prøv igen</string>
     <string name="msg_retry_media_unavailable">Vedhæftningen er ikke længere tilgængelig — den kan ikke sendes igen</string>
     <string name="msg_retry_failed">Kunne ikke prøve igen — tjek din forbindelse</string>
+    <string name="msg_still_in_outbox">Sender stadig — næste forsøg %1$s</string>
+    <string name="msg_next_attempt_minutes">om ca. %1$d min.</string>
+    <string name="msg_next_attempt_shortly">om lidt</string>
+    <string name="action_try_now">Prøv nu</string>
     <string name="label_edited">Redigeret: %1$s</string>
     <string name="label_size">Størrelse: %1$s</string>
     <string name="label_message_id">ID: %1$s</string>

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -73,6 +73,8 @@
     <string name="msg_status_failed_to_send">Kunne ikke sendes</string>
     <string name="msg_status_delivery_details_unavailable">Leveringsdetaljer kunne ikke indlæses</string>
     <string name="action_retry">Prøv igen</string>
+    <string name="msg_retry_media_unavailable">Vedhæftningen er ikke længere tilgængelig — den kan ikke sendes igen</string>
+    <string name="msg_retry_failed">Kunne ikke prøve igen — tjek din forbindelse</string>
     <string name="label_edited">Redigeret: %1$s</string>
     <string name="label_size">Størrelse: %1$s</string>
     <string name="label_message_id">ID: %1$s</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -49,6 +49,8 @@
     <string name="msg_status_failed_to_send">Failed to send</string>
     <string name="msg_status_delivery_details_unavailable">Couldn’t load delivery details</string>
     <string name="action_retry">Retry</string>
+    <string name="msg_retry_media_unavailable">The attachment is no longer available — it can’t be resent</string>
+    <string name="msg_retry_failed">Couldn’t retry — check your connection</string>
     <string name="label_edited">Edited: %1$s</string>
     <string name="label_size">Size: %1$s</string>
     <string name="label_message_id">ID: %1$s</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -51,6 +51,10 @@
     <string name="action_retry">Retry</string>
     <string name="msg_retry_media_unavailable">The attachment is no longer available — it can’t be resent</string>
     <string name="msg_retry_failed">Couldn’t retry — check your connection</string>
+    <string name="msg_still_in_outbox">Still sending — next attempt %1$s</string>
+    <string name="msg_next_attempt_minutes">in about %1$d min</string>
+    <string name="msg_next_attempt_shortly">shortly</string>
+    <string name="action_try_now">Try now</string>
     <string name="label_edited">Edited: %1$s</string>
     <string name="label_size">Size: %1$s</string>
     <string name="label_message_id">ID: %1$s</string>


### PR DESCRIPTION
## Summary

Wires up the Message Info **Retry** button (stubbed in #689) so a message whose send permanently failed (orange **!**) can actually be re-sent. PR 2 (Try-now for still-queued messages) follows on top of this.

### How retry decides what to do

`ChatMessageSenderService.resendMessage(messageId)`:

1. **Outbox safety net** — a row already queued → `AlreadyQueued`, no-op.
2. **Server check** (`getFileHeaderByUid`):
   - **absent** → the create never landed → re-enqueue an `UploadFileRequest` reusing the file's **original keyHeader** (`sendMessageInternal` is deliberately not reused — it mints a fresh `KeyHeader.newRandom16()`, which would orphan the existing encrypted payloads).
   - **present** → a later edit's update failed → enqueue an `UpdateFileByUniqueIdRequest` stamped with the **server's current versionTag** (same pattern as `DriveOutboxUploader.retryAsUpdate`).
3. Media payloads are recovered as pre-encrypted bytes via the new shared `resendablePayloads` helper (extracted from `ConversationService.reuseExistingPayloadsForResend`). If any media bytes are genuinely gone → **`UnrecoverableMedia`**: nothing is enqueued, the user gets a clear message — never a silent text-only resend.
4. On enqueue, local tags swap failed→pending (`tagsForRetry`, the inverse of `markSendFailed`) so the bubble shows *Sending* again.

### What makes failed media retryable: cache-seed on send

The outbox deletes its temp payload files when a row is permanently dropped, so previously a failed image had no recoverable bytes. Now `sendMessageInternal` seeds the encrypted payload/thumbnail disk cache (new public `cachePayloadBytesEncrypted` / `cacheThumbBytesEncrypted` on `DriveFileProviderCached`) under the optimistic fileId right after the optimistic write. `getPayloadBytesEncrypted` checks this cache before the network, so retry finds the bytes. The cache is the existing 200 MB LRU — a never-sent message's bytes eventually self-evict; eviction degrades retry to the explicit `UnrecoverableMedia` refusal.

**Deviation from the approved plan (found during implementation):** the plan said to seed media only and rebuild text from local plaintext. But overflow-length text rides as a payload under `DefaultPayloadKey` and `appData.content` holds only a *preview* — so all payloads are seeded (the overflow is a few KB) and retry rebuilds the text via `loadFullMessage` (cache-first) with a preview fallback.

### Message Info wiring

`RetryClicked` → optimistic *Sending* + button hidden → `resendMessage` → on refusal, revert to *Failed* and show a snackbar (`msg_retry_media_unavailable` / `msg_retry_failed`, en+da). The error rides the screen's existing `uiEvent` conduit rather than a new `SharedFlow` — one event mechanism per screen; migrating the whole screen to SharedFlow is an orthogonal refactor.

## Tests

- Cache seed round-trips (payload + thumb) with a network-poisoned MockEngine proving no fetch, and seeding clearing a prior 404 marker.
- `retryRecoverability` matrix + `tagsForRetry` idempotence (commonTest).
- `resendablePayloads`: iv carried, thumbs re-attached, null bytes → `unavailableKeys`, excludeKeys honored.
- E2E create path on the real in-memory DB/outbox: send → drop → mark failed → retry → one `UploadNewFile` row with the original keyHeader + tag swap; `AlreadyQueued`; **UnrecoverableMedia enqueues nothing**; server-error check → `Failed` (no guessing).
- Update path request shape: server versionTag stamped, pre-encrypted iv preserved, overflow delete descriptor.
- `ConversationServiceResendImageTest` unchanged (extraction regression gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)