### PR TITLE
CI: fix recurring iOS release hang — keychain auto-lock during codesign

### DIFF
--- a/.github/workflows/build-mobile-release-dev.yml
+++ b/.github/workflows/build-mobile-release-dev.yml
@@ -195,6 +195,31 @@ jobs:
             done
           done
 
+      # The build action's bundled Fastfile runs create_keychain(timeout: 3600):
+      # the build keychain auto-locks after 60 minutes. A cold-cache archive
+      # (Kotlin/Native invalidation, dependency bumps) takes >60min to reach the
+      # embedded-framework signing phase, at which point codesign blocks forever
+      # on the locked keychain (it posts an unlock dialog into the runner's GUI
+      # session) — the recurring "Build iOS timed out after 120 minutes" hang at
+      # "Signing libswscale.framework". This watcher outlives its step, waits for
+      # the keychain to appear, and re-clears its auto-lock every minute
+      # (set-keychain-settings with no -t = never lock; no password needed while
+      # the freshly created keychain is unlocked).
+      - name: Defuse build-keychain auto-lock (background watcher)
+        run: |
+          nohup bash -c '
+            kc="$HOME/Library/Keychains/ios-build.keychain-db"
+            while true; do
+              if [ -f "$kc" ]; then
+                if security set-keychain-settings "$kc" 2>>"$RUNNER_TEMP/keychain-watcher.log"; then
+                  echo "$(date -u +%FT%TZ) cleared auto-lock on $kc"
+                fi
+              fi
+              sleep 60
+            done
+          ' >> "$RUNNER_TEMP/keychain-watcher.log" 2>&1 &
+          echo "keychain watcher started (log: $RUNNER_TEMP/keychain-watcher.log)"
+
       - name: Build iOS
         timeout-minutes: 120
         uses: yukiarrr/ios-build-action@v1.12.0

--- a/.github/workflows/build-mobile-release-prod.yml
+++ b/.github/workflows/build-mobile-release-prod.yml
@@ -201,7 +201,32 @@ jobs:
                 done
               fi
             done
-          done          
+          done
+
+      # The build action's bundled Fastfile runs create_keychain(timeout: 3600):
+      # the build keychain auto-locks after 60 minutes. A cold-cache archive
+      # (Kotlin/Native invalidation, dependency bumps) takes >60min to reach the
+      # embedded-framework signing phase, at which point codesign blocks forever
+      # on the locked keychain (it posts an unlock dialog into the runner's GUI
+      # session) — the recurring "Build iOS timed out" hang at
+      # "Signing libswscale.framework". This watcher outlives its step, waits for
+      # the keychain to appear, and re-clears its auto-lock every minute
+      # (set-keychain-settings with no -t = never lock; no password needed while
+      # the freshly created keychain is unlocked).
+      - name: Defuse build-keychain auto-lock (background watcher)
+        run: |
+          nohup bash -c '
+            kc="$HOME/Library/Keychains/ios-build.keychain-db"
+            while true; do
+              if [ -f "$kc" ]; then
+                if security set-keychain-settings "$kc" 2>>"$RUNNER_TEMP/keychain-watcher.log"; then
+                  echo "$(date -u +%FT%TZ) cleared auto-lock on $kc"
+                fi
+              fi
+              sleep 60
+            done
+          ' >> "$RUNNER_TEMP/keychain-watcher.log" 2>&1 &
+          echo "keychain watcher started (log: $RUNNER_TEMP/keychain-watcher.log)"
 
       - name: Build iOS
         timeout-minutes: 180


### PR DESCRIPTION
Cherry-pick of 29226f7b from the location-app branch so the fix reaches main's release workflows.

The "Build iOS" step has been intermittently timing out (120/180 min) hung at "Signing libswscale.framework" with orphaned codesign processes. Root cause: yukiarrr/ios-build-action's bundled Fastfile runs `create_keychain(timeout: 3600)`, so the build keychain auto-locks after 60 minutes. Any archive that takes >60 min to reach the embedded-framework signing phase (cold Kotlin/Native cache, dependency bumps) then blocks forever — codesign posts an unlock dialog into the runner's GUI session that nobody can answer.

Fix: a background watcher step started just before the build action. It waits for ios-build.keychain-db to appear and re-clears the auto-lock every 60s via `security set-keychain-settings` (no -t flag = never lock). Applied to both dev and prod mobile release workflows.

Evidence: run 27328093862 — keychain created 06:23:54, extensions signed fine 06:25:58, archive compiled until 07:50:30 (84 min, cold K/N cache), then 3 codesign processes hung 33 min until the step timeout.

A validation run of Build Mobile Release Production was dispatched on this branch (identical app code to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)