### PR TITLE
Location add-on: GPS tracking to an encrypted per-device hourly drive

### DIFF
--- a/.github/workflows/build-mobile-release-dev.yml
+++ b/.github/workflows/build-mobile-release-dev.yml
@@ -195,6 +195,31 @@ jobs:
             done
           done
 
+      # The build action's bundled Fastfile runs create_keychain(timeout: 3600):
+      # the build keychain auto-locks after 60 minutes. A cold-cache archive
+      # (Kotlin/Native invalidation, dependency bumps) takes >60min to reach the
+      # embedded-framework signing phase, at which point codesign blocks forever
+      # on the locked keychain (it posts an unlock dialog into the runner's GUI
+      # session) — the recurring "Build iOS timed out after 120 minutes" hang at
+      # "Signing libswscale.framework". This watcher outlives its step, waits for
+      # the keychain to appear, and re-clears its auto-lock every minute
+      # (set-keychain-settings with no -t = never lock; no password needed while
+      # the freshly created keychain is unlocked).
+      - name: Defuse build-keychain auto-lock (background watcher)
+        run: |
+          nohup bash -c '
+            kc="$HOME/Library/Keychains/ios-build.keychain-db"
+            while true; do
+              if [ -f "$kc" ]; then
+                if security set-keychain-settings "$kc" 2>>"$RUNNER_TEMP/keychain-watcher.log"; then
+                  echo "$(date -u +%FT%TZ) cleared auto-lock on $kc"
+                fi
+              fi
+              sleep 60
+            done
+          ' >> "$RUNNER_TEMP/keychain-watcher.log" 2>&1 &
+          echo "keychain watcher started (log: $RUNNER_TEMP/keychain-watcher.log)"
+
       - name: Build iOS
         timeout-minutes: 120
         uses: yukiarrr/ios-build-action@v1.12.0

--- a/.github/workflows/build-mobile-release-prod.yml
+++ b/.github/workflows/build-mobile-release-prod.yml
@@ -201,7 +201,32 @@ jobs:
                 done
               fi
             done
-          done          
+          done
+
+      # The build action's bundled Fastfile runs create_keychain(timeout: 3600):
+      # the build keychain auto-locks after 60 minutes. A cold-cache archive
+      # (Kotlin/Native invalidation, dependency bumps) takes >60min to reach the
+      # embedded-framework signing phase, at which point codesign blocks forever
+      # on the locked keychain (it posts an unlock dialog into the runner's GUI
+      # session) — the recurring "Build iOS timed out" hang at
+      # "Signing libswscale.framework". This watcher outlives its step, waits for
+      # the keychain to appear, and re-clears its auto-lock every minute
+      # (set-keychain-settings with no -t = never lock; no password needed while
+      # the freshly created keychain is unlocked).
+      - name: Defuse build-keychain auto-lock (background watcher)
+        run: |
+          nohup bash -c '
+            kc="$HOME/Library/Keychains/ios-build.keychain-db"
+            while true; do
+              if [ -f "$kc" ]; then
+                if security set-keychain-settings "$kc" 2>>"$RUNNER_TEMP/keychain-watcher.log"; then
+                  echo "$(date -u +%FT%TZ) cleared auto-lock on $kc"
+                fi
+              fi
+              sleep 60
+            done
+          ' >> "$RUNNER_TEMP/keychain-watcher.log" 2>&1 &
+          echo "keychain watcher started (log: $RUNNER_TEMP/keychain-watcher.log)"
 
       - name: Build iOS
         timeout-minutes: 180

--- a/ADDING_ADDON_APPS.md
+++ b/ADDING_ADDON_APPS.md
@@ -222,17 +222,24 @@ class FooPreferences(private val databaseManager: DatabaseManager) {
     private fun encode(value: Boolean): ByteArray = byteArrayOf(if (value) 1 else 0)
 
     companion object {
-        // Bump the penultimate byte for each new add-on — Vault = 0a01xx, next = 0a02xx, etc.
-        val ACTIVATED_KEY:   Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0201")
-        val ICON_VISIBLE_KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0202")
-        val BIOMETRICS_KEY:  Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0203")
+        // Bump the penultimate byte for each new add-on — see the ownership
+        // table below for the next free 0a0Nxx slot.
+        val ACTIVATED_KEY:   Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0N01")
+        val ICON_VISIBLE_KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0N02")
+        val BIOMETRICS_KEY:  Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0N03")
     }
 }
 ```
 
-**UUID namespacing.** Vault owns `0000...0a01xx`. Pick the next free `0a0Nxx` slot for
-your add-on — these keys must be stable across releases, so never reuse an existing
-range.
+**UUID namespacing.** These keys must be stable across releases, so never reuse an
+existing range. Current owners:
+
+| Range | Owner |
+|---|---|
+| `0000...0a01xx` | Vault |
+| `0000...0a02xx` | Moments |
+| `0000...0a03xx` | Location |
+| `0000...0a04xx` | **next free** — claim it here when you take it |
 
 ---
 

--- a/androidApp/src/debug/AndroidManifest.xml
+++ b/androidApp/src/debug/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- Debug-only until the Play Console background-location declaration is
+         approved — see the note in src/main/AndroidManifest.xml. Sideloaded
+         debug builds keep full background tracking for development/testing;
+         Play-uploaded build types (dev, release) omit the permission so the
+         androidpublisher edit commit isn't rejected with 403
+         "Your background location permission declaration needs to be updated". -->
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+
+</manifest>

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -23,9 +23,14 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <!-- Location add-on: background tracking (runtime permission, API 29+) and
-         re-arming the fused PendingIntent registration after a reboot. -->
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <!-- Location add-on: re-arming the fused PendingIntent registration after a
+         reboot. ACCESS_BACKGROUND_LOCATION lives in src/debug/AndroidManifest.xml
+         ONLY: Google Play rejects any AAB carrying that permission until the
+         Play Console sensitive-permission declaration (use case + prominent-
+         disclosure video) is approved for the package — the dev-track upload
+         failed exactly there. Once the declaration is done, move it back here
+         so store builds can track in the background; until then store builds
+         record foreground-only (the Location screen explains this). -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <!-- Devices running Android 13 (API level 33) or higher -->

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -23,6 +23,10 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!-- Location add-on: background tracking (runtime permission, API 29+) and
+         re-arming the fused PendingIntent registration after a reboot. -->
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <!-- Devices running Android 13 (API level 33) or higher -->
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />

--- a/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
@@ -22,6 +22,7 @@ import id.homebase.api.sync.database.DatabaseDriverFactory
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.core.di.allModules
 import id.homebase.core.diagnostics.MainThreadWatchdog
+import id.homebase.core.location.tracking.LocationTrackingCoordinator
 import id.homebase.core.logging.CrashLogger
 import id.homebase.core.logging.LoggerConfig
 import id.homebase.core.logging.StartupLogger
@@ -146,6 +147,11 @@ class MainApplication : Application(), KoinComponent {
         // Cold-start is covered by StartupCacheAudit; this is the bound on
         // a same-process share's on-disk lifetime.
         registerShareOutboundForegroundSweep()
+
+        // Re-arm Location tracking on every process start (incl. boot-receiver
+        // and background-location wakes — onPostAuthenticated never runs on
+        // headless cold starts, so this cannot live there).
+        get<LocationTrackingCoordinator>().onProcessStart()
 
         StartupLogger.checkpoint("onCreate end")
     }

--- a/homebase-api/build.gradle.kts
+++ b/homebase-api/build.gradle.kts
@@ -163,6 +163,7 @@ kotlin {
         "id.homebase.api.sync.database.DriveMainIndexTest",
         "id.homebase.api.sync.database.DriveTagIndexTest",
         "id.homebase.api.sync.database.FileStateFilterTest",
+        "id.homebase.api.sync.database.LocationPointWrapperTest",
         "id.homebase.api.sync.database.MainIndexMetaTest",
         "id.homebase.api.sync.database.OutboxSetNextRunTimeTest",
         "id.homebase.api.sync.database.OutboxSyncTest",

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/location/LocationPreviewProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/location/LocationPreviewProvider.kt
@@ -7,7 +7,10 @@ import io.ktor.client.request.header
 import io.ktor.client.statement.bodyAsText
 import io.ktor.client.statement.readRawBytes
 import io.ktor.http.isSuccess
-import kotlinx.coroutines.CompletableDeferred
+import id.homebase.api.coroutines.ioDispatcher
+import id.homebase.api.coroutines.supervisedScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -146,40 +149,43 @@ class LocationPreviewProvider(
 
     /**
      * Fetch one raw OSM tile PNG for the Location history basemap. Same HTTP
-     * path, User-Agent and blank-tile guard as the chat preview; LRU-cached and
-     * single-flighted so a pan/zoom burst doesn't refetch or double-fetch.
-     * Returns null on failure or blank tile — callers leave the background empty.
+     * path and User-Agent as the chat preview; LRU-cached and single-flighted.
+     * The fetch runs on a provider-owned scope so a cancelled caller (the
+     * canvas effect restarting on pan/zoom) can neither kill an in-flight
+     * download other callers await nor strand its single-flight entry.
+     * Returns null on failure — callers leave the background empty.
+     *
+     * No blank-tile size guard here (unlike [fetchStaticMap]): a tiny
+     * uniform-color PNG is a legitimate basemap tile (open water, plain
+     * terrain), not a broken preview image.
      */
     suspend fun getTilePng(zoom: Int, xTile: Int, yTile: Int): ByteArray? {
         val key = TileKey(zoom, xTile, yTile)
-        var owner = false
         val flight = tileCacheMutex.withLock {
             tileCache[key]?.let { return it }
-            tileFlights[key] ?: CompletableDeferred<ByteArray?>().also {
-                tileFlights[key] = it
-                owner = true
-            }
-        }
-        if (!owner) return flight.await()
-
-        val bytes = try {
-            fetchTile(zoom, xTile, yTile)
-        } catch (e: Exception) {
-            Logger.w(throwable = e, tag = TAG) { "getTilePng($zoom/$xTile/$yTile) threw" }
-            null
-        }
-        tileCacheMutex.withLock {
-            if (bytes != null) {
-                tileCache[key] = bytes
-                // Insertion-order eviction — good enough for a pan/zoom cache.
-                while (tileCache.size > TILE_CACHE_MAX) {
-                    tileCache.remove(tileCache.keys.first())
+            tileFlights.getOrPut(key) {
+                tileScope.async {
+                    val bytes = try {
+                        fetchTile(zoom, xTile, yTile)
+                    } catch (e: Exception) {
+                        Logger.w(throwable = e, tag = TAG) { "getTilePng($zoom/$xTile/$yTile) threw" }
+                        null
+                    }
+                    tileCacheMutex.withLock {
+                        if (bytes != null) {
+                            tileCache[key] = bytes
+                            // Insertion-order eviction — good enough for a pan/zoom cache.
+                            while (tileCache.size > TILE_CACHE_MAX) {
+                                tileCache.remove(tileCache.keys.first())
+                            }
+                        }
+                        tileFlights.remove(key)
+                    }
+                    bytes
                 }
             }
-            tileFlights.remove(key)
         }
-        flight.complete(bytes)
-        return bytes
+        return flight.await()
     }
 
     private suspend fun fetchTile(zoom: Int, xTile: Int, yTile: Int): ByteArray? {
@@ -192,9 +198,7 @@ class LocationPreviewProvider(
             Logger.w(tag = TAG) { "tile HTTP ${response.status.value} for $zoom/$xTile/$yTile" }
             return null
         }
-        val bytes = response.readRawBytes()
-        if (bytes.size < BLANK_TILE_THRESHOLD_BYTES) return null
-        return bytes
+        return response.readRawBytes()
     }
 
     /** Web Mercator lat/lon → tile X/Y at the given zoom. Standard Slippy Map formula. */
@@ -230,7 +234,10 @@ class LocationPreviewProvider(
         // Raw-tile cache for the Location history basemap (~64 tiles ≈ 1-2MB).
         private const val TILE_CACHE_MAX = 64
         private val tileCache = LinkedHashMap<TileKey, ByteArray>()
-        private val tileFlights = mutableMapOf<TileKey, CompletableDeferred<ByteArray?>>()
+        private val tileFlights = mutableMapOf<TileKey, Deferred<ByteArray?>>()
         private val tileCacheMutex = Mutex()
+
+        // Owns tile downloads so they survive caller cancellation (see getTilePng).
+        private val tileScope = supervisedScope("OsmTileFetcher", ioDispatcher)
     }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/location/LocationPreviewProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/location/LocationPreviewProvider.kt
@@ -7,6 +7,7 @@ import io.ktor.client.request.header
 import io.ktor.client.statement.bodyAsText
 import io.ktor.client.statement.readRawBytes
 import io.ktor.http.isSuccess
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -16,10 +17,6 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
-import kotlin.math.PI
-import kotlin.math.cos
-import kotlin.math.ln
-import kotlin.math.tan
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeSource
 
@@ -147,14 +144,62 @@ class LocationPreviewProvider(
         return bytes
     }
 
-    /** Web Mercator lat/lon → tile X/Y at the given zoom. Standard Slippy Map formula. */
-    private fun latLonToTile(lat: Double, lon: Double, zoom: Int): Pair<Int, Int> {
-        val n = 1 shl zoom
-        val xTile = ((lon + 180.0) / 360.0 * n).toInt()
-        val latRad = lat * PI / 180.0
-        val yTile = ((1.0 - ln(tan(latRad) + 1.0 / cos(latRad)) / PI) / 2.0 * n).toInt()
-        return xTile to yTile
+    /**
+     * Fetch one raw OSM tile PNG for the Location history basemap. Same HTTP
+     * path, User-Agent and blank-tile guard as the chat preview; LRU-cached and
+     * single-flighted so a pan/zoom burst doesn't refetch or double-fetch.
+     * Returns null on failure or blank tile — callers leave the background empty.
+     */
+    suspend fun getTilePng(zoom: Int, xTile: Int, yTile: Int): ByteArray? {
+        val key = TileKey(zoom, xTile, yTile)
+        var owner = false
+        val flight = tileCacheMutex.withLock {
+            tileCache[key]?.let { return it }
+            tileFlights[key] ?: CompletableDeferred<ByteArray?>().also {
+                tileFlights[key] = it
+                owner = true
+            }
+        }
+        if (!owner) return flight.await()
+
+        val bytes = try {
+            fetchTile(zoom, xTile, yTile)
+        } catch (e: Exception) {
+            Logger.w(throwable = e, tag = TAG) { "getTilePng($zoom/$xTile/$yTile) threw" }
+            null
+        }
+        tileCacheMutex.withLock {
+            if (bytes != null) {
+                tileCache[key] = bytes
+                // Insertion-order eviction — good enough for a pan/zoom cache.
+                while (tileCache.size > TILE_CACHE_MAX) {
+                    tileCache.remove(tileCache.keys.first())
+                }
+            }
+            tileFlights.remove(key)
+        }
+        flight.complete(bytes)
+        return bytes
     }
+
+    private suspend fun fetchTile(zoom: Int, xTile: Int, yTile: Int): ByteArray? {
+        val url = "https://tile.openstreetmap.org/$zoom/$xTile/$yTile.png"
+        val response = httpClient.get(url) {
+            header("User-Agent", USER_AGENT)
+            header("Accept", "image/png,image/*")
+        }
+        if (!response.status.isSuccess()) {
+            Logger.w(tag = TAG) { "tile HTTP ${response.status.value} for $zoom/$xTile/$yTile" }
+            return null
+        }
+        val bytes = response.readRawBytes()
+        if (bytes.size < BLANK_TILE_THRESHOLD_BYTES) return null
+        return bytes
+    }
+
+    /** Web Mercator lat/lon → tile X/Y at the given zoom. Standard Slippy Map formula. */
+    private fun latLonToTile(lat: Double, lon: Double, zoom: Int): Pair<Int, Int> =
+        WebMercator.latLonToTile(lat, lon, zoom)
 
     private fun formatLatLon(lat: Double, lon: Double): String {
         val latStr = ((lat * 1e5).toLong() / 1e5).toString()
@@ -163,6 +208,8 @@ class LocationPreviewProvider(
     }
 
     private data class CacheKey(val lat: Double, val lon: Double, val zoom: Int)
+
+    private data class TileKey(val zoom: Int, val x: Int, val y: Int)
 
     private companion object {
         private const val TAG = "LocationPreviewProvider"
@@ -179,5 +226,11 @@ class LocationPreviewProvider(
         private val cache = mutableMapOf<CacheKey, LocationPreview>()
         private val nominatimMutex = Mutex()
         private var lastNominatimCallAt: TimeSource.Monotonic.ValueTimeMark? = null
+
+        // Raw-tile cache for the Location history basemap (~64 tiles ≈ 1-2MB).
+        private const val TILE_CACHE_MAX = 64
+        private val tileCache = LinkedHashMap<TileKey, ByteArray>()
+        private val tileFlights = mutableMapOf<TileKey, CompletableDeferred<ByteArray?>>()
+        private val tileCacheMutex = Mutex()
     }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/location/WebMercator.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/location/WebMercator.kt
@@ -1,0 +1,45 @@
+package id.homebase.api.client.location
+
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.floor
+import kotlin.math.ln
+import kotlin.math.tan
+
+/**
+ * Web Mercator / Slippy Map math, shared by the chat location preview
+ * (single-tile static map) and the Location history trace canvas.
+ *
+ * "Unit" coordinates are the continuous world position in 0..1 on both axes
+ * (x grows east, y grows south), i.e. tile coordinates divided by 2^zoom.
+ */
+object WebMercator {
+
+    const val TILE_SIZE_PX = 256
+
+    /** Continuous world position in 0..1 (Slippy Map projection). */
+    fun latLonToUnit(lat: Double, lon: Double): Pair<Double, Double> {
+        val x = (lon + 180.0) / 360.0
+        val latRad = lat * PI / 180.0
+        val y = (1.0 - ln(tan(latRad) + 1.0 / cos(latRad)) / PI) / 2.0
+        return x to y
+    }
+
+    /** Tile index along one axis for a unit coordinate at [zoom], clamped to the grid. */
+    fun unitToTile(unit: Double, zoom: Int): Int {
+        val n = 1 shl zoom
+        return floor(unit * n).toInt().coerceIn(0, n - 1)
+    }
+
+    /** Tile X/Y at [zoom] for a lat/lon — the standard Slippy Map formula. */
+    fun latLonToTile(lat: Double, lon: Double, zoom: Int): Pair<Int, Int> {
+        val (x, y) = latLonToUnit(lat, lon)
+        return unitToTile(x, zoom) to unitToTile(y, zoom)
+    }
+
+    /** Unit-space bounds of a tile: (minX, minY, maxX, maxY). */
+    fun tileToUnitBounds(xTile: Int, yTile: Int, zoom: Int): DoubleArray {
+        val n = (1 shl zoom).toDouble()
+        return doubleArrayOf(xTile / n, yTile / n, (xTile + 1) / n, (yTile + 1) / n)
+    }
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
@@ -68,6 +68,9 @@ private val driveLocalTagIndexAdapter = DriveLocalTagIndex.Adapter(
 private val keyValueAdapter = KeyValue.Adapter(
     keyAdapter = UuidAdapter
 )
+private val locationPointAdapter = LocationPoint.Adapter(
+    flushedFileUidAdapter = UuidAdapter
+)
 private val outboxAdapter = Outbox.Adapter(
     driveIdAdapter = UuidAdapter,
     uniqueIdAdapter = UuidAdapter,
@@ -138,6 +141,7 @@ class DatabaseManager(
             driveMainIndexAdapter,
             driveTagIndexAdapter,
             keyValueAdapter,
+            locationPointAdapter,
             outboxAdapter
         )
         logger.i { "Database initialized" }
@@ -207,6 +211,7 @@ class DatabaseManager(
             "DriveMainIndex",
             "DriveTagIndex",
             "KeyValue",
+            "LocationPoint",
             "Outbox"
         )
 
@@ -291,6 +296,9 @@ class DatabaseManager(
     }
     val outbox: OutboxWrapper by lazy {
         OutboxWrapper(driver, outboxAdapter, this)
+    }
+    val locationPoint: LocationPointWrapper by lazy {
+        LocationPointWrapper(driver, locationPointAdapter, this)
     }
     val connectionCache: ConnectionCacheWrapper by lazy {
         ConnectionCacheWrapper(driver, connectionCacheAdapter, this)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/LocationPointWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/LocationPointWrapper.kt
@@ -1,0 +1,123 @@
+package id.homebase.api.sync.database
+
+import app.cash.sqldelight.db.SqlDriver
+import kotlin.uuid.Uuid
+
+/**
+ * One buffered GPS point. Mirrors the LocationPoint table row; the Location
+ * add-on's tracker layer (homebase-common) maps its capture type to this.
+ */
+data class BufferedLocationPoint(
+    val t: Long,
+    val lat: Double,
+    val lon: Double,
+    val acc: Double?,
+    val alt: Double? = null,
+    val altAcc: Double? = null,
+    val spd: Double? = null,
+    val hdg: Double? = null,
+    val src: String,
+    val fg: Boolean,
+)
+
+/**
+ * Wrapper for the LocationPoint buffer table following the ChatReadCountWrapper
+ * pattern — reads on the read lane, writes through the single-writer dispatcher.
+ */
+class LocationPointWrapper(
+    driver: SqlDriver,
+    locationPointAdapter: LocationPoint.Adapter,
+    private val databaseManager: DatabaseManager,
+) {
+    private val delegate = LocationPointQueries(driver, locationPointAdapter)
+
+    suspend fun insertPoints(points: List<BufferedLocationPoint>) {
+        if (points.isEmpty()) return
+        databaseManager.withWriteTransaction { db ->
+            for (p in points) {
+                db.locationPointQueries.insertPoint(
+                    t = p.t,
+                    lat = p.lat,
+                    lon = p.lon,
+                    acc = p.acc,
+                    alt = p.alt,
+                    altAcc = p.altAcc,
+                    spd = p.spd,
+                    hdg = p.hdg,
+                    src = p.src,
+                    fg = if (p.fg) 1L else 0L,
+                )
+            }
+        }
+    }
+
+    /** Hour buckets (epoch ms / 3_600_000) that still have un-enqueued rows. */
+    suspend fun selectPendingHours(): List<Long> =
+        databaseManager.readValue("locationPoint.selectPendingHours") {
+            delegate.selectPendingHours().executeAsList()
+        }
+
+    suspend fun selectByTimeRange(fromInclusiveMs: Long, toExclusiveMs: Long): List<BufferedLocationPoint> {
+        val rows = databaseManager.readValue("locationPoint.selectByTimeRange") {
+            delegate.selectByTimeRange(fromInclusiveMs, toExclusiveMs).executeAsList()
+        }
+        return rows.map {
+            BufferedLocationPoint(
+                t = it.t, lat = it.lat, lon = it.lon, acc = it.acc,
+                alt = it.alt, altAcc = it.altAcc, spd = it.spd, hdg = it.hdg,
+                src = it.src, fg = it.fg != 0L,
+            )
+        }
+    }
+
+    suspend fun markFlushed(fileUid: Uuid, fromInclusiveMs: Long, toExclusiveMs: Long) {
+        databaseManager.withWrite { db ->
+            db.locationPointQueries.markFlushed(fileUid, fromInclusiveMs, toExclusiveMs)
+        }
+    }
+
+    suspend fun clearFlushMark(fileUid: Uuid) {
+        databaseManager.withWrite { db ->
+            db.locationPointQueries.clearFlushMark(fileUid)
+        }
+    }
+
+    suspend fun deleteByFlushUid(fileUid: Uuid) {
+        databaseManager.withWrite { db ->
+            db.locationPointQueries.deleteByFlushUid(fileUid)
+        }
+    }
+
+    suspend fun countAll(): Long =
+        databaseManager.readValue("locationPoint.countAll") {
+            delegate.countAll().executeAsOne()
+        }
+
+    suspend fun countSince(fromInclusiveMs: Long): Long =
+        databaseManager.readValue("locationPoint.countSince") {
+            delegate.countSince(fromInclusiveMs).executeAsOne()
+        }
+
+    suspend fun selectLatest(): BufferedLocationPoint? {
+        val row = databaseManager.readValue("locationPoint.selectLatest") {
+            delegate.selectLatest().executeAsOneOrNull()
+        } ?: return null
+        return BufferedLocationPoint(
+            t = row.t, lat = row.lat, lon = row.lon, acc = row.acc,
+            alt = row.alt, altAcc = row.altAcc, spd = row.spd, hdg = row.hdg,
+            src = row.src, fg = row.fg != 0L,
+        )
+    }
+
+    suspend fun deleteOlderThan(beforeMs: Long) {
+        databaseManager.withWrite { db ->
+            db.locationPointQueries.deleteOlderThan(beforeMs)
+        }
+    }
+
+    suspend fun deleteAll() {
+        databaseManager.withWrite { db ->
+            db.locationPointQueries.deleteAll()
+        }
+    }
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/LocationPointWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/LocationPointWrapper.kt
@@ -98,6 +98,12 @@ class LocationPointWrapper(
             delegate.countSince(fromInclusiveMs).executeAsOne()
         }
 
+    /** Rows since [fromInclusiveMs] not yet part of any enqueued hour file. */
+    suspend fun countUnmarkedSince(fromInclusiveMs: Long): Long =
+        databaseManager.readValue("locationPoint.countUnmarkedSince") {
+            delegate.countUnmarkedSince(fromInclusiveMs).executeAsOne()
+        }
+
     suspend fun selectLatest(): BufferedLocationPoint? {
         val row = databaseManager.readValue("locationPoint.selectLatest") {
             delegate.selectLatest().executeAsOneOrNull()

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/LocationPoint.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/LocationPoint.sq
@@ -1,0 +1,75 @@
+import kotlin.uuid.Uuid;
+
+-- Local buffer for GPS points captured by the Location add-on, drained into
+-- per-device per-UTC-hour track files on the Location drive by
+-- LocationTrackUploaderService. Drain semantics: rows are stamped with the
+-- target file's uniqueId on enqueue (markFlushed), deleted when the outbox
+-- confirms the upload (deleteByFlushUid), and un-stamped on failure
+-- (clearFlushMark) so the next flush retries them.
+CREATE TABLE IF NOT EXISTS LocationPoint(
+  t INTEGER NOT NULL PRIMARY KEY,  -- capture time, epoch ms; INSERT OR REPLACE dedups
+  lat REAL NOT NULL,
+  lon REAL NOT NULL,
+  acc REAL,                        -- horizontal accuracy, meters
+  alt REAL,                        -- altitude, meters
+  altAcc REAL,                     -- vertical accuracy, meters
+  spd REAL,                        -- speed, m/s
+  hdg REAL,                        -- heading/bearing, degrees
+  src TEXT NOT NULL,               -- gps | net | fused | slc
+  fg INTEGER NOT NULL,             -- 1 when captured in foreground precise mode
+  flushedFileUid BLOB AS Uuid      -- hour-file uniqueId once part of an enqueued flush
+);
+
+insertPoint:
+INSERT OR REPLACE INTO LocationPoint(t, lat, lon, acc, alt, altAcc, spd, hdg, src, fg, flushedFileUid)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL);
+
+-- Hours (epoch ms / 3600000) that still have rows not yet part of an enqueued flush.
+selectPendingHours:
+SELECT DISTINCT (t / 3600000) AS hourBucket
+FROM LocationPoint
+WHERE flushedFileUid IS NULL
+ORDER BY hourBucket;
+
+-- Every row of an hour (marked and unmarked) — a flush re-serializes the full hour.
+selectByTimeRange:
+SELECT t, lat, lon, acc, alt, altAcc, spd, hdg, src, fg
+FROM LocationPoint
+WHERE t >= ? AND t < ?
+ORDER BY t;
+
+markFlushed:
+UPDATE LocationPoint
+SET flushedFileUid = ?
+WHERE t >= ? AND t < ?;
+
+clearFlushMark:
+UPDATE LocationPoint
+SET flushedFileUid = NULL
+WHERE flushedFileUid = ?;
+
+deleteByFlushUid:
+DELETE FROM LocationPoint
+WHERE flushedFileUid = ?;
+
+-- Rows still on this device (enqueued or not) — the UI's "waiting to upload" count.
+countAll:
+SELECT COUNT(*) FROM LocationPoint;
+
+countSince:
+SELECT COUNT(*) FROM LocationPoint
+WHERE t >= ?;
+
+selectLatest:
+SELECT t, lat, lon, acc, alt, altAcc, spd, hdg, src, fg
+FROM LocationPoint
+ORDER BY t DESC
+LIMIT 1;
+
+-- Retention sweep: bounds buffer growth when uploads are persistently failing.
+deleteOlderThan:
+DELETE FROM LocationPoint
+WHERE t < ?;
+
+deleteAll:
+DELETE FROM LocationPoint;

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/LocationPoint.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/LocationPoint.sq
@@ -60,6 +60,13 @@ countSince:
 SELECT COUNT(*) FROM LocationPoint
 WHERE t >= ?;
 
+-- Rows captured since ? that are not yet serialized into any hour file.
+-- Used by the "points today" computation: hour files carry the counts for
+-- everything already enqueued; these rows are the not-yet-flushed remainder.
+countUnmarkedSince:
+SELECT COUNT(*) FROM LocationPoint
+WHERE t >= ? AND flushedFileUid IS NULL;
+
 selectLatest:
 SELECT t, lat, lon, acc, alt, altAcc, spd, hdg, src, fg
 FROM LocationPoint

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/client/location/WebMercatorTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/client/location/WebMercatorTest.kt
@@ -1,0 +1,53 @@
+package id.homebase.api.client.location
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class WebMercatorTest {
+
+    @Test
+    fun originOfTheWorld() {
+        val (x, y) = WebMercator.latLonToUnit(0.0, 0.0)
+        assertEquals(0.5, x, 1e-9)
+        assertEquals(0.5, y, 1e-9)
+    }
+
+    @Test
+    fun knownCityTileMatchesSlippyMapReference() {
+        // Berlin Alexanderplatz at zoom 15 — reference values from the
+        // OpenStreetMap slippy-map tilenames formula.
+        val (x, y) = WebMercator.latLonToTile(52.5219, 13.4132, 15)
+        assertEquals(17604, x)
+        assertEquals(10746, y)
+    }
+
+    @Test
+    fun unitGrowsEastAndSouth() {
+        val (xWest, _) = WebMercator.latLonToUnit(0.0, -120.0)
+        val (xEast, _) = WebMercator.latLonToUnit(0.0, 120.0)
+        assertTrue(xWest < 0.5 && xEast > 0.5)
+
+        val (_, yNorth) = WebMercator.latLonToUnit(60.0, 0.0)
+        val (_, ySouth) = WebMercator.latLonToUnit(-60.0, 0.0)
+        assertTrue(yNorth < 0.5 && ySouth > 0.5)
+    }
+
+    @Test
+    fun tileBoundsContainTheOriginatingPoint() {
+        val lat = 55.6761; val lon = 12.5683 // Copenhagen
+        for (zoom in listOf(3, 10, 16)) {
+            val (tx, ty) = WebMercator.latLonToTile(lat, lon, zoom)
+            val b = WebMercator.tileToUnitBounds(tx, ty, zoom)
+            val (ux, uy) = WebMercator.latLonToUnit(lat, lon)
+            assertTrue(ux >= b[0] && ux < b[2], "x out of bounds at z$zoom")
+            assertTrue(uy >= b[1] && uy < b[3], "y out of bounds at z$zoom")
+        }
+    }
+
+    @Test
+    fun unitToTileClampsToGrid() {
+        assertEquals(0, WebMercator.unitToTile(-0.1, 4))
+        assertEquals(15, WebMercator.unitToTile(1.1, 4))
+    }
+}

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/LocationPointWrapperTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/LocationPointWrapperTest.kt
@@ -92,6 +92,18 @@ class LocationPointWrapperTest {
     }
 
     @Test
+    fun countUnmarkedSinceExcludesEnqueuedRows() = runDbTest { buffer ->
+        val h0 = 0L
+        buffer.insertPoints(listOf(point(h0 + 1), point(h0 + 2)))
+        buffer.markFlushed(Uuid.random(), h0, hourMs)
+        // New point after the flush — the only one not yet in a file.
+        buffer.insertPoints(listOf(point(h0 + 3)))
+
+        assertEquals(1, buffer.countUnmarkedSince(0))
+        assertEquals(3, buffer.countSince(0))
+    }
+
+    @Test
     fun countSinceAndLatestAndRetention() = runDbTest { buffer ->
         buffer.insertPoints(listOf(point(1000), point(5000), point(9000)))
         assertEquals(2, buffer.countSince(5000))

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/LocationPointWrapperTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/LocationPointWrapperTest.kt
@@ -1,0 +1,107 @@
+package id.homebase.api.sync.database
+
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertNotNull
+import kotlin.uuid.Uuid
+
+/**
+ * Drain semantics of the Location buffer: mark-on-enqueue → delete-on-complete,
+ * mark → clear-on-failure → retry visibility. See LocationTrackUploaderService.
+ */
+class LocationPointWrapperTest {
+
+    private val hourMs = 3_600_000L
+
+    private fun point(t: Long, lat: Double = 52.0, lon: Double = 13.0) = BufferedLocationPoint(
+        t = t, lat = lat, lon = lon, acc = 10.0, src = "fused", fg = false,
+    )
+
+    private fun runDbTest(body: suspend TestScope.(LocationPointWrapper) -> Unit) = runTest {
+        val dbDispatcher = StandardTestDispatcher(testScheduler)
+        val db = DatabaseManager(
+            { createInMemoryDatabase() },
+            dispatcher = dbDispatcher,
+            readDispatcher = dbDispatcher,
+        )
+        try {
+            body(db.locationPoint)
+        } finally {
+            db.close()
+        }
+    }
+
+    @Test
+    fun insertIsIdempotentOnTimestamp() = runDbTest { buffer ->
+        buffer.insertPoints(listOf(point(1000), point(1000), point(2000)))
+        assertEquals(2, buffer.countAll())
+    }
+
+    @Test
+    fun pendingHoursOnlyCountsUnmarkedRows() = runDbTest { buffer ->
+        val h0 = 0L
+        val h1 = hourMs
+        buffer.insertPoints(listOf(point(h0 + 1), point(h1 + 1)))
+        assertEquals(listOf(0L, 1L), buffer.selectPendingHours())
+
+        val uid = Uuid.random()
+        buffer.markFlushed(uid, h0, h1)
+        assertEquals(listOf(1L), buffer.selectPendingHours())
+    }
+
+    @Test
+    fun completeDrainsOnlyTheMarkedHour() = runDbTest { buffer ->
+        val h0 = 0L
+        val h1 = hourMs
+        buffer.insertPoints(listOf(point(h0 + 1), point(h0 + 2), point(h1 + 1)))
+        val uid = Uuid.random()
+        buffer.markFlushed(uid, h0, h1)
+
+        buffer.deleteByFlushUid(uid)
+        assertEquals(1, buffer.countAll())
+        assertEquals(listOf(1L), buffer.selectPendingHours())
+    }
+
+    @Test
+    fun failureUnmarksRowsForRetry() = runDbTest { buffer ->
+        val h0 = 0L
+        buffer.insertPoints(listOf(point(h0 + 1)))
+        val uid = Uuid.random()
+        buffer.markFlushed(uid, h0, hourMs)
+        assertEquals(emptyList(), buffer.selectPendingHours())
+
+        buffer.clearFlushMark(uid)
+        assertEquals(listOf(0L), buffer.selectPendingHours())
+        assertEquals(1, buffer.countAll())
+    }
+
+    @Test
+    fun reFlushOfHourIncludesMarkedAndUnmarkedRows() = runDbTest { buffer ->
+        val h0 = 0L
+        buffer.insertPoints(listOf(point(h0 + 1)))
+        buffer.markFlushed(Uuid.random(), h0, hourMs)
+        // A new point lands in the same hour while the first flush is pending.
+        buffer.insertPoints(listOf(point(h0 + 2)))
+
+        assertEquals(listOf(0L), buffer.selectPendingHours())
+        assertEquals(2, buffer.selectByTimeRange(h0, hourMs).size)
+    }
+
+    @Test
+    fun countSinceAndLatestAndRetention() = runDbTest { buffer ->
+        buffer.insertPoints(listOf(point(1000), point(5000), point(9000)))
+        assertEquals(2, buffer.countSince(5000))
+        assertEquals(9000, assertNotNull(buffer.selectLatest()).t)
+
+        buffer.deleteOlderThan(5000)
+        assertEquals(2, buffer.countAll())
+
+        buffer.deleteAll()
+        assertEquals(0, buffer.countAll())
+        assertNull(buffer.selectLatest())
+    }
+}

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/TestDatabaseFactory.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/TestDatabaseFactory.kt
@@ -48,6 +48,8 @@ object TestDatabaseFactory {
 
     private val connectionCacheAdapter = ConnectionCache.Adapter(identityIdAdapter = UuidAdapter)
 
+    private val locationPointAdapter = LocationPoint.Adapter(flushedFileUidAdapter = UuidAdapter)
+
     /**
      * Creates a test database with all adapters pre-configured. Uses the platform-specific
      * in-memory driver.
@@ -67,6 +69,7 @@ object TestDatabaseFactory {
             driveMainIndexAdapter,
             driveTagIndexAdapter,
             keyValueAdapter,
+            locationPointAdapter,
             outboxAdapter
         )
     }

--- a/homebase-common/build.gradle.kts
+++ b/homebase-common/build.gradle.kts
@@ -145,6 +145,10 @@ kotlin {
             // `api` so the dep cascades transitively to androidApp (which
             // imports NotifierManager in MainApplication/MainActivity).
             api(libs.kmpnotifier)
+            // Location add-on tracker: fused provider (batched background
+            // PendingIntent updates) + app-foreground observation.
+            implementation(libs.play.services.location)
+            implementation(libs.androidx.lifecycle.process)
         }
         appleMain.dependencies {
             implementation(libs.ktor.client.darwin)

--- a/homebase-common/src/androidMain/AndroidManifest.xml
+++ b/homebase-common/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- Location add-on background tracking. Both receivers merge into the app
+         manifest; the app module declares the runtime permissions
+         (ACCESS_BACKGROUND_LOCATION, RECEIVE_BOOT_COMPLETED). -->
+    <application>
+        <receiver
+            android:name="id.homebase.core.location.tracking.LocationUpdatesReceiver"
+            android:enabled="true"
+            android:exported="false" />
+
+        <receiver
+            android:name="id.homebase.core.location.tracking.LocationBootReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+    </application>
+
+</manifest>

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/AppForegroundObserver.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/AppForegroundObserver.android.kt
@@ -1,0 +1,21 @@
+package id.homebase.core.location.tracking
+
+import android.os.Handler
+import android.os.Looper
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+
+actual fun observeAppForeground(onChange: (Boolean) -> Unit) {
+    // Lifecycle registration must happen on the main thread; a headless
+    // process start (boot receiver, background location wake) may call
+    // through from elsewhere.
+    Handler(Looper.getMainLooper()).post {
+        val lifecycle = ProcessLifecycleOwner.get().lifecycle
+        onChange(lifecycle.currentState.isAtLeast(androidx.lifecycle.Lifecycle.State.STARTED))
+        lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onStart(owner: LifecycleOwner) = onChange(true)
+            override fun onStop(owner: LifecycleOwner) = onChange(false)
+        })
+    }
+}

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/LocationBootReceiver.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/LocationBootReceiver.kt
@@ -1,0 +1,22 @@
+package id.homebase.core.location.tracking
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import co.touchlab.kermit.Logger
+
+/**
+ * Fused-provider PendingIntent registrations survive process death but NOT a
+ * reboot. This receiver exists solely so BOOT_COMPLETED starts the app process:
+ * MainApplication.onCreate then runs LocationTrackingCoordinator.onProcessStart(),
+ * which re-arms the registration when tracking is enabled. The body itself has
+ * nothing to do.
+ */
+class LocationBootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
+        Logger.withTag("LocationBootReceiver").i {
+            "Boot completed — process started; coordinator re-arms tracking if enabled"
+        }
+    }
+}

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/LocationTracker.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/LocationTracker.android.kt
@@ -1,0 +1,161 @@
+package id.homebase.core.location.tracking
+
+import android.annotation.SuppressLint
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Looper
+import co.touchlab.kermit.Logger
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+import id.homebase.api.ActivityProvider
+import id.homebase.api.coroutines.supervisedScope
+import kotlinx.coroutines.launch
+
+actual fun createLocationTracker(sink: LocationPointSink): LocationTracker =
+    AndroidLocationTracker(sink)
+
+/**
+ * FusedLocationProvider-based tracker, no foreground service.
+ *
+ * Two concurrent registrations while tracking:
+ * - **PendingIntent** (always on): balanced power, 60s interval with up to 10min
+ *   batched delivery — the OS coalesces wakeups; deliveries land in
+ *   [LocationUpdatesReceiver] even when the app process is dead (the receiver
+ *   wake restarts it). This is the only path that works in the background
+ *   without a foreground service, at whatever cadence the OS allows.
+ * - **Foreground overlay** (only in [TrackingMode.Foreground]): a high-accuracy
+ *   callback at 15s/10m feeding [sink] directly for precise capture while the
+ *   user has the app open. Removed on backgrounding; the PendingIntent stays
+ *   registered throughout so there is no gap, and the store's time/displacement
+ *   dedup absorbs the overlap.
+ *
+ * NOTE: this codebase previously saw fused *one-shot* reads (lastLocation /
+ * getCurrentLocation) return null (see chat's LocationLauncher.android.kt);
+ * continuous requestLocationUpdates is a different code path but must be
+ * validated on a device before shipping — fallback is the framework
+ * LocationManager with the same receiver.
+ */
+private class AndroidLocationTracker(
+    private val sink: LocationPointSink,
+) : LocationTracker {
+
+    private val logger = Logger.withTag("AndroidLocationTracker")
+    private val scope = supervisedScope("AndroidLocationTracker")
+
+    override val isAvailable: Boolean = true
+
+    private var started = false
+    private var foregroundCallback: LocationCallback? = null
+
+    private val context: Context get() = ActivityProvider.requireApplicationContext()
+    private val fusedClient get() = LocationServices.getFusedLocationProviderClient(context)
+
+    @SuppressLint("MissingPermission")
+    override fun start(mode: TrackingMode) {
+        if (started) {
+            setMode(mode)
+            return
+        }
+        runCatching {
+            val request = LocationRequest.Builder(
+                Priority.PRIORITY_BALANCED_POWER_ACCURACY,
+                BACKGROUND_INTERVAL_MS,
+            )
+                .setMaxUpdateDelayMillis(BACKGROUND_MAX_DELAY_MS)
+                .setMinUpdateDistanceMeters(BACKGROUND_MIN_DISPLACEMENT_M)
+                .build()
+            fusedClient.requestLocationUpdates(request, backgroundPendingIntent())
+            started = true
+            logger.i { "Started background PendingIntent updates" }
+        }.onFailure {
+            // Typically SecurityException when permission was revoked behind our back.
+            logger.e(it) { "Failed to start location updates" }
+            return
+        }
+        setMode(mode)
+    }
+
+    @SuppressLint("MissingPermission")
+    override fun setMode(mode: TrackingMode) {
+        if (!started) return
+        when (mode) {
+            TrackingMode.Foreground -> {
+                if (foregroundCallback != null) return
+                val callback = object : LocationCallback() {
+                    override fun onLocationResult(result: com.google.android.gms.location.LocationResult) {
+                        val points = result.locations.map { it.toRawPoint(fg = true) }
+                        if (points.isEmpty()) return
+                        scope.launch { sink.submit(points) }
+                    }
+                }
+                runCatching {
+                    val request = LocationRequest.Builder(
+                        Priority.PRIORITY_HIGH_ACCURACY,
+                        FOREGROUND_INTERVAL_MS,
+                    )
+                        .setMinUpdateDistanceMeters(FOREGROUND_MIN_DISPLACEMENT_M)
+                        .build()
+                    fusedClient.requestLocationUpdates(request, callback, Looper.getMainLooper())
+                    foregroundCallback = callback
+                    logger.i { "Foreground precise overlay on" }
+                }.onFailure { logger.e(it) { "Failed to start foreground overlay" } }
+            }
+
+            TrackingMode.Background -> {
+                foregroundCallback?.let {
+                    fusedClient.removeLocationUpdates(it)
+                    foregroundCallback = null
+                    logger.i { "Foreground precise overlay off" }
+                }
+            }
+        }
+    }
+
+    override fun stop() {
+        foregroundCallback?.let { fusedClient.removeLocationUpdates(it) }
+        foregroundCallback = null
+        fusedClient.removeLocationUpdates(backgroundPendingIntent())
+        started = false
+        logger.i { "Stopped all location updates" }
+    }
+
+    private fun backgroundPendingIntent(): PendingIntent {
+        val intent = Intent(context, LocationUpdatesReceiver::class.java)
+            .setAction(LocationUpdatesReceiver.ACTION_LOCATION_UPDATE)
+        // FLAG_MUTABLE is required: the fused provider appends the location
+        // payload to the intent on delivery.
+        return PendingIntent.getBroadcast(
+            context,
+            PENDING_INTENT_REQUEST_CODE,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
+        )
+    }
+
+    private companion object {
+        const val PENDING_INTENT_REQUEST_CODE = 5610
+
+        const val BACKGROUND_INTERVAL_MS = 60_000L
+        const val BACKGROUND_MAX_DELAY_MS = 600_000L
+        const val BACKGROUND_MIN_DISPLACEMENT_M = 25f
+
+        const val FOREGROUND_INTERVAL_MS = 15_000L
+        const val FOREGROUND_MIN_DISPLACEMENT_M = 10f
+    }
+}
+
+internal fun android.location.Location.toRawPoint(fg: Boolean): RawLocationPoint = RawLocationPoint(
+    t = time,
+    lat = latitude,
+    lon = longitude,
+    acc = if (hasAccuracy()) accuracy.toDouble() else null,
+    alt = if (hasAltitude()) altitude else null,
+    altAcc = if (hasVerticalAccuracy()) verticalAccuracyMeters.toDouble() else null,
+    spd = if (hasSpeed()) speed.toDouble() else null,
+    hdg = if (hasBearing()) bearing.toDouble() else null,
+    src = "fused",
+    fg = fg,
+)

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/LocationUpdatesReceiver.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/LocationUpdatesReceiver.kt
@@ -34,7 +34,8 @@ class LocationUpdatesReceiver : BroadcastReceiver(), KoinComponent {
         val points = result.locations.map { it.toRawPoint(fg = false) }
         if (points.isEmpty()) return
 
-        logger.d { "Background batch: ${points.size} points" }
+        // Info so the cold-process background path is auditable in homebase.log.
+        logger.i { "Background batch: ${points.size} points" }
         val pendingResult = goAsync()
         scope.launch {
             try {

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/LocationUpdatesReceiver.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/LocationUpdatesReceiver.kt
@@ -1,0 +1,58 @@
+package id.homebase.core.location.tracking
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import co.touchlab.kermit.Logger
+import com.google.android.gms.location.LocationResult
+import id.homebase.api.coroutines.supervisedScope
+import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
+import org.koin.core.context.GlobalContext
+
+/**
+ * Receives batched fused-location deliveries from the background PendingIntent
+ * registration (see AndroidLocationTracker). Manifest-registered, so a delivery
+ * wakes the app process if it is dead; MainApplication.onCreate has already
+ * initialized SecureStorage + DatabaseManager + Koin by the time onReceive runs
+ * (the same guarantee DriveFcmService relies on), so points go straight into
+ * the encrypted buffer table.
+ */
+class LocationUpdatesReceiver : BroadcastReceiver(), KoinComponent {
+
+    private val logger = Logger.withTag("LocationUpdatesReceiver")
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ACTION_LOCATION_UPDATE) return
+        // Defensive: a secondary process (none today) would have no Koin.
+        if (GlobalContext.getOrNull() == null) {
+            logger.w { "Koin not started — dropping location batch" }
+            return
+        }
+        val result = LocationResult.extractResult(intent) ?: return
+        val points = result.locations.map { it.toRawPoint(fg = false) }
+        if (points.isEmpty()) return
+
+        logger.d { "Background batch: ${points.size} points" }
+        val pendingResult = goAsync()
+        scope.launch {
+            try {
+                get<LocationPointStore>().submit(points)
+                // Opportunistic drain — we're awake anyway; the coordinator
+                // forwards to the uploader's rate-gated flushIfDue.
+                get<LocationTrackingCoordinator>().onBackgroundPointsDelivered()
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+
+    companion object {
+        const val ACTION_LOCATION_UPDATE = "id.homebase.core.location.ACTION_LOCATION_UPDATE"
+
+        // Receiver instances are throwaway; the scope must outlive them until
+        // pendingResult.finish() — process-scoped like the work it performs.
+        private val scope = supervisedScope("LocationUpdatesReceiver")
+    }
+}

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/permissions/PermissionsManager.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/permissions/PermissionsManager.android.kt
@@ -60,6 +60,10 @@ private fun String.toPermissionType(): PermissionType? {
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && this == Manifest.permission.POST_NOTIFICATIONS) return PermissionType.NOTIFICATION
 
+    if (this == Manifest.permission.ACCESS_FINE_LOCATION || this == Manifest.permission.ACCESS_COARSE_LOCATION) return PermissionType.LOCATION
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && this == Manifest.permission.ACCESS_BACKGROUND_LOCATION) return PermissionType.LOCATION_ALWAYS
+
     return null
 }
 
@@ -118,6 +122,26 @@ class AndroidPermissionsManager(
                     )
                 }
             }
+
+            PermissionType.LOCATION -> {
+                genericPermissionLauncher.launch(
+                    arrayOf(
+                        Manifest.permission.ACCESS_FINE_LOCATION,
+                        Manifest.permission.ACCESS_COARSE_LOCATION,
+                    )
+                )
+            }
+
+            PermissionType.LOCATION_ALWAYS -> {
+                // Background location is a separate runtime permission from API 29 and
+                // may only be requested once foreground location is already granted —
+                // callers gate the request on isPermissionGranted(LOCATION).
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    genericPermissionLauncher.launch(
+                        arrayOf(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+                    )
+                }
+            }
         }
     }
 
@@ -170,6 +194,26 @@ class AndroidPermissionsManager(
                     ) == PackageManager.PERMISSION_GRANTED
                 } else {
                     true
+                }
+            }
+
+            PermissionType.LOCATION -> {
+                // Coarse-only ("approximate") still counts as while-in-use access.
+                ContextCompat.checkSelfPermission(
+                    context, Manifest.permission.ACCESS_FINE_LOCATION
+                ) == PackageManager.PERMISSION_GRANTED ||
+                    ContextCompat.checkSelfPermission(
+                        context, Manifest.permission.ACCESS_COARSE_LOCATION
+                    ) == PackageManager.PERMISSION_GRANTED
+            }
+
+            PermissionType.LOCATION_ALWAYS -> {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    ContextCompat.checkSelfPermission(
+                        context, Manifest.permission.ACCESS_BACKGROUND_LOCATION
+                    ) == PackageManager.PERMISSION_GRANTED
+                } else {
+                    isPermissionGranted(PermissionType.LOCATION)
                 }
             }
         }

--- a/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/AppForegroundObserver.apple.kt
+++ b/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/AppForegroundObserver.apple.kt
@@ -2,14 +2,17 @@ package id.homebase.core.location.tracking
 
 import platform.Foundation.NSNotificationCenter
 import platform.Foundation.NSOperationQueue
-import platform.UIKit.UIApplication
 import platform.UIKit.UIApplicationDidBecomeActiveNotification
 import platform.UIKit.UIApplicationDidEnterBackgroundNotification
-import platform.UIKit.UIApplicationStateActive
 
 actual fun observeAppForeground(onChange: (Boolean) -> Unit) {
     val center = NSNotificationCenter.defaultCenter
-    onChange(UIApplication.sharedApplication.applicationState == UIApplicationStateActive)
+    // Registration happens during application(_:didFinishLaunching:) — before
+    // UIApplicationDidBecomeActive is posted — so reporting background here is
+    // correct for both launch shapes: a visible launch receives DidBecomeActive
+    // moments later, and a background location-key relaunch correctly stays
+    // in the background profile.
+    onChange(false)
     center.addObserverForName(
         name = UIApplicationDidBecomeActiveNotification,
         `object` = null,

--- a/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/AppForegroundObserver.apple.kt
+++ b/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/AppForegroundObserver.apple.kt
@@ -1,0 +1,23 @@
+package id.homebase.core.location.tracking
+
+import platform.Foundation.NSNotificationCenter
+import platform.Foundation.NSOperationQueue
+import platform.UIKit.UIApplication
+import platform.UIKit.UIApplicationDidBecomeActiveNotification
+import platform.UIKit.UIApplicationDidEnterBackgroundNotification
+import platform.UIKit.UIApplicationStateActive
+
+actual fun observeAppForeground(onChange: (Boolean) -> Unit) {
+    val center = NSNotificationCenter.defaultCenter
+    onChange(UIApplication.sharedApplication.applicationState == UIApplicationStateActive)
+    center.addObserverForName(
+        name = UIApplicationDidBecomeActiveNotification,
+        `object` = null,
+        queue = NSOperationQueue.mainQueue,
+    ) { _ -> onChange(true) }
+    center.addObserverForName(
+        name = UIApplicationDidEnterBackgroundNotification,
+        `object` = null,
+        queue = NSOperationQueue.mainQueue,
+    ) { _ -> onChange(false) }
+}

--- a/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/LocationTracker.apple.kt
+++ b/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/LocationTracker.apple.kt
@@ -12,6 +12,7 @@ import platform.CoreLocation.CLLocationManagerDelegateProtocol
 import platform.CoreLocation.kCLLocationAccuracyBest
 import platform.CoreLocation.kCLLocationAccuracyHundredMeters
 import platform.Foundation.NSError
+import platform.Foundation.timeIntervalSince1970
 import platform.darwin.NSObject
 
 actual fun createLocationTracker(sink: LocationPointSink): LocationTracker =

--- a/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/LocationTracker.apple.kt
+++ b/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/LocationTracker.apple.kt
@@ -1,0 +1,125 @@
+package id.homebase.core.location.tracking
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.coroutines.supervisedScope
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.useContents
+import kotlinx.coroutines.launch
+import platform.CoreLocation.CLActivityTypeOther
+import platform.CoreLocation.CLLocation
+import platform.CoreLocation.CLLocationManager
+import platform.CoreLocation.CLLocationManagerDelegateProtocol
+import platform.CoreLocation.kCLLocationAccuracyBest
+import platform.CoreLocation.kCLLocationAccuracyHundredMeters
+import platform.Foundation.NSError
+import platform.darwin.NSObject
+
+actual fun createLocationTracker(sink: LocationPointSink): LocationTracker =
+    AppleLocationTracker(sink)
+
+/**
+ * CLLocationManager-based tracker.
+ *
+ * Battery levers (the ones that demonstrably work — see the Anchor source dive):
+ * - `pausesLocationUpdatesAutomatically = true` lets iOS suspend standard
+ *   updates while the device is stationary.
+ * - Background profile drops to hundred-meter accuracy with a 50m distance
+ *   filter; foreground runs best-accuracy at 10m.
+ * - Significant-location-change monitoring is always on while tracking — it is
+ *   the relaunch vector after the OS terminates the app
+ *   (UIApplicationLaunchOptionsLocationKey → initializeApp →
+ *   LocationTrackingCoordinator.onProcessStart re-creates this manager inside
+ *   the launch runloop).
+ */
+private class AppleLocationTracker(
+    private val sink: LocationPointSink,
+) : LocationTracker {
+
+    private val logger = Logger.withTag("AppleLocationTracker")
+    private val scope = supervisedScope("AppleLocationTracker")
+
+    override val isAvailable: Boolean = true
+
+    private var started = false
+    private var mode = TrackingMode.Background
+
+    private val delegate = object : NSObject(), CLLocationManagerDelegateProtocol {
+        override fun locationManager(manager: CLLocationManager, didUpdateLocations: List<*>) {
+            val points = didUpdateLocations
+                .filterIsInstance<CLLocation>()
+                .map { it.toRawPoint(fg = mode == TrackingMode.Foreground) }
+            if (points.isEmpty()) return
+            scope.launch { sink.submit(points) }
+        }
+
+        override fun locationManager(manager: CLLocationManager, didFailWithError: NSError) {
+            logger.w { "didFailWithError: ${didFailWithError.localizedDescription}" }
+        }
+    }
+
+    private val manager: CLLocationManager by lazy {
+        CLLocationManager().apply {
+            delegate = this@AppleLocationTracker.delegate
+            allowsBackgroundLocationUpdates = true
+            pausesLocationUpdatesAutomatically = true
+            activityType = CLActivityTypeOther
+        }
+    }
+
+    override fun start(mode: TrackingMode) {
+        this.mode = mode
+        applyProfile(mode)
+        if (started) return
+        manager.startMonitoringSignificantLocationChanges()
+        manager.startUpdatingLocation()
+        started = true
+        logger.i { "Started (mode=$mode)" }
+    }
+
+    override fun setMode(mode: TrackingMode) {
+        if (this.mode == mode) return
+        this.mode = mode
+        if (!started) return
+        applyProfile(mode)
+        logger.i { "Profile -> $mode" }
+    }
+
+    override fun stop() {
+        manager.stopUpdatingLocation()
+        manager.stopMonitoringSignificantLocationChanges()
+        started = false
+        logger.i { "Stopped" }
+    }
+
+    private fun applyProfile(mode: TrackingMode) {
+        when (mode) {
+            TrackingMode.Foreground -> {
+                manager.desiredAccuracy = kCLLocationAccuracyBest
+                manager.distanceFilter = 10.0
+            }
+
+            TrackingMode.Background -> {
+                manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+                manager.distanceFilter = 50.0
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun CLLocation.toRawPoint(fg: Boolean): RawLocationPoint {
+    val (lat, lon) = coordinate.useContents { latitude to longitude }
+    return RawLocationPoint(
+        t = (timestamp.timeIntervalSince1970 * 1000).toLong(),
+        lat = lat,
+        lon = lon,
+        acc = horizontalAccuracy.takeIf { it >= 0 },
+        alt = altitude.takeIf { verticalAccuracy >= 0 },
+        altAcc = verticalAccuracy.takeIf { it >= 0 },
+        // CL uses negative values as "invalid" sentinels.
+        spd = speed.takeIf { it >= 0 },
+        hdg = course.takeIf { it >= 0 },
+        src = "gps",
+        fg = fg,
+    )
+}

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1221,6 +1221,10 @@
     <string name="location_status_pending">Waiting to upload</string>
     <string name="location_status_last_flush">Last upload</string>
     <string name="location_status_never">Never</string>
+    <string name="location_consent_title">Your private location history</string>
+    <string name="location_consent_text">Your app will collect location data to record your private location history and store it on your private Homebase Location drive — even when this app is closed or not in use. Your history is end-to-end encrypted to your personal drive; no one but you, not even your cloud operator, can read it.</string>
+    <string name="location_consent_agree">Agree</string>
+    <string name="location_consent_decline">No thanks</string>
     <string name="location_history_title">History</string>
     <string name="location_history_empty">No locations recorded on this day</string>
     <string name="location_history_show_map">Show map</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1194,6 +1194,7 @@
     <string name="location_onboarding_body_2">Set it up to mount the Location drive on this device. You choose when tracking is on.</string>
     <string name="location_onboarding_setup">Set it up</string>
     <string name="location_onboarding_dismiss">Not now</string>
+    <string name="location_settings">Settings</string>
     <string name="location_settings_section">Location</string>
     <string name="location_settings_open">Open Location</string>
     <string name="location_settings_show_icon">Show Location icon in bottom bar</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1213,5 +1213,16 @@
     <string name="location_status_pending">Waiting to upload</string>
     <string name="location_status_last_flush">Last upload</string>
     <string name="location_status_never">Never</string>
+    <string name="location_history_title">History</string>
+    <string name="location_history_empty">No locations recorded on this day</string>
+    <string name="location_history_show_map">Show map</string>
+    <string name="location_history_map_disclosure">Map tiles are fetched from OpenStreetMap — the viewed area becomes visible to their servers.</string>
+    <string name="location_history_previous_day">Previous day</string>
+    <string name="location_history_next_day">Next day</string>
+    <string name="location_history_pick_date">Pick a date</string>
+    <string name="location_history_distance">%1$s km</string>
+    <string name="location_history_points">%1$d points</string>
+    <string name="location_history_devices">%1$d devices</string>
+    <string name="location_history_span">%1$s – %2$s</string>
 
 </resources>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1186,4 +1186,31 @@
     <string name="file_share_failed">Failed to share: %1$s</string>
     <string name="error_unknown">Unknown error</string>
 
+    <!-- Location add-on -->
+    <string name="location_label">Location</string>
+    <string name="location_home_subtitle">Your private location history</string>
+    <string name="location_onboarding_title">Your places, only yours</string>
+    <string name="location_onboarding_body_1">Location keeps a private, encrypted history of where you\'ve been — stored on your own drive, visible to no one but you.</string>
+    <string name="location_onboarding_body_2">Set it up to mount the Location drive on this device. You choose when tracking is on.</string>
+    <string name="location_onboarding_setup">Set it up</string>
+    <string name="location_onboarding_dismiss">Not now</string>
+    <string name="location_settings_section">Location</string>
+    <string name="location_settings_open">Open Location</string>
+    <string name="location_settings_show_icon">Show Location icon in bottom bar</string>
+    <string name="location_tracking_switch">Track my location</string>
+    <string name="location_tracking_unavailable">Tracking isn\'t available on this device. Enable it on your phone to record location history.</string>
+    <string name="location_perm_section">Permissions</string>
+    <string name="location_perm_while_in_use">Location while using the app</string>
+    <string name="location_perm_always">Location all the time (background)</string>
+    <string name="location_perm_granted">Granted</string>
+    <string name="location_perm_grant">Grant</string>
+    <string name="location_perm_open_settings">Open settings</string>
+    <string name="location_perm_always_hint">Without this, locations are only recorded while the app is open.</string>
+    <string name="location_status_section">Status</string>
+    <string name="location_status_last_fix">Last fix</string>
+    <string name="location_status_points_today">Points today</string>
+    <string name="location_status_pending">Waiting to upload</string>
+    <string name="location_status_last_flush">Last upload</string>
+    <string name="location_status_never">Never</string>
+
 </resources>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/config/AppConfig.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/config/AppConfig.kt
@@ -127,6 +127,22 @@ val stickerLabeledDrive = LabeledDrive(
     label = "Stickers",
 )
 
+// Location drive — modeled on [stickerLabeledDrive] (app-generated stable alias GUID +
+// drive type GUID). Holds the user's encrypted location history: one file per device
+// per UTC hour (see LocationTrackContent). Optional drive (not in [mandatorySyncDrives]);
+// requested via the extend-permissions flow and mounted when the user activates the
+// Location add-on.
+//
+// The type GUID is a placeholder until the server team provisions the real Location
+// drive type (same caveat as Vault above).
+val locationLabeledDrive = LabeledDrive(
+    drive = TargetDrive(
+        alias = Uuid.parse("2e191a14-8640-4ebc-b0c8-aaac913f6fa8"),
+        type = Uuid.parse("9dbc3bf5-ca24-4d7d-98ca-6933af0ad491"),
+    ),
+    label = "Location",
+)
+
 // Default vault sections — stable UUIDs so re-running onboarding is idempotent
 val vaultDefaultSections = listOf(
     Uuid.parse("6da3968b-0edf-41f0-a136-0492034030e2") to "Passports",
@@ -318,6 +334,28 @@ val stickerTargetDriveAccessRequest: List<TargetDriveAccessRequest> = listOf(
         permissions = listOf(DrivePermission.Read, DrivePermission.Write),
     )
 )
+
+// Location-specific permission config — drive-only, no extra app permissions.
+// Mirrors the Vault/Moments optional-drive permission shape.
+val locationTargetDriveAccessRequest: List<TargetDriveAccessRequest> = listOf(
+    TargetDriveAccessRequest(
+        alias = locationLabeledDrive.drive.alias.toString(),
+        type = locationLabeledDrive.drive.type.toString(),
+        name = "Location Drive",
+        description = "Drive which contains your encrypted location history",
+        permissions = listOf(DrivePermission.Read, DrivePermission.Write),
+    )
+)
+
+fun getLocationPermissionExtensionConfig(): PermissionExtensionConfig {
+    return PermissionExtensionConfig(
+        appId = AppConfig.APP_ID,
+        appName = AppConfig.APP_NAME,
+        drives = locationTargetDriveAccessRequest,
+        permissions = emptyList(),
+        returnUrl = ::returnUrl,
+    )
+}
 
 fun getStickerPermissionExtensionConfig(): PermissionExtensionConfig {
     return PermissionExtensionConfig(

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LocationPreferences.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LocationPreferences.kt
@@ -31,6 +31,12 @@ class LocationPreferences(private val databaseManager: DatabaseManager) {
     private val _showMapTiles = MutableStateFlow(readBoolean(SHOW_MAP_TILES_KEY, default = false))
     val showMapTiles: StateFlow<Boolean> = _showMapTiles.asStateFlow()
 
+    // Google Play "prominent disclosure" consent: the user accepted the
+    // location-collection dialog. Gates the first permission request and the
+    // tracking switch; shown once, persisted.
+    private val _disclosureAccepted = MutableStateFlow(readBoolean(DISCLOSURE_ACCEPTED_KEY, default = false))
+    val disclosureAccepted: StateFlow<Boolean> = _disclosureAccepted.asStateFlow()
+
     suspend fun setActivated(value: Boolean) {
         if (_activated.value == value) return
         keyValue.upsertValue(ACTIVATED_KEY, encode(value))
@@ -55,6 +61,12 @@ class LocationPreferences(private val databaseManager: DatabaseManager) {
         _showMapTiles.value = value
     }
 
+    suspend fun setDisclosureAccepted(value: Boolean) {
+        if (_disclosureAccepted.value == value) return
+        keyValue.upsertValue(DISCLOSURE_ACCEPTED_KEY, encode(value))
+        _disclosureAccepted.value = value
+    }
+
     /**
      * Re-seed in-memory state from the DB for a clean login. Called from
      * `onPostAuthenticated` in `AppModule.kt`; after a logout wipe the reads
@@ -65,6 +77,7 @@ class LocationPreferences(private val databaseManager: DatabaseManager) {
         _iconVisible.value = readBoolean(ICON_VISIBLE_KEY, default = false)
         _trackingEnabled.value = readBoolean(TRACKING_ENABLED_KEY, default = false)
         _showMapTiles.value = readBoolean(SHOW_MAP_TILES_KEY, default = false)
+        _disclosureAccepted.value = readBoolean(DISCLOSURE_ACCEPTED_KEY, default = false)
     }
 
     private fun readBoolean(key: Uuid, default: Boolean): Boolean {
@@ -86,5 +99,6 @@ class LocationPreferences(private val databaseManager: DatabaseManager) {
         val ICON_VISIBLE_KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0302")
         val TRACKING_ENABLED_KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0303")
         val SHOW_MAP_TILES_KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0304")
+        val DISCLOSURE_ACCEPTED_KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0305")
     }
 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LocationPreferences.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LocationPreferences.kt
@@ -13,16 +13,23 @@ class LocationPreferences(private val databaseManager: DatabaseManager) {
     private val _activated = MutableStateFlow(readBoolean(ACTIVATED_KEY, default = false))
     val activated: StateFlow<Boolean> = _activated.asStateFlow()
 
-    // Visible by default — Location shows in the bottom nav out of the box; tapping
-    // it before onboarding routes to the activation flow (see AppNavHost.openLocation).
-    // Users can still hide it from Settings (persists false, overriding this default).
-    private val _iconVisible = MutableStateFlow(readBoolean(ICON_VISIBLE_KEY, default = true))
+    // Hidden by default — "soft launch": the bottom-nav icon only appears after the
+    // user opts in via Settings → Location → "Show Location icon in bottom bar"
+    // (persists true, overriding this default). The Home-screen tile and the
+    // Settings entry remain the discoverable entry points either way.
+    private val _iconVisible = MutableStateFlow(readBoolean(ICON_VISIBLE_KEY, default = false))
     val iconVisible: StateFlow<Boolean> = _iconVisible.asStateFlow()
 
     // Master tracking switch. Lives in keyValue, so it is wiped on logout —
     // tracking deliberately stops when the identity signs out.
     private val _trackingEnabled = MutableStateFlow(readBoolean(TRACKING_ENABLED_KEY, default = false))
     val trackingEnabled: StateFlow<Boolean> = _trackingEnabled.asStateFlow()
+
+    // History basemap opt-in. Default OFF: the trace renders fully offline;
+    // turning this on fetches OpenStreetMap tiles, revealing the viewed area
+    // to the tile server (disclosed next to the toggle).
+    private val _showMapTiles = MutableStateFlow(readBoolean(SHOW_MAP_TILES_KEY, default = false))
+    val showMapTiles: StateFlow<Boolean> = _showMapTiles.asStateFlow()
 
     suspend fun setActivated(value: Boolean) {
         if (_activated.value == value) return
@@ -42,6 +49,12 @@ class LocationPreferences(private val databaseManager: DatabaseManager) {
         _trackingEnabled.value = value
     }
 
+    suspend fun setShowMapTiles(value: Boolean) {
+        if (_showMapTiles.value == value) return
+        keyValue.upsertValue(SHOW_MAP_TILES_KEY, encode(value))
+        _showMapTiles.value = value
+    }
+
     /**
      * Re-seed in-memory state from the DB for a clean login. Called from
      * `onPostAuthenticated` in `AppModule.kt`; after a logout wipe the reads
@@ -49,8 +62,9 @@ class LocationPreferences(private val databaseManager: DatabaseManager) {
      */
     fun reset() {
         _activated.value = readBoolean(ACTIVATED_KEY, default = false)
-        _iconVisible.value = readBoolean(ICON_VISIBLE_KEY, default = true)
+        _iconVisible.value = readBoolean(ICON_VISIBLE_KEY, default = false)
         _trackingEnabled.value = readBoolean(TRACKING_ENABLED_KEY, default = false)
+        _showMapTiles.value = readBoolean(SHOW_MAP_TILES_KEY, default = false)
     }
 
     private fun readBoolean(key: Uuid, default: Boolean): Boolean {
@@ -71,5 +85,6 @@ class LocationPreferences(private val databaseManager: DatabaseManager) {
         val ACTIVATED_KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0301")
         val ICON_VISIBLE_KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0302")
         val TRACKING_ENABLED_KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0303")
+        val SHOW_MAP_TILES_KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0304")
     }
 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LocationPreferences.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LocationPreferences.kt
@@ -1,0 +1,75 @@
+package id.homebase.core.location
+
+import id.homebase.api.sync.database.DatabaseManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlin.uuid.Uuid
+
+class LocationPreferences(private val databaseManager: DatabaseManager) {
+
+    private val keyValue get() = databaseManager.keyValue
+
+    private val _activated = MutableStateFlow(readBoolean(ACTIVATED_KEY, default = false))
+    val activated: StateFlow<Boolean> = _activated.asStateFlow()
+
+    // Visible by default — Location shows in the bottom nav out of the box; tapping
+    // it before onboarding routes to the activation flow (see AppNavHost.openLocation).
+    // Users can still hide it from Settings (persists false, overriding this default).
+    private val _iconVisible = MutableStateFlow(readBoolean(ICON_VISIBLE_KEY, default = true))
+    val iconVisible: StateFlow<Boolean> = _iconVisible.asStateFlow()
+
+    // Master tracking switch. Lives in keyValue, so it is wiped on logout —
+    // tracking deliberately stops when the identity signs out.
+    private val _trackingEnabled = MutableStateFlow(readBoolean(TRACKING_ENABLED_KEY, default = false))
+    val trackingEnabled: StateFlow<Boolean> = _trackingEnabled.asStateFlow()
+
+    suspend fun setActivated(value: Boolean) {
+        if (_activated.value == value) return
+        keyValue.upsertValue(ACTIVATED_KEY, encode(value))
+        _activated.value = value
+    }
+
+    suspend fun setIconVisible(value: Boolean) {
+        if (_iconVisible.value == value) return
+        keyValue.upsertValue(ICON_VISIBLE_KEY, encode(value))
+        _iconVisible.value = value
+    }
+
+    suspend fun setTrackingEnabled(value: Boolean) {
+        if (_trackingEnabled.value == value) return
+        keyValue.upsertValue(TRACKING_ENABLED_KEY, encode(value))
+        _trackingEnabled.value = value
+    }
+
+    /**
+     * Re-seed in-memory state from the DB for a clean login. Called from
+     * `onPostAuthenticated` in `AppModule.kt`; after a logout wipe the reads
+     * return defaults.
+     */
+    fun reset() {
+        _activated.value = readBoolean(ACTIVATED_KEY, default = false)
+        _iconVisible.value = readBoolean(ICON_VISIBLE_KEY, default = true)
+        _trackingEnabled.value = readBoolean(TRACKING_ENABLED_KEY, default = false)
+    }
+
+    private fun readBoolean(key: Uuid, default: Boolean): Boolean {
+        // Bootstrap-only sync read — seeds the StateFlow at construction. See
+        // KeyValueWrapper.selectByKeyBootstrapSync for the rationale (commonMain
+        // has no runBlocking on wasmJs).
+        val bytes: ByteArray = runCatching {
+            keyValue.selectByKeyBootstrapSync(key) { _, data -> data }
+        }.getOrNull() ?: return default
+        return if (bytes.isEmpty()) default else bytes[0].toInt() != 0
+    }
+
+    private fun encode(value: Boolean): ByteArray = byteArrayOf(if (value) 1 else 0)
+
+    companion object {
+        // Stable namespace for Location. Vault owns 0a01xx, Moments 0a02xx;
+        // Location is the next free slot.
+        val ACTIVATED_KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0301")
+        val ICON_VISIBLE_KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0302")
+        val TRACKING_ENABLED_KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0303")
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/AppForegroundObserver.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/AppForegroundObserver.kt
@@ -1,0 +1,9 @@
+package id.homebase.core.location.tracking
+
+/**
+ * Observe whole-app foreground/background transitions (process-level, not
+ * per-screen). [onChange] receives `true` when the app becomes foreground.
+ * Fires the current state once on registration. Call from the main thread at
+ * process start; the registration lives for the process lifetime.
+ */
+expect fun observeAppForeground(onChange: (Boolean) -> Unit)

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationDeviceId.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationDeviceId.kt
@@ -1,0 +1,26 @@
+package id.homebase.core.location.tracking
+
+import id.homebase.api.storage.SharedPreferences
+import kotlin.uuid.Uuid
+
+/**
+ * Stable per-install device identifier used to key this device's location
+ * track files (one file per device per UTC hour), so multiple devices of the
+ * same identity can track concurrently without write conflicts.
+ *
+ * Stored in [SharedPreferences] (not the encrypted keyValue store) on purpose:
+ * it is identity-independent and must survive logout — after a re-login the
+ * device keeps appending to its own files instead of forking a second set.
+ */
+class LocationDeviceId {
+
+    val value: Uuid by lazy {
+        SharedPreferences.getString(KEY)?.let { stored ->
+            runCatching { Uuid.parse(stored) }.getOrNull()
+        } ?: Uuid.random().also { SharedPreferences.putString(KEY, it.toString()) }
+    }
+
+    private companion object {
+        const val KEY = "location_device_id"
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationPointStore.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationPointStore.kt
@@ -1,0 +1,99 @@
+package id.homebase.core.location.tracking
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.sync.database.BufferedLocationPoint
+import id.homebase.api.sync.database.DatabaseManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlin.math.PI
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/**
+ * The single funnel for captured GPS fixes: dedups against the last accepted
+ * point and buffers survivors into the LocationPoint table, from which
+ * `LocationTrackUploaderService` drains them into hour files on the drive.
+ *
+ * Both capture paths land here — the in-process tracker callbacks and the
+ * Android background `LocationUpdatesReceiver` woken in a cold process.
+ */
+class LocationPointStore(
+    private val databaseManager: DatabaseManager,
+) : LocationPointSink {
+
+    private val logger = Logger.withTag("LocationPointStore")
+
+    private val _lastPoint = MutableStateFlow<RawLocationPoint?>(null)
+    val lastPoint: StateFlow<RawLocationPoint?> = _lastPoint.asStateFlow()
+
+    override suspend fun submit(points: List<RawLocationPoint>) {
+        if (points.isEmpty()) return
+        val accepted = mutableListOf<RawLocationPoint>()
+        var last = _lastPoint.value ?: databaseManager.locationPoint.selectLatest()?.toRaw()
+        for (p in points.sortedBy { it.t }) {
+            if (last != null && p.t <= last.t) continue
+            // Thin stationary noise: skip fixes that moved < MIN_DISPLACEMENT_M
+            // AND arrived < MIN_INTERVAL_MS after the last accepted one.
+            if (last != null &&
+                p.t - last.t < MIN_INTERVAL_MS &&
+                haversineMeters(last.lat, last.lon, p.lat, p.lon) < MIN_DISPLACEMENT_M
+            ) continue
+            accepted += p
+            last = p
+        }
+        if (accepted.isEmpty()) return
+        databaseManager.locationPoint.insertPoints(accepted.map { it.toBuffered() })
+        _lastPoint.value = last
+        logger.d { "Buffered ${accepted.size}/${points.size} points (last src=${last?.src})" }
+    }
+
+    /** Rows still buffered on this device — the UI's "waiting to upload" count. */
+    suspend fun countPendingUpload(): Long = databaseManager.locationPoint.countAll()
+
+    suspend fun countSince(fromInclusiveMs: Long): Long =
+        databaseManager.locationPoint.countSince(fromInclusiveMs)
+
+    /** Re-seed [lastPoint] from the DB (e.g. on screen entry). */
+    suspend fun refresh() {
+        _lastPoint.value = databaseManager.locationPoint.selectLatest()?.toRaw()
+    }
+
+    /**
+     * Clear in-memory state for a clean login. Called from `onPostAuthenticated`
+     * in `AppModule.kt`; the table itself is wiped with the rest of the DB.
+     */
+    fun reset() {
+        _lastPoint.value = null
+    }
+
+    private fun RawLocationPoint.toBuffered() = BufferedLocationPoint(
+        t = t, lat = lat, lon = lon, acc = acc, alt = alt, altAcc = altAcc,
+        spd = spd, hdg = hdg, src = src, fg = fg,
+    )
+
+    private fun BufferedLocationPoint.toRaw() = RawLocationPoint(
+        t = t, lat = lat, lon = lon, acc = acc, alt = alt, altAcc = altAcc,
+        spd = spd, hdg = hdg, src = src, fg = fg,
+    )
+
+    companion object {
+        // A fix closer than this in BOTH space and time to the previous accepted
+        // fix is stationary noise — drop it before it costs DB and upload bytes.
+        const val MIN_DISPLACEMENT_M = 8.0
+        const val MIN_INTERVAL_MS = 20_000L
+
+        fun haversineMeters(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
+            val dLat = (lat2 - lat1) * PI / 180.0
+            val dLon = (lon2 - lon1) * PI / 180.0
+            val a = sin(dLat / 2) * sin(dLat / 2) +
+                cos(lat1 * PI / 180.0) * cos(lat2 * PI / 180.0) *
+                sin(dLon / 2) * sin(dLon / 2)
+            return EARTH_RADIUS_M * 2 * atan2(sqrt(a), sqrt(1 - a))
+        }
+
+        private const val EARTH_RADIUS_M = 6_371_000.0
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTracker.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTracker.kt
@@ -1,0 +1,75 @@
+package id.homebase.core.location.tracking
+
+/**
+ * Capture profile for the platform tracker.
+ *
+ * - [Foreground] — the app is visible: high accuracy, tight interval/displacement.
+ * - [Background] — the app is backgrounded: low power, batched/OS-throttled
+ *   delivery. No foreground service on Android; the OS decides the cadence.
+ */
+enum class TrackingMode { Foreground, Background }
+
+/**
+ * One captured GPS fix, platform-agnostic. Optional fields are null when the
+ * platform didn't report them.
+ */
+data class RawLocationPoint(
+    /** Capture time, epoch ms UTC. */
+    val t: Long,
+    val lat: Double,
+    val lon: Double,
+    /** Horizontal accuracy radius in meters. */
+    val acc: Double?,
+    /** Altitude in meters. */
+    val alt: Double? = null,
+    /** Vertical accuracy in meters. */
+    val altAcc: Double? = null,
+    /** Speed in m/s. */
+    val spd: Double? = null,
+    /** Heading/bearing in degrees. */
+    val hdg: Double? = null,
+    /** Capture source: gps | net | fused | slc (significant-location-change). */
+    val src: String,
+    /** True when captured in foreground precise mode. */
+    val fg: Boolean,
+)
+
+/**
+ * Where captured points land. Implemented by `LocationPointStore` (buffered into
+ * the local DB); a plain interface so platform actuals — including the Android
+ * BroadcastReceiver woken in a cold process — can submit without referencing the
+ * store type.
+ */
+interface LocationPointSink {
+    suspend fun submit(points: List<RawLocationPoint>)
+}
+
+/**
+ * Platform GPS tracker. Implementations register OS location callbacks and feed
+ * captured fixes into the [LocationPointSink] they were created with; they hold
+ * no business logic and never touch the network.
+ *
+ * Battery contract (see plan): Android uses FusedLocationProvider — a
+ * balanced-power batched PendingIntent registration that survives the app
+ * process, plus a high-accuracy callback overlay only while [TrackingMode.Foreground];
+ * no foreground service. iOS uses CLLocationManager with auto-pause and
+ * significant-location-change as the relaunch vector.
+ */
+interface LocationTracker {
+    /** False on desktop/web — drives the "tracking unavailable on this device" UI. */
+    val isAvailable: Boolean
+
+    /**
+     * Idempotent. Registers OS location updates with the profile for [mode].
+     * On platforms with [isAvailable] = false this is a no-op.
+     */
+    fun start(mode: TrackingMode)
+
+    /** Switch capture profile on app foreground/background transitions while running. */
+    fun setMode(mode: TrackingMode)
+
+    /** Unregister all OS location updates. */
+    fun stop()
+}
+
+expect fun createLocationTracker(sink: LocationPointSink): LocationTracker

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTrackingCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTrackingCoordinator.kt
@@ -1,0 +1,113 @@
+package id.homebase.core.location.tracking
+
+import co.touchlab.kermit.Logger
+import id.homebase.core.location.LocationPreferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * Lifecycle brain of the Location tracker — owns the start/stop/mode decisions
+ * so the platform trackers stay dumb.
+ *
+ * - [onProcessStart] re-arms the tracker on every process start when the
+ *   master switch is on. Hooked from MainApplication.onCreate (Android — also
+ *   covers boot-receiver and background-location wakes) and initializeApp
+ *   (iOS — also covers the UIApplicationLaunchOptionsLocationKey relaunch).
+ *   It deliberately does NOT hang off onPostAuthenticated, which never runs on
+ *   headless cold starts.
+ * - App foreground transitions switch the capture profile and run a periodic
+ *   foreground flush ticker; backgrounding stops the ticker (background
+ *   flushes piggyback on batch deliveries instead — no alarms/WorkManager).
+ * - [onFlushDue] is injected by DI (the uploader lives in homebase-core, which
+ *   this module cannot reference). It must be cheap and rate-gated by the callee.
+ */
+class LocationTrackingCoordinator(
+    private val preferences: LocationPreferences,
+    private val tracker: LocationTracker,
+    private val scope: CoroutineScope,
+) {
+    private val logger = Logger.withTag("LocationTrackingCoordinator")
+
+    /** Wired in AppModule to LocationTrackUploaderService.flushIfDue(). */
+    var onFlushDue: suspend () -> Unit = {}
+
+    private var processStarted = false
+    private var isForeground = false
+    private var tickerJob: Job? = null
+
+    fun onProcessStart() {
+        if (processStarted || !tracker.isAvailable) return
+        processStarted = true
+
+        if (preferences.trackingEnabled.value) {
+            tracker.start(TrackingMode.Background)
+            logger.i { "Process start: tracking re-armed" }
+        }
+
+        observeAppForeground { foreground ->
+            isForeground = foreground
+            if (preferences.trackingEnabled.value) {
+                tracker.setMode(if (foreground) TrackingMode.Foreground else TrackingMode.Background)
+            }
+            if (foreground) startTicker() else stopTicker()
+        }
+    }
+
+    suspend fun setTrackingEnabled(enabled: Boolean) {
+        preferences.setTrackingEnabled(enabled)
+        if (!tracker.isAvailable) return
+        if (enabled) {
+            tracker.start(if (isForeground) TrackingMode.Foreground else TrackingMode.Background)
+            if (isForeground) startTicker()
+        } else {
+            tracker.stop()
+            stopTicker()
+            // Final drain so the last points don't sit in the buffer until the
+            // next time tracking is enabled.
+            scope.launch { onFlushDue() }
+        }
+        logger.i { "Tracking ${if (enabled) "enabled" else "disabled"}" }
+    }
+
+    /** Called by the Android background receiver after buffering a batch. */
+    suspend fun onBackgroundPointsDelivered() {
+        onFlushDue()
+    }
+
+    /**
+     * Re-evaluate after a logout/login wipe. The pref StateFlow was reset by
+     * LocationPreferences.reset() before this runs; if the wipe turned the
+     * switch off, stop capturing.
+     */
+    fun reset() {
+        if (!tracker.isAvailable) return
+        if (!preferences.trackingEnabled.value) {
+            tracker.stop()
+            stopTicker()
+        }
+    }
+
+    private fun startTicker() {
+        if (tickerJob?.isActive == true) return
+        tickerJob = scope.launch {
+            // Immediate drain on entering the foreground, then periodic.
+            onFlushDue()
+            while (isActive) {
+                delay(FOREGROUND_FLUSH_INTERVAL_MS)
+                onFlushDue()
+            }
+        }
+    }
+
+    private fun stopTicker() {
+        tickerJob?.cancel()
+        tickerJob = null
+    }
+
+    private companion object {
+        const val FOREGROUND_FLUSH_INTERVAL_MS = 120_000L
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/permissions/PermissionType.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/permissions/PermissionType.kt
@@ -6,4 +6,14 @@ enum class PermissionType {
     GALLERY_LIMITED,
     NOTIFICATION,
     RECORD_AUDIO,
+
+    /** Foreground ("while in use") location access. */
+    LOCATION,
+
+    /**
+     * Background ("allow all the time") location access. On Android this is a
+     * separate runtime permission (API 29+) that may only be requested after
+     * [LOCATION] is granted; on iOS it is the Always authorization escalation.
+     */
+    LOCATION_ALWAYS,
 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
@@ -172,6 +172,18 @@ sealed class Route {
     data object MomentsSettings : Route()
 
     @Serializable
+    @SerialName("location")
+    data object Location : Route()
+
+    @Serializable
+    @SerialName("location-onboarding")
+    data object LocationOnboarding : Route()
+
+    @Serializable
+    @SerialName("location-settings")
+    data object LocationSettings : Route()
+
+    @Serializable
     @SerialName("crop")
     data class Crop(val requestId: String) : Route()
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
@@ -184,6 +184,10 @@ sealed class Route {
     data object LocationSettings : Route()
 
     @Serializable
+    @SerialName("location-history")
+    data object LocationHistory : Route()
+
+    @Serializable
     @SerialName("crop")
     data class Crop(val requestId: String) : Route()
 

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/location/tracking/AppForegroundObserver.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/location/tracking/AppForegroundObserver.jvm.kt
@@ -1,0 +1,6 @@
+package id.homebase.core.location.tracking
+
+actual fun observeAppForeground(onChange: (Boolean) -> Unit) {
+    // Desktop: no tracker, so the distinction is irrelevant — report foreground once.
+    onChange(true)
+}

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/location/tracking/LocationTracker.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/location/tracking/LocationTracker.jvm.kt
@@ -1,0 +1,12 @@
+package id.homebase.core.location.tracking
+
+actual fun createLocationTracker(sink: LocationPointSink): LocationTracker =
+    UnavailableLocationTracker
+
+/** Desktop has no GPS — the Location screen shows the unavailable state. */
+private object UnavailableLocationTracker : LocationTracker {
+    override val isAvailable: Boolean = false
+    override fun start(mode: TrackingMode) {}
+    override fun setMode(mode: TrackingMode) {}
+    override fun stop() {}
+}

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/tracking/LocationPointStoreTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/tracking/LocationPointStoreTest.kt
@@ -1,0 +1,92 @@
+package id.homebase.core.location.tracking
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import id.homebase.api.sync.database.DatabaseManager
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class LocationPointStoreTest {
+
+    private fun point(
+        t: Long,
+        lat: Double = 52.0,
+        lon: Double = 13.0,
+        src: String = "gps",
+    ) = RawLocationPoint(t = t, lat = lat, lon = lon, acc = 10.0, src = src, fg = true)
+
+    private fun runStoreTest(body: suspend (LocationPointStore, DatabaseManager) -> Unit) = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val db = DatabaseManager(
+            { JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY) },
+            dispatcher = dispatcher,
+            readDispatcher = dispatcher,
+        )
+        try {
+            body(LocationPointStore(db), db)
+        } finally {
+            db.close()
+        }
+    }
+
+    @Test
+    fun dropsStationaryNoiseWithinTimeAndDistanceWindow() = runStoreTest { store, _ ->
+        // ~5.5 m east of the first point (well under 8 m), 10 s later (under 20 s).
+        store.submit(
+            listOf(
+                point(t = 0),
+                point(t = 10_000, lon = 13.00008),
+            )
+        )
+        assertEquals(1, store.countPendingUpload())
+    }
+
+    @Test
+    fun keepsPointThatMovedFarEnough() = runStoreTest { store, _ ->
+        // ~70 m east, 10 s later — distance clears the gate even though time doesn't.
+        store.submit(
+            listOf(
+                point(t = 0),
+                point(t = 10_000, lon = 13.001),
+            )
+        )
+        assertEquals(2, store.countPendingUpload())
+    }
+
+    @Test
+    fun keepsStationaryPointAfterTimeWindow() = runStoreTest { store, _ ->
+        store.submit(
+            listOf(
+                point(t = 0),
+                point(t = 25_000),
+            )
+        )
+        assertEquals(2, store.countPendingUpload())
+    }
+
+    @Test
+    fun dropsOutOfOrderAndDuplicateTimestamps() = runStoreTest { store, _ ->
+        store.submit(listOf(point(t = 60_000, lon = 14.0)))
+        store.submit(listOf(point(t = 30_000), point(t = 60_000)))
+        assertEquals(1, store.countPendingUpload())
+        assertEquals(60_000, assertNotNull(store.lastPoint.value).t)
+    }
+
+    @Test
+    fun dedupsAgainstDbAfterColdStart() = runStoreTest { store, db ->
+        store.submit(listOf(point(t = 0)))
+        // Fresh store instance — in-memory lastPoint empty, must seed from DB.
+        val coldStore = LocationPointStore(db)
+        coldStore.submit(listOf(point(t = 5_000)))
+        assertEquals(1, coldStore.countPendingUpload())
+    }
+
+    @Test
+    fun haversineSanity() {
+        // One degree of longitude at the equator ≈ 111.3 km.
+        val d = LocationPointStore.haversineMeters(0.0, 0.0, 0.0, 1.0)
+        assertEquals(111_320.0, d, 200.0)
+    }
+}

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/permissions/PermissionsManager.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/permissions/PermissionsManager.native.kt
@@ -10,7 +10,16 @@ import platform.AVFoundation.AVMediaTypeAudio
 import platform.AVFoundation.AVMediaTypeVideo
 import platform.AVFoundation.authorizationStatusForMediaType
 import platform.AVFoundation.requestAccessForMediaType
+import platform.CoreLocation.CLAuthorizationStatus
+import platform.CoreLocation.CLLocationManager
+import platform.CoreLocation.CLLocationManagerDelegateProtocol
+import platform.CoreLocation.kCLAuthorizationStatusAuthorizedAlways
+import platform.CoreLocation.kCLAuthorizationStatusAuthorizedWhenInUse
+import platform.CoreLocation.kCLAuthorizationStatusDenied
+import platform.CoreLocation.kCLAuthorizationStatusNotDetermined
+import platform.CoreLocation.kCLAuthorizationStatusRestricted
 import platform.Foundation.NSURL
+import platform.darwin.NSObject
 import platform.Photos.PHAccessLevelReadWrite
 import platform.Photos.PHAuthorizationStatus
 import platform.Photos.PHAuthorizationStatusAuthorized
@@ -35,6 +44,58 @@ import kotlin.coroutines.suspendCoroutine
 @Composable
 actual fun createPermissionsManager(onPermissionResult: (PermissionType, PermissionStatus, Boolean) -> Unit): PermissionsManager {
     return IOSPermissionsManager(onPermissionResult)
+}
+
+/**
+ * Process-wide CLLocationManager used only for authorization requests/reads.
+ * A singleton (rather than per-[IOSPermissionsManager]) because the delegate
+ * must stay alive until the user answers the system prompt, while
+ * [createPermissionsManager] returns a fresh manager on every composition.
+ */
+private object LocationPermissionRequester {
+    private var pending: ((CLAuthorizationStatus) -> Unit)? = null
+
+    private val delegate = object : NSObject(), CLLocationManagerDelegateProtocol {
+        override fun locationManagerDidChangeAuthorization(manager: CLLocationManager) {
+            val status = manager.authorizationStatus
+            // Fires once when the delegate is first assigned; ignore the
+            // not-determined report and wait for the user's answer.
+            if (status == kCLAuthorizationStatusNotDetermined) return
+            pending?.invoke(status)
+            pending = null
+        }
+    }
+
+    private val manager = CLLocationManager().apply { delegate = this@LocationPermissionRequester.delegate }
+
+    val status: CLAuthorizationStatus get() = manager.authorizationStatus
+
+    fun requestWhenInUse(onResult: (CLAuthorizationStatus) -> Unit) {
+        val current = status
+        if (current != kCLAuthorizationStatusNotDetermined) {
+            onResult(current)
+            return
+        }
+        pending = onResult
+        manager.requestWhenInUseAuthorization()
+    }
+
+    fun requestAlways(onResult: (CLAuthorizationStatus) -> Unit) {
+        when (val current = status) {
+            kCLAuthorizationStatusAuthorizedAlways,
+            kCLAuthorizationStatusDenied,
+            kCLAuthorizationStatusRestricted -> {
+                onResult(current)
+                return
+            }
+        }
+        // Valid from NotDetermined (single combined prompt) or WhenInUse (the
+        // one-time "Change to Always Allow?" escalation). If the user picks
+        // "Keep Only While Using" iOS reports no change — callers re-check
+        // on resume, so a silently dropped callback is fine.
+        pending = onResult
+        manager.requestAlwaysAuthorization()
+    }
 }
 
 class IOSPermissionsManager(val onPermissionResult: (PermissionType, PermissionStatus, Boolean) -> Unit) :
@@ -71,6 +132,30 @@ class IOSPermissionsManager(val onPermissionResult: (PermissionType, PermissionS
                         askNotificationPermission(status, permission, onPermissionResult)
                     }
             }
+
+            PermissionType.LOCATION -> {
+                LocationPermissionRequester.requestWhenInUse { status ->
+                    val granted = status == kCLAuthorizationStatusAuthorizedWhenInUse ||
+                        status == kCLAuthorizationStatusAuthorizedAlways
+                    // iOS never re-prompts after a denial — settings is the only way back.
+                    onPermissionResult(
+                        permission,
+                        if (granted) PermissionStatus.GRANTED else PermissionStatus.DENIED,
+                        !granted,
+                    )
+                }
+            }
+
+            PermissionType.LOCATION_ALWAYS -> {
+                LocationPermissionRequester.requestAlways { status ->
+                    val granted = status == kCLAuthorizationStatusAuthorizedAlways
+                    onPermissionResult(
+                        permission,
+                        if (granted) PermissionStatus.GRANTED else PermissionStatus.DENIED,
+                        !granted,
+                    )
+                }
+            }
         }
     }
 
@@ -106,6 +191,16 @@ class IOSPermissionsManager(val onPermissionResult: (PermissionType, PermissionS
                             status == UNAuthorizationStatusAuthorized || status == UNAuthorizationStatusProvisional || status == UNAuthorizationStatusEphemeral
                         cont.resume(granted)
                     }
+            }
+
+            PermissionType.LOCATION -> {
+                val status = LocationPermissionRequester.status
+                status == kCLAuthorizationStatusAuthorizedWhenInUse ||
+                    status == kCLAuthorizationStatusAuthorizedAlways
+            }
+
+            PermissionType.LOCATION_ALWAYS -> {
+                LocationPermissionRequester.status == kCLAuthorizationStatusAuthorizedAlways
             }
         }
     }

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/location/tracking/AppForegroundObserver.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/location/tracking/AppForegroundObserver.web.kt
@@ -1,0 +1,6 @@
+package id.homebase.core.location.tracking
+
+actual fun observeAppForeground(onChange: (Boolean) -> Unit) {
+    // Web: no tracker, so the distinction is irrelevant — report foreground once.
+    onChange(true)
+}

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/location/tracking/LocationTracker.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/location/tracking/LocationTracker.web.kt
@@ -1,0 +1,15 @@
+package id.homebase.core.location.tracking
+
+actual fun createLocationTracker(sink: LocationPointSink): LocationTracker =
+    UnavailableLocationTracker
+
+/**
+ * Web v1 has no tracking (no background execution model worth the complexity);
+ * the Location screen shows the unavailable state.
+ */
+private object UnavailableLocationTracker : LocationTracker {
+    override val isAvailable: Boolean = false
+    override fun start(mode: TrackingMode) {}
+    override fun setMode(mode: TrackingMode) {}
+    override fun stop() {}
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -132,13 +132,24 @@ import org.koin.core.module.dsl.viewModelOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
+import id.homebase.core.config.getLocationPermissionExtensionConfig
 import id.homebase.core.config.getVaultPermissionExtensionConfig
+import id.homebase.core.location.LocationPreferences
+import id.homebase.core.location.tracking.LocationDeviceId
+import id.homebase.core.location.tracking.LocationPointStore
+import id.homebase.core.location.tracking.LocationTracker
+import id.homebase.core.location.tracking.LocationTrackingCoordinator
+import id.homebase.core.location.tracking.createLocationTracker
+import id.homebase.core.ui.screens.location.LocationTrackUploaderService
+import id.homebase.core.ui.screens.location.LocationViewModel
+import id.homebase.core.ui.screens.location.settings.LocationSettingsViewModel
 
 val VaultPermissionQualifier = named("vaultPermission")
 
 val FeedPermissionQualifier = named("feedPermission")
 val MomentsPermissionQualifier = named("momentsPermission")
 val StickerPermissionQualifier = named("stickerPermission")
+val LocationPermissionQualifier = named("locationPermission")
 
 val appModule = module {
     single { UserPreferences(get()) }
@@ -181,6 +192,39 @@ val appModule = module {
     singleOf(::MomentGroupService)
     single { MomentCreateFlowState() }
     single { VaultPreferences(get()) }
+
+    // region Location add-on
+    single { LocationPreferences(get()) }
+    single { LocationDeviceId() }
+    singleOf(::LocationPointStore)
+    single<LocationTracker> { createLocationTracker(get<LocationPointStore>()) }
+    single {
+        LocationTrackUploaderService(
+            outboxSync = get(),
+            optimisticWriter = get(),
+            payloadEncryptionService = get(),
+            fileOperationsProvider = get(),
+            driveFileProvider = get(),
+            databaseManager = get(),
+            credentialsManager = get(),
+            eventBus = get(),
+            deviceId = get(),
+            preferences = get(),
+            scope = get(),
+        )
+    }
+    single {
+        LocationTrackingCoordinator(
+            preferences = get(),
+            tracker = get(),
+            scope = get(),
+        ).apply {
+            // The uploader lives in homebase-core; the coordinator (homebase-common)
+            // reaches it through this seam only.
+            onFlushDue = { get<LocationTrackUploaderService>().flushIfDue() }
+        }
+    }
+    // endregion
 
     // DriveRegistry reads/writes a cross-device list of optional drives from the user's
     // Chat drive. See id.homebase.core.sync.DriveRegistry for the storage model.
@@ -351,6 +395,15 @@ val appModule = module {
                 get<VaultStream>().apply { reset(); start() }
                 // Hydrate the saved-stickers tray for the new identity (mirror Vault).
                 get<id.homebase.chat.services.sticker.StickerStream>().apply { reset(); start() }
+
+                // Location add-on: re-seed prefs from the (possibly wiped) DB,
+                // clear in-memory capture state, restart the flusher's outbox
+                // observer + retention sweep, and stop the tracker if the wipe
+                // turned the master switch off. Order matters: prefs first.
+                get<LocationPreferences>().reset()
+                get<LocationPointStore>().reset()
+                get<LocationTrackUploaderService>().apply { reset(); start() }
+                get<LocationTrackingCoordinator>().reset()
             }
         )
     }
@@ -591,6 +644,21 @@ val appModule = module {
     }
     viewModel { MomentsViewModel(get(), get(MomentsPermissionQualifier), get()) }
     viewModelOf(::MomentsSettingsViewModel)
+    viewModel(LocationPermissionQualifier) {
+        ExtendPermissionViewModel(get(), get(), get(), getLocationPermissionExtensionConfig())
+    }
+    viewModel {
+        LocationViewModel(
+            locationPreferences = get(),
+            locationPermissionViewModel = get(LocationPermissionQualifier),
+            authConnectionCoordinator = get(),
+            trackingCoordinator = get(),
+            pointStore = get(),
+            uploaderService = get(),
+            tracker = get(),
+        )
+    }
+    viewModelOf(::LocationSettingsViewModel)
     viewModelOf(::MomentComposeViewModel)
     viewModelOf(::MomentAudienceViewModel)
     viewModelOf(::CreateMomentGroupViewModel)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -142,6 +142,7 @@ import id.homebase.core.location.tracking.LocationTrackingCoordinator
 import id.homebase.core.location.tracking.createLocationTracker
 import id.homebase.core.ui.screens.location.LocationTrackUploaderService
 import id.homebase.core.ui.screens.location.LocationViewModel
+import id.homebase.core.ui.screens.location.history.LocationHistoryViewModel
 import id.homebase.core.ui.screens.location.settings.LocationSettingsViewModel
 
 val VaultPermissionQualifier = named("vaultPermission")
@@ -659,6 +660,7 @@ val appModule = module {
         )
     }
     viewModelOf(::LocationSettingsViewModel)
+    viewModelOf(::LocationHistoryViewModel)
     viewModelOf(::MomentComposeViewModel)
     viewModelOf(::MomentAudienceViewModel)
     viewModelOf(::CreateMomentGroupViewModel)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -109,6 +109,7 @@ import id.homebase.core.location.LocationPreferences
 import id.homebase.core.ui.screens.location.LocationScreen
 import id.homebase.core.ui.screens.location.LocationUiEvent
 import id.homebase.core.ui.screens.location.LocationViewModel
+import id.homebase.core.ui.screens.location.history.LocationHistoryScreen
 import id.homebase.core.ui.screens.location.onboarding.LocationOnboardingScreen
 import id.homebase.core.ui.screens.location.settings.LocationSettingsScreen
 import id.homebase.core.ui.screens.notifications.NotificationSettingsScreen
@@ -1168,6 +1169,18 @@ fun AppNavHost(
                                     onNavigateToSettings = {
                                         navController.navigate(Route.LocationSettings)
                                     },
+                                    onNavigateToHistory = {
+                                        navController.navigate(Route.LocationHistory)
+                                    },
+                                )
+                            }
+                        }
+
+                        composable<Route.LocationHistory> {
+                            if (isAuthenticated) {
+                                LocationHistoryScreen(
+                                    viewModel = koinViewModel(),
+                                    onNavigateBack = { navController.popBackStack() },
                                 )
                             }
                         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.filled.RssFeed
 import androidx.compose.material.icons.outlined.AutoAwesome
+import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Icon
@@ -104,6 +105,12 @@ import id.homebase.core.ui.screens.moments.MomentsUiEvent
 import id.homebase.core.ui.screens.moments.MomentsViewModel
 import id.homebase.core.moments.MomentsPreferences
 import id.homebase.core.moments.services.MomentsFeedService
+import id.homebase.core.location.LocationPreferences
+import id.homebase.core.ui.screens.location.LocationScreen
+import id.homebase.core.ui.screens.location.LocationUiEvent
+import id.homebase.core.ui.screens.location.LocationViewModel
+import id.homebase.core.ui.screens.location.onboarding.LocationOnboardingScreen
+import id.homebase.core.ui.screens.location.settings.LocationSettingsScreen
 import id.homebase.core.ui.screens.notifications.NotificationSettingsScreen
 import id.homebase.core.ui.screens.settings.SettingsScreen
 import androidx.compose.material3.CircularProgressIndicator
@@ -120,6 +127,7 @@ import id.homebase.core.vault.VaultPreferences
 import id.homebase.resources.nav_chats
 import id.homebase.resources.nav_feed
 import id.homebase.resources.nav_home
+import id.homebase.resources.location_label
 import id.homebase.resources.vault_label
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
@@ -176,12 +184,16 @@ fun AppNavHost(
     val vaultPreferences = koinInject<VaultPreferences>()
     val vaultIconVisible by vaultPreferences.iconVisible.collectAsStateWithLifecycle()
     val vaultViewModel: VaultViewModel = koinViewModel()
-    val topLevelRoutes = remember(momentsIconVisible, vaultIconVisible) {
+    val locationPreferences = koinInject<LocationPreferences>()
+    val locationIconVisible by locationPreferences.iconVisible.collectAsStateWithLifecycle()
+    val locationViewModel: LocationViewModel = koinViewModel()
+    val topLevelRoutes = remember(momentsIconVisible, vaultIconVisible, locationIconVisible) {
         buildList {
             add(TopLevelRoute.Chat)
             add(TopLevelRoute.Feed)
             if (momentsIconVisible) add(TopLevelRoute.Moments)
             if (vaultIconVisible) add(TopLevelRoute.Vault)
+            if (locationIconVisible) add(TopLevelRoute.Location)
             add(TopLevelRoute.Home)
         }
     }
@@ -194,6 +206,17 @@ fun AppNavHost(
             }
         } else {
             navController.navigate(Route.MomentsOnboarding)
+        }
+    }
+    val openLocation: () -> Unit = {
+        if (locationPreferences.activated.value) {
+            navController.navigate(Route.Location) {
+                popUpTo(Route.ChatList) { saveState = true }
+                launchSingleTop = true
+                restoreState = true
+            }
+        } else {
+            navController.navigate(Route.LocationOnboarding)
         }
     }
     val uriHandler = getUriHandler()
@@ -426,6 +449,22 @@ fun AppNavHost(
         }
     }
 
+    // Translate Location onboarding one-shot events into nav-stack changes.
+    LaunchedEffect(Unit) {
+        locationViewModel.events.collect { event ->
+            when (event) {
+                LocationUiEvent.Activated -> {
+                    navController.popBackStack(Route.LocationOnboarding, inclusive = true)
+                    navController.navigate(Route.Location) {
+                        popUpTo(Route.ChatList) { saveState = true }
+                        launchSingleTop = true
+                    }
+                }
+                LocationUiEvent.CloseOnboarding -> navController.popBackStack()
+            }
+        }
+    }
+
     // Auto-dismiss in-app banner after 4 seconds
     val inAppNotification = uiState.inAppNotification
     LaunchedEffect(inAppNotification) {
@@ -464,6 +503,7 @@ fun AppNavHost(
                                 when {
                                     topLevelRoute is TopLevelRoute.Moments -> openMoments()
                                     topLevelRoute is TopLevelRoute.Vault -> openVault()
+                                    topLevelRoute is TopLevelRoute.Location -> openLocation()
                                     else -> navController.navigate(topLevelRoute.route) {
                                         popUpTo(Route.ChatList) { saveState = true }
                                         launchSingleTop = true
@@ -498,6 +538,7 @@ fun AppNavHost(
                                     when {
                                         topLevelRoute is TopLevelRoute.Moments -> openMoments()
                                         topLevelRoute is TopLevelRoute.Vault -> openVault()
+                                        topLevelRoute is TopLevelRoute.Location -> openLocation()
                                         else -> navController.navigate(topLevelRoute.route) {
                                             popUpTo(Route.ChatList) { saveState = true }
                                             launchSingleTop = true
@@ -671,6 +712,7 @@ fun AppNavHost(
                                     viewModel = koinViewModel(),
                                     onNavigateToVault = openVault,
                                     onNavigateToMoments = openMoments,
+                                    onNavigateToLocation = openLocation,
                                     onNavigateToExamples = { navController.navigate(Route.Examples) },
                                 )
                             }
@@ -994,6 +1036,9 @@ fun AppNavHost(
                                     onNavigateToVaultSettings = {
                                         navController.navigate(Route.VaultSettings)
                                     },
+                                    onNavigateToLocationSettings = {
+                                        navController.navigate(Route.LocationSettings)
+                                    },
                                 )
                             }
                         }
@@ -1103,6 +1148,34 @@ fun AppNavHost(
                                     viewModel = koinViewModel(),
                                     onBackClick = { navController.popBackStack() },
                                     onOpenMoments = openMoments,
+                                )
+                            }
+                        }
+
+                        composable<Route.LocationOnboarding> {
+                            if (isAuthenticated) {
+                                LocationOnboardingScreen(
+                                    viewModel = locationViewModel,
+                                    onNavigateBack = { navController.popBackStack() },
+                                )
+                            }
+                        }
+
+                        composable<Route.Location> {
+                            if (isAuthenticated) {
+                                LocationScreen(
+                                    viewModel = locationViewModel,
+                                    onNavigateBack = { navController.popBackStack() },
+                                )
+                            }
+                        }
+
+                        composable<Route.LocationSettings> {
+                            if (isAuthenticated) {
+                                LocationSettingsScreen(
+                                    viewModel = koinViewModel(),
+                                    onBackClick = { navController.popBackStack() },
+                                    onOpenLocation = openLocation,
                                 )
                             }
                         }
@@ -1318,7 +1391,8 @@ private fun NavDestination?.isTopLevelRoute(): Boolean {
             this?.hasRoute(Route.Feed::class) == true ||
             this?.hasRoute(Route.Moments::class) == true ||
             this?.hasRoute(Route.Home::class) == true ||
-            this?.hasRoute(Route.Vault::class) == true
+            this?.hasRoute(Route.Vault::class) == true ||
+            this?.hasRoute(Route.Location::class) == true
 }
 
 private fun AnimatedContentTransitionScope<NavBackStackEntry>.isBetweenTopLevelRoutes(): Boolean {
@@ -1339,6 +1413,7 @@ sealed class TopLevelRoute(
     data object Moments : TopLevelRoute(Route.Moments, MR.string.nav_moments, Icons.Outlined.AutoAwesome)
     data object Home : TopLevelRoute(Route.Home, MR.string.nav_home, Icons.Default.Home)
     data object Vault : TopLevelRoute(Route.Vault, MR.string.vault_label, Icons.Outlined.Lock)
+    data object Location : TopLevelRoute(Route.Location, MR.string.location_label, Icons.Outlined.LocationOn)
 }
 
 /**

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -1163,7 +1163,12 @@ fun AppNavHost(
 
                         composable<Route.Location> {
                             if (isAuthenticated) {
-                                LocationScreen(viewModel = locationViewModel)
+                                LocationScreen(
+                                    viewModel = locationViewModel,
+                                    onNavigateToSettings = {
+                                        navController.navigate(Route.LocationSettings)
+                                    },
+                                )
                             }
                         }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -1163,10 +1163,7 @@ fun AppNavHost(
 
                         composable<Route.Location> {
                             if (isAuthenticated) {
-                                LocationScreen(
-                                    viewModel = locationViewModel,
-                                    onNavigateBack = { navController.popBackStack() },
-                                )
+                                LocationScreen(viewModel = locationViewModel)
                             }
                         }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/home/HomeScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/home/HomeScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material3.Button
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
@@ -50,6 +51,8 @@ import id.homebase.resources.app_version
 import id.homebase.resources.clear_log
 import id.homebase.resources.export_log
 import id.homebase.resources.homebase_logo
+import id.homebase.resources.location_home_subtitle
+import id.homebase.resources.location_label
 import id.homebase.resources.moments_home_subtitle
 import id.homebase.resources.moments_label
 import id.homebase.resources.vault_home_subtitle
@@ -62,6 +65,7 @@ fun HomeScreen(
     viewModel: HomeViewModel,
     onNavigateToVault: () -> Unit,
     onNavigateToMoments: () -> Unit,
+    onNavigateToLocation: () -> Unit,
     onNavigateToExamples: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -114,6 +118,7 @@ fun HomeScreen(
         onAction = viewModel::onAction,
         onNavigateToVault = onNavigateToVault,
         onNavigateToMoments = onNavigateToMoments,
+        onNavigateToLocation = onNavigateToLocation,
     )
 }
 
@@ -124,6 +129,7 @@ fun HomeUi(
     onAction: (HomeUiAction) -> Unit,
     onNavigateToVault: () -> Unit = {},
     onNavigateToMoments: () -> Unit = {},
+    onNavigateToLocation: () -> Unit = {},
 ) {
     val scrollState = rememberScrollState()
     Scaffold(
@@ -162,6 +168,15 @@ fun HomeUi(
                 label = stringResource(MR.string.moments_label),
                 subtitle = stringResource(MR.string.moments_home_subtitle),
                 onClick = onNavigateToMoments,
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            FeatureCard(
+                icon = Icons.Outlined.LocationOn,
+                label = stringResource(MR.string.location_label),
+                subtitle = stringResource(MR.string.location_home_subtitle),
+                onClick = onNavigateToLocation,
             )
 
             Spacer(modifier = Modifier.height(48.dp))

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationContent.kt
@@ -1,0 +1,242 @@
+package id.homebase.core.ui.screens.location
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import id.homebase.core.util.formatTimestamp
+import id.homebase.resources.MR
+import id.homebase.resources.location_perm_always
+import id.homebase.resources.location_perm_always_hint
+import id.homebase.resources.location_perm_grant
+import id.homebase.resources.location_perm_granted
+import id.homebase.resources.location_perm_open_settings
+import id.homebase.resources.location_perm_section
+import id.homebase.resources.location_perm_while_in_use
+import id.homebase.resources.location_status_last_fix
+import id.homebase.resources.location_status_last_flush
+import id.homebase.resources.location_status_never
+import id.homebase.resources.location_status_pending
+import id.homebase.resources.location_status_points_today
+import id.homebase.resources.location_status_section
+import id.homebase.resources.location_tracking_switch
+import id.homebase.resources.location_tracking_unavailable
+import kotlin.time.Instant
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun LocationContent(
+    uiState: LocationUiState,
+    innerPadding: PaddingValues,
+    onAction: (LocationUiAction) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .consumeWindowInsets(innerPadding)
+            .padding(innerPadding)
+            .padding(horizontal = 16.dp)
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+        Spacer(modifier = Modifier.height(0.dp))
+
+        // ── Master switch ──
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = stringResource(MR.string.location_tracking_switch),
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Switch(
+                        checked = uiState.trackingEnabled,
+                        onCheckedChange = { onAction(LocationUiAction.SetTrackingEnabled(it)) },
+                        enabled = uiState.trackingAvailable &&
+                            (uiState.trackingEnabled || uiState.whileInUseGranted),
+                    )
+                }
+                if (!uiState.trackingAvailable) {
+                    Text(
+                        text = stringResource(MR.string.location_tracking_unavailable),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 12.dp),
+                    )
+                }
+            }
+        }
+
+        // ── Permissions ──
+        if (uiState.trackingAvailable) {
+            SectionHeader(stringResource(MR.string.location_perm_section))
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column {
+                    PermissionRow(
+                        label = stringResource(MR.string.location_perm_while_in_use),
+                        granted = uiState.whileInUseGranted,
+                        permanentlyDenied = uiState.whileInUsePermanentlyDenied,
+                        requestEnabled = true,
+                        onRequest = { onAction(LocationUiAction.RequestWhileInUseClicked) },
+                        onOpenSettings = { onAction(LocationUiAction.OpenSystemSettingsClicked) },
+                    )
+                    HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                    PermissionRow(
+                        label = stringResource(MR.string.location_perm_always),
+                        granted = uiState.alwaysGranted,
+                        permanentlyDenied = uiState.alwaysPermanentlyDenied,
+                        // Android requires foreground location before background
+                        // may even be requested; iOS escalation likewise.
+                        requestEnabled = uiState.whileInUseGranted,
+                        onRequest = { onAction(LocationUiAction.RequestAlwaysClicked) },
+                        onOpenSettings = { onAction(LocationUiAction.OpenSystemSettingsClicked) },
+                    )
+                    if (!uiState.alwaysGranted) {
+                        Text(
+                            text = stringResource(MR.string.location_perm_always_hint),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 12.dp),
+                        )
+                    }
+                }
+            }
+        }
+
+        // ── Status ──
+        SectionHeader(stringResource(MR.string.location_status_section))
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column {
+                val never = stringResource(MR.string.location_status_never)
+                StatusRow(
+                    label = stringResource(MR.string.location_status_last_fix),
+                    value = uiState.lastFixEpochMs?.let { t ->
+                        val coords = if (uiState.lastFixLat != null && uiState.lastFixLon != null) {
+                            " (${uiState.lastFixLat.format5()}, ${uiState.lastFixLon.format5()})"
+                        } else ""
+                        formatTimestamp(Instant.fromEpochMilliseconds(t)) + coords
+                    } ?: never,
+                )
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                StatusRow(
+                    label = stringResource(MR.string.location_status_points_today),
+                    value = uiState.pointsToday.toString(),
+                )
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                StatusRow(
+                    label = stringResource(MR.string.location_status_pending),
+                    value = uiState.pendingUploadCount.toString(),
+                )
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                StatusRow(
+                    label = stringResource(MR.string.location_status_last_flush),
+                    value = uiState.lastFlushEpochMs?.let {
+                        formatTimestamp(Instant.fromEpochMilliseconds(it))
+                    } ?: never,
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+    }
+}
+
+@Composable
+private fun SectionHeader(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleMedium,
+        color = MaterialTheme.colorScheme.onSurface,
+        modifier = Modifier.padding(horizontal = 4.dp),
+    )
+}
+
+@Composable
+private fun PermissionRow(
+    label: String,
+    granted: Boolean,
+    permanentlyDenied: Boolean,
+    requestEnabled: Boolean,
+    onRequest: () -> Unit,
+    onOpenSettings: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.weight(1f),
+        )
+        when {
+            granted -> Text(
+                text = stringResource(MR.string.location_perm_granted),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+
+            permanentlyDenied -> Button(onClick = onOpenSettings) {
+                Text(stringResource(MR.string.location_perm_open_settings))
+            }
+
+            else -> Button(onClick = onRequest, enabled = requestEnabled) {
+                Text(stringResource(MR.string.location_perm_grant))
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusRow(label: String, value: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+    }
+}
+
+private fun Double.format5(): String {
+    val scaled = kotlin.math.round(this * 1e5) / 1e5
+    return scaled.toString()
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
@@ -1,0 +1,126 @@
+package id.homebase.core.ui.screens.location
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.homebase.core.permissions.PermissionStatus
+import id.homebase.core.permissions.PermissionType
+import id.homebase.core.permissions.createPermissionsManager
+import id.homebase.resources.MR
+import id.homebase.resources.location_label
+import id.homebase.resources.menu_back
+import org.jetbrains.compose.resources.stringResource
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LocationScreen(
+    viewModel: LocationViewModel,
+    onNavigateBack: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    val permissionsManager = createPermissionsManager { type, status, isPermanentlyDenied ->
+        when (type) {
+            PermissionType.LOCATION ->
+                viewModel.updateWhileInUseStatus(
+                    granted = status == PermissionStatus.GRANTED,
+                    permanentlyDenied = isPermanentlyDenied,
+                )
+
+            PermissionType.LOCATION_ALWAYS ->
+                viewModel.updateAlwaysStatus(
+                    granted = status == PermissionStatus.GRANTED,
+                    permanentlyDenied = isPermanentlyDenied,
+                )
+
+            else -> {}
+        }
+    }
+
+    suspend fun recheckPermissions() {
+        // Re-query both rather than trusting per-key callbacks: the LOCATION
+        // request maps two manifest permissions (fine + coarse) to one type,
+        // and iOS may not call back at all on a silently kept status.
+        viewModel.updateWhileInUseStatus(
+            granted = permissionsManager.isPermissionGranted(PermissionType.LOCATION),
+            permanentlyDenied = false,
+        )
+        viewModel.updateAlwaysStatus(
+            granted = permissionsManager.isPermissionGranted(PermissionType.LOCATION_ALWAYS),
+            permanentlyDenied = false,
+        )
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.refresh()
+        recheckPermissions()
+    }
+
+    // Returning from the system settings screen must refresh both permission rows.
+    var resumeTick by remember { mutableIntStateOf(0) }
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) resumeTick++
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+    LaunchedEffect(resumeTick) {
+        if (resumeTick > 0) {
+            viewModel.refresh()
+            recheckPermissions()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(MR.string.location_label)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(MR.string.menu_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        LocationContent(
+            uiState = uiState,
+            innerPadding = innerPadding,
+            onAction = { action ->
+                when (action) {
+                    LocationUiAction.RequestWhileInUseClicked ->
+                        permissionsManager.askPermission(PermissionType.LOCATION)
+
+                    LocationUiAction.RequestAlwaysClicked ->
+                        permissionsManager.askPermission(PermissionType.LOCATION_ALWAYS)
+
+                    LocationUiAction.OpenSystemSettingsClicked ->
+                        permissionsManager.launchSettings()
+
+                    else -> viewModel.onAction(action)
+                }
+            },
+        )
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
@@ -1,10 +1,6 @@
 package id.homebase.core.ui.screens.location
 
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -24,14 +20,12 @@ import id.homebase.core.permissions.PermissionType
 import id.homebase.core.permissions.createPermissionsManager
 import id.homebase.resources.MR
 import id.homebase.resources.location_label
-import id.homebase.resources.menu_back
 import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LocationScreen(
     viewModel: LocationViewModel,
-    onNavigateBack: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -91,16 +85,10 @@ fun LocationScreen(
 
     Scaffold(
         topBar = {
+            // No back arrow: Location is a top-level destination reached from the
+            // bottom nav bar (which stays visible here), matching Vault/Moments.
             TopAppBar(
                 title = { Text(stringResource(MR.string.location_label)) },
-                navigationIcon = {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(MR.string.menu_back),
-                        )
-                    }
-                },
             )
         },
     ) { innerPadding ->

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
@@ -3,17 +3,20 @@ package id.homebase.core.ui.screens.location
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.History
 import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.Lifecycle
@@ -24,6 +27,10 @@ import id.homebase.core.permissions.PermissionStatus
 import id.homebase.core.permissions.PermissionType
 import id.homebase.core.permissions.createPermissionsManager
 import id.homebase.resources.MR
+import id.homebase.resources.location_consent_agree
+import id.homebase.resources.location_consent_decline
+import id.homebase.resources.location_consent_text
+import id.homebase.resources.location_consent_title
 import id.homebase.resources.location_history_title
 import id.homebase.resources.location_label
 import id.homebase.resources.location_settings
@@ -92,6 +99,33 @@ fun LocationScreen(
         }
     }
 
+    // Google Play prominent disclosure: the consent dialog must be accepted
+    // before the first location permission request or tracking enable. Holds
+    // the intercepted action and replays it on Agree.
+    var pendingConsentAction by remember { mutableStateOf<LocationUiAction?>(null) }
+
+    fun execute(action: LocationUiAction) {
+        when (action) {
+            LocationUiAction.RequestWhileInUseClicked ->
+                permissionsManager.askPermission(PermissionType.LOCATION)
+
+            LocationUiAction.RequestAlwaysClicked ->
+                permissionsManager.askPermission(PermissionType.LOCATION_ALWAYS)
+
+            LocationUiAction.OpenSystemSettingsClicked ->
+                permissionsManager.launchSettings()
+
+            else -> viewModel.onAction(action)
+        }
+    }
+
+    fun needsConsent(action: LocationUiAction): Boolean {
+        if (uiState.disclosureAccepted) return false
+        return action == LocationUiAction.RequestWhileInUseClicked ||
+            action == LocationUiAction.RequestAlwaysClicked ||
+            (action as? LocationUiAction.SetTrackingEnabled)?.enabled == true
+    }
+
     Scaffold(
         topBar = {
             // No back arrow: Location is a top-level destination reached from the
@@ -119,17 +153,26 @@ fun LocationScreen(
             uiState = uiState,
             innerPadding = innerPadding,
             onAction = { action ->
-                when (action) {
-                    LocationUiAction.RequestWhileInUseClicked ->
-                        permissionsManager.askPermission(PermissionType.LOCATION)
+                if (needsConsent(action)) pendingConsentAction = action else execute(action)
+            },
+        )
+    }
 
-                    LocationUiAction.RequestAlwaysClicked ->
-                        permissionsManager.askPermission(PermissionType.LOCATION_ALWAYS)
-
-                    LocationUiAction.OpenSystemSettingsClicked ->
-                        permissionsManager.launchSettings()
-
-                    else -> viewModel.onAction(action)
+    pendingConsentAction?.let { pending ->
+        AlertDialog(
+            onDismissRequest = { pendingConsentAction = null },
+            title = { Text(stringResource(MR.string.location_consent_title)) },
+            text = { Text(stringResource(MR.string.location_consent_text)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.acceptDisclosure()
+                    pendingConsentAction = null
+                    execute(pending)
+                }) { Text(stringResource(MR.string.location_consent_agree)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingConsentAction = null }) {
+                    Text(stringResource(MR.string.location_consent_decline))
                 }
             },
         )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
@@ -1,6 +1,7 @@
 package id.homebase.core.ui.screens.location
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.History
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -23,6 +24,7 @@ import id.homebase.core.permissions.PermissionStatus
 import id.homebase.core.permissions.PermissionType
 import id.homebase.core.permissions.createPermissionsManager
 import id.homebase.resources.MR
+import id.homebase.resources.location_history_title
 import id.homebase.resources.location_label
 import id.homebase.resources.location_settings
 import org.jetbrains.compose.resources.stringResource
@@ -32,6 +34,7 @@ import org.jetbrains.compose.resources.stringResource
 fun LocationScreen(
     viewModel: LocationViewModel,
     onNavigateToSettings: () -> Unit,
+    onNavigateToHistory: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -96,6 +99,12 @@ fun LocationScreen(
             TopAppBar(
                 title = { Text(stringResource(MR.string.location_label)) },
                 actions = {
+                    IconButton(onClick = onNavigateToHistory) {
+                        Icon(
+                            imageVector = Icons.Outlined.History,
+                            contentDescription = stringResource(MR.string.location_history_title),
+                        )
+                    }
                     IconButton(onClick = onNavigateToSettings) {
                         Icon(
                             imageVector = Icons.Outlined.Settings,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
@@ -1,6 +1,10 @@
 package id.homebase.core.ui.screens.location
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -20,12 +24,14 @@ import id.homebase.core.permissions.PermissionType
 import id.homebase.core.permissions.createPermissionsManager
 import id.homebase.resources.MR
 import id.homebase.resources.location_label
+import id.homebase.resources.location_settings
 import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LocationScreen(
     viewModel: LocationViewModel,
+    onNavigateToSettings: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -89,6 +95,14 @@ fun LocationScreen(
             // bottom nav bar (which stays visible here), matching Vault/Moments.
             TopAppBar(
                 title = { Text(stringResource(MR.string.location_label)) },
+                actions = {
+                    IconButton(onClick = onNavigateToSettings) {
+                        Icon(
+                            imageVector = Icons.Outlined.Settings,
+                            contentDescription = stringResource(MR.string.location_settings),
+                        )
+                    }
+                },
             )
         },
     ) { innerPadding ->

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationTrackUploaderService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationTrackUploaderService.kt
@@ -119,9 +119,13 @@ class LocationTrackUploaderService(
     suspend fun flush() {
         flushMutex.withLock {
             lastFlushAttemptMs = Clock.System.now().toEpochMilliseconds()
-            if (!preferences.activated.value) return
+            if (!preferences.activated.value) {
+                logger.d { "Flush skipped: Location add-on not activated" }
+                return
+            }
             if (credentialsManager.getActiveCredentials() == null) {
                 // Logged out / not yet logged in: points stay buffered.
+                logger.d { "Flush skipped: no active credentials — points stay buffered" }
                 return
             }
             val hours = runCatching { buffer.selectPendingHours() }
@@ -152,11 +156,42 @@ class LocationTrackUploaderService(
 
         if (enqueued) {
             buffer.markFlushed(uid, hourStartMs, hourStartMs + HOUR_MS)
-            logger.d {
-                "Flushed hour=$hourStartMs points=${points.size} stored=${stored.size} " +
+            logger.i {
+                "Flushed hour=$hourStartMs uid=$uid points=${points.size} stored=${stored.size} " +
                     "overflowPayload=$overflow mode=${if (existing == null) "create" else "update"}"
             }
         }
+    }
+
+    /**
+     * Points captured today (UTC) by this device: the sum of today's hour-file
+     * counts (`full` raw count when the header trace was thinned) plus buffered
+     * rows not yet serialized into any file. NOT the upload buffer's row count —
+     * the buffer drains on upload confirmation, which is exactly why the UI must
+     * not derive "points today" from it.
+     *
+     * Transient overcount window: after an upload FAILS, its rows are unmarked
+     * for retry while the optimistic local header still carries their count;
+     * the next successful flush reconverges.
+     */
+    suspend fun countPointsToday(): Int {
+        val creds = credentialsManager.getActiveCredentials() ?: return 0
+        val now = Clock.System.now().toEpochMilliseconds()
+        val dayStart = now - now % DAY_MS
+        val hourUids = (0 until 24)
+            .map { dayStart + it * HOUR_MS }
+            .filter { it <= now }
+            .map { locationHourFileUid(deviceId.value, it) }
+        val fromFiles = runCatching {
+            databaseManager.driveMainIndex
+                .selectHomebaseFilesByUniqueIds(creds.getIdentityId(), driveId, hourUids)
+                .sumOf { file ->
+                    file.fileMetadata.appData.content
+                        ?.let { LocationTrackCodec.decodeHeader(it)?.fullCount } ?: 0
+                }
+        }.getOrDefault(0)
+        val unflushed = runCatching { buffer.countUnmarkedSince(dayStart) }.getOrDefault(0L)
+        return fromFiles + unflushed.toInt()
     }
 
     /** Local index first; on miss one HTTP probe (fresh login mid-hour, before sync). */
@@ -311,6 +346,7 @@ class LocationTrackUploaderService(
             when (event) {
                 is BackendEvent.OutboxEvent.ItemCompleted -> {
                     if (event.driveId != driveId) return@collect
+                    logger.i { "Hour-file upload confirmed uid=${event.uniqueId} — draining buffer rows" }
                     runCatching { buffer.deleteByFlushUid(event.uniqueId) }
                         .onFailure { logger.e(it) { "deleteByFlushUid failed" } }
                     _lastFlushTime.value = Clock.System.now().toEpochMilliseconds()
@@ -337,5 +373,6 @@ class LocationTrackUploaderService(
     private companion object {
         const val MIN_FLUSH_INTERVAL_MS = 60_000L
         const val RETENTION_MS = 7L * 24 * HOUR_MS
+        const val DAY_MS = 24 * HOUR_MS
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationTrackUploaderService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationTrackUploaderService.kt
@@ -1,0 +1,341 @@
+package id.homebase.core.ui.screens.location
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.FileSystemType
+import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.client.drives.files.DriveFileProvider
+import id.homebase.api.client.drives.files.PayloadFile
+import id.homebase.api.client.drives.upload.FileUpdateInstructionSet
+import id.homebase.api.client.drives.upload.UpdateFileByUniqueIdRequest
+import id.homebase.api.client.drives.upload.UpdateLocale
+import id.homebase.api.client.drives.upload.UpdateManifest
+import id.homebase.api.client.drives.upload.UploadAppFileMetaData
+import id.homebase.api.client.drives.upload.UploadFileMetadata
+import id.homebase.api.client.drives.upload.UploadFileRequest
+import id.homebase.api.client.eventbus.BackendEvent
+import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.crypto.ByteArrayUtil
+import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.sync.database.BufferedLocationPoint
+import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.sync.database.OutboxSync
+import id.homebase.chat.services.PayloadBundle
+import id.homebase.chat.services.PayloadBundleEncryptionService
+import id.homebase.chat.services.outbox.OptimisticWriter
+import id.homebase.core.config.locationLabeledDrive
+import id.homebase.core.location.LocationPreferences
+import id.homebase.core.location.tracking.LocationDeviceId
+import id.homebase.core.ui.screens.location.model.HOUR_MS
+import id.homebase.core.ui.screens.location.model.LOCATION_POINTS_PAYLOAD_KEY
+import id.homebase.core.ui.screens.location.model.LOCATION_TRACK_FILE_TYPE
+import id.homebase.core.ui.screens.location.model.LocationTrackCodec
+import id.homebase.core.ui.screens.location.model.locationHourFileUid
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.time.Clock
+import kotlin.uuid.Uuid
+
+private const val TAG = "LocationTrackUploader"
+
+/**
+ * Drains the LocationPoint buffer into per-device per-UTC-hour files on the
+ * Location drive.
+ *
+ * Flush algorithm per pending hour (an hour with un-enqueued rows):
+ * 1. Re-serialize the FULL hour (marked + unmarked rows) — the hour file is a
+ *    whole-document replace, never an append.
+ * 2. Header gets the compact (possibly thinned) trace; when thinning dropped
+ *    points, a full-resolution encrypted JSON payload rides along (overflow
+ *    case — rare under v1 capture cadences, so the server's expensive payload
+ *    ingest path is only paid when actually needed).
+ * 3. Create vs update: local index first, then one HTTP header probe (fresh
+ *    login mid-hour). Updates reuse the existing AES key with a fresh IV
+ *    ("AES key must match") and go through replaceEnqueue so multiple flushes
+ *    of the same hour coalesce into one pending outbox row.
+ * 4. Rows are marked with the file uid on enqueue, deleted on
+ *    OutboxEvent.ItemCompleted, and un-marked on ItemFailed for retry.
+ */
+class LocationTrackUploaderService(
+    private val outboxSync: OutboxSync,
+    private val optimisticWriter: OptimisticWriter,
+    private val payloadEncryptionService: PayloadBundleEncryptionService,
+    private val fileOperationsProvider: FileOperationsProvider,
+    private val driveFileProvider: DriveFileProvider,
+    private val databaseManager: DatabaseManager,
+    private val credentialsManager: CredentialsManager,
+    private val eventBus: EventBus,
+    private val deviceId: LocationDeviceId,
+    private val preferences: LocationPreferences,
+    private val scope: CoroutineScope,
+) {
+    private val logger = Logger.withTag(TAG)
+    private val driveId = locationLabeledDrive.drive.alias
+    private val buffer get() = databaseManager.locationPoint
+
+    private val flushMutex = Mutex()
+    private var lastFlushAttemptMs = 0L
+    private var observerStarted = false
+
+    private val _lastFlushTime = MutableStateFlow<Long?>(null)
+    val lastFlushTime: StateFlow<Long?> = _lastFlushTime.asStateFlow()
+
+    private val _pendingCount = MutableStateFlow(0L)
+    val pendingCount: StateFlow<Long> = _pendingCount.asStateFlow()
+
+    /**
+     * Begin observing outbox completions and run the retention sweep. Called
+     * from `onPostAuthenticated` (after reset()); safe to call repeatedly.
+     */
+    fun start() {
+        scope.launch {
+            buffer.deleteOlderThan(Clock.System.now().toEpochMilliseconds() - RETENTION_MS)
+            refreshPendingCount()
+        }
+        if (observerStarted) return
+        observerStarted = true
+        scope.launch { observeOutbox() }
+    }
+
+    fun reset() {
+        _lastFlushTime.value = null
+        _pendingCount.value = 0
+        lastFlushAttemptMs = 0
+    }
+
+    /** Rate-gated flush — the entry point for tickers and background batch wakes. */
+    suspend fun flushIfDue() {
+        val now = Clock.System.now().toEpochMilliseconds()
+        if (now - lastFlushAttemptMs < MIN_FLUSH_INTERVAL_MS) return
+        flush()
+    }
+
+    suspend fun flush() {
+        flushMutex.withLock {
+            lastFlushAttemptMs = Clock.System.now().toEpochMilliseconds()
+            if (!preferences.activated.value) return
+            if (credentialsManager.getActiveCredentials() == null) {
+                // Logged out / not yet logged in: points stay buffered.
+                return
+            }
+            val hours = runCatching { buffer.selectPendingHours() }
+                .onFailure { logger.e(it) { "selectPendingHours failed" } }
+                .getOrNull() ?: return
+            for (hourBucket in hours) {
+                runCatching { flushHour(hourBucket * HOUR_MS) }
+                    .onFailure { logger.e(it) { "flushHour($hourBucket) failed" } }
+            }
+            refreshPendingCount()
+        }
+    }
+
+    private suspend fun flushHour(hourStartMs: Long) {
+        val points = buffer.selectByTimeRange(hourStartMs, hourStartMs + HOUR_MS)
+        if (points.isEmpty()) return
+
+        val uid = locationHourFileUid(deviceId.value, hourStartMs)
+        val (headerJson, stored) = LocationTrackCodec.encodeHeader(deviceId.value, hourStartMs, points)
+        val overflow = stored.size < points.size
+
+        val existing = findExistingFile(uid)
+        val enqueued = if (existing == null) {
+            enqueueCreate(uid, hourStartMs, headerJson, if (overflow) points else null)
+        } else {
+            enqueueUpdate(existing, uid, hourStartMs, headerJson, if (overflow) points else null)
+        }
+
+        if (enqueued) {
+            buffer.markFlushed(uid, hourStartMs, hourStartMs + HOUR_MS)
+            logger.d {
+                "Flushed hour=$hourStartMs points=${points.size} stored=${stored.size} " +
+                    "overflowPayload=$overflow mode=${if (existing == null) "create" else "update"}"
+            }
+        }
+    }
+
+    /** Local index first; on miss one HTTP probe (fresh login mid-hour, before sync). */
+    private suspend fun findExistingFile(uid: Uuid): HomebaseFile? {
+        val creds = credentialsManager.getActiveCredentials() ?: return null
+        val local = runCatching {
+            databaseManager.driveMainIndex
+                .selectHomebaseFilesByUniqueIds(creds.getIdentityId(), driveId, listOf(uid))
+                .firstOrNull()
+        }.getOrNull()
+        if (local != null) return local
+        return runCatching { driveFileProvider.getFileHeaderByUid(driveId, uid) }
+            .onFailure {
+                // Offline probe failure: treat as miss. If the file does exist
+                // server-side the create fails permanently and the rows are
+                // un-marked for retry by the ItemFailed handler — loud but safe.
+                logger.w(it) { "Header probe failed for $uid — assuming create" }
+            }
+            .getOrNull()
+    }
+
+    private suspend fun enqueueCreate(
+        uid: Uuid,
+        hourStartMs: Long,
+        headerJson: String,
+        overflowPoints: List<BufferedLocationPoint>?,
+    ): Boolean {
+        val keyHeader = KeyHeader.newRandom16()
+        val (payloads, tempPath) = buildOverflowPayload(uid, hourStartMs, overflowPoints, keyHeader)
+        try {
+            val unencryptedMetadata = UploadFileMetadata(
+                allowDistribution = false,
+                isEncrypted = true,
+                appData = UploadAppFileMetaData(
+                    uniqueId = uid,
+                    content = headerJson,
+                    fileType = LOCATION_TRACK_FILE_TYPE,
+                    userDate = hourStartMs,
+                ),
+            )
+            val request = UploadFileRequest(
+                driveId = driveId,
+                keyHeader = keyHeader,
+                metadata = unencryptedMetadata.encryptContent(keyHeader),
+                payloads = payloads ?: emptyList(),
+            )
+            val enqueued = outboxSync.replaceEnqueue(request)
+            if (enqueued) {
+                runCatching {
+                    optimisticWriter.writeNewFile(
+                        driveId = driveId,
+                        keyHeader = keyHeader,
+                        unecryptedMetadata = unencryptedMetadata,
+                        originalRecipientCount = 0,
+                        fileSystemType = FileSystemType.Standard,
+                    )
+                }.onFailure { logger.e(it) { "Optimistic write failed (non-fatal) for $uid" } }
+            }
+            return enqueued
+        } finally {
+            tempPath?.let { fileOperationsProvider.deleteTempFile(it) }
+        }
+    }
+
+    private suspend fun enqueueUpdate(
+        existing: HomebaseFile,
+        uid: Uuid,
+        hourStartMs: Long,
+        headerJson: String,
+        overflowPoints: List<BufferedLocationPoint>?,
+    ): Boolean {
+        // The server rejects an update whose AES key differs from the file's
+        // ("AES key must match") — reuse it with a fresh IV.
+        val newKeyHeader = KeyHeader(
+            iv = ByteArrayUtil.getRndByteArray(16),
+            aesKey = existing.keyHeader.aesKey,
+        )
+        val (payloads, tempPath) = buildOverflowPayload(uid, hourStartMs, overflowPoints, newKeyHeader)
+        try {
+            val unencryptedMetadata = UploadFileMetadata(
+                allowDistribution = false,
+                isEncrypted = true,
+                appData = UploadAppFileMetaData(
+                    uniqueId = uid,
+                    content = headerJson,
+                    fileType = LOCATION_TRACK_FILE_TYPE,
+                    userDate = hourStartMs,
+                ),
+                versionTag = existing.fileMetadata.versionTag,
+            )
+            val request = UpdateFileByUniqueIdRequest(
+                driveId = driveId,
+                uniqueId = uid,
+                keyHeader = newKeyHeader,
+                instructions = FileUpdateInstructionSet(
+                    transferIv = ByteArrayUtil.getRndByteArray(16),
+                    locale = UpdateLocale.Local,
+                    recipients = emptyList(),
+                    manifest = UpdateManifest.build(payloads = payloads),
+                ),
+                metadata = unencryptedMetadata.encryptContent(newKeyHeader),
+                payloads = payloads,
+            )
+            // replaceEnqueue keyed on (driveId, uniqueId): successive flushes of
+            // the same hour collapse to one pending upload.
+            val enqueued = outboxSync.replaceEnqueue(request)
+            if (enqueued) {
+                runCatching {
+                    optimisticWriter.writeUpdate(driveId, newKeyHeader, unencryptedMetadata)
+                }.onFailure { logger.e(it) { "Optimistic update failed (non-fatal) for $uid" } }
+            }
+            return enqueued
+        } finally {
+            tempPath?.let { fileOperationsProvider.deleteTempFile(it) }
+        }
+    }
+
+    /**
+     * Full-resolution payload for overflow hours. Returns (payloads, tempPath);
+     * (null, null) for the common header-only case.
+     */
+    private suspend fun buildOverflowPayload(
+        uid: Uuid,
+        hourStartMs: Long,
+        points: List<BufferedLocationPoint>?,
+        keyHeader: KeyHeader,
+    ): Pair<List<PayloadFile>?, String?> {
+        if (points == null) return null to null
+        val json = LocationTrackCodec.encodePayload(deviceId.value, hourStartMs, points)
+        val tempPath = fileOperationsProvider.writeBytesToTempFile(
+            bytes = json.encodeToByteArray(),
+            prefix = "loc_track_",
+            suffix = ".json",
+        )
+        val bundle = PayloadBundle(
+            payloads = listOf(
+                PayloadFile(
+                    key = LOCATION_POINTS_PAYLOAD_KEY,
+                    filePath = tempPath,
+                    contentType = "application/json",
+                )
+            ),
+            thumbnails = emptyList(),
+            previewThumbs = emptyList(),
+        )
+        val encrypted = payloadEncryptionService.encryptBundle(uid, bundle, keyHeader.aesKey, scope)
+        return encrypted.payloads to tempPath
+    }
+
+    private suspend fun observeOutbox() {
+        eventBus.events.collect { event ->
+            when (event) {
+                is BackendEvent.OutboxEvent.ItemCompleted -> {
+                    if (event.driveId != driveId) return@collect
+                    runCatching { buffer.deleteByFlushUid(event.uniqueId) }
+                        .onFailure { logger.e(it) { "deleteByFlushUid failed" } }
+                    _lastFlushTime.value = Clock.System.now().toEpochMilliseconds()
+                    refreshPendingCount()
+                }
+
+                is BackendEvent.OutboxEvent.ItemFailed -> {
+                    if (event.driveId != driveId) return@collect
+                    logger.w { "Hour-file upload failed for ${event.uniqueId} — rows unmarked for retry" }
+                    runCatching { buffer.clearFlushMark(event.uniqueId) }
+                        .onFailure { logger.e(it) { "clearFlushMark failed" } }
+                    refreshPendingCount()
+                }
+
+                else -> {}
+            }
+        }
+    }
+
+    private suspend fun refreshPendingCount() {
+        _pendingCount.value = runCatching { buffer.countAll() }.getOrDefault(0L)
+    }
+
+    private companion object {
+        const val MIN_FLUSH_INTERVAL_MS = 60_000L
+        const val RETENTION_MS = 7L * 24 * HOUR_MS
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
@@ -1,0 +1,33 @@
+package id.homebase.core.ui.screens.location
+
+data class LocationUiState(
+    val isCheckingPermissions: Boolean = false,
+    val setupInitiated: Boolean = false,
+    // Main-screen state
+    val trackingEnabled: Boolean = false,
+    val trackingAvailable: Boolean = false,
+    val whileInUseGranted: Boolean = false,
+    val whileInUsePermanentlyDenied: Boolean = false,
+    val alwaysGranted: Boolean = false,
+    val alwaysPermanentlyDenied: Boolean = false,
+    val lastFixEpochMs: Long? = null,
+    val lastFixLat: Double? = null,
+    val lastFixLon: Double? = null,
+    val pointsToday: Int = 0,
+    val pendingUploadCount: Int = 0,
+    val lastFlushEpochMs: Long? = null,
+)
+
+sealed interface LocationUiAction {
+    data object SetupClicked : LocationUiAction
+    data object DismissOnboardingClicked : LocationUiAction
+    data class SetTrackingEnabled(val enabled: Boolean) : LocationUiAction
+    data object RequestWhileInUseClicked : LocationUiAction
+    data object RequestAlwaysClicked : LocationUiAction
+    data object OpenSystemSettingsClicked : LocationUiAction
+}
+
+sealed interface LocationUiEvent {
+    data object Activated : LocationUiEvent
+    data object CloseOnboarding : LocationUiEvent
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
@@ -6,6 +6,8 @@ data class LocationUiState(
     // Main-screen state
     val trackingEnabled: Boolean = false,
     val trackingAvailable: Boolean = false,
+    /** Google Play prominent-disclosure consent (persisted; gates first grant/enable). */
+    val disclosureAccepted: Boolean = false,
     val whileInUseGranted: Boolean = false,
     val whileInUsePermanentlyDenied: Boolean = false,
     val alwaysGranted: Boolean = false,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlin.time.Clock
 
 class LocationViewModel(
     private val locationPreferences: LocationPreferences,
@@ -157,12 +156,13 @@ class LocationViewModel(
     }
 
     private suspend fun refreshCounts() {
-        val now = Clock.System.now().toEpochMilliseconds()
-        val utcDayStart = now - now % 86_400_000L
-        val today = pointStore.countSince(utcDayStart)
+        // "Points today" comes from the hour files (+ unflushed remainder), NOT
+        // the upload buffer — the buffer drains on upload confirmation, so its
+        // row count is the "waiting to upload" number, not the day's history.
+        val today = uploaderService.countPointsToday()
         val pending = pointStore.countPendingUpload()
         _uiState.update {
-            it.copy(pointsToday = today.toInt(), pendingUploadCount = pending.toInt())
+            it.copy(pointsToday = today, pendingUploadCount = pending.toInt())
         }
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
@@ -84,6 +84,11 @@ class LocationViewModel(
             }
         }
         viewModelScope.launch {
+            locationPreferences.disclosureAccepted.collect { accepted ->
+                _uiState.update { it.copy(disclosureAccepted = accepted) }
+            }
+        }
+        viewModelScope.launch {
             pointStore.lastPoint.collect { p ->
                 _uiState.update {
                     it.copy(lastFixEpochMs = p?.t, lastFixLat = p?.lat, lastFixLon = p?.lon)
@@ -133,6 +138,11 @@ class LocationViewModel(
             LocationUiAction.RequestAlwaysClicked,
             LocationUiAction.OpenSystemSettingsClicked -> Unit
         }
+    }
+
+    /** Persist the prominent-disclosure consent (Agree in the dialog). */
+    fun acceptDisclosure() {
+        viewModelScope.launch { locationPreferences.setDisclosureAccepted(true) }
     }
 
     fun updateWhileInUseStatus(granted: Boolean, permanentlyDenied: Boolean) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
@@ -1,0 +1,168 @@
+package id.homebase.core.ui.screens.location
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import id.homebase.chat.conversationlist.ExtendPermissionUiState
+import id.homebase.chat.conversationlist.ExtendPermissionViewModel
+import id.homebase.core.auth.AuthConnectionCoordinator
+import id.homebase.core.config.locationLabeledDrive
+import id.homebase.core.location.LocationPreferences
+import id.homebase.core.location.tracking.LocationPointStore
+import id.homebase.core.location.tracking.LocationTracker
+import id.homebase.core.location.tracking.LocationTrackingCoordinator
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlin.time.Clock
+
+class LocationViewModel(
+    private val locationPreferences: LocationPreferences,
+    private val locationPermissionViewModel: ExtendPermissionViewModel,
+    private val authConnectionCoordinator: AuthConnectionCoordinator,
+    private val trackingCoordinator: LocationTrackingCoordinator,
+    private val pointStore: LocationPointStore,
+    private val uploaderService: LocationTrackUploaderService,
+    tracker: LocationTracker,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(
+        LocationUiState(
+            trackingAvailable = tracker.isAvailable,
+            trackingEnabled = locationPreferences.trackingEnabled.value,
+        )
+    )
+    val uiState: StateFlow<LocationUiState> = _uiState.asStateFlow()
+
+    private val _events = MutableSharedFlow<LocationUiEvent>(extraBufferCapacity = 4)
+    val events: SharedFlow<LocationUiEvent> = _events.asSharedFlow()
+
+    val locationExtendPermissionViewModel: ExtendPermissionViewModel
+        get() = locationPermissionViewModel
+
+    init {
+        viewModelScope.launch {
+            locationPermissionViewModel.permissionsGranted
+                .filter { it }
+                .collect {
+                    if (!locationPreferences.activated.value) {
+                        // Auto-activate as soon as the drive is authorized — including the
+                        // passive launch-time autoCheck grant. Activation persists the flag
+                        // and mounts the drive; it does not move the user.
+                        val initiatedByUser = _uiState.value.setupInitiated
+                        locationPreferences.setActivated(true)
+                        authConnectionCoordinator.mountDrive(locationLabeledDrive)
+                        _uiState.update {
+                            it.copy(isCheckingPermissions = false, setupInitiated = false)
+                        }
+                        if (initiatedByUser) {
+                            _events.tryEmit(LocationUiEvent.Activated)
+                        }
+                    }
+                }
+        }
+
+        // Resetting setupInitiated on every Dismissed transition (Cancel button, outside-tap,
+        // or owner-console cancellation) ensures the next visit to onboarding starts clean.
+        viewModelScope.launch {
+            locationPermissionViewModel.uiState
+                .filter { it is ExtendPermissionUiState.Dismissed }
+                .collect {
+                    _uiState.update {
+                        it.copy(isCheckingPermissions = false, setupInitiated = false)
+                    }
+                }
+        }
+
+        viewModelScope.launch {
+            locationPreferences.trackingEnabled.collect { enabled ->
+                _uiState.update { it.copy(trackingEnabled = enabled) }
+            }
+        }
+        viewModelScope.launch {
+            pointStore.lastPoint.collect { p ->
+                _uiState.update {
+                    it.copy(lastFixEpochMs = p?.t, lastFixLat = p?.lat, lastFixLon = p?.lon)
+                }
+                refreshCounts()
+            }
+        }
+        viewModelScope.launch {
+            uploaderService.lastFlushTime.collect { t ->
+                _uiState.update { it.copy(lastFlushEpochMs = t) }
+                refreshCounts()
+            }
+        }
+        viewModelScope.launch {
+            uploaderService.pendingCount.collect { n ->
+                _uiState.update { it.copy(pendingUploadCount = n.toInt()) }
+            }
+        }
+    }
+
+    fun onAction(action: LocationUiAction) {
+        when (action) {
+            LocationUiAction.SetupClicked -> {
+                _uiState.update {
+                    it.copy(isCheckingPermissions = true, setupInitiated = true)
+                }
+                locationPermissionViewModel.recheckPermissions()
+            }
+
+            LocationUiAction.DismissOnboardingClicked -> {
+                viewModelScope.launch {
+                    locationPreferences.setIconVisible(false)
+                    _events.tryEmit(LocationUiEvent.CloseOnboarding)
+                }
+            }
+
+            is LocationUiAction.SetTrackingEnabled -> {
+                viewModelScope.launch {
+                    trackingCoordinator.setTrackingEnabled(action.enabled)
+                }
+            }
+
+            // Permission requests are dispatched at the screen level (the
+            // PermissionsManager is composition-scoped); the VM only receives
+            // status updates via updatePermissionStatus.
+            LocationUiAction.RequestWhileInUseClicked,
+            LocationUiAction.RequestAlwaysClicked,
+            LocationUiAction.OpenSystemSettingsClicked -> Unit
+        }
+    }
+
+    fun updateWhileInUseStatus(granted: Boolean, permanentlyDenied: Boolean) {
+        _uiState.update {
+            it.copy(whileInUseGranted = granted, whileInUsePermanentlyDenied = permanentlyDenied)
+        }
+    }
+
+    fun updateAlwaysStatus(granted: Boolean, permanentlyDenied: Boolean) {
+        _uiState.update {
+            it.copy(alwaysGranted = granted, alwaysPermanentlyDenied = permanentlyDenied)
+        }
+    }
+
+    /** Called on screen entry / resume to refresh DB-backed status numbers. */
+    fun refresh() {
+        viewModelScope.launch {
+            pointStore.refresh()
+            refreshCounts()
+        }
+    }
+
+    private suspend fun refreshCounts() {
+        val now = Clock.System.now().toEpochMilliseconds()
+        val utcDayStart = now - now % 86_400_000L
+        val today = pointStore.countSince(utcDayStart)
+        val pending = pointStore.countPendingUpload()
+        _uiState.update {
+            it.copy(pointsToday = today.toInt(), pendingUploadCount = pending.toInt())
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryAssembler.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryAssembler.kt
@@ -1,0 +1,107 @@
+package id.homebase.core.ui.screens.location.history
+
+import id.homebase.api.sync.database.BufferedLocationPoint
+import id.homebase.core.location.tracking.LocationPointStore
+import id.homebase.core.ui.screens.location.model.LocationTrackHour
+import kotlin.uuid.Uuid
+
+/**
+ * One device's day of movement, split into [segments] at tracking gaps so the
+ * canvas never draws a line across a flight or an off-period.
+ */
+data class DeviceTrace(
+    val deviceId: Uuid,
+    /** Each segment is a time-ordered polyline; segments are non-overlapping. */
+    val segments: List<List<BufferedLocationPoint>>,
+) {
+    val pointCount: Int get() = segments.sumOf { it.size }
+}
+
+data class DayStats(
+    val distanceMeters: Double,
+    /** First-to-last fix across all devices, epoch ms; null when empty. */
+    val firstFixMs: Long?,
+    val lastFixMs: Long?,
+    val pointCount: Int,
+    val deviceCount: Int,
+)
+
+/**
+ * Pure assembly of decoded hour files (+ this device's unflushed buffer rows)
+ * into per-device, gap-segmented traces for one local day. Kept free of DB and
+ * clock dependencies so it is unit-testable.
+ */
+object LocationHistoryAssembler {
+
+    const val GAP_MAX_INTERVAL_MS = 15 * 60_000L
+    const val GAP_MAX_JUMP_METERS = 2_000.0
+
+    fun assemble(
+        hours: List<LocationTrackHour>,
+        /** This device's not-yet-flushed buffer rows (today only); may be empty. */
+        bufferPoints: List<BufferedLocationPoint>,
+        bufferDeviceId: Uuid,
+        dayStartMs: Long,
+        dayEndMs: Long,
+    ): List<DeviceTrace> {
+        val byDevice = mutableMapOf<Uuid, MutableMap<Long, BufferedLocationPoint>>()
+        for (hour in hours) {
+            val device = byDevice.getOrPut(hour.deviceId) { mutableMapOf() }
+            for (p in hour.points) {
+                if (p.t in dayStartMs until dayEndMs) device[p.t] = p
+            }
+        }
+        // Buffer rows are authoritative for their timestamps (full precision vs
+        // the header's quantized trace) — overwrite on collision.
+        if (bufferPoints.isNotEmpty()) {
+            val device = byDevice.getOrPut(bufferDeviceId) { mutableMapOf() }
+            for (p in bufferPoints) {
+                if (p.t in dayStartMs until dayEndMs) device[p.t] = p
+            }
+        }
+        return byDevice.entries
+            .sortedBy { it.key.toString() }
+            .mapNotNull { (deviceId, pointsByT) ->
+                if (pointsByT.isEmpty()) return@mapNotNull null
+                DeviceTrace(deviceId, segment(pointsByT.values.sortedBy { it.t }))
+            }
+    }
+
+    fun stats(traces: List<DeviceTrace>): DayStats {
+        var distance = 0.0
+        var first: Long? = null
+        var last: Long? = null
+        for (trace in traces) {
+            for (segment in trace.segments) {
+                for (i in 1 until segment.size) {
+                    distance += LocationPointStore.haversineMeters(
+                        segment[i - 1].lat, segment[i - 1].lon,
+                        segment[i].lat, segment[i].lon,
+                    )
+                }
+                segment.firstOrNull()?.t?.let { t -> first = minOf(first ?: t, t) }
+                segment.lastOrNull()?.t?.let { t -> last = maxOf(last ?: t, t) }
+            }
+        }
+        return DayStats(
+            distanceMeters = distance,
+            firstFixMs = first,
+            lastFixMs = last,
+            pointCount = traces.sumOf { it.pointCount },
+            deviceCount = traces.size,
+        )
+    }
+
+    private fun segment(points: List<BufferedLocationPoint>): List<List<BufferedLocationPoint>> {
+        if (points.isEmpty()) return emptyList()
+        val segments = mutableListOf<MutableList<BufferedLocationPoint>>(mutableListOf(points.first()))
+        for (i in 1 until points.size) {
+            val prev = points[i - 1]
+            val cur = points[i]
+            val gap = cur.t - prev.t > GAP_MAX_INTERVAL_MS ||
+                LocationPointStore.haversineMeters(prev.lat, prev.lon, cur.lat, cur.lon) > GAP_MAX_JUMP_METERS
+            if (gap) segments.add(mutableListOf(cur)) else segments.last().add(cur)
+        }
+        return segments
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryScreen.kt
@@ -1,0 +1,262 @@
+package id.homebase.core.ui.screens.location.history
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.CalendarToday
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.homebase.api.client.location.LocationPreviewProvider
+import id.homebase.core.util.formatMediumDate
+import id.homebase.core.util.formatTime
+import id.homebase.resources.MR
+import id.homebase.resources.cancel
+import id.homebase.resources.location_history_devices
+import id.homebase.resources.location_history_distance
+import id.homebase.resources.location_history_empty
+import id.homebase.resources.location_history_map_disclosure
+import id.homebase.resources.location_history_next_day
+import id.homebase.resources.location_history_pick_date
+import id.homebase.resources.location_history_points
+import id.homebase.resources.location_history_previous_day
+import id.homebase.resources.location_history_show_map
+import id.homebase.resources.location_history_span
+import id.homebase.resources.location_history_title
+import id.homebase.resources.menu_back
+import id.homebase.resources.ok
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
+import kotlin.math.roundToInt
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LocationHistoryScreen(
+    viewModel: LocationHistoryViewModel,
+    onNavigateBack: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val previewProvider = koinInject<LocationPreviewProvider>()
+    var showPicker by remember { mutableStateOf(false) }
+    val deviceTz = remember { TimeZone.currentSystemDefault() }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(MR.string.location_history_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(MR.string.menu_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(innerPadding)
+                .padding(innerPadding),
+        ) {
+            // ── Day navigation ──
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconButton(onClick = { viewModel.onAction(LocationHistoryUiAction.PreviousDay) }) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                        contentDescription = stringResource(MR.string.location_history_previous_day),
+                    )
+                }
+                AssistChip(
+                    onClick = { showPicker = true },
+                    label = { Text(formatMediumDate(Instant.fromEpochMilliseconds(uiState.dayStartMs))) },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Default.CalendarToday,
+                            contentDescription = stringResource(MR.string.location_history_pick_date),
+                            modifier = Modifier.size(AssistChipDefaults.IconSize),
+                        )
+                    },
+                )
+                IconButton(onClick = { viewModel.onAction(LocationHistoryUiAction.NextDay) }) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        contentDescription = stringResource(MR.string.location_history_next_day),
+                    )
+                }
+            }
+
+            // ── Trace canvas ──
+            Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                LocationTraceCanvas(
+                    traces = uiState.traces,
+                    showMapTiles = uiState.showMapTiles,
+                    fetchTile = { z, x, y -> previewProvider.getTilePng(z, x, y) },
+                    traceColors = listOf(
+                        MaterialTheme.colorScheme.primary,
+                        MaterialTheme.colorScheme.tertiary,
+                        MaterialTheme.colorScheme.secondary,
+                        MaterialTheme.colorScheme.error,
+                    ),
+                )
+                if (uiState.isLoading) {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                } else if (uiState.isEmpty) {
+                    Text(
+                        text = stringResource(MR.string.location_history_empty),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.align(Alignment.Center).padding(24.dp),
+                    )
+                }
+            }
+
+            // ── Stats ──
+            uiState.stats?.takeIf { it.pointCount > 0 }?.let { stats ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text(
+                        text = stringResource(
+                            MR.string.location_history_distance,
+                            ((stats.distanceMeters / 100.0).roundToInt() / 10.0).toString(),
+                        ),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    if (stats.firstFixMs != null && stats.lastFixMs != null) {
+                        Text(
+                            text = stringResource(
+                                MR.string.location_history_span,
+                                formatTime(Instant.fromEpochMilliseconds(stats.firstFixMs)),
+                                formatTime(Instant.fromEpochMilliseconds(stats.lastFixMs)),
+                            ),
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                    Text(
+                        text = stringResource(MR.string.location_history_points, stats.pointCount),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Text(
+                        text = stringResource(MR.string.location_history_devices, stats.deviceCount),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            }
+
+            // ── Basemap opt-in ──
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(MR.string.location_history_show_map),
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+                Switch(
+                    checked = uiState.showMapTiles,
+                    onCheckedChange = {
+                        viewModel.onAction(LocationHistoryUiAction.SetShowMapTiles(it))
+                    },
+                )
+            }
+            Text(
+                text = stringResource(MR.string.location_history_map_disclosure),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
+            )
+        }
+    }
+
+    if (showPicker) {
+        // DatePicker thinks in UTC midnight (see MomentDateChip for the full
+        // rationale); seed from the shown local day and translate the pick
+        // back through local noon so tz boundaries can't flip the day.
+        val initialMs = remember(uiState.dayStartMs) {
+            val d = Instant.fromEpochMilliseconds(uiState.dayStartMs).toLocalDateTime(deviceTz)
+            LocalDate(d.year, d.month, d.day)
+                .atStartOfDayIn(TimeZone.UTC).toEpochMilliseconds()
+        }
+        val state = rememberDatePickerState(initialSelectedDateMillis = initialMs)
+        DatePickerDialog(
+            onDismissRequest = { showPicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    val ms = state.selectedDateMillis ?: initialMs
+                    val ldtUtc = Instant.fromEpochMilliseconds(ms).toLocalDateTime(TimeZone.UTC)
+                    val pickedLocalNoon = LocalDateTime(
+                        year = ldtUtc.year, month = ldtUtc.month, day = ldtUtc.day,
+                        hour = 12, minute = 0, second = 0,
+                    )
+                    viewModel.onAction(
+                        LocationHistoryUiAction.SelectDay(
+                            pickedLocalNoon.toInstant(deviceTz).toEpochMilliseconds()
+                        )
+                    )
+                    showPicker = false
+                }) { Text(stringResource(MR.string.ok)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showPicker = false }) {
+                    Text(stringResource(MR.string.cancel))
+                }
+            },
+        ) {
+            DatePicker(state = state)
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryUiState.kt
@@ -1,0 +1,19 @@
+package id.homebase.core.ui.screens.location.history
+
+data class LocationHistoryUiState(
+    /** Device-local midnight of the shown day, epoch ms. */
+    val dayStartMs: Long = 0L,
+    val traces: List<DeviceTrace> = emptyList(),
+    val stats: DayStats? = null,
+    val isLoading: Boolean = true,
+    val showMapTiles: Boolean = false,
+) {
+    val isEmpty: Boolean get() = !isLoading && traces.isEmpty()
+}
+
+sealed interface LocationHistoryUiAction {
+    data class SelectDay(val dayStartMs: Long) : LocationHistoryUiAction
+    data object PreviousDay : LocationHistoryUiAction
+    data object NextDay : LocationHistoryUiAction
+    data class SetShowMapTiles(val show: Boolean) : LocationHistoryUiAction
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryViewModel.kt
@@ -1,0 +1,135 @@
+package id.homebase.core.ui.screens.location.history
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.FileSystemType
+import id.homebase.api.common.time.UnixTimeUtc
+import id.homebase.api.common.time.UnixTimeUtcRange
+import id.homebase.api.client.drives.QueryBatchSortField
+import id.homebase.api.client.drives.QueryBatchSortOrder
+import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.sync.database.QueryBatch
+import id.homebase.core.config.locationLabeledDrive
+import id.homebase.core.location.LocationPreferences
+import id.homebase.core.location.tracking.LocationDeviceId
+import id.homebase.core.ui.screens.location.model.HOUR_MS
+import id.homebase.core.ui.screens.location.model.LOCATION_TRACK_FILE_TYPE
+import id.homebase.core.ui.screens.location.model.LocationTrackCodec
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.plus
+import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+class LocationHistoryViewModel(
+    private val databaseManager: DatabaseManager,
+    private val credentialsManager: CredentialsManager,
+    private val locationPreferences: LocationPreferences,
+    private val deviceId: LocationDeviceId,
+) : ViewModel() {
+
+    private val logger = Logger.withTag("LocationHistoryViewModel")
+    private val driveId = locationLabeledDrive.drive.alias
+
+    private val _uiState = MutableStateFlow(
+        LocationHistoryUiState(
+            dayStartMs = localDayStart(Clock.System.now().toEpochMilliseconds()),
+            showMapTiles = locationPreferences.showMapTiles.value,
+        )
+    )
+    val uiState: StateFlow<LocationHistoryUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            locationPreferences.showMapTiles.collect { show ->
+                _uiState.update { it.copy(showMapTiles = show) }
+            }
+        }
+        loadDay(_uiState.value.dayStartMs)
+    }
+
+    fun onAction(action: LocationHistoryUiAction) {
+        when (action) {
+            is LocationHistoryUiAction.SelectDay -> loadDay(localDayStart(action.dayStartMs))
+            LocationHistoryUiAction.PreviousDay -> loadDay(shiftDay(_uiState.value.dayStartMs, -1))
+            LocationHistoryUiAction.NextDay -> loadDay(shiftDay(_uiState.value.dayStartMs, 1))
+            is LocationHistoryUiAction.SetShowMapTiles -> viewModelScope.launch {
+                locationPreferences.setShowMapTiles(action.show)
+            }
+        }
+    }
+
+    private fun loadDay(dayStartMs: Long) {
+        _uiState.update { it.copy(dayStartMs = dayStartMs, isLoading = true) }
+        viewModelScope.launch {
+            val dayEndMs = shiftDay(dayStartMs, 1)
+            val traces = runCatching { loadTraces(dayStartMs, dayEndMs) }
+                .onFailure { logger.e(it) { "loadTraces failed for $dayStartMs" } }
+                .getOrDefault(emptyList())
+            _uiState.update {
+                // Drop stale results if the user already moved to another day.
+                if (it.dayStartMs != dayStartMs) it
+                else it.copy(traces = traces, stats = LocationHistoryAssembler.stats(traces), isLoading = false)
+            }
+        }
+    }
+
+    private suspend fun loadTraces(dayStartMs: Long, dayEndMs: Long): List<DeviceTrace> {
+        val creds = credentialsManager.getActiveCredentials() ?: return emptyList()
+        val result = QueryBatch(creds.getIdentityId()).queryBatchAsync(
+            dbm = databaseManager,
+            driveId = driveId,
+            noOfItems = 24 * 16, // a day of hour files for up to 16 devices
+            sortOrder = QueryBatchSortOrder.NewestFirst,
+            sortField = QueryBatchSortField.UserDate,
+            fileSystemType = FileSystemType.Standard.value,
+            filetypesAnyOf = listOf(LOCATION_TRACK_FILE_TYPE),
+            // userDate = UTC hour start; widen by an hour on the left so an hour
+            // file straddling the local-day boundary is included (its points are
+            // filtered to the day by the assembler).
+            userDateSpan = UnixTimeUtcRange(
+                start = UnixTimeUtc(dayStartMs - HOUR_MS),
+                end = UnixTimeUtc(dayEndMs),
+            ),
+        )
+        val hours = result.records.mapNotNull { file ->
+            file.fileMetadata.appData.content?.let { LocationTrackCodec.decodeHeader(it) }
+        }
+        val bufferPoints = databaseManager.locationPoint.selectByTimeRange(dayStartMs, dayEndMs)
+        return LocationHistoryAssembler.assemble(
+            hours = hours,
+            bufferPoints = bufferPoints,
+            bufferDeviceId = deviceId.value,
+            dayStartMs = dayStartMs,
+            dayEndMs = dayEndMs,
+        )
+    }
+
+    /** Device-local midnight of the day containing [epochMs]. */
+    private fun localDayStart(epochMs: Long): Long {
+        val tz = TimeZone.currentSystemDefault()
+        return Instant.fromEpochMilliseconds(epochMs)
+            .toLocalDateTime(tz).date
+            .atStartOfDayIn(tz)
+            .toEpochMilliseconds()
+    }
+
+    /** Local midnight [days] away — DST-safe via LocalDate arithmetic. */
+    private fun shiftDay(dayStartMs: Long, days: Int): Long {
+        val tz = TimeZone.currentSystemDefault()
+        return Instant.fromEpochMilliseconds(dayStartMs)
+            .toLocalDateTime(tz).date
+            .plus(days, DateTimeUnit.DAY)
+            .atStartOfDayIn(tz)
+            .toEpochMilliseconds()
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationTraceCanvas.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationTraceCanvas.kt
@@ -1,0 +1,215 @@
+package id.homebase.core.ui.screens.location.history
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import id.homebase.api.client.location.WebMercator
+import org.jetbrains.compose.resources.decodeToImageBitmap
+import kotlin.math.ceil
+import kotlin.math.floor
+import kotlin.math.ln
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+/**
+ * Viewport over Web-Mercator unit space (0..1 world): a center point plus the
+ * unit-width of one screen pixel. Pure data so gestures and tile math share it.
+ */
+private data class Viewport(val centerX: Double, val centerY: Double, val unitsPerPx: Double)
+
+private data class TileKey(val zoom: Int, val x: Int, val y: Int)
+
+@Composable
+fun LocationTraceCanvas(
+    traces: List<DeviceTrace>,
+    showMapTiles: Boolean,
+    fetchTile: suspend (zoom: Int, x: Int, y: Int) -> ByteArray?,
+    traceColors: List<Color>,
+    modifier: Modifier = Modifier,
+) {
+    var canvasSize by remember { mutableStateOf(IntSize.Zero) }
+    // User pan/zoom override; null = fit the day's bbox. Reset when the day's data changes.
+    var userViewport by remember(traces) { mutableStateOf<Viewport?>(null) }
+
+    // Project once per data change: trace -> segments -> unit-space points.
+    val unitTraces = remember(traces) {
+        traces.map { trace ->
+            trace.segments.map { segment ->
+                segment.map { p -> WebMercator.latLonToUnit(p.lat, p.lon) }
+            }
+        }
+    }
+    val bbox = remember(unitTraces) {
+        var minX = Double.MAX_VALUE; var minY = Double.MAX_VALUE
+        var maxX = -Double.MAX_VALUE; var maxY = -Double.MAX_VALUE
+        unitTraces.forEach { segs ->
+            segs.forEach { seg ->
+                seg.forEach { (x, y) ->
+                    minX = min(minX, x); maxX = max(maxX, x)
+                    minY = min(minY, y); maxY = max(maxY, y)
+                }
+            }
+        }
+        if (minX > maxX) null else doubleArrayOf(minX, minY, maxX, maxY)
+    }
+
+    val viewport = userViewport ?: fitViewport(bbox, canvasSize)
+
+    // ── Tile layer state ──
+    val tileBitmaps = remember { mutableStateMapOf<TileKey, ImageBitmap>() }
+    val failedTiles = remember { mutableStateMapOf<TileKey, Boolean>() }
+    val visibleTiles = if (showMapTiles && viewport != null && canvasSize != IntSize.Zero) {
+        visibleTileKeys(viewport, canvasSize)
+    } else emptyList()
+    LaunchedEffect(visibleTiles, showMapTiles) {
+        if (!showMapTiles) return@LaunchedEffect
+        for (key in visibleTiles) {
+            if (tileBitmaps.containsKey(key) || failedTiles.containsKey(key)) continue
+            val bytes = fetchTile(key.zoom, key.x, key.y)
+            val bitmap = bytes?.let { runCatching { it.decodeToImageBitmap() }.getOrNull() }
+            if (bitmap != null) tileBitmaps[key] = bitmap else failedTiles[key] = true
+        }
+    }
+
+    Canvas(
+        modifier = modifier
+            .fillMaxSize()
+            .onSizeChanged { canvasSize = it }
+            .pointerInput(traces) {
+                detectTransformGestures { centroid, pan, zoom, _ ->
+                    val current = userViewport ?: fitViewport(bbox, canvasSize) ?: return@detectTransformGestures
+                    val newUnitsPerPx = (current.unitsPerPx / zoom)
+                        .coerceIn(MIN_UNITS_PER_PX, MAX_UNITS_PER_PX)
+                    // Keep the gesture centroid anchored while zooming, then pan.
+                    val cx = centroid.x - size.width / 2f
+                    val cy = centroid.y - size.height / 2f
+                    val anchoredX = current.centerX + cx * (current.unitsPerPx - newUnitsPerPx)
+                    val anchoredY = current.centerY + cy * (current.unitsPerPx - newUnitsPerPx)
+                    userViewport = Viewport(
+                        centerX = anchoredX - pan.x * newUnitsPerPx,
+                        centerY = anchoredY - pan.y * newUnitsPerPx,
+                        unitsPerPx = newUnitsPerPx,
+                    )
+                }
+            },
+    ) {
+        val vp = viewport ?: return@Canvas
+        fun toPx(unit: Pair<Double, Double>): Offset = Offset(
+            x = ((unit.first - vp.centerX) / vp.unitsPerPx + size.width / 2.0).toFloat(),
+            y = ((unit.second - vp.centerY) / vp.unitsPerPx + size.height / 2.0).toFloat(),
+        )
+
+        // ── Basemap tiles (under the traces) ──
+        for (key in visibleTiles) {
+            val bitmap = tileBitmaps[key] ?: continue
+            val b = WebMercator.tileToUnitBounds(key.x, key.y, key.zoom)
+            val topLeft = toPx(b[0] to b[1])
+            val bottomRight = toPx(b[2] to b[3])
+            drawImage(
+                image = bitmap,
+                dstOffset = IntOffset(topLeft.x.roundToInt(), topLeft.y.roundToInt()),
+                dstSize = IntSize(
+                    width = (bottomRight.x - topLeft.x).roundToInt().coerceAtLeast(1),
+                    height = (bottomRight.y - topLeft.y).roundToInt().coerceAtLeast(1),
+                ),
+            )
+        }
+
+        // ── Traces ──
+        val strokeWidth = 3.dp.toPx()
+        val dotRadius = 5.dp.toPx()
+        unitTraces.forEachIndexed { traceIndex, segments ->
+            val color = traceColors[traceIndex % traceColors.size]
+            for (segment in segments) {
+                if (segment.isEmpty()) continue
+                if (segment.size == 1) {
+                    drawCircle(color, radius = strokeWidth, center = toPx(segment.first()))
+                    continue
+                }
+                val path = Path()
+                val first = toPx(segment.first())
+                path.moveTo(first.x, first.y)
+                for (i in 1 until segment.size) {
+                    val p = toPx(segment[i])
+                    path.lineTo(p.x, p.y)
+                }
+                drawPath(
+                    path = path,
+                    color = color,
+                    style = Stroke(width = strokeWidth, cap = StrokeCap.Round, join = StrokeJoin.Round),
+                )
+            }
+            // Start dot (filled) and end marker (ring) for the whole trace.
+            segments.firstOrNull()?.firstOrNull()?.let { drawCircle(color, dotRadius, toPx(it)) }
+            segments.lastOrNull()?.lastOrNull()?.let {
+                drawCircle(color, dotRadius, toPx(it), style = Stroke(width = strokeWidth))
+            }
+        }
+    }
+}
+
+private fun fitViewport(bbox: DoubleArray?, canvasSize: IntSize): Viewport? {
+    if (bbox == null || canvasSize.width == 0 || canvasSize.height == 0) return null
+    val minX = bbox[0]; val minY = bbox[1]; val maxX = bbox[2]; val maxY = bbox[3]
+    val spanX = max(maxX - minX, MIN_FIT_SPAN_UNITS)
+    val spanY = max(maxY - minY, MIN_FIT_SPAN_UNITS)
+    val unitsPerPx = max(
+        spanX * FIT_PADDING / canvasSize.width,
+        spanY * FIT_PADDING / canvasSize.height,
+    ).coerceIn(MIN_UNITS_PER_PX, MAX_UNITS_PER_PX)
+    return Viewport(
+        centerX = (minX + maxX) / 2,
+        centerY = (minY + maxY) / 2,
+        unitsPerPx = unitsPerPx,
+    )
+}
+
+private fun visibleTileKeys(vp: Viewport, canvasSize: IntSize): List<TileKey> {
+    // Pick the zoom where one tile (256px-native) renders at roughly 1:1.
+    val zoom = (-ln(vp.unitsPerPx * WebMercator.TILE_SIZE_PX) / ln(2.0))
+        .roundToInt().coerceIn(MIN_TILE_ZOOM, MAX_TILE_ZOOM)
+    val n = 1 shl zoom
+    val halfW = canvasSize.width / 2.0 * vp.unitsPerPx
+    val halfH = canvasSize.height / 2.0 * vp.unitsPerPx
+    val x0 = floor((vp.centerX - halfW) * n).toInt().coerceIn(0, n - 1)
+    val x1 = ceil((vp.centerX + halfW) * n).toInt().coerceIn(0, n - 1)
+    val y0 = floor((vp.centerY - halfH) * n).toInt().coerceIn(0, n - 1)
+    val y1 = ceil((vp.centerY + halfH) * n).toInt().coerceIn(0, n - 1)
+    val keys = mutableListOf<TileKey>()
+    outer@ for (y in y0..y1) {
+        for (x in x0..x1) {
+            keys += TileKey(zoom, x, y)
+            if (keys.size >= MAX_TILES_PER_VIEW) break@outer
+        }
+    }
+    return keys
+}
+
+private const val FIT_PADDING = 1.2
+private const val MIN_FIT_SPAN_UNITS = 1e-5 // ~ city block; avoids infinite zoom on 1 point
+private const val MIN_UNITS_PER_PX = 1e-9
+private const val MAX_UNITS_PER_PX = 1.0 / 256.0
+private const val MIN_TILE_ZOOM = 3
+private const val MAX_TILE_ZOOM = 19
+private const val MAX_TILES_PER_VIEW = 16

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationTraceCanvas.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationTraceCanvas.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import id.homebase.api.client.location.WebMercator
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.decodeToImageBitmap
 import kotlin.math.ceil
 import kotlin.math.floor
@@ -78,17 +79,21 @@ fun LocationTraceCanvas(
 
     // ── Tile layer state ──
     val tileBitmaps = remember { mutableStateMapOf<TileKey, ImageBitmap>() }
-    val failedTiles = remember { mutableStateMapOf<TileKey, Boolean>() }
     val visibleTiles = if (showMapTiles && viewport != null && canvasSize != IntSize.Zero) {
         visibleTileKeys(viewport, canvasSize)
     } else emptyList()
     LaunchedEffect(visibleTiles, showMapTiles) {
         if (!showMapTiles) return@LaunchedEffect
+        // Concurrent fetches: the provider single-flights and runs downloads on
+        // its own scope, so restarts of this effect (pan/zoom) neither cancel
+        // nor duplicate them. Failures are simply retried on the next restart.
         for (key in visibleTiles) {
-            if (tileBitmaps.containsKey(key) || failedTiles.containsKey(key)) continue
-            val bytes = fetchTile(key.zoom, key.x, key.y)
-            val bitmap = bytes?.let { runCatching { it.decodeToImageBitmap() }.getOrNull() }
-            if (bitmap != null) tileBitmaps[key] = bitmap else failedTiles[key] = true
+            if (tileBitmaps.containsKey(key)) continue
+            launch {
+                val bytes = fetchTile(key.zoom, key.x, key.y)
+                val bitmap = bytes?.let { runCatching { it.decodeToImageBitmap() }.getOrNull() }
+                if (bitmap != null) tileBitmaps[key] = bitmap
+            }
         }
     }
 
@@ -186,24 +191,33 @@ private fun fitViewport(bbox: DoubleArray?, canvasSize: IntSize): Viewport? {
 }
 
 private fun visibleTileKeys(vp: Viewport, canvasSize: IntSize): List<TileKey> {
-    // Pick the zoom where one tile (256px-native) renders at roughly 1:1.
-    val zoom = (-ln(vp.unitsPerPx * WebMercator.TILE_SIZE_PX) / ln(2.0))
+    // Start at the zoom where one tile (256px-native) renders ~1:1, then step
+    // DOWN until the full visible grid fits the tile budget — a portrait phone
+    // at 1:1 needs ~30-40 tiles, so coverage beats crispness: coarser tiles are
+    // upscaled but the whole view gets a basemap (truncating the grid instead
+    // left the bottom of the screen bare).
+    val idealZoom = (-ln(vp.unitsPerPx * WebMercator.TILE_SIZE_PX) / ln(2.0))
         .roundToInt().coerceIn(MIN_TILE_ZOOM, MAX_TILE_ZOOM)
-    val n = 1 shl zoom
     val halfW = canvasSize.width / 2.0 * vp.unitsPerPx
     val halfH = canvasSize.height / 2.0 * vp.unitsPerPx
-    val x0 = floor((vp.centerX - halfW) * n).toInt().coerceIn(0, n - 1)
-    val x1 = ceil((vp.centerX + halfW) * n).toInt().coerceIn(0, n - 1)
-    val y0 = floor((vp.centerY - halfH) * n).toInt().coerceIn(0, n - 1)
-    val y1 = ceil((vp.centerY + halfH) * n).toInt().coerceIn(0, n - 1)
-    val keys = mutableListOf<TileKey>()
-    outer@ for (y in y0..y1) {
-        for (x in x0..x1) {
-            keys += TileKey(zoom, x, y)
-            if (keys.size >= MAX_TILES_PER_VIEW) break@outer
+    for (zoom in idealZoom downTo MIN_TILE_ZOOM) {
+        val n = 1 shl zoom
+        val x0 = floor((vp.centerX - halfW) * n).toInt().coerceIn(0, n - 1)
+        val x1 = ceil((vp.centerX + halfW) * n).toInt().coerceIn(0, n - 1)
+        val y0 = floor((vp.centerY - halfH) * n).toInt().coerceIn(0, n - 1)
+        val y1 = ceil((vp.centerY + halfH) * n).toInt().coerceIn(0, n - 1)
+        val count = (x1 - x0 + 1) * (y1 - y0 + 1)
+        if (count > MAX_TILES_PER_VIEW && zoom > MIN_TILE_ZOOM) continue
+        return buildList {
+            for (y in y0..y1) {
+                for (x in x0..x1) {
+                    add(TileKey(zoom, x, y))
+                    if (size >= MAX_TILES_PER_VIEW) return@buildList
+                }
+            }
         }
     }
-    return keys
+    return emptyList()
 }
 
 private const val FIT_PADDING = 1.2
@@ -212,4 +226,7 @@ private const val MIN_UNITS_PER_PX = 1e-9
 private const val MAX_UNITS_PER_PX = 1.0 / 256.0
 private const val MIN_TILE_ZOOM = 3
 private const val MAX_TILE_ZOOM = 19
-private const val MAX_TILES_PER_VIEW = 16
+
+// Budget per view. 24 fits a portrait phone one zoom step below 1:1 (×2
+// upscale worst case) while keeping per-view OSM traffic modest.
+private const val MAX_TILES_PER_VIEW = 24

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/model/LocationTrackContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/model/LocationTrackContent.kt
@@ -1,0 +1,237 @@
+package id.homebase.core.ui.screens.location.model
+
+import id.homebase.api.crypto.Md5
+import id.homebase.api.sync.database.BufferedLocationPoint
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import kotlinx.serialization.json.longOrNull
+import kotlinx.serialization.json.put
+import kotlin.math.max
+import kotlin.math.roundToInt
+import kotlin.math.roundToLong
+import kotlin.uuid.Uuid
+
+/** Reserve with the team — see ADDING_TYPED_MESSAGE_KIND.md for the registry habit. */
+const val LOCATION_TRACK_FILE_TYPE = 5610
+
+/** Payload key for the full-resolution overflow payload; matches ^[a-z0-9_]{8,10}$. */
+const val LOCATION_POINTS_PAYLOAD_KEY = "loc_points"
+
+const val LOCATION_TRACK_CONTENT_VERSION = 1
+
+/**
+ * Plaintext budget for the header trace. appData.content is validated against
+ * HomebaseProtocol.MaxHeaderContentBytes (7000) AFTER encryption, which is
+ * base64(AES-CBC(plaintext)) ≈ ceil((n + pad) / 3) * 4 bytes. 5200 plaintext
+ * bytes encrypt to ~6960 — just under the cap. ≈150 points per hour file.
+ */
+const val LOCATION_HEADER_PLAINTEXT_BUDGET = 5200
+
+/** Deterministic per-device per-UTC-hour file identity. */
+fun locationHourFileUid(deviceId: Uuid, hourStartMs: Long): Uuid =
+    Md5.toGuidId("loc-track:$deviceId:$hourStartMs")
+
+fun hourStartMs(epochMs: Long): Long = (epochMs / HOUR_MS) * HOUR_MS
+
+const val HOUR_MS = 3_600_000L
+
+/** Decoded hour-file content (header trace or payload). */
+data class LocationTrackHour(
+    val deviceId: Uuid,
+    val hourStartMs: Long,
+    val points: List<BufferedLocationPoint>,
+    /** Raw captured count for the hour; > points.size when the header trace was thinned. */
+    val fullCount: Int,
+) {
+    /** True when a full-resolution payload rides alongside the header trace. */
+    val hasOverflowPayload: Boolean get() = fullCount > points.size
+}
+
+/**
+ * Compact positional encoding of the header trace:
+ * ```
+ * { "v":1, "deviceId":"…", "hourStart":…, "count":n, "full":N?, "t0":ms,
+ *   "bbox":[minLatE5,minLonE5,maxLatE5,maxLonE5],
+ *   "pts":[[dtSec,latE5,lonE5,accM,spdE1,hdgDeg,flags],…] }
+ * ```
+ * lat/lon as integer 1e-5 degrees (≈1.1 m — below GPS accuracy), dt as whole
+ * seconds from t0, speed as 0.1 m/s, heading as whole degrees; flags bit0 = fg,
+ * bits1+ = source index. Integers keep the JSON dense and avoid double-repr noise.
+ */
+object LocationTrackCodec {
+
+    private val sources = listOf("gps", "net", "fused", "slc")
+
+    /**
+     * Encode the header trace for an hour, thinning uniformly by time until the
+     * plaintext fits [budgetBytes]. Returns the JSON and the points actually
+     * stored (callers attach the overflow payload when storedCount < points.size).
+     */
+    fun encodeHeader(
+        deviceId: Uuid,
+        hourStartMs: Long,
+        points: List<BufferedLocationPoint>,
+        budgetBytes: Int = LOCATION_HEADER_PLAINTEXT_BUDGET,
+    ): Pair<String, List<BufferedLocationPoint>> {
+        require(points.isNotEmpty()) { "encodeHeader needs at least one point" }
+        var stored = points
+        var json = encodeHeaderExact(deviceId, hourStartMs, stored, fullCount = points.size)
+        while (json.encodeToByteArray().size > budgetBytes && stored.size > 2) {
+            val ratio = budgetBytes.toDouble() / json.encodeToByteArray().size
+            val target = max(2, (stored.size * ratio * 0.95).toInt())
+                .coerceAtMost(stored.size - 1)
+            stored = thinUniform(stored, target)
+            json = encodeHeaderExact(deviceId, hourStartMs, stored, fullCount = points.size)
+        }
+        return json to stored
+    }
+
+    private fun encodeHeaderExact(
+        deviceId: Uuid,
+        hourStartMs: Long,
+        stored: List<BufferedLocationPoint>,
+        fullCount: Int,
+    ): String {
+        val t0 = stored.first().t
+        val obj = buildJsonObject {
+            put("v", LOCATION_TRACK_CONTENT_VERSION)
+            put("deviceId", deviceId.toString())
+            put("hourStart", hourStartMs)
+            put("count", stored.size)
+            if (fullCount > stored.size) put("full", fullCount)
+            put("t0", t0)
+            put("bbox", buildJsonArray {
+                add(JsonPrimitive(stored.minOf { it.lat.toE5() }))
+                add(JsonPrimitive(stored.minOf { it.lon.toE5() }))
+                add(JsonPrimitive(stored.maxOf { it.lat.toE5() }))
+                add(JsonPrimitive(stored.maxOf { it.lon.toE5() }))
+            })
+            put("pts", buildJsonArray {
+                for (p in stored) {
+                    add(buildJsonArray {
+                        add(JsonPrimitive(((p.t - t0) / 1000).toInt()))
+                        add(JsonPrimitive(p.lat.toE5()))
+                        add(JsonPrimitive(p.lon.toE5()))
+                        add(p.acc?.let { JsonPrimitive(it.roundToInt()) } ?: JsonNull)
+                        add(p.spd?.let { JsonPrimitive((it * 10).roundToInt()) } ?: JsonNull)
+                        add(p.hdg?.let { JsonPrimitive(it.roundToInt()) } ?: JsonNull)
+                        add(JsonPrimitive(flagsOf(p)))
+                    })
+                }
+            })
+        }
+        return obj.toString()
+    }
+
+    fun decodeHeader(json: String): LocationTrackHour? = runCatching {
+        val obj = Json.parseToJsonElement(json).jsonObject
+        val deviceId = Uuid.parse(obj.getValue("deviceId").jsonPrimitive.content)
+        val hourStart = obj.getValue("hourStart").jsonPrimitive.long
+        val t0 = obj.getValue("t0").jsonPrimitive.long
+        val pts = obj.getValue("pts").jsonArray.map { el ->
+            val a = el.jsonArray
+            val flags = a[6].jsonPrimitive.intOrNull ?: 0
+            BufferedLocationPoint(
+                t = t0 + (a[0].jsonPrimitive.long * 1000),
+                lat = a[1].jsonPrimitive.long.fromE5(),
+                lon = a[2].jsonPrimitive.long.fromE5(),
+                acc = a[3].jsonPrimitive.intOrNull?.toDouble(),
+                spd = a[4].jsonPrimitive.intOrNull?.let { it / 10.0 },
+                hdg = a[5].jsonPrimitive.intOrNull?.toDouble(),
+                src = sources.getOrElse(flags shr 1) { "gps" },
+                fg = flags and 1 == 1,
+            )
+        }
+        LocationTrackHour(
+            deviceId = deviceId,
+            hourStartMs = hourStart,
+            points = pts,
+            fullCount = obj["full"]?.jsonPrimitive?.intOrNull ?: pts.size,
+        )
+    }.getOrNull()
+
+    /**
+     * Full-resolution payload for overflow hours — same positional shape, but
+     * absolute ms timestamps and unrounded doubles, plus alt/altAcc:
+     * `[t,lat,lon,acc,alt,altAcc,spd,hdg,flags]`.
+     */
+    fun encodePayload(deviceId: Uuid, hourStartMs: Long, points: List<BufferedLocationPoint>): String {
+        val obj = buildJsonObject {
+            put("v", LOCATION_TRACK_CONTENT_VERSION)
+            put("deviceId", deviceId.toString())
+            put("hourStart", hourStartMs)
+            put("points", buildJsonArray {
+                for (p in points) {
+                    add(buildJsonArray {
+                        add(JsonPrimitive(p.t))
+                        add(JsonPrimitive(p.lat))
+                        add(JsonPrimitive(p.lon))
+                        add(p.acc?.let { JsonPrimitive(it) } ?: JsonNull)
+                        add(p.alt?.let { JsonPrimitive(it) } ?: JsonNull)
+                        add(p.altAcc?.let { JsonPrimitive(it) } ?: JsonNull)
+                        add(p.spd?.let { JsonPrimitive(it) } ?: JsonNull)
+                        add(p.hdg?.let { JsonPrimitive(it) } ?: JsonNull)
+                        add(JsonPrimitive(flagsOf(p)))
+                    })
+                }
+            })
+        }
+        return obj.toString()
+    }
+
+    fun decodePayload(json: String): LocationTrackHour? = runCatching {
+        val obj = Json.parseToJsonElement(json).jsonObject
+        val pts = obj.getValue("points").jsonArray.map { el ->
+            val a = el.jsonArray
+            val flags = a[8].jsonPrimitive.intOrNull ?: 0
+            BufferedLocationPoint(
+                t = a[0].jsonPrimitive.long,
+                lat = a[1].jsonPrimitive.content.toDouble(),
+                lon = a[2].jsonPrimitive.content.toDouble(),
+                acc = a[3].jsonPrimitive.contentOrNullDouble(),
+                alt = a[4].jsonPrimitive.contentOrNullDouble(),
+                altAcc = a[5].jsonPrimitive.contentOrNullDouble(),
+                spd = a[6].jsonPrimitive.contentOrNullDouble(),
+                hdg = a[7].jsonPrimitive.contentOrNullDouble(),
+                src = sources.getOrElse(flags shr 1) { "gps" },
+                fg = flags and 1 == 1,
+            )
+        }
+        LocationTrackHour(
+            deviceId = Uuid.parse(obj.getValue("deviceId").jsonPrimitive.content),
+            hourStartMs = obj.getValue("hourStart").jsonPrimitive.long,
+            points = pts,
+            fullCount = pts.size,
+        )
+    }.getOrNull()
+
+    /** Uniform sample of [target] points preserving the first and last. */
+    fun thinUniform(points: List<BufferedLocationPoint>, target: Int): List<BufferedLocationPoint> {
+        if (target >= points.size) return points
+        if (target <= 2) return listOf(points.first(), points.last())
+        val n = points.size
+        return List(target) { i ->
+            points[((i.toLong() * (n - 1)) / (target - 1)).toInt()]
+        }
+    }
+
+    private fun flagsOf(p: BufferedLocationPoint): Int {
+        val srcIndex = sources.indexOf(p.src).coerceAtLeast(0)
+        return (srcIndex shl 1) or (if (p.fg) 1 else 0)
+    }
+
+    private fun Double.toE5(): Long = (this * 1e5).roundToLong()
+    private fun Long.fromE5(): Double = this / 1e5
+
+    private fun JsonPrimitive.contentOrNullDouble(): Double? =
+        if (this is JsonNull) null else content.toDoubleOrNull()
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/onboarding/LocationOnboardingScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/onboarding/LocationOnboardingScreen.kt
@@ -1,0 +1,143 @@
+package id.homebase.core.ui.screens.location.onboarding
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.homebase.chat.widget.ExtendPermissionDialog
+import id.homebase.core.ui.screens.location.LocationUiAction
+import id.homebase.core.ui.screens.location.LocationViewModel
+import id.homebase.resources.MR
+import id.homebase.resources.location_label
+import id.homebase.resources.location_onboarding_body_1
+import id.homebase.resources.location_onboarding_body_2
+import id.homebase.resources.location_onboarding_dismiss
+import id.homebase.resources.location_onboarding_setup
+import id.homebase.resources.location_onboarding_title
+import id.homebase.resources.menu_back
+import org.jetbrains.compose.resources.stringResource
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LocationOnboardingScreen(
+    viewModel: LocationViewModel,
+    onNavigateBack: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val lifecycleOwner = LocalLifecycleOwner.current
+    // Re-checking permissions on every ON_RESUME would surface the missing-permissions
+    // dialog before the user has confirmed they want to set Location up. Only re-check
+    // (and render the dialog) once the user has tapped Set it up.
+    DisposableEffect(lifecycleOwner, uiState.setupInitiated) {
+        if (!uiState.setupInitiated) return@DisposableEffect onDispose { }
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.locationExtendPermissionViewModel.recheckPermissions()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    if (uiState.setupInitiated) {
+        ExtendPermissionDialog(viewModel = viewModel.locationExtendPermissionViewModel)
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(MR.string.location_label)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(MR.string.menu_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(innerPadding)
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp, vertical = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Top,
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.LocationOn,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(96.dp),
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(
+                text = stringResource(MR.string.location_onboarding_title),
+                style = MaterialTheme.typography.headlineSmall,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = stringResource(MR.string.location_onboarding_body_1),
+                style = MaterialTheme.typography.bodyLarge,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = stringResource(MR.string.location_onboarding_body_2),
+                style = MaterialTheme.typography.bodyLarge,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(40.dp))
+            FilledTonalButton(
+                onClick = { viewModel.onAction(LocationUiAction.SetupClicked) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(MR.string.location_onboarding_setup))
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            TextButton(
+                onClick = { viewModel.onAction(LocationUiAction.DismissOnboardingClicked) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(MR.string.location_onboarding_dismiss))
+            }
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/settings/LocationSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/settings/LocationSettingsScreen.kt
@@ -1,0 +1,105 @@
+package id.homebase.core.ui.screens.location.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material.icons.outlined.Visibility
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.homebase.core.widget.SettingsItemAction
+import id.homebase.resources.MR
+import id.homebase.resources.location_settings_open
+import id.homebase.resources.location_settings_section
+import id.homebase.resources.location_settings_show_icon
+import id.homebase.resources.menu_back
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun LocationSettingsScreen(
+    viewModel: LocationSettingsViewModel,
+    onBackClick: () -> Unit,
+    onOpenLocation: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    LocationSettingsUi(
+        uiState = uiState,
+        onAction = { action ->
+            if (action is LocationSettingsUiAction.OpenLocationClicked) onOpenLocation()
+            else viewModel.onAction(action)
+        },
+        onBackClick = onBackClick,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LocationSettingsUi(
+    uiState: LocationSettingsUiState,
+    onAction: (LocationSettingsUiAction) -> Unit,
+    onBackClick: () -> Unit,
+) {
+    val scrollState = rememberScrollState()
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(MR.string.location_settings_section)) },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(MR.string.menu_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(innerPadding)
+                .padding(innerPadding)
+                .verticalScroll(scrollState),
+        ) {
+            Spacer(modifier = Modifier.height(8.dp))
+            SettingsItemAction(
+                imageVector = Icons.Outlined.LocationOn,
+                text = stringResource(MR.string.location_settings_open),
+                onClick = { onAction(LocationSettingsUiAction.OpenLocationClicked) },
+            )
+            SettingsItemAction(
+                imageVector = Icons.Outlined.Visibility,
+                text = stringResource(MR.string.location_settings_show_icon),
+                onClick = { onAction(LocationSettingsUiAction.SetIconVisible(!uiState.iconVisible)) },
+                trailingContent = {
+                    Switch(
+                        checked = uiState.iconVisible,
+                        onCheckedChange = { onAction(LocationSettingsUiAction.SetIconVisible(it)) },
+                    )
+                },
+            )
+            Spacer(modifier = Modifier
+                .fillMaxWidth()
+                .height(24.dp))
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/settings/LocationSettingsUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/settings/LocationSettingsUiState.kt
@@ -1,0 +1,10 @@
+package id.homebase.core.ui.screens.location.settings
+
+data class LocationSettingsUiState(
+    val iconVisible: Boolean = true,
+)
+
+sealed interface LocationSettingsUiAction {
+    data object OpenLocationClicked : LocationSettingsUiAction
+    data class SetIconVisible(val visible: Boolean) : LocationSettingsUiAction
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/settings/LocationSettingsViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/settings/LocationSettingsViewModel.kt
@@ -1,0 +1,41 @@
+package id.homebase.core.ui.screens.location.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import id.homebase.core.location.LocationPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class LocationSettingsViewModel(
+    private val locationPreferences: LocationPreferences,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(
+        LocationSettingsUiState(
+            iconVisible = locationPreferences.iconVisible.value,
+        )
+    )
+    val uiState: StateFlow<LocationSettingsUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            locationPreferences.iconVisible.collect { v ->
+                _uiState.update { it.copy(iconVisible = v) }
+            }
+        }
+    }
+
+    fun onAction(action: LocationSettingsUiAction) {
+        when (action) {
+            LocationSettingsUiAction.OpenLocationClicked -> {
+                // Handled by the screen — it dispatches to the navigation callback.
+            }
+            is LocationSettingsUiAction.SetIconVisible -> {
+                viewModelScope.launch { locationPreferences.setIconVisible(action.visible) }
+            }
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Error
 import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.People
 import androidx.compose.material.icons.outlined.Person
@@ -90,6 +91,7 @@ import id.homebase.resources.settings_security_setup
 import id.homebase.resources.cd_open_externally
 import id.homebase.resources.settings_section_danger_zone
 import id.homebase.resources.settings_section_general
+import id.homebase.resources.location_settings_section
 import id.homebase.resources.vault_settings_section
 import id.homebase.resources.settings_storage
 import org.jetbrains.compose.resources.stringResource
@@ -105,6 +107,7 @@ fun SettingsScreen(
     onNavigateToHelp: () -> Unit,
     onNavigateToMomentsSettings: () -> Unit,
     onNavigateToVaultSettings: () -> Unit,
+    onNavigateToLocationSettings: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val uriHandler = getUriHandler()
@@ -163,6 +166,7 @@ fun SettingsScreen(
             onNavigateToStorage = onNavigateToStorage,
             onNavigateToHelp = onNavigateToHelp,
             onNavigateToMomentsSettings = onNavigateToMomentsSettings,
+            onNavigateToLocationSettings = onNavigateToLocationSettings,
         )
 
         if (uiState.isLoggingOut) {
@@ -224,6 +228,7 @@ fun SettingsUi(
     onNavigateToHelp: () -> Unit,
     onNavigateToMomentsSettings: () -> Unit,
     onNavigateToVaultSettings: () -> Unit = {},
+    onNavigateToLocationSettings: () -> Unit = {},
 ) {
     val scrollState = rememberScrollState()
 
@@ -380,6 +385,13 @@ fun SettingsUi(
                 imageVector = Icons.Outlined.Lock,
                 text = stringResource(MR.string.vault_settings_section),
                 onClick = onNavigateToVaultSettings,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            SettingsItemAction(
+                modifier = Modifier.testTag("locationSettingsButton"),
+                imageVector = Icons.Outlined.LocationOn,
+                text = stringResource(MR.string.location_settings_section),
+                onClick = onNavigateToLocationSettings,
             )
             Spacer(modifier = Modifier.height(8.dp))
             SettingsItemAction(

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryAssemblerTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryAssemblerTest.kt
@@ -1,0 +1,157 @@
+package id.homebase.core.ui.screens.location.history
+
+import id.homebase.api.sync.database.BufferedLocationPoint
+import id.homebase.core.ui.screens.location.model.LocationTrackHour
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+class LocationHistoryAssemblerTest {
+
+    private val deviceA = Uuid.parse("aaaaaaaa-0000-0000-0000-000000000001")
+    private val deviceB = Uuid.parse("bbbbbbbb-0000-0000-0000-000000000002")
+    private val dayStart = 1_765_324_800_000L
+    private val dayEnd = dayStart + 24 * 3_600_000L
+
+    private fun point(t: Long, lat: Double = 52.0, lon: Double = 13.0) =
+        BufferedLocationPoint(t = t, lat = lat, lon = lon, acc = 10.0, src = "gps", fg = true)
+
+    private fun hour(deviceId: Uuid, points: List<BufferedLocationPoint>) =
+        LocationTrackHour(
+            deviceId = deviceId,
+            hourStartMs = (points.first().t / 3_600_000L) * 3_600_000L,
+            points = points,
+            fullCount = points.size,
+        )
+
+    @Test
+    fun groupsByDeviceAndSortsByTime() {
+        val traces = LocationHistoryAssembler.assemble(
+            hours = listOf(
+                hour(deviceA, listOf(point(dayStart + 2000), point(dayStart + 1000))),
+                hour(deviceB, listOf(point(dayStart + 500))),
+            ),
+            bufferPoints = emptyList(),
+            bufferDeviceId = deviceA,
+            dayStartMs = dayStart,
+            dayEndMs = dayEnd,
+        )
+        assertEquals(2, traces.size)
+        val a = traces.first { it.deviceId == deviceA }
+        assertEquals(listOf(dayStart + 1000, dayStart + 2000), a.segments.single().map { it.t })
+    }
+
+    @Test
+    fun filtersPointsOutsideTheDay() {
+        // An hour file straddling the local-day boundary delivers points from
+        // both sides; only the in-day ones survive.
+        val traces = LocationHistoryAssembler.assemble(
+            hours = listOf(
+                hour(deviceA, listOf(point(dayStart - 1), point(dayStart), point(dayEnd - 1), point(dayEnd))),
+            ),
+            bufferPoints = emptyList(),
+            bufferDeviceId = deviceA,
+            dayStartMs = dayStart,
+            dayEndMs = dayEnd,
+        )
+        // The two survivors are ~24h apart, so they also land in separate segments.
+        assertEquals(
+            listOf(dayStart, dayEnd - 1),
+            traces.single().segments.flatten().map { it.t },
+        )
+    }
+
+    @Test
+    fun bufferPointsMergeAndOverrideHeaderDuplicates() {
+        val headerPoint = point(dayStart + 1000, lat = 52.00001) // quantized header copy
+        val bufferPoint = point(dayStart + 1000, lat = 52.000012345) // full precision
+        val traces = LocationHistoryAssembler.assemble(
+            hours = listOf(hour(deviceA, listOf(headerPoint))),
+            bufferPoints = listOf(bufferPoint, point(dayStart + 2000)),
+            bufferDeviceId = deviceA,
+            dayStartMs = dayStart,
+            dayEndMs = dayEnd,
+        )
+        val segment = traces.single().segments.single()
+        assertEquals(2, segment.size)
+        assertEquals(52.000012345, segment.first().lat)
+    }
+
+    @Test
+    fun splitsSegmentsOnTimeGap() {
+        val traces = LocationHistoryAssembler.assemble(
+            hours = listOf(
+                hour(
+                    deviceA,
+                    listOf(
+                        point(dayStart),
+                        point(dayStart + 60_000),
+                        // 20-minute hole — tracking was off.
+                        point(dayStart + 60_000 + 20 * 60_000),
+                    )
+                ),
+            ),
+            bufferPoints = emptyList(),
+            bufferDeviceId = deviceA,
+            dayStartMs = dayStart,
+            dayEndMs = dayEnd,
+        )
+        assertEquals(listOf(2, 1), traces.single().segments.map { it.size })
+    }
+
+    @Test
+    fun splitsSegmentsOnDistanceJump() {
+        val traces = LocationHistoryAssembler.assemble(
+            hours = listOf(
+                hour(
+                    deviceA,
+                    listOf(
+                        point(dayStart, lat = 52.0),
+                        // ~5.5 km north one minute later — GPS glitch or data hole.
+                        point(dayStart + 60_000, lat = 52.05),
+                    )
+                ),
+            ),
+            bufferPoints = emptyList(),
+            bufferDeviceId = deviceA,
+            dayStartMs = dayStart,
+            dayEndMs = dayEnd,
+        )
+        assertEquals(listOf(1, 1), traces.single().segments.map { it.size })
+    }
+
+    @Test
+    fun statsSumAcrossDevicesAndSkipGapDistance() {
+        val traces = LocationHistoryAssembler.assemble(
+            hours = listOf(
+                // ~1.11 km east-west leg.
+                hour(deviceA, listOf(point(dayStart, lon = 13.0), point(dayStart + 60_000, lon = 13.0163))),
+                hour(deviceB, listOf(point(dayStart + 1000))),
+            ),
+            bufferPoints = emptyList(),
+            bufferDeviceId = deviceA,
+            dayStartMs = dayStart,
+            dayEndMs = dayEnd,
+        )
+        val stats = LocationHistoryAssembler.stats(traces)
+        assertEquals(3, stats.pointCount)
+        assertEquals(2, stats.deviceCount)
+        assertTrue(stats.distanceMeters in 1_000.0..1_250.0, "distance=${stats.distanceMeters}")
+        assertEquals(dayStart, stats.firstFixMs)
+        assertEquals(dayStart + 60_000, stats.lastFixMs)
+    }
+
+    @Test
+    fun emptyInputYieldsNoTraces() {
+        val traces = LocationHistoryAssembler.assemble(
+            hours = emptyList(),
+            bufferPoints = emptyList(),
+            bufferDeviceId = deviceA,
+            dayStartMs = dayStart,
+            dayEndMs = dayEnd,
+        )
+        assertTrue(traces.isEmpty())
+        assertEquals(0, LocationHistoryAssembler.stats(traces).pointCount)
+    }
+}

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/model/LocationTrackContentTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/model/LocationTrackContentTest.kt
@@ -1,0 +1,124 @@
+package id.homebase.core.ui.screens.location.model
+
+import id.homebase.api.sync.database.BufferedLocationPoint
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+class LocationTrackContentTest {
+
+    private val deviceId = Uuid.parse("5e0a1111-2222-3333-4444-555566667777")
+    private val hourStart = 1_765_360_800_000L
+
+    private fun point(
+        offsetMs: Long,
+        lat: Double = 52.31235,
+        lon: Double = 13.42346,
+        acc: Double? = 12.0,
+        spd: Double? = 1.4,
+        hdg: Double? = 271.0,
+        src: String = "gps",
+        fg: Boolean = true,
+    ) = BufferedLocationPoint(
+        t = hourStart + offsetMs, lat = lat, lon = lon, acc = acc,
+        spd = spd, hdg = hdg, src = src, fg = fg,
+    )
+
+    @Test
+    fun hourFileUidIsDeterministicAndDeviceScoped() {
+        val a = locationHourFileUid(deviceId, hourStart)
+        val b = locationHourFileUid(deviceId, hourStart)
+        val otherHour = locationHourFileUid(deviceId, hourStart + HOUR_MS)
+        val otherDevice = locationHourFileUid(Uuid.random(), hourStart)
+        assertEquals(a, b)
+        assertTrue(a != otherHour)
+        assertTrue(a != otherDevice)
+    }
+
+    @Test
+    fun hourBucketing() {
+        assertEquals(hourStart, hourStartMs(hourStart))
+        assertEquals(hourStart, hourStartMs(hourStart + HOUR_MS - 1))
+        assertEquals(hourStart + HOUR_MS, hourStartMs(hourStart + HOUR_MS))
+    }
+
+    @Test
+    fun headerRoundTripPreservesPointsWithinQuantization() {
+        val points = listOf(
+            point(0),
+            point(22_000, lat = 52.31301, lon = 13.42410, acc = 8.0, spd = 1.3, hdg = 268.0),
+            point(841_000, lat = 52.31999, lon = 13.43102, acc = 25.0, spd = null, hdg = null, src = "slc", fg = false),
+        )
+        val (json, stored) = LocationTrackCodec.encodeHeader(deviceId, hourStart, points)
+        assertEquals(points.size, stored.size)
+
+        val decoded = assertNotNull(LocationTrackCodec.decodeHeader(json))
+        assertEquals(deviceId, decoded.deviceId)
+        assertEquals(hourStart, decoded.hourStartMs)
+        assertEquals(points.size, decoded.fullCount)
+        assertTrue(!decoded.hasOverflowPayload)
+        assertEquals(points.size, decoded.points.size)
+
+        for ((orig, round) in points.zip(decoded.points)) {
+            assertEquals(orig.t / 1000, round.t / 1000)        // second resolution
+            assertEquals(orig.lat, round.lat, 1e-5)            // 1e-5 deg quantization
+            assertEquals(orig.lon, round.lon, 1e-5)
+            assertEquals(orig.src, round.src)
+            assertEquals(orig.fg, round.fg)
+            if (orig.spd == null) assertEquals(null, round.spd)
+            else assertEquals(orig.spd!!, round.spd!!, 0.05)   // 0.1 m/s quantization
+        }
+    }
+
+    @Test
+    fun headerThinsToFitBudgetAndKeepsEndpoints() {
+        // 1200 points ≈ a 3s-cadence hour — far beyond the header budget.
+        val points = (0 until 1200).map { i ->
+            point(i * 3_000L, lat = 52.0 + i * 1e-4, lon = 13.0 + i * 1e-4)
+        }
+        val (json, stored) = LocationTrackCodec.encodeHeader(deviceId, hourStart, points)
+
+        assertTrue(json.encodeToByteArray().size <= LOCATION_HEADER_PLAINTEXT_BUDGET)
+        assertTrue(stored.size < points.size)
+        assertTrue(stored.size > 50, "thinning should keep a useful trace, got ${stored.size}")
+        assertEquals(points.first().t, stored.first().t)
+        assertEquals(points.last().t, stored.last().t)
+
+        val decoded = assertNotNull(LocationTrackCodec.decodeHeader(json))
+        assertTrue(decoded.hasOverflowPayload)
+        assertEquals(points.size, decoded.fullCount)
+        assertEquals(stored.size, decoded.points.size)
+    }
+
+    @Test
+    fun payloadRoundTripIsLossless() {
+        val points = listOf(
+            BufferedLocationPoint(
+                t = hourStart + 1234, lat = 52.312345678, lon = 13.423456789,
+                acc = 12.5, alt = 38.2, altAcc = 4.0, spd = 1.44, hdg = 271.3,
+                src = "fused", fg = true,
+            ),
+            BufferedLocationPoint(
+                t = hourStart + 60_000, lat = -33.9, lon = 151.2,
+                acc = null, src = "net", fg = false,
+            ),
+        )
+        val json = LocationTrackCodec.encodePayload(deviceId, hourStart, points)
+        val decoded = assertNotNull(LocationTrackCodec.decodePayload(json))
+        assertEquals(points, decoded.points)
+        assertEquals(deviceId, decoded.deviceId)
+        assertEquals(hourStart, decoded.hourStartMs)
+    }
+
+    @Test
+    fun thinUniformKeepsOrderAndEndpoints() {
+        val points = (0 until 100).map { point(it * 1000L) }
+        val thinned = LocationTrackCodec.thinUniform(points, 10)
+        assertEquals(10, thinned.size)
+        assertEquals(points.first(), thinned.first())
+        assertEquals(points.last(), thinned.last())
+        assertEquals(thinned, thinned.sortedBy { it.t })
+    }
+}

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/MainViewController.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/MainViewController.kt
@@ -99,6 +99,17 @@ fun initializeApp() {
         DatabaseManager.initializeWithRecovery(DatabaseDriverFactory())
     }
     Logger.i(tag = "TextRendering") { "DB init (runBlocking): ${dbMark.elapsedNow().inWholeMilliseconds}ms" }
+
+    // Re-arm Location tracking on every process start — including the
+    // UIApplicationLaunchOptionsLocationKey relaunch after the OS terminated
+    // the app (AppDelegate calls initializeApp() before the launch runloop
+    // drains, so the CLLocationManager is re-created in time to receive the
+    // pending significant-location-change delivery). Must run after DB init:
+    // the coordinator's preferences read the encrypted keyValue store.
+    org.koin.mp.KoinPlatformTools.defaultContext().get()
+        .get<id.homebase.core.location.tracking.LocationTrackingCoordinator>()
+        .onProcessStart()
+
     Logger.i(tag = "TextRendering") { "initializeApp() total: ${startMark.elapsedNow().inWholeMilliseconds}ms" }
 }
 

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -30,7 +30,9 @@
 	<key>NSCalendarsUsageDescription</key>
 	<string>Used to add chat events to your calendar.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Used to share your current location in chat.</string>
+	<string>Used to share your current location in chat and, when you enable it, to record your private location history.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Allows Homebase to keep recording your private, encrypted location history while the app is in the background. Only you can see it.</string>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>INSendMessageIntent</string>
@@ -39,6 +41,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>
+		<string>location</string>
 		<string>remote-notification</string>
 	</array>
 </dict>


### PR DESCRIPTION
## Summary

New top-level **Location** add-on app (Vault/Moments pattern): nav icon + home tile + onboarding + settings on all platforms; actual GPS tracking on **Android + iOS**. When the user activates it, the extend-permissions flow mounts a dedicated **Location drive** and a master switch starts recording encrypted location history — precise while the app is foregrounded, light/OS-throttled in the background, with **no Android foreground service**. History visualization and live sharing are out of scope (future work).

### Capture (battery-first design)
- `LocationTracker` expect/actual (`homebase-common/.../location/tracking/`):
  - **Android**: fused PendingIntent registration — `PRIORITY_BALANCED_POWER_ACCURACY`, 60s interval, **10min batched delivery** (`maxUpdateDelay`), 25m displacement — survives process death; deliveries land in the manifest-registered `LocationUpdatesReceiver` even in a cold process (MainApplication initializes DB+Koin before any component). A high-accuracy callback overlay (15s/10m) runs only while the whole app is foregrounded. Boot receiver + `onProcessStart()` hooks (MainApplication / `initializeApp`) re-arm after reboot/termination — deliberately *not* `onPostAuthenticated`, which never runs on headless cold starts.
  - **iOS**: `CLLocationManager` with `pausesLocationUpdatesAutomatically`, foreground/background accuracy tiers (Best/10m ↔ HundredMeters/50m), and significant-location-change as the relaunch vector (`UIBackgroundModes` + `location`).
- Store-level dedup (8m AND 20s window) thins stationary noise before it costs DB or upload bytes.

### Storage format
- **One file per device per UTC hour**: `uniqueId = md5("loc-track:deviceId:hourStart")`, `userDate = hourStart`, `fileType = 5610`. Per-device files mean multiple devices of one identity can track concurrently without version conflicts.
- Header carries a **compact positional trace** (`[dtSec, latE5, lonE5, accM, spdE1, hdgDeg, flags]`, ~35–45 B/point ≈ 150 points/hour) budgeted at 5200 plaintext bytes — the 7000-byte `MaxHeaderContentBytes` cap is validated **after** encryption (base64+AES ≈ ×1.37). Header content syncs decrypted into every device's local index, so the future history UI is an offline local-DB read.
- **Overflow payload**: when an hour captures more than the header fits (skiing/running), the header keeps a uniformly time-thinned preview and a full-resolution encrypted `loc_points` JSON payload rides along. Sparse hours stay header-only — the server's expensive payload-ingest path is only paid when needed.

### Upload — all via the outbox
Creates/updates go through `OutboxSync.replaceEnqueue` (+ `OptimisticWriter`), so successive flushes of the same hour coalesce into one pending upload; updates reuse the file's AES key with a fresh IV. Buffered points are stamped with the file uid on enqueue, **deleted on `ItemCompleted`, un-stamped on `ItemFailed`** for retry. Flushes piggyback on existing wakeups (2-min foreground ticker + background batch deliveries) — no alarms/WorkManager.

### Local buffer
`LocationPoint` table (client-local, `ChatReadCount`-style; added to `TABLE_NAMES` so logout wipes it; no schema-version bump needed). A durable buffer is required: the drive index is a cache of server state, so un-enqueued points stored there would be clobbered by the next sync cycle, and buffering decouples capture cadence (15s) from upload cadence (~2min).

### Other
- `PermissionType.LOCATION` / `LOCATION_ALWAYS` across all four `PermissionsManager` actuals (Android two-step background grant incl. permanently-denied → settings; iOS when-in-use → always escalation).
- `ADDING_ADDON_APPS.md`: the Step-1 template showed Moments' live UUID keys as "the next free slot" — replaced with an ownership table (Vault `0a01xx`, Moments `0a02xx`, Location `0a03xx`, next free `0a04xx`).
- Strings/M3/`collectAsStateWithLifecycle` per CLAUDE.md UI checklist; Konsist architecture test passes.

## Known gaps before release
- [ ] **Drive type GUID is a placeholder** (`AppConfig.kt`) — needs server-team provisioning, same caveat as Vault. Until then the WS subscribes to a non-existent drive → 403 session-only unmount.
- [ ] **Validate fused continuous updates on a real device** — this codebase saw fused *one-shot* reads return null (`LocationLauncher.android.kt`); continuous `requestLocationUpdates` is a different path but unproven here. Fallback: framework `LocationManager` into the same receiver.
- [ ] **iOS targets not compiled** (Linux dev host) — needs a macOS `:homebase-common:compileKotlinIosSimulatorArm64` / `:homebase-core:compileKotlinIosSimulatorArm64` pass; the new CoreLocation interop (`PermissionsManager.native.kt`, `LocationTracker.apple.kt`) is the risk area.
- [ ] Google Play `ACCESS_BACKGROUND_LOCATION` declaration + prominent-disclosure review (release task).
- [ ] iOS SLC-relaunch-after-force-quit behavior to verify on a real device.

## Test plan
- [x] 18 new jvm tests: hour-file uid determinism + bucketing, header codec round-trip (flags packing, quantization), thin-to-fit budget + endpoint preservation, lossless payload round-trip, store dedup policy (incl. cold-start DB re-seed), buffer drain semantics (mark→complete→delete, mark→fail→unmark, re-flush includes marked+unmarked rows).
- [x] `homebase-{api,common,core,chat,auth}:jvmTest` green (incl. Konsist).
- [x] Compile: JVM + Android + wasmJs for api/common/core; `androidApp:assembleDebug` green; merged manifest contains both receivers + new permissions.
- [ ] Manual (emulator): activate → grant → GPX route playback → status rows; background ≥10 min → batched receiver deliveries; force-stop wake; reboot re-arm; airplane-mode buffering → reconnect drain; logout wipes buffer + stops tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)