### PR TITLE
feat(stickers): WhatsApp-style sticker tap → options bottom sheet

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
@@ -319,6 +319,26 @@ sealed interface ConversationListUiAction {
         val sticker: id.homebase.chat.services.sticker.SavedSticker,
     ) : ConversationListUiAction
 
+    /**
+     * Tapping a sticker message bubble. Opens the sticker-options bottom sheet (Add/Remove +
+     * Save to device) instead of the fullscreen media viewer.
+     */
+    data class ShowStickerOptions(
+        val message: MessageUiModel,
+        val payloadKey: String,
+    ) : ConversationListUiAction
+
+    /** Dismiss the sticker-options bottom sheet. */
+    data object DismissStickerOptions : ConversationListUiAction
+
+    /**
+     * "Remove from my stickers" in the sticker-options sheet. Deletes the saved copy created
+     * from the given source message file; does NOT delete the chat message.
+     */
+    data class RemoveStickerFromMessage(
+        val sourceFileId: Uuid,
+    ) : ConversationListUiAction
+
     /** Ensure the optional Stickers drive is mounted (first tray open). */
     data object EnsureStickerDriveMounted : ConversationListUiAction
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -83,6 +83,8 @@ data class MessageListUiState(
     val messageReactions: List<ReactionDisplayItem>? = null,
     val reactionDetailsMessageId: Uuid? = null,
     val isReactionsLoading: Boolean = false,
+    /** Non-null while the sticker-tap bottom sheet is open; null otherwise. */
+    val stickerOptionsSheet: StickerOptionsSheetState? = null,
     val downloadingFiles: Set<String> = emptySet(),
     val recordingData: RecordingData? = null,
     val uiSheet: MessageListUiSheet? = null,
@@ -133,6 +135,23 @@ data class ReplyTargetEventDetail(
     val ownReactions: ImmutableList<String>,
     val reactionSummary: ReactionSummary?,
     val organizer: OdinId?,
+)
+
+/**
+ * State for the sticker-tap bottom sheet (WhatsApp-style). Opening a sticker bubble routes
+ * here instead of the fullscreen viewer; the sheet offers "Add to my stickers" /
+ * "Remove from my stickers" (by [isAlreadySaved]) and "Save to device".
+ *
+ * [sourceFileId] is the chat message's fileId — used both to remove the saved copy created
+ * from this message and to recompute "already saved" when the library changes while the sheet
+ * is open. [payloadKey] addresses the sticker image payload for the device-export path.
+ */
+@Immutable
+data class StickerOptionsSheetState(
+    val messageId: Uuid,
+    val payloadKey: String,
+    val sourceFileId: Uuid,
+    val isAlreadySaved: Boolean,
 )
 
 @Immutable

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -16,6 +16,7 @@ import id.homebase.chat.services.ReplyPreview
 import id.homebase.chat.services.convo.EnrichedConversationUiModel
 import id.homebase.core.avatars.AppConnectionStatus
 import id.homebase.core.gallery.GalleryImage
+import id.homebase.core.image.HomebaseImageData
 import id.homebase.core.util.ScrollPosition
 import id.homebase.core.widget.ReactionDisplayItem
 import io.github.vinceglb.filekit.PlatformFile
@@ -145,6 +146,8 @@ data class ReplyTargetEventDetail(
  * [sourceFileId] is the chat message's fileId — used both to remove the saved copy created
  * from this message and to recompute "already saved" when the library changes while the sheet
  * is open. [payloadKey] addresses the sticker image payload for the device-export path.
+ * [stickerImage] is the render descriptor for the larger in-sheet preview (built once when the
+ * sheet opens, reusing the same drive/keyHeader the bubble used).
  */
 @Immutable
 data class StickerOptionsSheetState(
@@ -152,6 +155,7 @@ data class StickerOptionsSheetState(
     val payloadKey: String,
     val sourceFileId: Uuid,
     val isAlreadySaved: Boolean,
+    val stickerImage: HomebaseImageData,
 )
 
 @Immutable

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -246,6 +246,7 @@ class ConversationListViewModel(
         scope = viewModelScope,
         messagesUiState = _messagesUiState,
         stickerService = stickerService,
+        stickerStream = stickerStream,
         chatMessageActionService = chatMessageActionService,
         sendEvent = ::sendEvent,
         addMessageWithFiles = messageActionsHandler::addMessageWithFiles,
@@ -1101,6 +1102,16 @@ class ConversationListViewModel(
             is ConversationListUiAction.DismissStickerCreate -> stickerCreator.dismiss()
 
             is ConversationListUiAction.RemoveSticker -> stickerHandler.handleRemoveSticker(action)
+
+            // Sticker-tap bottom sheet (WhatsApp-style): open the sheet, dismiss it, or
+            // remove the saved copy created from this message. "Add to my stickers" reuses
+            // SaveStickerFromMessage; "Save to device" reuses DownloadMedia.
+            is ConversationListUiAction.ShowStickerOptions ->
+                stickerHandler.handleShowStickerOptions(action)
+            is ConversationListUiAction.DismissStickerOptions ->
+                stickerHandler.handleDismissStickerOptions()
+            is ConversationListUiAction.RemoveStickerFromMessage ->
+                stickerHandler.handleRemoveStickerFromMessage(action)
         }
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MediaDownloadHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MediaDownloadHandler.kt
@@ -2,6 +2,7 @@ package id.homebase.chat.conversationlist
 
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.drives.files.DescriptorContent
 import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.coroutines.ioDispatcher
 import id.homebase.api.file.FileOperationsProvider
@@ -315,7 +316,23 @@ internal class MediaDownloadHandler(
                     action.message.payloads?.firstOrNull { it.key == action.payloadKey }
                         ?: return@launch
                 val contentType = selectedPayload.contentType ?: ""
+                // A sticker tap (WhatsApp-style) opens the sticker-options bottom sheet — add/
+                // remove from the user's library + save to device — instead of the fullscreen
+                // viewer. Detected the same way the bubble decides to render bare (PR #664
+                // descriptorContent {"isSticker":true}). Regular images fall through to the
+                // fullscreen path unchanged.
+                val isSticker =
+                    (selectedPayload.descriptorInfo() as? DescriptorContent.ImageFile)?.isSticker == true
                 when {
+                    contentType.startsWith("image/") && isSticker -> {
+                        dispatch(
+                            ConversationListUiAction.ShowStickerOptions(
+                                message = action.message,
+                                payloadKey = action.payloadKey,
+                            )
+                        )
+                    }
+
                     contentType.startsWith("image/") -> {
                         Logger.d("Image clicked: ${action.message.id}:${action.payloadKey}")
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/StickerHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/StickerHandler.kt
@@ -10,6 +10,8 @@ import id.homebase.chat.services.sticker.SavedSticker
 import id.homebase.chat.services.sticker.StickerService
 import id.homebase.chat.services.sticker.StickerStream
 import id.homebase.core.clipboard.platformFileFromPath
+import id.homebase.core.config.chatTargetDrive
+import id.homebase.core.image.HomebaseImageData
 import id.homebase.resources.MR
 import id.homebase.resources.chat_sticker_remove_failed
 import id.homebase.resources.chat_sticker_removed
@@ -141,6 +143,20 @@ internal class StickerHandler(
     fun handleShowStickerOptions(action: ConversationListUiAction.ShowStickerOptions) {
         val message = action.message
         val isAlreadySaved = findSavedFromMessage(message.fileId) != null
+        val stickerPayload = message.payloads?.firstOrNull { it.key == action.payloadKey }
+        val stickerImage = HomebaseImageData(
+            driveId = chatTargetDrive.alias,
+            fileId = message.fileId,
+            payloadKey = action.payloadKey,
+            previewThumbnail = stickerPayload?.previewThumbnail?.toEmbeddedThumb()
+                ?: message.previewThumbnail,
+            // Load the full sticker (a small payload) so the enlarged preview is crisp and animates
+            // for animated-WebP/GIF stickers, matching the bubble's inline treatment.
+            loadFullPayload = true,
+            isEncrypted = true,
+            payloadContentType = stickerPayload?.contentType,
+            keyHeader = message.keyHeader,
+        )
         messagesUiState.update {
             it.copy(
                 stickerOptionsSheet = StickerOptionsSheetState(
@@ -148,6 +164,7 @@ internal class StickerHandler(
                     payloadKey = action.payloadKey,
                     sourceFileId = message.fileId,
                     isAlreadySaved = isAlreadySaved,
+                    stickerImage = stickerImage,
                 )
             )
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/StickerHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/StickerHandler.kt
@@ -6,7 +6,9 @@ import co.touchlab.kermit.Logger
 import id.homebase.api.client.KeyHeader
 import id.homebase.chat.conversationlist.ConversationListUiEvent.ShowInfoMessage
 import id.homebase.chat.services.ChatMessageActionService
+import id.homebase.chat.services.sticker.SavedSticker
 import id.homebase.chat.services.sticker.StickerService
+import id.homebase.chat.services.sticker.StickerStream
 import id.homebase.core.clipboard.platformFileFromPath
 import id.homebase.resources.MR
 import id.homebase.resources.chat_sticker_remove_failed
@@ -16,6 +18,7 @@ import id.homebase.resources.chat_sticker_saved
 import id.homebase.resources.chat_sticker_send_failed
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
@@ -38,6 +41,7 @@ internal class StickerHandler(
     private val scope: CoroutineScope,
     private val messagesUiState: MutableStateFlow<MessageListUiState>,
     private val stickerService: StickerService,
+    private val stickerStream: StickerStream,
     private val chatMessageActionService: ChatMessageActionService,
     private val sendEvent: (ConversationListUiEvent) -> Unit,
     private val addMessageWithFiles: (conversationId: Uuid, content: String, files: List<AttachmentPendingFile>) -> Unit,
@@ -99,6 +103,9 @@ internal class StickerHandler(
                     bytes = bytes,
                     contentType = payload.contentType ?: "image/png",
                     scope = scope,
+                    // Record which message this sticker came from, so a later sheet open can
+                    // detect it's already saved and offer "Remove" instead of "Add".
+                    sourceFileId = message.fileId,
                 )
                 sendEvent(
                     ShowInfoMessage(
@@ -124,4 +131,55 @@ internal class StickerHandler(
             }
         }
     }
+
+    /**
+     * Tapping a sticker bubble opens the sticker-options bottom sheet instead of the
+     * fullscreen viewer. We compute whether this received sticker is already in the user's
+     * library — by matching any [SavedSticker.sourceFileId] to this message's fileId — so the
+     * sheet shows "Add to my stickers" or "Remove from my stickers" accordingly.
+     */
+    fun handleShowStickerOptions(action: ConversationListUiAction.ShowStickerOptions) {
+        val message = action.message
+        val isAlreadySaved = findSavedFromMessage(message.fileId) != null
+        messagesUiState.update {
+            it.copy(
+                stickerOptionsSheet = StickerOptionsSheetState(
+                    messageId = message.id,
+                    payloadKey = action.payloadKey,
+                    sourceFileId = message.fileId,
+                    isAlreadySaved = isAlreadySaved,
+                )
+            )
+        }
+    }
+
+    fun handleDismissStickerOptions() {
+        messagesUiState.update { it.copy(stickerOptionsSheet = null) }
+    }
+
+    /**
+     * "Remove from my stickers" arm of the sheet: deletes the saved copy that was created from
+     * this message (matched by [SavedSticker.sourceFileId]) WITHOUT touching the chat message
+     * itself. No-op (with a failure toast) if no matching saved sticker is found.
+     */
+    fun handleRemoveStickerFromMessage(action: ConversationListUiAction.RemoveStickerFromMessage) {
+        scope.launch {
+            try {
+                val saved = findSavedFromMessage(action.sourceFileId)
+                if (saved == null) {
+                    sendEvent(ShowInfoMessage(MR.string.chat_sticker_remove_failed))
+                    return@launch
+                }
+                val ok = stickerService.deleteSticker(saved)
+                if (ok) sendEvent(ShowInfoMessage(MR.string.chat_sticker_removed))
+                else sendEvent(ShowInfoMessage(MR.string.chat_sticker_remove_failed))
+            } catch (e: Exception) {
+                Logger.e(e, TAG) { "Failed to remove sticker from message" }
+                sendEvent(ShowInfoMessage(MR.string.chat_sticker_remove_failed))
+            }
+        }
+    }
+
+    private fun findSavedFromMessage(sourceFileId: Uuid): SavedSticker? =
+        stickerStream.stickers.value.firstOrNull { it.sourceFileId == sourceFileId }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/StickerHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/StickerHandler.kt
@@ -12,6 +12,7 @@ import id.homebase.chat.services.sticker.StickerStream
 import id.homebase.core.clipboard.platformFileFromPath
 import id.homebase.core.config.chatTargetDrive
 import id.homebase.core.image.HomebaseImageData
+import id.homebase.core.image.ImageSize
 import id.homebase.resources.MR
 import id.homebase.resources.chat_sticker_remove_failed
 import id.homebase.resources.chat_sticker_removed
@@ -144,18 +145,22 @@ internal class StickerHandler(
         val message = action.message
         val isAlreadySaved = findSavedFromMessage(message.fileId) != null
         val stickerPayload = message.payloads?.firstOrNull { it.key == action.payloadKey }
+        val payloadIv = stickerPayload?.iv?.let { Base64.decode(it) }
         val stickerImage = HomebaseImageData(
             driveId = chatTargetDrive.alias,
             fileId = message.fileId,
             payloadKey = action.payloadKey,
             previewThumbnail = stickerPayload?.previewThumbnail?.toEmbeddedThumb()
                 ?: message.previewThumbnail,
-            // Load the full sticker (a small payload) so the enlarged preview is crisp and animates
-            // for animated-WebP/GIF stickers, matching the bubble's inline treatment.
-            loadFullPayload = true,
+            requestedSize = ImageSize.THUMB_MEDIUM,
+            lastModified = stickerPayload?.lastModified,
             isEncrypted = true,
             payloadContentType = stickerPayload?.contentType,
-            keyHeader = message.keyHeader,
+            keyHeader = if (payloadIv != null) {
+                KeyHeader(iv = payloadIv, aesKey = message.keyHeader.aesKey)
+            } else {
+                message.keyHeader
+            },
         )
         messagesUiState.update {
             it.copy(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/sticker/SavedSticker.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/sticker/SavedSticker.kt
@@ -7,6 +7,7 @@ import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.drives.HomebaseFile
 import id.homebase.api.client.drives.files.PayloadDescriptor
 import id.homebase.api.client.drives.upload.EmbeddedThumb
+import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.core.image.HomebaseImageData
 import id.homebase.core.image.ImageSize
 import kotlin.io.encoding.Base64
@@ -34,6 +35,13 @@ data class SavedSticker(
     val payloadDescriptor: PayloadDescriptor,
     val createdAt: Long,
     val groupId: Uuid? = null,
+    /**
+     * The chat-message file this sticker was saved FROM, or null if it was created in-app
+     * (editor / background-remover). Read off [StickerFileContent.sourceFileId] in the
+     * envelope's appData.content. Lets the sticker-tap bottom sheet detect that a received
+     * sticker is already in the user's library (`sourceFileId == message.fileId`).
+     */
+    val sourceFileId: Uuid? = null,
     /** True until the outbox confirms the upload (optimistic local entry). */
     val isPending: Boolean = false,
 )
@@ -47,9 +55,18 @@ fun HomebaseFile.toSavedSticker(): SavedSticker? {
     val payloads = fileMetadata.payloads
     val payload = payloads?.firstOrNull() ?: return null
 
-    // appData.content carries only an optional [StickerFileContent.name], which the v1
-    // tray does not surface — so we deliberately don't read it here. The sticker identity
-    // and render data all come from the envelope + payload below.
+    // appData.content carries an optional [StickerFileContent]. The v1 tray ignores the
+    // label (name); we read it only for [StickerFileContent.sourceFileId] — the back-pointer
+    // to the chat message a sticker was saved from, used by the sticker-tap bottom sheet to
+    // detect an already-saved sticker. A blank/legacy/corrupt content parses to null source.
+    val savedContent = fileMetadata.appData.content?.let { json ->
+        try {
+            OdinSystemSerializer.deserialize<StickerFileContent>(json)
+        } catch (_: Exception) {
+            null
+        }
+    }
+
     return SavedSticker(
         fileId = fileId,
         uniqueId = fileMetadata.appData.uniqueId ?: fileId,
@@ -61,6 +78,7 @@ fun HomebaseFile.toSavedSticker(): SavedSticker? {
         payloadDescriptor = payload,
         createdAt = fileMetadata.created.milliseconds,
         groupId = fileMetadata.appData.groupId,
+        sourceFileId = savedContent?.sourceFileId,
     )
 }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/sticker/StickerProtocol.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/sticker/StickerProtocol.kt
@@ -1,6 +1,11 @@
+@file:OptIn(ExperimentalUuidApi::class)
+
 package id.homebase.chat.services.sticker
 
+import id.homebase.api.serialization.UuidSerializer
 import kotlinx.serialization.Serializable
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 /**
  * Wire constants + tiny appData content shape for saved stickers.
@@ -36,7 +41,20 @@ object StickerProtocol {
     const val STICKER_PAYLOAD_KEY = "sticker_0"
 }
 
+/**
+ * Tiny appData content for a saved sticker.
+ *
+ * [name] is an optional label (unused by the v1 tray). [sourceFileId] records the
+ * chat-message file a sticker was saved FROM, so the sticker-tap bottom sheet can ask
+ * "is this received sticker already in my library?" — a saved copy is re-uploaded with a
+ * fresh random uniqueId and shares no identity with the source message, so without this
+ * back-reference there is no way to detect a duplicate. Null when the sticker was created
+ * by the in-app editor / background-remover (no originating message). Per CLAUDE.md this is
+ * NOT a duplicated envelope field: it points at a *different* file (the source message),
+ * not this sticker's own identity.
+ */
 @Serializable
 data class StickerFileContent(
     val name: String? = null,
+    @Serializable(with = UuidSerializer::class) val sourceFileId: Uuid? = null,
 )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/sticker/StickerService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/sticker/StickerService.kt
@@ -87,6 +87,13 @@ class StickerService(
         scope: CoroutineScope,
         name: String? = null,
         uniqueId: Uuid = Uuid.random(),
+        /**
+         * The chat-message file this sticker is being saved FROM. Persisted in the sticker
+         * file's appData content ([StickerFileContent.sourceFileId]) so the sticker-tap bottom
+         * sheet can later detect that the same received sticker is already saved. Null when the
+         * sticker originates in-app (editor / background-remover) with no source message.
+         */
+        sourceFileId: Uuid? = null,
     ): Uuid? {
         ensureDriveMounted()
 
@@ -133,7 +140,9 @@ class StickerService(
                 uniqueId, bundle, keyHeader.aesKey, scope,
             )
 
-            val content = OdinSystemSerializer.serialize(StickerFileContent(name = name))
+            val content = OdinSystemSerializer.serialize(
+                StickerFileContent(name = name, sourceFileId = sourceFileId)
+            )
             val unencryptedMetadata = UploadFileMetadata(
                 allowDistribution = false,
                 isEncrypted = true,
@@ -205,6 +214,7 @@ class StickerService(
                     payloadDescriptor = payloadDescriptors?.firstOrNull()
                         ?: PayloadDescriptor(key = key, contentType = uploadType),
                     createdAt = Clock.System.now().toEpochMilliseconds(),
+                    sourceFileId = sourceFileId,
                     isPending = true,
                 )
             )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -644,6 +644,7 @@ fun ConversationContent(
     // dispatches then dismisses; the sheet state is cleared on dismiss.
     uiState.stickerOptionsSheet?.let { sheet ->
         StickerOptionsSheet(
+            stickerImage = sheet.stickerImage,
             isAlreadySaved = sheet.isAlreadySaved,
             onAddToLibrary = {
                 onUiAction(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -639,6 +639,36 @@ fun ConversationContent(
         )
     }
 
+    // Sticker-tap bottom sheet (WhatsApp-style): tapping a sticker message opens this instead
+    // of the fullscreen viewer. Add/Remove from the user's library + Save to device. Each row
+    // dispatches then dismisses; the sheet state is cleared on dismiss.
+    uiState.stickerOptionsSheet?.let { sheet ->
+        StickerOptionsSheet(
+            isAlreadySaved = sheet.isAlreadySaved,
+            onAddToLibrary = {
+                onUiAction(
+                    ConversationListUiAction.SaveStickerFromMessage(sheet.messageId, sheet.payloadKey)
+                )
+                onUiAction(ConversationListUiAction.DismissStickerOptions)
+            },
+            onRemoveFromLibrary = {
+                onUiAction(
+                    ConversationListUiAction.RemoveStickerFromMessage(sheet.sourceFileId)
+                )
+                onUiAction(ConversationListUiAction.DismissStickerOptions)
+            },
+            onSaveToDevice = {
+                // Reuse the existing decrypt-to-cache + SaveFileToDevice path the fullscreen
+                // viewer's onSave uses — no new device-export code.
+                onUiAction(
+                    ConversationListUiAction.DownloadMedia(sheet.messageId, sheet.payloadKey)
+                )
+                onUiAction(ConversationListUiAction.DismissStickerOptions)
+            },
+            onDismiss = { onUiAction(ConversationListUiAction.DismissStickerOptions) },
+        )
+    }
+
     if (showBlockConfirmDialog) {
         AlertDialog(
             onDismissRequest = { showBlockConfirmDialog = false },

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/StickerOptionsSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/StickerOptionsSheet.kt
@@ -77,8 +77,12 @@ fun StickerOptionsSheet(
                 .padding(horizontal = 16.dp)
                 .padding(bottom = 8.dp),
         ) {
-            // Enlarged sticker preview (bigger than the bubble's ~160dp cap) so the user can see
-            // it clearly when they tap. Transparent stickers show the sheet surface through.
+            val previewHeight = 160.dp
+            val stickerAspect = stickerImage.previewThumbnail
+                ?.takeIf { it.pixelWidth > 0 && it.pixelHeight > 0 }
+                ?.let { (it.pixelWidth.toFloat() / it.pixelHeight.toFloat()).coerceIn(0.6f, 1.8f) }
+                ?: 1f
+
             HomebaseImage(
                 imageData = stickerImage,
                 contentDescription = stringResource(MR.string.cd_sticker_thumbnail),
@@ -86,7 +90,7 @@ fun StickerOptionsSheet(
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
                     .padding(top = 8.dp, bottom = 16.dp)
-                    .size(200.dp),
+                    .size(width = previewHeight * stickerAspect, height = previewHeight),
             )
 
             Text(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/StickerOptionsSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/StickerOptionsSheet.kt
@@ -25,11 +25,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
+import id.homebase.core.image.HomebaseImage
+import id.homebase.core.image.HomebaseImageData
 import id.homebase.resources.MR
 import id.homebase.resources.cd_sticker_options_add
 import id.homebase.resources.cd_sticker_options_remove
 import id.homebase.resources.cd_sticker_options_save
+import id.homebase.resources.cd_sticker_thumbnail
 import id.homebase.resources.chat_sticker_add_to_library
 import id.homebase.resources.chat_sticker_options_title
 import id.homebase.resources.chat_sticker_remove_from_library
@@ -52,6 +56,7 @@ import org.jetbrains.compose.resources.stringResource
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun StickerOptionsSheet(
+    stickerImage: HomebaseImageData,
     isAlreadySaved: Boolean,
     onAddToLibrary: () -> Unit,
     onRemoveFromLibrary: () -> Unit,
@@ -72,6 +77,18 @@ fun StickerOptionsSheet(
                 .padding(horizontal = 16.dp)
                 .padding(bottom = 8.dp),
         ) {
+            // Enlarged sticker preview (bigger than the bubble's ~160dp cap) so the user can see
+            // it clearly when they tap. Transparent stickers show the sheet surface through.
+            HomebaseImage(
+                imageData = stickerImage,
+                contentDescription = stringResource(MR.string.cd_sticker_thumbnail),
+                contentScale = ContentScale.Fit,
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(top = 8.dp, bottom = 16.dp)
+                    .size(200.dp),
+            )
+
             Text(
                 text = stringResource(MR.string.chat_sticker_options_title),
                 style = MaterialTheme.typography.titleLarge,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/StickerOptionsSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/StickerOptionsSheet.kt
@@ -1,0 +1,137 @@
+package id.homebase.chat.widget
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import id.homebase.resources.MR
+import id.homebase.resources.cd_sticker_options_add
+import id.homebase.resources.cd_sticker_options_remove
+import id.homebase.resources.cd_sticker_options_save
+import id.homebase.resources.chat_sticker_add_to_library
+import id.homebase.resources.chat_sticker_options_title
+import id.homebase.resources.chat_sticker_remove_from_library
+import id.homebase.resources.chat_sticker_save_to_device
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * WhatsApp-style bottom sheet shown when a sticker MESSAGE is tapped (instead of opening the
+ * fullscreen media viewer). It is purely about the user's own sticker collection plus a device
+ * export — there is no "delete message" action here.
+ *
+ * Mirrors [id.homebase.core.widget.ReactionsBottomSheet]'s [ModalBottomSheet] pattern:
+ *  - "Add to my stickers" — shown when the sticker is NOT already saved.
+ *  - "Remove from my stickers" — shown INSTEAD of "Add" when it IS saved (does NOT delete the
+ *     message).
+ *  - "Save to device" — always shown; exports the sticker image to the gallery/files.
+ *
+ * Each row fires its callback then the caller dismisses; dismissing clears the sheet state.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StickerOptionsSheet(
+    isAlreadySaved: Boolean,
+    onAddToLibrary: () -> Unit,
+    onRemoveFromLibrary: () -> Unit,
+    onSaveToDevice: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        sheetMaxWidth = 640.dp,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 8.dp),
+        ) {
+            Text(
+                text = stringResource(MR.string.chat_sticker_options_title),
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            if (isAlreadySaved) {
+                StickerOptionRow(
+                    icon = Icons.Filled.Delete,
+                    label = stringResource(MR.string.chat_sticker_remove_from_library),
+                    contentDescription = stringResource(MR.string.cd_sticker_options_remove),
+                    onClick = onRemoveFromLibrary,
+                )
+            } else {
+                StickerOptionRow(
+                    icon = Icons.Filled.Add,
+                    label = stringResource(MR.string.chat_sticker_add_to_library),
+                    contentDescription = stringResource(MR.string.cd_sticker_options_add),
+                    onClick = onAddToLibrary,
+                )
+            }
+
+            StickerOptionRow(
+                icon = Icons.Filled.Download,
+                label = stringResource(MR.string.chat_sticker_save_to_device),
+                contentDescription = stringResource(MR.string.cd_sticker_options_save),
+                onClick = onSaveToDevice,
+            )
+        }
+    }
+}
+
+@Composable
+private fun StickerOptionRow(
+    icon: ImageVector,
+    label: String,
+    contentDescription: String,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Start,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = contentDescription,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(24.dp),
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/services/sticker/SavedStickerTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/services/sticker/SavedStickerTest.kt
@@ -147,6 +147,36 @@ class SavedStickerTest {
     }
 
     @Test
+    fun toSavedSticker_readsSourceFileIdFromContent() {
+        val source = Uuid.random()
+        val sticker = buildStickerFile(
+            contentJson = OdinSystemSerializer.serialize(
+                StickerFileContent(name = "smile", sourceFileId = source)
+            ),
+        ).toSavedSticker()
+        assertNotNull(sticker)
+        assertEquals(source, sticker.sourceFileId)
+    }
+
+    @Test
+    fun toSavedSticker_sourceFileIdNullForLegacyContent() {
+        // A legacy sticker file (content without sourceFileId) maps to a null source — it was
+        // not saved from a known message, so the bottom sheet can't claim a duplicate.
+        val sticker = buildStickerFile(
+            contentJson = OdinSystemSerializer.serialize(StickerFileContent(name = "smile")),
+        ).toSavedSticker()
+        assertNotNull(sticker)
+        assertNull(sticker.sourceFileId)
+    }
+
+    @Test
+    fun toSavedSticker_sourceFileIdNullForBlankContent() {
+        val sticker = buildStickerFile(contentJson = null).toSavedSticker()
+        assertNotNull(sticker)
+        assertNull(sticker.sourceFileId)
+    }
+
+    @Test
     fun toImageData_decodesIvIntoKeyHeader() {
         val sticker = buildStickerFile().toSavedSticker()
         assertNotNull(sticker)

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -788,6 +788,14 @@
     <string name="cd_sticker_variant_original">Original photo version</string>
     <string name="cd_tab_emoji">Emoji</string>
     <string name="cd_tab_stickers">Stickers</string>
+    <!-- Sticker-tap bottom sheet (tap a sticker message) -->
+    <string name="chat_sticker_options_title">Sticker</string>
+    <string name="chat_sticker_add_to_library">Add to my stickers</string>
+    <string name="chat_sticker_remove_from_library">Remove from my stickers</string>
+    <string name="chat_sticker_save_to_device">Save to device</string>
+    <string name="cd_sticker_options_add">Add to my stickers</string>
+    <string name="cd_sticker_options_remove">Remove from my stickers</string>
+    <string name="cd_sticker_options_save">Save to device</string>
 
     <!-- Groodle (group-scheduling poll) -->
     <string name="chat_groodle_share">Groodle</string>


### PR DESCRIPTION
## Summary
Tapping a sticker message used to open the fullscreen media viewer. It now opens a bottom sheet (`StickerOptionsSheet`) with:
- **Add to my stickers** / **Remove from my stickers** — swaps based on whether the sticker is already in your library (does **not** delete the message)
- **Save to device**

Regular image messages are unchanged. Routing happens at the single point `MediaDownloadHandler.handleMediaClicked` using the existing `descriptorInfo().isSticker` flag.

## Already-saved detection (wire-format note)
A saved sticker is re-uploaded with a fresh `uniqueId`, so it shares no identity with the source message. To detect "already saved," this adds a **persisted** field `StickerFileContent.sourceFileId` (a back-reference to the originating message's `fileId`).
- Additive + nullable; `OdinSystemSerializer` uses `ignoreUnknownKeys = true`, so it's forward/backward compatible (old clients never read this content anyway).
- **Limitation:** stickers saved before this change (and editor/background-remover stickers) have no `sourceFileId`, so the sheet shows "Add" for them (can create a duplicate). New saves are detected correctly.

## Changes
- `StickerOptionsSheet.kt` (new) — mirrors `ReactionsBottomSheet`; Material3, all strings via `stringResource`.
- `ShowStickerOptions` / `DismissStickerOptions` / `RemoveStickerFromMessage` actions + `StickerHandler` handlers.
- `MessageListUiState.stickerOptionsSheet` + `StickerOptionsSheetState`.
- `StickerFileContent.sourceFileId`, written by `StickerService.saveSticker`, read by `toSavedSticker`.
- Save-to-device reuses the existing `DownloadMedia` → `SaveFileToDevice` path.
- 7 new string resources; `SavedStickerTest` coverage for the new field.

## Verification
- Compiles on **JVM, Android, iOS (sim), WasmJs** ✅
- `homebase-common:jvmTest` (Konsist `ArchitectureTest`) + `homebase-chat:jvmTest` (incl. new `SavedStickerTest`) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)