### PR TITLE
Fix Read more scroll-in bounce: decide chip placement in the measure pass

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -201,12 +201,18 @@ fun MessageBubbleRaw(
     // overflow a screenful, on mobile only. Transient (no rememberSaveable) and reset per
     // message identity so recycled bubbles don't inherit a stale expanded state.
     var bodyExpanded by remember(message.id) { mutableStateOf(false) }
+    val isMobileDevice = isMobile()
     // Desktop always shows the full body and never an expander.
-    val bodyMaxLines = if (isMobile() && !bodyExpanded) CollapsedBodyMaxLines else Int.MAX_VALUE
-    // Derive truncation from the captured layout result rather than measuring screen height.
-    // hasVisualOverflow is true exactly when the line cap clipped the body.
-    val isBodyTruncated =
-        isMobile() && !bodyExpanded && (textLayoutResult?.hasVisualOverflow == true)
+    val bodyMaxLines = if (isMobileDevice && !bodyExpanded) CollapsedBodyMaxLines else Int.MAX_VALUE
+    // Whether a "Read more" affordance is *eligible* for this bubble. This is deliberately
+    // derived WITHOUT the post-layout textLayoutResult, so the chip's presence as a custom-
+    // Layout child is stable across the first measure→layout pass. Whether the chip is
+    // actually placed (and contributes height) is decided inside the Layout below from the
+    // freshly-written textLayoutResult, in the SAME measure pass that produces it. Gating the
+    // chip on textLayoutResult HERE instead would lag one frame behind onTextLayout: the
+    // bubble would lay out without the chip, then grow by the chip's height a frame later —
+    // the "bounce" seen as a clipped message scrolls into view.
+    val canShowReadMore = !bodyExpanded && (message.hasMore || isMobileDevice)
     val pressInteractionSource = remember { MutableInteractionSource() }
     val isPressed by pressInteractionSource.collectIsPressedAsState()
 
@@ -666,9 +672,14 @@ fun MessageBubbleRaw(
                             // OR clipped by the mobile line cap. Tapping downloads the spilled
                             // payload when present AND expands, in a single action — there is
                             // no collapse-back ("Read more" only).
-                            val showReadMore = !bodyExpanded && (message.hasMore || isBodyTruncated)
+                            //
+                            // The chip is *composed* whenever it is eligible (canShowReadMore);
+                            // whether it is actually placed and contributes height is decided in
+                            // the Layout's measure pass from the freshly-written
+                            // textLayoutResult. Composing it here on a layout-independent flag is
+                            // what keeps the bubble from growing a frame after it appears.
                             Box(modifier = Modifier.fillMaxWidth()) {
-                                if (showReadMore) {
+                                if (canShowReadMore) {
                                     Text(
                                         text = stringResource(MR.string.chat_message_read_more),
                                         style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Bold),
@@ -761,6 +772,17 @@ fun MessageBubbleRaw(
 
                         // Calculate potential final width BEFORE measuring reply
                         val layoutResult = textLayoutResult
+
+                        // Decide read-more visibility HERE, from the layout result written
+                        // during THIS measure pass (the body was measured just above), so a
+                        // clipped body sizes the chip in on its first frame. hasMore is known
+                        // pre-layout; the mobile line-cap case reads hasVisualOverflow off the
+                        // fresh result. canShowReadMore (composition) guarantees the chip child
+                        // exists whenever this is true, so we never place an absent child.
+                        val showReadMore = !bodyExpanded &&
+                            (message.hasMore || (isMobileDevice && layoutResult?.hasVisualOverflow == true))
+                        val readMoreHeight = if (showReadMore) showMorePlaceable.height else 0
+
                         val rawPotentialFinalWidth: Int
 
                         if (layoutResult != null && layoutResult.lineCount > 0) {
@@ -849,7 +871,7 @@ fun MessageBubbleRaw(
                                     placeables.sumOf { it.height } +
                                             replyHeight +
                                             textPlaceable.height +
-                                            (showMorePlaceable.height)
+                                            readMoreHeight
                             } else {
                                 finalWidth = maxOf(
                                     mediaWidth,
@@ -865,7 +887,7 @@ fun MessageBubbleRaw(
                                     placeables.sumOf { it.height } +
                                             replyHeight +
                                             textPlaceable.height +
-                                            (showMorePlaceable.height) +
+                                            readMoreHeight +
                                             infoPlaceable.height +
                                             8.dp.roundToPx() +
                                             4.dp.roundToPx()
@@ -879,10 +901,10 @@ fun MessageBubbleRaw(
                                 authorWidth
                             )
                             infoY =
-                                placeables.sumOf { it.height } + replyHeight + textPlaceable.height
+                                placeables.sumOf { it.height } + replyHeight + textPlaceable.height + readMoreHeight
                             infoX = finalWidth - infoPlaceable.width
                             finalHeight =
-                                placeables.sumOf { it.height } + replyHeight + textPlaceable.height + infoPlaceable.height + 4.dp.roundToPx()
+                                placeables.sumOf { it.height } + replyHeight + textPlaceable.height + readMoreHeight + infoPlaceable.height + 4.dp.roundToPx()
                         }
 
                         // Same containment as `potentialFinalWidth`: never report a width
@@ -907,8 +929,13 @@ fun MessageBubbleRaw(
                             textPlaceable.placeRelative(0, yPos)
                             yPos += textPlaceable.height
 
-                            showMorePlaceable.placeRelative(0, yPos)
-                            yPos += showMorePlaceable.height
+                            // Only place (and advance past) the chip when the measure pass
+                            // above decided to show it; readMoreHeight in finalHeight/infoY
+                            // matches this so the timestamp never overlaps an absent chip.
+                            if (showReadMore) {
+                                showMorePlaceable.placeRelative(0, yPos)
+                                yPos += showMorePlaceable.height
+                            }
 
                             infoPlaceable.placeRelative(clampedInfoX, infoY)
                         }


### PR DESCRIPTION
## Regression

PR #662 (inline "Read more" expander, `MessageBubbleRaw`) introduced a visible **"bounce"** as moderately-long messages scroll into view: the bubble appears at one height, then a frame later grows. It hits header-resident bodies just over the 10-line cap (< 7 KB, so **not** payload-spilled) — what the reporter described as messages "not too long / within the threshold" that "look like they are calculating their recomposition."

## Root cause

The chip's visibility was gated **in composition** on a **post-layout** signal:

```kotlin
val isBodyTruncated = isMobile() && !bodyExpanded && (textLayoutResult?.hasVisualOverflow == true)
val showReadMore   = !bodyExpanded && (message.hasMore || isBodyTruncated)
```

Composition runs *before* measure, so on the frame an item scrolls in `textLayoutResult` is still `null`:

1. **Frame 1** — chip absent, bubble measured short.
2. The body's `onTextLayout` fires *during measure*, writes `textLayoutResult` → schedules recomposition.
3. **Frame 2** — `isBodyTruncated` flips true, chip appears, **bubble grows by the chip's height** = the bounce.

`hasMore` chips never bounced (`hasMore` is known pre-layout), and the last-line timestamp tuck never bounced because it reads the *freshly-written* `textLayoutResult` **inside the measure pass**. The chip was the one thing left gated on the lagging composition phase.

## Fix

Move the chip's placement decision into that same measure pass:

- **Composition** computes only *eligibility* (`canShowReadMore`) from layout-independent inputs (`!bodyExpanded && (message.hasMore || isMobile)`), so the chip child's existence is stable across the first measure→layout pass.
- The real `showReadMore` and its height contribution (`readMoreHeight`) are derived **in the Layout's measure block** from the in-pass-fresh `layoutResult` — so a clipped body sizes the chip in and places it on its **first** frame, no second-pass grow.
- The chip is placed (and advances `yPos`) only when `showReadMore`; `readMoreHeight` is folded into `finalHeight`/`infoY` in all three branches — including the `layoutResult == null` branch, which previously placed a `hasMore` chip **without** counting its height (latent overlap, now closed).

**Custom-`Layout` child count and the `textIndex`/`showMoreIndex`/`infoIndex` math are unchanged** — the chip is still exactly one `Box` child. Desktop behaviour preserved (no line cap; `hasMore` chip only).

## Verification

- `:homebase-chat:compileKotlinJvm` + `:homebase-chat:compileAndroidMain` — build clean (no warnings on the edited file).
- `:homebase-common:jvmTest` (Konsist `ArchitectureTest` gate — no hardcoded `Text("…")` introduced) + `:homebase-chat:jvmTest` — pass.
- iOS / wasmJs left to CI (`build-check.yml` / `test.yml`) — common Compose only, same posture as #662.
- ⚠️ **On-device visual confirmation of the no-bounce behaviour is still pending** — compile/unit tests cannot observe a layout-timing glitch. Recommend a quick scroll test with a ~12–30 line message before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)