### PR TITLE
Outbox: cancelPending facade, in-flight cancel honesty, drop-aware location buffer

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
@@ -89,6 +89,28 @@ sealed interface EnqueueResult {
 /** True only for [EnqueueResult.Enqueued] — exactly the old Boolean `true`. */
 val EnqueueResult.enqueued: Boolean get() = this == EnqueueResult.Enqueued
 
+/**
+ * Outcome of [OutboxSync.cancelPending]. Replaces callers reaching into the
+ * raw outbox table (`selectByDriveAndUnique` + unconditional `deleteBy`) —
+ * which silently "cancelled" rows whose upload was already running.
+ */
+sealed interface CancelOutcome {
+    /** A queued `UploadNewFile` was removed — the create never reached the
+     *  server, so there is nothing to delete remotely. */
+    data object CancelledCreate : CancelOutcome
+
+    /** A queued non-create row (edit, delete, …) was removed. */
+    data object Cancelled : CancelOutcome
+
+    /** A worker currently holds the row: the upload is running and CANNOT be
+     *  stopped by deleting the row. Nothing was changed. [isCreate] tells the
+     *  caller whether the in-flight request is the file's create. */
+    data class InFlight(val isCreate: Boolean) : CancelOutcome
+
+    /** No row for (driveId, uniqueId) — already sent, dropped, or never queued. */
+    data object NothingPending : CancelOutcome
+}
+
 class OutboxSync(
     private val databaseManager: DatabaseManager,
     private val uploader: OutboxUploader,
@@ -443,6 +465,31 @@ class OutboxSync(
             isCheckedOut = row.checkOutStamp != null,
             uploadType = row.uploadType,
         )
+    }
+
+    /**
+     * Cancel the pending outbox row for (driveId, uniqueId), if any — but never
+     * a row whose upload is in flight: deleting a checked-out row doesn't stop
+     * the worker (it already read the row), it only turns the cancel into a
+     * silent lie while the request still ships. Callers branch on the returned
+     * [CancelOutcome] instead of guessing.
+     */
+    public suspend fun cancelPending(driveId: Uuid, uniqueId: Uuid): CancelOutcome {
+        val row = databaseManager.outbox.selectByDriveAndUnique(driveId, uniqueId)
+            ?: return CancelOutcome.NothingPending
+        val isCreate = row.uploadType == DriveOutboxUploader.UploadNewFile
+        if (row.checkOutStamp != null) return CancelOutcome.InFlight(isCreate)
+
+        val deleted = databaseManager.outbox.deleteByIfNotCheckedOut(driveId, uniqueId)
+        if (deleted == 0L) {
+            // Raced: between the select and the guarded delete the row was
+            // either checked out or drained. Re-read to report which.
+            val now = databaseManager.outbox.selectByDriveAndUnique(driveId, uniqueId)
+                ?: return CancelOutcome.NothingPending
+            return CancelOutcome.InFlight(now.uploadType == DriveOutboxUploader.UploadNewFile)
+        }
+        Logger.i("OutboxSync: cancelPending removed queued ${if (isCreate) "create" else "row"} uniqueId=$uniqueId")
+        return if (isCreate) CancelOutcome.CancelledCreate else CancelOutcome.Cancelled
     }
 
     /**

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxWrapper.kt
@@ -133,6 +133,18 @@ class OutboxWrapper(
         }
     }
 
+    /** Guarded cancel: deletes the row only when no worker holds it
+     *  (checkOutStamp IS NULL). Returns rows deleted — 0 means the row is
+     *  either gone or in flight; see [OutboxSync.cancelPending]. */
+    suspend fun deleteByIfNotCheckedOut(
+        driveId: Uuid,
+        uniqueId: Uuid,
+    ): Long {
+        return databaseManager.withWriteValue {
+            delegate.deleteByIfNotCheckedOut(driveId, uniqueId).value
+        }
+    }
+
     suspend fun deleteAll(): Long {
         return databaseManager.withWriteValue { delegate.deleteAll().value }
     }

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/Outbox.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/Outbox.sq
@@ -96,6 +96,15 @@ deleteBy:
 DELETE FROM Outbox
 WHERE driveId = ? AND uniqueId = ?;
 
+-- Cancel a queued row ONLY when no worker holds it. Deleting a checked-out
+-- row does NOT stop its upload (the worker already read the row) — it just
+-- makes the cancel a silent lie while the message still ships. Callers that
+-- need cancellation use this guarded form via OutboxSync.cancelPending and
+-- get an explicit InFlight answer instead.
+deleteByIfNotCheckedOut:
+DELETE FROM Outbox
+WHERE driveId = ? AND uniqueId = ? AND checkOutStamp IS NULL;
+
 
 -- Select the (single, by UNIQUE(driveId,uniqueId)) pending row for a message.
 -- Lets a caller tell a queued create apart from a queued edit before deleting.

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSyncTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSyncTest.kt
@@ -1013,6 +1013,81 @@ class OutboxSyncTest {
     }
 
     /**
+     * cancelPending contract: queued rows are removed and classified
+     * (create vs other); a missing row reports NothingPending.
+     */
+    @Test
+    fun testCancelPendingRemovesQueuedRowsAndClassifies() = runOutboxTest { db ->
+        val eventBus = EventBus()
+        val uploader = TestUploader()
+        val sync = OutboxSync(
+            databaseManager = db, uploader = uploader, eventBus = eventBus, scope = backgroundScope
+        )
+
+        val driveId = Uuid.random()
+        val createId = Uuid.random()
+        val editId = Uuid.random()
+
+        sync.tryEnqueue(
+            driveId = driveId, uniqueId = createId, dependencyUniqueId = null,
+            priority = 1, uploadType = DriveOutboxUploader.UploadNewFile, json = "create",
+        )
+        sync.tryEnqueue(
+            driveId = driveId, uniqueId = editId, dependencyUniqueId = null,
+            priority = 1, uploadType = DriveOutboxUploader.UpdateFile, json = "edit",
+        )
+        assertEquals(2L, db.outbox.count())
+
+        assertEquals(CancelOutcome.CancelledCreate, sync.cancelPending(driveId, createId))
+        assertEquals(CancelOutcome.Cancelled, sync.cancelPending(driveId, editId))
+        assertEquals(0L, db.outbox.count(), "both queued rows must be removed")
+
+        assertEquals(
+            CancelOutcome.NothingPending, sync.cancelPending(driveId, createId),
+            "a second cancel finds nothing",
+        )
+        sync.clearCheckout(timeoutMs = 5_000)  // drain before db.close(); see file kdoc
+    }
+
+    /**
+     * cancelPending must NOT delete a checked-out row: the worker already read
+     * it, so deleting it can't stop the upload — it only fakes the cancel while
+     * the request still ships (the old raw-deleteBy "ghost message" race).
+     * The row must survive untouched and the caller gets InFlight(isCreate).
+     */
+    @Test
+    fun testCancelPendingRefusesInFlightRow() = runOutboxTest { db ->
+        val eventBus = EventBus()
+        val uploader = TestUploader()
+        val sync = OutboxSync(
+            databaseManager = db, uploader = uploader, eventBus = eventBus, scope = backgroundScope
+        )
+
+        val driveId = Uuid.random()
+        val uniqueId = Uuid.random()
+        db.outbox.insert(
+            driveId = driveId,
+            uniqueId = uniqueId,
+            dependencyUniqueId = null,
+            priority = 0,
+            uploadType = DriveOutboxUploader.UploadNewFile,
+            json = byteArrayOf(),
+            filePaths = null,
+        )
+        // Simulate a worker holding the row.
+        val checkedOut = db.outbox.checkout()
+        assertNotNull(checkedOut)
+
+        val outcome = sync.cancelPending(driveId, uniqueId)
+        assertEquals(CancelOutcome.InFlight(isCreate = true), outcome)
+
+        val row = db.outbox.selectByDriveAndUnique(driveId, uniqueId)
+        assertNotNull(row, "in-flight row must survive a cancel attempt")
+        assertNotNull(row.checkOutStamp, "row must remain checked out")
+        sync.clearCheckout(timeoutMs = 5_000)  // drain before db.close(); see file kdoc
+    }
+
+    /**
      * Cancelling the outbox scope mid-upload (logout, shutdown) must NOT be
      * recorded as a failed attempt: no `ItemFailed`/`Failed`/`OutboxItemDropped`
      * events, no `checkInFailed` (checkOutCount stays 0). The row stays checked

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
@@ -5,7 +5,6 @@ import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.client.drives.files.DeleteLocalFilesByFileIdRequest
-import id.homebase.api.client.drives.files.DriveOutboxUploader
 import id.homebase.api.client.drives.files.SendReadReceiptByFileIdsOutboxRequest
 import id.homebase.api.client.drives.files.reactions.DriveFileGroupReactionProvider
 import id.homebase.api.client.drives.files.reactions.ToggleReactionOutboxRequest
@@ -14,6 +13,7 @@ import id.homebase.api.client.drives.files.reactions.ToggleReactionResultType
 import id.homebase.api.common.OdinId
 import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.sync.database.CancelOutcome
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.OutboxSync
 import id.homebase.api.sync.database.enqueued
@@ -282,18 +282,40 @@ class ChatMessageActionService(
         // server; a pending *edit* (UpdateFile) means it did. We can't use
         // msg.isPendingSend for this — an edit re-stamps isPendingSendTag, so a
         // sent-then-edited message looks "pending" yet still needs a server delete.
-        val pendingUploadType =
-            dbm.outbox.selectByDriveAndUnique(chatDrive, messageId)?.uploadType
+        // cancelPending also removes any queued *edit* here — its content is moot,
+        // and leaving it would race the server delete enqueued below.
+        when (val cancel = outboxSync.cancelPending(chatDrive, messageId)) {
+            CancelOutcome.CancelledCreate -> {
+                // Never reached the server: drop it locally. No server delete —
+                // recipients never received it, and there is no remote file to
+                // remove.
+                optimisticWriter.removeOptimisticFile(chatDrive, messageId)
+                return
+            }
 
-        if (pendingUploadType == DriveOutboxUploader.UploadNewFile) {
-            // Never reached the server: cancel the queued send and drop it
-            // locally. No server delete — recipients never received it, and there
-            // is no remote file to remove. (Narrow race: if the send confirms
-            // between the lookup and here, removeOptimisticFile self-guards on
-            // isPendingSendTag and no-ops; a second delete then takes the path
-            // below.)
-            optimisticWriter.removeOptimisticFile(chatDrive, messageId)
-            return
+            is CancelOutcome.InFlight -> {
+                if (cancel.isCreate) {
+                    // The create is uploading RIGHT NOW. It can't be stopped
+                    // (the worker already read the row) and the server-assigned
+                    // fileId isn't known yet, so neither a local cancel nor a
+                    // server delete is sound. The old unconditional cancel here
+                    // produced a ghost: the upload completed anyway and the next
+                    // sync resurrected the locally-deleted message. Refuse —
+                    // deleting again once the send confirms (a moment later)
+                    // takes the normal server-delete path below.
+                    Logger.w {
+                        "deleteMessage: create for $messageId is in flight — delete refused; retry after send confirms"
+                    }
+                    return
+                }
+                // An in-flight *edit* can't be cancelled either, but the file
+                // exists server-side, so the delete below is sound: it drains
+                // after the edit and removes the file — the same end state the
+                // old unconditional deleteBy produced (it never stopped a
+                // running edit upload anyway).
+            }
+
+            CancelOutcome.Cancelled, CancelOutcome.NothingPending -> Unit
         }
 
         val conversation = conversationService.getConversation(msg.conversationId) ?: return
@@ -311,11 +333,6 @@ class ChatMessageActionService(
         } else {
             null
         }
-
-        // Cancel any queued *edit* before deleting — its content is moot, and
-        // leaving it would race the delete against the server. No-op when nothing
-        // is queued (a normally-sent message).
-        dbm.outbox.deleteBy(chatDrive, messageId)
 
         val original = optimisticWriter.writeDelete(chatDrive, messageId)
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -31,6 +31,7 @@ import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.DriveSyncManager
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.QueryBatch
+import id.homebase.api.sync.database.EnqueueResult
 import id.homebase.api.sync.database.OutboxSync
 import id.homebase.api.sync.database.enqueued
 import id.homebase.api.toBase64
@@ -2470,10 +2471,18 @@ class ConversationService(
                     }
                     continue
                 }
-                // tryEnqueue returning false means an outbox row is already
-                // queued for this file — that row will pick up the latest
-                // localAppData when it drains, so the writeback still lands.
-                outboxSync.tryEnqueue(request)
+                // AlreadyQueued is expected and benign: the queued row picks up
+                // the latest localAppData when it drains, so the writeback still
+                // lands. A real Failed means nothing is queued — leave the
+                // conversation dirty so the next debounce flush retries instead
+                // of silently losing the writeback.
+                val result = outboxSync.tryEnqueue(request)
+                if (!result.enqueued && result != EnqueueResult.AlreadyQueued) {
+                    Logger.w(tag = "MarkAsRead") {
+                        "ConversationService.flushDirtyLastRead: enqueue → $result for convo=$id — left dirty, will retry next flush"
+                    }
+                    continue
+                }
                 // Clear dirty only if nothing advanced lastRead while we were
                 // pushing — a concurrent advance leaves it dirty so the newer
                 // value goes out next round.

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
@@ -20,8 +20,10 @@ import id.homebase.api.client.drives.upload.UploadFileMetadata
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.common.time.UnixTimeUtc
+import id.homebase.api.sync.database.CancelOutcome
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.MainIndexMetaHelpers
+import id.homebase.api.sync.database.OutboxSync
 import id.homebase.api.client.drives.upload.UpdateLocalAppdataContentOutboxRequest
 import id.homebase.api.crypto.ByteArrayUtil
 import id.homebase.api.serialization.OdinSystemSerializer
@@ -39,6 +41,7 @@ class OptimisticWriter(
     private val credentialsManager: CredentialsManager,
     private val dbm: DatabaseManager,
     private val eventBus: EventBus,
+    private val outboxSync: OutboxSync,
 ) {
     companion object {
         private const val TAG = "OptimisticWriter"
@@ -464,10 +467,9 @@ class OptimisticWriter(
             // Cancel the queued send FIRST. The create/edit row is keyed by this
             // uniqueId; leaving it would re-upload the file we're about to drop.
             // Ordered before the local delete so a failure can't leave a message
-            // that's gone locally but still queued to send. Guarded: a checked-out
-            // row is left alone and the removal aborted (see KDoc).
-            val deleted = dbm.outbox.deleteByIfNotCheckedOut(driveId, uniqueId)
-            if (deleted == 0L && dbm.outbox.selectByDriveAndUnique(driveId, uniqueId) != null) {
+            // that's gone locally but still queued to send. InFlight aborts the
+            // removal — see KDoc.
+            if (outboxSync.cancelPending(driveId, uniqueId) is CancelOutcome.InFlight) {
                 Logger.w(tag = TAG) {
                     "removeOptimisticFile: outbox row for uniqueId=$uniqueId is in flight — keeping local file"
                 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
@@ -440,26 +440,39 @@ class OptimisticWriter(
      * file without cancelling the row would still upload the message we just
      * removed (the "deleted message still gets sent" bug). Only acts while the
      * file is still pending (`isPendingSendTag`) — a no-op once the send confirms.
+     *
+     * Returns true when the local file was removed. Returns false without
+     * touching anything when the file isn't pending, or when the outbox row is
+     * **in flight**: a checked-out row's upload can't be stopped by deleting the
+     * row, so removing the local file would only create a ghost — the upload
+     * completes and the next sync resurrects the "removed" message.
      */
-    suspend fun removeOptimisticFile(driveId: Uuid, uniqueId: Uuid) {
+    suspend fun removeOptimisticFile(driveId: Uuid, uniqueId: Uuid): Boolean {
         val credentials = credentialsManager.requireActiveCredentials()
 
         val file = dbm.driveMainIndex.selectHomebaseFileByUnique(
             credentials.getIdentityId(), driveId, uniqueId
-        ) ?: return
+        ) ?: return false
 
         // Only remove files that are still pending — if the outbox already sent the message
         // the isPendingSendTag will have been removed, and we must not delete it.
         val isPending = file.fileMetadata.localAppData?.tags
             ?.contains(ChatProtocol.isPendingSendTag) == true
-        if (!isPending) return
+        if (!isPending) return false
 
         try {
             // Cancel the queued send FIRST. The create/edit row is keyed by this
             // uniqueId; leaving it would re-upload the file we're about to drop.
             // Ordered before the local delete so a failure can't leave a message
-            // that's gone locally but still queued to send.
-            dbm.outbox.deleteBy(driveId, uniqueId)
+            // that's gone locally but still queued to send. Guarded: a checked-out
+            // row is left alone and the removal aborted (see KDoc).
+            val deleted = dbm.outbox.deleteByIfNotCheckedOut(driveId, uniqueId)
+            if (deleted == 0L && dbm.outbox.selectByDriveAndUnique(driveId, uniqueId) != null) {
+                Logger.w(tag = TAG) {
+                    "removeOptimisticFile: outbox row for uniqueId=$uniqueId is in flight — keeping local file"
+                }
+                return false
+            }
             fileProcessor.deleteEntryDriveMainIndex(
                 identityId = credentials.getIdentityId(),
                 driveId = driveId,
@@ -471,8 +484,10 @@ class OptimisticWriter(
                     uniqueId = uniqueId,
                 )
             )
+            return true
         } catch (e: Exception) {
             Logger.e(throwable = e, tag = TAG) { "Optimistic remove failed for uniqueId=$uniqueId" }
+            return false
         }
     }
 

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
@@ -215,6 +215,7 @@ class ChatMessageActionServiceTestFixture(
             credentialsManager = credentialsManager,
             dbm = dbm,
             eventBus = eventBus,
+            outboxSync = outboxSync,
         )
 
         // ConversationService is a ctor-required dep even though markAsReadByFiles

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceTestFixture.kt
@@ -114,6 +114,7 @@ class ChatMessageSenderServiceTestFixture : AutoCloseable {
             credentialsManager = credentialsManager,
             dbm = dbm,
             eventBus = eventBus,
+            outboxSync = outboxSync,
         )
 
         // Real DriveFileProvider with a scriptable mock engine (default: 500s

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/DeleteMessageCancelsPendingTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/DeleteMessageCancelsPendingTest.kt
@@ -2,6 +2,7 @@ package id.homebase.chat.services
 
 import id.homebase.api.client.drives.files.DriveOutboxUploader
 import kotlin.test.Test
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.uuid.Uuid
@@ -55,6 +56,52 @@ class DeleteMessageCancelsPendingTest {
                     fixture.testIdentityId, fixture.chatDriveId, messageId,
                 ),
                 "the optimistic local file must be removed",
+            )
+        }
+    }
+
+    /**
+     * A create whose upload is IN FLIGHT (row checked out) can't be cancelled —
+     * the worker already read the row, so deleting it wouldn't stop the upload;
+     * it would only remove the local file and let the next sync resurrect the
+     * message as a ghost. deleteMessage must refuse: keep the local file, keep
+     * the row, and enqueue no server delete (the server-assigned fileId isn't
+     * known yet). A second delete after the send confirms takes the normal path.
+     */
+    @Test
+    fun delete_inFlightCreate_isRefused_nothingChanges() = runTest {
+        ChatMessageActionServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val messageId = fixture.seedDeletableMessage(
+                conversationId = Uuid.random(),
+                isPendingSend = true,
+            )
+            fixture.dbm.outbox.insert(
+                driveId = fixture.chatDriveId,
+                uniqueId = messageId,
+                dependencyUniqueId = null,
+                priority = 1L,
+                uploadType = DriveOutboxUploader.UploadNewFile,
+                json = "{}".encodeToByteArray(),
+                filePaths = null,
+            )
+            // Simulate the worker holding the row mid-upload.
+            checkNotNull(fixture.dbm.outbox.checkout())
+
+            service.deleteMessage(messageId, deleteForEveryone = true)
+
+            val row = fixture.dbm.outbox.selectByDriveAndUnique(fixture.chatDriveId, messageId)
+            assertNotNull(row, "the in-flight create row must survive")
+            assertNotNull(row.checkOutStamp, "the row must remain checked out")
+            assertNotNull(
+                fixture.dbm.driveMainIndex.selectHomebaseFileByUnique(
+                    fixture.testIdentityId, fixture.chatDriveId, messageId,
+                ),
+                "the local file must be kept — removing it would create a ghost",
+            )
+            assertTrue(
+                fixture.drainOutbox().none { it.uploadType == DriveOutboxUploader.DeleteFile },
+                "no server delete may be enqueued for a file whose fileId is not yet server-confirmed",
             )
         }
     }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceTestFixture.kt
@@ -117,7 +117,8 @@ class ConversationServiceTestFixture : AutoCloseable {
         optimisticWriter = OptimisticWriter(
             credentialsManager = credentialsManager,
             dbm = dbm,
-            eventBus = eventBus
+            eventBus = eventBus,
+            outboxSync = outboxSync,
         )
 
         return ConversationService(

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/outbox/OptimisticWriterReactionToggleTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/outbox/OptimisticWriterReactionToggleTest.kt
@@ -13,6 +13,9 @@ import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.MainIndexMetaHelpers
 import id.homebase.api.sync.database.OdinDatabase
+import id.homebase.api.sync.database.Outbox
+import id.homebase.api.sync.database.OutboxSync
+import id.homebase.api.sync.database.OutboxUploader
 import id.homebase.chat.services.ChatProtocol
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -81,6 +84,14 @@ class OptimisticWriterReactionToggleTest {
             credentialsManager = credentialsManager,
             dbm = dbm,
             eventBus = eventBus,
+            outboxSync = OutboxSync(
+                databaseManager = dbm,
+                uploader = object : OutboxUploader {
+                    override suspend fun upload(outboxRecord: Outbox, eventBus: EventBus) =
+                        error("no uploads in this test")
+                },
+                eventBus = eventBus,
+            ),
         )
     }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationTrackUploaderService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationTrackUploaderService.kt
@@ -344,25 +344,32 @@ class LocationTrackUploaderService(
 
     private suspend fun observeOutbox() {
         eventBus.events.collect { event ->
-            when (event) {
-                is BackendEvent.OutboxEvent.ItemCompleted -> {
-                    if (event.driveId != driveId) return@collect
-                    logger.i { "Hour-file upload confirmed uid=${event.uniqueId} — draining buffer rows" }
-                    runCatching { buffer.deleteByFlushUid(event.uniqueId) }
+            if (event !is BackendEvent.OutboxEvent) return@collect
+            when (bufferActionFor(event, driveId)) {
+                BufferAction.DrainFlushed -> {
+                    val uid = (event as BackendEvent.OutboxEvent.ItemCompleted).uniqueId
+                    logger.i { "Hour-file upload confirmed uid=$uid — draining buffer rows" }
+                    runCatching { buffer.deleteByFlushUid(uid) }
                         .onFailure { logger.e(it) { "deleteByFlushUid failed" } }
                     _lastFlushTime.value = Clock.System.now().toEpochMilliseconds()
                     refreshPendingCount()
                 }
 
-                is BackendEvent.OutboxEvent.ItemFailed -> {
-                    if (event.driveId != driveId) return@collect
-                    logger.w { "Hour-file upload failed for ${event.uniqueId} — rows unmarked for retry" }
-                    runCatching { buffer.clearFlushMark(event.uniqueId) }
+                BufferAction.UnmarkForRetry -> {
+                    val (uid, detail) = when (event) {
+                        is BackendEvent.OutboxEvent.ItemFailed ->
+                            event.uniqueId to "failed — will retry"
+                        is BackendEvent.OutboxEvent.OutboxItemDropped ->
+                            event.uniqueId to "permanently dropped (${event.reason ?: "no reason"}) — rows re-flush next cycle"
+                        else -> return@collect // unreachable by construction of bufferActionFor
+                    }
+                    logger.w { "Hour-file upload $detail uid=$uid — rows unmarked" }
+                    runCatching { buffer.clearFlushMark(uid) }
                         .onFailure { logger.e(it) { "clearFlushMark failed" } }
                     refreshPendingCount()
                 }
 
-                else -> {}
+                BufferAction.None -> {}
             }
         }
     }
@@ -376,4 +383,41 @@ class LocationTrackUploaderService(
         const val RETENTION_MS = 7L * 24 * HOUR_MS
         const val DAY_MS = 24 * HOUR_MS
     }
+}
+
+/** What an outbox event means for the location point buffer. */
+internal enum class BufferAction {
+    /** Hour file confirmed on the server — delete the flushed rows. */
+    DrainFlushed,
+
+    /** Upload didn't land — clear the flush mark so the next cycle re-flushes
+     *  the hour from live state (fresh request, fresh key, current points). */
+    UnmarkForRetry,
+
+    None,
+}
+
+/**
+ * Pure event → buffer-action mapping; unit-tested in LocationBufferActionTest.
+ *
+ * `OutboxItemDropped` must map to [BufferAction.UnmarkForRetry]: a permanent
+ * drop (retries exhausted, or a permanent failure such as "AES key must
+ * match") emits ONLY this event — no `ItemFailed` — so without this branch the
+ * dropped hour's rows stayed flush-marked forever: never re-flushed, never
+ * deleted, pending count silently wrong.
+ */
+internal fun bufferActionFor(
+    event: BackendEvent.OutboxEvent,
+    locationDriveId: Uuid,
+): BufferAction = when (event) {
+    is BackendEvent.OutboxEvent.ItemCompleted ->
+        if (event.driveId == locationDriveId) BufferAction.DrainFlushed else BufferAction.None
+
+    is BackendEvent.OutboxEvent.ItemFailed ->
+        if (event.driveId == locationDriveId) BufferAction.UnmarkForRetry else BufferAction.None
+
+    is BackendEvent.OutboxEvent.OutboxItemDropped ->
+        if (event.driveId == locationDriveId) BufferAction.UnmarkForRetry else BufferAction.None
+
+    else -> BufferAction.None
 }

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/LocationBufferActionTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/LocationBufferActionTest.kt
@@ -1,0 +1,84 @@
+package id.homebase.core.ui.screens.location
+
+import id.homebase.api.client.eventbus.BackendEvent
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+
+/**
+ * Locks the outbox-event → buffer-action mapping for the location uploader.
+ *
+ * Regression: `OutboxItemDropped` (permanent drop — retries exhausted or a
+ * permanent failure like "AES key must match") had NO handler, so the buffered
+ * points for that hour stayed flush-marked forever: never re-flushed, never
+ * deleted, and the pending count silently wrong. The drop path emits ONLY
+ * `OutboxItemDropped` — no `ItemFailed` — so the retry-unmark must happen on
+ * the drop event too. The next flush of that hour rebuilds the request from
+ * live state (fresh key, current points) via replaceEnqueue.
+ */
+class LocationBufferActionTest {
+
+    private val locationDrive = Uuid.random()
+    private val otherDrive = Uuid.random()
+    private val uid = Uuid.random()
+
+    @Test
+    fun itemCompletedDrainsFlushedRows() {
+        assertEquals(
+            BufferAction.DrainFlushed,
+            bufferActionFor(BackendEvent.OutboxEvent.ItemCompleted(locationDrive, uid), locationDrive),
+        )
+    }
+
+    @Test
+    fun itemFailedUnmarksForRetry() {
+        assertEquals(
+            BufferAction.UnmarkForRetry,
+            bufferActionFor(BackendEvent.OutboxEvent.ItemFailed(locationDrive, uid), locationDrive),
+        )
+    }
+
+    @Test
+    fun outboxItemDroppedUnmarksForRetry() {
+        assertEquals(
+            BufferAction.UnmarkForRetry,
+            bufferActionFor(
+                BackendEvent.OutboxEvent.OutboxItemDropped(
+                    locationDrive, uid, attempts = 20, reason = "retries exhausted (20)",
+                ),
+                locationDrive,
+            ),
+        )
+    }
+
+    @Test
+    fun otherDrivesEventsAreIgnored() {
+        assertEquals(
+            BufferAction.None,
+            bufferActionFor(BackendEvent.OutboxEvent.ItemCompleted(otherDrive, uid), locationDrive),
+        )
+        assertEquals(
+            BufferAction.None,
+            bufferActionFor(BackendEvent.OutboxEvent.ItemFailed(otherDrive, uid), locationDrive),
+        )
+        assertEquals(
+            BufferAction.None,
+            bufferActionFor(
+                BackendEvent.OutboxEvent.OutboxItemDropped(otherDrive, uid, attempts = 1),
+                locationDrive,
+            ),
+        )
+    }
+
+    @Test
+    fun unrelatedEventsAreIgnored() {
+        assertEquals(
+            BufferAction.None,
+            bufferActionFor(BackendEvent.OutboxEvent.ItemEnqueued(locationDrive, uid), locationDrive),
+        )
+        assertEquals(
+            BufferAction.None,
+            bufferActionFor(BackendEvent.OutboxEvent.Started, locationDrive),
+        )
+    }
+}


### PR DESCRIPTION
Follow-ups P1/P2/P4 from the post-#707 outbox review.

## P1 — Location buffer leaked on permanent drops (bug fix)

The drop path emits **only** `OutboxItemDropped` (no `ItemFailed`), and `LocationTrackUploaderService` had no handler for it: when an hour-file upload was permanently dropped (retries exhausted, or a permanent failure like "AES key must match"), its buffered points stayed flush-marked forever — never re-flushed, never deleted, pending count silently wrong.

- The event→buffer-action decision is now a pure function `bufferActionFor()` (same pattern as `wouldStrandPendingCreate`), locked by `LocationBufferActionTest`.
- A drop unmarks the rows; the next flush cycle rebuilds the request from live state (fresh key, current points), and the drop `reason` from #707 is logged.

## P2 — `cancelPending()` facade + guarded delete (closes the last facade bypass and the ghost-message race)

Deleting a **checked-out** outbox row never stopped its upload — the worker already read the row — it only made the cancel a silent lie while the request still shipped. New on `OutboxSync`:

```kotlin
suspend fun cancelPending(driveId, uniqueId): CancelOutcome
// CancelledCreate | Cancelled | InFlight(isCreate) | NothingPending
```

backed by a guarded `DELETE … AND checkOutStamp IS NULL` (`Outbox.sq`).

- **`ChatMessageActionService.deleteMessage`** branches on the outcome instead of reading `dbm.outbox` raw and comparing wire constants. Deliberate behavior change: deleting a message whose **create is mid-upload** is now refused with a warning. Previously it force-cancelled the row and removed the local file — the upload completed anyway and the next sync resurrected the message as a **ghost**. The server-assigned fileId isn't known mid-create, so no sound server delete exists in that window; a second delete after the send confirms (moments later) takes the normal path. An in-flight *edit* still proceeds to the server delete — identical end state to before.
- **`OptimisticWriter.removeOptimisticFile`** uses the guarded delete and now returns whether it removed; an in-flight row aborts the removal instead of manufacturing the same ghost (shared by chat delete, conversation heal, and moments undo paths — callers compile unchanged).

## P4 — `flushDirtyLastRead` acts on the `EnqueueResult` distinction

`AlreadyQueued` → clear dirty as before (the queued row picks up the latest localAppData when it drains). `Failed` → **leave the conversation dirty** so the next debounce flush retries, instead of silently losing the lastRead writeback.

## Tests

- `LocationBufferActionTest` (new): drop/fail/complete/foreign-drive/unrelated-event mapping.
- `OutboxSyncTest` additions: `cancelPending` removes + classifies queued rows; refuses an in-flight row (row survives, still checked out, `InFlight(isCreate)` reported).
- `DeleteMessageCancelsPendingTest` addition: in-flight create → delete refused, local file kept, no server delete enqueued.
- Suites green: `homebase-api`/`homebase-chat`/`homebase-core` jvmTest; compile sweep JVM + AndroidMain + WasmJs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)