### PR TITLE
fix(vault): copy picked file at pick time for append-pages (iOS security scope)

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
@@ -552,12 +552,27 @@ class VaultViewModel(
         vaultStream.updateOptimisticEntry(optimisticEntry)
 
         viewModelScope.launch {
+            // Copy each picked file into the sandbox NOW for the upload read. By upload
+            // time the iOS document picker's security scope is gone, so reading the raw
+            // "File Provider Storage" path there throws ("Unable to read file"). The raw
+            // paths above are fine for the instant optimistic preview because the picker
+            // scope is still live at pick time. Mirrors handleAddFiles (and chat's
+            // materializeForUpload fix).
+            val uploadData = action.newFiles.mapIndexed { index, file ->
+                val ext = file.name.substringAfterLast('.', "tmp")
+                val tempPath = "${fileOperationsProvider.getCacheDirectory()}/vault_upload_${Uuid.random()}.$ext"
+                file.copyToPath(tempPath)
+                tempPath to fileData[index].second
+            }
             val success = vaultUploaderService.appendPages(
                 file = action.file,
-                newFiles = fileData,
+                newFiles = uploadData,
                 scope = viewModelScope,
             )
             if (!success) {
+                uploadData.forEach { (path, _) ->
+                    try { fileOperationsProvider.deleteTempFile(path) } catch (_: Exception) { }
+                }
                 vaultStream.updateOptimisticEntry(action.file)
                 _events.tryEmit(VaultUiEvent.Error(VaultError.AppendPagesFailed))
             }


### PR DESCRIPTION
## Problem
Vault's **append-pages** flow (`VaultViewModel.handleAppendPages`) passes the raw `pathCompat` of a picked file to `vaultUploaderService.appendPages`, which reads it at **upload time** via `withResolvedFiles → resolveToFilePath`. On iOS, `resolveToFilePath` is a no-op (its `"File Provider Storage"` copy branch was removed in `4e75d830`), so the read hits the raw **security-scoped** path *after* the document picker's scope has expired → the same `IllegalStateException: Unable to read file` crash as chat (#716).

Unlike `handleAddFiles`, this path **never copied the picked file into the sandbox**.

## Fix
Mirror `handleAddFiles`: inside the launch, copy each picked file to a `vault_upload_` temp at pick time via FileKit `copyToPath` (which reads through the still-live scoped `NSURL`), and upload the temp. The raw path is kept only for the **instant optimistic preview** (readable while the picker scope is still live). The temp is cleaned up on failure (CacheSweeper reaps it on cold start otherwise, same as the main flow).

## Scope / verification
- Latent bug (append-pages is a rarer flow than the main add-files path), surfaced while fixing the chat instance in #716. Same root cause, different feature.
- Compiles `homebase-core:compileKotlinJvm`.
- ⚠️ **Needs on-device verification:** append a page to a multi-page vault entry from the **Files app** on iOS.
- Depends conceptually on the same analysis as #716 but touches a different module — kept separate so the chat crash fix can merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
