### PR TITLE
Shared Lists — Phase 1: Drive + Activation Shell

### DIFF
--- a/ADDING_ADDON_APPS.md
+++ b/ADDING_ADDON_APPS.md
@@ -239,7 +239,8 @@ existing range. Current owners:
 | `0000...0a01xx` | Vault |
 | `0000...0a02xx` | Moments |
 | `0000...0a03xx` | Location |
-| `0000...0a04xx` | **next free** — claim it here when you take it |
+| `0000...0a04xx` | Lists |
+| `0000...0a05xx` | **next free** — claim it here when you take it |
 
 ---
 

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1259,4 +1259,19 @@
     <string name="location_history_devices">%1$d devices</string>
     <string name="location_history_span">%1$s – %2$s</string>
 
+
+    <!-- Lists add-on -->
+    <string name="lists_label">Lists</string>
+    <string name="nav_lists">Lists</string>
+    <string name="lists_onboarding_title">Shared lists for everyone</string>
+    <string name="lists_onboarding_body_1">Lists is a shared space where you and your family build and check off lists together.</string>
+    <string name="lists_onboarding_body_2">Set it up to mount the Lists drive on this device and start collaborating.</string>
+    <string name="lists_onboarding_setup">Set it up</string>
+    <string name="lists_onboarding_dismiss">Not now</string>
+    <string name="lists_settings_section">Lists</string>
+    <string name="lists_settings_open">Open Lists</string>
+    <string name="lists_settings_show_icon">Show Lists icon in bottom bar</string>
+    <string name="lists_home_subtitle">Shared to-do lists</string>
+    <string name="lists_empty_title">No lists yet</string>
+    <string name="lists_empty_body">Create a list to start collaborating with your family.</string>
 </resources>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/config/AppConfig.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/config/AppConfig.kt
@@ -143,6 +143,23 @@ val locationLabeledDrive = LabeledDrive(
     label = "Location",
 )
 
+// Lists drive — collaborative shared lists add-on. Modeled on [locationLabeledDrive]
+// (app-generated stable alias GUID + drive type GUID). One optional drive per identity
+// (not in [mandatorySyncDrives]); requested via the extend-permissions flow and mounted
+// when the user activates the Lists add-on. Every list lives on this one drive,
+// partitioned by groupId = listId (see Shared Lists design spec). ownerOdinId is null —
+// each identity owns its own Lists drive, exactly like chat.
+//
+// The type GUID is a placeholder until the server team provisions the real Lists drive
+// type (same caveat as Vault/Location above).
+val listsLabeledDrive = LabeledDrive(
+    drive = TargetDrive(
+        alias = Uuid.parse("c1d2e3f4-5a6b-4c7d-8e9f-0a1b2c3d4e5f"),
+        type = Uuid.parse("b7a1c9d3-4e62-4f8a-9c0d-1e2f3a4b5c6d"),
+    ),
+    label = "Lists",
+)
+
 // Default vault sections — stable UUIDs so re-running onboarding is idempotent
 val vaultDefaultSections = listOf(
     Uuid.parse("6da3968b-0edf-41f0-a136-0492034030e2") to "Passports",
@@ -352,6 +369,30 @@ fun getLocationPermissionExtensionConfig(): PermissionExtensionConfig {
         appId = AppConfig.APP_ID,
         appName = AppConfig.APP_NAME,
         drives = locationTargetDriveAccessRequest,
+        permissions = emptyList(),
+        returnUrl = ::returnUrl,
+    )
+}
+
+// Lists-specific permission config — drive-only, no extra app permissions.
+// Mirrors the Location optional-drive permission shape. Phase 1 requests only self
+// Read + Write; the connected-identities circle write-grant required for cross-identity
+// collaboration is added in Phase 4 (see Shared Lists design spec, "Risks").
+val listsTargetDriveAccessRequest: List<TargetDriveAccessRequest> = listOf(
+    TargetDriveAccessRequest(
+        alias = listsLabeledDrive.drive.alias.toString(),
+        type = listsLabeledDrive.drive.type.toString(),
+        name = "Lists Drive",
+        description = "Drive which contains your shared lists",
+        permissions = listOf(DrivePermission.Read, DrivePermission.Write),
+    )
+)
+
+fun getListsPermissionExtensionConfig(): PermissionExtensionConfig {
+    return PermissionExtensionConfig(
+        appId = AppConfig.APP_ID,
+        appName = AppConfig.APP_NAME,
+        drives = listsTargetDriveAccessRequest,
         permissions = emptyList(),
         returnUrl = ::returnUrl,
     )

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/config/AppConfig.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/config/AppConfig.kt
@@ -143,27 +143,13 @@ val locationLabeledDrive = LabeledDrive(
     label = "Location",
 )
 
-// Lists drive — collaborative shared lists add-on. One optional drive per identity
-// (not in [mandatorySyncDrives]); requested via the extend-permissions flow and mounted
-// when the user activates the Lists add-on. Every list lives on this one drive,
-// partitioned by groupId = listId (see Shared Lists design spec). ownerOdinId is null —
-// each identity owns its own Lists drive, exactly like chat.
-//
-// Drive identity is the (alias, type) pair (TargetDrive.toKey = type + alias):
-//  - alias: an app-chosen stable RANDOM GUID — the real per-drive identifier (the client
-//    mounts / registers / websockets by alias; cf. TargetDrive's "rename alias to driveId"
-//    TODO). Must be unique across drives.
-//  - type:  REUSES the Moments app-content drive type (4338d7d2-…), NOT a freshly invented
-//    one. In this system `type` is a category that drives share — profile/wallet/
-//    homePageConfig all share one type, and Vault reuses the Contact drive type — and the
-//    server only honours provisioned types, so an invented type would not be recognised.
-//    Lists is the same kind of app-content drive as Moments; a shared type with a distinct
-//    alias is still a distinct drive. (Swap to a dedicated Lists type here if the server
-//    team ever provisions one.)
+// Lists add-on drive — optional, per-identity (not in [mandatorySyncDrives]), mounted via
+// extend-permissions on activation. `type` reuses the Moments app-content drive type (the
+// server only recognises provisioned types); the unique random `alias` is the per-drive id.
 val listsLabeledDrive = LabeledDrive(
     drive = TargetDrive(
         alias = Uuid.parse("a44e7a26-51f4-4a26-ad12-5d7627b35d0e"),
-        type = Uuid.parse("4338d7d2-f217-486a-8790-a4982644c15f"), // = momentsLabeledDrive.drive.type
+        type = Uuid.parse("4338d7d2-f217-486a-8790-a4982644c15f"), // = Moments drive type
     ),
     label = "Lists",
 )

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/config/AppConfig.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/config/AppConfig.kt
@@ -143,19 +143,27 @@ val locationLabeledDrive = LabeledDrive(
     label = "Location",
 )
 
-// Lists drive — collaborative shared lists add-on. Modeled on [locationLabeledDrive]
-// (app-generated stable alias GUID + drive type GUID). One optional drive per identity
+// Lists drive — collaborative shared lists add-on. One optional drive per identity
 // (not in [mandatorySyncDrives]); requested via the extend-permissions flow and mounted
 // when the user activates the Lists add-on. Every list lives on this one drive,
 // partitioned by groupId = listId (see Shared Lists design spec). ownerOdinId is null —
 // each identity owns its own Lists drive, exactly like chat.
 //
-// The type GUID is a placeholder until the server team provisions the real Lists drive
-// type (same caveat as Vault/Location above).
+// Drive identity is the (alias, type) pair (TargetDrive.toKey = type + alias):
+//  - alias: an app-chosen stable RANDOM GUID — the real per-drive identifier (the client
+//    mounts / registers / websockets by alias; cf. TargetDrive's "rename alias to driveId"
+//    TODO). Must be unique across drives.
+//  - type:  REUSES the Moments app-content drive type (4338d7d2-…), NOT a freshly invented
+//    one. In this system `type` is a category that drives share — profile/wallet/
+//    homePageConfig all share one type, and Vault reuses the Contact drive type — and the
+//    server only honours provisioned types, so an invented type would not be recognised.
+//    Lists is the same kind of app-content drive as Moments; a shared type with a distinct
+//    alias is still a distinct drive. (Swap to a dedicated Lists type here if the server
+//    team ever provisions one.)
 val listsLabeledDrive = LabeledDrive(
     drive = TargetDrive(
-        alias = Uuid.parse("c1d2e3f4-5a6b-4c7d-8e9f-0a1b2c3d4e5f"),
-        type = Uuid.parse("b7a1c9d3-4e62-4f8a-9c0d-1e2f3a4b5c6d"),
+        alias = Uuid.parse("a44e7a26-51f4-4a26-ad12-5d7627b35d0e"),
+        type = Uuid.parse("4338d7d2-f217-486a-8790-a4982644c15f"), // = momentsLabeledDrive.drive.type
     ),
     label = "Lists",
 )

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/lists/ListsPreferences.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/lists/ListsPreferences.kt
@@ -1,0 +1,68 @@
+package id.homebase.core.lists
+
+import id.homebase.api.sync.database.DatabaseManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlin.uuid.Uuid
+
+/**
+ * Local, per-identity state for the Lists add-on. Lives in `keyValue`, so it is wiped on
+ * logout; [reset] re-seeds the in-memory StateFlows from the (now-empty) DB on the next
+ * login. Modeled on [id.homebase.core.location.LocationPreferences].
+ */
+class ListsPreferences(private val databaseManager: DatabaseManager) {
+
+    private val keyValue get() = databaseManager.keyValue
+
+    // Whether the user has activated Lists (mounted the drive via extend-permissions).
+    private val _activated = MutableStateFlow(readBoolean(ACTIVATED_KEY, default = false))
+    val activated: StateFlow<Boolean> = _activated.asStateFlow()
+
+    // Hidden by default — "soft launch": the bottom-nav icon only appears after the user
+    // opts in via Settings → Lists → "Show Lists icon in bottom bar" (persists true,
+    // overriding this default). The Home-screen tile and the Settings entry remain the
+    // discoverable entry points either way.
+    private val _iconVisible = MutableStateFlow(readBoolean(ICON_VISIBLE_KEY, default = false))
+    val iconVisible: StateFlow<Boolean> = _iconVisible.asStateFlow()
+
+    suspend fun setActivated(value: Boolean) {
+        if (_activated.value == value) return
+        keyValue.upsertValue(ACTIVATED_KEY, encode(value))
+        _activated.value = value
+    }
+
+    suspend fun setIconVisible(value: Boolean) {
+        if (_iconVisible.value == value) return
+        keyValue.upsertValue(ICON_VISIBLE_KEY, encode(value))
+        _iconVisible.value = value
+    }
+
+    /**
+     * Re-seed in-memory state from the DB for a clean login. Called from
+     * `onPostAuthenticated` in `AppModule.kt`; after a logout wipe the reads return defaults.
+     */
+    fun reset() {
+        _activated.value = readBoolean(ACTIVATED_KEY, default = false)
+        _iconVisible.value = readBoolean(ICON_VISIBLE_KEY, default = false)
+    }
+
+    private fun readBoolean(key: Uuid, default: Boolean): Boolean {
+        // Bootstrap-only sync read — seeds the StateFlow at construction. See
+        // KeyValueWrapper.selectByKeyBootstrapSync for the rationale (commonMain has no
+        // runBlocking on wasmJs).
+        val bytes: ByteArray = runCatching {
+            keyValue.selectByKeyBootstrapSync(key) { _, data -> data }
+        }.getOrNull() ?: return default
+        return if (bytes.isEmpty()) default else bytes[0].toInt() != 0
+    }
+
+    private fun encode(value: Boolean): ByteArray = byteArrayOf(if (value) 1 else 0)
+
+    companion object {
+        // Stable namespace for Lists. Vault owns 0a01xx, Moments 0a02xx, Location 0a03xx;
+        // Lists is the next free slot (0a04xx).
+        val ACTIVATED_KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0401")
+        val ICON_VISIBLE_KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0402")
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
@@ -172,6 +172,18 @@ sealed class Route {
     data object MomentsSettings : Route()
 
     @Serializable
+    @SerialName("lists")
+    data object Lists : Route()
+
+    @Serializable
+    @SerialName("lists-onboarding")
+    data object ListsOnboarding : Route()
+
+    @Serializable
+    @SerialName("lists-settings")
+    data object ListsSettings : Route()
+
+    @Serializable
     @SerialName("location")
     data object Location : Route()
 

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/config/ListsDriveConfigTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/config/ListsDriveConfigTest.kt
@@ -1,0 +1,41 @@
+package id.homebase.core.config
+
+import id.homebase.api.youauth.DrivePermission
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+class ListsDriveConfigTest {
+
+    @Test
+    fun `lists drive has valid distinct guids`() {
+        assertNotEquals(listsLabeledDrive.drive.alias, listsLabeledDrive.drive.type)
+        assertNotEquals(listsLabeledDrive.drive.alias, locationLabeledDrive.drive.alias)
+        assertNotEquals(listsLabeledDrive.drive.type, locationLabeledDrive.drive.type)
+        assertEquals("Lists", listsLabeledDrive.label)
+    }
+
+    @Test
+    fun `lists drive is not a mandatory sync drive`() {
+        assertTrue(mandatorySyncDrives.none { it.drive.alias == listsLabeledDrive.drive.alias })
+    }
+
+    @Test
+    fun `lists permission request grants read and write on the lists drive`() {
+        val req = listsTargetDriveAccessRequest.single()
+        assertEquals(listsLabeledDrive.drive.alias.toString(), req.alias)
+        assertEquals(listsLabeledDrive.drive.type.toString(), req.type)
+        assertTrue(DrivePermission.Read in req.permissions)
+        assertTrue(DrivePermission.Write in req.permissions)
+    }
+
+    @Test
+    fun `lists permission extension config exposes the lists drive only`() {
+        val config = getListsPermissionExtensionConfig()
+        assertEquals(1, config.drives.size)
+        assertEquals(listsLabeledDrive.drive.alias.toString(), config.drives.single().alias)
+        assertEquals(null, config.circleDrives)
+    }
+}

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/config/ListsDriveConfigTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/config/ListsDriveConfigTest.kt
@@ -10,11 +10,25 @@ import kotlin.uuid.Uuid
 class ListsDriveConfigTest {
 
     @Test
-    fun `lists drive has valid distinct guids`() {
+    fun `lists drive reuses the moments app-content drive type with its own unique alias`() {
+        // `type` is a shared category (Moments is the app-content drive type the server
+        // provisions); `alias` is the unique per-drive id. Lists deliberately reuses the
+        // Moments type and MUST keep a distinct alias so it is a separate drive. If someone
+        // "fixes" the type back to a random GUID, the server won't recognise the drive.
+        assertEquals(momentsLabeledDrive.drive.type, listsLabeledDrive.drive.type)
+        assertNotEquals(momentsLabeledDrive.drive.alias, listsLabeledDrive.drive.alias)
         assertNotEquals(listsLabeledDrive.drive.alias, listsLabeledDrive.drive.type)
-        assertNotEquals(listsLabeledDrive.drive.alias, locationLabeledDrive.drive.alias)
-        assertNotEquals(listsLabeledDrive.drive.type, locationLabeledDrive.drive.type)
         assertEquals("Lists", listsLabeledDrive.label)
+    }
+
+    @Test
+    fun `lists drive alias is unique across all optional drives`() {
+        // The alias is the effective driveId — a collision would silently mount the wrong drive.
+        val aliases = listOf(
+            momentsLabeledDrive, vaultLabeledDrive, stickerLabeledDrive,
+            locationLabeledDrive, listsLabeledDrive,
+        ).map { it.drive.alias }
+        assertEquals(aliases.size, aliases.toSet().size)
     }
 
     @Test

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -135,6 +135,10 @@ import org.koin.dsl.bind
 import org.koin.dsl.module
 import id.homebase.core.config.getLocationPermissionExtensionConfig
 import id.homebase.core.config.getVaultPermissionExtensionConfig
+import id.homebase.core.config.getListsPermissionExtensionConfig
+import id.homebase.core.lists.ListsPreferences
+import id.homebase.core.ui.screens.lists.ListsSettingsViewModel
+import id.homebase.core.ui.screens.lists.ListsViewModel
 import id.homebase.core.location.LocationPreferences
 import id.homebase.core.location.tracking.LocationDeviceId
 import id.homebase.core.location.tracking.DeviceSensors
@@ -156,10 +160,12 @@ val FeedPermissionQualifier = named("feedPermission")
 val MomentsPermissionQualifier = named("momentsPermission")
 val StickerPermissionQualifier = named("stickerPermission")
 val LocationPermissionQualifier = named("locationPermission")
+val ListsPermissionQualifier = named("listsPermission")
 
 val appModule = module {
     single { UserPreferences(get()) }
     single { MomentsPreferences(get()) }
+    single { ListsPreferences(get()) }
     singleOf(::MomentsPostSenderService)
     // User-state store mirrors DriveRegistry's wiring — narrow lambda deps for
     // the write path (DriveFileProvider.getFileHeaderByUid + DriveUploadProvider
@@ -661,6 +667,9 @@ val appModule = module {
     }
     viewModel { MomentsViewModel(get(), get(MomentsPermissionQualifier), get()) }
     viewModelOf(::MomentsSettingsViewModel)
+    viewModel(ListsPermissionQualifier) { ExtendPermissionViewModel(get(), get(), get(), getListsPermissionExtensionConfig()) }
+    viewModel { ListsViewModel(get(), get(ListsPermissionQualifier), get()) }
+    viewModelOf(::ListsSettingsViewModel)
     viewModel(LocationPermissionQualifier) {
         ExtendPermissionViewModel(get(), get(), get(), getLocationPermissionExtensionConfig())
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -418,6 +418,7 @@ val appModule = module {
                 get<VaultStream>().apply { reset(); start() }
                 // Hydrate the saved-stickers tray for the new identity (mirror Vault).
                 get<id.homebase.chat.services.sticker.StickerStream>().apply { reset(); start() }
+                get<ListsPreferences>().reset()
 
                 // Location add-on: re-seed prefs from the (possibly wiped) DB,
                 // clear in-memory capture state, restart the flusher's outbox

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -107,6 +107,14 @@ import id.homebase.core.ui.screens.moments.MomentsViewModel
 import id.homebase.core.moments.MomentsPreferences
 import id.homebase.core.moments.services.MomentsFeedService
 import id.homebase.core.location.LocationPreferences
+import androidx.compose.material.icons.automirrored.outlined.ListAlt
+import id.homebase.core.lists.ListsPreferences
+import id.homebase.core.ui.screens.lists.ListsOnboardingScreen
+import id.homebase.core.ui.screens.lists.ListsScreen
+import id.homebase.core.ui.screens.lists.ListsSettingsScreen
+import id.homebase.core.ui.screens.lists.ListsUiEvent
+import id.homebase.core.ui.screens.lists.ListsViewModel
+import id.homebase.resources.nav_lists
 import id.homebase.core.ui.screens.location.LocationScreen
 import id.homebase.core.ui.screens.location.LocationUiEvent
 import id.homebase.core.ui.screens.location.LocationViewModel
@@ -190,13 +198,17 @@ fun AppNavHost(
     val locationPreferences = koinInject<LocationPreferences>()
     val locationIconVisible by locationPreferences.iconVisible.collectAsStateWithLifecycle()
     val locationViewModel: LocationViewModel = koinViewModel()
-    val topLevelRoutes = remember(momentsIconVisible, vaultIconVisible, locationIconVisible) {
+    val listsPreferences = koinInject<ListsPreferences>()
+    val listsIconVisible by listsPreferences.iconVisible.collectAsStateWithLifecycle()
+    val listsViewModel: ListsViewModel = koinViewModel()
+    val topLevelRoutes = remember(momentsIconVisible, vaultIconVisible, locationIconVisible, listsIconVisible) {
         buildList {
             add(TopLevelRoute.Chat)
             add(TopLevelRoute.Feed)
             if (momentsIconVisible) add(TopLevelRoute.Moments)
             if (vaultIconVisible) add(TopLevelRoute.Vault)
             if (locationIconVisible) add(TopLevelRoute.Location)
+            if (listsIconVisible) add(TopLevelRoute.Lists)
             add(TopLevelRoute.Home)
         }
     }
@@ -209,6 +221,17 @@ fun AppNavHost(
             }
         } else {
             navController.navigate(Route.MomentsOnboarding)
+        }
+    }
+    val openLists: () -> Unit = {
+        if (listsPreferences.activated.value) {
+            navController.navigate(Route.Lists) {
+                popUpTo(Route.ChatList) { saveState = true }
+                launchSingleTop = true
+                restoreState = true
+            }
+        } else {
+            navController.navigate(Route.ListsOnboarding)
         }
     }
     val openLocation: () -> Unit = {
@@ -454,6 +477,22 @@ fun AppNavHost(
         }
     }
 
+    // Translate Lists onboarding one-shot events into nav-stack changes.
+    LaunchedEffect(Unit) {
+        listsViewModel.events.collect { event ->
+            when (event) {
+                ListsUiEvent.Activated -> {
+                    navController.popBackStack(Route.ListsOnboarding, inclusive = true)
+                    navController.navigate(Route.Lists) {
+                        popUpTo(Route.ChatList) { saveState = true }
+                        launchSingleTop = true
+                    }
+                }
+                ListsUiEvent.CloseOnboarding -> navController.popBackStack()
+            }
+        }
+    }
+
     // Translate Location onboarding one-shot events into nav-stack changes.
     LaunchedEffect(Unit) {
         locationViewModel.events.collect { event ->
@@ -509,6 +548,7 @@ fun AppNavHost(
                                     topLevelRoute is TopLevelRoute.Moments -> openMoments()
                                     topLevelRoute is TopLevelRoute.Vault -> openVault()
                                     topLevelRoute is TopLevelRoute.Location -> openLocation()
+                                    topLevelRoute is TopLevelRoute.Lists -> openLists()
                                     else -> navController.navigate(topLevelRoute.route) {
                                         popUpTo(Route.ChatList) { saveState = true }
                                         launchSingleTop = true
@@ -544,6 +584,7 @@ fun AppNavHost(
                                         topLevelRoute is TopLevelRoute.Moments -> openMoments()
                                         topLevelRoute is TopLevelRoute.Vault -> openVault()
                                         topLevelRoute is TopLevelRoute.Location -> openLocation()
+                                        topLevelRoute is TopLevelRoute.Lists -> openLists()
                                         else -> navController.navigate(topLevelRoute.route) {
                                             popUpTo(Route.ChatList) { saveState = true }
                                             launchSingleTop = true
@@ -718,6 +759,7 @@ fun AppNavHost(
                                     onNavigateToVault = openVault,
                                     onNavigateToMoments = openMoments,
                                     onNavigateToLocation = openLocation,
+                                    onNavigateToLists = openLists,
                                     onNavigateToExamples = { navController.navigate(Route.Examples) },
                                 )
                             }
@@ -1056,6 +1098,9 @@ fun AppNavHost(
                                     onNavigateToLocationSettings = {
                                         navController.navigate(Route.LocationSettings)
                                     },
+                                    onNavigateToListsSettings = {
+                                        navController.navigate(Route.ListsSettings)
+                                    },
                                 )
                             }
                         }
@@ -1165,6 +1210,29 @@ fun AppNavHost(
                                     viewModel = koinViewModel(),
                                     onBackClick = { navController.popBackStack() },
                                     onOpenMoments = openMoments,
+                                )
+                            }
+                        }
+
+                        composable<Route.ListsOnboarding> {
+                            if (isAuthenticated) {
+                                ListsOnboardingScreen(
+                                    viewModel = listsViewModel,
+                                    onNavigateBack = { navController.popBackStack() },
+                                )
+                            }
+                        }
+                        composable<Route.Lists> {
+                            if (isAuthenticated) {
+                                ListsScreen()
+                            }
+                        }
+                        composable<Route.ListsSettings> {
+                            if (isAuthenticated) {
+                                ListsSettingsScreen(
+                                    viewModel = koinViewModel(),
+                                    onBackClick = { navController.popBackStack() },
+                                    onOpenLists = openLists,
                                 )
                             }
                         }
@@ -1452,7 +1520,8 @@ private fun NavDestination?.isTopLevelRoute(): Boolean {
             this?.hasRoute(Route.Moments::class) == true ||
             this?.hasRoute(Route.Home::class) == true ||
             this?.hasRoute(Route.Vault::class) == true ||
-            this?.hasRoute(Route.Location::class) == true
+            this?.hasRoute(Route.Location::class) == true ||
+            this?.hasRoute(Route.Lists::class) == true
 }
 
 private fun AnimatedContentTransitionScope<NavBackStackEntry>.isBetweenTopLevelRoutes(): Boolean {
@@ -1474,6 +1543,7 @@ sealed class TopLevelRoute(
     data object Home : TopLevelRoute(Route.Home, MR.string.nav_home, Icons.Default.Home)
     data object Vault : TopLevelRoute(Route.Vault, MR.string.vault_label, Icons.Outlined.Lock)
     data object Location : TopLevelRoute(Route.Location, MR.string.location_label, Icons.Outlined.LocationOn)
+    data object Lists : TopLevelRoute(Route.Lists, MR.string.nav_lists, Icons.AutoMirrored.Outlined.ListAlt)
 }
 
 /**

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/home/HomeScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/home/HomeScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material.icons.automirrored.outlined.ListAlt
 import androidx.compose.material3.Button
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
@@ -53,6 +54,8 @@ import id.homebase.resources.export_log
 import id.homebase.resources.homebase_logo
 import id.homebase.resources.location_home_subtitle
 import id.homebase.resources.location_label
+import id.homebase.resources.lists_home_subtitle
+import id.homebase.resources.lists_label
 import id.homebase.resources.moments_home_subtitle
 import id.homebase.resources.moments_label
 import id.homebase.resources.vault_home_subtitle
@@ -66,6 +69,7 @@ fun HomeScreen(
     onNavigateToVault: () -> Unit,
     onNavigateToMoments: () -> Unit,
     onNavigateToLocation: () -> Unit,
+    onNavigateToLists: () -> Unit,
     onNavigateToExamples: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -119,6 +123,7 @@ fun HomeScreen(
         onNavigateToVault = onNavigateToVault,
         onNavigateToMoments = onNavigateToMoments,
         onNavigateToLocation = onNavigateToLocation,
+        onNavigateToLists = onNavigateToLists,
     )
 }
 
@@ -130,6 +135,7 @@ fun HomeUi(
     onNavigateToVault: () -> Unit = {},
     onNavigateToMoments: () -> Unit = {},
     onNavigateToLocation: () -> Unit = {},
+    onNavigateToLists: () -> Unit = {},
 ) {
     val scrollState = rememberScrollState()
     Scaffold(
@@ -177,6 +183,15 @@ fun HomeUi(
                 label = stringResource(MR.string.location_label),
                 subtitle = stringResource(MR.string.location_home_subtitle),
                 onClick = onNavigateToLocation,
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            FeatureCard(
+                icon = Icons.AutoMirrored.Outlined.ListAlt,
+                label = stringResource(MR.string.lists_label),
+                subtitle = stringResource(MR.string.lists_home_subtitle),
+                onClick = onNavigateToLists,
             )
 
             Spacer(modifier = Modifier.height(48.dp))

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListsOnboardingScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListsOnboardingScreen.kt
@@ -1,0 +1,141 @@
+package id.homebase.core.ui.screens.lists
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.ListAlt
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.homebase.chat.widget.ExtendPermissionDialog
+import id.homebase.resources.MR
+import id.homebase.resources.lists_label
+import id.homebase.resources.lists_onboarding_body_1
+import id.homebase.resources.lists_onboarding_body_2
+import id.homebase.resources.lists_onboarding_dismiss
+import id.homebase.resources.lists_onboarding_setup
+import id.homebase.resources.lists_onboarding_title
+import id.homebase.resources.menu_back
+import org.jetbrains.compose.resources.stringResource
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ListsOnboardingScreen(
+    viewModel: ListsViewModel,
+    onNavigateBack: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val lifecycleOwner = LocalLifecycleOwner.current
+    // Re-checking permissions on every ON_RESUME would surface the missing-permissions
+    // dialog before the user has confirmed they want to set Lists up. Only re-check (and
+    // render the dialog) once the user has tapped Set it up.
+    DisposableEffect(lifecycleOwner, uiState.setupInitiated) {
+        if (!uiState.setupInitiated) return@DisposableEffect onDispose { }
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.listsExtendPermissionViewModel.recheckPermissions()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    if (uiState.setupInitiated) {
+        ExtendPermissionDialog(viewModel = viewModel.listsExtendPermissionViewModel)
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(MR.string.lists_label)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(MR.string.menu_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(innerPadding)
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp, vertical = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Top,
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Outlined.ListAlt,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(96.dp),
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(
+                text = stringResource(MR.string.lists_onboarding_title),
+                style = MaterialTheme.typography.headlineSmall,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = stringResource(MR.string.lists_onboarding_body_1),
+                style = MaterialTheme.typography.bodyLarge,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = stringResource(MR.string.lists_onboarding_body_2),
+                style = MaterialTheme.typography.bodyLarge,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(40.dp))
+            FilledTonalButton(
+                onClick = { viewModel.onAction(ListsUiAction.SetupClicked) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(MR.string.lists_onboarding_setup))
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            TextButton(
+                onClick = { viewModel.onAction(ListsUiAction.DismissOnboardingClicked) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(MR.string.lists_onboarding_dismiss))
+            }
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListsScreen.kt
@@ -1,0 +1,64 @@
+package id.homebase.core.ui.screens.lists
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ListAlt
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import id.homebase.resources.MR
+import id.homebase.resources.lists_empty_body
+import id.homebase.resources.lists_empty_title
+import id.homebase.resources.lists_label
+import org.jetbrains.compose.resources.stringResource
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ListsScreen() {
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(stringResource(MR.string.lists_label)) })
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(horizontal = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Outlined.ListAlt,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(72.dp),
+            )
+            Text(
+                text = stringResource(MR.string.lists_empty_title),
+                style = MaterialTheme.typography.titleMedium,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = 16.dp),
+            )
+            Text(
+                text = stringResource(MR.string.lists_empty_body),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListsSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListsSettingsScreen.kt
@@ -1,0 +1,107 @@
+package id.homebase.core.ui.screens.lists
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.ListAlt
+import androidx.compose.material.icons.outlined.Visibility
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.homebase.core.widget.SettingsItemAction
+import id.homebase.resources.MR
+import id.homebase.resources.lists_settings_open
+import id.homebase.resources.lists_settings_section
+import id.homebase.resources.lists_settings_show_icon
+import id.homebase.resources.menu_back
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun ListsSettingsScreen(
+    viewModel: ListsSettingsViewModel,
+    onBackClick: () -> Unit,
+    onOpenLists: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    ListsSettingsUi(
+        uiState = uiState,
+        onAction = { action ->
+            if (action is ListsSettingsUiAction.OpenListsClicked) onOpenLists()
+            else viewModel.onAction(action)
+        },
+        onBackClick = onBackClick,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ListsSettingsUi(
+    uiState: ListsSettingsUiState,
+    onAction: (ListsSettingsUiAction) -> Unit,
+    onBackClick: () -> Unit,
+) {
+    val scrollState = rememberScrollState()
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(MR.string.lists_settings_section)) },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(MR.string.menu_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(innerPadding)
+                .padding(innerPadding)
+                .verticalScroll(scrollState),
+        ) {
+            Spacer(modifier = Modifier.height(8.dp))
+            SettingsItemAction(
+                imageVector = Icons.AutoMirrored.Outlined.ListAlt,
+                text = stringResource(MR.string.lists_settings_open),
+                onClick = { onAction(ListsSettingsUiAction.OpenListsClicked) },
+            )
+            SettingsItemAction(
+                imageVector = Icons.Outlined.Visibility,
+                text = stringResource(MR.string.lists_settings_show_icon),
+                onClick = { onAction(ListsSettingsUiAction.SetIconVisible(!uiState.iconVisible)) },
+                trailingContent = {
+                    Switch(
+                        checked = uiState.iconVisible,
+                        onCheckedChange = { onAction(ListsSettingsUiAction.SetIconVisible(it)) },
+                    )
+                },
+            )
+            Spacer(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(24.dp),
+            )
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListsSettingsUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListsSettingsUiState.kt
@@ -1,0 +1,10 @@
+package id.homebase.core.ui.screens.lists
+
+data class ListsSettingsUiState(
+    val iconVisible: Boolean = false,
+)
+
+sealed interface ListsSettingsUiAction {
+    data object OpenListsClicked : ListsSettingsUiAction
+    data class SetIconVisible(val visible: Boolean) : ListsSettingsUiAction
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListsSettingsViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListsSettingsViewModel.kt
@@ -1,0 +1,41 @@
+package id.homebase.core.ui.screens.lists
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import id.homebase.core.lists.ListsPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class ListsSettingsViewModel(
+    private val listsPreferences: ListsPreferences,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(
+        ListsSettingsUiState(
+            iconVisible = listsPreferences.iconVisible.value,
+        )
+    )
+    val uiState: StateFlow<ListsSettingsUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            listsPreferences.iconVisible.collect { v ->
+                _uiState.update { it.copy(iconVisible = v) }
+            }
+        }
+    }
+
+    fun onAction(action: ListsSettingsUiAction) {
+        when (action) {
+            ListsSettingsUiAction.OpenListsClicked -> {
+                // Handled by the screen — it dispatches to the navigation callback.
+            }
+            is ListsSettingsUiAction.SetIconVisible -> {
+                viewModelScope.launch { listsPreferences.setIconVisible(action.visible) }
+            }
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListsUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListsUiState.kt
@@ -1,0 +1,16 @@
+package id.homebase.core.ui.screens.lists
+
+data class ListsUiState(
+    val isCheckingPermissions: Boolean = false,
+    val setupInitiated: Boolean = false,
+)
+
+sealed interface ListsUiAction {
+    data object SetupClicked : ListsUiAction
+    data object DismissOnboardingClicked : ListsUiAction
+}
+
+sealed interface ListsUiEvent {
+    data object Activated : ListsUiEvent
+    data object CloseOnboarding : ListsUiEvent
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListsViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListsViewModel.kt
@@ -1,0 +1,92 @@
+package id.homebase.core.ui.screens.lists
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import id.homebase.chat.conversationlist.ExtendPermissionUiState
+import id.homebase.chat.conversationlist.ExtendPermissionViewModel
+import id.homebase.core.auth.AuthConnectionCoordinator
+import id.homebase.core.config.listsLabeledDrive
+import id.homebase.core.lists.ListsPreferences
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class ListsViewModel(
+    private val listsPreferences: ListsPreferences,
+    private val listsPermissionViewModel: ExtendPermissionViewModel,
+    private val authConnectionCoordinator: AuthConnectionCoordinator,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ListsUiState())
+    val uiState: StateFlow<ListsUiState> = _uiState.asStateFlow()
+
+    private val _events = MutableSharedFlow<ListsUiEvent>(extraBufferCapacity = 4)
+    val events: SharedFlow<ListsUiEvent> = _events.asSharedFlow()
+
+    val listsExtendPermissionViewModel: ExtendPermissionViewModel
+        get() = listsPermissionViewModel
+
+    init {
+        viewModelScope.launch {
+            listsPermissionViewModel.permissionsGranted
+                .filter { it }
+                .collect {
+                    if (!listsPreferences.activated.value) {
+                        // Auto-activate as soon as the drive is authorized — including the
+                        // passive launch-time autoCheck grant. Activation persists the flag
+                        // and mounts the drive; it does not move the user.
+                        val initiatedByUser = _uiState.value.setupInitiated
+                        listsPreferences.setActivated(true)
+                        authConnectionCoordinator.mountDrive(listsLabeledDrive)
+                        _uiState.update {
+                            it.copy(isCheckingPermissions = false, setupInitiated = false)
+                        }
+                        // Only navigate when the user actively completed onboarding (tapped
+                        // "Set it up"). AppNavHost pops the onboarding screen and navigates to
+                        // Route.Lists on this event; firing it for a passive launch-time grant
+                        // would yank the user off the default ChatList tab.
+                        if (initiatedByUser) {
+                            _events.tryEmit(ListsUiEvent.Activated)
+                        }
+                    }
+                }
+        }
+
+        // Resetting setupInitiated on every Dismissed transition (Cancel button, outside-tap,
+        // or owner-console cancellation) ensures the next visit to onboarding starts clean —
+        // so the lifecycle ON_RESUME re-check no longer re-prompts a user who already said no.
+        viewModelScope.launch {
+            listsPermissionViewModel.uiState
+                .filter { it is ExtendPermissionUiState.Dismissed }
+                .collect {
+                    _uiState.update {
+                        it.copy(isCheckingPermissions = false, setupInitiated = false)
+                    }
+                }
+        }
+    }
+
+    fun onAction(action: ListsUiAction) {
+        when (action) {
+            ListsUiAction.SetupClicked -> {
+                _uiState.update {
+                    it.copy(isCheckingPermissions = true, setupInitiated = true)
+                }
+                listsPermissionViewModel.recheckPermissions()
+            }
+
+            ListsUiAction.DismissOnboardingClicked -> {
+                viewModelScope.launch {
+                    listsPreferences.setIconVisible(false)
+                    _events.tryEmit(ListsUiEvent.CloseOnboarding)
+                }
+            }
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Error
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material.icons.automirrored.outlined.ListAlt
 import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.People
 import androidx.compose.material.icons.outlined.Person
@@ -93,6 +94,7 @@ import id.homebase.resources.settings_section_danger_zone
 import id.homebase.resources.settings_section_general
 import id.homebase.resources.location_settings_section
 import id.homebase.resources.vault_settings_section
+import id.homebase.resources.lists_settings_section
 import id.homebase.resources.settings_storage
 import org.jetbrains.compose.resources.stringResource
 
@@ -108,6 +110,7 @@ fun SettingsScreen(
     onNavigateToMomentsSettings: () -> Unit,
     onNavigateToVaultSettings: () -> Unit,
     onNavigateToLocationSettings: () -> Unit,
+    onNavigateToListsSettings: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val uriHandler = getUriHandler()
@@ -167,6 +170,7 @@ fun SettingsScreen(
             onNavigateToHelp = onNavigateToHelp,
             onNavigateToMomentsSettings = onNavigateToMomentsSettings,
             onNavigateToLocationSettings = onNavigateToLocationSettings,
+            onNavigateToListsSettings = onNavigateToListsSettings,
         )
 
         if (uiState.isLoggingOut) {
@@ -229,6 +233,7 @@ fun SettingsUi(
     onNavigateToMomentsSettings: () -> Unit,
     onNavigateToVaultSettings: () -> Unit = {},
     onNavigateToLocationSettings: () -> Unit = {},
+    onNavigateToListsSettings: () -> Unit = {},
 ) {
     val scrollState = rememberScrollState()
 
@@ -392,6 +397,13 @@ fun SettingsUi(
                 imageVector = Icons.Outlined.LocationOn,
                 text = stringResource(MR.string.location_settings_section),
                 onClick = onNavigateToLocationSettings,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            SettingsItemAction(
+                modifier = Modifier.testTag("listsSettingsButton"),
+                imageVector = Icons.AutoMirrored.Outlined.ListAlt,
+                text = stringResource(MR.string.lists_settings_section),
+                onClick = onNavigateToListsSettings,
             )
             Spacer(modifier = Modifier.height(8.dp))
             SettingsItemAction(


### PR DESCRIPTION
## Summary

Phase 1 of the **Shared Lists** add-on — the *activation shell* only. Stands up a mountable, per-identity **Lists** drive with the full add-on scaffolding, cloned task-by-task from the existing **Moments** add-on (and **Location** for preferences). **No real list data yet** — that is Phase 2.

What's included:
- **Drive + permissions** — `listsLabeledDrive` (optional, *not* in `mandatorySyncDrives`), `listsTargetDriveAccessRequest` (self Read+Write), `getListsPermissionExtensionConfig()`, plus a `ListsDriveConfigTest`.
- **`ListsPreferences`** — fresh `0a04xx` UUID namespace (claimed in `ADDING_ADDON_APPS.md`), `activated`/`iconVisible` flags, `reset()`; modeled on `LocationPreferences`.
- **Activation flow** — `ListsViewModel` mounts the drive via `authConnectionCoordinator.mountDrive(listsLabeledDrive)` on permission grant; `ListsOnboardingScreen` (extend-permissions), `ListsSettingsScreen` (Open Lists + show-icon toggle), placeholder `ListsScreen` (empty state).
- **Wiring** — `Route.Lists` / `ListsOnboarding` / `ListsSettings`, `TopLevelRoute.Lists`, full `AppNavHost` integration (reactive bottom-bar gating, `openLists` branch, onboarding event, both bottom-bar **and** nav-rail taps, `composable` destinations), Home tile, Settings entry, DI registrations, and `onPostAuthenticated` preferences reset (per-identity isolation).
- `lists_*` strings (English).

## Deliberate scope decisions (not omissions)
- **No connected-circle write grant** on the Lists drive yet — Phase 1 requests only self `Read + Write`. The cross-identity circle grant (and the owner-console verification / chat-drive fallback flagged as the top risk in the design spec) lands in **Phase 4**, where it's first exercised. This keeps Phase 1 identical to the proven Location/Moments activation path.
- **`iconVisible` defaults to `false`** (soft-launch, like Location): the bottom-nav icon stays hidden until enabled in Settings, so merging this shell doesn't expose a half-built feature to all users. Discoverable via the Home tile + Settings. Flipping to always-visible is a one-line change.
- **No `ListStream`** (Phase 2) — so `onPostAuthenticated` adds only the preferences reset.

## Verification done
- `:homebase-common:jvmTest` + `:homebase-core:jvmTest` — green (includes Konsist `ArchitectureTest`, i.e. no hardcoded `Text("…")`, and `ListsDriveConfigTest`).
- `:homebase-common` + `:homebase-core` compile clean on **JVM**, **Android** (`compileAndroidMain`), and **iOS** (`compileKotlinIosSimulatorArm64`).
- Final comprehensive code review: APPROVED, zero issues.

## Test plan — manual device walkthrough (not yet run on a device)
- [ ] Home → **Lists** tile → routes to onboarding (since `activated = false`).
- [ ] Onboarding → **Set it up** → extend-permissions dialog requests the Lists drive.
- [ ] Grant → activates, mounts `listsLabeledDrive`, lands on placeholder Lists screen ("No lists yet").
- [ ] Re-entry: Home → **Lists** → goes straight to the Lists screen (activation persisted).
- [ ] Settings → **Lists** → toggle **Show Lists icon in bottom bar** ON → bottom-nav icon appears; OFF → disappears.
- [ ] Settings → **Lists** → **Open Lists** navigates to the Lists screen.
- [ ] Logout/login (or switch identity): Lists state reflects the new identity (defaults for a fresh one) — confirms `reset()` ran; no crash / AES-key mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)