### PR TITLE
fix(share): only auto-send an incoming share on a share-triggered navigation

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -103,6 +103,14 @@ enum class ConversationLoadTrigger {
     /** A notification tap resolved to a now-loaded conversation. */
     NotificationResolved,
 
+    /**
+     * Navigation caused by an incoming OS share (homebase-share:// on iOS,
+     * ShareReceiverActivity → MainActivity on Android). This is the ONLY trigger
+     * that may auto-send a pending share descriptor — see
+     * [MessageActionsHandler.processPendingSharedContent].
+     */
+    ShareIntent,
+
     /** Caller did not specify — investigate if these show up in a burst. */
     Unknown,
 }
@@ -757,9 +765,11 @@ class ConversationListViewModel(
         Logger.i(tag = "ConversationListViewModel") {
             "selectConversation id=$conversationId scrollToBottom=$scrollToBottom trigger=$trigger"
         }
-        // Check for pending shared content (from iOS share extension or other handoff)
+        // Check for pending shared content (from iOS share extension or other handoff).
+        // Pass the trigger: only a ShareIntent-caused open consumes the descriptor, so a
+        // leftover share can't be auto-re-sent by an ordinary open or a notification tap.
         viewModelScope.launch {
-            messageActionsHandler.processPendingSharedContent(conversationId)
+            messageActionsHandler.processPendingSharedContent(conversationId, trigger)
         }
 
         ActiveConversation.selectConversation(conversationId)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -914,7 +914,18 @@ internal class MessageActionsHandler(
      * Checks for pending shared content (from iOS share extension handoff)
      * and sends it to the given conversation automatically.
      */
-    internal suspend fun processPendingSharedContent(conversationId: Uuid) {
+    internal suspend fun processPendingSharedContent(
+        conversationId: Uuid,
+        trigger: ConversationLoadTrigger,
+    ) {
+        // Only a share-intent navigation may auto-send the pending descriptor. Any other
+        // open of this conversation (notification tap, ordinary navigation) must NOT consume
+        // it — otherwise a descriptor left on disk from an earlier share would be re-sent the
+        // next time its target conversation is opened. A leftover descriptor is harmless: a
+        // ShareIntent navigation is always preceded by the share extension writing a *fresh*
+        // descriptor (it overwrites), so a stale one can never be the thing consumed here.
+        if (trigger != ConversationLoadTrigger.ShareIntent) return
+
         val descriptor = shareContentProcessor.readPendingContent() ?: return
         // Only process if the target conversation matches
         if (descriptor.targetConversationId != conversationId.toString()) return

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -72,6 +72,7 @@ import id.homebase.chat.contactinfo.ContactInfoScreen
 import id.homebase.chat.conversationlist.ConversationListScreen
 import id.homebase.chat.conversationmedia.ConversationMediaScreen
 import id.homebase.chat.conversationlist.ConversationListViewModel
+import id.homebase.chat.conversationlist.ConversationLoadTrigger
 import id.homebase.chat.conversationsettings.ConversationSettingsScreen
 import id.homebase.chat.createconversation.CreateConversationScreen
 import id.homebase.chat.createconversationgroup.CreateConversationGroupScreen
@@ -360,7 +361,9 @@ fun AppNavHost(
                     // runs processPendingSharedContent so the shared file lands
                     // in the correct conversation.
                     if (event.source == NotificationNavigationEvent.OpenConversation.Source.ShareIntent) {
-                        navController.selectConversationOnChatList(id)
+                        // Tag this as a share-caused navigation so processPendingSharedContent
+                        // actually sends the pending descriptor (and only this path does).
+                        navController.selectConversationOnChatList(id, fromShareIntent = true)
                     }
                     TextRenderingHelper.nudge()
                 }
@@ -748,6 +751,9 @@ fun AppNavHost(
                                 val pendingScrollToMessageId by backStackEntry.savedStateHandle.getStateFlow<String?>(
                                     "pendingScrollToMessageId", null
                                 ).collectAsStateWithLifecycle()
+                                val pendingFromShareIntent by backStackEntry.savedStateHandle.getStateFlow(
+                                    "pendingFromShareIntent", false
+                                ).collectAsStateWithLifecycle()
                                 LaunchedEffect(pendingConversationId) {
                                     pendingConversationId?.let { idStr ->
                                         Uuid.parseOrNull(idStr)?.let {
@@ -758,6 +764,13 @@ fun AppNavHost(
                                                 it,
                                                 messageId = pendingScrollToMessageId?.let { m -> Uuid.parseOrNull(m) },
                                                 scrollToBottom = pendingScrollToBottom,
+                                                // Only a share-intent navigation may auto-send the
+                                                // pending share descriptor (processPendingSharedContent).
+                                                trigger = if (pendingFromShareIntent) {
+                                                    ConversationLoadTrigger.ShareIntent
+                                                } else {
+                                                    ConversationLoadTrigger.Navigation
+                                                },
                                             )
                                             backStackEntry.savedStateHandle["pendingConversationId"] =
                                                 null
@@ -765,6 +778,8 @@ fun AppNavHost(
                                                 false
                                             backStackEntry.savedStateHandle["pendingScrollToMessageId"] =
                                                 null
+                                            backStackEntry.savedStateHandle["pendingFromShareIntent"] =
+                                                false
                                         }
                                     }
                                 }
@@ -1414,7 +1429,8 @@ fun AppNavHost(
 
 
 private fun NavHostController.selectConversationOnChatList(
-    conversationId: Uuid, scrollToBottom: Boolean = false, messageId: Uuid? = null
+    conversationId: Uuid, scrollToBottom: Boolean = false, messageId: Uuid? = null,
+    fromShareIntent: Boolean = false,
 ): Boolean {
     val entry = runCatching { getBackStackEntry<Route.ChatList>() }.getOrNull()
     if (entry == null) {
@@ -1426,6 +1442,7 @@ private fun NavHostController.selectConversationOnChatList(
     entry.savedStateHandle["pendingConversationId"] = conversationId.toString()
     entry.savedStateHandle["pendingScrollToBottom"] = scrollToBottom
     entry.savedStateHandle["pendingScrollToMessageId"] = messageId?.toString()
+    entry.savedStateHandle["pendingFromShareIntent"] = fromShareIntent
     return true
 }
 


### PR DESCRIPTION
## Problem
A file/text shared **into** the app re-sends a **stale copy** when a later notification tap (often in a new session) opens the share's target conversation.

## Root cause
The pending-share descriptor (`shared_content.json`) is consumed **lazily** by `MessageActionsHandler.processPendingSharedContent`, which runs on **any** `selectConversation`. So a descriptor left on disk from an earlier share is re-sent the next time its target conversation is opened — by a notification tap or an ordinary open, not the share itself.

## Fix — tie consumption to its cause
Consume the descriptor **only when the navigation was caused by a share intent**:
- `processPendingSharedContent` now takes the `ConversationLoadTrigger` and early-returns unless it's `ShareIntent`.
- The `AppNavHost` `Source.ShareIntent` branch tags the navigation with a `pendingFromShareIntent` `savedStateHandle` flag (mirroring `pendingConversationId`), threaded through `selectConversation` to the handler.
- A notification tap (`NotificationResolved`) or ordinary open (`Navigation`) never consumes it.

**No TTL, no stale-clearing, no race:** a `ShareIntent` navigation is always preceded by the share extension writing a *fresh* descriptor (it overwrites), so a leftover can never be the thing consumed here. Cross-platform (iOS `homebase-share://` and Android `ShareReceiverActivity → MainActivity` both emit `Source.ShareIntent`).

## Note on the change of approach
The first version of this PR used a `PendingShareSession` TTL-gate (modeled on `PendingNotificationTap`). Reviewer feedback flagged it as patch-like — correctly: a time window is a heuristic the *share* case doesn't need (its target conversation already exists, unlike notification resolution which waits on async drive-sync). This version replaces it with a precise causal link (the navigation trigger) — no new stateful singleton, no clock.

## Verification
- Compiles `homebase-core` (pulls `homebase-chat` + `homebase-common`).
- `homebase-chat:jvmTest` + `homebase-core:jvmTest` green (incl. the share-routing + notification-tap cold-start tests).
- Trade-off: the gate now lives in nav wiring rather than an isolated class, so the dedicated `PendingShareSession` unit tests were dropped; coverage is the existing share-flow/cold-start tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
