### PR TITLE
Message Details: show metrics for an offline / not-yet-attempted queued message

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
@@ -126,6 +126,11 @@ class OutboxSync(
         isOnline = online
     }
 
+    /** Whether the outbox is currently allowed to send (the connection is up).
+     *  When false, queued items can't even attempt — Message Info shows
+     *  "waiting for connection" rather than a meaningless backoff countdown. */
+    fun isCurrentlyOnline(): Boolean = isOnline
+
     private val MAX_SENDING_THREADS = 3
     private val BASE_DELAY_SECONDS = 30L        // first retry after 30s
     private val MAX_DELAY_SECONDS = 14400L      // 4 hours cap

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoScreen.kt
@@ -75,6 +75,7 @@ import id.homebase.resources.msg_outbox_checked_out_stuck
 import id.homebase.resources.msg_outbox_entry_lingering
 import id.homebase.resources.msg_send_attempt
 import id.homebase.resources.msg_stuck_reason
+import id.homebase.resources.msg_waiting_for_connection
 import id.homebase.resources.msg_waiting_on_earlier_message
 import id.homebase.resources.msg_status_delivery_details_unavailable
 import id.homebase.resources.msg_status_failed_to_send
@@ -292,6 +293,8 @@ fun MessageInfoUi(
                                             stringResource(MR.string.msg_outbox_checked_out_stuck)
                                         uiState.isActivelyUploading ->
                                             stringResource(MR.string.msg_status_sending)
+                                        uiState.outboxIsOffline ->
+                                            stringResource(MR.string.msg_waiting_for_connection)
                                         else -> stringResource(
                                             MR.string.msg_still_in_outbox,
                                             rememberNextAttemptText(uiState.nextAttemptAtMs),

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoUiState.kt
@@ -124,6 +124,9 @@ data class MessageInfoUiState(
     /** The message reads Sent/Delivered, yet a (dead/lingering) outbox row still
      *  exists for it — surfaced honestly with a Try-now to clear it. */
     val hasLingeringOutboxRow: Boolean = false,
+    /** The outbox is offline (no connection), so a queued message can't even
+     *  attempt — show "waiting for connection" instead of a backoff countdown. */
+    val outboxIsOffline: Boolean = false,
 )
 
 sealed interface MessageInfoUiEvent {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/messageinfo/MessageInfoViewModel.kt
@@ -192,13 +192,18 @@ class MessageInfoViewModel(
                 canRetry = overlay.canRetry,
                 canTryNow = overlay.canTryNow,
                 nextAttemptInMinutes = overlay.nextAttemptInMinutes,
-                attemptNumber = effective?.takeIf { it.checkOutCount >= 1 }?.let { (it.checkOutCount + 1).toInt() },
+                // Show the attempt counter for ANY queued row — including a
+                // never-yet-attempted one (offline / first attempt) — so it isn't
+                // blank exactly when a message is stuck waiting to send.
+                attemptNumber = effective?.let { (it.checkOutCount + 1).toInt() },
                 nextAttemptAtMs = effective?.let { nextAttemptDeadlineMs(it.isCheckedOut, it.nextRunTime) },
                 waitingOnEarlierMessage = waiting,
                 stuckReason = effective?.lastError,
                 blockingRow = state.blockingRow,
                 isCheckedOut = effective?.isCheckedOut == true,
                 isActivelyUploading = effective?.isActivelyUploading == true,
+                // Offline only matters while something is actually queued.
+                outboxIsOffline = row != null && !outboxSync.isCurrentlyOnline(),
                 hasLingeringOutboxRow = row != null &&
                     (overlay.sendState == OutgoingSendState.Sent ||
                         overlay.sendState == OutgoingSendState.DeliveryFailed),

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -60,6 +60,7 @@
     <string name="msg_stuck_reason">Couldn’t send: %1$s</string>
     <string name="msg_outbox_checked_out_stuck">Stuck — the upload didn’t finish and is still checked out</string>
     <string name="msg_outbox_entry_lingering">A pending outbox entry is still present for this message</string>
+    <string name="msg_waiting_for_connection">Waiting for connection</string>
     <string name="action_try_now">Try now</string>
     <string name="label_edited">Edited: %1$s</string>
     <string name="label_size">Size: %1$s</string>


### PR DESCRIPTION
## Problem (repro: flight mode → send → Message Details)

An offline send is **never attempted** — `send()` is skipped while disconnected — so its outbox row sits at `checkOutCount=0`, `nextRunTime=0` indefinitely. The Message Details metrics are all derived from *attempts*, so they showed **nothing** exactly when a message is stuck waiting to send:

- the **attempt counter** was gated on `checkOutCount >= 1` (hidden until a failure),
- the **countdown** read the sentinel `nextRunTime=0` → rendered "shortly", not a real time,
- the **reason** needs a failed attempt → none yet.

So a flight-mode message read only "Still sending — next attempt shortly" with no metrics.

## Fix

- **Always show the attempt counter** for a queued row — "Attempt 1 of 20" from the first attempt, not only after a failure.
- **Surface offline explicitly**: `OutboxSync.isCurrentlyOnline()` feeds a new `outboxIsOffline` UiState flag; a queued message with no connection shows **"Waiting for connection"** instead of a meaningless backoff countdown.

Once the device is back online and a send actually fails, the existing behaviour takes over (attempt increments, real countdown, reason).

`homebase-api`/`chat`/`common` jvmTest green; Android + wasmJs compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)