### PR TITLE
CI: drop the pre-build link step — it ran the 60-min link twice

### DIFF
--- a/.github/workflows/build-mobile-release-prod.yml
+++ b/.github/workflows/build-mobile-release-prod.yml
@@ -213,9 +213,12 @@ jobs:
           kotlin.native.disableCompilerDaemon=true
           # 8g, not less: run 27407420160's GC log proved ~5.1 GB is genuinely
           # live during linkReleaseFrameworkIosArm64 (full GC clearing soft refs
-          # reclaimed nothing at a 6g cap). 8g exceeds the runner's 7 GB RAM but
-          # macOS swap absorbs it once xcodebuild isn't resident (see the
-          # pre-build step below).
+          # reclaimed nothing at a 6g cap). 8g exceeds the runner's 7 GB RAM;
+          # macOS swap absorbs it, proven even with xcodebuild resident: run
+          # 27414487423's in-Xcode link completed at 8g. (A pre-build step that
+          # linked before fastlane was removed — embedAndSignAppleFrameworkForXcode
+          # configures the link differently, so the pre-built framework was not
+          # UP-TO-DATE and the ~60 min link ran twice.)
           kotlin.native.jvmArgs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/Users/runner/work/jvm-dumps -Xlog:gc*:file=/Users/runner/work/jvm-dumps/kn-gc-%p.log
           EOF
           echo "Appended CI memory overrides to gradle.properties:"
@@ -236,21 +239,6 @@ jobs:
               fi
             done
           done
-
-      # Pre-build the Kotlin frameworks BEFORE fastlane/xcodebuild start, so the
-      # memory-hungry release link has the runner's 7 GB to itself instead of
-      # competing with xcodebuild/SWBBuildService/fastlane (run 27407420160 saw
-      # both a heap-space OOM in the link and SIGKILLs of java processes —
-      # system-level memory exhaustion). The Xcode script phase ("Compile Kotlin
-      # Framework") then finds the link tasks UP-TO-DATE and just copies the
-      # frameworks. Must run AFTER the FFmpegKit signature strip so task inputs
-      # are identical between this invocation and Xcode's.
-      # Rollback: delete this step together with the other CI-memory steps.
-      - name: Pre-build Kotlin frameworks (link outside Xcode)
-        run: |
-          ./gradlew :homebase-core:linkReleaseFrameworkIosArm64 \
-                    :homebase-notifshared:linkReleaseFrameworkIosArm64
-          ./gradlew --stop
 
       # fastlane's build_app starts with `xcodebuild -resolvePackageDependencies`,
       # which has no timeout: run 27409300090 hung there for 35 min (vs 80 s in


### PR DESCRIPTION
## Problem

Run [27414487423](https://github.com/homebase-id/chat-kmp/actions/runs/27414487423) (green, TestFlight uploaded) revealed that the pre-build step from #712 doesn't actually get reused: the Xcode script phase **re-executed** `:homebase-core:linkReleaseFrameworkIosArm64` instead of finding it UP-TO-DATE. `embedAndSignAppleFrameworkForXcode` configures the link task differently than a plain CLI invocation (Xcode env vars feed into task inputs), so the job paid for the ~60-minute link **twice** — 2h07m total.

## Why removing it is safe

The same run accidentally provided the control experiment: the 8 GB fresh-process link **completed inside the Xcode script phase with xcodebuild resident** (13:08 → 14:09). So the actual OOM fix is `kotlin.native.disableCompilerDaemon=true` + `-Xmx8g` — the pre-build isolation was never load-bearing.

## Change

Remove the `Pre-build Kotlin frameworks (link outside Xcode)` step; update the comment justifying the 8g heap. Everything else from #712 stays: memory overrides, SPM pre-resolve watchdog, failure-only OOM diagnostics artifact.

**Expected effect:** iOS release job returns from ~2h07m to ~70 min.

## If a future run OOMs in-Xcode again

Reintroduce the pre-build *and* fix the reuse properly (diagnose with `org.gradle.logging.level=info` to get the not-up-to-date reason) — don't just revert this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)