### PR TITLE
fix(ios): file-share crash — restore pick-time sandbox copy for security-scoped files

### DIFF
--- a/homebase-chat/src/androidMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.android.kt
+++ b/homebase-chat/src/androidMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.android.kt
@@ -1,11 +1,26 @@
 package id.homebase.chat.conversationlist
 
 import id.homebase.api.file.FileOperationsProvider
+import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.cacheDir
+import io.github.vinceglb.filekit.copyTo
+import io.github.vinceglb.filekit.name
+import kotlin.uuid.Uuid
 
 // Native PlatformFile carries a real path / content:// URI; the existing path-based send
-// pipeline (and resolveToFilePath for content URIs) already handles it. No copy needed.
+// pipeline (and resolveToFilePath for content URIs) already handles it. No copy needed at send time.
 actual suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): String = toString()
+
+// Copy the picked file into the sandbox cache dir at pick time, mirroring the working Vault upload
+// contract. On Android the picked file is a content:// URI whose read grant can be transient;
+// copying through FileKit's copyTo (which reads the content URI) yields a stable plain file the
+// send path can always read — equivalent to the downstream resolveToFilePath copy, just earlier.
+actual suspend fun PlatformFile.materializeForUpload(fileOps: FileOperationsProvider): PlatformFile {
+    val dest = PlatformFile(FileKit.cacheDir, "chat_attach_${Uuid.random()}_$name")
+    copyTo(dest)
+    return dest
+}
 
 // Native: ExoPlayer/MediaMetadataRetriever read the path/content:// URI directly; nothing to revoke.
 actual fun PlatformFile.toPlayableUrl(): String = toString()

--- a/homebase-chat/src/appleMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.apple.kt
+++ b/homebase-chat/src/appleMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.apple.kt
@@ -1,11 +1,28 @@
 package id.homebase.chat.conversationlist
 
 import id.homebase.api.file.FileOperationsProvider
+import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.cacheDir
+import io.github.vinceglb.filekit.copyTo
+import io.github.vinceglb.filekit.name
+import kotlin.uuid.Uuid
 
 // iOS PlatformFile carries a real file path; the path-based send pipeline reads it directly.
-// No copy needed.
+// No copy needed at send time — the scoped copy happened at pick time (materializeForUpload).
 actual suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): String = toString()
+
+// Copy the picked file into the sandbox cache dir WHILE the picker's security scope is still live
+// (this runs in the picker-callback launch before any further suspension). FileKit's copyTo opens
+// the source through its NSURL — which still holds the scope grant here — and writes a plain
+// sandbox file, so the later scope-less path read in the send path always succeeds.
+// Preserve the original name so the send path's content-type / display-name resolution is unchanged;
+// prefix with a uuid to keep concurrent picks from colliding.
+actual suspend fun PlatformFile.materializeForUpload(fileOps: FileOperationsProvider): PlatformFile {
+    val dest = PlatformFile(FileKit.cacheDir, "chat_attach_${Uuid.random()}_$name")
+    copyTo(dest)
+    return dest
+}
 
 // Native: AVPlayer/AVAssetImageGenerator read the path directly; nothing to revoke.
 actual fun PlatformFile.toPlayableUrl(): String = toString()

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentHandler.kt
@@ -123,7 +123,14 @@ internal class AttachmentHandler(
     fun handleAttachPlatformFile(action: ConversationListUiAction.AttachPlatformFile) {
         scope.launch {
             try {
-                val newFiles = action.files.map {
+                val newFiles = action.files.map { picked ->
+                    // Copy the picked file into the sandbox NOW, while the picker's iOS
+                    // security scope is still live. The send path later reads the file by
+                    // path from a separate coroutine, where a path-rebuilt NSURL has no
+                    // scope — so without this copy `readFileData` throws "Unable to read
+                    // file". No-op on web; a cheap sandbox copy elsewhere. See
+                    // AttachmentUploadResolve.materializeForUpload.
+                    val it = picked.materializeForUpload(fileOperationsProvider)
                     val ct = it.mimeType()?.toString()
                         ?: detectContentTypeFromExtensionOrHint(it.name)
                     when {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.kt
@@ -21,6 +21,29 @@ import io.github.vinceglb.filekit.PlatformFile
 expect suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): String
 
 /**
+ * Copy a freshly-picked [PlatformFile] into the app sandbox **at pick time** and return a
+ * sandbox-backed [PlatformFile], or return `this` unchanged when no copy is needed.
+ *
+ * This exists because an iOS document/Files-app picker vends a **security-scoped** `NSURL`: the
+ * read grant is bound to that specific URL object, not to its path string. The chat send path is
+ * path-based — it keeps only `file.toString()` and reads the bytes later, inside a separate
+ * `scope.launch`, by rebuilding a scope-LESS `NSURL.fileURLWithPath(path)`. By then the original
+ * scoped URL is gone, `startAccessingSecurityScopedResource()` on the path-built URL returns false,
+ * and `NSData.dataWithContentsOfFile` returns nil → "Unable to read file". Copying into the sandbox
+ * **while the picker's scope is still live** (this is called synchronously in the picker callback's
+ * launch, before any further suspension) yields a path the send path can always read with no scope.
+ *
+ * Mirrors the working Vault contract (`VaultViewModel` copies picked files via FileKit `copyTo`
+ * before upload). FileKit's `copyTo` is what handles the security scope on apple.
+ *
+ * - apple/android/jvm: copy into the FileKit cache dir, preserving the original file name (so the
+ *   send path's content-type / display-name resolution from `file.name` is unchanged).
+ * - web: no-op (`this`). The browser has no path and no security scope; the picked `PlatformFile`
+ *   keeps its bytes and [toUploadPath]'s web actual materializes them at send time via `readBytes()`.
+ */
+expect suspend fun PlatformFile.materializeForUpload(fileOps: FileOperationsProvider): PlatformFile
+
+/**
  * A handle the in-editor video decoder/player can read **immediately**, without the expensive
  * okio materialization [toUploadPath] performs (whole-file read + in-memory copy).
  *

--- a/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.jvm.kt
+++ b/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.jvm.kt
@@ -1,11 +1,25 @@
 package id.homebase.chat.conversationlist
 
 import id.homebase.api.file.FileOperationsProvider
+import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.cacheDir
+import io.github.vinceglb.filekit.copyTo
+import io.github.vinceglb.filekit.name
+import kotlin.uuid.Uuid
 
 // Desktop PlatformFile carries a real filesystem path; the path-based send pipeline reads it
-// directly. No copy needed.
+// directly. No copy needed at send time.
 actual suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): String = toString()
+
+// Copy the picked file into the sandbox cache dir at pick time, mirroring the working Vault upload
+// contract so all native platforms behave the same. Desktop has no security scope, but copying a
+// real filesystem path is cheap and harmless and keeps the send path reading a sandbox file.
+actual suspend fun PlatformFile.materializeForUpload(fileOps: FileOperationsProvider): PlatformFile {
+    val dest = PlatformFile(FileKit.cacheDir, "chat_attach_${Uuid.random()}_$name")
+    copyTo(dest)
+    return dest
+}
 
 // Native: the real path is already okio/VLCJ-readable; no blob URL to mint or revoke.
 actual fun PlatformFile.toPlayableUrl(): String = toString()

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.web.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.web.kt
@@ -14,6 +14,11 @@ import io.github.vinceglb.filekit.readBytes
 actual suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): String =
     materializeBytesToUploadPath(fileOps, name, readBytes())
 
+// No-op on web: the browser has no filesystem path to copy to and no security scope to lose. The
+// picked PlatformFile keeps its bytes; toUploadPath() above materializes them at send time via
+// readBytes(). (FileKit's copyTo / cacheDir aren't available on wasmJs.)
+actual suspend fun PlatformFile.materializeForUpload(fileOps: FileOperationsProvider): PlatformFile = this
+
 // Mint a blob: object URL straight from the picked browser File. This is O(1): the browser keeps
 // the File's bytes and the <video>/canvas stream from the URL on demand — no readBytes(), no copy
 // into wasm, no base64. Reused for poster, duration, filmstrip and playback (the old code base64'd


### PR DESCRIPTION
## Problem
Sending a file picked via the in-app document/Files picker crashes on iOS:
`kotlin.IllegalStateException: Unable to read file at /private/var/.../File Provider Storage/...` in `IOSFileOperationsProvider.readFileData`.

## Root cause
iOS document-picker URLs are **security-scoped** — the read grant is bound to the specific `NSURL` the picker vended, not to the path string. The chat send path kept only `file.toString()` (the raw path) and, at send time in a separate `scope.launch`, rebuilt a scope-**less** `NSURL.fileURLWithPath(path)`; `startAccessingSecurityScopedResource()` returns `false` on a path-built URL, so `NSData.dataWithContentsOfFile` returns nil → throw.

This is a regression from commit `4e75d830`, which removed the pick-time sandbox copy for chat (keeping it only for Vault, which is why Vault file uploads still work).

## Fix
Add `PlatformFile.materializeForUpload(fileOps)` (expect/actual) that copies the picked file into `FileKit.cacheDir` **at pick time** via FileKit `copyTo` (which reads through the still-live scoped `NSURL`), called in `AttachmentHandler.handleAttachPlatformFile` for every picked file. The send path then reads a plain sandbox file with no scope needed.
- apple/android/jvm: copy (mirrors the working `VaultViewModel` contract), preserving the original name.
- web: no-op (no path/scope; bytes are materialized at send time).
- Temp files reaped by the existing `CacheSweeper`.

## Verification
- Compiles `homebase-chat:compileKotlinJvm` **and** `compileKotlinIosSimulatorArm64`.
- ⚠️ **Needs on-device verification**: pick a file via the in-app Files/document picker and send it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)