### PR TITLE
Location: fix hour-file truncation + give iOS a background flush trigger

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/LocationPointWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/LocationPointWrapper.kt
@@ -100,6 +100,30 @@ class LocationPointWrapper(
             delegate.countAll().executeAsOne()
         }
 
+    /** Rows not yet part of an enqueued hour file — the UI's "waiting to upload" count. */
+    suspend fun countUnmarked(): Long =
+        databaseManager.readValue("locationPoint.countUnmarked") {
+            delegate.countUnmarked().executeAsOne()
+        }
+
+    /** Distinct hour buckets (epoch ms / 3_600_000) that still hold any rows, marked or not. */
+    suspend fun selectHoursWithRows(): List<Long> =
+        databaseManager.readValue("locationPoint.selectHoursWithRows") {
+            delegate.selectHoursWithRows().executeAsList()
+        }
+
+    /**
+     * Drains rows flushed under [fileUid], but only if the hour they belong to
+     * has closed (its bucket is strictly before the bucket of [nowMs]). A no-op
+     * while the hour is still open — the marked rows stay so the next flush
+     * re-serializes the complete hour.
+     */
+    suspend fun deleteFlushedIfHourClosed(fileUid: Uuid, nowMs: Long) {
+        databaseManager.withWrite { db ->
+            db.locationPointQueries.deleteFlushedIfHourClosed(fileUid, nowMs)
+        }
+    }
+
     suspend fun countSince(fromInclusiveMs: Long): Long =
         databaseManager.readValue("locationPoint.countSince") {
             delegate.countSince(fromInclusiveMs).executeAsOne()

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/LocationPoint.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/LocationPoint.sq
@@ -3,9 +3,12 @@ import kotlin.uuid.Uuid;
 -- Local buffer for GPS points captured by the Location add-on, drained into
 -- per-device per-UTC-hour track files on the Location drive by
 -- LocationTrackUploaderService. Drain semantics: rows are stamped with the
--- target file's uniqueId on enqueue (markFlushed), deleted when the outbox
--- confirms the upload (deleteByFlushUid), and un-stamped on failure
--- (clearFlushMark) so the next flush retries them.
+-- target file's uniqueId on enqueue (markFlushed) but KEPT — marked, not
+-- deleted — until the hour they belong to has closed, so every flush
+-- re-serializes the complete hour (the file is a whole-document replace). The
+-- outbox confirmation deletes them only once the hour is closed
+-- (deleteFlushedIfHourClosed); failures un-stamp them (clearFlushMark) so the
+-- next flush retries.
 CREATE TABLE IF NOT EXISTS LocationPoint(
   t INTEGER NOT NULL PRIMARY KEY,  -- capture time, epoch ms; INSERT OR REPLACE dedups
   lat REAL NOT NULL,
@@ -54,9 +57,34 @@ deleteByFlushUid:
 DELETE FROM LocationPoint
 WHERE flushedFileUid = ?;
 
--- Rows still on this device (enqueued or not) — the UI's "waiting to upload" count.
+-- Rows still on this device (enqueued or not).
 countAll:
 SELECT COUNT(*) FROM LocationPoint;
+
+-- Rows not yet part of an enqueued hour file — the UI's "waiting to upload"
+-- count. (Marked rows are already uploaded and kept only until the hour closes,
+-- so they must NOT count as pending.)
+countUnmarked:
+SELECT COUNT(*) FROM LocationPoint
+WHERE flushedFileUid IS NULL;
+
+-- Distinct hour buckets (epoch ms / 3600000) that still hold any rows. Used to
+-- finalize a closed hour (flush its complete contents one last time) even when
+-- no new points have arrived to put it in selectPendingHours.
+selectHoursWithRows:
+SELECT DISTINCT (t / 3600000) AS hourBucket
+FROM LocationPoint
+ORDER BY hourBucket;
+
+-- Drain a confirmed hour's rows, but ONLY once the hour has closed (its bucket
+-- is strictly before the current one). While the hour is still open we keep the
+-- marked rows so the next flush re-serializes the COMPLETE hour — the hour file
+-- is a whole-document replace, so dropping rows mid-hour truncates it. All rows
+-- of a given flush share one hour, so this deletes all-or-nothing.
+deleteFlushedIfHourClosed:
+DELETE FROM LocationPoint
+WHERE flushedFileUid = :fileUid
+  AND (t / 3600000) < (:nowMs / 3600000);
 
 countSince:
 SELECT COUNT(*) FROM LocationPoint

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/LocationPointWrapperTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/LocationPointWrapperTest.kt
@@ -104,6 +104,60 @@ class LocationPointWrapperTest {
     }
 
     @Test
+    fun countUnmarkedExcludesEnqueuedRows() = runDbTest { buffer ->
+        buffer.insertPoints(listOf(point(1), point(2), point(hourMs + 1)))
+        assertEquals(3, buffer.countUnmarked())
+        // Mark hour 0's two rows as flushed; only hour 1's row stays unmarked.
+        buffer.markFlushed(Uuid.random(), 0, hourMs)
+        assertEquals(1, buffer.countUnmarked())
+        assertEquals(3, buffer.countAll())
+    }
+
+    @Test
+    fun selectHoursWithRowsReturnsMarkedAndUnmarkedHours() = runDbTest { buffer ->
+        buffer.insertPoints(listOf(point(1), point(hourMs + 1), point(2 * hourMs + 1)))
+        // Mark hour 0 — it must STILL appear (rows are kept until the hour closes).
+        buffer.markFlushed(Uuid.random(), 0, hourMs)
+        assertEquals(listOf(0L, 1L, 2L), buffer.selectHoursWithRows())
+        // selectPendingHours, by contrast, drops the marked hour.
+        assertEquals(listOf(1L, 2L), buffer.selectPendingHours())
+    }
+
+    @Test
+    fun drainKeepsRowsWhileHourOpenAndDeletesOnceClosed() = runDbTest { buffer ->
+        // Hour 0 holds two points; flush marks them under uid.
+        val uid = Uuid.random()
+        buffer.insertPoints(listOf(point(1), point(2)))
+        buffer.markFlushed(uid, 0, hourMs)
+
+        // Confirmation arrives while hour 0 is still the current hour (now within
+        // hour 0): rows must be KEPT so the next flush re-serializes the full hour.
+        buffer.deleteFlushedIfHourClosed(uid, nowMs = 1_000)
+        assertEquals(2, buffer.countAll())
+        // The complete hour is still re-serializable (marked rows included).
+        assertEquals(2, buffer.selectByTimeRange(0, hourMs).size)
+
+        // Confirmation after the hour has closed (now in hour 1): rows drained.
+        buffer.deleteFlushedIfHourClosed(uid, nowMs = hourMs + 1)
+        assertEquals(0, buffer.countAll())
+    }
+
+    @Test
+    fun drainOnlyTouchesTheConfirmedUidsHour() = runDbTest { buffer ->
+        // Two closed hours, each flushed under its own uid.
+        val uid0 = Uuid.random()
+        val uid1 = Uuid.random()
+        buffer.insertPoints(listOf(point(1), point(hourMs + 1)))
+        buffer.markFlushed(uid0, 0, hourMs)
+        buffer.markFlushed(uid1, hourMs, 2 * hourMs)
+
+        // Now is well past both hours, but only hour 0's confirmation arrives.
+        buffer.deleteFlushedIfHourClosed(uid0, nowMs = 5 * hourMs)
+        assertEquals(listOf(1L), buffer.selectHoursWithRows())
+        assertEquals(1, buffer.countAll())
+    }
+
+    @Test
     fun countSinceAndLatestAndRetention() = runDbTest { buffer ->
         buffer.insertPoints(listOf(point(1000), point(5000), point(9000)))
         assertEquals(2, buffer.countSince(5000))

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/LocationUpdatesReceiver.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/LocationUpdatesReceiver.kt
@@ -39,10 +39,10 @@ class LocationUpdatesReceiver : BroadcastReceiver(), KoinComponent {
         val pendingResult = goAsync()
         scope.launch {
             try {
+                // submit() drains via its onPointsBuffered hook (wired to the
+                // uploader's rate-gated flushIfDue in AppModule) — the same
+                // common trigger iOS now uses, so no platform-specific call here.
                 get<LocationPointStore>().submit(points)
-                // Opportunistic drain — we're awake anyway; the coordinator
-                // forwards to the uploader's rate-gated flushIfDue.
-                get<LocationTrackingCoordinator>().onBackgroundPointsDelivered()
             } finally {
                 pendingResult.finish()
             }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationPointStore.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationPointStore.kt
@@ -24,6 +24,14 @@ import kotlin.math.sqrt
 class LocationPointStore(
     private val databaseManager: DatabaseManager,
     private val deviceSensors: DeviceSensors,
+    /**
+     * Invoked after a non-empty batch lands in the buffer, on submit()'s
+     * coroutine. Wired in AppModule to the uploader's rate-gated flushIfDue so
+     * EVERY capture path triggers a drain — the Android background receiver AND
+     * the iOS CLLocationManager delegate, which previously had no background
+     * flush trigger and let points pile up unsent. Default no-op for tests.
+     */
+    private val onPointsBuffered: suspend () -> Unit = {},
 ) : LocationPointSink {
 
     private val logger = Logger.withTag("LocationPointStore")
@@ -69,10 +77,18 @@ class LocationPointStore(
         }
         databaseManager.locationPoint.insertPoints(buffered)
         _lastPoint.value = last
-        logger.d {
-            "Buffered ${accepted.size}/${points.size} points " +
+        // Info (not debug) so the background capture/upload pipeline is auditable
+        // in homebase.log — pending is the not-yet-uploaded backlog that the
+        // iPhone stall would have shown climbing without a flush.
+        val pending = runCatching { databaseManager.locationPoint.countUnmarked() }.getOrDefault(-1L)
+        logger.i {
+            "Buffered ${accepted.size}/${points.size} points pending=$pending " +
                 "(last src=${last?.src} bat=$battery steps=${sample?.deltaSteps})"
         }
+        // Trigger a drain from common code so iOS gets the same background flush
+        // as Android. flushIfDue is rate-gated, so calling it per batch is cheap.
+        runCatching { onPointsBuffered() }
+            .onFailure { logger.e(it) { "onPointsBuffered (flush trigger) failed" } }
     }
 
     private fun loadCumulative(): Long? = runCatching {
@@ -85,8 +101,12 @@ class LocationPointStore(
         runCatching { SharedPreferences.putLong(STEP_CUMULATIVE_KEY, value) }
     }
 
-    /** Rows still buffered on this device — the UI's "waiting to upload" count. */
-    suspend fun countPendingUpload(): Long = databaseManager.locationPoint.countAll()
+    /**
+     * Rows not yet part of an enqueued hour file — the UI's "waiting to upload"
+     * count. Marked rows are already uploaded (kept only until the hour closes),
+     * so they must not count here.
+     */
+    suspend fun countPendingUpload(): Long = databaseManager.locationPoint.countUnmarked()
 
     suspend fun countSince(fromInclusiveMs: Long): Long =
         databaseManager.locationPoint.countSince(fromInclusiveMs)

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTrackingCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTrackingCoordinator.kt
@@ -72,11 +72,6 @@ class LocationTrackingCoordinator(
         logger.i { "Tracking ${if (enabled) "enabled" else "disabled"}" }
     }
 
-    /** Called by the Android background receiver after buffering a batch. */
-    suspend fun onBackgroundPointsDelivered() {
-        onFlushDue()
-    }
-
     /**
      * Re-evaluate after a logout/login wipe. The pref StateFlow was reset by
      * LocationPreferences.reset() before this runs; if the wipe turned the

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/tracking/LocationPointStoreTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/tracking/LocationPointStoreTest.kt
@@ -123,6 +123,33 @@ class LocationPointStoreTest {
     }
 
     @Test
+    fun firesFlushTriggerWhenPointsAreBuffered() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val db = DatabaseManager(
+            { JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY) },
+            dispatcher = dispatcher,
+            readDispatcher = dispatcher,
+        )
+        try {
+            var triggers = 0
+            val store = LocationPointStore(db, FakeSensors(), onPointsBuffered = { triggers++ })
+            // First batch accepts a point → one trigger.
+            store.submit(listOf(point(t = 0)))
+            assertEquals(1, triggers)
+            // A stationary-noise-only batch buffers nothing → no trigger (the
+            // common flush trigger is the iOS background-flush fix; it must not
+            // fire on dropped fixes).
+            store.submit(listOf(point(t = 5_000, lon = 13.00008)))
+            assertEquals(1, triggers)
+            // A far-enough point is accepted → another trigger.
+            store.submit(listOf(point(t = 25_000, lon = 13.001)))
+            assertEquals(2, triggers)
+        } finally {
+            db.close()
+        }
+    }
+
+    @Test
     fun haversineSanity() {
         // One degree of longitude at the equator ≈ 111.3 km.
         val d = LocationPointStore.haversineMeters(0.0, 0.0, 0.0, 1.0)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -203,7 +203,17 @@ val appModule = module {
     single { LocationPreferences(get()) }
     single { LocationDeviceId() }
     single<DeviceSensors> { createDeviceSensors() }
-    singleOf(::LocationPointStore)
+    single {
+        LocationPointStore(
+            databaseManager = get(),
+            deviceSensors = get(),
+            // Every buffered batch drains immediately (rate-gated by the
+            // uploader). Lazy get() avoids the construction-time cycle; resolved
+            // at flush time. This is the iOS background-flush fix — the Apple
+            // tracker funnels through submit() and now triggers a flush too.
+            onPointsBuffered = { get<LocationTrackUploaderService>().flushIfDue() },
+        )
+    }
     single<LocationTracker> { createLocationTracker(get<LocationPointStore>()) }
     single {
         LocationTrackUploaderService(

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationTrackUploaderService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationTrackUploaderService.kt
@@ -81,6 +81,8 @@ class LocationTrackUploaderService(
     private val deviceId: LocationDeviceId,
     private val preferences: LocationPreferences,
     private val scope: CoroutineScope,
+    /** Injectable for tests; production reads the wall clock. */
+    private val nowMs: () -> Long = { Clock.System.now().toEpochMilliseconds() },
 ) {
     private val logger = Logger.withTag(TAG)
     private val driveId = locationLabeledDrive.drive.alias
@@ -103,7 +105,7 @@ class LocationTrackUploaderService(
      */
     fun start() {
         scope.launch {
-            buffer.deleteOlderThan(Clock.System.now().toEpochMilliseconds() - RETENTION_MS)
+            buffer.deleteOlderThan(nowMs() - RETENTION_MS)
             refreshPendingCount()
         }
         if (observerStarted) return
@@ -120,14 +122,15 @@ class LocationTrackUploaderService(
 
     /** Rate-gated flush — the entry point for tickers and background batch wakes. */
     suspend fun flushIfDue() {
-        val now = Clock.System.now().toEpochMilliseconds()
+        val now = nowMs()
         if (now - lastFlushAttemptMs < MIN_FLUSH_INTERVAL_MS) return
         flush()
     }
 
     suspend fun flush() {
         flushMutex.withLock {
-            lastFlushAttemptMs = Clock.System.now().toEpochMilliseconds()
+            val now = nowMs()
+            lastFlushAttemptMs = now
             if (!preferences.activated.value) {
                 logger.d { "Flush skipped: Location add-on not activated" }
                 return
@@ -140,13 +143,25 @@ class LocationTrackUploaderService(
             val hours = runCatching { buffer.selectPendingHours() }
                 .onFailure { logger.e(it) { "selectPendingHours failed" } }
                 .getOrNull() ?: return
-            if (hours.isNotEmpty()) {
+            // Closed hours that still hold rows but no UN-marked ones (so they
+            // never appear in selectPendingHours): their confirmation arrived
+            // while the hour was open, so the drain kept the rows. Re-flush each
+            // once now that it has closed — the resulting ItemCompleted finally
+            // drains them. Without this they'd linger until the 7-day sweep.
+            val currentHour = now / HOUR_MS
+            val finalizeHours = runCatching { buffer.selectHoursWithRows() }
+                .onFailure { logger.e(it) { "selectHoursWithRows failed" } }
+                .getOrNull().orEmpty()
+                .filter { it < currentHour && it !in hours }
+
+            if (hours.isNotEmpty() || finalizeHours.isNotEmpty()) {
                 // Only devices that actually capture points register an identity —
                 // viewer devices (desktop/web) never reach this branch.
                 runCatching { ensureDeviceProfile() }
                     .onFailure { logger.e(it) { "ensureDeviceProfile failed" } }
+                logger.d { "Flush: ${hours.size} pending hour(s), ${finalizeHours.size} closed to finalize" }
             }
-            for (hourBucket in hours) {
+            for (hourBucket in hours + finalizeHours) {
                 runCatching { flushHour(hourBucket * HOUR_MS) }
                     .onFailure { logger.e(it) { "flushHour($hourBucket) failed" } }
             }
@@ -175,6 +190,15 @@ class LocationTrackUploaderService(
                 "Flushed hour=$hourStartMs uid=$uid points=${points.size} stored=${stored.size} " +
                     "overflowPayload=$overflow mode=${if (existing == null) "create" else "update"}"
             }
+        } else {
+            // replaceEnqueue declined (e.g. outbox backpressure): the rows stay
+            // UN-marked and a later flush retries the hour. Surfaced loudly
+            // because a silent enqueued==false is exactly what hid the iPhone
+            // "105 points waiting for hours" stall from the log.
+            logger.w {
+                "Flush NOT enqueued hour=$hourStartMs uid=$uid points=${points.size} " +
+                    "mode=${if (existing == null) "create" else "update"} — rows stay buffered, will retry"
+            }
         }
     }
 
@@ -191,7 +215,7 @@ class LocationTrackUploaderService(
      */
     suspend fun countPointsToday(): Int {
         val creds = credentialsManager.getActiveCredentials() ?: return 0
-        val now = Clock.System.now().toEpochMilliseconds()
+        val now = nowMs()
         val dayStart = now - now % DAY_MS
         val hourUids = (0 until 24)
             .map { dayStart + it * HOUR_MS }
@@ -410,10 +434,15 @@ class LocationTrackUploaderService(
             when (bufferActionFor(event, driveId)) {
                 BufferAction.DrainFlushed -> {
                     val uid = (event as BackendEvent.OutboxEvent.ItemCompleted).uniqueId
-                    logger.i { "Hour-file upload confirmed uid=$uid — draining buffer rows" }
-                    runCatching { buffer.deleteByFlushUid(uid) }
-                        .onFailure { logger.e(it) { "deleteByFlushUid failed" } }
-                    _lastFlushTime.value = Clock.System.now().toEpochMilliseconds()
+                    val now = nowMs()
+                    // Delete the hour's rows ONLY if the hour has closed; while
+                    // still open they stay marked so the next flush re-serializes
+                    // the complete hour (otherwise the file is truncated to the
+                    // points captured since the last drain — the original bug).
+                    logger.i { "Hour-file upload confirmed uid=$uid — draining rows if hour closed" }
+                    runCatching { buffer.deleteFlushedIfHourClosed(uid, now) }
+                        .onFailure { logger.e(it) { "deleteFlushedIfHourClosed failed" } }
+                    _lastFlushTime.value = now
                     refreshPendingCount()
                 }
 
@@ -437,7 +466,9 @@ class LocationTrackUploaderService(
     }
 
     private suspend fun refreshPendingCount() {
-        _pendingCount.value = runCatching { buffer.countAll() }.getOrDefault(0L)
+        // Unmarked rows only: marked rows are already uploaded and kept just
+        // until the hour closes, so they must NOT show as "waiting to upload".
+        _pendingCount.value = runCatching { buffer.countUnmarked() }.getOrDefault(0L)
     }
 
     private companion object {


### PR DESCRIPTION
Three coupled fixes for the Location add-on's background capture/upload path, folded into one PR.

## (A) Hour files were silently truncated
`flushHour` rebuilds the **whole** hour file from the buffer (`selectByTimeRange` returns marked + unmarked rows) as a whole-document replace — but `observeOutbox` drained the hour's rows on **every** `ItemCompleted`, mid-hour. The next flush then re-serialized only the points captured since that drain and overwrote the file with just those, so each ~2-min confirmation **shrank** the hour file.

`homebase.log` proved it: a walk's hour climbed `1→2→8` points, then collapsed `8→5→4→6→2→1`, ending as a 1-point file.

**Fix:** keep flush-marked rows until the hour has **closed**.
- Drain on confirmation now goes through `deleteFlushedIfHourClosed(uid, now)` — a no-op while the hour is still the current one (rows stay marked so the next flush re-serializes the complete hour).
- A **finalize pass** in `flush()` re-flushes any closed hour that still holds rows (`selectHoursWithRows`, `h < currentHour`) so its rows get drained promptly rather than lingering until the 7-day retention sweep.
- "Waiting to upload" / `pendingCount` now count **unmarked** rows only (`countUnmarked`) — marked rows are already uploaded.

## (B) iOS had no background flush trigger
The flush trigger lived in Android-only code (`receiver → coordinator.onBackgroundPointsDelivered`). iOS only flushed on the foreground 2-min ticker, so background points piled up unsent (a colleague's iPhone: **116 captured, 105 waiting for hours**).

Both capture paths funnel through `LocationPointStore.submit()`, so the trigger moves into common code: an injected `onPointsBuffered` hook, wired in `AppModule` to the uploader's rate-gated `flushIfDue`. Android's redundant `onBackgroundPointsDelivered` call and the coordinator method are removed.

## (C) Instrumentation
The iPhone stall was undiagnosable from the log — a silent `enqueued == false` left rows buffered with no trace. `flushHour` now **Warns** when not enqueued; `submit()` logs buffered/pending counts at **Info** as a heartbeat.

## Tests
- Wrapper-level drain semantics: rows kept while the hour is open, file stays fully re-serializable, deleted once the hour closes, and only the confirmed uid's hour is touched.
- Store flush trigger: fires on accepted points, **not** on stationary-noise fixes that buffer nothing.

Verified: `homebase-api/core/common:jvmTest` green; `androidApp:assembleDebug` green (runs the Konsist ArchitectureTest).

## Notes
- **Forward-only**: today's already-overwritten hour files are unrecoverable — those points were drained from the buffer and overwritten on the drive. The fix prevents recurrence.
- iOS targets were not compiled (Linux host); the iOS change is the common `submit()` trigger plus the existing Apple delegate, no new native interop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)