### PR TITLE
Shared Lists — Phase 2: Data Layer

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -137,6 +137,10 @@ import id.homebase.core.config.getLocationPermissionExtensionConfig
 import id.homebase.core.config.getVaultPermissionExtensionConfig
 import id.homebase.core.config.getListsPermissionExtensionConfig
 import id.homebase.core.lists.ListsPreferences
+import id.homebase.core.lists.services.ListFileWriter
+import id.homebase.core.lists.services.ListItemSenderService
+import id.homebase.core.lists.services.ListService
+import id.homebase.core.lists.services.ListStream
 import id.homebase.core.ui.screens.lists.ListsSettingsViewModel
 import id.homebase.core.ui.screens.lists.ListsViewModel
 import id.homebase.core.location.LocationPreferences
@@ -198,6 +202,10 @@ val appModule = module {
     }
     singleOf(::MomentsRecipientLookupService)
     singleOf(::MomentsFeedService)
+    singleOf(::ListFileWriter)
+    singleOf(::ListStream)
+    singleOf(::ListService)
+    singleOf(::ListItemSenderService)
     singleOf(::MomentsVideoSession)
     singleOf(::MomentCommentsService)
     singleOf(::MomentActionService)
@@ -419,6 +427,7 @@ val appModule = module {
                 // Hydrate the saved-stickers tray for the new identity (mirror Vault).
                 get<id.homebase.chat.services.sticker.StickerStream>().apply { reset(); start() }
                 get<ListsPreferences>().reset()
+                get<ListStream>().apply { reset(); start() }
 
                 // Location add-on: re-seed prefs from the (possibly wiped) DB,
                 // clear in-memory capture state, restart the flusher's outbox

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/ListsProtocol.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/ListsProtocol.kt
@@ -1,0 +1,17 @@
+package id.homebase.core.lists
+
+/**
+ * Drive protocol constants for the Lists add-on. Lists files live on `listsLabeledDrive`
+ * (see AppConfig). A list is a [ListDefinitionFileType] file whose uniqueId == groupId ==
+ * listId (the conversation-file analog, fileType 8888); each item is a [ListItemFileType]
+ * file whose uniqueId == itemId and groupId == listId. Both are header-only (descriptor JSON
+ * in fileMetadata.appData.content) — no payloads — so they sit well under the 7 KB header cap.
+ */
+object ListsProtocol {
+    const val ListDefinitionFileType = 9100
+    const val ListItemFileType = 9101
+
+    /** Code-point caps for user text (enforced at write time via truncateToCodePoints). */
+    const val MaxTitleCodePoints = 80
+    const val MaxItemBodyCodePoints = 2000
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/model/ListDefinition.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/model/ListDefinition.kt
@@ -1,0 +1,43 @@
+package id.homebase.core.lists.model
+
+import id.homebase.api.common.OdinId
+import id.homebase.core.lists.ListsProtocol
+import kotlinx.serialization.Serializable
+
+/**
+ * Descriptor for a list (one [ListsProtocol.ListDefinitionFileType] file per list,
+ * uniqueId == groupId == listId). Envelope facts (creator, timestamps) come from the
+ * HomebaseFile (originalAuthor / created) — never duplicated here.
+ *
+ * @property title user-visible list name.
+ * @property members source of truth for transit recipients; the creator is implied (read
+ *   it from the file's originalAuthor). Serializes as domain strings via OdinIdSerializer.
+ * @property colorOrEmoji optional accent (rendered richly later).
+ * @property schemaVersion forward-compat marker.
+ */
+@Serializable
+data class ListDefinition(
+    val title: String,
+    val members: List<OdinId> = emptyList(),
+    val colorOrEmoji: String? = null,
+    val schemaVersion: Int = 1,
+) {
+    fun isValid(): Boolean {
+        if (title.isBlank()) return false
+        if (title.codePointLength() > ListsProtocol.MaxTitleCodePoints) return false
+        if ((colorOrEmoji?.codePointLength() ?: 0) > 16) return false
+        if (schemaVersion < 1) return false
+        return true
+    }
+}
+
+/** UTF-16-safe code-point count (emoji are surrogate pairs). */
+internal fun String.codePointLength(): Int {
+    var count = 0
+    var i = 0
+    while (i < length) {
+        i += if (i + 1 < length && this[i].isHighSurrogate() && this[i + 1].isLowSurrogate()) 2 else 1
+        count++
+    }
+    return count
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/model/ListDefinition.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/model/ListDefinition.kt
@@ -1,6 +1,7 @@
 package id.homebase.core.lists.model
 
 import id.homebase.api.common.OdinId
+import id.homebase.api.util.truncateToCodePoints
 import id.homebase.core.lists.ListsProtocol
 import kotlinx.serialization.Serializable
 
@@ -24,20 +25,12 @@ data class ListDefinition(
 ) {
     fun isValid(): Boolean {
         if (title.isBlank()) return false
-        if (title.codePointLength() > ListsProtocol.MaxTitleCodePoints) return false
-        if ((colorOrEmoji?.codePointLength() ?: 0) > 16) return false
+        if (title.exceedsCodePoints(ListsProtocol.MaxTitleCodePoints)) return false
+        if (colorOrEmoji != null && colorOrEmoji.exceedsCodePoints(16)) return false
         if (schemaVersion < 1) return false
         return true
     }
 }
 
-/** UTF-16-safe code-point count (emoji are surrogate pairs). */
-internal fun String.codePointLength(): Int {
-    var count = 0
-    var i = 0
-    while (i < length) {
-        i += if (i + 1 < length && this[i].isHighSurrogate() && this[i + 1].isLowSurrogate()) 2 else 1
-        count++
-    }
-    return count
-}
+/** True iff [this] is longer than [max] code points — reuses the surrogate-safe truncate helper. */
+internal fun String.exceedsCodePoints(max: Int): Boolean = truncateToCodePoints(max) != this

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/model/ListItem.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/model/ListItem.kt
@@ -1,0 +1,28 @@
+package id.homebase.core.lists.model
+
+import id.homebase.api.common.OdinId
+import id.homebase.core.lists.ListsProtocol
+import kotlinx.serialization.Serializable
+
+/**
+ * Descriptor for one list item (one [ListsProtocol.ListItemFileType] file, uniqueId == itemId,
+ * groupId == listId). Header-only. Body is markdown stored as a plain String. Envelope facts
+ * come from the HomebaseFile.
+ */
+@Serializable
+data class ListItem(
+    val body: String,
+    val checked: Boolean = false,
+    val checkedByOdinId: OdinId? = null,
+    val sortKey: String,
+    val schemaVersion: Int = 1,
+) {
+    fun isValid(): Boolean {
+        if (body.isBlank()) return false
+        if (body.codePointLength() > ListsProtocol.MaxItemBodyCodePoints) return false
+        if (sortKey.isBlank()) return false
+        if (!checked && checkedByOdinId != null) return false
+        if (schemaVersion < 1) return false
+        return true
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/model/ListItem.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/model/ListItem.kt
@@ -19,7 +19,7 @@ data class ListItem(
 ) {
     fun isValid(): Boolean {
         if (body.isBlank()) return false
-        if (body.codePointLength() > ListsProtocol.MaxItemBodyCodePoints) return false
+        if (body.exceedsCodePoints(ListsProtocol.MaxItemBodyCodePoints)) return false
         if (sortKey.isBlank()) return false
         if (!checked && checkedByOdinId != null) return false
         if (schemaVersion < 1) return false

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/model/ListSortKeys.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/model/ListSortKeys.kt
@@ -1,80 +1,47 @@
 package id.homebase.core.lists.model
 
 /**
- * Fractional order keys for manual drag-reorder. Keys are short strings compared
- * lexicographically. The first character is always in 'a'..'z' (visible); characters at
- * deeper positions may be any char code ≥ 1, allowing fine-grained insertion between a
- * short key and its 'a'-extended neighbour without limit. No renumbering is ever needed.
+ * Fractional order keys for manual drag-reorder. A key is a short string compared
+ * lexicographically; [between] returns a new key strictly between two existing keys (either
+ * bound may be null = open). New items append via [after]; a drag computes between(prev, next).
+ * No renumbering is ever required.
+ *
+ * Each character position is a base-fraction digit. A position past the end of `a` reads as
+ * [FLOOR] (below every real digit); a position past the end of `b` — or `b == null` — reads as
+ * [CEIL] (above every real digit). That makes "n" sit strictly between "" and "na", so the
+ * recursion always finds a midpoint and never collides with a bound.
  */
 object ListSortKeys {
-    private const val MIN = 'a'
-    private const val MAX = 'z'
-    private const val MID = 'n'
+    private const val FLOOR = 0           // implicit digit at/after the end of `a`
+    private const val CEIL = 'z'.code + 1 // implicit digit at/after the end of `b` (or b == null)
+    private const val MID = 'n'.code      // a pleasant, middle-of-the-alphabet first key
 
     /** Key for the first item in a fresh list. */
-    fun first(): String = MID.toString()
+    fun first(): String = MID.toChar().toString()
 
     /** A key that sorts strictly after [last]. */
     fun after(last: String): String = between(last, null)
 
     /**
-     * A key strictly greater than [a] (or after nothing, when a is null) and strictly
-     * less than [b] (or before nothing, when b is null).
-     *
-     * The algorithm treats each string as a base-∞ fraction: missing trailing characters
-     * have the implicit value 0 (below any printable character). This means "n" and "na"
-     * are not adjacent — "n" sits between them — so the recursion always terminates
-     * with a valid midpoint no matter how many halvings have already occurred.
-     *
-     * Position 0 of every key is always a visible ASCII letter ('a'..'z'). Deeper positions
-     * may contain any char whose code is ≥ 1 (they sort correctly via standard Char ordering).
+     * Shortest key strictly greater than [a] (null = nothing below) and strictly less than [b]
+     * (null = nothing above). If the bounds are equal or inverted (`a >= b`), gracefully appends
+     * after [a] rather than throwing.
      */
     fun between(a: String?, b: String?): String {
-        val lo = a ?: ""
+        if (a != null && b != null && a >= b) return between(a, null)
         val sb = StringBuilder()
         var i = 0
         while (true) {
-            // Treat missing lo characters as code 0 (implicit floor below every printable char).
-            val lc: Int = if (i < lo.length) lo[i].code else 0
-            // Treat missing b characters as MAX+1 (open upper bound) when b is exhausted;
-            // null b means "no upper bound".
-            val hc: Int = when {
-                b == null -> MAX.code + 1
-                i < b.length -> b[i].code
-                else -> MAX.code + 1   // b exhausted: any extension is strictly < b (prefix rule)
-            }
-
-            val gap = hc - lc
-            if (gap >= 2) {
-                // Room for a midpoint strictly between lc and hc.
-                val mid = lc + gap / 2
-                // Position 0: clamp to visible alphabet ('a'..'z').
-                // Deeper positions: allow any char code ≥ 0. char(0) sorts below everything
-                // and is a valid Kotlin String character; char(≥1) is used when the midpoint
-                // falls in the visible range naturally.
-                val out = if (i == 0) mid.coerceIn(MIN.code, MAX.code) else mid
-                sb.append(out.toChar())
+            val lo = if (a != null && i < a.length) a[i].code else FLOOR
+            val hi = if (b != null && i < b.length) b[i].code else CEIL
+            if (hi - lo >= 2) {
+                // Room for a digit strictly between lo and hi at this position.
+                sb.append((lo + (hi - lo) / 2).toChar())
                 return sb.toString()
             }
-
-            // gap == 0 or gap == 1 — no room for a midpoint here; go one level deeper.
-            //
-            // When gap == 1 and we are past lo: we append lc (the floor value at this
-            // position — may be 0) so that this digit is strictly below b[i] = lc+1.
-            // The next iteration then has an open upper bound (b is exhausted one level
-            // deeper) giving gap ≥ 2 and a valid midpoint.  We do NOT stop here because
-            // returning the key as-is would make it adjacent to lo (e.g. "n" and "n\0"
-            // would be prefix-adjacent with nothing between them).
-            //
-            // When gap == 0: copy the common digit and continue.
-            val appendCode: Int = when {
-                gap == 1 && i >= lo.length -> lc          // past lo, gap=1: pin to floor
-                i < lo.length              -> lo[i].code   // within lo: copy lo's digit
-                else                       -> b!![i].code  // past lo, gap=0: copy b's digit
-            }
-            // Position 0 must stay in the visible alphabet.
-            val out = if (i == 0) appendCode.coerceIn(MIN.code, MAX.code) else appendCode
-            sb.append(out.toChar())
+            // Gap of 0 or 1: copy a's digit (or FLOOR past a's end) and descend one position.
+            // Since a < b, lo <= hi here, so this never picks a digit above the upper bound.
+            sb.append((if (a != null && i < a.length) a[i].code else FLOOR).toChar())
             i++
         }
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/model/ListSortKeys.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/model/ListSortKeys.kt
@@ -1,0 +1,81 @@
+package id.homebase.core.lists.model
+
+/**
+ * Fractional order keys for manual drag-reorder. Keys are short strings compared
+ * lexicographically. The first character is always in 'a'..'z' (visible); characters at
+ * deeper positions may be any char code ≥ 1, allowing fine-grained insertion between a
+ * short key and its 'a'-extended neighbour without limit. No renumbering is ever needed.
+ */
+object ListSortKeys {
+    private const val MIN = 'a'
+    private const val MAX = 'z'
+    private const val MID = 'n'
+
+    /** Key for the first item in a fresh list. */
+    fun first(): String = MID.toString()
+
+    /** A key that sorts strictly after [last]. */
+    fun after(last: String): String = between(last, null)
+
+    /**
+     * A key strictly greater than [a] (or after nothing, when a is null) and strictly
+     * less than [b] (or before nothing, when b is null).
+     *
+     * The algorithm treats each string as a base-∞ fraction: missing trailing characters
+     * have the implicit value 0 (below any printable character). This means "n" and "na"
+     * are not adjacent — "n" sits between them — so the recursion always terminates
+     * with a valid midpoint no matter how many halvings have already occurred.
+     *
+     * Position 0 of every key is always a visible ASCII letter ('a'..'z'). Deeper positions
+     * may contain any char whose code is ≥ 1 (they sort correctly via standard Char ordering).
+     */
+    fun between(a: String?, b: String?): String {
+        val lo = a ?: ""
+        val sb = StringBuilder()
+        var i = 0
+        while (true) {
+            // Treat missing lo characters as code 0 (implicit floor below every printable char).
+            val lc: Int = if (i < lo.length) lo[i].code else 0
+            // Treat missing b characters as MAX+1 (open upper bound) when b is exhausted;
+            // null b means "no upper bound".
+            val hc: Int = when {
+                b == null -> MAX.code + 1
+                i < b.length -> b[i].code
+                else -> MAX.code + 1   // b exhausted: any extension is strictly < b (prefix rule)
+            }
+
+            val gap = hc - lc
+            if (gap >= 2) {
+                // Room for a midpoint strictly between lc and hc.
+                val mid = lc + gap / 2
+                // Position 0: clamp to visible alphabet ('a'..'z').
+                // Deeper positions: allow any char code ≥ 0. char(0) sorts below everything
+                // and is a valid Kotlin String character; char(≥1) is used when the midpoint
+                // falls in the visible range naturally.
+                val out = if (i == 0) mid.coerceIn(MIN.code, MAX.code) else mid
+                sb.append(out.toChar())
+                return sb.toString()
+            }
+
+            // gap == 0 or gap == 1 — no room for a midpoint here; go one level deeper.
+            //
+            // When gap == 1 and we are past lo: we append lc (the floor value at this
+            // position — may be 0) so that this digit is strictly below b[i] = lc+1.
+            // The next iteration then has an open upper bound (b is exhausted one level
+            // deeper) giving gap ≥ 2 and a valid midpoint.  We do NOT stop here because
+            // returning the key as-is would make it adjacent to lo (e.g. "n" and "n\0"
+            // would be prefix-adjacent with nothing between them).
+            //
+            // When gap == 0: copy the common digit and continue.
+            val appendCode: Int = when {
+                gap == 1 && i >= lo.length -> lc          // past lo, gap=1: pin to floor
+                i < lo.length              -> lo[i].code   // within lo: copy lo's digit
+                else                       -> b!![i].code  // past lo, gap=0: copy b's digit
+            }
+            // Position 0 must stay in the visible alphabet.
+            val out = if (i == 0) appendCode.coerceIn(MIN.code, MAX.code) else appendCode
+            sb.append(out.toChar())
+            i++
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/services/ListFileWriter.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/services/ListFileWriter.kt
@@ -1,0 +1,152 @@
+package id.homebase.core.lists.services
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.FileSystemType
+import id.homebase.api.client.drives.files.DeleteLocalFilesByFileIdRequest
+import id.homebase.api.client.drives.upload.FileUpdateInstructionSet
+import id.homebase.api.client.drives.upload.TransitOptions
+import id.homebase.api.client.drives.upload.UpdateFileByUniqueIdRequest
+import id.homebase.api.client.drives.upload.UpdateLocale
+import id.homebase.api.client.drives.upload.UpdateManifest
+import id.homebase.api.client.drives.upload.UploadAppFileMetaData
+import id.homebase.api.client.drives.upload.UploadFileMetadata
+import id.homebase.api.client.drives.upload.UploadFileRequest
+import id.homebase.api.common.OdinId
+import id.homebase.api.crypto.ByteArrayUtil
+import id.homebase.api.sync.database.OutboxSync
+import id.homebase.api.sync.database.enqueued
+import id.homebase.chat.services.outbox.OptimisticWriter
+import id.homebase.core.config.listsLabeledDrive
+import kotlin.uuid.Uuid
+
+/**
+ * Shared write primitives for header-only Lists files (no payloads). Encapsulates the
+ * keyHeader/encrypt/optimistic/outbox boilerplate, mirroring ConversationService.writeConversationFile
+ * (create), ChatMessageSenderService.updateMessage (update), and ChatMessageActionService.deleteMessage
+ * (delete). Used by both ListService and ListItemSenderService.
+ */
+class ListFileWriter(
+    private val outboxSync: OutboxSync,
+    private val optimisticWriter: OptimisticWriter,
+    private val credentialsManager: CredentialsManager,
+) {
+    private val listsDrive = listsLabeledDrive.drive.alias
+
+    /** The active identity's own OdinId — never a transit recipient. */
+    suspend fun selfDomain(): OdinId = credentialsManager.requireActiveCredentials().domain
+
+    /** Transit recipients = members minus self, de-duplicated. */
+    suspend fun recipientsExcludingSelf(members: List<OdinId>): List<OdinId> {
+        val self = selfDomain()
+        return members.filter { it != self }.distinct()
+    }
+
+    /** Create a header-only file (descriptor JSON in appData.content). */
+    suspend fun createFile(
+        uniqueId: Uuid,
+        groupId: Uuid?,
+        fileType: Int,
+        contentJson: String,
+        recipients: List<OdinId>,
+    ): Boolean {
+        val keyHeader = KeyHeader.newRandom16()
+        val metadata = UploadFileMetadata(
+            allowDistribution = true,
+            isEncrypted = true,
+            appData = UploadAppFileMetaData(
+                uniqueId = uniqueId,
+                groupId = groupId,
+                fileType = fileType,
+                content = contentJson,
+            ),
+        )
+        val request = UploadFileRequest(
+            driveId = listsDrive,
+            keyHeader = keyHeader,
+            metadata = metadata.encryptContent(keyHeader),
+            transitOptions = TransitOptions(recipients = recipients, useAppNotification = false),
+        )
+        optimisticWriter.writeNewFile(
+            driveId = listsDrive,
+            keyHeader = keyHeader,
+            unecryptedMetadata = metadata,
+            originalRecipientCount = recipients.size,
+            fileSystemType = FileSystemType.Standard,
+        )
+        return outboxSync.tryEnqueue(request).enqueued
+    }
+
+    /** Update a header-only file's content by uniqueId (last-writer-wins via versionTag). */
+    suspend fun updateFile(
+        uniqueId: Uuid,
+        groupId: Uuid?,
+        fileType: Int,
+        contentJson: String,
+        versionTag: Uuid?,
+        recipients: List<OdinId>,
+    ): Boolean {
+        val keyHeader = KeyHeader.newRandom16()
+        val metadata = UploadFileMetadata(
+            allowDistribution = true,
+            isEncrypted = true,
+            versionTag = versionTag,
+            appData = UploadAppFileMetaData(
+                uniqueId = uniqueId,
+                groupId = groupId,
+                fileType = fileType,
+                content = contentJson,
+            ),
+        )
+        val request = UpdateFileByUniqueIdRequest(
+            driveId = listsDrive,
+            uniqueId = uniqueId,
+            keyHeader = keyHeader,
+            instructions = FileUpdateInstructionSet(
+                transferIv = ByteArrayUtil.getRndByteArray(16),
+                locale = UpdateLocale.Local,
+                recipients = recipients,
+                manifest = UpdateManifest.build(
+                    payloads = emptyList(),
+                    toDeletePayloads = null,
+                    thumbnails = null,
+                    generatePayloadIv = false,
+                ),
+                useAppNotification = false,
+                appNotificationOptions = null,
+            ),
+            metadata = metadata.encryptContent(keyHeader),
+            payloads = emptyList(),
+            thumbnails = emptyList(),
+        )
+        val enqueued = outboxSync.replaceEnqueue(request, priority = 1, dependencyUniqueId = null).enqueued
+        if (enqueued) {
+            optimisticWriter.writeUpdate(
+                driveId = listsDrive,
+                keyHeader = keyHeader,
+                unecryptedMetadata = metadata,
+            )
+        }
+        return enqueued
+    }
+
+    /** Soft-delete a file by fileId (optimistic, with rollback on enqueue failure). */
+    suspend fun deleteFile(fileId: Uuid, uniqueId: Uuid, recipients: List<OdinId>): Boolean {
+        val original = optimisticWriter.writeDelete(listsDrive, uniqueId)
+        return runCatching {
+            val result = outboxSync.tryEnqueue(
+                DeleteLocalFilesByFileIdRequest(
+                    driveId = listsDrive,
+                    fileIds = listOf(fileId),
+                    recipients = recipients,
+                    hardDelete = false,
+                )
+            )
+            if (!result.enqueued && original != null) optimisticWriter.rollbackWrite(listsDrive, original)
+            result.enqueued
+        }.getOrElse {
+            if (original != null) runCatching { optimisticWriter.rollbackWrite(listsDrive, original) }
+            false
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/services/ListFileWriter.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/services/ListFileWriter.kt
@@ -18,6 +18,7 @@ import id.homebase.api.sync.database.OutboxSync
 import id.homebase.api.sync.database.enqueued
 import id.homebase.chat.services.outbox.OptimisticWriter
 import id.homebase.core.config.listsLabeledDrive
+import co.touchlab.kermit.Logger
 import kotlin.uuid.Uuid
 
 /**
@@ -74,7 +75,16 @@ class ListFileWriter(
             originalRecipientCount = recipients.size,
             fileSystemType = FileSystemType.Standard,
         )
-        return outboxSync.tryEnqueue(request).enqueued
+        val enqueued = outboxSync.tryEnqueue(request).enqueued
+        if (!enqueued) {
+            // The upload was never queued (e.g. DB error): drop the optimistic row so it
+            // doesn't linger forever as a local-only ghost that never reaches the server.
+            Logger.w(tag = "ListFileWriter") {
+                "createFile enqueue failed for $uniqueId — rolling back optimistic write"
+            }
+            optimisticWriter.removeOptimisticFile(listsDrive, uniqueId)
+        }
+        return enqueued
     }
 
     /** Update a header-only file's content by uniqueId (last-writer-wins via versionTag). */

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/services/ListItemSenderService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/services/ListItemSenderService.kt
@@ -1,0 +1,76 @@
+package id.homebase.core.lists.services
+
+import id.homebase.api.common.OdinId
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.util.truncateToCodePoints
+import id.homebase.core.lists.ListsProtocol
+import id.homebase.core.lists.model.ListItem
+import id.homebase.core.lists.model.ListSortKeys
+import kotlin.uuid.Uuid
+
+/** Add / edit / check / reorder / delete list items (ListItem files, fileType 9101). */
+class ListItemSenderService(
+    private val writer: ListFileWriter,
+    private val listStream: ListStream,
+) {
+    private fun membersOf(listId: Uuid): List<OdinId> =
+        listStream.lists.value.lists.find { it.listId == listId }?.definition?.members ?: emptyList()
+
+    private fun itemRecord(listId: Uuid, itemId: Uuid): ListItemRecord? =
+        listStream.itemsByList.value[listId]?.find { it.itemId == itemId }
+
+    /** Append a new item to the end of the list. Returns the new itemId. */
+    suspend fun addItem(listId: Uuid, body: String): Uuid {
+        val itemId = Uuid.random()
+        val lastKey = listStream.itemsByList.value[listId]?.lastOrNull()?.item?.sortKey
+        val sortKey = if (lastKey == null) ListSortKeys.first() else ListSortKeys.after(lastKey)
+        val item = ListItem(
+            body = body.truncateToCodePoints(ListsProtocol.MaxItemBodyCodePoints),
+            sortKey = sortKey,
+        )
+        writer.createFile(
+            uniqueId = itemId,
+            groupId = listId,
+            fileType = ListsProtocol.ListItemFileType,
+            contentJson = OdinSystemSerializer.serialize(item),
+            recipients = writer.recipientsExcludingSelf(membersOf(listId)),
+        )
+        return itemId
+    }
+
+    private suspend fun updateItem(listId: Uuid, itemId: Uuid, transform: (ListItem) -> ListItem) {
+        val rec = itemRecord(listId, itemId) ?: return
+        val updated = transform(rec.item)
+        writer.updateFile(
+            uniqueId = itemId,
+            groupId = listId,
+            fileType = ListsProtocol.ListItemFileType,
+            contentJson = OdinSystemSerializer.serialize(updated),
+            versionTag = rec.versionTag,
+            recipients = writer.recipientsExcludingSelf(membersOf(listId)),
+        )
+    }
+
+    suspend fun editItem(listId: Uuid, itemId: Uuid, newBody: String) =
+        updateItem(listId, itemId) {
+            it.copy(body = newBody.truncateToCodePoints(ListsProtocol.MaxItemBodyCodePoints))
+        }
+
+    suspend fun setChecked(listId: Uuid, itemId: Uuid, checked: Boolean) {
+        // writer.selfDomain() is suspend → resolve it here, NOT inside the non-suspend copy lambda.
+        val checkedBy: OdinId? = if (checked) writer.selfDomain() else null
+        updateItem(listId, itemId) { it.copy(checked = checked, checkedByOdinId = checkedBy) }
+    }
+
+    suspend fun reorderItem(listId: Uuid, itemId: Uuid, newSortKey: String) =
+        updateItem(listId, itemId) { it.copy(sortKey = newSortKey) }
+
+    suspend fun deleteItem(listId: Uuid, itemId: Uuid) {
+        val rec = itemRecord(listId, itemId) ?: return
+        writer.deleteFile(
+            fileId = rec.fileId,
+            uniqueId = itemId,
+            recipients = writer.recipientsExcludingSelf(membersOf(listId)),
+        )
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/services/ListItemSenderService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/services/ListItemSenderService.kt
@@ -6,6 +6,8 @@ import id.homebase.api.util.truncateToCodePoints
 import id.homebase.core.lists.ListsProtocol
 import id.homebase.core.lists.model.ListItem
 import id.homebase.core.lists.model.ListSortKeys
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.uuid.Uuid
 
 /** Add / edit / check / reorder / delete list items (ListItem files, fileType 9101). */
@@ -13,6 +15,12 @@ class ListItemSenderService(
     private val writer: ListFileWriter,
     private val listStream: ListStream,
 ) {
+    // Serializes appends and remembers the last sort key we issued per list, so two rapid
+    // addItem calls get distinct increasing keys even before the optimistic write has been
+    // merged back into listStream.itemsByList (which updates asynchronously via BatchReceived).
+    private val addMutex = Mutex()
+    private val lastIssuedSortKey = mutableMapOf<Uuid, String>()
+
     private fun membersOf(listId: Uuid): List<OdinId> =
         listStream.lists.value.lists.find { it.listId == listId }?.definition?.members ?: emptyList()
 
@@ -20,10 +28,13 @@ class ListItemSenderService(
         listStream.itemsByList.value[listId]?.find { it.itemId == itemId }
 
     /** Append a new item to the end of the list. Returns the new itemId. */
-    suspend fun addItem(listId: Uuid, body: String): Uuid {
+    suspend fun addItem(listId: Uuid, body: String): Uuid = addMutex.withLock {
         val itemId = Uuid.random()
-        val lastKey = listStream.itemsByList.value[listId]?.lastOrNull()?.item?.sortKey
+        val streamLast = listStream.itemsByList.value[listId]?.lastOrNull()?.item?.sortKey
+        // High-water mark of the highest key known, whether from the stream or our own pending adds.
+        val lastKey = listOfNotNull(streamLast, lastIssuedSortKey[listId]).maxOrNull()
         val sortKey = if (lastKey == null) ListSortKeys.first() else ListSortKeys.after(lastKey)
+        lastIssuedSortKey[listId] = sortKey
         val item = ListItem(
             body = body.truncateToCodePoints(ListsProtocol.MaxItemBodyCodePoints),
             sortKey = sortKey,
@@ -35,7 +46,7 @@ class ListItemSenderService(
             contentJson = OdinSystemSerializer.serialize(item),
             recipients = writer.recipientsExcludingSelf(membersOf(listId)),
         )
-        return itemId
+        itemId
     }
 
     private suspend fun updateItem(listId: Uuid, itemId: Uuid, transform: (ListItem) -> ListItem) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/services/ListService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/services/ListService.kt
@@ -1,0 +1,56 @@
+package id.homebase.core.lists.services
+
+import id.homebase.api.common.OdinId
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.util.truncateToCodePoints
+import id.homebase.core.lists.ListsProtocol
+import id.homebase.core.lists.model.ListDefinition
+import kotlin.uuid.Uuid
+
+/** Create / rename / delete a list (the ListDefinition file). Membership add/remove is Phase 4. */
+class ListService(
+    private val writer: ListFileWriter,
+    private val listStream: ListStream,
+) {
+    /** Create a list. members = the people to share with (creator is implied via originalAuthor). */
+    suspend fun createList(title: String, members: List<OdinId> = emptyList()): Uuid {
+        val listId = Uuid.random()
+        val def = ListDefinition(
+            title = title.truncateToCodePoints(ListsProtocol.MaxTitleCodePoints),
+            members = members,
+        )
+        writer.createFile(
+            uniqueId = listId,
+            groupId = listId,
+            fileType = ListsProtocol.ListDefinitionFileType,
+            contentJson = OdinSystemSerializer.serialize(def),
+            recipients = writer.recipientsExcludingSelf(members),
+        )
+        return listId
+    }
+
+    suspend fun renameList(listId: Uuid, newTitle: String? = null, newColorOrEmoji: String? = null) {
+        val rec = listStream.lists.value.lists.find { it.listId == listId } ?: return
+        val def = rec.definition.copy(
+            title = (newTitle ?: rec.definition.title).truncateToCodePoints(ListsProtocol.MaxTitleCodePoints),
+            colorOrEmoji = newColorOrEmoji ?: rec.definition.colorOrEmoji,
+        )
+        writer.updateFile(
+            uniqueId = listId,
+            groupId = listId,
+            fileType = ListsProtocol.ListDefinitionFileType,
+            contentJson = OdinSystemSerializer.serialize(def),
+            versionTag = rec.versionTag,
+            recipients = writer.recipientsExcludingSelf(rec.definition.members),
+        )
+    }
+
+    suspend fun deleteList(listId: Uuid) {
+        val rec = listStream.lists.value.lists.find { it.listId == listId } ?: return
+        writer.deleteFile(
+            fileId = rec.fileId,
+            uniqueId = listId,
+            recipients = writer.recipientsExcludingSelf(rec.definition.members),
+        )
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/services/ListStream.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/services/ListStream.kt
@@ -1,0 +1,163 @@
+package id.homebase.core.lists.services
+
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.FileState
+import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.client.eventbus.BackendEvent
+import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.common.OdinId
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.client.drives.QueryBatchSortField
+import id.homebase.api.client.drives.QueryBatchSortOrder
+import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.sync.database.QueryBatch
+import id.homebase.core.config.listsLabeledDrive
+import id.homebase.core.lists.ListsProtocol
+import id.homebase.core.lists.model.ListDefinition
+import id.homebase.core.lists.model.ListItem
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlin.uuid.Uuid
+
+// ---- pure, testable state (do not change; the test depends on these exact shapes) ----
+
+data class ListRecord(
+    val listId: Uuid,
+    val fileId: Uuid,
+    val versionTag: Uuid?,
+    val createdBy: OdinId?,
+    val definition: ListDefinition,
+)
+
+data class ListItemRecord(
+    val itemId: Uuid,
+    val listId: Uuid,
+    val fileId: Uuid,
+    val versionTag: Uuid?,
+    val createdBy: OdinId?,
+    val item: ListItem,
+)
+
+data class ListsData(
+    val dataReady: Boolean = false,
+    val lists: List<ListRecord> = emptyList(),
+)
+
+class ListStreamState {
+    private val defs = LinkedHashMap<Uuid, ListRecord>()
+    private val items = LinkedHashMap<Uuid, ListItemRecord>()
+
+    fun upsertDefinition(rec: ListRecord) { defs[rec.listId] = rec }
+    fun removeDefinition(listId: Uuid) { defs.remove(listId) }
+    fun upsertItem(rec: ListItemRecord) { items[rec.itemId] = rec }
+    fun removeItem(itemId: Uuid) { items.remove(itemId) }
+    fun clear() { defs.clear(); items.clear() }
+
+    fun lists(): List<ListRecord> = defs.values.sortedBy { it.definition.title.lowercase() }
+
+    fun itemsByList(): Map<Uuid, List<ListItemRecord>> =
+        items.values.groupBy { it.listId }
+            .mapValues { (_, v) -> v.sortedWith(compareBy({ it.item.sortKey }, { it.itemId.toString() })) }
+}
+
+// ---- IO shell ----
+
+class ListStream(
+    private val credentialsManager: CredentialsManager,
+    private val databaseManager: DatabaseManager,
+    private val eventBus: EventBus,
+    private val scope: CoroutineScope,
+) {
+    private val listsDrive = listsLabeledDrive.drive.alias
+    private val state = ListStreamState()
+
+    private val _lists = MutableStateFlow(ListsData(dataReady = false))
+    val lists: StateFlow<ListsData> = _lists.asStateFlow()
+
+    private val _itemsByList = MutableStateFlow<Map<Uuid, List<ListItemRecord>>>(emptyMap())
+    val itemsByList: StateFlow<Map<Uuid, List<ListItemRecord>>> = _itemsByList.asStateFlow()
+
+    private var started = false
+
+    init {
+        scope.launch {
+            eventBus.events.collect { event ->
+                when (event) {
+                    is BackendEvent.SessionEnded -> reset()
+                    is BackendEvent.DriveEvent.Stopped ->
+                        if (event.driveId == listsDrive && event.totalCount > 0) loadAll()
+                    is BackendEvent.DataEvent.BatchReceived ->
+                        if (event.driveId == listsDrive) mergeBatch(event.batchData)
+                    is BackendEvent.OutboxEvent.ItemCompleted ->
+                        if (event.driveId == listsDrive) loadAll()
+                    is BackendEvent.OutboxEvent.ItemFailed ->
+                        if (event.driveId == listsDrive) loadAll()
+                    else -> Unit
+                }
+            }
+        }
+    }
+
+    fun reset() {
+        started = false
+        state.clear()
+        publish(dataReady = false)
+    }
+
+    fun start() {
+        if (started) return
+        started = true
+        scope.launch { loadAll() }
+    }
+
+    private suspend fun loadAll() {
+        val identityId = credentialsManager.getActiveCredentials()?.getIdentityId() ?: return
+        state.clear()
+        val result = QueryBatch(identityId).queryBatchAsync(
+            dbm = databaseManager,
+            driveId = listsDrive,
+            noOfItems = 1000,
+            cursor = null,
+            sortOrder = QueryBatchSortOrder.NewestFirst,
+            sortField = QueryBatchSortField.UserDate,
+            fileSystemType = 0,
+            filetypesAnyOf = listOf(ListsProtocol.ListDefinitionFileType, ListsProtocol.ListItemFileType),
+        )
+        result.records.forEach { parseInto(it) }
+        publish(dataReady = true)
+    }
+
+    private fun mergeBatch(files: List<HomebaseFile>) {
+        files.forEach { parseInto(it) }
+        publish(dataReady = _lists.value.dataReady)
+    }
+
+    private fun parseInto(file: HomebaseFile) {
+        val app = file.fileMetadata.appData
+        val deleted = file.fileState == FileState.Deleted
+        when (app.fileType) {
+            ListsProtocol.ListDefinitionFileType -> {
+                val listId = app.uniqueId ?: return
+                if (deleted) { state.removeDefinition(listId); return }
+                val def = app.content?.let { runCatching { OdinSystemSerializer.deserialize<ListDefinition>(it) }.getOrNull() } ?: return
+                state.upsertDefinition(ListRecord(listId, file.fileId, file.fileMetadata.versionTag, file.fileMetadata.originalAuthor, def))
+            }
+            ListsProtocol.ListItemFileType -> {
+                val itemId = app.uniqueId ?: return
+                if (deleted) { state.removeItem(itemId); return }
+                val listId = app.groupId ?: return
+                val item = app.content?.let { runCatching { OdinSystemSerializer.deserialize<ListItem>(it) }.getOrNull() } ?: return
+                state.upsertItem(ListItemRecord(itemId, listId, file.fileId, file.fileMetadata.versionTag, file.fileMetadata.originalAuthor, item))
+            }
+            else -> Unit
+        }
+    }
+
+    private fun publish(dataReady: Boolean) {
+        _lists.value = ListsData(dataReady = dataReady, lists = state.lists())
+        _itemsByList.value = state.itemsByList()
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/services/ListStream.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/lists/services/ListStream.kt
@@ -3,14 +3,16 @@ package id.homebase.core.lists.services
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.drives.FileState
 import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.client.drives.QueryBatchSortField
+import id.homebase.api.client.drives.QueryBatchSortOrder
+import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.common.OdinId
 import id.homebase.api.serialization.OdinSystemSerializer
-import id.homebase.api.client.drives.QueryBatchSortField
-import id.homebase.api.client.drives.QueryBatchSortOrder
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.QueryBatch
+import id.homebase.api.client.drives.query.QueryBatchCursor
 import id.homebase.core.config.listsLabeledDrive
 import id.homebase.core.lists.ListsProtocol
 import id.homebase.core.lists.model.ListDefinition
@@ -20,6 +22,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.uuid.Uuid
 
 // ---- pure, testable state (do not change; the test depends on these exact shapes) ----
@@ -54,6 +58,8 @@ class ListStreamState {
     fun removeDefinition(listId: Uuid) { defs.remove(listId) }
     fun upsertItem(rec: ListItemRecord) { items[rec.itemId] = rec }
     fun removeItem(itemId: Uuid) { items.remove(itemId) }
+    /** Drop every item belonging to [listId] — used when a list definition is deleted. */
+    fun removeItemsForList(listId: Uuid) { items.entries.removeAll { it.value.listId == listId } }
     fun clear() { defs.clear(); items.clear() }
 
     fun lists(): List<ListRecord> = defs.values.sortedBy { it.definition.title.lowercase() }
@@ -68,11 +74,16 @@ class ListStreamState {
 class ListStream(
     private val credentialsManager: CredentialsManager,
     private val databaseManager: DatabaseManager,
+    private val driveFileProvider: DriveFileProvider,
     private val eventBus: EventBus,
     private val scope: CoroutineScope,
 ) {
     private val listsDrive = listsLabeledDrive.drive.alias
     private val state = ListStreamState()
+
+    // Serializes every mutation of [state] + publish so concurrent loaders/merges (start(),
+    // sync-stopped, outbox events, logout) can never interleave clear()+upsert on the maps.
+    private val stateMutex = Mutex()
 
     private val _lists = MutableStateFlow(ListsData(dataReady = false))
     val lists: StateFlow<ListsData> = _lists.asStateFlow()
@@ -92,9 +103,9 @@ class ListStream(
                     is BackendEvent.DataEvent.BatchReceived ->
                         if (event.driveId == listsDrive) mergeBatch(event.batchData)
                     is BackendEvent.OutboxEvent.ItemCompleted ->
-                        if (event.driveId == listsDrive) loadAll()
+                        if (event.driveId == listsDrive) refreshFile(event.uniqueId)
                     is BackendEvent.OutboxEvent.ItemFailed ->
-                        if (event.driveId == listsDrive) loadAll()
+                        if (event.driveId == listsDrive) refreshFile(event.uniqueId)
                     else -> Unit
                 }
             }
@@ -103,8 +114,18 @@ class ListStream(
 
     fun reset() {
         started = false
-        state.clear()
-        publish(dataReady = false)
+        // Clear under the same lock as every other mutation. Identity-guarded so that a
+        // relogin's freshly-loaded data isn't wiped by a late logout-clear: only clear when
+        // there is no active identity (a true logout). On relogin, start()->loadAll() clears
+        // and reloads under the lock.
+        scope.launch {
+            stateMutex.withLock {
+                if (credentialsManager.getActiveCredentials() == null) {
+                    state.clear()
+                    publish(dataReady = false)
+                }
+            }
+        }
     }
 
     fun start() {
@@ -115,33 +136,78 @@ class ListStream(
 
     private suspend fun loadAll() {
         val identityId = credentialsManager.getActiveCredentials()?.getIdentityId() ?: return
-        state.clear()
-        val result = QueryBatch(identityId).queryBatchAsync(
-            dbm = databaseManager,
-            driveId = listsDrive,
-            noOfItems = 1000,
-            cursor = null,
-            sortOrder = QueryBatchSortOrder.NewestFirst,
-            sortField = QueryBatchSortField.UserDate,
-            fileSystemType = 0,
-            filetypesAnyOf = listOf(ListsProtocol.ListDefinitionFileType, ListsProtocol.ListItemFileType),
-        )
-        result.records.forEach { parseInto(it) }
-        publish(dataReady = true)
+        // Query outside the lock (it's the slow part) so live BatchReceived merges aren't blocked.
+        val records = queryAllPaginated(identityId)
+        stateMutex.withLock {
+            // Discard if the active identity changed (logout / account switch) while we queried —
+            // never publish identity A's lists into identity B's session.
+            if (credentialsManager.getActiveCredentials()?.getIdentityId() != identityId) return@withLock
+            state.clear()
+            records.forEach { parseInto(it) }
+            publish(dataReady = true)
+        }
     }
 
-    private fun mergeBatch(files: List<HomebaseFile>) {
-        files.forEach { parseInto(it) }
-        publish(dataReady = _lists.value.dataReady)
+    /** Page through ALL Lists files (cursor honoured), so >1000 files are never silently dropped. */
+    private suspend fun queryAllPaginated(identityId: Uuid): List<HomebaseFile> {
+        val all = mutableListOf<HomebaseFile>()
+        var cursor: QueryBatchCursor? = null
+        while (true) {
+            val result = QueryBatch(identityId).queryBatchAsync(
+                dbm = databaseManager,
+                driveId = listsDrive,
+                noOfItems = 1000,
+                cursor = cursor,
+                sortOrder = QueryBatchSortOrder.NewestFirst,
+                sortField = QueryBatchSortField.UserDate,
+                fileSystemType = 0,
+                filetypesAnyOf = listOf(ListsProtocol.ListDefinitionFileType, ListsProtocol.ListItemFileType),
+            )
+            all += result.records
+            if (!result.hasMoreRows) break
+            cursor = result.cursor
+        }
+        return all
     }
 
+    private suspend fun mergeBatch(files: List<HomebaseFile>) {
+        stateMutex.withLock {
+            files.forEach { parseInto(it) }
+            publish(dataReady = _lists.value.dataReady)
+        }
+    }
+
+    /**
+     * Reconcile a SINGLE file after its outbox item completes/fails — cheaper than a full
+     * loadAll() (the optimistic BatchReceived already merged the change; this just picks up the
+     * server-confirmed versionTag, or removes the row if the file is gone).
+     */
+    private suspend fun refreshFile(uniqueId: Uuid) {
+        val file = driveFileProvider.getFileHeaderByUid(listsDrive, uniqueId)
+        stateMutex.withLock {
+            if (file != null) {
+                parseInto(file)
+            } else {
+                state.removeItem(uniqueId)
+                state.removeDefinition(uniqueId)
+                state.removeItemsForList(uniqueId)
+            }
+            publish(dataReady = _lists.value.dataReady)
+        }
+    }
+
+    /** Decode one indexed file into [state]. content is plaintext JSON. MUST be called under [stateMutex]. */
     private fun parseInto(file: HomebaseFile) {
         val app = file.fileMetadata.appData
         val deleted = file.fileState == FileState.Deleted
         when (app.fileType) {
             ListsProtocol.ListDefinitionFileType -> {
                 val listId = app.uniqueId ?: return
-                if (deleted) { state.removeDefinition(listId); return }
+                if (deleted) {
+                    state.removeDefinition(listId)
+                    state.removeItemsForList(listId)   // don't leave the list's items orphaned
+                    return
+                }
                 val def = app.content?.let { runCatching { OdinSystemSerializer.deserialize<ListDefinition>(it) }.getOrNull() } ?: return
                 state.upsertDefinition(ListRecord(listId, file.fileId, file.fileMetadata.versionTag, file.fileMetadata.originalAuthor, def))
             }

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/lists/ListsProtocolTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/lists/ListsProtocolTest.kt
@@ -1,0 +1,20 @@
+package id.homebase.core.lists
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ListsProtocolTest {
+    @Test
+    fun `file types are the reserved values and distinct`() {
+        assertEquals(9100, ListsProtocol.ListDefinitionFileType)
+        assertEquals(9101, ListsProtocol.ListItemFileType)
+        assertTrue(ListsProtocol.ListDefinitionFileType != ListsProtocol.ListItemFileType)
+    }
+
+    @Test
+    fun `caps are sane and under the header budget`() {
+        assertTrue(ListsProtocol.MaxTitleCodePoints in 1..200)
+        assertTrue(ListsProtocol.MaxItemBodyCodePoints in 1..7000)
+    }
+}

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/lists/model/ListDefinitionTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/lists/model/ListDefinitionTest.kt
@@ -1,0 +1,42 @@
+package id.homebase.core.lists.model
+
+import id.homebase.api.common.OdinId
+import id.homebase.api.serialization.OdinSystemSerializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ListDefinitionTest {
+    @Test
+    fun `valid definition round-trips through OdinSystemSerializer`() {
+        val def = ListDefinition(
+            title = "Groceries",
+            members = listOf(OdinId("alice.example.com"), OdinId("bob.example.com")),
+            colorOrEmoji = "🛒",
+        )
+        val json = OdinSystemSerializer.serialize(def)
+        val back = OdinSystemSerializer.deserialize<ListDefinition>(json)
+        assertEquals(def, back)
+        assertTrue(back.isValid())
+        assertTrue(json.contains("alice.example.com"))
+    }
+
+    @Test
+    fun `blank title is invalid`() {
+        assertFalse(ListDefinition(title = "  ").isValid())
+    }
+
+    @Test
+    fun `over-long title is invalid`() {
+        val long = "x".repeat(id.homebase.core.lists.ListsProtocol.MaxTitleCodePoints + 1)
+        assertFalse(ListDefinition(title = long).isValid())
+    }
+
+    @Test
+    fun `unknown json keys are ignored (forward-compat)`() {
+        val json = """{"title":"T","members":[],"futureField":42,"schemaVersion":1}"""
+        val def = OdinSystemSerializer.deserialize<ListDefinition>(json)
+        assertEquals("T", def.title)
+    }
+}

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/lists/model/ListItemTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/lists/model/ListItemTest.kt
@@ -1,0 +1,36 @@
+package id.homebase.core.lists.model
+
+import id.homebase.api.common.OdinId
+import id.homebase.api.serialization.OdinSystemSerializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ListItemTest {
+    @Test
+    fun `valid item round-trips`() {
+        val item = ListItem(body = "Buy **milk**", checked = false, sortKey = "n")
+        val json = OdinSystemSerializer.serialize(item)
+        assertEquals(item, OdinSystemSerializer.deserialize<ListItem>(json))
+        assertTrue(item.isValid())
+    }
+
+    @Test
+    fun `checked item may record who checked it`() {
+        val item = ListItem(body = "x", checked = true, checkedByOdinId = OdinId("mom.example.com"), sortKey = "n")
+        assertTrue(item.isValid())
+        assertEquals("mom.example.com", item.checkedByOdinId?.domainName)
+    }
+
+    @Test
+    fun `checkedBy without checked is invalid`() {
+        assertFalse(ListItem(body = "x", checked = false, checkedByOdinId = OdinId("a.example.com"), sortKey = "n").isValid())
+    }
+
+    @Test
+    fun `blank body or blank sortKey is invalid`() {
+        assertFalse(ListItem(body = "   ", sortKey = "n").isValid())
+        assertFalse(ListItem(body = "x", sortKey = "").isValid())
+    }
+}

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/lists/model/ListSortKeysTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/lists/model/ListSortKeysTest.kt
@@ -1,0 +1,32 @@
+package id.homebase.core.lists.model
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class ListSortKeysTest {
+    @Test
+    fun `first comes before after-first`() {
+        val a = ListSortKeys.first()
+        val b = ListSortKeys.after(a)
+        assertTrue(a < b)
+    }
+
+    @Test
+    fun `between produces a key strictly between two adjacent keys`() {
+        val a = ListSortKeys.first()
+        val b = ListSortKeys.after(a)
+        val mid = ListSortKeys.between(a, b)
+        assertTrue(a < mid && mid < b)
+    }
+
+    @Test
+    fun `repeated between insertions stay ordered`() {
+        var lo = ListSortKeys.first()
+        var hi = ListSortKeys.after(lo)
+        repeat(20) {
+            val mid = ListSortKeys.between(lo, hi)
+            assertTrue(lo < mid && mid < hi)
+            hi = mid
+        }
+    }
+}

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/lists/model/ListSortKeysTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/lists/model/ListSortKeysTest.kt
@@ -29,4 +29,36 @@ class ListSortKeysTest {
             hi = mid
         }
     }
+
+    @Test
+    fun `between with null lower bound is strictly below the upper bound`() {
+        // regression: the old position-0 clamp could return a key == the upper bound
+        val hi = ListSortKeys.first()                 // "n"
+        val mid = ListSortKeys.between(null, hi)
+        assertTrue(mid < hi)
+    }
+
+    @Test
+    fun `repeated insert-at-top stays strictly below and ordered`() {
+        var hi = ListSortKeys.first()
+        repeat(20) {
+            val mid = ListSortKeys.between(null, hi)
+            assertTrue(mid < hi)
+            hi = mid
+        }
+    }
+
+    @Test
+    fun `equal or inverted bounds append after a instead of crashing`() {
+        val k = ListSortKeys.first()
+        assertTrue(ListSortKeys.between(k, k) > k)     // a == b → after(a)
+        assertTrue(ListSortKeys.between("z", "a") > "z") // inverted → after("z")
+    }
+
+    @Test
+    fun `after is always strictly greater than its input`() {
+        for (k in listOf("a", "n", "z", "az", "n=")) {
+            assertTrue(ListSortKeys.after(k) > k)
+        }
+    }
 }

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/lists/services/ListStreamParsingTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/lists/services/ListStreamParsingTest.kt
@@ -1,0 +1,50 @@
+package id.homebase.core.lists.services
+
+import id.homebase.core.lists.model.ListDefinition
+import id.homebase.core.lists.model.ListItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.uuid.Uuid
+
+class ListStreamParsingTest {
+    private fun listId() = Uuid.parse("11111111-1111-1111-1111-111111111111")
+    private fun itemId() = Uuid.parse("22222222-2222-2222-2222-222222222222")
+
+    @Test
+    fun `definition + items group under one list, items sorted by sortKey`() {
+        val state = ListStreamState()
+        state.upsertDefinition(ListRecord(listId(), Uuid.random(), null, null, ListDefinition("Groceries")))
+        state.upsertItem(ListItemRecord(Uuid.random(), listId(), Uuid.random(), null, null, ListItem("milk", sortKey = "n")))
+        state.upsertItem(ListItemRecord(Uuid.random(), listId(), Uuid.random(), null, null, ListItem("bread", sortKey = "g")))
+        val lists = state.lists()
+        assertEquals(1, lists.size)
+        assertEquals("Groceries", lists.single().definition.title)
+        assertEquals(listOf("bread", "milk"), state.itemsByList()[listId()]!!.map { it.item.body })
+    }
+
+    @Test
+    fun `removing a definition drops the list`() {
+        val state = ListStreamState()
+        state.upsertDefinition(ListRecord(listId(), Uuid.random(), null, null, ListDefinition("X")))
+        state.removeDefinition(listId())
+        assertEquals(0, state.lists().size)
+    }
+
+    @Test
+    fun `removing an item drops it from its list`() {
+        val state = ListStreamState()
+        state.upsertDefinition(ListRecord(listId(), Uuid.random(), null, null, ListDefinition("X")))
+        state.upsertItem(ListItemRecord(itemId(), listId(), Uuid.random(), null, null, ListItem("a", sortKey = "n")))
+        state.removeItem(itemId())
+        assertNull(state.itemsByList()[listId()]?.firstOrNull())
+    }
+
+    @Test
+    fun `clear resets all state`() {
+        val state = ListStreamState()
+        state.upsertDefinition(ListRecord(listId(), Uuid.random(), null, null, ListDefinition("X")))
+        state.clear()
+        assertEquals(0, state.lists().size)
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of **Shared Lists** — the data layer. Adds two drive file types, a slim read-model, and the write services, so a single identity can create lists and add/edit/check/delete/reorder items that survive an app restart. PR into the `feat-shared-lists` integration branch (Part 2 of 1→5).

**File types & descriptors** (`ListsProtocol`, fileTypes `9100`/`9101` — confirmed free):
- `ListDefinition { title ≤80cp, members: List<OdinId>, colorOrEmoji?, schemaVersion }` + `isValid()`.
- `ListItem { body markdown String ≤2000cp, checked, checkedByOdinId?, sortKey, schemaVersion }` + `isValid()`.
- Plain `@Serializable` + `OdinSystemSerializer` (DiceRoll/Event pattern). Envelope fields (author/timestamps) read from the `HomebaseFile`, never duplicated in JSON.
- `ListSortKeys` — fractional order keys for drag-reorder.

**`ListStream`** — a slim read-model (no `ConversationStream` unread/enrichment/orphan machinery):
- Pure, unit-tested `ListStreamState` (group by `listId`, sort items by `sortKey`).
- `loadAll()` via `QueryBatch` over the generic `DriveMainIndex`, filtered to fileTypes `[9100, 9101]` (content comes back decrypted, like Moments/Location).
- EventBus collector (filtered to the lists drive): `BatchReceived` → merge; `DriveEvent.Stopped`(totalCount>0) / `OutboxEvent.ItemCompleted|Failed` → `loadAll()`; `SessionEnded` → `reset()`.

**Write services** (`ListFileWriter` holds the encrypted-write boilerplate; the services are thin):
- `ListFileWriter` — `createFile`/`updateFile`/`deleteFile` (header-only), cloned from `ConversationService.writeConversationFile` / `ChatMessageSenderService.updateMessage` / `ChatMessageActionService.deleteMessage`: keyHeader → `UploadFileMetadata` → `encryptContent` → `OptimisticWriter` (instant local echo) → `OutboxSync` (durable upload + `TransitOptions(recipients)`).
- `ListService` — `createList` / `renameList` / `deleteList`.
- `ListItemSenderService` — `addItem` / `editItem` / `setChecked` / `reorderItem` / `deleteItem`.
- Transit to `members − self`; updates carry `versionTag` (last-writer-wins).

**Wiring:** `singleOf` for all four services; `ListStream.reset()/start()` in `onPostAuthenticated`.

## Out of scope (deferred)
- **Membership add/remove + backfill-on-join** → Phase 4 (Part 2 sends to the creator's initial member set only).
- **Cross-identity real-time** → Phase 4.
- **UI** (`ListsScreen`/`ListDetailScreen`) → Phase 3 (the Phase-1 placeholder screen stays).
- **Share-to-chat** → Phase 5. (Heads-up: the spec reserved `dataType 213`, but `ChatGroodleMessageDataType = 213` is taken — Phase 5 uses **214**.)

## Verification
- ✅ `:homebase-core:jvmTest` + `:homebase-common:jvmTest` — green, incl. 5 new test classes (`ListsProtocolTest`, `ListDefinitionTest`, `ListItemTest`, `ListSortKeysTest`, `ListStreamParsingTest`) and the Konsist `ArchitectureTest`.
- ✅ Compiles clean on **JVM**, **Android** (`compileAndroidMain`), and **iOS** (`compileKotlinIosSimulatorArm64`).
- ⚠️ **End-to-end runtime smoke is deferred.** The write path (optimistic + outbox + transit) is compile-verified and cloned 1:1 from chat's proven paths, but the live single-identity run (create list → add/check/edit/reorder/delete → restart → reload) is blocked by the **Phase-1 activation read-grant bug** (see PR #733 comment) — the drive isn't subscribed until that's fixed. Recommend running the manual smoke once Phase-1 activation is sorted.

## Test plan (manual, once the drive is usable)
- [ ] Create a list; add two items; check one; edit one; reorder; delete one.
- [ ] Force-quit + relaunch → `ListStream` reloads the same lists/items from `DriveMainIndex` (survive restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)