### PR TITLE
Test: fix OutboxSetNextRunTimeTest iOS-sim teardown-race flake

### DIFF
--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/CloseIgnoringTeardownRace.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/CloseIgnoringTeardownRace.kt
@@ -1,0 +1,31 @@
+package id.homebase.api.sync.database
+
+/**
+ * Closes a per-test in-memory [DatabaseManager], swallowing the teardown-time
+ * race that the real-dispatcher outbox tests provoke.
+ *
+ * Those tests (`OutboxSyncTest.testFailureAndRetry`,
+ * `OutboxSetNextRunTimeTest.failedAttemptStoresAFutureMillisecondsDeadline`)
+ * keep the production real-thread DB dispatchers so the retry backoff parks
+ * instead of being advanced through. `runTest` cancels `backgroundScope` (where
+ * the outbox uploader/retry runs) when the body returns, but a DB op already
+ * dispatched to `Dispatchers.Default`/`Dispatchers.IO` can outlive
+ * `advanceUntilIdle`/`clearCheckout` and land *during* `close()`:
+ *
+ * - iOS-sim `NativeSqliteDriver`: connection-pool teardown throws
+ *   `ConcurrentModificationException at null:-1` (occasionally a segfault).
+ * - JVM `JdbcSqliteDriver`: `SQLException("database has been closed")`.
+ *
+ * Per the already-merged precedent (PR #390, `ChatMessageActionServiceTestFixture`),
+ * swallowing is safe: the DB is private to the test, the leak is harmless, and
+ * every assertion ran inside the `runTest` body before this is reached.
+ */
+fun DatabaseManager.closeIgnoringTeardownRace() {
+    try {
+        close()
+    } catch (_: Throwable) {
+        // Teardown race on a per-test in-memory DB — nothing to recover, and
+        // propagating would mask the real assertions. (A rare native segfault
+        // can't be caught here; the catchable CME is the dominant case.)
+    }
+}

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSetNextRunTimeTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSetNextRunTimeTest.kt
@@ -152,6 +152,10 @@ class OutboxSetNextRunTimeTest {
             )
             sync.clearCheckout(timeoutMs = 5_000)
         }
-        db.close()
+        // Real-dispatcher DB: a cancelled retry coroutine's DB op can land
+        // during close() and race NativeSqliteDriver teardown on iOS-sim
+        // (ConcurrentModificationException at null:-1). Harmless on a per-test
+        // in-memory DB — see closeIgnoringTeardownRace.
+        db.closeIgnoringTeardownRace()
     }
 }

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSyncTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSyncTest.kt
@@ -254,7 +254,7 @@ class OutboxSyncTest {
             assertEquals(0, uploader.uploaded.size)
             sync.clearCheckout(timeoutMs = 5_000)  // drain before db.close(); see file kdoc
         }
-        db.close()
+        db.closeIgnoringTeardownRace()  // real-dispatcher teardown race; see helper
     }
 
     @Test
@@ -446,7 +446,7 @@ class OutboxSyncTest {
             collectorJob.cancel()
             sync.clearCheckout(timeoutMs = 5_000)  // drain before db.close(); see file kdoc
         }
-        db.close()
+        db.closeIgnoringTeardownRace()  // real-dispatcher teardown race; see helper
     }
 
     /**


### PR DESCRIPTION
## Summary
`OutboxSetNextRunTimeTest.failedAttemptStoresAFutureMillisecondsDeadline` intermittently fails the **iOS** Build Check with `kotlin.ConcurrentModificationException at null:-1` (surfaced on an unrelated PR's rerun). Compiles fine; it's a test-teardown race, not a product bug.

**Root cause:** that test — and its `OutboxSyncTest` siblings `testFailureAndRetry` / `testTryEnqueueDoesNotBlockOnSaturatedEventBus` — must keep the production real-thread DB dispatchers so the retry backoff *parks* instead of being advanced through `advanceUntilIdle()` (they explicitly can't use the virtual-time `runOutboxTest` binding, per that class's KDoc). When `runTest` cancels `backgroundScope`, a cancelled retry coroutine's DB op can still land during `db.close()` and race `NativeSqliteDriver`'s connection-pool teardown → CME on iOS-sim (`SQLException` on JVM, though JDBC's single connection rarely trips it).

**Fix:** follow the already-merged precedent for this exact failure class — **PR #390** (`Swallow SQLException in outbox test fixture close()`). New multiplatform helper `closeIgnoringTeardownRace()` swallows the teardown race on both native and JVM; applied to all three real-dispatcher `db.close()` sites. Safe because each test owns a private in-memory DB and all assertions run inside the `runTest` body before close.

## Test plan
- [x] `homebase-api:jvmTest` for both classes green locally
- [ ] **iOS Build Check green** — the real validation (the flake is iOS-sim only); CI on this PR is the check