### PR TITLE
Fix empty conversation list in share picker cold start

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/share/SharePickerScreen.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/SharePickerScreen.kt
@@ -49,8 +49,10 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import co.touchlab.kermit.Logger
+import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.api.util.truncateToCodePoints
+import id.homebase.chat.conversationlist.synthesizeOwnerSession
 import id.homebase.chat.services.convo.ConversationEnricher
 import id.homebase.chat.services.convo.ConversationStream
 import id.homebase.chat.services.convo.EnrichedConversationUiModel
@@ -84,6 +86,7 @@ fun SharePickerScreen(
     conversationStream: ConversationStream,
     contactService: ContactService,
     ownerSessionRepository: OwnerSessionRepository,
+    credentialsManager: CredentialsManager,
     sharedContent: SharedContent,
     hasFiles: Boolean,
     isSending: Boolean,
@@ -94,14 +97,29 @@ fun SharePickerScreen(
     val conversationsData by conversationStream.conversations.collectAsStateWithLifecycle()
     val contactsState by contactService.contacts.collectAsStateWithLifecycle()
     val ownerSession by ownerSessionRepository.user.collectAsStateWithLifecycle()
+    val credentials by credentialsManager.credentialsFlow.collectAsStateWithLifecycle()
     val searchFieldState = remember { TextFieldState() }
     var selectedIds by remember { mutableStateOf(emptySet<Uuid>()) }
     val enricher = remember { ConversationEnricher() }
 
-    // Enrich conversations with contact names — same pattern as ConversationListViewModel
+    // Enrich conversations with contact names — same pattern as ConversationListViewModel.
+    //
+    // Prefer the fully-resolved owner session, but fall back to a minimal one
+    // synthesized from the active credentials when the async profile load hasn't
+    // landed yet. credentialsFlow is set synchronously at login/restore, so it
+    // fills the gap before OwnerSessionRepository.load() runs.
+    //
+    // This matters in the share-activity cold start: conversationStream.start()
+    // reads the local DB and flips dataReady=true fast, but OwnerSessionRepository
+    // .load() runs last in the auth bootstrap (after connect + driveRegistry), so
+    // ownerSession is null for a window — or indefinitely if connect stalls.
+    // Gating on `ownerSession != null` left the conversation list empty while the
+    // New Moment row (which only needs dataReady) still showed: the user could
+    // share to a moment but not to a conversation.
     val enrichedConversations by remember {
         derivedStateOf {
-            val session = ownerSession ?: return@derivedStateOf emptyList()
+            val session = synthesizeOwnerSession(ownerSession, credentials)
+                ?: return@derivedStateOf emptyList()
             val contactMap = contactsState.associateBy { it.odinId }
             conversationsData.items.map { enricher.enrich(it, contactMap, session) }
         }

--- a/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import co.touchlab.kermit.Logger
 import com.mohamedrejeb.richeditor.model.RichTextState
+import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.file.safeDeleteRecursively
@@ -79,6 +80,7 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
     private val conversationStream: ConversationStream by inject()
     private val contactService: ContactService by inject()
     private val ownerSessionRepository: OwnerSessionRepository by inject()
+    private val credentialsManager: CredentialsManager by inject()
     private val chatMessageSenderService: ChatMessageSenderService by inject()
     private val fileOperationsProvider: FileOperationsProvider by inject()
     private val userPreferences: UserPreferences by inject()
@@ -223,6 +225,7 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
                             conversationStream = conversationStream,
                             contactService = contactService,
                             ownerSessionRepository = ownerSessionRepository,
+                            credentialsManager = credentialsManager,
                             sharedContent = sharedContent,
                             hasFiles = sharedContent.hasFiles,
                             isSending = isSending,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -1740,7 +1740,7 @@ internal fun shouldClearLoadingSpinnerOnLoadEnd(
  * (pre-login). The preference order is load-bearing — inverting it would replace a resolved
  * display name / profile image with a bare odinId.
  */
-internal fun synthesizeOwnerSession(
+fun synthesizeOwnerSession(
     live: OwnerSession?,
     credentials: ApiCredentials?,
 ): OwnerSession? = live ?: credentials?.let {


### PR DESCRIPTION
## Problem

The share picker already supports sharing to a conversation (Recents / Contacts / Groups multi-select → `ShareTarget.Conversations`), but on a cold-start share the conversation list rendered **empty** — so in practice only the **New Moment** option was usable.

## Root cause

`SharePickerScreen.kt` hard-returned `emptyList()` whenever `ownerSession` was null:

```kotlin
val session = ownerSession ?: return@derivedStateOf emptyList()
```

The enricher only uses `ownerSession` for its `.odinId` (to identify "self" and filter the current user out of participants). But in the share-activity cold start there's an ordering gap:

- `conversationStream.start()` reads the local DB and flips `dataReady=true` **fast** → the **New Moment** row appears (gated only on `dataReady`).
- `ownerSession` is populated by `OwnerSessionRepository.load()`, which runs **last** in the auth bootstrap (`AuthConnectionCoordinator`, after `connect()` + `driveRegistry.start()`) → null for a window, or indefinitely if connect stalls.

Result: Moments worked, the conversation list stayed blank.

## Fix

Mirror what `ConversationListViewModel` already does (but which the picker skipped despite claiming the "same pattern"): fall back to a minimal `OwnerSession` synthesized from `credentialsManager.credentialsFlow` (set synchronously at login/restore) via the now-public `synthesizeOwnerSession` helper. The enricher gets the self-`odinId` it needs immediately, independent of the slow async profile fetch.

This isn't a symptom mask — it removes an incorrect hard dependency on an async field the screen never needed in full. The `dataReady` gate and the data itself are untouched; we just stop discarding a loaded list because a secondary field is briefly null.

## Changes

- `ConversationListViewModel.kt` — made the existing `synthesizeOwnerSession` helper public so both call sites share it and stay in lock-step.
- `SharePickerScreen.kt` — added a `CredentialsManager` param, collect `credentialsFlow`, use `synthesizeOwnerSession(ownerSession, credentials)` instead of the null short-circuit.
- `ShareReceiverActivity.kt` — inject and pass `CredentialsManager`.

## Testing

Compiles cleanly (`:homebase-chat:compileAndroidMain`, `:androidApp:compileDebugKotlin`). Not yet verified on a device — no device was connected. The existing `ShareCold` instrumentation logs `ownerSession`, `enrichedConversations size`, and `dataReady`/`items`, so a pre-fix run shows `ownerSession=null` / `enrichedConversations size=0` / `dataReady=true items=N>0`, and a post-fix run should show the list populating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)