### PR TITLE
fix(chat): show local thumbnail for pending link preview (no broken-image icon)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LinkPreview.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LinkPreview.kt
@@ -234,8 +234,11 @@ fun LinkPreviewCard(
  * @param payloadKey Payload key (e.g. `PAYLOAD_KEY_LINKS`).
  * @param keyHeader Key header for decryption.
  * @param previewThumbnail Optional embedded tiny thumbnail for instant display.
+ * @param isUploading If true, the message is still being sent and its payload does not yet exist on
+ * the drive — render the embedded [previewThumbnail] directly instead of attempting a drive fetch.
  * @param modifier Modifier for the composable.
  */
+@OptIn(ExperimentalEncodingApi::class, ExperimentalResourceApi::class)
 @Composable
 fun LinkPreviewCard(
     descriptor: LinkPreviewDescriptor,
@@ -244,10 +247,31 @@ fun LinkPreviewCard(
     payloadKey: String,
     keyHeader: KeyHeader,
     previewThumbnail: EmbeddedThumb? = null,
+    isUploading: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
     val uriHandler = LocalUriHandler.current
     val domain = extractDomain(descriptor.url)
+
+    val imageCornerShape = RoundedCornerShape(
+        topStart = Dimens.Message.cornerRadius, topEnd = Dimens.Message.cornerRadius
+    )
+
+    // While the message is pending/uploading the drive payload does not exist yet, so a
+    // HomebaseImage fetch would fail and overlay a broken-image triangle. Decode the embedded
+    // tinyThumb (always a tiny WebP, base64) and show it directly during that window — mirroring
+    // how a pending sent IMAGE renders its local file instead of the remote drive payload. Once
+    // the send completes the bubble re-renders with isUploading=false and swaps to HomebaseImage.
+    val pendingThumbBitmap = remember(previewThumbnail?.content, isUploading) {
+        if (!isUploading) return@remember null
+        previewThumbnail?.content?.let {
+            try {
+                Base64.decode(it).decodeToImageBitmap()
+            } catch (_: Exception) {
+                null
+            }
+        }
+    }
 
     Column(
         modifier = modifier.fillMaxWidth()
@@ -256,30 +280,34 @@ fun LinkPreviewCard(
             .clickable { uriHandler.openUri(descriptor.url) },
     ) {
         if (descriptor.hasImage) {
-            val imageData = remember(driveId, fileId, payloadKey) {
-                HomebaseImageData(
-                    driveId = driveId,
-                    fileId = fileId,
-                    payloadKey = payloadKey,
-                    previewThumbnail = previewThumbnail,
-                    requestedSize = ImageSize.THUMB_MEDIUM,
-                    isEncrypted = true,
-                    keyHeader = keyHeader,
-                    loadFullPayload = true,
+            if (pendingThumbBitmap != null) {
+                Image(
+                    bitmap = pendingThumbBitmap,
+                    contentDescription = descriptor.title,
+                    modifier = Modifier.fillMaxWidth().heightIn(max = 180.dp).clip(imageCornerShape),
+                    contentScale = ContentScale.Crop,
+                )
+            } else {
+                val imageData = remember(driveId, fileId, payloadKey) {
+                    HomebaseImageData(
+                        driveId = driveId,
+                        fileId = fileId,
+                        payloadKey = payloadKey,
+                        previewThumbnail = previewThumbnail,
+                        requestedSize = ImageSize.THUMB_MEDIUM,
+                        isEncrypted = true,
+                        keyHeader = keyHeader,
+                        loadFullPayload = true,
+                    )
+                }
+
+                HomebaseImage(
+                    imageData = imageData,
+                    modifier = Modifier.fillMaxWidth().heightIn(max = 180.dp).clip(imageCornerShape),
+                    contentScale = ContentScale.Crop,
+                    contentDescription = descriptor.title,
                 )
             }
-
-            HomebaseImage(
-                imageData = imageData,
-                modifier = Modifier.fillMaxWidth().heightIn(max = 180.dp).clip(
-                    RoundedCornerShape(
-                        topStart = Dimens.Message.cornerRadius, topEnd = Dimens.Message.cornerRadius
-                    )
-                ),
-                contentScale = ContentScale.Crop,
-                contentDescription = descriptor.title,
-
-                )
         }
 
         Column(modifier = Modifier.padding(12.dp)) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
@@ -184,6 +184,7 @@ fun MediaItem(
                     keyHeader = KeyHeader(payloadIv, keyHeader.aesKey),
                     previewThumbnail = payload.previewThumbnail?.toEmbeddedThumb()
                         ?: previewThumbnail,
+                    isUploading = isUploading,
                     modifier = baseModifier,
                 )
             } else {

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/LinkPreviewPendingImageTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/LinkPreviewPendingImageTest.kt
@@ -1,0 +1,70 @@
+package id.homebase.chat.widget
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.drives.upload.EmbeddedThumb
+import id.homebase.api.common.SecureByteArray
+import id.homebase.chat.services.builder.LinkPreviewDescriptor
+import kotlin.test.Test
+import kotlin.uuid.Uuid
+
+/**
+ * Locks the pending/upload behaviour of the receiver-side [LinkPreviewCard].
+ *
+ * While a link-preview message is still uploading, its drive payload does not exist yet, so the
+ * normal [id.homebase.core.image.HomebaseImage] fetch would fail and overlay a broken-image
+ * triangle. The card must instead decode and show the embedded tinyThumb directly.
+ *
+ * The test environment intentionally has NO Koin container. [HomebaseImage] resolves an
+ * `ImageLoader` via `koinInject()` during composition, so any path that reaches it throws. The
+ * `isUploading = true` case below renders to completion (title + description visible), which proves
+ * it took the embedded-thumbnail branch and never touched HomebaseImage.
+ */
+@OptIn(ExperimentalTestApi::class)
+class LinkPreviewPendingImageTest {
+
+    // 1x1 transparent PNG — decodes under Skiko/Android image decoders. Used as the embedded
+    // tinyThumb so the pending branch produces a non-null bitmap.
+    private val onePxPngBase64 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+
+    private val keyHeader = KeyHeader(iv = ByteArray(16), aesKey = SecureByteArray(ByteArray(32)))
+
+    private val descriptor = LinkPreviewDescriptor(
+        url = "https://example.com/article",
+        hasImage = true,
+        imageWidth = 1,
+        imageHeight = 1,
+        title = "Pending Title",
+        description = "Pending Description",
+    )
+
+    @Test
+    fun whileUploading_rendersEmbeddedThumbnail_withoutHittingHomebaseImage() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                LinkPreviewCard(
+                    descriptor = descriptor,
+                    fileId = Uuid.random(),
+                    driveId = Uuid.random(),
+                    payloadKey = "chat_links",
+                    keyHeader = keyHeader,
+                    previewThumbnail = EmbeddedThumb(
+                        pixelWidth = 1,
+                        pixelHeight = 1,
+                        contentType = "image/png",
+                        content = onePxPngBase64,
+                    ),
+                    isUploading = true,
+                )
+            }
+        }
+        // Composition completed (no Koin/ImageLoader required) and the card body rendered,
+        // confirming the embedded-thumbnail branch was taken instead of HomebaseImage.
+        onNodeWithText("Pending Title").assertExists()
+        onNodeWithText("Pending Description").assertExists()
+    }
+}


### PR DESCRIPTION
## Summary
When you send a message containing a link preview, the preview image showed a gray broken-image triangle **while the message was still uploading**, even though the local thumbnail was available the whole time.

## Root cause
The receiver-side `LinkPreviewCard` always built a `HomebaseImageData` pointed at the drive payload (`driveId/fileId/payloadKey`), which does not exist on the drive yet during the upload window → Coil fetch fails → `HomebaseImage` lands in its error branch and overlays the triangle. The `isUploading` signal was already in scope at the `MediaItem` link branch but was never passed through.

## Fix (surgical, at the call site)
- Thread `isUploading` into the receiver-side `LinkPreviewCard`.
- While uploading, decode and render the embedded `previewThumbnail` (tinyThumb) directly — mirroring how a pending **sent image** renders its local file instead of the remote payload.
- On send completion the bubble re-renders with `isUploading = false` and swaps to `HomebaseImage` (which still receives the thumbnail, so no flash).
- `HomebaseImage`'s global error rendering is **not** changed — the triangle still appears for genuine permanent failures of non-pending images.

## Verification
- `:homebase-chat:compileKotlinJvm` / `compileAndroidMain` / `compileKotlinIosSimulatorArm64` ✅
- New `LinkPreviewPendingImageTest` passes (asserts the pending branch renders without resolving a Coil `ImageLoader`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)