### PR TITLE
feat(chat): render pending link preview crisp + drop its upload scrim

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -18,6 +18,7 @@ import id.homebase.chat.services.ChatMessageStream
 import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.LocalAttachmentContext
 import id.homebase.chat.services.LocalAttachmentContextStore
+import id.homebase.chat.services.PayloadBundle
 import id.homebase.chat.services.MAX_REACTIONS_PER_USER_PER_MESSAGE
 import id.homebase.chat.services.ReplyContext
 import id.homebase.chat.services.ReplyPreview
@@ -1025,6 +1026,7 @@ internal class MessageActionsHandler(
 
                 val newMessageId = Uuid.random()
                 pendingMessageId = newMessageId
+                registerLocalPreviewContexts(newMessageId, payloadBundle)
                 Logger.d(tag = TAG) { "addMessage: message=$newMessageId conversation=$conversationId" }
 
                 chatMessageSenderService.sendNewMessage(
@@ -1050,6 +1052,28 @@ internal class MessageActionsHandler(
         }
     }
 
+    /**
+     * Register the plaintext local copy of a link preview's OG image so the optimistic bubble can
+     * render it crisp via AsyncImage while the payload uploads — instead of the 20px embedded
+     * tinyThumb. [PayloadFile.filePath] is the same temp file that feeds the encryption pipeline,
+     * which reads it and writes ciphertext to a *separate* file (see PayloadBundleEncryptionService),
+     * so it stays plaintext and decodable for the upload window. A present
+     * [PayloadFile.previewThumbnail] is the signal that a real raster image was produced — the
+     * no-image case writes a 1-byte sentinel we must not hand to Coil. Keyed by the link payload key
+     * so MediaItem can look it up by (messageId, payloadKey).
+     */
+    private fun registerLocalPreviewContexts(messageId: Uuid, bundle: PayloadBundle?) {
+        bundle?.payloads?.forEach { payload ->
+            if (payload.key == ChatProtocol.PAYLOAD_KEY_LINKS && payload.previewThumbnail != null) {
+                localVideoContextStore.put(
+                    messageId,
+                    payload.key,
+                    LocalAttachmentContext.Image(localFilePath = payload.filePath, aspectRatio = null),
+                )
+            }
+        }
+    }
+
     private fun MessageUiModel.toReplyPreview() = ReplyPreview(
         replyUniqueId = id,
         authorOdinId = originalAuthor?.domainName ?: "null",
@@ -1071,6 +1095,7 @@ internal class MessageActionsHandler(
 
                 val newMessageId = Uuid.random()
                 pendingMessageId = newMessageId
+                registerLocalPreviewContexts(newMessageId, payloadBundle)
                 Logger.d(tag = TAG) { "replyToMessage: message=$newMessageId conversation=$conversationId replyTo=${replyTo.id}" }
 
                 chatMessageSenderService.replyToMessage(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LinkPreview.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LinkPreview.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.drives.upload.EmbeddedThumb
 import id.homebase.api.client.link.LinkPreview
@@ -235,10 +236,14 @@ fun LinkPreviewCard(
  * @param keyHeader Key header for decryption.
  * @param previewThumbnail Optional embedded tiny thumbnail for instant display.
  * @param isUploading If true, the message is still being sent and its payload does not yet exist on
- * the drive — render the embedded [previewThumbnail] directly instead of attempting a drive fetch.
+ * the drive — render a local image instead of attempting a drive fetch.
+ * @param localImagePath Optional path to the plaintext local copy of the OG image (the same temp
+ * file that feeds the upload pipeline). When present during [isUploading] it renders crisp and
+ * full-resolution, mirroring how a pending sent IMAGE shows its local file. Falls back to the 20px
+ * embedded [previewThumbnail] when absent (e.g. a pending message restored after app restart).
  * @param modifier Modifier for the composable.
  */
-@OptIn(ExperimentalEncodingApi::class, ExperimentalResourceApi::class)
+@OptIn(ExperimentalEncodingApi::class)
 @Composable
 fun LinkPreviewCard(
     descriptor: LinkPreviewDescriptor,
@@ -248,6 +253,7 @@ fun LinkPreviewCard(
     keyHeader: KeyHeader,
     previewThumbnail: EmbeddedThumb? = null,
     isUploading: Boolean = false,
+    localImagePath: String? = null,
     modifier: Modifier = Modifier,
 ) {
     val uriHandler = LocalUriHandler.current
@@ -258,19 +264,17 @@ fun LinkPreviewCard(
     )
 
     // While the message is pending/uploading the drive payload does not exist yet, so a
-    // HomebaseImage fetch would fail and overlay a broken-image triangle. Decode the embedded
-    // tinyThumb (always a tiny WebP, base64) and show it directly during that window — mirroring
-    // how a pending sent IMAGE renders its local file instead of the remote drive payload. Once
-    // the send completes the bubble re-renders with isUploading=false and swaps to HomebaseImage.
-    val pendingThumbBitmap = remember(previewThumbnail?.content, isUploading) {
+    // HomebaseImage fetch would 404 into a broken-image triangle. Feed Coil a local source
+    // instead: the crisp, full-resolution [localImagePath] (the plaintext temp file that also
+    // feeds the upload) when we still hold it, else the 20px embedded tinyThumb bytes as a soft
+    // fallback (e.g. a pending message restored after an app restart, when the in-memory local
+    // path is gone). Coil takes both a file-path String and a ByteArray model (cf.
+    // StickerCreatorSheet / VideoTrimScrubber). Once the send completes the bubble re-renders with
+    // isUploading=false and swaps to HomebaseImage.
+    val pendingModel: Any? = remember(localImagePath, previewThumbnail?.content, isUploading) {
         if (!isUploading) return@remember null
-        previewThumbnail?.content?.let {
-            try {
-                Base64.decode(it).decodeToImageBitmap()
-            } catch (_: Exception) {
-                null
-            }
-        }
+        localImagePath
+            ?: previewThumbnail?.content?.let { runCatching { Base64.decode(it) }.getOrNull() }
     }
 
     Column(
@@ -280,9 +284,11 @@ fun LinkPreviewCard(
             .clickable { uriHandler.openUri(descriptor.url) },
     ) {
         if (descriptor.hasImage) {
-            if (pendingThumbBitmap != null) {
-                Image(
-                    bitmap = pendingThumbBitmap,
+            if (pendingModel != null) {
+                // Coil decodes a plaintext file path or raw bytes by sniffing content, so the temp
+                // file's `.dat` suffix is irrelevant.
+                AsyncImage(
+                    model = pendingModel,
                     contentDescription = descriptor.title,
                     modifier = Modifier.fillMaxWidth().heightIn(max = 180.dp).clip(imageCornerShape),
                     contentScale = ContentScale.Crop,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
@@ -185,6 +185,7 @@ fun MediaItem(
                     previewThumbnail = payload.previewThumbnail?.toEmbeddedThumb()
                         ?: previewThumbnail,
                     isUploading = isUploading,
+                    localImagePath = (localContext as? LocalAttachmentContext.Image)?.localFilePath,
                     modifier = baseModifier,
                 )
             } else {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
@@ -31,6 +31,7 @@ import id.homebase.api.client.drives.upload.EmbeddedThumb
 import id.homebase.api.video.VideoProcessingPhase
 import id.homebase.chat.conversationlist.DecryptedFileKey
 import id.homebase.chat.conversationlist.UploadStatus
+import id.homebase.chat.services.ChatProtocol
 import id.homebase.core.image.ImageSize
 import id.homebase.core.ui.theme.Dimens
 import id.homebase.resources.MR
@@ -96,6 +97,15 @@ fun MediaMessage(
             (payloads[0].descriptorInfo() as? DescriptorContent.ImageFile)?.isSticker == true
     }
 
+    // A link preview is a single auto-generated card (image + title/description). Unlike a photo or
+    // video upload its payload is tiny and the card carries text, so the full-bleed dark
+    // UploadProgressOverlay scrim is heavy, redundant with the message's own pending tick, and would
+    // hide the crisp local image we now render during send. Skip the scrim for it — the inner card
+    // still receives isUploading so it renders the local source instead of a failing drive fetch.
+    val isLinkPreview = remember(payloads) {
+        payloads.size == 1 && payloads[0].key == ChatProtocol.PAYLOAD_KEY_LINKS
+    }
+
     Box(modifier = Modifier.animateContentSize()) {
         when (payloads.size) {
             1 -> {
@@ -158,7 +168,7 @@ fun MediaMessage(
             }
         }
 
-        if (uploadStatus != null) {
+        if (uploadStatus != null && !isLinkPreview) {
             UploadProgressOverlay(
                 status = uploadStatus,
                 modifier = Modifier.matchParentSize(),

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/LinkPreviewPendingImageTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/LinkPreviewPendingImageTest.kt
@@ -16,12 +16,15 @@ import kotlin.uuid.Uuid
  *
  * While a link-preview message is still uploading, its drive payload does not exist yet, so the
  * normal [id.homebase.core.image.HomebaseImage] fetch would fail and overlay a broken-image
- * triangle. The card must instead decode and show the embedded tinyThumb directly.
+ * triangle. The card must instead render a local source via Coil [coil3.compose.AsyncImage] — the
+ * crisp `localImagePath` when present, else the embedded tinyThumb bytes. This case passes no
+ * `localImagePath`, so it exercises the tinyThumb fallback.
  *
  * The test environment intentionally has NO Koin container. [HomebaseImage] resolves an
- * `ImageLoader` via `koinInject()` during composition, so any path that reaches it throws. The
- * `isUploading = true` case below renders to completion (title + description visible), which proves
- * it took the embedded-thumbnail branch and never touched HomebaseImage.
+ * `ImageLoader` via `koinInject()` during composition, so any path that reaches it throws; AsyncImage
+ * instead uses Coil's singleton loader and needs no Koin. The `isUploading = true` case below renders
+ * to completion (title + description visible), which proves it took the local-source branch and never
+ * touched HomebaseImage.
  */
 @OptIn(ExperimentalTestApi::class)
 class LinkPreviewPendingImageTest {


### PR DESCRIPTION
While a link-preview message uploads, the receiver-side LinkPreviewCard showed the 20px embedded tinyThumb, upscaled into the 180dp card as blurry mush. Register the plaintext OG-image temp file (the same PayloadFile that feeds the upload) into LocalAttachmentContextStore at send time — the existing pending-preview mechanism photos/videos already use — and render it crisp via Coil AsyncImage. Falls back to the tinyThumb bytes if the local copy is gone mid-upload.

Also suppress the full-bleed UploadProgressOverlay scrim for a link-preview-only message: the payload is tiny, the card carries text, the scrim is redundant with the message's own pending tick, and it would hide the crisp image.