### PR TITLE
Try now: honest Queued state for outbox-backed-off messages (+ fix in-session retries never running)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
@@ -280,9 +280,14 @@ class OutboxSync(
                     e
                 )
 
+                // nextRunTime is a MILLISECONDS epoch — checkout/nextScheduled
+                // compare it against UnixTimeUtc.now().milliseconds. Storing
+                // `.seconds` here (the pre-fix bug) made every backoff deadline
+                // a ~1970s-era value, so failed rows were immediately
+                // re-eligible and the 30s→4h backoff was never enforced.
                 databaseManager.outbox.checkInFailed(
                     outboxRecord.checkOutStamp!!,
-                    UnixTimeUtc.now().addSeconds(n).seconds
+                    UnixTimeUtc.now().addSeconds(n).milliseconds
                 )
 
                 eventBus.emit(
@@ -471,6 +476,46 @@ class OutboxSync(
         val row = databaseManager.outbox.selectByDriveAndUnique(driveId, uniqueId) ?: return null
         if (row.uploadType != DriveOutboxUploader.UploadNewFile) return null
         return OdinSystemSerializer.deserialize<UploadFileRequest>(row.json.decodeToString())
+    }
+
+    /** Display-oriented snapshot of the pending row for (driveId, uniqueId) —
+     *  what Message Info needs to render "still sending, next attempt in ~N min"
+     *  without deserializing the request json. */
+    public data class PendingRowSnapshot(
+        /** Milliseconds epoch of the next attempt (0 / sentinel = "shortly").
+         *  Rows written before the checkInFailed unit fix may carry a
+         *  seconds-epoch value — display code must normalize. */
+        val nextRunTime: Long,
+        val checkOutCount: Long,
+        /** True when an upload worker currently holds the row. */
+        val isCheckedOut: Boolean,
+        val uploadType: Long,
+    )
+
+    public suspend fun pendingRowSnapshot(driveId: Uuid, uniqueId: Uuid): PendingRowSnapshot? {
+        val row = databaseManager.outbox.selectByDriveAndUnique(driveId, uniqueId) ?: return null
+        return PendingRowSnapshot(
+            nextRunTime = row.nextRunTime,
+            checkOutCount = row.checkOutCount,
+            isCheckedOut = row.checkOutStamp != null,
+            uploadType = row.uploadType,
+        )
+    }
+
+    /**
+     * Force a queued (backed-off) row to be eligible immediately and kick the
+     * send loop — the "Try now" button. Returns false when nothing changed:
+     * the row is gone (already sent/dropped) or currently checked out (the
+     * upload is literally running — a harmless no-op either way). A row with
+     * an unresolved dependency gets its time reset but still waits for the
+     * dependency to drain (the checkout SQL's NOT EXISTS guard).
+     */
+    public suspend fun runNow(driveId: Uuid, uniqueId: Uuid): Boolean {
+        val changed = databaseManager.outbox.setNextRunTime(driveId, uniqueId, 0L)
+        if (changed > 0) {
+            scope.launch { send() }
+        }
+        return changed > 0
     }
 
     public suspend fun tryEnqueue(

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxWrapper.kt
@@ -84,8 +84,26 @@ class OutboxWrapper(
         checkOutStamp: Long,
         nextRunTime: Long,
     ): Long {
+        // Named args are load-bearing: the generated query's parameter order is
+        // (nextRunTime, checkOutStamp) — SQL appearance order, both Long. The
+        // original positional call had them SWAPPED, so the WHERE never matched:
+        // failed rows stayed checked out (zombies) until the next app start's
+        // clearCheckedOut, and in-session retry/backoff never actually ran.
         return databaseManager.withWriteValue {
-            delegate.checkInFailed(checkOutStamp, nextRunTime).value
+            delegate.checkInFailed(nextRunTime = nextRunTime, checkOutStamp = checkOutStamp).value
+        }
+    }
+
+    /** Reset a queued row's next-attempt time (ms epoch). Returns the number of
+     *  rows changed: 0 when the row is missing or currently checked out — an
+     *  in-flight row's nextRunTime is owned by [checkInFailed]. */
+    suspend fun setNextRunTime(
+        driveId: Uuid,
+        uniqueId: Uuid,
+        nextRunTime: Long,
+    ): Long {
+        return databaseManager.withWriteValue {
+            delegate.setNextRunTime(nextRunTime = nextRunTime, driveId = driveId, uniqueId = uniqueId).value
         }
     }
 

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/Outbox.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/Outbox.sq
@@ -70,6 +70,14 @@ SET checkOutStamp=NULL,
     nextRunTime=:nextRunTime
 WHERE checkOutStamp=:checkOutStamp;
 
+-- Force a queued row's next attempt (e.g. "Try now" resetting a backed-off
+-- item to run immediately). Guarded on checkOutStamp IS NULL: an in-flight
+-- row's nextRunTime is owned by checkInFailed and must not be raced.
+setNextRunTime:
+UPDATE Outbox
+SET nextRunTime = :nextRunTime
+WHERE driveId = :driveId AND uniqueId = :uniqueId AND checkOutStamp IS NULL;
+
 -- When the app starts, clear all checked out items
 clearCheckedOut:
 UPDATE Outbox

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSetNextRunTimeTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSetNextRunTimeTest.kt
@@ -1,0 +1,155 @@
+package id.homebase.api.sync.database
+
+import id.homebase.api.client.eventbus.BackendEvent
+import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.common.time.UnixTimeUtc
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * The outbox `setNextRunTime` primitive behind [OutboxSync.runNow] ("Try now"),
+ * plus regressions for the two stacked bugs that meant in-session retry/backoff
+ * never actually ran:
+ *
+ * 1. **Swapped checkInFailed arguments** — the generated query's parameter
+ *    order is (nextRunTime, checkOutStamp); the wrapper passed them positionally
+ *    reversed (both Long, so it compiled). The WHERE never matched: failed rows
+ *    stayed checked out (zombies) until the next app start's `clearCheckedOut`.
+ * 2. **Seconds-vs-ms deadline** — the OutboxSync call site stored
+ *    `.seconds` while `checkout` compares an ms epoch, so even a matching
+ *    check-in would have made the row immediately re-eligible.
+ */
+class OutboxSetNextRunTimeTest {
+
+    private suspend fun insertRow(dbm: DatabaseManager, driveId: Uuid, uniqueId: Uuid) {
+        dbm.outbox.insert(
+            driveId = driveId,
+            uniqueId = uniqueId,
+            dependencyUniqueId = null,
+            priority = 0L,
+            uploadType = 0L,
+            json = byteArrayOf(),
+            filePaths = null,
+        )
+    }
+
+    @Test
+    fun backedOffRowIsNotEligibleUntilItsDeadline() = runTest {
+        DatabaseManager({ createInMemoryDatabase() }).use { dbm ->
+            val driveId = Uuid.random()
+            val uniqueId = Uuid.random()
+            insertRow(dbm, driveId, uniqueId)
+
+            val row = dbm.outbox.checkout()
+            assertNotNull(row)
+            // Check in as failed with a deadline 30s out — a ms epoch.
+            val changed = dbm.outbox.checkInFailed(row.checkOutStamp!!, UnixTimeUtc.now().addSeconds(30).milliseconds)
+
+            assertEquals(
+                1L, changed,
+                "checkInFailed must match the checked-out row — 0 means the " +
+                    "swapped-positional-arguments bug is back (zombie rows)",
+            )
+            assertNull(
+                dbm.outbox.checkout(),
+                "a row backed off into the future must not be eligible for checkout",
+            )
+        }
+    }
+
+    @Test
+    fun setNextRunTimeMakesABackedOffRowImmediatelyEligible() = runTest {
+        DatabaseManager({ createInMemoryDatabase() }).use { dbm ->
+            val driveId = Uuid.random()
+            val uniqueId = Uuid.random()
+            insertRow(dbm, driveId, uniqueId)
+            val row = dbm.outbox.checkout()!!
+            dbm.outbox.checkInFailed(row.checkOutStamp!!, UnixTimeUtc.now().addSeconds(3600).milliseconds)
+            assertNull(dbm.outbox.checkout(), "precondition: row is backed off")
+
+            val changed = dbm.outbox.setNextRunTime(driveId, uniqueId, 0L)
+
+            assertEquals(1L, changed, "exactly the one queued row must be updated")
+            val checkedOut = dbm.outbox.checkout()
+            assertNotNull(checkedOut, "the reset row must be eligible immediately")
+            assertEquals(uniqueId, checkedOut.uniqueId)
+        }
+    }
+
+    @Test
+    fun setNextRunTimeDoesNotTouchACheckedOutRow() = runTest {
+        DatabaseManager({ createInMemoryDatabase() }).use { dbm ->
+            val driveId = Uuid.random()
+            val uniqueId = Uuid.random()
+            insertRow(dbm, driveId, uniqueId)
+            val row = dbm.outbox.checkout()
+            assertNotNull(row, "precondition: row is in flight")
+
+            val changed = dbm.outbox.setNextRunTime(driveId, uniqueId, 0L)
+
+            assertEquals(0L, changed, "an in-flight row's nextRunTime is owned by checkInFailed")
+        }
+    }
+
+    @Test
+    fun setNextRunTimeOnAMissingRowChangesNothing() = runTest {
+        DatabaseManager({ createInMemoryDatabase() }).use { dbm ->
+            assertEquals(0L, dbm.outbox.setNextRunTime(Uuid.random(), Uuid.random(), 0L))
+        }
+    }
+
+    /**
+     * Unit regression THROUGH the send loop: after one failed attempt,
+     * OutboxSync's checkInFailed call site must have stored a future
+     * MILLISECONDS deadline. Pre-fix it stored `.seconds` (~1.7e9), which is
+     * far in the past as an ms epoch — this assertion fails on that code.
+     * Real-dispatcher DB (not runOutboxTest's virtual-time binding) for the
+     * same reason as `OutboxSyncTest.testFailureAndRetry`.
+     */
+    @Test
+    fun failedAttemptStoresAFutureMillisecondsDeadline() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val uploader = TestUploader().apply { shouldFail = true }
+            val sync = OutboxSync(
+                databaseManager = db, uploader = uploader, eventBus = eventBus, scope = backgroundScope,
+            )
+            sync.setOnline(true)
+
+            // checkInFailed runs BEFORE ItemFailed is emitted, so awaiting the
+            // event guarantees the deadline is in the DB.
+            val failedDeferred = async {
+                eventBus.events.filterIsInstance<BackendEvent.OutboxEvent.ItemFailed>().first()
+            }
+            testScheduler.runCurrent()
+
+            val driveId = Uuid.random()
+            val uniqueId = Uuid.random()
+            insertRow(db, driveId, uniqueId)
+
+            sync.send()
+            advanceUntilIdle()
+            failedDeferred.await()
+
+            val row = db.outbox.selectByDriveAndUnique(driveId, uniqueId)
+            assertNotNull(row, "one failed attempt must re-queue, not drop")
+            assertTrue(
+                row.nextRunTime > UnixTimeUtc.now().milliseconds,
+                "backoff deadline must be a FUTURE ms epoch (got ${row.nextRunTime}) — " +
+                    "a seconds-epoch value here means the checkInFailed unit bug is back",
+            )
+            sync.clearCheckout(timeoutMs = 5_000)
+        }
+        db.close()
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoScreen.kt
@@ -64,10 +64,14 @@ import id.homebase.resources.copy_message_id
 import id.homebase.resources.label_message_id
 import id.homebase.resources.label_sent
 import id.homebase.resources.error_delivery_failed
+import id.homebase.resources.action_try_now
+import id.homebase.resources.msg_next_attempt_minutes
+import id.homebase.resources.msg_next_attempt_shortly
 import id.homebase.resources.msg_status_delivery_details_unavailable
 import id.homebase.resources.msg_status_failed_to_send
 import id.homebase.resources.msg_status_sending
 import id.homebase.resources.msg_status_sent
+import id.homebase.resources.msg_still_in_outbox
 import id.homebase.resources.label_size
 import id.homebase.resources.menu_back
 import id.homebase.resources.reactions
@@ -217,6 +221,40 @@ fun MessageInfoUi(
                                     text = stringResource(MR.string.msg_status_sending),
                                     style = MaterialTheme.typography.bodyMedium,
                                 )
+                            }
+                        }
+
+                        OutgoingSendState.Queued -> {
+                            // Still in the outbox: it WILL be sent (after its
+                            // backoff). Honest copy + a Try-now escape hatch
+                            // instead of an indefinite "Sending…" spinner.
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
+                            ) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(16.dp),
+                                    strokeWidth = 2.dp,
+                                )
+                                val minutes = uiState.nextAttemptInMinutes
+                                val attemptText = if (minutes == null || minutes <= 0L) {
+                                    stringResource(MR.string.msg_next_attempt_shortly)
+                                } else {
+                                    stringResource(MR.string.msg_next_attempt_minutes, minutes)
+                                }
+                                Text(
+                                    text = stringResource(MR.string.msg_still_in_outbox, attemptText),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                )
+                            }
+                            if (uiState.canTryNow) {
+                                OutlinedButton(
+                                    onClick = { onUiAction(MessageInfoUiAction.TryNowClicked) },
+                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                                ) {
+                                    Text(stringResource(MR.string.action_try_now))
+                                }
                             }
                         }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoUiAction.kt
@@ -3,4 +3,5 @@ package id.homebase.chat.messageinfo
 sealed interface MessageInfoUiAction {
     data object BackClicked : MessageInfoUiAction
     data object RetryClicked : MessageInfoUiAction
+    data object TryNowClicked : MessageInfoUiAction
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoUiState.kt
@@ -2,6 +2,7 @@ package id.homebase.chat.messageinfo
 
 import androidx.compose.runtime.Immutable
 import id.homebase.api.client.auth.OwnerSession
+import id.homebase.api.sync.database.OutboxSync
 import id.homebase.chat.data.MessageUiModel
 import id.homebase.chat.services.ChatDeliveryStatus
 import kotlin.coroutines.cancellation.CancellationException
@@ -22,11 +23,13 @@ data class ReactionUiModel(
 
 /** High-level send status for an *outgoing* (own) message, shown as the single
  *  status row in Message Info. Null for inbound messages (which keep the
- *  sender-sent / we-received rows instead). [Failed] is a local send failure
- *  (the file never settled on our server); [DeliveryFailed] is recipient-level
- *  (the file settled, but ≥1 recipient transfer failed) — distinct wording and
- *  no retry, matching the bubble's orange failed indicator. */
-enum class OutgoingSendState { Sending, Sent, Failed, DeliveryFailed }
+ *  sender-sent / we-received rows instead). [Queued] means an outbox row still
+ *  exists for the message — it WILL be sent (possibly after a backoff wait), so
+ *  the affordance is "Try now", never "Retry". [Failed] is a local send failure
+ *  (the file never settled on our server, no outbox row left); [DeliveryFailed]
+ *  is recipient-level (the file settled, but ≥1 recipient transfer failed) —
+ *  distinct wording and no retry, matching the bubble's orange failed indicator. */
+enum class OutgoingSendState { Sending, Queued, Sent, Failed, DeliveryFailed }
 
 /** What a (future, currently stubbed) retry would do, derived from whether the
  *  file already exists on the server: [Create] = re-upload a never-landed file;
@@ -75,6 +78,9 @@ data class MessageInfoUiState(
     val isOwnMessage: Boolean = false,
     /** Server-side existence of the message file, keyed by uniqueId. */
     val serverPresence: ServerPresence = ServerPresence.Unknown,
+    /** Pending outbox row for the message (own pending/failed messages only);
+     *  non-null means the send is still queued → Queued state + Try-now. */
+    val outboxRow: OutboxSync.PendingRowSnapshot? = null,
     /** True while the by-uniqueId server existence check is in flight. */
     val isServerCheckLoading: Boolean = false,
     /** Status row for own messages; null for inbound. */
@@ -84,8 +90,13 @@ data class MessageInfoUiState(
     val transferHistoryFailed: Boolean = false,
     /** Intent a retry would carry; null when no retry is offered. */
     val retryMode: RetryMode? = null,
-    /** Whether to surface the Retry affordance (currently a no-op stub). */
+    /** Whether to surface the Retry affordance. */
     val canRetry: Boolean = false,
+    /** Whether to surface the Try-now affordance (Queued message, not in flight). */
+    val canTryNow: Boolean = false,
+    /** Whole minutes until the queued message's next attempt; null = no
+     *  meaningful deadline (fresh row / in-flight) → render "shortly". */
+    val nextAttemptInMinutes: Long? = null,
 )
 
 sealed interface MessageInfoUiEvent {
@@ -142,4 +153,60 @@ fun deriveSendStatus(
     }
     deliveryFailed -> SendStatusResult(OutgoingSendState.DeliveryFailed, null, false)
     else -> SendStatusResult(OutgoingSendState.Sent, null, false)
+}
+
+/** [deriveSendStatus]'s fields plus the outbox-row overlay (Try-now). */
+data class RetryUiState(
+    val sendState: OutgoingSendState?,
+    val retryMode: RetryMode?,
+    val canRetry: Boolean,
+    val canTryNow: Boolean,
+    val nextAttemptInMinutes: Long?,
+)
+
+/** Below this raw `nextRunTime`, the value can't be a current ms-epoch: it's a
+ *  fresh-insert sentinel (0 / 42) or a legacy seconds-epoch row written before
+ *  the checkInFailed unit fix. Either way the row is due "shortly". */
+private const val MIN_PLAUSIBLE_MS_EPOCH = 100_000_000_000L // 2001-09-09 in ms
+
+/**
+ * Layer the outbox-row reality on top of [deriveSendStatus]'s tag/server view.
+ *
+ * An existing outbox row is authoritative "still sending": the queued item WILL
+ * run again (after its backoff), so the screen shows **Queued** with the next
+ * attempt time and a **Try now** button — never Retry (the message is not
+ * failed) and never the bare Sending spinner (which reads as "in flight" when
+ * the item may be hours of backoff away).
+ *
+ * - No row → [base] passes through untouched.
+ * - Row checked out → the upload is literally running: Queued with
+ *   `nextAttemptInMinutes = null` ("sending now"-ish copy) and no Try-now
+ *   (resetting an in-flight row is meaningless; [id.homebase.api.sync.database.OutboxSync.runNow]
+ *   would no-op anyway).
+ * - Row waiting → minutes until [nextRunTimeRaw], floored at 0; raw values
+ *   below [MIN_PLAUSIBLE_MS_EPOCH] (insert sentinels, legacy seconds-epoch
+ *   rows) normalize to "shortly" (null is reserved for checked-out).
+ */
+fun retryUiState(
+    base: SendStatusResult,
+    inOutbox: Boolean,
+    isCheckedOut: Boolean,
+    nextRunTimeRaw: Long?,
+    nowMs: Long,
+): RetryUiState {
+    if (!inOutbox) {
+        return RetryUiState(base.sendState, base.retryMode, base.canRetry, canTryNow = false, nextAttemptInMinutes = null)
+    }
+    val minutes = when {
+        isCheckedOut -> null
+        nextRunTimeRaw == null || nextRunTimeRaw < MIN_PLAUSIBLE_MS_EPOCH -> 0L
+        else -> ((nextRunTimeRaw - nowMs).coerceAtLeast(0L)) / 60_000L
+    }
+    return RetryUiState(
+        sendState = OutgoingSendState.Queued,
+        retryMode = null,
+        canRetry = false,
+        canTryNow = !isCheckedOut,
+        nextAttemptInMinutes = minutes,
+    )
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoViewModel.kt
@@ -8,6 +8,8 @@ import co.touchlab.kermit.Logger
 import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.common.OdinId
+import id.homebase.api.common.time.UnixTimeUtc
+import id.homebase.api.sync.database.OutboxSync
 import id.homebase.chat.services.ChatDeliveryStatus
 import id.homebase.chat.services.ChatMessageActionService
 import id.homebase.chat.services.ChatMessageSenderService
@@ -21,6 +23,7 @@ import id.homebase.core.ui.navigation.Route
 import id.homebase.resources.MR
 import id.homebase.resources.msg_retry_failed
 import id.homebase.resources.msg_retry_media_unavailable
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -37,6 +40,7 @@ class MessageInfoViewModel(
     private val contactService: ContactService,
     private val chatMessageActionService: ChatMessageActionService,
     private val chatMessageSenderService: ChatMessageSenderService,
+    private val outboxSync: OutboxSync,
 ) : ViewModel() {
 
     val messageInfo = savedStateHandle.toRoute<Route.MessageInfo>()
@@ -47,12 +51,16 @@ class MessageInfoViewModel(
     // message (or vice-versa) can't kick it twice.
     private var serverCheckStarted = false
 
+    // Same one-shot guard for the outbox-row read (Queued / Try-now display).
+    private var outboxReadStarted = false
+
     init {
         viewModelScope.launch {
             ownerSessionRepository.user.collect { session ->
                 _uiState.update { it.copy(ownerSession = session) }
                 recomputeSendStatus()
                 startServerCheckIfNeeded()
+                startOutboxReadIfNeeded()
             }
         }
         viewModelScope.launch {
@@ -68,6 +76,7 @@ class MessageInfoViewModel(
                 }
                 recomputeSendStatus()
                 startServerCheckIfNeeded()
+                startOutboxReadIfNeeded()
 
                 // Load transfer history
                 viewModelScope.launch {
@@ -157,13 +166,48 @@ class MessageInfoViewModel(
                 deliveryFailed = message.messageAppData.deliveryStatus == ChatDeliveryStatus.Failed.value,
                 serverPresence = state.serverPresence,
             )
+            // The outbox row (when present) overrides the tag/server view —
+            // a queued item is "still sending", whatever the tags claim.
+            val overlay = retryUiState(
+                base = result,
+                inOutbox = isOwn && state.outboxRow != null,
+                isCheckedOut = state.outboxRow?.isCheckedOut == true,
+                nextRunTimeRaw = state.outboxRow?.nextRunTime,
+                nowMs = UnixTimeUtc.now().milliseconds,
+            )
             state.copy(
                 isOwnMessage = isOwn,
-                sendState = result.sendState,
-                retryMode = result.retryMode,
-                canRetry = result.canRetry,
+                sendState = overlay.sendState,
+                retryMode = overlay.retryMode,
+                canRetry = overlay.canRetry,
+                canTryNow = overlay.canTryNow,
+                nextAttemptInMinutes = overlay.nextAttemptInMinutes,
             )
         }
+    }
+
+    /**
+     * One-shot read of the message's pending outbox row at open (own message
+     * still pending or failed only). A row means the send is queued/backed-off:
+     * the screen shows Queued + "next attempt in ~N min" + Try now instead of
+     * the bare Sending spinner or a Retry that would be a no-op.
+     */
+    private fun startOutboxReadIfNeeded() {
+        if (outboxReadStarted) return
+        val state = _uiState.value
+        val message = state.message ?: return
+        if (!message.isAuthoredBy(state.ownerSession?.odinId)) return
+        if (!message.isPendingSend && !message.isFailedSend) return
+
+        outboxReadStarted = true
+        viewModelScope.launch { refreshOutboxRow() }
+    }
+
+    private suspend fun refreshOutboxRow() {
+        val message = _uiState.value.message ?: return
+        val row = outboxSync.pendingRowSnapshot(chatTargetDrive.alias, message.id)
+        _uiState.update { it.copy(outboxRow = row) }
+        recomputeSendStatus()
     }
 
     /**
@@ -201,6 +245,26 @@ class MessageInfoViewModel(
         when (action) {
             is MessageInfoUiAction.BackClicked -> _uiState.update { it.copy(uiEvent = MessageInfoUiEvent.Back) }
             is MessageInfoUiAction.RetryClicked -> retryFailedSend()
+            is MessageInfoUiAction.TryNowClicked -> tryNow()
+        }
+    }
+
+    /**
+     * Reset the queued item's backoff so it runs immediately
+     * ([OutboxSync.runNow]). Optimistically collapses the wait to "shortly";
+     * one delayed re-read then settles the row's real state (usually gone →
+     * back to the plain tag-derived status). No polling loop — the screen is
+     * a snapshot, not a live monitor.
+     */
+    private fun tryNow() {
+        val state = _uiState.value
+        val message = state.message ?: return
+        if (!state.canTryNow) return
+        _uiState.update { it.copy(canTryNow = false, nextAttemptInMinutes = 0L) }
+        viewModelScope.launch {
+            outboxSync.runNow(chatTargetDrive.alias, message.id)
+            delay(POST_TRY_NOW_REFRESH_MS)
+            refreshOutboxRow()
         }
     }
 
@@ -224,11 +288,12 @@ class MessageInfoViewModel(
                 ResendOutcome.EnqueuedUpdate,
                 ResendOutcome.AlreadyQueued -> {
                     Logger.i { "MessageInfo: retry enqueued ($outcome) uniqueId=${message.id}" }
-                    // Refresh so the swapped tags (failed→pending) drive any later
-                    // recompute instead of the stale Failed snapshot.
+                    // Refresh so the swapped tags (failed→pending) and the fresh
+                    // outbox row drive any later recompute instead of the stale
+                    // Failed snapshot.
                     val refreshed = chatMessageStream.getMessage(message.id)
                     _uiState.update { it.copy(message = refreshed ?: it.message) }
-                    recomputeSendStatus()
+                    refreshOutboxRow()
                 }
 
                 ResendOutcome.UnrecoverableMedia ->
@@ -250,5 +315,11 @@ class MessageInfoViewModel(
 
     fun eventConsumed() {
         _uiState.update { it.copy(uiEvent = null) }
+    }
+
+    private companion object {
+        /** Single post-Try-now settle re-read — long enough for a fast send to
+         *  drain the row, short enough to feel responsive. */
+        const val POST_TRY_NOW_REFRESH_MS = 3_000L
     }
 }

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/messageinfo/RetryUiStateTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/messageinfo/RetryUiStateTest.kt
@@ -1,0 +1,109 @@
+package id.homebase.chat.messageinfo
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * [retryUiState] — the outbox-row overlay on top of [deriveSendStatus]. A
+ * pending outbox row is authoritative "still sending": Queued + Try-now wins
+ * over both the Sending spinner and a (theoretically stale) Failed/Retry.
+ */
+class RetryUiStateTest {
+
+    private val nowMs = 1_780_000_000_000L // a current-era ms epoch
+
+    private val failedBase = SendStatusResult(OutgoingSendState.Failed, RetryMode.Create, canRetry = true)
+    private val sendingBase = SendStatusResult(OutgoingSendState.Sending, null, canRetry = false)
+    private val sentBase = SendStatusResult(OutgoingSendState.Sent, null, canRetry = false)
+
+    // ---- no outbox row: base passes through ----
+
+    @Test
+    fun noRowPassesTheBaseThroughUntouched() {
+        for (base in listOf(failedBase, sendingBase, sentBase)) {
+            val result = retryUiState(base, inOutbox = false, isCheckedOut = false, nextRunTimeRaw = null, nowMs = nowMs)
+            assertEquals(base.sendState, result.sendState)
+            assertEquals(base.retryMode, result.retryMode)
+            assertEquals(base.canRetry, result.canRetry)
+            assertFalse(result.canTryNow)
+            assertNull(result.nextAttemptInMinutes)
+        }
+    }
+
+    // ---- row present: Queued is authoritative ----
+
+    @Test
+    fun queuedRowOverridesSendingWithTryNow() {
+        val result = retryUiState(
+            sendingBase, inOutbox = true, isCheckedOut = false,
+            nextRunTimeRaw = nowMs + 10 * 60_000L, nowMs = nowMs,
+        )
+        assertEquals(OutgoingSendState.Queued, result.sendState)
+        assertFalse(result.canRetry)
+        assertTrue(result.canTryNow)
+        assertEquals(10L, result.nextAttemptInMinutes)
+    }
+
+    @Test
+    fun queuedRowSuppressesRetryEvenForAFailedBase() {
+        val result = retryUiState(
+            failedBase, inOutbox = true, isCheckedOut = false,
+            nextRunTimeRaw = nowMs + 60_000L, nowMs = nowMs,
+        )
+        assertEquals(OutgoingSendState.Queued, result.sendState)
+        assertFalse(result.canRetry, "a queued message must never offer Retry")
+        assertNull(result.retryMode)
+        assertTrue(result.canTryNow)
+    }
+
+    @Test
+    fun checkedOutRowShowsNoTryNowAndNoDeadline() {
+        val result = retryUiState(
+            sendingBase, inOutbox = true, isCheckedOut = true,
+            nextRunTimeRaw = nowMs + 60_000L, nowMs = nowMs,
+        )
+        assertEquals(OutgoingSendState.Queued, result.sendState)
+        assertFalse(result.canTryNow, "resetting an in-flight upload is meaningless")
+        assertNull(result.nextAttemptInMinutes)
+    }
+
+    // ---- deadline normalization ----
+
+    @Test
+    fun pastDeadlineFloorsToZeroMinutes() {
+        val result = retryUiState(
+            sendingBase, inOutbox = true, isCheckedOut = false,
+            nextRunTimeRaw = nowMs - 5_000L, nowMs = nowMs,
+        )
+        assertEquals(0L, result.nextAttemptInMinutes)
+    }
+
+    @Test
+    fun insertSentinelsAndLegacySecondsEpochsReadAsShortly() {
+        // 0 and 42 are fresh-insert/clearCheckedOut sentinels; ~1.7e9 is a
+        // legacy seconds-epoch row written before the checkInFailed unit fix.
+        for (raw in listOf(0L, 42L, 1_780_000_000L)) {
+            val result = retryUiState(
+                sendingBase, inOutbox = true, isCheckedOut = false,
+                nextRunTimeRaw = raw, nowMs = nowMs,
+            )
+            assertEquals(
+                0L, result.nextAttemptInMinutes,
+                "raw=$raw must normalize to 'shortly', not a year-count of minutes",
+            )
+            assertTrue(result.canTryNow)
+        }
+    }
+
+    @Test
+    fun subMinuteWaitRoundsDownToShortly() {
+        val result = retryUiState(
+            sendingBase, inOutbox = true, isCheckedOut = false,
+            nextRunTimeRaw = nowMs + 45_000L, nowMs = nowMs,
+        )
+        assertEquals(0L, result.nextAttemptInMinutes)
+    }
+}

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -75,6 +75,10 @@
     <string name="action_retry">Prøv igen</string>
     <string name="msg_retry_media_unavailable">Vedhæftningen er ikke længere tilgængelig — den kan ikke sendes igen</string>
     <string name="msg_retry_failed">Kunne ikke prøve igen — tjek din forbindelse</string>
+    <string name="msg_still_in_outbox">Sender stadig — næste forsøg %1$s</string>
+    <string name="msg_next_attempt_minutes">om ca. %1$d min.</string>
+    <string name="msg_next_attempt_shortly">om lidt</string>
+    <string name="action_try_now">Prøv nu</string>
     <string name="label_edited">Redigeret: %1$s</string>
     <string name="label_size">Størrelse: %1$s</string>
     <string name="label_message_id">ID: %1$s</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -51,6 +51,10 @@
     <string name="action_retry">Retry</string>
     <string name="msg_retry_media_unavailable">The attachment is no longer available — it can’t be resent</string>
     <string name="msg_retry_failed">Couldn’t retry — check your connection</string>
+    <string name="msg_still_in_outbox">Still sending — next attempt %1$s</string>
+    <string name="msg_next_attempt_minutes">in about %1$d min</string>
+    <string name="msg_next_attempt_shortly">shortly</string>
+    <string name="action_try_now">Try now</string>
     <string name="label_edited">Edited: %1$s</string>
     <string name="label_size">Size: %1$s</string>
     <string name="label_message_id">ID: %1$s</string>


### PR DESCRIPTION
## Summary

Second PR of the retry plan, stacked on #698. A message still queued in the outbox (mid-backoff) now shows an honest **Queued** status in Message Info — "Still sending — next attempt in about N min" — with a **Try now** button that makes it run immediately. A queued message never offers Retry; the queued send already covers it.

### Found during implementation: in-session outbox retries have never run

The plan flagged a seconds-vs-milliseconds bug in the backoff deadline. Writing the regression test exposed a second, masking bug:

1. **Swapped `checkInFailed` arguments** (`OutboxWrapper`): the generated query's parameter order is `(nextRunTime, checkOutStamp)` — SQL appearance order — but the wrapper passed them positionally reversed. Both are `Long`, so it compiled; the `WHERE checkOutStamp = ?` then compared against the deadline and **matched nothing**. A failed upload's row stayed checked out forever (a zombie) and was only revived by the next app start's `clearCheckedOut`.
2. **Units**: the `OutboxSync` call site stored `UnixTimeUtc.….seconds` while `checkout`/`nextScheduled` compare a **milliseconds** epoch — so even a matching check-in would have been instantly re-eligible.

Net effect before this PR: the designed 30s→4h exponential backoff never ran in-session; failed sends retried only across app restarts. Both are fixed (named arguments + `.milliseconds`), each pinned by its own regression test (`OutboxSetNextRunTimeTest`). This is a real behavior change: failed uploads now retry within the session on the backoff schedule — which is exactly what makes the Try-now button meaningful.

### Feature

- `Outbox.sq setNextRunTime` — guarded on `checkOutStamp IS NULL` (an in-flight row's deadline is owned by `checkInFailed`); `OutboxSync.runNow` resets the deadline and kicks `send()`; `pendingRowSnapshot` exposes `(nextRunTime, checkOutCount, isCheckedOut)` for display without deserializing the request json.
- `retryUiState()` (pure, tested) layers the outbox row over `deriveSendStatus()`: row present → **Queued** (overrides both Sending and a stale Failed), checked-out row → no Try-now/no deadline, and raw deadlines below a plausible ms epoch (fresh-insert sentinels `0`/`42`, legacy seconds-epoch rows written by the pre-fix code) normalize to "shortly".
- ViewModel reads the row once at open (own pending/failed messages only); Try now optimistically collapses the wait and one delayed re-read settles the real state — no polling. Strings en + da.

## Tests

- `OutboxSetNextRunTimeTest`: backed-off row not eligible until its deadline; `checkInFailed` must match the checked-out row (zombie regression); `setNextRunTime` makes a backed-off row immediately eligible, refuses checked-out rows, no-ops on missing rows; a failed attempt **through the send loop** stores a future ms deadline (unit regression).
- `RetryUiStateTest`: pass-through without a row; Queued overrides Sending and suppresses Retry even for a Failed base; checked-out → no button; sentinel/legacy/past/sub-minute deadline normalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)