### PR TITLE
fix(chat): show "You" + own profile photo for the note-to-self avatar

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationEnricher.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationEnricher.kt
@@ -1,12 +1,17 @@
 package id.homebase.chat.services.convo
 
 import co.touchlab.kermit.Logger
+import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.auth.OwnerSession
 import id.homebase.api.client.connections.ConnectionStatus
+import id.homebase.api.client.drives.upload.EmbeddedThumb
 import id.homebase.api.client.connections.RedactedIdentityConnectionRegistration
 import id.homebase.api.common.OdinId
 import id.homebase.chat.data.*
 import id.homebase.chat.services.convo.contact.ContactConnectionState
+import id.homebase.core.avatars.ConversationAvatarModel
+import id.homebase.core.image.HomebaseImageData
+import kotlin.uuid.Uuid
 
 class ConversationEnricher {
 
@@ -31,7 +36,7 @@ class ConversationEnricher {
 
         if (convo.isWithSelf) {
             return EnrichedConversationUiModel(
-                conversation = convo,
+                conversation = convo.withOwnerProfileAvatar(ownerSession),
                 participants = emptyList(),
                 missingConnections = emptyList()
             )
@@ -90,4 +95,49 @@ class ConversationEnricher {
             oneOnOneConnectionStatus = oneOnOneConnectionStatus,
         )
     }
+}
+
+/**
+ * Patches the note-to-self conversation's [ConversationAvatarModel] so the
+ * Owner avatar renders the user's own profile photo.
+ *
+ * [ConversationMapper.buildConversationAvatarModel] builds the self avatar with
+ * `imageData = null`, which makes [id.homebase.core.avatars.OwnerAvatar] fall
+ * through to [id.homebase.core.avatars.PublicAvatar] — and the owner's own
+ * `https://{odinId}/pub/image` is empty, so the avatar shows blank. The owner's
+ * profile-image bytes never live on the chat drive, but [OwnerSession] already
+ * carries the base64 [OwnerSession.profileImagePreviewThumbnail] that renders
+ * without any decryption keys. We attach it as the avatar's
+ * [HomebaseImageData.previewThumbnail] so the photo shows immediately.
+ *
+ * The synthetic image data is deliberately preview-only: [HomebaseImageData.fileId]
+ * is [Uuid.NIL] so [OwnerAvatar] paints the embedded preview directly instead of
+ * attempting a server fetch on the chat drive (which has no such file). When the
+ * owner has no profile photo (preview is null), the avatar is left untouched so
+ * the existing [PublicAvatar] fallback still applies.
+ */
+internal fun ConversationUiModel.withOwnerProfileAvatar(
+    ownerSession: OwnerSession,
+): ConversationUiModel {
+    val previewContent = ownerSession.profileImagePreviewThumbnail?.takeIf { it.isNotBlank() }
+        ?: return this
+
+    if (avatarModel.type != ConversationAvatarModel.Type.Owner) return this
+
+    val ownerImageData = HomebaseImageData(
+        driveId = Uuid.NIL,
+        fileId = Uuid.NIL,
+        payloadKey = "",
+        isEncrypted = false,
+        previewThumbnail = EmbeddedThumb(
+            pixelWidth = 0,
+            pixelHeight = 0,
+            contentType = "image/webp",
+            content = previewContent,
+        ),
+        lastModified = ownerSession.profileImageLastModified,
+        keyHeader = KeyHeader.newRandom16(),
+    )
+
+    return copy(avatarModel = avatarModel.copy(imageData = ownerImageData))
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/EnrichedConversationUiModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/EnrichedConversationUiModel.kt
@@ -13,6 +13,10 @@ data class EnrichedConversationUiModel(
     val oneOnOneConnectionStatus: OneOnOneConnectionStatus? = null,
 ) {
     fun getDisplayName(youLabel: String = "You"): String {
+        // Note-to-self: the single "participant" is the owner, so a name lookup
+        // would surface the owner's own domain. Label it with [youLabel] instead.
+        if (conversation.isWithSelf) return youLabel
+
         if (!conversation.isGroupConversation) {
             participants.firstOrNull()?.let {
                 return it.name

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/avatars/OwnerAvatar.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/avatars/OwnerAvatar.kt
@@ -1,7 +1,10 @@
+@file:OptIn(ExperimentalEncodingApi::class, ExperimentalResourceApi::class)
+
 package id.homebase.core.avatars
 
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -10,6 +13,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -22,7 +26,12 @@ import id.homebase.core.ui.theme.ExtendedColors
 import id.homebase.core.util.ifTrue
 import id.homebase.resources.MR
 import id.homebase.resources.avatar_owner
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.decodeToImageBitmap
 import org.jetbrains.compose.resources.stringResource
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.uuid.Uuid
 
 @Composable
 fun OwnerAvatar(
@@ -37,11 +46,43 @@ fun OwnerAvatar(
     sharedTransitionScope: SharedTransitionScope?,
     animatedVisibilityScope: AnimatedVisibilityScope?
 ) {
+    // Preview-only owner image (e.g. the note-to-self avatar built from
+    // OwnerSession.profileImagePreviewThumbnail): there is no server-fetchable
+    // file (fileId == NIL), so decode and paint the embedded base64 preview
+    // directly. Routing it through HomebaseImage would 404 on the chat drive and
+    // overlay an error triangle. A real fetchable owner image (fileId != NIL)
+    // still goes through HomebaseImage below for progressive loading.
+    val previewOnlyBitmap = remember(profileImageData?.previewThumbnail, profileImageData?.fileId) {
+        val data = profileImageData ?: return@remember null
+        if (data.fileId != Uuid.NIL) return@remember null
+        data.previewThumbnail?.content?.takeIf { it.isNotBlank() }?.let { content ->
+            try {
+                Base64.decode(content).decodeToImageBitmap()
+            } catch (_: Exception) {
+                null
+            }
+        }
+    }
+
     Box(
         modifier = modifier
             .ifTrue(connectionStatus != null) { Modifier.size(options.size + 6.dp) }
     ) {
-        if (profileImageData != null) {
+        if (previewOnlyBitmap != null) {
+            Image(
+                bitmap = previewOnlyBitmap,
+                contentDescription = stringResource(MR.string.avatar_owner),
+                contentScale = options.contentScale,
+                modifier = Modifier
+                    .size(options.size)
+                    .clip(CircleShape)
+                    .let {
+                        if (options.onClick != null) {
+                            it.clickable { options.onClick.invoke() }
+                        } else it
+                    },
+            )
+        } else if (profileImageData != null) {
             HomebaseImage(
                 imageData = profileImageData,
                 modifier = Modifier


### PR DESCRIPTION
## Problem
Sharing/forwarding to your **own** identity (note-to-self) showed a blank avatar, and the share/forward picker showed your domain instead of a name.

## Root cause
`ConversationMapper.buildConversationAvatarModel` builds the self avatar with `imageData = null` → `OwnerAvatar` falls through to `PublicAvatar` → `https://{ownOdinId}/pub/image`, which is empty for your own identity → blank. The owner's profile-image bytes (`OwnerSession.profileImagePreviewThumbnail`) were populated but never rendered.

## Fix
- `ConversationEnricher.withOwnerProfileAvatar` attaches the base64 `profileImagePreviewThumbnail` (renders with **no decryption keys**) as the avatar's preview — only when present and only for the `Owner` avatar, so the `PublicAvatar` fallback is preserved for identities with no profile photo.
- `OwnerAvatar` paints the embedded base64 directly when `fileId == NIL`, avoiding a doomed chat-drive fetch (which would 404 and overlay an error triangle).
- `getDisplayName` returns "You" (`MR.string.you`) for the self conversation.

**Preview-thumbnail only** (intentional): the owner photo lives on the profile drive and `OwnerSession` carries no key header for full-res decryption. The preview is a real, correct image and is plenty for an avatar.

## Verification
- Compiles `homebase-chat` + `homebase-common` + `homebase-api` (JVM); `ConversationEnricherTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)