### PR TITLE
Outbox: honest drop reporting + typed enqueue results

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveOutboxUploader.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveOutboxUploader.kt
@@ -47,42 +47,13 @@ class DriveOutboxUploader(
                 DeleteFilesByGroupId -> deleteFilesByGroupId(outboxRecord)
             }
         } catch (e: ClientException) {
-            if (e.status == 400) {
-                // Self-recipient: the outbox item's recipient list contains the
-                // logged-in identity. The server will reject this forever, so drop
-                // the row rather than scheduling 20 retries. Title-match because the
-                // server returns errorCode=UnhandledScenario for this case; there's
-                // no dedicated enum value. Mirrors the VersionTagMismatch pattern
-                // below: return normally and OutboxSync deletes the row.
-                if (e.message?.startsWith("Cannot transfer to yourself") == true) {
-                    Logger.w(
-                        "$TAG upload: dropping outbox item ${outboxRecord.uniqueId} " +
-                                "uploadType=${outboxRecord.uploadType} — terminal: ${e.message}"
-                    )
-                    return
-                }
-                // Title-match in addition to the structured errorCode because the server
-                // sometimes collapses VersionTagMismatch into errorCode=UnhandledScenario
-                // while preserving the title text "Mismatching version tag …". Without
-                // this fallback the outbox burns 20 attempts (~48h) on a stale tag.
-                val isVersionTagMismatch =
-                    e.errorCode == OdinClientErrorCode.VersionTagMismatch ||
-                            e.message?.contains("Mismatching version tag", ignoreCase = true) == true
-                if (isVersionTagMismatch) {
-                    Logger.w(
-                        "$TAG upload: dropping outbox item ${outboxRecord.uniqueId} " +
-                                "uploadType=${outboxRecord.uploadType} driveId=${outboxRecord.driveId} " +
-                                "— VersionTagMismatch (errorCode=${e.errorCode}): ${e.message}"
-                    )
-                    return
-                }
-                Logger.e(
-                    "$TAG upload: 400 for outbox item ${outboxRecord.uniqueId} " +
-                            "uploadType=${outboxRecord.uploadType} errorCode=${e.errorCode} " +
-                            "— will retry (server message: ${e.message})"
-                )
-                throw e
-            }
+            // Always rethrow — never swallow a terminal error by returning
+            // normally. Doing so used to make OutboxSync take the success path
+            // and emit ItemCompleted for an upload the server rejected (the
+            // bubble showed *sent* for a message that never landed). All
+            // permanent-vs-retryable classification lives in
+            // [classifyPermanentFailure]; OutboxSync drops permanent failures
+            // with an honest OutboxItemDropped.
             Logger.e(
                 "$TAG upload: failing outbox item ${outboxRecord.uniqueId} " +
                         "uploadType=${outboxRecord.uploadType} status=${e.status} " +

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/eventbus/BackendEvent.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/eventbus/BackendEvent.kt
@@ -154,11 +154,15 @@ sealed interface BackendEvent {
             val uniqueId: Uuid,
         ) : OutboxEvent
 
-        /** Fired when an item is permanently dropped after exceeding the max retry limit. */
+        /** Fired when an item is permanently dropped — either a permanent
+         *  (never-retryable) failure or the max retry limit was exceeded.
+         *  [reason] is human-readable diagnostics (classifier reason or
+         *  "retries exhausted (N)"), for logs/Message Info — not for branching. */
         data class OutboxItemDropped(
             val driveId: Uuid,
             val uniqueId: Uuid,
-            val attempts: Int
+            val attempts: Int,
+            val reason: String? = null,
         ) : OutboxEvent
 
     }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxFailureClassifier.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxFailureClassifier.kt
@@ -1,0 +1,74 @@
+package id.homebase.api.sync.database
+
+import id.homebase.api.client.ClientException
+import id.homebase.api.client.NotFoundException
+import id.homebase.api.client.OdinClientErrorCode
+
+/**
+ * The single classification point for outbox upload failures: returns a
+ * human-readable reason when [e] describes a state that won't be fixed by
+ * retrying (file not found server-side, missing version tag for an update,
+ * etc.), or null when the failure is retryable. A non-null result makes
+ * [OutboxSync] drop the row immediately instead of burning ~48h of
+ * exponential-backoff retries, and the reason rides on the
+ * `OutboxItemDropped` event and the DROPPING log line.
+ *
+ * Pure + unit-testable (see OutboxFailureClassifierTest). Every uploader-side
+ * terminal condition belongs HERE — uploaders must throw, never swallow a
+ * terminal error by returning normally (that made OutboxSync emit
+ * ItemCompleted for an upload that never reached the server).
+ */
+internal fun classifyPermanentFailure(e: Throwable): String? {
+    if (e is NotFoundException) return "404 NotFound"
+    if (e is ClientException) {
+        when (e.errorCode) {
+            OdinClientErrorCode.FileNotFound,
+            OdinClientErrorCode.MissingVersionTag,
+            OdinClientErrorCode.VersionTagMismatch,
+            OdinClientErrorCode.CannotOverwriteNonExistentFile,
+            OdinClientErrorCode.UnknownId -> return reasonOf(e)
+            else -> Unit
+        }
+        // The server sometimes returns 400 with the structured errorCode
+        // collapsed to UnhandledScenario but the message text intact.
+        // Catch the recurring local-only-placeholder failures we've seen
+        // so they don't loop in the outbox. The version-tag check matches
+        // both "Missing version tag" and "Mismatching version tag".
+        val msg = e.message ?: return null
+        if (msg.contains("Could not find file", ignoreCase = true)) return reasonOf(e)
+        if (msg.contains(Regex("Mis(sing|matching) version tag", RegexOption.IGNORE_CASE))) return reasonOf(e)
+        // Server-enforced size invariants — never recover with retry.
+        // Catches "Thumbnail size of N exceeds 1024" (the bug behind
+        // the URL-preview SVG outbox stall on 2026-05-17) and any
+        // sibling quota messages the server emits in the same shape
+        // with errorCode collapsed to UnhandledScenario.
+        if (msg.contains(Regex("size of \\d+ exceeds \\d+", RegexOption.IGNORE_CASE))) return reasonOf(e)
+        // Encrypted-file key mismatch on update: the server rejects an update
+        // whose AES key differs from the existing file's ("When updating an
+        // encrypted file, the AES key must match the existing key …"). The
+        // outbox row carries a fixed key, so every retry replays the same
+        // wrong key against an unchanging server file — deterministically
+        // unrecoverable. Drop it instead of burning ~48h of retries.
+        // GUARDRAIL, not the fix: the root cause is DriveOutboxUploader.
+        // retryAsUpdate adopting the server's versionTag but reusing the
+        // client's freshly-minted keyHeader (seen when the local DB lost the
+        // conversation's key, e.g. the in-memory web DB after a reload, and
+        // optimistically recreated the conversation with a new key). The real
+        // fix re-hydrates the existing server key on ExistingFileWithUniqueId.
+        if (msg.contains("AES key must match", ignoreCase = true)) return reasonOf(e)
+        // Client-side pre-flight rejections from
+        // [UploadValidation.kt]. The validator throws ClientException
+        // shaped like a server response so we land here on attempt 1.
+        if (msg.startsWith("Upload validation failed: ")) return reasonOf(e)
+        // Self-recipient: the outbox item's recipient list contains the
+        // logged-in identity. The server will reject this forever. Title-match
+        // because the server returns errorCode=UnhandledScenario for this
+        // case; there's no dedicated enum value. (Previously swallowed inside
+        // DriveOutboxUploader.upload by returning normally, which faked a
+        // successful send — ItemCompleted for an upload the server 400'd.)
+        if (msg.startsWith("Cannot transfer to yourself")) return reasonOf(e)
+    }
+    return null
+}
+
+private fun reasonOf(e: ClientException): String = "errorCode=${e.errorCode} msg=${e.message}"

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
@@ -1,9 +1,6 @@
 package id.homebase.api.sync.database
 
 import co.touchlab.kermit.Logger
-import id.homebase.api.client.ClientException
-import id.homebase.api.client.NotFoundException
-import id.homebase.api.client.OdinClientErrorCode
 import id.homebase.api.client.drives.files.DeleteFilesByGroupIdOutboxRequest
 import id.homebase.api.client.drives.files.DeleteLocalFilesByFileIdRequest
 import id.homebase.api.client.drives.files.DriveOutboxUploader
@@ -24,6 +21,7 @@ import id.homebase.api.coroutines.supervisedScope
 import id.homebase.api.crypto.toUtf8ByteArray
 import id.homebase.api.serialization.OdinSystemSerializer
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -61,6 +59,36 @@ internal fun wouldStrandPendingCreate(existingUploadType: Long?, incomingUploadT
     incomingUploadType == DriveOutboxUploader.UpdateFile &&
         existingUploadType == DriveOutboxUploader.UploadNewFile
 
+/**
+ * Outcome of [OutboxSync.tryEnqueue]/[OutboxSync.replaceEnqueue]. Replaces the
+ * old Boolean, whose `false` collapsed three very different situations —
+ * a benign UNIQUE(driveId, uniqueId) collision ("already queued, fine"), the
+ * strand guard refusing a downgrade, and a real DB failure ("this request is
+ * silently lost") — leaving callers to guess which one happened.
+ */
+sealed interface EnqueueResult {
+    /** The request is durably queued. */
+    data object Enqueued : EnqueueResult
+
+    /** A row for this (driveId, uniqueId) is already pending — the UNIQUE
+     *  constraint rejected the insert. Usually benign: the queued request will
+     *  be sent. Use [OutboxSync.replaceEnqueue] when the new request should
+     *  supersede it. */
+    data object AlreadyQueued : EnqueueResult
+
+    /** replaceEnqueue refused to replace a pending `UploadNewFile` with an
+     *  `UpdateFile` — that would strand the un-sent create (see
+     *  [wouldStrandPendingCreate]). Re-enqueue the edit AS a create instead. */
+    data object WouldStrandCreate : EnqueueResult
+
+    /** The insert failed for a reason other than the UNIQUE constraint — the
+     *  request was NOT queued and will not be sent. */
+    data class Failed(val cause: Throwable) : EnqueueResult
+}
+
+/** True only for [EnqueueResult.Enqueued] — exactly the old Boolean `true`. */
+val EnqueueResult.enqueued: Boolean get() = this == EnqueueResult.Enqueued
+
 class OutboxSync(
     private val databaseManager: DatabaseManager,
     private val uploader: OutboxUploader,
@@ -83,63 +111,6 @@ class OutboxSync(
     private val semaphore = Semaphore(MAX_SENDING_THREADS)
     private val activeThreads = atomic(0)
 
-    /**
-     * Returns true when the upload exception describes a state that won't be
-     * fixed by retrying (file not found server-side, missing version tag for
-     * an update, etc.). Drops these immediately instead of burning ~48h of
-     * exponential-backoff retries.
-     */
-    private fun isPermanentFailure(e: Throwable): Boolean {
-        if (e is NotFoundException) return true
-        if (e is ClientException) {
-            when (e.errorCode) {
-                OdinClientErrorCode.FileNotFound,
-                OdinClientErrorCode.MissingVersionTag,
-                OdinClientErrorCode.VersionTagMismatch,
-                OdinClientErrorCode.CannotOverwriteNonExistentFile,
-                OdinClientErrorCode.UnknownId -> return true
-                else -> Unit
-            }
-            // The server sometimes returns 400 with the structured errorCode
-            // collapsed to UnhandledScenario but the message text intact.
-            // Catch the recurring local-only-placeholder failures we've seen
-            // so they don't loop in the outbox. The version-tag check matches
-            // both "Missing version tag" and "Mismatching version tag".
-            val msg = e.message ?: return false
-            if (msg.contains("Could not find file", ignoreCase = true)) return true
-            if (msg.contains(Regex("Mis(sing|matching) version tag", RegexOption.IGNORE_CASE))) return true
-            // Server-enforced size invariants — never recover with retry.
-            // Catches "Thumbnail size of N exceeds 1024" (the bug behind
-            // the URL-preview SVG outbox stall on 2026-05-17) and any
-            // sibling quota messages the server emits in the same shape
-            // with errorCode collapsed to UnhandledScenario.
-            if (msg.contains(Regex("size of \\d+ exceeds \\d+", RegexOption.IGNORE_CASE))) return true
-            // Encrypted-file key mismatch on update: the server rejects an update
-            // whose AES key differs from the existing file's ("When updating an
-            // encrypted file, the AES key must match the existing key …"). The
-            // outbox row carries a fixed key, so every retry replays the same
-            // wrong key against an unchanging server file — deterministically
-            // unrecoverable. Drop it instead of burning ~48h of retries.
-            // GUARDRAIL, not the fix: the root cause is DriveOutboxUploader.
-            // retryAsUpdate adopting the server's versionTag but reusing the
-            // client's freshly-minted keyHeader (seen when the local DB lost the
-            // conversation's key, e.g. the in-memory web DB after a reload, and
-            // optimistically recreated the conversation with a new key). The real
-            // fix re-hydrates the existing server key on ExistingFileWithUniqueId.
-            if (msg.contains("AES key must match", ignoreCase = true)) return true
-            // Client-side pre-flight rejections from
-            // [UploadValidation.kt]. The validator throws ClientException
-            // shaped like a server response so we land here on attempt 1.
-            if (msg.startsWith("Upload validation failed: ")) return true
-        }
-        return false
-    }
-
-    private fun permanentFailureReason(e: Throwable): String = when {
-        e is NotFoundException -> "404 NotFound"
-        e is ClientException -> "errorCode=${e.errorCode} msg=${e.message}"
-        else -> e::class.simpleName ?: "unknown"
-    }
     private val totalSent = atomic(0)
     private val counterMutex = Mutex()
 
@@ -233,14 +204,24 @@ class OutboxSync(
                     )
                 )
                 totalSent.incrementAndGet()
+            } catch (e: CancellationException) {
+                // Worker scope cancelled (logout, shutdown) — not an upload
+                // failure. Don't classify, don't checkInFailed, don't emit
+                // failure events: the row stays checked out and the next
+                // start's clearCheckedOut recovers it, exactly like an app
+                // kill. Without this rethrow the catch below would record a
+                // bogus failed attempt (it only avoids that today because its
+                // first suspension point happens to rethrow cancellation).
+                throw e
             } catch (e: Exception) {
                 val attempts = outboxRecord.checkOutCount + 1
 
-                if (attempts >= MAX_RETRIES || isPermanentFailure(e)) {
-                    val reason = if (attempts >= MAX_RETRIES) {
-                        "after $attempts failed attempts"
+                val permanentReason = classifyPermanentFailure(e)
+                if (attempts >= MAX_RETRIES || permanentReason != null) {
+                    val reason = if (permanentReason != null) {
+                        "permanent failure ($permanentReason)"
                     } else {
-                        "permanent failure (${permanentFailureReason(e)})"
+                        "after $attempts failed attempts"
                     }
                     Logger.e(
                         "OutboxSync: DROPPING uniqueId=${outboxRecord.uniqueId} " +
@@ -267,7 +248,8 @@ class OutboxSync(
                         BackendEvent.OutboxEvent.OutboxItemDropped(
                             outboxRecord.driveId,
                             outboxRecord.uniqueId,
-                            attempts.toInt()
+                            attempts.toInt(),
+                            reason = permanentReason ?: "retries exhausted ($attempts)",
                         )
                     )
                     continue
@@ -302,121 +284,96 @@ class OutboxSync(
         }
     }
 
+    /**
+     * Fire-and-forget send kick after a successful enqueue: the caller (e.g.
+     * the chat Send button) must not wait on outbox worker startup. send() is
+     * non-blocking today, but we launch it on the outbox's own scope so future
+     * changes to send() can't leak back into the caller's suspension chain.
+     */
+    private fun kickIfEnqueued(result: EnqueueResult, sendNow: Boolean): EnqueueResult {
+        if (sendNow && result.enqueued) {
+            scope.launch { send() }
+        }
+        return result
+    }
+
     public suspend fun tryEnqueue(
         request: DeleteFilesByGroupIdOutboxRequest,
         priority: Long = 100,
         dependencyUniqueId: Uuid? = null,
         sendNow: Boolean = true
-    ): Boolean {
-        val enqueued = tryEnqueue(
+    ): EnqueueResult = kickIfEnqueued(
+        tryEnqueue(
             driveId = request.driveId,
             uniqueId = Uuid.random(),
             dependencyUniqueId = dependencyUniqueId,
             priority = priority,
             uploadType = DriveOutboxUploader.DeleteFilesByGroupId,
             json = OdinSystemSerializer.serialize(request)
-        )
-
-        if (enqueued && sendNow) {
-            // Fire-and-forget: the enqueue caller (e.g. chat Send button) must not
-            // wait on outbox worker startup. send() is non-blocking today, but we
-            // launch it on the outbox's own scope so future changes to send() can't
-            // leak back into the caller's suspension chain.
-            scope.launch { send() }
-        }
-
-        return enqueued
-    }
+        ),
+        sendNow,
+    )
 
     public suspend fun tryEnqueue(
         request: DeleteLocalFilesByFileIdRequest,
         priority: Long = 100,
         dependencyUniqueId: Uuid? = null,
         sendNow: Boolean = true
-    ): Boolean {
-        val enqueued = tryEnqueue(
+    ): EnqueueResult = kickIfEnqueued(
+        tryEnqueue(
             driveId = request.driveId,
             uniqueId = Uuid.random(), //random because our request is a list of files
             dependencyUniqueId = dependencyUniqueId,
             priority = priority,
             uploadType = DriveOutboxUploader.DeleteFile,
             json = OdinSystemSerializer.serialize(request)
-        )
-
-        if (enqueued && sendNow) {
-            // Fire-and-forget: the enqueue caller (e.g. chat Send button) must not
-            // wait on outbox worker startup. send() is non-blocking today, but we
-            // launch it on the outbox's own scope so future changes to send() can't
-            // leak back into the caller's suspension chain.
-            scope.launch { send() }
-        }
-
-        return enqueued
-    }
+        ),
+        sendNow,
+    )
 
     public suspend fun tryEnqueue(
         request: UpdateFileByUniqueIdRequest,
         priority: Long = 100,
         dependencyUniqueId: Uuid? = null,
         sendNow: Boolean = true
-    ): Boolean {
-        val json = OdinSystemSerializer.serialize(request)
-        val enqueued = tryEnqueue(
+    ): EnqueueResult = kickIfEnqueued(
+        tryEnqueue(
             driveId = request.driveId,
             uniqueId = request.metadata.appData.uniqueId
                 ?: error("unique id required to place in outbox"),
             dependencyUniqueId = dependencyUniqueId,
             priority = priority,
             uploadType = DriveOutboxUploader.UpdateFile,
-            json = json
-        )
-
-        if (enqueued && sendNow) {
-            // Fire-and-forget: the enqueue caller (e.g. chat Send button) must not
-            // wait on outbox worker startup. send() is non-blocking today, but we
-            // launch it on the outbox's own scope so future changes to send() can't
-            // leak back into the caller's suspension chain.
-            scope.launch { send() }
-        }
-
-        return enqueued
-    }
+            json = OdinSystemSerializer.serialize(request)
+        ),
+        sendNow,
+    )
 
     public suspend fun replaceEnqueue(
         request: UpdateFileByUniqueIdRequest,
         priority: Long = 100,
         dependencyUniqueId: Uuid? = null,
         sendNow: Boolean = true
-    ): Boolean {
-        val json = OdinSystemSerializer.serialize(request)
-        val enqueued = replaceEnqueue(
+    ): EnqueueResult = kickIfEnqueued(
+        replaceEnqueue(
             driveId = request.driveId,
             uniqueId = request.metadata.appData.uniqueId
                 ?: error("unique id required to place in outbox"),
             dependencyUniqueId = dependencyUniqueId,
             priority = priority,
             uploadType = DriveOutboxUploader.UpdateFile,
-            json = json
-        )
-
-        if (enqueued && sendNow) {
-            // Fire-and-forget: the enqueue caller (e.g. chat Send button) must not
-            // wait on outbox worker startup. send() is non-blocking today, but we
-            // launch it on the outbox's own scope so future changes to send() can't
-            // leak back into the caller's suspension chain.
-            scope.launch { send() }
-        }
-
-        return enqueued
-    }
+            json = OdinSystemSerializer.serialize(request)
+        ),
+        sendNow,
+    )
 
     public suspend fun tryEnqueue(
         request: UploadFileRequest,
         priority: Long = 100,
         dependencyUniqueId: Uuid? = null,
         sendNow: Boolean = true
-    ): Boolean {
-        val enqueued = tryEnqueue(
+    ): EnqueueResult = kickIfEnqueued(
+        tryEnqueue(
             driveId = request.driveId,
             uniqueId = request.metadata.appData.uniqueId
                 ?: error("unique id required to place in outbox"),
@@ -424,18 +381,9 @@ class OutboxSync(
             priority = priority,
             uploadType = DriveOutboxUploader.UploadNewFile,
             json = OdinSystemSerializer.serialize(request)
-        )
-
-        if (enqueued && sendNow) {
-            // Fire-and-forget: the enqueue caller (e.g. chat Send button) must not
-            // wait on outbox worker startup. send() is non-blocking today, but we
-            // launch it on the outbox's own scope so future changes to send() can't
-            // leak back into the caller's suspension chain.
-            scope.launch { send() }
-        }
-
-        return enqueued
-    }
+        ),
+        sendNow,
+    )
 
     /** Replace any pending row for this message with a fresh create. Used to
      *  coalesce an edit into a still-queued (not-yet-sent) create so the edit
@@ -445,8 +393,8 @@ class OutboxSync(
         priority: Long = 100,
         dependencyUniqueId: Uuid? = null,
         sendNow: Boolean = true
-    ): Boolean {
-        val enqueued = replaceEnqueue(
+    ): EnqueueResult = kickIfEnqueued(
+        replaceEnqueue(
             driveId = request.driveId,
             uniqueId = request.metadata.appData.uniqueId
                 ?: error("unique id required to place in outbox"),
@@ -454,14 +402,9 @@ class OutboxSync(
             priority = priority,
             uploadType = DriveOutboxUploader.UploadNewFile,
             json = OdinSystemSerializer.serialize(request)
-        )
-
-        if (enqueued && sendNow) {
-            scope.launch { send() }
-        }
-
-        return enqueued
-    }
+        ),
+        sendNow,
+    )
 
     /** Upload type of the pending row for (driveId, uniqueId), or null if none
      *  is queued. Lets a caller branch on create-vs-update before enqueuing. */
@@ -525,37 +468,28 @@ class OutboxSync(
         priority: Long = 100,
         dependencyUniqueId: Uuid? = null,
         sendNow: Boolean = true
-    ): Boolean {
-        val enqueued = tryEnqueue(
+    ): EnqueueResult = kickIfEnqueued(
+        tryEnqueue(
             driveId = driveId,
             uniqueId = uniqueId,
             dependencyUniqueId = dependencyUniqueId,
             priority = priority,
             uploadType = DriveOutboxUploader.UpdateLocalMetadataTags,
             json = OdinSystemSerializer.serialize(request)
-        )
-
-        if (enqueued && sendNow) {
-            // Fire-and-forget: the enqueue caller (e.g. chat Send button) must not
-            // wait on outbox worker startup. send() is non-blocking today, but we
-            // launch it on the outbox's own scope so future changes to send() can't
-            // leak back into the caller's suspension chain.
-            scope.launch { send() }
-        }
-
-        return enqueued
-    }
+        ),
+        sendNow,
+    )
 
     public suspend fun tryEnqueue(
         request: UpdateLocalAppdataContentOutboxRequest,
         priority: Long = 100,
         dependencyUniqueId: Uuid? = null,
         sendNow: Boolean = true
-    ): Boolean {
+    ): EnqueueResult {
         Logger.d(tag = "MarkAsRead") {
             "OutboxSync.tryEnqueue(UpdateLocalAppdataContent): drive=${request.driveId} fileId=${request.fileId} hasIv=${request.iv != null} sendNow=$sendNow"
         }
-        val enqueued = tryEnqueue(
+        val result = tryEnqueue(
             driveId = request.driveId,
             uniqueId = request.fileId,
             dependencyUniqueId = dependencyUniqueId,
@@ -564,18 +498,9 @@ class OutboxSync(
             json = OdinSystemSerializer.serialize(request)
         )
         Logger.d(tag = "MarkAsRead") {
-            "OutboxSync.tryEnqueue(UpdateLocalAppdataContent): enqueued=$enqueued drive=${request.driveId} fileId=${request.fileId}"
+            "OutboxSync.tryEnqueue(UpdateLocalAppdataContent): result=$result drive=${request.driveId} fileId=${request.fileId}"
         }
-
-        if (enqueued && sendNow) {
-            // Fire-and-forget: the enqueue caller (e.g. chat Send button) must not
-            // wait on outbox worker startup. send() is non-blocking today, but we
-            // launch it on the outbox's own scope so future changes to send() can't
-            // leak back into the caller's suspension chain.
-            scope.launch { send() }
-        }
-
-        return enqueued
+        return kickIfEnqueued(result, sendNow)
     }
 
     public suspend fun tryEnqueue(
@@ -583,37 +508,28 @@ class OutboxSync(
         priority: Long = 100,
         dependencyUniqueId: Uuid? = null,
         sendNow: Boolean = true
-    ): Boolean {
-        val enqueued = tryEnqueue(
+    ): EnqueueResult = kickIfEnqueued(
+        tryEnqueue(
             driveId = request.driveId,
             uniqueId = Uuid.random(),
             dependencyUniqueId = dependencyUniqueId,
             priority = priority,
             uploadType = DriveOutboxUploader.ToggleReaction,
             json = OdinSystemSerializer.serialize(request)
-        )
-
-        if (enqueued && sendNow) {
-            // Fire-and-forget: the enqueue caller (e.g. chat Send button) must not
-            // wait on outbox worker startup. send() is non-blocking today, but we
-            // launch it on the outbox's own scope so future changes to send() can't
-            // leak back into the caller's suspension chain.
-            scope.launch { send() }
-        }
-
-        return enqueued
-    }
+        ),
+        sendNow,
+    )
 
     public suspend fun tryEnqueue(
         request: SendReadReceiptByFileIdsOutboxRequest,
         priority: Long = 100,
         dependencyUniqueId: Uuid? = null,
         sendNow: Boolean = true
-    ): Boolean {
+    ): EnqueueResult {
         Logger.d(tag = "MarkAsRead") {
             "OutboxSync.tryEnqueue(SendReadReceiptByFileIds): drive=${request.driveId} fileIdsCount=${request.fileIds.size} sendNow=$sendNow"
         }
-        val enqueued = tryEnqueue(
+        val result = tryEnqueue(
             driveId = request.driveId,
             uniqueId = Uuid.random(),
             dependencyUniqueId = dependencyUniqueId,
@@ -622,18 +538,9 @@ class OutboxSync(
             json = OdinSystemSerializer.serialize(request)
         )
         Logger.d(tag = "MarkAsRead") {
-            "OutboxSync.tryEnqueue(SendReadReceiptByFileIds): enqueued=$enqueued drive=${request.driveId}"
+            "OutboxSync.tryEnqueue(SendReadReceiptByFileIds): result=$result drive=${request.driveId}"
         }
-
-        if (enqueued && sendNow) {
-            // Fire-and-forget: the enqueue caller (e.g. chat Send button) must not
-            // wait on outbox worker startup. send() is non-blocking today, but we
-            // launch it on the outbox's own scope so future changes to send() can't
-            // leak back into the caller's suspension chain.
-            scope.launch { send() }
-        }
-
-        return enqueued
+        return kickIfEnqueued(result, sendNow)
     }
 
     /** Like tryEnqueue but replaces any existing pending item with the same (driveId, uniqueId).
@@ -646,7 +553,7 @@ class OutboxSync(
         priority: Long,
         uploadType: Long,
         json: String
-    ): Boolean {
+    ): EnqueueResult {
         // Defense in depth: never silently downgrade a pending create to an
         // update. Chat's edit path coalesces into a create before reaching here
         // (see ChatMessageSenderService.updateMessage); this guard ensures no
@@ -657,7 +564,7 @@ class OutboxSync(
                 "OutboxSync: refusing to replace a pending UploadNewFile with an UpdateFile " +
                     "for uniqueId=$uniqueId — would strand the un-sent create."
             )
-            return false
+            return EnqueueResult.WouldStrandCreate
         }
         databaseManager.outbox.deleteBy(driveId, uniqueId)
         return tryEnqueue(driveId, uniqueId, dependencyUniqueId, priority, uploadType, json)
@@ -670,7 +577,7 @@ class OutboxSync(
         priority: Long,
         uploadType: Long,
         json: String
-    ): Boolean {
+    ): EnqueueResult {
         try {
             databaseManager.outbox.insert(
                 driveId,
@@ -694,14 +601,27 @@ class OutboxSync(
                 Logger.w("OutboxSync: ItemEnqueued event dropped (EventBus buffer full) uniqueId=$uniqueId")
             }
 
-            return true
+            return EnqueueResult.Enqueued
 
+        } catch (e: CancellationException) {
+            // The caller's coroutine was cancelled — propagate; classifying it
+            // as Failed would misreport routine cancellation as a lost request.
+            throw e
         } catch (t: Throwable) {
+            // Tell the benign UNIQUE(driveId, uniqueId) collision apart from a
+            // real DB failure: if a pending row exists for this key, the insert
+            // hit the constraint. (Driver-agnostic — constraint exception types
+            // differ across JDBC/Android/native.)
+            val alreadyQueued = runCatching {
+                databaseManager.outbox.selectByDriveAndUnique(driveId, uniqueId) != null
+            }.getOrDefault(false)
+            if (alreadyQueued) {
+                Logger.i("OutboxSync: tryEnqueue found a pending row for uniqueId=$uniqueId — AlreadyQueued")
+                return EnqueueResult.AlreadyQueued
+            }
             Logger.e("OutboxSync - Failed to Enqueue", t)
+            return EnqueueResult.Failed(t)
         }
-
-        return false
-
     }
 
     /**

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxFailureClassifierTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxFailureClassifierTest.kt
@@ -1,0 +1,156 @@
+package id.homebase.api.sync.database
+
+import id.homebase.api.client.ClientException
+import id.homebase.api.client.NotFoundException
+import id.homebase.api.client.OdinClientErrorCode
+import id.homebase.api.client.ProblemDetails
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+private fun clientException(
+    status: Int = 400,
+    errorCode: OdinClientErrorCode = OdinClientErrorCode.UnhandledScenario,
+    message: String,
+): ClientException = ClientException(
+    status = status,
+    errorCode = errorCode,
+    message = message,
+    correlationId = null,
+    problem = ProblemDetails(status = status, title = message),
+)
+
+/**
+ * Unit tests for [classifyPermanentFailure] — the single classification point
+ * for "this outbox failure will never be fixed by retrying". Each permanent
+ * case must return a non-null reason; retryable cases must return null.
+ *
+ * The string-match cases each correspond to a server behavior where the
+ * structured errorCode is collapsed to UnhandledScenario but the message text
+ * survives — see the comments in OutboxFailureClassifier.kt for the incident
+ * each one was added for.
+ */
+class OutboxFailureClassifierTest {
+
+    // ---- permanent: exception type ----
+
+    @Test
+    fun notFoundExceptionIsPermanent() {
+        assertNotNull(classifyPermanentFailure(NotFoundException()))
+    }
+
+    // ---- permanent: structured error codes ----
+
+    @Test
+    fun permanentErrorCodesArePermanent() {
+        val permanentCodes = listOf(
+            OdinClientErrorCode.FileNotFound,
+            OdinClientErrorCode.MissingVersionTag,
+            OdinClientErrorCode.VersionTagMismatch,
+            OdinClientErrorCode.CannotOverwriteNonExistentFile,
+            OdinClientErrorCode.UnknownId,
+        )
+        for (code in permanentCodes) {
+            assertNotNull(
+                classifyPermanentFailure(clientException(errorCode = code, message = "irrelevant")),
+                "errorCode=$code must classify as permanent",
+            )
+        }
+    }
+
+    // ---- permanent: message text with errorCode collapsed to UnhandledScenario ----
+
+    @Test
+    fun couldNotFindFileMessageIsPermanent() {
+        assertNotNull(
+            classifyPermanentFailure(
+                clientException(message = "Could not find file with uniqueId 7373d519-d042-d100-4aad-a8e5d48dd851")
+            )
+        )
+    }
+
+    @Test
+    fun missingVersionTagMessageIsPermanent() {
+        assertNotNull(
+            classifyPermanentFailure(clientException(message = "Missing version tag for file update"))
+        )
+    }
+
+    @Test
+    fun mismatchingVersionTagMessageIsPermanent() {
+        assertNotNull(
+            classifyPermanentFailure(
+                clientException(message = "Mismatching version tag 7373d519-d042-d100-4aad-a8e5d48dd851")
+            )
+        )
+    }
+
+    @Test
+    fun sizeExceedsMessageIsPermanent() {
+        assertNotNull(
+            classifyPermanentFailure(clientException(message = "Thumbnail size of 1634 exceeds 1024"))
+        )
+    }
+
+    @Test
+    fun aesKeyMismatchMessageIsPermanent() {
+        assertNotNull(
+            classifyPermanentFailure(
+                clientException(
+                    message = "When updating an encrypted file, the AES key must match the existing key. " +
+                        "Changing the AES key can invalidate existing encrypted payloads."
+                )
+            )
+        )
+    }
+
+    @Test
+    fun uploadValidationFailureIsPermanent() {
+        assertNotNull(
+            classifyPermanentFailure(
+                clientException(message = "Upload validation failed: payload key 'abc' exceeds 10 chars")
+            )
+        )
+    }
+
+    /**
+     * "Cannot transfer to yourself": the outbox item's recipient list contains
+     * the logged-in identity; the server rejects this forever. Previously this
+     * was swallowed inside DriveOutboxUploader.upload by returning normally —
+     * which made OutboxSync emit ItemCompleted (fake success). The classifier
+     * owns it now so the drop is honest (OutboxItemDropped).
+     */
+    @Test
+    fun cannotTransferToYourselfIsPermanent() {
+        assertNotNull(
+            classifyPermanentFailure(
+                clientException(message = "Cannot transfer to yourself: frodo.dotyou.cloud")
+            )
+        )
+    }
+
+    // ---- retryable: must return null ----
+
+    @Test
+    fun genericServerErrorIsRetryable() {
+        assertNull(
+            classifyPermanentFailure(
+                clientException(status = 500, message = "Internal server error")
+            )
+        )
+    }
+
+    @Test
+    fun unmatchedBadRequestIsRetryable() {
+        assertNull(
+            classifyPermanentFailure(
+                clientException(message = "Some transient condition the server reports as 400")
+            )
+        )
+    }
+
+    @Test
+    fun plainExceptionIsRetryable() {
+        assertNull(classifyPermanentFailure(Exception("network blip")))
+    }
+}

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSyncTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSyncTest.kt
@@ -6,9 +6,12 @@ import id.homebase.api.client.eventbus.EventBus
 import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.update
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -29,6 +32,7 @@ import id.homebase.api.client.ClientException
 import id.homebase.api.client.NotFoundException
 import id.homebase.api.client.OdinClientErrorCode
 import id.homebase.api.client.ProblemDetails
+import id.homebase.api.client.drives.files.DriveOutboxUploader
 
 class TestUploader : OutboxUploader {
     var shouldFail = false
@@ -351,6 +355,7 @@ class OutboxSyncTest {
         assertEquals(uniqueId, dropped.uniqueId)
         assertEquals(driveId, dropped.driveId)
         assertEquals(20, dropped.attempts)
+        assertEquals("retries exhausted (20)", dropped.reason)
         sync.clearCheckout(timeoutMs = 5_000)  // drain before db.close(); see file kdoc
     }
 
@@ -433,7 +438,7 @@ class OutboxSyncTest {
                 }
             }
 
-            assertTrue(enqueued, "tryEnqueue should report success")
+            assertTrue(enqueued.enqueued, "tryEnqueue should report success")
             assertEquals(1L, db.outbox.count(), "record should be durably inserted in outbox")
 
             // Clean up — release the blocked collector so backgroundScope can finish.
@@ -456,12 +461,13 @@ class OutboxSyncTest {
      * `ChatMessageSenderService.updateMessage` re-threw as `IllegalStateException: Failed to
      * update chat message`, which surfaced as a user-visible toast on every retry attempt.
      *
-     * Contract under test: `tryEnqueue` on a duplicate `(driveId, uniqueId)` reports failure
-     * (doesn't throw) and leaves the original row untouched. Callers that want the new request
-     * to supersede the old one must use `replaceEnqueue`.
+     * Contract under test: `tryEnqueue` on a duplicate `(driveId, uniqueId)` reports
+     * [EnqueueResult.AlreadyQueued] (doesn't throw) and leaves the original row untouched —
+     * distinguishable from a real DB failure ([EnqueueResult.Failed]). Callers that want the
+     * new request to supersede the old one must use `replaceEnqueue`.
      */
     @Test
-    fun testTryEnqueueDuplicateReturnsFalseAndKeepsOriginal() = runOutboxTest { db ->
+    fun testTryEnqueueDuplicateReturnsAlreadyQueuedAndKeepsOriginal() = runOutboxTest { db ->
         val eventBus = EventBus()
         val uploader = TestUploader()
         val sync = OutboxSync(
@@ -471,7 +477,7 @@ class OutboxSyncTest {
         val driveId = Uuid.random()
         val uniqueId = Uuid.random()
 
-        val firstOk = sync.tryEnqueue(
+        val first = sync.tryEnqueue(
             driveId = driveId,
             uniqueId = uniqueId,
             dependencyUniqueId = null,
@@ -479,10 +485,11 @@ class OutboxSyncTest {
             uploadType = 2, // UpdateFile
             json = "original"
         )
-        assertTrue(firstOk, "first enqueue should succeed")
+        assertEquals(EnqueueResult.Enqueued, first, "first enqueue should succeed")
+        assertTrue(first.enqueued)
         assertEquals(1L, db.outbox.count())
 
-        val secondOk = sync.tryEnqueue(
+        val second = sync.tryEnqueue(
             driveId = driveId,
             uniqueId = uniqueId,
             dependencyUniqueId = null,
@@ -490,12 +497,60 @@ class OutboxSyncTest {
             uploadType = 2,
             json = "superseding"
         )
-        assertFalse(secondOk, "duplicate tryEnqueue should report failure, not throw")
+        assertEquals(
+            EnqueueResult.AlreadyQueued, second,
+            "duplicate tryEnqueue must report AlreadyQueued — not throw, and not a generic failure"
+        )
+        assertFalse(second.enqueued)
         assertEquals(1L, db.outbox.count(), "original row must remain")
 
         val row = db.outbox.checkout()
         assertNotNull(row)
         assertEquals("original", row.json.decodeToString(), "original row's payload must be preserved")
+        sync.clearCheckout(timeoutMs = 5_000)  // drain before db.close(); see file kdoc
+    }
+
+    /**
+     * The strand guard in `replaceEnqueue` (see `wouldStrandPendingCreate`) must be
+     * distinguishable from a DB failure: replacing a pending UploadNewFile with an
+     * UpdateFile is refused with [EnqueueResult.WouldStrandCreate] and the queued
+     * create stays untouched.
+     */
+    @Test
+    fun testReplaceEnqueueRefusesToStrandPendingCreate() = runOutboxTest { db ->
+        val eventBus = EventBus()
+        val uploader = TestUploader()
+        val sync = OutboxSync(
+            databaseManager = db, uploader = uploader, eventBus = eventBus, scope = backgroundScope
+        )
+
+        val driveId = Uuid.random()
+        val uniqueId = Uuid.random()
+
+        val create = sync.tryEnqueue(
+            driveId = driveId,
+            uniqueId = uniqueId,
+            dependencyUniqueId = null,
+            priority = 1,
+            uploadType = DriveOutboxUploader.UploadNewFile,
+            json = "create"
+        )
+        assertTrue(create.enqueued)
+
+        val result = sync.replaceEnqueue(
+            driveId = driveId,
+            uniqueId = uniqueId,
+            dependencyUniqueId = null,
+            priority = 1,
+            uploadType = DriveOutboxUploader.UpdateFile,
+            json = "edit"
+        )
+        assertEquals(EnqueueResult.WouldStrandCreate, result)
+        assertEquals(1L, db.outbox.count(), "the pending create must remain")
+
+        val row = db.outbox.checkout()
+        assertNotNull(row)
+        assertEquals("create", row.json.decodeToString(), "the un-sent create must not be replaced")
         sync.clearCheckout(timeoutMs = 5_000)  // drain before db.close(); see file kdoc
     }
 
@@ -515,7 +570,7 @@ class OutboxSyncTest {
         val driveId = Uuid.random()
         val uniqueId = Uuid.random()
 
-        val firstOk = sync.tryEnqueue(
+        val first = sync.tryEnqueue(
             driveId = driveId,
             uniqueId = uniqueId,
             dependencyUniqueId = null,
@@ -523,9 +578,9 @@ class OutboxSyncTest {
             uploadType = 2,
             json = "stale"
         )
-        assertTrue(firstOk)
+        assertTrue(first.enqueued)
 
-        val replacedOk = sync.replaceEnqueue(
+        val replaced = sync.replaceEnqueue(
             driveId = driveId,
             uniqueId = uniqueId,
             dependencyUniqueId = null,
@@ -533,7 +588,7 @@ class OutboxSyncTest {
             uploadType = 2,
             json = "fresh"
         )
-        assertTrue(replacedOk, "replaceEnqueue must succeed even when a row already exists")
+        assertEquals(EnqueueResult.Enqueued, replaced, "replaceEnqueue must succeed even when a row already exists")
         assertEquals(1L, db.outbox.count(), "exactly one row should remain after replace")
 
         val row = db.outbox.checkout()
@@ -639,8 +694,10 @@ class OutboxSyncTest {
      * Regression for the actual user-reported scenario (homebase.log 2026-05-04):
      * the server collapsed `errorCode` to `UnhandledScenario` while preserving the
      * title `Mismatching version tag …`. Without a title-match fallback this loops
-     * for 20 retries / ~48h. The fallback in `isPermanentFailure` (and the
-     * symmetrical fallback in `DriveOutboxUploader.upload`) must drop on attempt 1.
+     * for 20 retries / ~48h. The fallback in `classifyPermanentFailure` must drop
+     * on attempt 1 — and the drop must be honest: no `ItemCompleted` for an
+     * update the server rejected (previously `DriveOutboxUploader.upload`
+     * swallowed this case by returning normally, faking a successful send).
      */
     @Test
     fun testPermanentFailure_MismatchingVersionTagByTitleDroppedOnFirstAttempt() = runOutboxTest { db ->
@@ -656,8 +713,15 @@ class OutboxSyncTest {
         )
         sync.setOnline(true)
 
-        val droppedDeferred = async {
-            eventBus.events.filterIsInstance<BackendEvent.OutboxEvent.OutboxItemDropped>().first()
+        // Collect ALL outbox events so we can assert what was NOT emitted; await
+        // the terminal `Completed` before asserting (see class KDoc — a bare
+        // advanceUntilIdle() can return before the worker drains).
+        val events = mutableListOf<BackendEvent.OutboxEvent>()
+        val collectorJob = backgroundScope.launch {
+            eventBus.events.filterIsInstance<BackendEvent.OutboxEvent>().collect { events.add(it) }
+        }
+        val completedDeferred = async {
+            eventBus.events.filterIsInstance<BackendEvent.OutboxEvent.Completed>().first()
         }
         testScheduler.runCurrent()
 
@@ -676,11 +740,101 @@ class OutboxSyncTest {
         try { sync.send() } catch (_: Exception) {}
         advanceUntilIdle()
 
-        val dropped = droppedDeferred.await()
+        completedDeferred.await()
+        advanceUntilIdle() // let the list collector drain anything still buffered
+
+        val dropped = events.filterIsInstance<BackendEvent.OutboxEvent.OutboxItemDropped>().single()
 
         assertEquals(0L, db.outbox.count())
         assertEquals(uniqueId, dropped.uniqueId)
         assertEquals(1, dropped.attempts)
+        assertTrue(
+            events.filterIsInstance<BackendEvent.OutboxEvent.ItemCompleted>().isEmpty(),
+            "a dropped item must NOT be reported as completed",
+        )
+
+        collectorJob.cancel()
+        sync.clearCheckout(timeoutMs = 5_000)  // drain before db.close(); see file kdoc
+    }
+
+    /**
+     * Honest-drop contract for the self-recipient rejection: "Cannot transfer
+     * to yourself" is a terminal 400 (the recipient list contains the
+     * logged-in identity; the server rejects it forever).
+     *
+     * Previously this case was swallowed inside `DriveOutboxUploader.upload`
+     * by returning normally — OutboxSync then took the success path and
+     * emitted `ItemCompleted`, so the chat bubble showed *sent* for a message
+     * that never reached the server. The classification now lives in
+     * `classifyPermanentFailure` and the drop must be honest: row deleted on
+     * attempt 1, `OutboxItemDropped` emitted, NO `ItemCompleted`, and the
+     * final `Completed` batch event counts 0 sent items.
+     */
+    @Test
+    fun testPermanentFailure_CannotTransferToYourselfDropsHonestly() = runOutboxTest { db ->
+        val eventBus = EventBus()
+        val uploader = TestUploader()
+        uploader.failureException = clientException(
+            errorCode = OdinClientErrorCode.UnhandledScenario,
+            message = "Cannot transfer to yourself: frodo.dotyou.cloud",
+        )
+
+        val sync = OutboxSync(
+            databaseManager = db, uploader = uploader, eventBus = eventBus, scope = backgroundScope
+        )
+        sync.setOnline(true)
+
+        // Collect ALL outbox events so we can assert what was NOT emitted.
+        // `advanceUntilIdle()` alone is not enough to drain the worker (see the
+        // class KDoc) — the established pattern in this file is to await the
+        // terminal `Completed` event (emitted when the last worker exits)
+        // before asserting.
+        val events = mutableListOf<BackendEvent.OutboxEvent>()
+        val collectorJob = backgroundScope.launch {
+            eventBus.events.filterIsInstance<BackendEvent.OutboxEvent>().collect { events.add(it) }
+        }
+        val completedDeferred = async {
+            eventBus.events.filterIsInstance<BackendEvent.OutboxEvent.Completed>().first()
+        }
+        testScheduler.runCurrent()
+
+        val driveId = Uuid.random()
+        val uniqueId = Uuid.random()
+        db.outbox.insert(
+            driveId = driveId,
+            uniqueId = uniqueId,
+            dependencyUniqueId = null,
+            priority = 0,
+            uploadType = 0,
+            json = byteArrayOf(),
+            filePaths = null,
+        )
+
+        try { sync.send() } catch (_: Exception) {}
+        advanceUntilIdle()
+
+        val completed = completedDeferred.await()
+        advanceUntilIdle() // let the list collector drain anything still buffered
+
+        assertEquals(0L, db.outbox.count(), "row must be dropped on first attempt")
+
+        val dropped = events.filterIsInstance<BackendEvent.OutboxEvent.OutboxItemDropped>().single()
+        assertEquals(uniqueId, dropped.uniqueId)
+        assertEquals(driveId, dropped.driveId)
+        assertEquals(1, dropped.attempts, "drop must happen on attempt 1, not after MAX_RETRIES")
+        assertNotNull(dropped.reason, "a permanent drop must carry its classifier reason")
+        assertTrue(
+            dropped.reason!!.contains("Cannot transfer to yourself"),
+            "reason should surface the server message; was: ${dropped.reason}",
+        )
+
+        assertTrue(
+            events.filterIsInstance<BackendEvent.OutboxEvent.ItemCompleted>().isEmpty(),
+            "a dropped item must NOT be reported as completed — that's the fake-success bug",
+        )
+        assertEquals(0, completed.totalCount, "nothing was sent, so the batch count must be 0")
+
+        collectorJob.cancel()
         sync.clearCheckout(timeoutMs = 5_000)  // drain before db.close(); see file kdoc
     }
 
@@ -856,6 +1010,84 @@ class OutboxSyncTest {
                     "stays in outbox only as long as the head exists"
         )
         sync.clearCheckout(timeoutMs = 5_000)  // drain before db.close(); see file kdoc
+    }
+
+    /**
+     * Cancelling the outbox scope mid-upload (logout, shutdown) must NOT be
+     * recorded as a failed attempt: no `ItemFailed`/`Failed`/`OutboxItemDropped`
+     * events, no `checkInFailed` (checkOutCount stays 0). The row stays checked
+     * out and is recovered by the next start's `clearCheckedOut` — exactly like
+     * an app kill. Locks in the CancellationException rethrow at the top of
+     * `outboxSend`'s catch.
+     */
+    @Test
+    fun testScopeCancellationMidUploadIsNotAFailedAttempt() = runOutboxTest { db ->
+        val eventBus = EventBus()
+        // A dedicated, cancellable scope on the same virtual scheduler.
+        val workerScope = CoroutineScope(StandardTestDispatcher(testScheduler) + Job())
+
+        val uploadStarted = CompletableDeferred<Unit>()
+        val uploader = object : OutboxUploader {
+            override suspend fun upload(outboxRecord: Outbox, eventBus: EventBus) {
+                uploadStarted.complete(Unit)
+                kotlinx.coroutines.delay(600_000) // parked until the scope is cancelled
+                error("unreachable — upload should have been cancelled")
+            }
+        }
+
+        val sync = OutboxSync(
+            databaseManager = db, uploader = uploader, eventBus = eventBus, scope = workerScope
+        )
+        sync.setOnline(true)
+
+        val events = mutableListOf<BackendEvent.OutboxEvent>()
+        val collectorJob = backgroundScope.launch {
+            eventBus.events.filterIsInstance<BackendEvent.OutboxEvent>().collect { events.add(it) }
+        }
+        testScheduler.runCurrent()
+
+        val driveId = Uuid.random()
+        val uniqueId = Uuid.random()
+        db.outbox.insert(
+            driveId = driveId,
+            uniqueId = uniqueId,
+            dependencyUniqueId = null,
+            priority = 0,
+            uploadType = 0,
+            json = byteArrayOf(),
+            filePaths = null,
+        )
+
+        sync.send()
+        uploadStarted.await() // upload is now parked inside delay()
+
+        workerScope.cancel()
+        advanceUntilIdle()
+
+        assertTrue(
+            events.filterIsInstance<BackendEvent.OutboxEvent.ItemFailed>().isEmpty(),
+            "cancellation must not be reported as an upload failure",
+        )
+        assertTrue(
+            events.filterIsInstance<BackendEvent.OutboxEvent.Failed>().isEmpty(),
+            "cancellation must not be reported as an upload failure",
+        )
+        assertTrue(
+            events.filterIsInstance<BackendEvent.OutboxEvent.OutboxItemDropped>().isEmpty(),
+            "cancellation must never drop the row",
+        )
+
+        val row = db.outbox.selectByDriveAndUnique(driveId, uniqueId)
+        assertNotNull(row, "row must survive cancellation")
+        assertEquals(0L, row.checkOutCount, "cancellation must not count as a failed attempt")
+        assertNotNull(
+            row.checkOutStamp,
+            "row stays checked out — the next start's clearCheckedOut recovers it",
+        )
+
+        collectorJob.cancel()
+        // No sync.clearCheckout() here: the worker scope is dead, so activeThreads
+        // never decremented — clearCheckout would just spin to its timeout.
     }
 
     @Test

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
@@ -16,6 +16,7 @@ import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.OutboxSync
+import id.homebase.api.sync.database.enqueued
 import id.homebase.chat.data.MessageUiModel
 import id.homebase.chat.services.outbox.OptimisticWriter
 import id.homebase.api.client.drives.files.reactions.ReactionContent
@@ -120,16 +121,21 @@ class ChatMessageActionService(
         // Note-to-Self / all-self-authored views, we skip the outbox but still advance local state.
         val enqueued = if (unreadRecords.isNotEmpty()) {
             val fileIds = unreadRecords.map { it.fileId }
-            val ok = outboxSync.tryEnqueue(
+            val result = outboxSync.tryEnqueue(
                 request = SendReadReceiptByFileIdsOutboxRequest(
                     driveId = chatDrive,
                     fileIds = fileIds,
                 )
             )
             Logger.d(tag = TAG) {
-                "enqueue receipt: enqueued=$ok drive=$chatDrive fileIdsCount=${fileIds.size}"
+                "enqueue receipt: result=$result drive=$chatDrive fileIdsCount=${fileIds.size}"
             }
-            ok
+            if (!result.enqueued) {
+                Logger.w(tag = TAG) {
+                    "outbox.tryEnqueue → $result — skipped DB upsert + enrich; convo=$conversationId"
+                }
+            }
+            result.enqueued
         } else {
             Logger.d(tag = TAG) {
                 "no receipt-eligible records — skipping outbox; advancing local read state only"
@@ -138,9 +144,6 @@ class ChatMessageActionService(
         }
 
         if (!enqueued) {
-            Logger.w(tag = TAG) {
-                "outbox.tryEnqueue returned false — skipped DB upsert + enrich; convo=$conversationId"
-            }
             return
         }
 
@@ -243,7 +246,7 @@ class ChatMessageActionService(
         if (original == null) return ToggleReactionResult(resultType = resultType)
 
         try {
-            val enqueued = outboxSync.tryEnqueue(
+            val result = outboxSync.tryEnqueue(
                 request = ToggleReactionOutboxRequest(
                     driveId = chatDrive,
                     fileId = original.fileId,
@@ -251,7 +254,8 @@ class ChatMessageActionService(
                     recipients = getRecipients(conversationId),
                 )
             )
-            if (!enqueued) {
+            if (!result.enqueued) {
+                Logger.w("toggleReaction: outbox enqueue → $result — rolling back optimistic write")
                 optimisticWriter.rollbackWrite(chatDrive, original)
             }
         } catch (t: Throwable) {
@@ -316,7 +320,7 @@ class ChatMessageActionService(
         val original = optimisticWriter.writeDelete(chatDrive, messageId)
 
         try {
-            val enqueued = outboxSync.tryEnqueue(
+            val result = outboxSync.tryEnqueue(
                 request = DeleteLocalFilesByFileIdRequest(
                     driveId = chatDrive,
                     fileIds = listOf(fileId),
@@ -324,7 +328,8 @@ class ChatMessageActionService(
                     hardDelete = hardDelete,
                 )
             )
-            if (!enqueued && original != null) {
+            if (!result.enqueued && original != null) {
+                Logger.w("deleteMessage: outbox enqueue → $result — rolling back optimistic write")
                 optimisticWriter.rollbackWrite(chatDrive, original)
             }
         } catch (t: Throwable) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
@@ -27,6 +27,7 @@ import id.homebase.api.crypto.ByteArrayUtil
 import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.OutboxSync
+import id.homebase.api.sync.database.enqueued
 import id.homebase.chat.data.ConversationState
 import id.homebase.chat.data.MessageUiModel
 import id.homebase.chat.services.chat.ChatMessageSizer
@@ -311,8 +312,8 @@ class ChatMessageSenderService(
             dependencyUniqueId = effectiveDep,
         )
 
-        if (!enqueued) {
-            error("Failed to send chat message")
+        if (!enqueued.enqueued) {
+            error("Failed to send chat message (outbox: $enqueued)")
         }
         // Record this message as the new chain tail for the conversation. Done after
         // a successful enqueue so a failure doesn't leave a dangling pointer that
@@ -494,7 +495,7 @@ class ChatMessageSenderService(
                 encryptedOverflowPayloads = encryptedOverflow
             )
             val enqueued = outboxSync.replaceEnqueue(amended, priority = 1, dependencyUniqueId = null)
-            if (!enqueued) error("Failed to update chat message")
+            if (!enqueued.enqueued) error("Failed to update chat message (outbox: $enqueued)")
             optimisticWriter.writeUpdate(
                 driveId = chatDrive,
                 keyHeader = createKey,
@@ -572,8 +573,8 @@ class ChatMessageSenderService(
                 dependencyUniqueId = null,
             )
 
-            if (!enqueued) {
-                error("Failed to update chat message")
+            if (!enqueued.enqueued) {
+                error("Failed to update chat message (outbox: $enqueued)")
             }
 
             optimisticWriter.writeUpdate(
@@ -765,7 +766,7 @@ class ChatMessageSenderService(
             thumbnails = recovered.thumbnails,
         )
         val enqueued = outboxSync.tryEnqueue(request, priority = 1, dependencyUniqueId = null)
-        if (!enqueued) return ResendOutcome.Failed(IllegalStateException("outbox refused the retry create"))
+        if (!enqueued.enqueued) return ResendOutcome.Failed(IllegalStateException("outbox refused the retry create: $enqueued"))
         return ResendOutcome.EnqueuedCreate
     }
 
@@ -818,7 +819,7 @@ class ChatMessageSenderService(
             thumbnails = recovered.thumbnails,
         )
         val enqueued = outboxSync.replaceEnqueue(request, priority = 1, dependencyUniqueId = null)
-        if (!enqueued) return ResendOutcome.Failed(IllegalStateException("outbox refused the retry update"))
+        if (!enqueued.enqueued) return ResendOutcome.Failed(IllegalStateException("outbox refused the retry update: $enqueued"))
         return ResendOutcome.EnqueuedUpdate
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -32,6 +32,7 @@ import id.homebase.api.sync.DriveSyncManager
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.QueryBatch
 import id.homebase.api.sync.database.OutboxSync
+import id.homebase.api.sync.database.enqueued
 import id.homebase.api.toBase64
 import id.homebase.chat.data.ConversationState
 import id.homebase.chat.data.ConversationUiModel
@@ -501,12 +502,12 @@ class ConversationService(
             }
         audit.step(3, "outboxSync.tryEnqueue(UploadFileRequest)")
         val enqueued = outboxSync.tryEnqueue(request)
-        audit.info("STEP 3 returned enqueued=$enqueued")
-        audit.check("outboxEnqueue", enqueued, "outboxSync.tryEnqueue returned false — file will not be uploaded; conversation creation effectively failed")
+        audit.info("STEP 3 returned $enqueued")
+        audit.check("outboxEnqueue", enqueued.enqueued, "outboxSync.tryEnqueue → $enqueued — file will not be uploaded; conversation creation effectively failed")
         val outboxAfter = dbm.outbox.count()
         audit.post("counts: outboxRows=$outboxAfter (delta=${outboxAfter - outboxBefore}, expected ≥+1 if enqueue succeeded)")
         audit.finish("returned $enqueued")
-        return enqueued
+        return enqueued.enqueued
         // ---- end DEBUG ----
     }
 
@@ -1352,14 +1353,14 @@ class ConversationService(
         // ---- end DEBUG ----
         val enqueued = outboxSync.replaceEnqueue(request, dependencyUniqueId = dependencyUniqueId)
         // ---- DEBUG instrumentation ----
-        audit.info("STEP 1 returned enqueued=$enqueued")
-        audit.check("replaceEnqueue", enqueued, "outboxSync.replaceEnqueue returned false — update will not happen")
-        if (!enqueued) {
-            audit.finish("ABORTED — replaceEnqueue false")
+        audit.info("STEP 1 returned $enqueued")
+        audit.check("replaceEnqueue", enqueued.enqueued, "outboxSync.replaceEnqueue → $enqueued — update will not happen")
+        if (!enqueued.enqueued) {
+            audit.finish("ABORTED — replaceEnqueue $enqueued")
         }
         // ---- end DEBUG ----
-        if (!enqueued) {
-            error("Failed to update conversation")
+        if (!enqueued.enqueued) {
+            error("Failed to update conversation (outbox: $enqueued)")
         }
         // ---- DEBUG instrumentation: POST verification ----
         val postFile = getConversationHomebaseFile(conversationId)
@@ -1966,8 +1967,8 @@ class ConversationService(
             )
         }
         step1.onSuccess { result ->
-            audit.info("STEP 1 returned enqueued=$result")
-            if (result == false) audit.checkFail("step1Enqueue", "tryEnqueue returned false — UNIQUE(driveId, uniqueId) collision; server-side delete will NOT happen this attempt") else audit.checkPass("step1Enqueue")
+            audit.info("STEP 1 returned $result")
+            if (!result.enqueued) audit.checkFail("step1Enqueue", "tryEnqueue → $result — server-side delete will NOT happen this attempt") else audit.checkPass("step1Enqueue")
         }.onFailure { e ->
             audit.threw("step1Enqueue", e)
             audit.finish("ABORTED at STEP 1")
@@ -2047,7 +2048,7 @@ class ConversationService(
         )
         // ---- DEBUG instrumentation ----
         audit.info("tryEnqueue returned $enqueued")
-        audit.check("enqueue", enqueued, "tryEnqueue returned false — UNIQUE(driveId, uniqueId) collision; clear NOT performed")
+        audit.check("enqueue", enqueued.enqueued, "tryEnqueue → $enqueued — clear NOT performed")
         val outboxAfter = dbm.outbox.count()
         audit.post("counts: outboxRows=$outboxAfter (delta=${outboxAfter - outboxBefore}, expected ≥+1)")
         audit.finish()
@@ -2106,8 +2107,8 @@ class ConversationService(
             uniqueId = Uuid.random(),
             dependencyUniqueId = dependencyUniqueId
         )
-        audit.info("STEP 2 returned enqueued=$enqueued")
-        audit.check("step2Enqueue", enqueued, "tryEnqueue returned false — server-side tags update will NOT happen")
+        audit.info("STEP 2 returned $enqueued")
+        audit.check("step2Enqueue", enqueued.enqueued, "tryEnqueue → $enqueued — server-side tags update will NOT happen")
 
         // POST verify the optimistic write applied
         val postFile = getConversationHomebaseFile(conversationId)
@@ -2236,8 +2237,8 @@ class ConversationService(
         // parallel — but it removes the local-outbox half of the race, which is the
         // half we control.
         val enqueued = outboxSync.tryEnqueue(request, dependencyUniqueId = conversationId)
-        if (!enqueued) {
-            Logger.w { "uploadAdminFile: outbox enqueue returned false for $conversationId — likely UNIQUE conflict on adminUniqueId=$adminUniqueId; the file was NOT scheduled for upload" }
+        if (!enqueued.enqueued) {
+            Logger.w { "uploadAdminFile: outbox enqueue → $enqueued for $conversationId (adminUniqueId=$adminUniqueId); the file was NOT scheduled for upload" }
         } else {
             Logger.d { "uploadAdminFile: enqueued upload for adminUniqueId=$adminUniqueId dependencyUniqueId=$conversationId" }
         }
@@ -2334,8 +2335,8 @@ class ConversationService(
         // file is benign: the conversation file's outbox row, if any, drains first,
         // otherwise the dependency resolves immediately.
         val enqueued = outboxSync.tryEnqueue(request, dependencyUniqueId = conversationId)
-        if (!enqueued) {
-            Logger.w { "updateAdminFile: outbox enqueue returned false for $conversationId — likely UNIQUE conflict on adminUniqueId=$adminUniqueId (something already pending); the update was NOT scheduled" }
+        if (!enqueued.enqueued) {
+            Logger.w { "updateAdminFile: outbox enqueue → $enqueued for $conversationId (adminUniqueId=$adminUniqueId); the update was NOT scheduled" }
         } else {
             Logger.d { "updateAdminFile: enqueued update for adminUniqueId=$adminUniqueId versionTag=${existingFile.fileMetadata.versionTag} dependencyUniqueId=$conversationId" }
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/GroupHealService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/GroupHealService.kt
@@ -7,6 +7,7 @@ import id.homebase.api.client.drives.files.DeleteLocalFilesByFileIdRequest
 import id.homebase.api.common.OdinId
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.OutboxSync
+import id.homebase.api.sync.database.enqueued
 import id.homebase.chat.data.ConversationState
 import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.GroupHealCleanupInfo
@@ -464,8 +465,8 @@ class GroupHealService(
                 )
             )
         }.onSuccess { enqueued ->
-            if (enqueued) audit.checkPass("healMsgSoftDeleteEnqueue")
-            else audit.checkWarn("healMsgSoftDeleteEnqueue", "tryEnqueue returned false")
+            if (enqueued.enqueued) audit.checkPass("healMsgSoftDeleteEnqueue")
+            else audit.checkWarn("healMsgSoftDeleteEnqueue", "tryEnqueue → $enqueued")
         }.onFailure { e -> audit.threw("healMsgSoftDeleteEnqueue", e) }
 
         val mainFile = convoOps.getConversationHomebaseFile(info.conversationUniqueId)
@@ -562,7 +563,7 @@ class GroupHealService(
                 )
             }.onSuccess { enqueued ->
                 audit.info("STEP 1 enqueued=$enqueued")
-                if (enqueued) audit.checkPass("hardDeleteEnqueue") else audit.checkWarn("hardDeleteEnqueue", "tryEnqueue returned false (UNIQUE collision)")
+                if (enqueued.enqueued) audit.checkPass("hardDeleteEnqueue") else audit.checkWarn("hardDeleteEnqueue", "tryEnqueue → $enqueued")
             }.onFailure { e -> audit.threw("hardDeleteEnqueue", e) }
         } else {
             audit.info("STEP 1 SKIPPED — no broken local files to hard-delete (mainMissing=$mainMissing adminMissing=$adminMissing)")
@@ -735,8 +736,8 @@ class GroupHealService(
                 )
             )
         }.onSuccess { enqueued ->
-            if (enqueued) audit.checkPass("healMsgHardDeleteEnqueue")
-            else audit.checkWarn("healMsgHardDeleteEnqueue", "tryEnqueue returned false")
+            if (enqueued.enqueued) audit.checkPass("healMsgHardDeleteEnqueue")
+            else audit.checkWarn("healMsgHardDeleteEnqueue", "tryEnqueue → $enqueued")
         }.onFailure { e -> audit.threw("healMsgHardDeleteEnqueue", e) }
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/sticker/StickerService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/sticker/StickerService.kt
@@ -19,6 +19,7 @@ import id.homebase.api.image.convertHeicToJpeg
 import id.homebase.api.lib.image.ImageFormatDetector
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.OutboxSync
+import id.homebase.api.sync.database.enqueued
 import id.homebase.chat.services.PayloadBundle
 import id.homebase.chat.services.PayloadBundleEncryptionService
 import id.homebase.chat.services.builder.MessageThumbnailGenerator
@@ -171,7 +172,7 @@ class StickerService(
             )
 
             val enqueued = outboxSync.tryEnqueue(request)
-            if (!enqueued) return null
+            if (!enqueued.enqueued) return null
 
             // Optimistic local write + in-memory insert so the tray shows the sticker
             // immediately, before the outbox round-trips. The real fileId is assigned by
@@ -261,7 +262,7 @@ class StickerService(
                     driveId = driveId,
                     fileIds = listOf(sticker.fileId),
                 ),
-            )
+            ).enqueued
         } catch (e: Exception) {
             Logger.e(e, TAG) { "Failed to enqueue sticker delete: ${sticker.uniqueId}" }
             false

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -90,6 +90,7 @@ import id.homebase.core.moments.services.MomentsPostSenderService
 import id.homebase.core.moments.services.MomentsRecipientLookupService
 import id.homebase.core.moments.services.MomentsVideoSession
 import id.homebase.api.sync.database.OutboxSync
+import id.homebase.api.sync.database.enqueued
 import id.homebase.core.config.momentsLabeledDrive
 import id.homebase.core.moments.services.MomentsUserStateStore
 import id.homebase.core.sync.DriveRegistry
@@ -168,7 +169,7 @@ val appModule = module {
                     content = content,
                 )
             },
-            enqueueOutbox = { request -> outboxSync.tryEnqueue(request) },
+            enqueueOutbox = { request -> outboxSync.tryEnqueue(request).enqueued },
             eventBus = get(),
             scope = get(),
         )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentActionService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentActionService.kt
@@ -15,6 +15,7 @@ import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.OutboxSync
+import id.homebase.api.sync.database.enqueued
 import id.homebase.chat.services.outbox.OptimisticWriter
 import id.homebase.core.config.momentsLabeledDrive
 import id.homebase.core.widget.EmojiReaction
@@ -126,7 +127,8 @@ class MomentActionService(
                     recipients = recipients,
                 ),
             )
-            if (!enqueued) {
+            if (!enqueued.enqueued) {
+                Logger.w(tag = TAG) { "outbox enqueue -> $enqueued; rolling back optimistic write" }
                 optimisticWriter.rollbackWrite(drive, original)
             }
         } catch (t: Throwable) {
@@ -212,7 +214,8 @@ class MomentActionService(
                     hardDelete = false,
                 ),
             )
-            if (!enqueued) {
+            if (!enqueued.enqueued) {
+                Logger.w(tag = TAG) { "outbox enqueue -> $enqueued; rolling back optimistic write" }
                 optimisticWriter.rollbackWrite(drive, original)
             }
         } catch (t: Throwable) {
@@ -245,7 +248,8 @@ class MomentActionService(
                     hardDelete = false,
                 ),
             )
-            if (!enqueued) {
+            if (!enqueued.enqueued) {
+                Logger.w(tag = TAG) { "outbox enqueue -> $enqueued; rolling back optimistic write" }
                 optimisticWriter.rollbackWrite(drive, original)
             }
         } catch (t: Throwable) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentGroupService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentGroupService.kt
@@ -24,6 +24,7 @@ import id.homebase.api.crypto.ByteArrayUtil
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.OutboxSync
+import id.homebase.api.sync.database.enqueued
 import id.homebase.api.sync.database.QueryBatch
 import id.homebase.chat.services.outbox.OptimisticWriter
 import id.homebase.core.config.momentsLabeledDrive
@@ -123,8 +124,9 @@ class MomentGroupService(
             thumbnails = emptyList(),
         )
 
-        if (!outboxSync.tryEnqueue(request, priority = 1, dependencyUniqueId = null)) {
-            error("Failed to enqueue group create")
+        val createResult = outboxSync.tryEnqueue(request, priority = 1, dependencyUniqueId = null)
+        if (!createResult.enqueued) {
+            error("Failed to enqueue group create (outbox: $createResult)")
         }
 
         try {
@@ -207,8 +209,9 @@ class MomentGroupService(
             thumbnails = emptyList(),
         )
 
-        if (!outboxSync.replaceEnqueue(request, priority = 1, dependencyUniqueId = null)) {
-            error("Failed to enqueue group update")
+        val updateResult = outboxSync.replaceEnqueue(request, priority = 1, dependencyUniqueId = null)
+        if (!updateResult.enqueued) {
+            error("Failed to enqueue group update (outbox: $updateResult)")
         }
 
         try {
@@ -274,8 +277,9 @@ class MomentGroupService(
             payloads = emptyList(),
             thumbnails = emptyList(),
         )
-        if (!outboxSync.tryEnqueue(noticeRequest, priority = 1, dependencyUniqueId = null)) {
-            error("Failed to enqueue group leave notice")
+        val noticeResult = outboxSync.tryEnqueue(noticeRequest, priority = 1, dependencyUniqueId = null)
+        if (!noticeResult.enqueued) {
+            error("Failed to enqueue group leave notice (outbox: $noticeResult)")
         }
 
         // Local-only soft-delete of the group file; the leaver's `groups`

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentsPostSenderService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentsPostSenderService.kt
@@ -31,6 +31,7 @@ import id.homebase.api.image.ImageUtils
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.OutboxSync
+import id.homebase.api.sync.database.enqueued
 import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.PayloadBundleEncryptor
 import id.homebase.chat.services.builder.AttachmentInput
@@ -367,14 +368,15 @@ class MomentsPostSenderService(
                 thumbnails = encrypted.thumbnails,
             )
 
-            enqueued = outboxSync.tryEnqueue(
+            val result = outboxSync.tryEnqueue(
                 request,
                 priority = 1,
                 dependencyUniqueId = null,
             )
+            enqueued = result.enqueued
 
             if (!enqueued) {
-                error("Failed to enqueue moment for upload")
+                error("Failed to enqueue moment for upload (outbox: $result)")
             }
 
             Logger.d(tag = TAG) { "finalizeMomentSend: outbox enqueued moment=$momentUniqueId" }
@@ -550,8 +552,8 @@ class MomentsPostSenderService(
             dependencyUniqueId = null,
         )
 
-        if (!enqueued) {
-            error("Failed to enqueue moment update")
+        if (!enqueued.enqueued) {
+            error("Failed to enqueue moment update (outbox: $enqueued)")
         }
 
         Logger.d(tag = TAG) { "updateMoment: outbox enqueued moment=$momentUniqueId" }
@@ -734,8 +736,8 @@ class MomentsPostSenderService(
             dependencyUniqueId = null,
         )
 
-        if (!enqueued) {
-            error("Failed to enqueue moment recipient update")
+        if (!enqueued.enqueued) {
+            error("Failed to enqueue moment recipient update (outbox: $enqueued)")
         }
 
         Logger.d(tag = TAG) {
@@ -1013,8 +1015,8 @@ class MomentsPostSenderService(
             dependencyUniqueId = null,
         )
 
-        if (!enqueued) {
-            error("Failed to enqueue comment for upload")
+        if (!enqueued.enqueued) {
+            error("Failed to enqueue comment for upload (outbox: $enqueued)")
         }
 
         Logger.d(tag = TAG) { "postComment: outbox enqueued comment=$commentUniqueId" }
@@ -1147,8 +1149,8 @@ class MomentsPostSenderService(
             dependencyUniqueId = null,
         )
 
-        if (!enqueued) {
-            error("Failed to enqueue comment update")
+        if (!enqueued.enqueued) {
+            error("Failed to enqueue comment update (outbox: $enqueued)")
         }
 
         Logger.d(tag = TAG) { "updateComment: outbox enqueued comment=$commentUniqueId" }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationTrackUploaderService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationTrackUploaderService.kt
@@ -21,6 +21,7 @@ import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.sync.database.BufferedLocationPoint
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.OutboxSync
+import id.homebase.api.sync.database.enqueued
 import id.homebase.chat.services.PayloadBundle
 import id.homebase.chat.services.PayloadBundleEncryptionService
 import id.homebase.chat.services.outbox.OptimisticWriter
@@ -238,7 +239,7 @@ class LocationTrackUploaderService(
                 metadata = unencryptedMetadata.encryptContent(keyHeader),
                 payloads = payloads ?: emptyList(),
             )
-            val enqueued = outboxSync.replaceEnqueue(request)
+            val enqueued = outboxSync.replaceEnqueue(request).enqueued
             if (enqueued) {
                 runCatching {
                     optimisticWriter.writeNewFile(
@@ -297,7 +298,7 @@ class LocationTrackUploaderService(
             )
             // replaceEnqueue keyed on (driveId, uniqueId): successive flushes of
             // the same hour collapse to one pending upload.
-            val enqueued = outboxSync.replaceEnqueue(request)
+            val enqueued = outboxSync.replaceEnqueue(request).enqueued
             if (enqueued) {
                 runCatching {
                     optimisticWriter.writeUpdate(driveId, newKeyHeader, unencryptedMetadata)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultService.kt
@@ -19,6 +19,7 @@ import id.homebase.api.client.drives.upload.UploadFileRequest
 import id.homebase.api.crypto.ByteArrayUtil
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.OutboxSync
+import id.homebase.api.sync.database.enqueued
 import id.homebase.chat.services.outbox.OptimisticWriter
 import id.homebase.core.config.vaultLabeledDrive
 import id.homebase.core.ui.screens.vault.model.VaultEntry
@@ -60,7 +61,7 @@ class VaultService(
                 keyHeader = keyHeader,
                 metadata = unencryptedMetadata.encryptContent(keyHeader),
             )
-            val enqueued = outboxSync.tryEnqueue(request)
+            val enqueued = outboxSync.tryEnqueue(request).enqueued
             if (enqueued) {
                 try {
                     optimisticWriter.writeNewFile(
@@ -90,7 +91,7 @@ class VaultService(
                     driveId = driveId,
                     fileIds = listOf(fileId),
                 ),
-            )
+            ).enqueued
         } catch (e: Exception) {
             Logger.e(e, TAG) { "Failed to enqueue vault file delete: $uniqueId" }
             false
@@ -139,7 +140,7 @@ class VaultService(
                 payloads = payloads,
                 thumbnails = thumbnails,
             ),
-        )
+        ).enqueued
 
         if (enqueued) {
             try {
@@ -205,13 +206,13 @@ class VaultService(
                     driveId = driveId,
                     groupIds = listOf(sectionUniqueId),
                 ),
-            )
+            ).enqueued
             val sectionEnqueued = outboxSync.tryEnqueue(
                 request = DeleteLocalFilesByFileIdRequest(
                     driveId = driveId,
                     fileIds = listOf(sectionFileId),
                 ),
-            )
+            ).enqueued
             childrenEnqueued && sectionEnqueued
         } catch (e: Exception) {
             Logger.e(e, TAG) { "Failed to delete vault section: $sectionUniqueId" }
@@ -255,7 +256,7 @@ class VaultService(
                     ),
                     metadata = unencryptedMetadata.encryptContent(newKeyHeader),
                 ),
-            )
+            ).enqueued
 
             if (enqueued) {
                 try {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultUploaderService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultUploaderService.kt
@@ -21,6 +21,7 @@ import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.file.withResolvedFiles
 import id.homebase.api.image.convertHeicToJpeg
 import id.homebase.api.sync.database.OutboxSync
+import id.homebase.api.sync.database.enqueued
 import id.homebase.chat.services.LocalAttachmentContextStore
 import id.homebase.chat.services.PayloadBundle
 import id.homebase.chat.services.PayloadBundleEncryptionService
@@ -152,7 +153,7 @@ class VaultUploaderService(
                 thumbnails = encryptedBundle.thumbnails,
             )
 
-            val enqueued = outboxSync.tryEnqueue(request)
+            val enqueued = outboxSync.tryEnqueue(request).enqueued
             if (enqueued) {
                 try {
                     optimisticWriter.writeNewFile(


### PR DESCRIPTION
## What

Two ruggedness fixes for the outbox stack, from the Outbox code review.

### 1. Unified permanent-failure classification (fixes misreported delivery)

`DriveOutboxUploader.upload()` used to swallow two terminal 400s — `"Cannot transfer to yourself"` and title-matched VersionTagMismatch — by **returning normally**. `OutboxSync` then took the success path: deleted the row, incremented `totalSent`, and emitted **`ItemCompleted`** — the bubble showed *sent* for a message the server rejected.

- All classification now lives in one pure function: `classifyPermanentFailure()` in `OutboxFailureClassifier.kt` (verbatim extraction of `OutboxSync.isPermanentFailure` + the uploader's two cases; every incident comment preserved).
- The uploader **always rethrows**; terminal failures drop through the honest path: row deleted, payload temps reaped, `OutboxItemDropped` emitted.
- `OutboxItemDropped` gains an optional `reason` (classifier reason or `"retries exhausted (N)"`) for logs/Message Info.

### 2. Sealed `EnqueueResult` replaces the Boolean (fixes caller guesswork)

`tryEnqueue`/`replaceEnqueue` returned `false` for a benign UNIQUE(driveId, uniqueId) collision, the strand guard, and a real DB failure alike — audit strings literally guessed which one happened.

```kotlin
sealed interface EnqueueResult { Enqueued; AlreadyQueued; WouldStrandCreate; Failed(cause) }
val EnqueueResult.enqueued: Boolean  // == old `true`, used for the behavior-preserving migration
```

- ~30 call sites across chat/moments/vault migrated via `result.enqueued` — **no behavior change**; logs/audits now print the actual result.
- `CancellationException` is rethrown in `tryEnqueue` and the send loop instead of being recorded as a failed attempt (previously survived only by coincidence of the next suspension point).
- The 8 copy-pasted send-kick blocks collapsed into one `kickIfEnqueued()` helper.

## Deliberate behavior change

Self-transfer and title-matched VersionTagMismatch rejections now emit `OutboxItemDropped` → `ChatMessageStream` marks the message **failed with Retry** (and the Moments overlay shows permanent failure) instead of falsely showing *sent*. That is the point of fix 1.

## Tests (TDD)

- `OutboxFailureClassifierTest` — every permanent error code and message pattern, plus retryable negatives.
- `OutboxSyncTest` additions: honest-drop e2e (drop emits `OutboxItemDropped`, **never** `ItemCompleted`, `Completed(0)`), drop `reason` assertions, `AlreadyQueued` duplicate contract, `WouldStrandCreate` strand-guard contract, and scope-cancellation mid-upload (no failure events, `checkOutCount` unchanged, row recovered by `clearCheckedOut`).
- Suites green: `homebase-api`/`homebase-chat`/`homebase-common` jvmTest; compile sweep JVM + AndroidMain + WasmJs (iOS not buildable on this Linux host).

## Note for `location-app`

`LocationTrackUploaderService` (not on main) has the same two-line `.enqueued` migration pending — patch saved, to be applied when that branch merges main (the compiler will flag the two sites regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)