### PR TITLE
Play unblock: scope ACTIVITY_RECOGNITION to debug builds

### DIFF
--- a/androidApp/src/debug/AndroidManifest.xml
+++ b/androidApp/src/debug/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- Debug-only until the Play Console Health Apps declaration is approved —
+         see the note in src/main/AndroidManifest.xml. Sideloaded debug builds
+         keep pedometer step capture; Play-uploaded build types (dev, release)
+         omit the permission so the androidpublisher edit commit isn't rejected
+         with 403 "You must let us know whether your app includes any health
+         features". The DB columns, codec and sensor code stay regardless —
+         store builds simply record null steps until the permission returns. -->
+    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
+
+</manifest>

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -30,10 +30,13 @@
          PendingIntent registration after a reboot. -->
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-    <!-- Location add-on: pedometer (steps per GPS point). Runtime permission on
-         API 29+; best-effort, location tracking continues if denied. No Play
-         declaration gate, but the Data safety form must disclose activity data. -->
-    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
+    <!-- Location add-on: pedometer (steps per GPS point). ACTIVITY_RECOGNITION
+         lives in src/debug/AndroidManifest.xml ONLY: Google Play rejects any
+         store bundle declaring it with 403 "You must let us know whether your
+         app includes any health features" until the Play Console Health Apps
+         declaration is completed. Sideloaded debug builds keep step capture;
+         store builds (dev/release) record GPS + battery and leave steps null
+         until the declaration clears, at which point this moves back here. -->
 
     <!-- Devices running Android 13 (API level 33) or higher -->
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />


### PR DESCRIPTION
## Summary
Release upload 403'd at the Play edit commit: *"You must let us know whether your app includes any health features."* Google Play gates `ACTIVITY_RECOGNITION` (added in #727) behind the **Health Apps declaration** — the same upload-time gate `ACCESS_BACKGROUND_LOCATION` hit, different form.

Move the permission to `src/debug/AndroidManifest.xml`. Store build types (dev, release) omit it → upload passes; sideloaded **debug** builds keep step capture. **No code reverted** — DB columns, codec, sensor reads, consent text, and iOS are unchanged; store builds record GPS + battery and leave `steps` null (no permission → the Android step sensor returns nothing) until the declaration clears, at which point the permission moves back to the main manifest.

Verified via merged manifests: `debug` carries the `<uses-permission>` element, `dev` carries 0.

## Follow-up (console, out of code scope)
Complete the Play Console **Health Apps** declaration for `id.homebase.feed` / `id.homebase.feed.dev`; then revert this to put `ACTIVITY_RECOGNITION` back in the main manifest so store builds capture steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)