### PR TITLE
Location: per-point step delta + per-hour battery

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -30,6 +30,10 @@
          PendingIntent registration after a reboot. -->
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <!-- Location add-on: pedometer (steps per GPS point). Runtime permission on
+         API 29+; best-effort, location tracking continues if denied. No Play
+         declaration gate, but the Data safety form must disclose activity data. -->
+    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
 
     <!-- Devices running Android 13 (API level 33) or higher -->
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/LocationPointWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/LocationPointWrapper.kt
@@ -18,6 +18,10 @@ data class BufferedLocationPoint(
     val hdg: Double? = null,
     val src: String,
     val fg: Boolean,
+    /** Pedometer steps since the previous point on this device (delta), or null. */
+    val steps: Int? = null,
+    /** Battery %, 0..100, or null. */
+    val bat: Int? = null,
 )
 
 /**
@@ -46,6 +50,8 @@ class LocationPointWrapper(
                     hdg = p.hdg,
                     src = p.src,
                     fg = if (p.fg) 1L else 0L,
+                    steps = p.steps?.toLong(),
+                    bat = p.bat?.toLong(),
                 )
             }
         }
@@ -66,6 +72,7 @@ class LocationPointWrapper(
                 t = it.t, lat = it.lat, lon = it.lon, acc = it.acc,
                 alt = it.alt, altAcc = it.altAcc, spd = it.spd, hdg = it.hdg,
                 src = it.src, fg = it.fg != 0L,
+                steps = it.steps?.toInt(), bat = it.bat?.toInt(),
             )
         }
     }
@@ -112,6 +119,7 @@ class LocationPointWrapper(
             t = row.t, lat = row.lat, lon = row.lon, acc = row.acc,
             alt = row.alt, altAcc = row.altAcc, spd = row.spd, hdg = row.hdg,
             src = row.src, fg = row.fg != 0L,
+            steps = row.steps?.toInt(), bat = row.bat?.toInt(),
         )
     }
 

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/LocationPoint.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/LocationPoint.sq
@@ -17,12 +17,14 @@ CREATE TABLE IF NOT EXISTS LocationPoint(
   hdg REAL,                        -- heading/bearing, degrees
   src TEXT NOT NULL,               -- gps | net | fused | slc
   fg INTEGER NOT NULL,             -- 1 when captured in foreground precise mode
+  steps INTEGER,                   -- pedometer steps since the previous point (delta), or null
+  bat INTEGER,                     -- battery %, 0..100, or null
   flushedFileUid BLOB AS Uuid      -- hour-file uniqueId once part of an enqueued flush
 );
 
 insertPoint:
-INSERT OR REPLACE INTO LocationPoint(t, lat, lon, acc, alt, altAcc, spd, hdg, src, fg, flushedFileUid)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL);
+INSERT OR REPLACE INTO LocationPoint(t, lat, lon, acc, alt, altAcc, spd, hdg, src, fg, steps, bat, flushedFileUid)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL);
 
 -- Hours (epoch ms / 3600000) that still have rows not yet part of an enqueued flush.
 selectPendingHours:
@@ -33,7 +35,7 @@ ORDER BY hourBucket;
 
 -- Every row of an hour (marked and unmarked) — a flush re-serializes the full hour.
 selectByTimeRange:
-SELECT t, lat, lon, acc, alt, altAcc, spd, hdg, src, fg
+SELECT t, lat, lon, acc, alt, altAcc, spd, hdg, src, fg, steps, bat
 FROM LocationPoint
 WHERE t >= ? AND t < ?
 ORDER BY t;
@@ -68,7 +70,7 @@ SELECT COUNT(*) FROM LocationPoint
 WHERE t >= ? AND flushedFileUid IS NULL;
 
 selectLatest:
-SELECT t, lat, lon, acc, alt, altAcc, spd, hdg, src, fg
+SELECT t, lat, lon, acc, alt, altAcc, spd, hdg, src, fg, steps, bat
 FROM LocationPoint
 ORDER BY t DESC
 LIMIT 1;

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.android.kt
@@ -1,0 +1,57 @@
+package id.homebase.core.location.tracking
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.os.BatteryManager
+import co.touchlab.kermit.Logger
+import id.homebase.api.ActivityProvider
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.coroutines.resume
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+actual fun createDeviceSensors(): DeviceSensors = AndroidDeviceSensors
+
+private object AndroidDeviceSensors : DeviceSensors {
+    private val logger = Logger.withTag("AndroidDeviceSensors")
+    private val context: Context get() = ActivityProvider.requireApplicationContext()
+
+    override suspend fun batteryPercent(): Int? {
+        val bm = context.getSystemService(Context.BATTERY_SERVICE) as? BatteryManager ?: return null
+        val pct = bm.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY)
+        return pct.takeIf { it in 0..100 }
+    }
+
+    override suspend fun stepsSince(prevPointTimeMs: Long?, lastCumulative: Long?): StepSample {
+        val cumulative = readCumulativeSteps() ?: return StepSample(null, lastCumulative)
+        // A decrease means the counter reset (reboot) — can't attribute a delta.
+        val delta = if (lastCumulative != null && cumulative >= lastCumulative) {
+            (cumulative - lastCumulative).toInt()
+        } else null
+        return StepSample(delta, cumulative)
+    }
+
+    /** TYPE_STEP_COUNTER is a one-shot read: register, take the first event, unregister. */
+    private suspend fun readCumulativeSteps(): Long? {
+        val sm = context.getSystemService(Context.SENSOR_SERVICE) as? SensorManager ?: return null
+        val sensor = sm.getDefaultSensor(Sensor.TYPE_STEP_COUNTER) ?: return null
+        return withTimeoutOrNull(STEP_READ_TIMEOUT_MS) {
+            suspendCancellableCoroutine { cont ->
+                val listener = object : SensorEventListener {
+                    override fun onSensorChanged(event: SensorEvent) {
+                        sm.unregisterListener(this)
+                        if (cont.isActive) cont.resume(event.values.firstOrNull()?.toLong())
+                    }
+                    override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {}
+                }
+                val ok = sm.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_FASTEST)
+                if (!ok && cont.isActive) cont.resume(null)
+                cont.invokeOnCancellation { sm.unregisterListener(listener) }
+            }
+        }.also { if (it == null) logger.d { "step counter read timed out / unavailable" } }
+    }
+
+    private const val STEP_READ_TIMEOUT_MS = 2_000L
+}

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/permissions/PermissionsManager.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/permissions/PermissionsManager.android.kt
@@ -64,6 +64,8 @@ private fun String.toPermissionType(): PermissionType? {
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && this == Manifest.permission.ACCESS_BACKGROUND_LOCATION) return PermissionType.LOCATION_ALWAYS
 
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && this == Manifest.permission.ACTIVITY_RECOGNITION) return PermissionType.ACTIVITY
+
     return null
 }
 
@@ -142,6 +144,16 @@ class AndroidPermissionsManager(
                     )
                 }
             }
+
+            PermissionType.ACTIVITY -> {
+                // Runtime permission from API 29; below that the step sensor
+                // needs no grant.
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    genericPermissionLauncher.launch(
+                        arrayOf(Manifest.permission.ACTIVITY_RECOGNITION)
+                    )
+                }
+            }
         }
     }
 
@@ -214,6 +226,16 @@ class AndroidPermissionsManager(
                     ) == PackageManager.PERMISSION_GRANTED
                 } else {
                     isPermissionGranted(PermissionType.LOCATION)
+                }
+            }
+
+            PermissionType.ACTIVITY -> {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    ContextCompat.checkSelfPermission(
+                        context, Manifest.permission.ACTIVITY_RECOGNITION
+                    ) == PackageManager.PERMISSION_GRANTED
+                } else {
+                    true
                 }
             }
         }

--- a/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.apple.kt
+++ b/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.apple.kt
@@ -1,0 +1,40 @@
+package id.homebase.core.location.tracking
+
+import platform.CoreMotion.CMPedometer
+import platform.Foundation.NSDate
+import platform.Foundation.dateWithTimeIntervalSince1970
+import platform.UIKit.UIDevice
+import kotlin.coroutines.resume
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+actual fun createDeviceSensors(): DeviceSensors = AppleDeviceSensors
+
+private object AppleDeviceSensors : DeviceSensors {
+
+    private val pedometer = CMPedometer()
+
+    init {
+        UIDevice.currentDevice.batteryMonitoringEnabled = true
+    }
+
+    override suspend fun batteryPercent(): Int? {
+        // -1.0 when monitoring is off or unsupported (e.g. simulator).
+        val level = UIDevice.currentDevice.batteryLevel
+        if (level < 0f) return null
+        return (level * 100f).toInt().coerceIn(0, 100)
+    }
+
+    override suspend fun stepsSince(prevPointTimeMs: Long?, lastCumulative: Long?): StepSample {
+        // iOS answers historical intervals directly — no cumulative needed.
+        if (prevPointTimeMs == null) return StepSample(null, null)
+        if (!CMPedometer.isStepCountingAvailable()) return StepSample(null, null)
+        val from = NSDate.dateWithTimeIntervalSince1970(prevPointTimeMs / 1000.0)
+        val to = NSDate()
+        val delta = suspendCancellableCoroutine<Int?> { cont ->
+            pedometer.queryPedometerDataFromDate(from, to) { data, _ ->
+                if (cont.isActive) cont.resume(data?.numberOfSteps?.intValue)
+            }
+        }
+        return StepSample(delta, null)
+    }
+}

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1241,7 +1241,7 @@
     <string name="location_dashboard_perm_banner">Location permission needs attention — tap to fix</string>
     <string name="location_dashboard_empty_today">No locations recorded yet today</string>
     <string name="location_consent_title">Your private location history</string>
-    <string name="location_consent_text">Your app will collect location data to record your private location history and store it on your private Homebase Location drive — even when this app is closed or not in use. Your history is end-to-end encrypted to your personal drive; no one but you, not even your cloud operator, can read it.</string>
+    <string name="location_consent_text">Your app will collect location data — and, while tracking, your step count and battery level — to record your private location history and store it on your private Homebase Location drive, even when this app is closed or not in use. Your history is end-to-end encrypted to your personal drive; no one but you, not even your cloud operator, can read it.</string>
     <string name="location_consent_agree">Agree</string>
     <string name="location_consent_decline">No thanks</string>
     <string name="location_history_title">History</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.kt
@@ -1,0 +1,28 @@
+package id.homebase.core.location.tracking
+
+/**
+ * One pedometer read: the step [deltaSteps] over the queried window, plus the
+ * platform's running [cumulative] count when it has one (Android = since-boot;
+ * iOS answers intervals directly and returns null). The store persists
+ * [cumulative] so the next delta can be computed across process death.
+ */
+data class StepSample(val deltaSteps: Int?, val cumulative: Long?)
+
+/**
+ * Cheap, hardware-backed device readings attached to GPS points by
+ * `LocationPointStore`. Battery is free and permission-less; steps need the
+ * activity/motion runtime permission and degrade to null when denied.
+ */
+interface DeviceSensors {
+    /** Battery charge 0..100, or null if unavailable (desktop/web, simulator). */
+    suspend fun batteryPercent(): Int?
+
+    /**
+     * Steps since [prevPointTimeMs] (the previous accepted point's time).
+     * [lastCumulative] is the store's persisted running count (Android uses it
+     * to subtract; iOS ignores it and queries the interval directly).
+     */
+    suspend fun stepsSince(prevPointTimeMs: Long?, lastCumulative: Long?): StepSample
+}
+
+expect fun createDeviceSensors(): DeviceSensors

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationPointStore.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationPointStore.kt
@@ -1,6 +1,7 @@
 package id.homebase.core.location.tracking
 
 import co.touchlab.kermit.Logger
+import id.homebase.api.storage.SharedPreferences
 import id.homebase.api.sync.database.BufferedLocationPoint
 import id.homebase.api.sync.database.DatabaseManager
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,6 +23,7 @@ import kotlin.math.sqrt
  */
 class LocationPointStore(
     private val databaseManager: DatabaseManager,
+    private val deviceSensors: DeviceSensors,
 ) : LocationPointSink {
 
     private val logger = Logger.withTag("LocationPointStore")
@@ -32,7 +34,8 @@ class LocationPointStore(
     override suspend fun submit(points: List<RawLocationPoint>) {
         if (points.isEmpty()) return
         val accepted = mutableListOf<RawLocationPoint>()
-        var last = _lastPoint.value ?: databaseManager.locationPoint.selectLatest()?.toRaw()
+        val prevPoint = _lastPoint.value ?: databaseManager.locationPoint.selectLatest()?.toRaw()
+        var last = prevPoint
         for (p in points.sortedBy { it.t }) {
             if (last != null && p.t <= last.t) continue
             // Thin stationary noise: skip fixes that moved < MIN_DISPLACEMENT_M
@@ -45,9 +48,41 @@ class LocationPointStore(
             last = p
         }
         if (accepted.isEmpty()) return
-        databaseManager.locationPoint.insertPoints(accepted.map { it.toBuffered() })
+
+        // Device readings. Battery (free, permission-less) is stamped on every
+        // point — the encoder surfaces only the hour's first, but any point may
+        // be it. The step delta covers the window since the previous accepted
+        // point and is attributed to the newest point of this batch (exact
+        // per-point in foreground; a batch window's steps in background).
+        val battery = runCatching { deviceSensors.batteryPercent() }
+            .onFailure { logger.d(it) { "battery read failed" } }.getOrNull()
+        val sample = runCatching { deviceSensors.stepsSince(prevPoint?.t, loadCumulative()) }
+            .onFailure { logger.d(it) { "step read failed" } }.getOrNull()
+        sample?.cumulative?.let { saveCumulative(it) }
+
+        val lastIndex = accepted.lastIndex
+        val buffered = accepted.mapIndexed { i, p ->
+            p.toBuffered().copy(
+                bat = battery,
+                steps = if (i == lastIndex) sample?.deltaSteps else null,
+            )
+        }
+        databaseManager.locationPoint.insertPoints(buffered)
         _lastPoint.value = last
-        logger.d { "Buffered ${accepted.size}/${points.size} points (last src=${last?.src})" }
+        logger.d {
+            "Buffered ${accepted.size}/${points.size} points " +
+                "(last src=${last?.src} bat=$battery steps=${sample?.deltaSteps})"
+        }
+    }
+
+    private fun loadCumulative(): Long? = runCatching {
+        if (SharedPreferences.contains(STEP_CUMULATIVE_KEY)) {
+            SharedPreferences.getLong(STEP_CUMULATIVE_KEY)
+        } else null
+    }.getOrNull()
+
+    private fun saveCumulative(value: Long) {
+        runCatching { SharedPreferences.putLong(STEP_CUMULATIVE_KEY, value) }
     }
 
     /** Rows still buffered on this device — the UI's "waiting to upload" count. */
@@ -84,6 +119,10 @@ class LocationPointStore(
         // fix is stationary noise — drop it before it costs DB and upload bytes.
         const val MIN_DISPLACEMENT_M = 8.0
         const val MIN_INTERVAL_MS = 20_000L
+
+        // Persisted (survives process death like the device id) so the Android
+        // background receiver can compute a step delta after a cold wake.
+        private const val STEP_CUMULATIVE_KEY = "location_last_step_cumulative"
 
         fun haversineMeters(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
             val dLat = (lat2 - lat1) * PI / 180.0

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTracker.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTracker.kt
@@ -32,6 +32,10 @@ data class RawLocationPoint(
     val src: String,
     /** True when captured in foreground precise mode. */
     val fg: Boolean,
+    /** Pedometer steps since the previous accepted point (delta); set by the store. */
+    val steps: Int? = null,
+    /** Battery %, 0..100; set by the store. */
+    val bat: Int? = null,
 )
 
 /**

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/permissions/PermissionType.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/permissions/PermissionType.kt
@@ -16,4 +16,11 @@ enum class PermissionType {
      * [LOCATION] is granted; on iOS it is the Always authorization escalation.
      */
     LOCATION_ALWAYS,
+
+    /**
+     * Physical-activity / motion access for the pedometer: Android
+     * `ACTIVITY_RECOGNITION` (runtime permission API 29+; auto-granted below),
+     * iOS Core Motion. Best-effort — denial just omits step counts.
+     */
+    ACTIVITY,
 }

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.jvm.kt
@@ -1,0 +1,10 @@
+package id.homebase.core.location.tracking
+
+actual fun createDeviceSensors(): DeviceSensors = NoDeviceSensors
+
+/** Desktop is a viewer — no battery/step capture. */
+private object NoDeviceSensors : DeviceSensors {
+    override suspend fun batteryPercent(): Int? = null
+    override suspend fun stepsSince(prevPointTimeMs: Long?, lastCumulative: Long?): StepSample =
+        StepSample(null, null)
+}

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/tracking/LocationPointStoreTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/tracking/LocationPointStoreTest.kt
@@ -7,6 +7,18 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/** Sensors stub: fixed battery + step delta, so the store's stamping is testable. */
+private class FakeSensors(
+    private val battery: Int? = null,
+    private val delta: Int? = null,
+    private val cumulative: Long? = null,
+) : DeviceSensors {
+    override suspend fun batteryPercent(): Int? = battery
+    override suspend fun stepsSince(prevPointTimeMs: Long?, lastCumulative: Long?): StepSample =
+        StepSample(delta, cumulative)
+}
 
 class LocationPointStoreTest {
 
@@ -17,7 +29,10 @@ class LocationPointStoreTest {
         src: String = "gps",
     ) = RawLocationPoint(t = t, lat = lat, lon = lon, acc = 10.0, src = src, fg = true)
 
-    private fun runStoreTest(body: suspend (LocationPointStore, DatabaseManager) -> Unit) = runTest {
+    private fun runStoreTest(
+        sensors: DeviceSensors = FakeSensors(),
+        body: suspend (LocationPointStore, DatabaseManager) -> Unit,
+    ) = runTest {
         val dispatcher = StandardTestDispatcher(testScheduler)
         val db = DatabaseManager(
             { JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY) },
@@ -25,7 +40,7 @@ class LocationPointStoreTest {
             readDispatcher = dispatcher,
         )
         try {
-            body(LocationPointStore(db), db)
+            body(LocationPointStore(db, sensors), db)
         } finally {
             db.close()
         }
@@ -78,9 +93,33 @@ class LocationPointStoreTest {
     fun dedupsAgainstDbAfterColdStart() = runStoreTest { store, db ->
         store.submit(listOf(point(t = 0)))
         // Fresh store instance — in-memory lastPoint empty, must seed from DB.
-        val coldStore = LocationPointStore(db)
+        val coldStore = LocationPointStore(db, FakeSensors())
         coldStore.submit(listOf(point(t = 5_000)))
         assertEquals(1, coldStore.countPendingUpload())
+    }
+
+    @Test
+    fun stampsBatteryOnEveryPointAndStepDeltaOnNewest() = runStoreTest(
+        sensors = FakeSensors(battery = 80, delta = 42, cumulative = 1000L),
+    ) { store, db ->
+        // Two far-apart points accepted in one submit.
+        store.submit(listOf(point(t = 0), point(t = 60_000, lon = 13.01)))
+        val rows = db.locationPoint.selectByTimeRange(0, 3_600_000)
+        assertEquals(2, rows.size)
+        // Battery on both.
+        assertEquals(80, rows[0].bat)
+        assertEquals(80, rows[1].bat)
+        // Step delta only on the newest (the window since the previous point).
+        assertNull(rows[0].steps)
+        assertEquals(42, rows[1].steps)
+    }
+
+    @Test
+    fun nullSensorsLeaveStepsAndBatteryNull() = runStoreTest { store, db ->
+        store.submit(listOf(point(t = 0)))
+        val row = db.locationPoint.selectByTimeRange(0, 3_600_000).single()
+        assertNull(row.steps)
+        assertNull(row.bat)
     }
 
     @Test

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/permissions/PermissionsManager.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/permissions/PermissionsManager.native.kt
@@ -38,6 +38,11 @@ import platform.UserNotifications.UNAuthorizationStatusEphemeral
 import platform.UserNotifications.UNAuthorizationStatusNotDetermined
 import platform.UserNotifications.UNAuthorizationStatusProvisional
 import platform.UserNotifications.UNUserNotificationCenter
+import platform.CoreMotion.CMAuthorizationStatusAuthorized
+import platform.CoreMotion.CMPedometer
+import platform.Foundation.NSDate
+import platform.Foundation.dateWithTimeIntervalSince1970
+import platform.Foundation.timeIntervalSince1970
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
@@ -95,6 +100,27 @@ private object LocationPermissionRequester {
         // on resume, so a silently dropped callback is fine.
         pending = onResult
         manager.requestAlwaysAuthorization()
+    }
+}
+
+/**
+ * Core Motion (pedometer) authorization. The first pedometer query triggers the
+ * system motion prompt; the auth status afterward reflects the user's choice.
+ */
+private object MotionPermissionRequester {
+    fun isAuthorized(): Boolean =
+        CMPedometer.authorizationStatus() == CMAuthorizationStatusAuthorized
+
+    fun request(onResult: (Boolean) -> Unit) {
+        if (!CMPedometer.isStepCountingAvailable()) {
+            onResult(false)
+            return
+        }
+        val now = NSDate()
+        val from = NSDate.dateWithTimeIntervalSince1970(now.timeIntervalSince1970 - 1.0)
+        CMPedometer().queryPedometerDataFromDate(from, now) { _, _ ->
+            onResult(CMPedometer.authorizationStatus() == CMAuthorizationStatusAuthorized)
+        }
     }
 }
 
@@ -156,6 +182,18 @@ class IOSPermissionsManager(val onPermissionResult: (PermissionType, PermissionS
                     )
                 }
             }
+
+            PermissionType.ACTIVITY -> {
+                // A throwaway pedometer query surfaces the Core Motion prompt;
+                // the result is reported via the status read afterwards.
+                MotionPermissionRequester.request { granted ->
+                    onPermissionResult(
+                        permission,
+                        if (granted) PermissionStatus.GRANTED else PermissionStatus.DENIED,
+                        !granted,
+                    )
+                }
+            }
         }
     }
 
@@ -202,6 +240,8 @@ class IOSPermissionsManager(val onPermissionResult: (PermissionType, PermissionS
             PermissionType.LOCATION_ALWAYS -> {
                 LocationPermissionRequester.status == kCLAuthorizationStatusAuthorizedAlways
             }
+
+            PermissionType.ACTIVITY -> MotionPermissionRequester.isAuthorized()
         }
     }
 

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.web.kt
@@ -1,0 +1,10 @@
+package id.homebase.core.location.tracking
+
+actual fun createDeviceSensors(): DeviceSensors = NoDeviceSensors
+
+/** Web is a viewer — no battery/step capture. */
+private object NoDeviceSensors : DeviceSensors {
+    override suspend fun batteryPercent(): Int? = null
+    override suspend fun stepsSince(prevPointTimeMs: Long?, lastCumulative: Long?): StepSample =
+        StepSample(null, null)
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -137,6 +137,8 @@ import id.homebase.core.config.getLocationPermissionExtensionConfig
 import id.homebase.core.config.getVaultPermissionExtensionConfig
 import id.homebase.core.location.LocationPreferences
 import id.homebase.core.location.tracking.LocationDeviceId
+import id.homebase.core.location.tracking.DeviceSensors
+import id.homebase.core.location.tracking.createDeviceSensors
 import id.homebase.core.location.tracking.LocationPointStore
 import id.homebase.core.location.tracking.LocationTracker
 import id.homebase.core.location.tracking.LocationTrackingCoordinator
@@ -200,6 +202,7 @@ val appModule = module {
     // region Location add-on
     single { LocationPreferences(get()) }
     single { LocationDeviceId() }
+    single<DeviceSensors> { createDeviceSensors() }
     singleOf(::LocationPointStore)
     single<LocationTracker> { createLocationTracker(get<LocationPointStore>()) }
     single {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
@@ -92,6 +92,20 @@ fun LocationScreen(
         recheckPermissions()
     }
 
+    // Best-effort activity/motion permission for the pedometer: requested once,
+    // after location is granted and the disclosure (which covers steps) was
+    // accepted. Denial is ignored — location tracking and the rest of the
+    // feature continue, steps just stay null.
+    var activityRequested by remember { mutableStateOf(false) }
+    LaunchedEffect(uiState.whileInUseGranted, uiState.disclosureAccepted) {
+        if (uiState.whileInUseGranted && uiState.disclosureAccepted && !activityRequested) {
+            activityRequested = true
+            if (!permissionsManager.isPermissionGranted(PermissionType.ACTIVITY)) {
+                permissionsManager.askPermission(PermissionType.ACTIVITY)
+            }
+        }
+    }
+
     // Returning from the system settings screen must refresh both permission rows.
     var resumeTick by remember { mutableIntStateOf(0) }
     DisposableEffect(lifecycleOwner) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/model/LocationTrackContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/model/LocationTrackContent.kt
@@ -78,6 +78,8 @@ data class LocationTrackHour(
     val points: List<BufferedLocationPoint>,
     /** Raw captured count for the hour; > points.size when the header trace was thinned. */
     val fullCount: Int,
+    /** Battery % at the hour's first point (header only); null for payload/older files. */
+    val battery: Int? = null,
 ) {
     /** True when a full-resolution payload rides alongside the header trace. */
     val hasOverflowPayload: Boolean get() = fullCount > points.size
@@ -86,13 +88,16 @@ data class LocationTrackHour(
 /**
  * Compact positional encoding of the header trace:
  * ```
- * { "v":1, "deviceId":"…", "hourStart":…, "count":n, "full":N?, "t0":ms,
+ * { "v":1, "deviceId":"…", "hourStart":…, "count":n, "full":N?, "t0":ms, "bat":pct?,
  *   "bbox":[minLatE5,minLonE5,maxLatE5,maxLonE5],
- *   "pts":[[dtSec,latE5,lonE5,accM,spdE1,hdgDeg,flags],…] }
+ *   "pts":[[dtSec,latE5,lonE5,accM,spdE1,hdgDeg,flags,steps?],…] }
  * ```
  * lat/lon as integer 1e-5 degrees (≈1.1 m — below GPS accuracy), dt as whole
  * seconds from t0, speed as 0.1 m/s, heading as whole degrees; flags bit0 = fg,
- * bits1+ = source index. Integers keep the JSON dense and avoid double-repr noise.
+ * bits1+ = source index; steps = pedometer delta since the previous point (or
+ * null); bat = battery % at the hour's first point. Integers keep the JSON
+ * dense. Trailing optional fields are appended, so older 7-element points and
+ * `bat`-less summaries still decode.
  */
 object LocationTrackCodec {
 
@@ -136,6 +141,9 @@ object LocationTrackCodec {
             put("count", stored.size)
             if (fullCount > stored.size) put("full", fullCount)
             put("t0", t0)
+            // Battery for the hour = the first point's reading (chaining hour
+            // files reconstructs the curve). thinUniform always keeps point 0.
+            stored.first().bat?.let { put("bat", it) }
             put("bbox", buildJsonArray {
                 add(JsonPrimitive(stored.minOf { it.lat.toE5() }))
                 add(JsonPrimitive(stored.minOf { it.lon.toE5() }))
@@ -152,6 +160,7 @@ object LocationTrackCodec {
                         add(p.spd?.let { JsonPrimitive((it * 10).roundToInt()) } ?: JsonNull)
                         add(p.hdg?.let { JsonPrimitive(it.roundToInt()) } ?: JsonNull)
                         add(JsonPrimitive(flagsOf(p)))
+                        add(p.steps?.let { JsonPrimitive(it) } ?: JsonNull)
                     })
                 }
             })
@@ -176,6 +185,8 @@ object LocationTrackCodec {
                 hdg = a[5].jsonPrimitive.intOrNull?.toDouble(),
                 src = sources.getOrElse(flags shr 1) { "gps" },
                 fg = flags and 1 == 1,
+                // Index 7 appended later — null on older 7-element points.
+                steps = a.getOrNull(7)?.jsonPrimitive?.intOrNull,
             )
         }
         LocationTrackHour(
@@ -183,13 +194,14 @@ object LocationTrackCodec {
             hourStartMs = hourStart,
             points = pts,
             fullCount = obj["full"]?.jsonPrimitive?.intOrNull ?: pts.size,
+            battery = obj["bat"]?.jsonPrimitive?.intOrNull,
         )
     }.getOrNull()
 
     /**
      * Full-resolution payload for overflow hours — same positional shape, but
      * absolute ms timestamps and unrounded doubles, plus alt/altAcc:
-     * `[t,lat,lon,acc,alt,altAcc,spd,hdg,flags]`.
+     * `[t,lat,lon,acc,alt,altAcc,spd,hdg,flags,steps?]`.
      */
     fun encodePayload(deviceId: Uuid, hourStartMs: Long, points: List<BufferedLocationPoint>): String {
         val obj = buildJsonObject {
@@ -208,6 +220,7 @@ object LocationTrackCodec {
                         add(p.spd?.let { JsonPrimitive(it) } ?: JsonNull)
                         add(p.hdg?.let { JsonPrimitive(it) } ?: JsonNull)
                         add(JsonPrimitive(flagsOf(p)))
+                        add(p.steps?.let { JsonPrimitive(it) } ?: JsonNull)
                     })
                 }
             })
@@ -231,6 +244,7 @@ object LocationTrackCodec {
                 hdg = a[7].jsonPrimitive.contentOrNullDouble(),
                 src = sources.getOrElse(flags shr 1) { "gps" },
                 fg = flags and 1 == 1,
+                steps = a.getOrNull(9)?.jsonPrimitive?.intOrNull,
             )
         }
         LocationTrackHour(

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/model/LocationTrackContentTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/model/LocationTrackContentTest.kt
@@ -4,6 +4,7 @@ import id.homebase.api.sync.database.BufferedLocationPoint
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.uuid.Uuid
 
@@ -21,9 +22,11 @@ class LocationTrackContentTest {
         hdg: Double? = 271.0,
         src: String = "gps",
         fg: Boolean = true,
+        steps: Int? = null,
+        bat: Int? = null,
     ) = BufferedLocationPoint(
         t = hourStart + offsetMs, lat = lat, lon = lon, acc = acc,
-        spd = spd, hdg = hdg, src = src, fg = fg,
+        spd = spd, hdg = hdg, src = src, fg = fg, steps = steps, bat = bat,
     )
 
     @Test
@@ -144,5 +147,46 @@ class LocationTrackContentTest {
         assertEquals(points.first(), thinned.first())
         assertEquals(points.last(), thinned.last())
         assertEquals(thinned, thinned.sortedBy { it.t })
+    }
+
+    @Test
+    fun headerCarriesStepsAndFirstPointBattery() {
+        val points = listOf(
+            point(0, steps = null, bat = 88),       // first → battery source
+            point(20_000, lat = 52.31301, steps = 23, bat = 70),
+        )
+        val (json, stored) = LocationTrackCodec.encodeHeader(deviceId, hourStart, points)
+        assertEquals(2, stored.size)
+        val decoded = assertNotNull(LocationTrackCodec.decodeHeader(json))
+        assertEquals(88, decoded.battery)               // first point's battery
+        assertNull(decoded.points[0].steps)
+        assertEquals(23, decoded.points[1].steps)
+    }
+
+    @Test
+    fun payloadCarriesStepsLossless() {
+        val points = listOf(
+            point(0, steps = null),
+            point(60_000, lat = 52.4, steps = 117),
+        )
+        val json = LocationTrackCodec.encodePayload(deviceId, hourStart, points)
+        val decoded = assertNotNull(LocationTrackCodec.decodePayload(json))
+        assertNull(decoded.points[0].steps)
+        assertEquals(117, decoded.points[1].steps)
+    }
+
+    @Test
+    fun decodesLegacyHeaderWithoutStepsOrBattery() {
+        // A header written before steps/bat existed: 7-element points, no "bat".
+        val legacy = """
+            {"v":1,"deviceId":"$deviceId","hourStart":$hourStart,"count":1,"t0":${hourStart / 1000},
+             "bbox":[5231235,1342346,5231235,1342346],
+             "pts":[[0,5231235,1342346,12,14,271,1]]}
+        """.trimIndent().replace("\n", "")
+        val decoded = assertNotNull(LocationTrackCodec.decodeHeader(legacy))
+        assertNull(decoded.battery)
+        assertEquals(1, decoded.points.size)
+        assertNull(decoded.points[0].steps)
+        assertEquals("gps", decoded.points[0].src)
     }
 }

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -33,6 +33,8 @@
 	<string>Used to share your current location in chat and, when you enable it, to record your private location history.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>Allows Homebase to keep recording your private, encrypted location history while the app is in the background. Only you can see it.</string>
+	<key>NSMotionUsageDescription</key>
+	<string>Used to record your step count alongside your private location history, so you can tell walking from cycling or driving.</string>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>INSendMessageIntent</string>


### PR DESCRIPTION
## Summary
Adds activity + power context to recorded GPS history:
- **Per-point step delta** — pedometer steps since the previous point on this device, on every GPS line. Cadence between fixes distinguishes **walking / cycling / driving** along a route (the reason it's per-point, not per-hour).
- **Per-hour battery %** — battery level at the hour file's **first point** only. An hour's first reading ≈ the previous file's last, so chaining files reconstructs the curve at zero per-point budget cost.

Both reads are hardware-backed and effectively free; no battery drain.

## How
- **`DeviceSensors` expect/actual** (`homebase-common/.../location/tracking/`): Android = `BatteryManager` + `TYPE_STEP_COUNTER` (cumulative-since-boot → delta by subtraction, persisted via `SharedPreferences` so the cold-process background receiver can compute deltas after a wake); iOS = `UIDevice.batteryLevel` + `CMPedometer` historical interval query (delta directly); desktop/web no-op. All sensor logic lives in `LocationPointStore.submit`, so the background receiver path is unchanged — battery stamped on every accepted point (encoder surfaces only the hour's first), step delta on the batch's newest point (exact per-point in foreground, batch-window in background).
- **Data model**: `steps`/`bat` threaded through `RawLocationPoint`, `BufferedLocationPoint`, and `LocationPoint.sq` — columns added straight into `CREATE TABLE`. **No migration**: only two devices have ever activated Location; they reinstall and the disposable buffer rebuilds.
- **Codec**: `steps` appended to the header point array (index 7) and payload (index 9); `bat` on the header summary. Trailing-optional layout → older 7-element points and `bat`-less summaries still decode (regression-tested). Header budget unchanged (`thinToFit` still caps at 5200 B); steps cost ~10% header resolution as discussed.
- **Permission**: `PermissionType.ACTIVITY` (Android `ACTIVITY_RECOGNITION` API 29+, iOS Core Motion). Requested **best-effort during setup** once location is granted; denial leaves steps null and never blocks tracking. The existing consent dialog text now discloses steps + battery. `ACTIVITY_RECOGNITION` manifest perm + `NSMotionUsageDescription` plist.

## Not a Play declaration gate
Unlike background location, `ACTIVITY_RECOGNITION` has **no** sensitive-permission declaration/upload gate — but the **Data safety** form must disclose activity data (console task, out of code scope).

## Test plan
- [x] `homebase-{api,common,core}:jvmTest` green (incl. Konsist); `androidApp:assembleDebug` green; merged manifest carries `ACTIVITY_RECOGNITION`. JVM + Android + wasmJs compile.
- [x] New tests: codec header+payload round-trip with steps/bat; **legacy decode** of a 7-element point + `bat`-less summary; store stamping (battery on all accepted, delta on newest, null sensors → null).
- [ ] iOS compile (CMPedometer/UIDevice interop) — CI macOS runner.
- [ ] Manual (debug): walk with mock steps → points carry deltas; deny activity permission → location still tracks, steps null; hour file's `bat` = first point's level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)