### PR TITLE
fix(stickers): unify sticker upload spinner with sent-image loading treatment

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/StickerTray.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/StickerTray.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -167,12 +168,22 @@ private fun StickerTile(
     }
 }
 
-/** Small centered spinner used for a sticker tile that is uploading / loading its thumbnail. */
+/**
+ * Small centered spinner used for a sticker tile that is uploading / loading its thumbnail.
+ * Matches the sent-image upload treatment (a white indicator + translucent track on a dark
+ * scrim, see [id.homebase.chat.widget.MediaMessage]) so a still-uploading sticker reads the
+ * same as any other media that is still arriving, instead of the default `primary` blue.
+ */
 @Composable
 private fun StickerTileSpinner(modifier: Modifier = Modifier) {
-    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+    Box(
+        modifier = modifier.background(Color.Black.copy(alpha = 0.35f)),
+        contentAlignment = Alignment.Center,
+    ) {
         CircularProgressIndicator(
             modifier = Modifier.sizeIn(maxWidth = 20.dp, maxHeight = 20.dp),
+            color = Color.White,
+            trackColor = Color.White.copy(alpha = 0.2f),
             strokeWidth = 2.dp,
         )
     }


### PR DESCRIPTION
## Summary
The sticker upload indicator (`StickerTileSpinner`, shown while a just-added sticker uploads or while its thumbnail loads) used the default Material3 `primary` blue. That read inconsistently next to the app's established sent-image upload indicator, which is a **white spinner + translucent track on a dark scrim** (`MediaMessage` / `MediaItem`). This unifies the sticker upload spinner with that treatment.

Note: the sticker spinners were already on the app-default `primary` — so simply "adding `color = primary`" would have been a no-op. The real mismatch was against the sent-image white-on-scrim convention.

## Scope
- Changed only `StickerTileSpinner` — the genuine sticker **upload** indicator.
- Left the create-dialog spinner and the tray DB-hydration spinner unchanged (not image-upload contexts; white-on-scrim would be invisible on their light surfaces).

## Verification
- `:homebase-chat:compileKotlinJvm` ✅ (cosmetic common-API change; CI covers other targets)
- Visual: scrim treatment in the tray grid is best eyeballed on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)