### PR TITLE
feat(ios): blank-text auto-trigger hypothesis + native toast (observe-only)

### DIFF
--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/diagnostics/BlankTextTrigger.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/diagnostics/BlankTextTrigger.kt
@@ -1,0 +1,35 @@
+package id.homebase.core.diagnostics
+
+/** Implemented by the iOS layer (Swift) to surface the blank-text auto-trigger as a visible toast. */
+fun interface BlankTextTriggerListener {
+    fun onTriggerFired(usedBytes: Long, peakBytes: Long)
+}
+
+/**
+ * Bridge for the iOS blank-text auto-trigger (see `IosGpuTextDiagnostics`).
+ *
+ * Trigger HYPOTHESIS: on foreground, the skiko font cache is near-empty (`usedBytes` tiny) although
+ * it was substantial earlier this session (`peakBytes` large) — i.e. iOS reclaimed the app's
+ * GPU/font resources while backgrounded, the condition that precedes the blank-text bug. We can't
+ * actually *see* the blank (the cache rebuilds even when blank, the Metal surface looks healthy), so
+ * this is a proxy that needs field validation.
+ *
+ * This is **observe-only**: when the trigger fires we show a VISIBLE toast (native SwiftUI, so it
+ * renders even while Compose text is blank) plus a log — but we do NOT attempt recovery yet. The
+ * toast is the instrument: in TestFlight a tester reports whether the screen was actually blank when
+ * it appeared (true positive) or fine (false positive). Without it we can't measure the
+ * false-positive rate, and we won't justify auto-firing a recovery off this signal until we have.
+ *
+ * No-op on platforms with no registered [BlankTextTriggerListener] (the bug is iOS-only).
+ */
+object BlankTextTrigger {
+    private var listener: BlankTextTriggerListener? = null
+
+    fun register(listener: BlankTextTriggerListener) {
+        this.listener = listener
+    }
+
+    fun fire(usedBytes: Long, peakBytes: Long) {
+        listener?.onTriggerFired(usedBytes, peakBytes)
+    }
+}

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/diagnostics/IosGpuTextDiagnostics.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/diagnostics/IosGpuTextDiagnostics.kt
@@ -40,6 +40,20 @@ private object IosGpuTextProbe : GpuTextDiagnostics.Probe {
         return ((NSDate().timeIntervalSince1970 - started) * 1000.0).toLong()
     }
 
+    // Session high-water mark of the font cache. The cache builds during USE (between lifecycle
+    // events), so a periodic sampler updates this; it's the gate that proves text really rendered
+    // this session (so the blank-text trigger doesn't fire on a fresh cold start). Main-thread only.
+    var peakFontCacheUsedBytes: Long = 0L
+        private set
+
+    fun currentFontCacheUsedBytes(): Long =
+        runCatching { Graphics.fontCacheUsed }.getOrNull()?.toLong() ?: 0L
+
+    fun samplePeak() {
+        val used = currentFontCacheUsedBytes()
+        if (used > peakFontCacheUsedBytes) peakFontCacheUsedBytes = used
+    }
+
     override fun snapshot(
         event: GpuTextDiagnostics.Event,
         note: String?,
@@ -91,6 +105,7 @@ fun installGpuTextDiagnostics() {
             GpuTextDiagnostics.Event.Foreground,
             backgroundDurationMs = IosGpuTextProbe.consumeBackgroundDurationMs(),
         )
+        maybeFireBlankTextTrigger()
     }
 
     center.addObserverForName(
@@ -99,8 +114,43 @@ fun installGpuTextDiagnostics() {
         queue = mainQueue,
     ) { _ -> GpuTextDiagnostics.log(GpuTextDiagnostics.Event.MemoryWarning) }
 
+    // Periodic peak sampler: the cache builds during USE (between lifecycle events), so sample it so
+    // we know text really rendered this session — the gate that stops the trigger firing on cold
+    // starts. Cheap (reads one global counter). iOS suspends this loop while backgrounded.
+    MainScope().launch {
+        while (true) {
+            IosGpuTextProbe.samplePeak()
+            delay(PEAK_SAMPLE_INTERVAL_MS)
+        }
+    }
+
     Logger.i(tag = GpuTextDiagnostics.TAG) { "installed (probe + lifecycle observers attached)" }
     GpuTextDiagnostics.log(GpuTextDiagnostics.Event.ColdStart)
+}
+
+// --- Blank-text auto-trigger (observe-only hypothesis; see BlankTextTrigger) ---
+
+private const val TRIGGER_PEAK_RENDERED_BYTES = 200_000L // text rendered substantially this session
+private const val TRIGGER_BLANK_BYTES = 10_000L          // font cache now near-empty (reclaimed)
+private const val PEAK_SAMPLE_INTERVAL_MS = 5_000L
+
+/**
+ * Blank-text auto-trigger HYPOTHESIS, evaluated on every foreground. If the font cache is near-empty
+ * yet it was substantial earlier this session, iOS likely reclaimed the GPU/font resources while
+ * backgrounded — the condition that precedes blank text. OBSERVE-ONLY: fire a visible toast + log so
+ * TestFlight can measure the false-positive rate. No recovery yet. Thresholds are starting
+ * hypotheses (blank foregrounds measured ~6.9KB used; healthy ~1.9MB) — tune from the logged values.
+ */
+private fun maybeFireBlankTextTrigger() {
+    val used = IosGpuTextProbe.currentFontCacheUsedBytes()
+    val peak = IosGpuTextProbe.peakFontCacheUsedBytes
+    if (peak > TRIGGER_PEAK_RENDERED_BYTES && used < TRIGGER_BLANK_BYTES) {
+        Logger.i(tag = GpuTextDiagnostics.TAG) {
+            "TRIGGER MET (observe-only): foreground font cache reclaimed — used=$used peak=$peak " +
+                "(rule: used<$TRIGGER_BLANK_BYTES AND peak>$TRIGGER_PEAK_RENDERED_BYTES) — firing toast"
+        }
+        BlankTextTrigger.fire(used, peak)
+    }
 }
 
 /**

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -23,6 +23,7 @@ struct ContentView: View {
     @Environment(\.scenePhase) var scenePhase
     @Environment(\.colorScheme) var colorScheme
     @State private var showPrivacyOverlay = false
+    @State private var triggerToast: String? = nil
 
     var body: some View {
         ZStack {
@@ -33,6 +34,24 @@ struct ContentView: View {
                 PrivacyOverlayView()
                     .ignoresSafeArea()
                     .transition(.opacity)
+            }
+
+            // Native (UIKit) toast for the blank-text auto-trigger — renders even while Compose text
+            // is blank, so a TestFlight tester can judge true vs. false positive at the moment it fires.
+            if let msg = triggerToast {
+                VStack {
+                    Text(msg)
+                        .font(.footnote.weight(.semibold))
+                        .foregroundColor(.white)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 10)
+                        .background(Color.red.opacity(0.92), in: Capsule())
+                        .padding(.top, 12)
+                    Spacer()
+                }
+                .transition(.move(edge: .top).combined(with: .opacity))
+                .zIndex(1)
             }
         }
         .onAppear {
@@ -75,6 +94,16 @@ struct ContentView: View {
             // Blank-text recovery experiment: log cache state, purge Skia caches + force a full
             // re-composition, then log again ~1.5s later. See captureAndRecoverOnShake.
             captureAndRecoverOnShake()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .blankTextTriggerFired)) { note in
+            // Blank-text auto-trigger fired (observe-only). Show a native toast asking the tester to
+            // judge true/false positive. Auto-dismisses after 6s.
+            let used = (note.userInfo?["used"] as? Int64) ?? -1
+            let peak = (note.userInfo?["peak"] as? Int64) ?? -1
+            withAnimation { triggerToast = "⚠️ Blank-text trigger fired (cache \(used)B, peak \(peak)B). Is text missing? If not, it's a false positive." }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 6) {
+                withAnimation { triggerToast = nil }
+            }
         }
     }
 }

--- a/iosApp/iosApp/TextRenderingNudge.swift
+++ b/iosApp/iosApp/TextRenderingNudge.swift
@@ -63,6 +63,25 @@ class MetalLayerNudger: TextRenderingNudger {
 extension Notification.Name {
     /// Posted by `UIWindow.motionEnded` below when the user shakes the device.
     static let deviceDidShake = Notification.Name("id.homebase.feed.deviceDidShake")
+    /// Posted by `BlankTextTriggerToastListener` when the Kotlin blank-text auto-trigger fires.
+    static let blankTextTriggerFired = Notification.Name("id.homebase.feed.blankTextTriggerFired")
+}
+
+/// Receives the Kotlin blank-text auto-trigger (observe-only) and surfaces it as a native toast in
+/// ContentView. Native SwiftUI text renders even while Compose is blank, so the toast is visible at
+/// exactly the moment we need a tester to judge: was the screen actually blank (true positive) or
+/// fine (false positive)? Registered in `iOSApp.init`.
+class BlankTextTriggerToastListener: BlankTextTriggerListener {
+    func onTriggerFired(usedBytes: Int64, peakBytes: Int64) {
+        os_log("BLANK-TEXT trigger fired (observe-only): used=%lld peak=%lld", log: textRenderLog, type: .error, usedBytes, peakBytes)
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(
+                name: .blankTextTriggerFired,
+                object: nil,
+                userInfo: ["used": usedBytes, "peak": peakBytes]
+            )
+        }
+    }
 }
 
 extension UIWindow {

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -194,6 +194,10 @@ struct iOSApp: App {
 
         // Register Metal layer nudge so Compose UI can trigger glyph atlas rebuilds
         TextRenderingHelper.shared.register(nudger: MetalLayerNudger())
+
+        // Surface the Kotlin blank-text auto-trigger (observe-only) as a native toast in ContentView,
+        // so TestFlight testers can report whether it's a true or false positive.
+        BlankTextTrigger.shared.register(listener: BlankTextTriggerToastListener())
     }
     
     var body: some Scene {


### PR DESCRIPTION
## Context

We confirmed (06-10 capture) the blank-text bug is a **per-context GPU glyph-atlas eviction**: iOS silently reclaims a backgrounded app's GPU resources (no memory warning fires), and on foreground the atlas is dead while Skia thinks glyphs are resident → blank. The Metal surface stays healthy (`device=true`, full drawable) and the font cache *rebuilds* even when blank — so **we can't detect the blank directly.**

The only signal we have is a **proxy**: at foreground, the font cache is near-empty although it was substantial earlier this session (= iOS reclaimed it while backgrounded).

## What this does — observe-only

Forms that trigger hypothesis and **surfaces it as a visible toast, with no recovery**, so we can measure its **false-positive rate in TestFlight** before trusting it to auto-fire a fix.

- **Trigger** (on `willEnterForeground`): `fontCacheUsed < 10 KB` **AND** session-peak `fontCacheUsed > 200 KB`.
  - blank foregrounds measured **6.9 KB**; healthy **~1.9 MB** (a ~300× gap).
  - the peak gate stops it firing on cold starts (nothing rendered yet).
  - thresholds are **starting hypotheses** — every firing logs the actual `used`/`peak` so we tune from data.
- A **periodic sampler** (every 5 s while active) tracks the session peak, since the cache builds during *use*, between our lifecycle events.
- When met → log `TRIGGER MET …` + a **native SwiftUI toast** in `ContentView`.

## Why the toast (and why native)

Without a visible signal we can't tell a true positive from a false one. The toast **is the instrument**: when it appears, a tester reports "was text actually missing?" It's **native SwiftUI**, not skiko — so it renders *even while Compose text is blank* (same as the existing privacy overlay), which is exactly when we need it.

## Explicitly NOT in this PR

- **No recovery.** Once the toast shows a low false-positive rate, the same trigger drives the surface-recreation recovery (the proven mechanism gap: `purgeAllCaches` + recompose does *not* rebuild the per-context atlas — confirmed by the last shake capture).

## Verification

- Common (`BlankTextTrigger`): `:homebase-common:jvmTest` green; JVM + metadata compiles clean.
- `nativeMain` (peak sampler, trigger eval) + Swift (listener, toast) validated by **CI (iosArm64 / Xcode)** — can't compile on the Linux dev host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
