### PR TITLE
retryAsUpdate: re-encrypt header-only updates with the server's key

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveOutboxUploader.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveOutboxUploader.kt
@@ -2,6 +2,9 @@ package id.homebase.api.client.drives.files
 
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.ClientException
+import id.homebase.api.client.KeyHeader
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 import id.homebase.api.client.NotFoundException
 import id.homebase.api.client.OdinClientErrorCode
 import id.homebase.api.client.drives.upload.DriveUploadProvider
@@ -159,13 +162,31 @@ class DriveOutboxUploader(
                     "recipients=${original.transitOptions?.recipients?.size ?: 0}"
         )
 
-        // original.metadata is already encrypted (encryptContent was called before
-        // the request was serialized into the outbox). Just stamp the versionTag.
-        val metadataWithVersionTag = original.metadata.copy(
-            versionTag = versionTag
+        // The server rejects an update whose AES key differs from the existing
+        // file's ("AES key must match"). When the client's key has diverged
+        // (local DB lost the key and minted a fresh one, or a replaceEnqueue
+        // superseded an in-flight create carrying a different key), re-encrypt
+        // a header-only request with the SERVER's key — the owner can always
+        // read it off the fetched header. Payload-carrying requests can't be
+        // re-keyed (bytes are pre-encrypted on disk); they fall through to the
+        // standard path and, on divergence, the server rejection drops the row
+        // (see OutboxFailureClassifier).
+        val rekeyed = rekeyedUpdateForExistingServerFile(
+            original = original,
+            serverKeyHeader = serverFile.keyHeader,
+            serverVersionTag = versionTag,
         )
+        if (rekeyed != null) {
+            Logger.w(
+                "$TAG retryAsUpdate: local AES key diverged from the server file for uniqueId=$uniqueId — " +
+                        "re-encrypted the header with the server's key"
+            )
+        }
 
-        val updateRequest = UpdateFileByUniqueIdRequest(
+        // Standard path: original.metadata is already encrypted (encryptContent
+        // was called before the request was serialized into the outbox). Just
+        // stamp the versionTag.
+        val updateRequest = rekeyed ?: UpdateFileByUniqueIdRequest(
             driveId = original.driveId,
             uniqueId = uniqueId,
             keyHeader = original.keyHeader,
@@ -180,7 +201,7 @@ class DriveOutboxUploader(
                     generatePayloadIv = false
                 )
             ),
-            metadata = metadataWithVersionTag,
+            metadata = original.metadata.copy(versionTag = versionTag),
             payloads = original.payloads,
             thumbnails = original.thumbnails
         )
@@ -351,4 +372,74 @@ class DriveOutboxUploader(
         const val ToggleReaction = 8L
         const val DeleteFilesByGroupId = 9L
     }
+}
+
+/**
+ * Root-cause fix for the "AES key must match" drop (see
+ * OutboxFailureClassifier): when `retryAsUpdate` converts a failed
+ * UploadNewFile into an update and the client's AES key has diverged from the
+ * server file's, re-encrypt the request with the SERVER's key (fresh IV) so
+ * the update is acceptable instead of deterministically rejected.
+ *
+ * Returns null when re-keying doesn't apply and the standard versionTag-stamp
+ * path is correct or the only option:
+ *  - the request isn't encrypted, or the server header has no usable key;
+ *  - the keys already match (the common case — e.g. chat's edit-coalesce
+ *    reuses the pending create's key);
+ *  - the request carries payloads or thumbnails: their bytes are
+ *    pre-encrypted on disk with the client key, and re-encrypting
+ *    arbitrarily large media in memory is not safe. Those requests take the
+ *    standard path; on divergence the server rejects and the row drops with
+ *    the classifier's reason — the owning flows self-heal (location
+ *    re-flushes its buffer, chat offers Retry).
+ *
+ * Pure given its inputs (plus IV randomness) — unit-tested in
+ * RetryAsUpdateRekeyTest.
+ */
+@OptIn(ExperimentalEncodingApi::class)
+internal suspend fun rekeyedUpdateForExistingServerFile(
+    original: UploadFileRequest,
+    serverKeyHeader: KeyHeader,
+    serverVersionTag: Uuid?,
+): UpdateFileByUniqueIdRequest? {
+    if (!original.metadata.isEncrypted) return null
+    if (serverKeyHeader == KeyHeader.empty()) return null
+    if (original.payloads.isNotEmpty() || original.thumbnails.isNotEmpty()) return null
+    if (original.keyHeader.aesKey == serverKeyHeader.aesKey) return null
+    val uniqueId = original.metadata.appData.uniqueId ?: return null
+
+    val newKeyHeader = KeyHeader(
+        iv = ByteArrayUtil.getRndByteArray(16),
+        aesKey = serverKeyHeader.aesKey,
+    )
+
+    // encryptContent stored Base64(AES(plaintext, clientKey)) — recover the
+    // plaintext with the client key, re-encrypt with the server key.
+    val reEncryptedContent = original.metadata.appData.content?.let { contentB64 ->
+        val plaintext = original.keyHeader.decrypt(Base64.decode(contentB64))
+        Base64.encode(newKeyHeader.encryptDataAes(plaintext))
+    }
+
+    return UpdateFileByUniqueIdRequest(
+        driveId = original.driveId,
+        uniqueId = uniqueId,
+        keyHeader = newKeyHeader,
+        instructions = FileUpdateInstructionSet(
+            transferIv = ByteArrayUtil.getRndByteArray(16),
+            locale = UpdateLocale.Local,
+            recipients = original.transitOptions?.recipients ?: emptyList(),
+            manifest = UpdateManifest.build(
+                payloads = emptyList(),
+                toDeletePayloads = null,
+                thumbnails = emptyList(),
+                generatePayloadIv = false,
+            ),
+        ),
+        metadata = original.metadata.copy(
+            versionTag = serverVersionTag,
+            appData = original.metadata.appData.copy(content = reEncryptedContent),
+        ),
+        payloads = emptyList(),
+        thumbnails = emptyList(),
+    )
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxFailureClassifier.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxFailureClassifier.kt
@@ -49,12 +49,13 @@ internal fun classifyPermanentFailure(e: Throwable): String? {
         // outbox row carries a fixed key, so every retry replays the same
         // wrong key against an unchanging server file — deterministically
         // unrecoverable. Drop it instead of burning ~48h of retries.
-        // GUARDRAIL, not the fix: the root cause is DriveOutboxUploader.
-        // retryAsUpdate adopting the server's versionTag but reusing the
-        // client's freshly-minted keyHeader (seen when the local DB lost the
-        // conversation's key, e.g. the in-memory web DB after a reload, and
-        // optimistically recreated the conversation with a new key). The real
-        // fix re-hydrates the existing server key on ExistingFileWithUniqueId.
+        // The root cause (DriveOutboxUploader.retryAsUpdate reusing the
+        // client's diverged keyHeader on ExistingFileWithUniqueId) is fixed
+        // for header-only requests by `rekeyedUpdateForExistingServerFile`,
+        // which re-encrypts with the server's key. This remains the guardrail
+        // for payload-carrying requests, whose pre-encrypted bytes can't be
+        // safely re-keyed in memory — those flows self-heal (location
+        // re-flushes its buffer on OutboxItemDropped, chat offers Retry).
         if (msg.contains("AES key must match", ignoreCase = true)) return reasonOf(e)
         // Client-side pre-flight rejections from
         // [UploadValidation.kt]. The validator throws ClientException

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/client/drives/files/RetryAsUpdateRekeyTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/client/drives/files/RetryAsUpdateRekeyTest.kt
@@ -1,0 +1,200 @@
+package id.homebase.api.client.drives.files
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.drives.upload.UploadAppFileMetaData
+import id.homebase.api.client.drives.upload.UploadFileMetadata
+import id.homebase.api.client.drives.upload.UploadFileRequest
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Unit tests for [rekeyedUpdateForExistingServerFile] — the root-cause fix for
+ * the "AES key must match" drop documented in OutboxFailureClassifier.
+ *
+ * Scenario: an UploadNewFile hits `ExistingFileWithUniqueId` (the server
+ * already has a file with this uniqueId) and `retryAsUpdate` converts it to an
+ * update. The server rejects any update whose AES key differs from the
+ * existing file's, so when the client's key has diverged (local DB lost the
+ * key and minted a fresh one — the web-reload case; or a replaceEnqueue
+ * superseded an in-flight create that carried a different key), the update
+ * must be re-encrypted with the SERVER's key, which the owner can always
+ * read from the fetched header (shared-secret decryption).
+ *
+ * Re-keying is only possible when the request is header-only: payload and
+ * thumbnail bytes are pre-encrypted on disk with the client key, and
+ * re-encrypting arbitrarily large media in memory is not safe. Those requests
+ * return null and take the standard path (server rejects, classifier drops —
+ * the owning flows self-heal: location re-flushes, chat offers Retry).
+ */
+@OptIn(ExperimentalEncodingApi::class)
+class RetryAsUpdateRekeyTest {
+
+    private val driveId = Uuid.random()
+    private val uniqueId = Uuid.random()
+    private val serverVersionTag = Uuid.random()
+
+    private suspend fun encryptedHeaderOnlyRequest(
+        clientKey: KeyHeader,
+        plaintext: String? = "hello from the client",
+        payloads: List<PayloadFile> = emptyList(),
+        thumbnails: List<ThumbnailFile> = emptyList(),
+    ): UploadFileRequest {
+        val metadata = UploadFileMetadata(
+            allowDistribution = false,
+            isEncrypted = true,
+            appData = UploadAppFileMetaData(
+                uniqueId = uniqueId,
+                fileType = 8888,
+                content = plaintext,
+            ),
+        )
+        return UploadFileRequest(
+            driveId = driveId,
+            keyHeader = clientKey,
+            metadata = metadata.encryptContent(clientKey),
+            payloads = payloads,
+            thumbnails = thumbnails,
+        )
+    }
+
+    @Test
+    fun mismatchedHeaderOnlyRequestIsRekeyedWithServerKey() = runTest {
+        val clientKey = KeyHeader.newRandom16()
+        val serverKey = KeyHeader.newRandom16()
+        val original = encryptedHeaderOnlyRequest(clientKey)
+
+        val rekeyed = rekeyedUpdateForExistingServerFile(original, serverKey, serverVersionTag)
+
+        assertNotNull(rekeyed, "mismatched header-only request must be re-keyed")
+        val newKeyHeader = assertNotNull(rekeyed.keyHeader)
+        assertEquals(serverKey.aesKey, newKeyHeader.aesKey, "update must carry the SERVER's AES key")
+        assertFalse(
+            newKeyHeader.iv.contentEquals(serverKey.iv),
+            "IV must be freshly minted, not the server header's",
+        )
+        assertEquals(serverVersionTag, rekeyed.metadata.versionTag, "server versionTag must be stamped")
+        assertEquals(driveId, rekeyed.driveId)
+        assertEquals(uniqueId, rekeyed.uniqueId)
+
+        // The re-encrypted content must decrypt with the NEW keyHeader back to
+        // the original plaintext.
+        val contentB64 = assertNotNull(rekeyed.metadata.appData.content)
+        val decrypted = newKeyHeader.decrypt(Base64.decode(contentB64)).decodeToString()
+        assertEquals("hello from the client", decrypted)
+    }
+
+    @Test
+    fun matchingKeysReturnNull_standardPathSuffices() = runTest {
+        val clientKey = KeyHeader.newRandom16()
+        // Same AES key, different IV — the server only compares the key.
+        val serverKey = KeyHeader(
+            iv = ByteArray(16) { 7 },
+            aesKey = clientKey.aesKey,
+        )
+        val original = encryptedHeaderOnlyRequest(clientKey)
+
+        assertNull(
+            rekeyedUpdateForExistingServerFile(original, serverKey, serverVersionTag),
+            "matching keys need no re-key — the standard versionTag stamp is correct",
+        )
+    }
+
+    @Test
+    fun payloadCarryingRequestReturnsNull() = runTest {
+        val original = encryptedHeaderOnlyRequest(
+            clientKey = KeyHeader.newRandom16(),
+            payloads = listOf(
+                PayloadFile(key = "pyld_0001", filePath = "/tmp/nope", contentType = "image/jpeg"),
+            ),
+        )
+
+        assertNull(
+            rekeyedUpdateForExistingServerFile(original, KeyHeader.newRandom16(), serverVersionTag),
+            "payload bytes are pre-encrypted with the client key — cannot re-key header-only",
+        )
+    }
+
+    @Test
+    fun thumbnailCarryingRequestReturnsNull() = runTest {
+        val original = encryptedHeaderOnlyRequest(
+            clientKey = KeyHeader.newRandom16(),
+            thumbnails = listOf(
+                ThumbnailFile(
+                    key = "pyld_0001",
+                    thumbnailBytes = byteArrayOf(1, 2, 3),
+                    contentType = "image/jpeg",
+                    pixelWidth = 8,
+                    pixelHeight = 8,
+                ),
+            ),
+        )
+
+        assertNull(
+            rekeyedUpdateForExistingServerFile(original, KeyHeader.newRandom16(), serverVersionTag),
+        )
+    }
+
+    @Test
+    fun nullContentRequestIsRekeyedWithoutContent() = runTest {
+        val serverKey = KeyHeader.newRandom16()
+        val original = encryptedHeaderOnlyRequest(
+            clientKey = KeyHeader.newRandom16(),
+            plaintext = null,
+        )
+
+        val rekeyed = rekeyedUpdateForExistingServerFile(original, serverKey, serverVersionTag)
+
+        assertNotNull(rekeyed, "no content to re-encrypt — re-key is just the key swap")
+        assertEquals(serverKey.aesKey, assertNotNull(rekeyed.keyHeader).aesKey)
+        assertNull(rekeyed.metadata.appData.content)
+    }
+
+    @Test
+    fun unencryptedRequestReturnsNull() = runTest {
+        val clientKey = KeyHeader.newRandom16()
+        val metadata = UploadFileMetadata(
+            allowDistribution = false,
+            isEncrypted = false,
+            appData = UploadAppFileMetaData(uniqueId = uniqueId, content = "plain"),
+        )
+        val original = UploadFileRequest(
+            driveId = driveId,
+            keyHeader = clientKey,
+            metadata = metadata,
+        )
+
+        assertNull(
+            rekeyedUpdateForExistingServerFile(original, KeyHeader.newRandom16(), serverVersionTag),
+        )
+    }
+
+    @Test
+    fun emptyServerKeyReturnsNull() = runTest {
+        val original = encryptedHeaderOnlyRequest(clientKey = KeyHeader.newRandom16())
+
+        assertNull(
+            rekeyedUpdateForExistingServerFile(original, KeyHeader.empty(), serverVersionTag),
+            "an unencrypted/empty server header cannot be used as a re-key target",
+        )
+    }
+
+    @Test
+    fun recipientsAreCarriedOver() = runTest {
+        val serverKey = KeyHeader.newRandom16()
+        val original = encryptedHeaderOnlyRequest(clientKey = KeyHeader.newRandom16())
+        val rekeyed = rekeyedUpdateForExistingServerFile(original, serverKey, serverVersionTag)
+        assertNotNull(rekeyed)
+        assertTrue(
+            rekeyed.instructions.recipients.isEmpty(),
+            "no transitOptions on the original → no recipients on the update",
+        )
+    }
+}


### PR DESCRIPTION
Root-cause fix for the **"AES key must match"** outbox drop — the one item flagged as *important* in the post-#709 outbox review. The classifier's own comment called its string-match a *"GUARDRAIL, not the fix"*; this is the fix.

## The bug

When an `UploadNewFile` hits `ExistingFileWithUniqueId` (server already has the uniqueId), `DriveOutboxUploader.retryAsUpdate` converts it to an update — adopting the **server's versionTag** but reusing the **client's keyHeader**. The server rejects any update whose AES key differs from the existing file's, so when the local key has diverged, every retry replays the same wrong key and the row drops: a lost update. Divergence happens when:
- the local DB lost the file's key and optimistically minted a fresh one (the documented web-reload conversation-file incident), or
- a `replaceEnqueue` superseded an **in-flight** create that carried a different key (routine for location hour-files: the old create still lands, the fresh one then funnels into `retryAsUpdate`).

## The fix

`getFileHeaderByUid` already returns the server file's **decrypted** keyHeader (owner shared-secret decryption in `ServerFile.asHomebaseFile`). New pure function `rekeyedUpdateForExistingServerFile(original, serverKeyHeader, serverVersionTag)`:

- **keys diverged + header-only request** → decrypt `appData.content` with the client key, re-encrypt with the **server's** AES key under a fresh IV, stamp the server versionTag. The update is now acceptable.
- **keys match** (the common case — chat's edit-coalesce reuses the pending create's key) → `null`, today's versionTag-stamp path, unchanged.
- **payloads/thumbnails present** → `null`: their bytes are pre-encrypted on disk with the client key, and re-encrypting arbitrarily large media in memory isn't safe. These keep the classifier guardrail drop, and the owning flows self-heal (location re-flushes its buffer on `OutboxItemDropped` since #709; chat offers Retry).

The classifier's GUARDRAIL comment is updated to describe the remaining (payload-carrying) scope.

## Tests

`RetryAsUpdateRekeyTest` (8 cases, real AES round-trips): mismatch+header-only re-keys with the server key and fresh IV, content decrypts back to plaintext with the new keyHeader, versionTag stamped; null for keys-match / payloads / thumbnails / unencrypted / empty server key; null-content re-key is a pure key swap; recipients carried over.

Suites green: `homebase-api` + `homebase-chat` jvmTest; AndroidMain + WasmJs compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)