### PR TITLE
Shared Lists Phase 3: Lists + Detail UI

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -88,6 +88,7 @@ play-app-update = "2.1.0"
 play-services-location = "21.3.0"
 mlkit-subject-segmentation = "16.0.0-beta1"
 metadataExtractor = "2.19.0"
+reorderable = "3.1.0"
 
 [libraries]
 ffmpeg-kit = { module = "id.homebase.libs:ffmpeg-kit", version.ref = "ffmpegKit" }
@@ -218,6 +219,7 @@ play-app-update = { module = "com.google.android.play:app-update-ktx", version.r
 play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "play-services-location" }
 mlkit-subject-segmentation = { module = "com.google.android.gms:play-services-mlkit-subject-segmentation", version.ref = "mlkit-subject-segmentation" }
 metadata-extractor = { module = "com.drewnoakes:metadata-extractor", version.ref = "metadataExtractor" }
+reorderable = { module = "sh.calvin.reorderable:reorderable", version.ref = "reorderable" }
 nucleus-notification-common = { module = "io.github.kdroidfilter:nucleus.notification-common", version.ref = "nucleus" }
 nucleus-notification-windows = { module = "io.github.kdroidfilter:nucleus.notification-windows", version.ref = "nucleus" }
 nucleus-notification-macos = { module = "io.github.kdroidfilter:nucleus.notification-macos", version.ref = "nucleus" }

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1274,4 +1274,23 @@
     <string name="lists_home_subtitle">Shared to-do lists</string>
     <string name="lists_empty_title">No lists yet</string>
     <string name="lists_empty_body">Create a list to start collaborating with your family.</string>
+    <!-- Lists Phase 3: overview + detail UI -->
+    <string name="list_overview_new">New list</string>
+    <string name="list_overview_create_title">New list</string>
+    <string name="list_overview_name_hint">List name</string>
+    <string name="list_overview_progress">%1$d / %2$d</string>
+    <string name="list_overview_rename_title">Rename list</string>
+    <string name="list_overview_more">List options</string>
+    <string name="list_delete_title">Delete list?</string>
+    <string name="list_delete_body">This permanently deletes the list and all of its items.</string>
+    <string name="list_action_rename">Rename</string>
+    <string name="list_action_delete_list">Delete list</string>
+    <string name="list_detail_add_hint">Add an item</string>
+    <string name="list_detail_add_action">Add item</string>
+    <string name="list_detail_empty_title">No items yet</string>
+    <string name="list_detail_empty_body">Add your first item below.</string>
+    <string name="list_item_more">Item options</string>
+    <string name="list_item_edit_title">Edit item</string>
+    <string name="list_item_check_desc">Toggle item completed</string>
+    <string name="list_item_reorder_desc">Drag to reorder</string>
 </resources>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
@@ -184,6 +184,10 @@ sealed class Route {
     data object ListsSettings : Route()
 
     @Serializable
+    @SerialName("list-detail")
+    data class ListDetail(val listId: String) : Route()
+
+    @Serializable
     @SerialName("location")
     data object Location : Route()
 

--- a/homebase-core/build.gradle.kts
+++ b/homebase-core/build.gradle.kts
@@ -115,6 +115,7 @@ kotlin {
             implementation(libs.markdown.renderer)
             implementation(libs.markdown.renderer.m3)
             implementation(libs.markdown.renderer.coil3)
+            implementation(libs.reorderable)
             implementation(libs.filekit.dialogs.compose)
         }
         nativeMain.dependencies {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -142,6 +142,7 @@ import id.homebase.core.lists.services.ListItemSenderService
 import id.homebase.core.lists.services.ListService
 import id.homebase.core.lists.services.ListStream
 import id.homebase.core.ui.screens.lists.ListOverviewViewModel
+import id.homebase.core.ui.screens.lists.ListDetailViewModel
 import id.homebase.core.ui.screens.lists.ListsSettingsViewModel
 import id.homebase.core.ui.screens.lists.ListsViewModel
 import id.homebase.core.location.LocationPreferences
@@ -682,6 +683,14 @@ val appModule = module {
     viewModel { ListsViewModel(get(), get(ListsPermissionQualifier), get()) }
     viewModelOf(::ListsSettingsViewModel)
     viewModelOf(::ListOverviewViewModel)
+    viewModel { params ->
+        ListDetailViewModel(
+            listId = params.get(),
+            listStream = get(),
+            itemSender = get(),
+            listService = get(),
+        )
+    }
     viewModel(LocationPermissionQualifier) {
         ExtendPermissionViewModel(get(), get(), get(), getLocationPermissionExtensionConfig())
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -141,6 +141,7 @@ import id.homebase.core.lists.services.ListFileWriter
 import id.homebase.core.lists.services.ListItemSenderService
 import id.homebase.core.lists.services.ListService
 import id.homebase.core.lists.services.ListStream
+import id.homebase.core.ui.screens.lists.ListOverviewViewModel
 import id.homebase.core.ui.screens.lists.ListsSettingsViewModel
 import id.homebase.core.ui.screens.lists.ListsViewModel
 import id.homebase.core.location.LocationPreferences
@@ -680,6 +681,7 @@ val appModule = module {
     viewModel(ListsPermissionQualifier) { ExtendPermissionViewModel(get(), get(), get(), getListsPermissionExtensionConfig()) }
     viewModel { ListsViewModel(get(), get(ListsPermissionQualifier), get()) }
     viewModelOf(::ListsSettingsViewModel)
+    viewModelOf(::ListOverviewViewModel)
     viewModel(LocationPermissionQualifier) {
         ExtendPermissionViewModel(get(), get(), get(), getLocationPermissionExtensionConfig())
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -1224,7 +1224,12 @@ fun AppNavHost(
                         }
                         composable<Route.Lists> {
                             if (isAuthenticated) {
-                                ListsScreen()
+                                ListsScreen(
+                                    viewModel = koinViewModel(),
+                                    onOpenList = { listId ->
+                                        navController.navigate(Route.ListDetail(listId.toString()))
+                                    },
+                                )
                             }
                         }
                         composable<Route.ListsSettings> {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -111,6 +111,7 @@ import androidx.compose.material.icons.automirrored.outlined.ListAlt
 import id.homebase.core.lists.ListsPreferences
 import id.homebase.core.ui.screens.lists.ListsOnboardingScreen
 import id.homebase.core.ui.screens.lists.ListsScreen
+import id.homebase.core.ui.screens.lists.ListDetailScreen
 import id.homebase.core.ui.screens.lists.ListsSettingsScreen
 import id.homebase.core.ui.screens.lists.ListsUiEvent
 import id.homebase.core.ui.screens.lists.ListsViewModel
@@ -1229,6 +1230,20 @@ fun AppNavHost(
                                     onOpenList = { listId ->
                                         navController.navigate(Route.ListDetail(listId.toString()))
                                     },
+                                )
+                            }
+                        }
+                        composable<Route.ListDetail> { backStackEntry ->
+                            if (isAuthenticated) {
+                                val route = backStackEntry.toRoute<Route.ListDetail>()
+                                ListDetailScreen(
+                                    viewModel = koinViewModel(
+                                        key = route.listId,
+                                        parameters = {
+                                            org.koin.core.parameter.parametersOf(Uuid.parse(route.listId))
+                                        },
+                                    ),
+                                    onNavigateBack = { navController.popBackStack() },
                                 )
                             }
                         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListDetailScreen.kt
@@ -72,7 +72,6 @@ import id.homebase.resources.list_item_reorder_desc
 import id.homebase.resources.list_overview_more
 import id.homebase.resources.menu_back
 import id.homebase.resources.save
-import kotlinx.coroutines.flow.collectLatest
 import org.jetbrains.compose.resources.stringResource
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
@@ -99,13 +98,15 @@ fun ListDetailScreen(
     LaunchedEffect(uiState.items) {
         if (!reorderableState.isAnyItemDragging) localItems = uiState.items
     }
+    // Render the stream order normally; only show the locally-dragged order WHILE a drag is active.
+    // This keeps the empty/list branch and the rendered list reading the SAME source (no first-frame
+    // blank flash) and lets the list re-sync to the stream the instant a drag ends.
+    val displayItems = if (reorderableState.isAnyItemDragging) localItems else uiState.items
 
-    LaunchedEffect(Unit) {
-        viewModel.events.collectLatest { event ->
-            when (event) {
-                is ListDetailEvent.ListDeleted -> onNavigateBack()
-            }
-        }
+    // Leave the screen when the list is gone — local delete, a collaborator delete (Phase 4), or an
+    // invalid deep-linked listId. One guard covers all three (replaces a local-only delete event).
+    LaunchedEffect(uiState.isLoading, uiState.exists) {
+        if (!uiState.isLoading && !uiState.exists) onNavigateBack()
     }
 
     Scaffold(
@@ -151,13 +152,13 @@ fun ListDetailScreen(
             uiState.isLoading -> Box(Modifier.fillMaxSize().padding(innerPadding), contentAlignment = Alignment.Center) {
                 CircularProgressIndicator()
             }
-            uiState.items.isEmpty() -> DetailEmptyState(Modifier.fillMaxSize().padding(innerPadding))
+            displayItems.isEmpty() -> DetailEmptyState(Modifier.fillMaxSize().padding(innerPadding))
             else -> LazyColumn(
                 state = lazyListState,
                 modifier = Modifier.fillMaxSize().padding(innerPadding),
                 contentPadding = PaddingValues(vertical = 4.dp),
             ) {
-                items(localItems, key = { it.itemId.toString() }) { item ->
+                items(displayItems, key = { it.itemId.toString() }) { item ->
                     ReorderableItem(reorderableState, key = item.itemId.toString()) { _ ->
                         ListItemRow(
                             item = item,
@@ -334,9 +335,10 @@ private fun EditItemSheet(
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val richTextState = rememberRichTextState()
-    // Seed the editor ONCE with the existing markdown body (LaunchedEffect(Unit) so it does not
-    // re-apply on recomposition and clobber the user's edits).
-    LaunchedEffect(Unit) { richTextState.applyMarkDownContent(initialBody) }
+    // Seed the editor with the existing markdown body. Keyed on [initialBody] (not Unit) so it
+    // re-seeds if the same sheet is ever reused for a different item, but does NOT re-apply on
+    // unrelated recompositions and clobber the user's in-progress edits.
+    LaunchedEffect(initialBody) { richTextState.applyMarkDownContent(initialBody) }
 
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
         Column(

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListDetailScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.material.icons.automirrored.outlined.ListAlt
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -46,7 +48,10 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.mohamedrejeb.richeditor.model.rememberRichTextState
+import com.mohamedrejeb.richeditor.ui.material3.RichTextEditor
 import id.homebase.chat.widget.ChatMarkdown
+import id.homebase.core.util.applyMarkDownContent
 import id.homebase.resources.MR
 import id.homebase.resources.cancel
 import id.homebase.resources.delete
@@ -59,8 +64,9 @@ import id.homebase.resources.list_detail_add_action
 import id.homebase.resources.list_detail_add_hint
 import id.homebase.resources.list_detail_empty_body
 import id.homebase.resources.list_detail_empty_title
-import id.homebase.resources.list_overview_more
+import id.homebase.resources.list_item_edit_title
 import id.homebase.resources.list_item_more
+import id.homebase.resources.list_overview_more
 import id.homebase.resources.menu_back
 import id.homebase.resources.save
 import kotlinx.coroutines.flow.collectLatest
@@ -78,6 +84,7 @@ fun ListDetailScreen(
     var renameDialog by remember { mutableStateOf(false) }
     var deleteListDialog by remember { mutableStateOf(false) }
     var draft by remember { mutableStateOf("") }
+    var editTarget by remember { mutableStateOf<ListDetailItem?>(null) }
 
     LaunchedEffect(Unit) {
         viewModel.events.collectLatest { event ->
@@ -139,7 +146,7 @@ fun ListDetailScreen(
                     ListItemRow(
                         item = item,
                         onToggle = { viewModel.setChecked(item.itemId, !item.checked) },
-                        onEdit = { /* Task 6 */ },
+                        onEdit = { editTarget = item },
                         onDelete = { viewModel.deleteItem(item.itemId) },
                     )
                 }
@@ -167,6 +174,14 @@ fun ListDetailScreen(
             dismissButton = {
                 TextButton(onClick = { deleteListDialog = false }) { Text(stringResource(MR.string.cancel)) }
             },
+        )
+    }
+
+    editTarget?.let { target ->
+        EditItemSheet(
+            initialBody = target.body,
+            onSave = { newBody -> viewModel.editItem(target.itemId, newBody); editTarget = null },
+            onDismiss = { editTarget = null },
         )
     }
 }
@@ -270,6 +285,40 @@ private fun ListDetailTitleDialog(
         },
         dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(MR.string.cancel)) } },
     )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun EditItemSheet(
+    initialBody: String,
+    onSave: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val richTextState = rememberRichTextState()
+    // Seed the editor ONCE with the existing markdown body (LaunchedEffect(Unit) so it does not
+    // re-apply on recomposition and clobber the user's edits).
+    LaunchedEffect(Unit) { richTextState.applyMarkDownContent(initialBody) }
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier.fillMaxWidth().imePadding().padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(stringResource(MR.string.list_item_edit_title), style = MaterialTheme.typography.titleMedium)
+            RichTextEditor(
+                state = richTextState,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                TextButton(onClick = onDismiss) { Text(stringResource(MR.string.cancel)) }
+                TextButton(
+                    onClick = { onSave(richTextState.toMarkdown()) },
+                    enabled = richTextState.annotatedString.text.isNotBlank(),
+                ) { Text(stringResource(MR.string.save)) }
+            }
+        }
+    }
 }
 
 @Composable

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListDetailScreen.kt
@@ -13,10 +13,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.automirrored.outlined.ListAlt
+import androidx.compose.material.icons.filled.DragHandle
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
@@ -66,11 +68,14 @@ import id.homebase.resources.list_detail_empty_body
 import id.homebase.resources.list_detail_empty_title
 import id.homebase.resources.list_item_edit_title
 import id.homebase.resources.list_item_more
+import id.homebase.resources.list_item_reorder_desc
 import id.homebase.resources.list_overview_more
 import id.homebase.resources.menu_back
 import id.homebase.resources.save
 import kotlinx.coroutines.flow.collectLatest
 import org.jetbrains.compose.resources.stringResource
+import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.rememberReorderableLazyListState
 import kotlin.uuid.Uuid
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -85,6 +90,15 @@ fun ListDetailScreen(
     var deleteListDialog by remember { mutableStateOf(false) }
     var draft by remember { mutableStateOf("") }
     var editTarget by remember { mutableStateOf<ListDetailItem?>(null) }
+    val lazyListState = rememberLazyListState()
+    // Local working copy the drag mutates live; re-seeded from the stream whenever no drag is active.
+    var localItems by remember { mutableStateOf<List<ListDetailItem>>(emptyList()) }
+    val reorderableState = rememberReorderableLazyListState(lazyListState) { from, to ->
+        localItems = localItems.toMutableList().apply { add(to.index, removeAt(from.index)) }
+    }
+    LaunchedEffect(uiState.items) {
+        if (!reorderableState.isAnyItemDragging) localItems = uiState.items
+    }
 
     LaunchedEffect(Unit) {
         viewModel.events.collectLatest { event ->
@@ -139,16 +153,38 @@ fun ListDetailScreen(
             }
             uiState.items.isEmpty() -> DetailEmptyState(Modifier.fillMaxSize().padding(innerPadding))
             else -> LazyColumn(
+                state = lazyListState,
                 modifier = Modifier.fillMaxSize().padding(innerPadding),
                 contentPadding = PaddingValues(vertical = 4.dp),
             ) {
-                items(uiState.items, key = { it.itemId.toString() }) { item ->
-                    ListItemRow(
-                        item = item,
-                        onToggle = { viewModel.setChecked(item.itemId, !item.checked) },
-                        onEdit = { editTarget = item },
-                        onDelete = { viewModel.deleteItem(item.itemId) },
-                    )
+                items(localItems, key = { it.itemId.toString() }) { item ->
+                    ReorderableItem(reorderableState, key = item.itemId.toString()) { _ ->
+                        ListItemRow(
+                            item = item,
+                            dragHandle = {
+                                Icon(
+                                    imageVector = Icons.Filled.DragHandle,
+                                    contentDescription = stringResource(MR.string.list_item_reorder_desc),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.draggableHandle(
+                                        onDragStopped = {
+                                            val idx = localItems.indexOfFirst { it.itemId == item.itemId }
+                                            if (idx >= 0) {
+                                                viewModel.reorder(
+                                                    itemId = item.itemId,
+                                                    aboveItemId = localItems.getOrNull(idx - 1)?.itemId,
+                                                    belowItemId = localItems.getOrNull(idx + 1)?.itemId,
+                                                )
+                                            }
+                                        },
+                                    ),
+                                )
+                            },
+                            onToggle = { viewModel.setChecked(item.itemId, !item.checked) },
+                            onEdit = { editTarget = item },
+                            onDelete = { viewModel.deleteItem(item.itemId) },
+                        )
+                    }
                 }
             }
         }
@@ -190,6 +226,7 @@ fun ListDetailScreen(
 @Composable
 private fun ListItemRow(
     item: ListDetailItem,
+    dragHandle: @Composable () -> Unit,
     onToggle: () -> Unit,
     onEdit: () -> Unit,
     onDelete: () -> Unit,
@@ -199,6 +236,7 @@ private fun ListItemRow(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 2.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        dragHandle()
         Checkbox(
             checked = item.checked,
             onCheckedChange = { onToggle() },

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListDetailScreen.kt
@@ -1,0 +1,302 @@
+package id.homebase.core.ui.screens.lists
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.automirrored.outlined.ListAlt
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.homebase.chat.widget.ChatMarkdown
+import id.homebase.resources.MR
+import id.homebase.resources.cancel
+import id.homebase.resources.delete
+import id.homebase.resources.edit
+import id.homebase.resources.list_action_delete_list
+import id.homebase.resources.list_action_rename
+import id.homebase.resources.list_delete_body
+import id.homebase.resources.list_delete_title
+import id.homebase.resources.list_detail_add_action
+import id.homebase.resources.list_detail_add_hint
+import id.homebase.resources.list_detail_empty_body
+import id.homebase.resources.list_detail_empty_title
+import id.homebase.resources.list_overview_more
+import id.homebase.resources.list_item_more
+import id.homebase.resources.menu_back
+import id.homebase.resources.save
+import kotlinx.coroutines.flow.collectLatest
+import org.jetbrains.compose.resources.stringResource
+import kotlin.uuid.Uuid
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ListDetailScreen(
+    viewModel: ListDetailViewModel,
+    onNavigateBack: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var listMenuOpen by remember { mutableStateOf(false) }
+    var renameDialog by remember { mutableStateOf(false) }
+    var deleteListDialog by remember { mutableStateOf(false) }
+    var draft by remember { mutableStateOf("") }
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collectLatest { event ->
+            when (event) {
+                is ListDetailEvent.ListDeleted -> onNavigateBack()
+            }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(uiState.title) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(MR.string.menu_back))
+                    }
+                },
+                actions = {
+                    Box {
+                        IconButton(onClick = { listMenuOpen = true }) {
+                            Icon(Icons.Filled.MoreVert, contentDescription = stringResource(MR.string.list_overview_more))
+                        }
+                        DropdownMenu(expanded = listMenuOpen, onDismissRequest = { listMenuOpen = false }) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(MR.string.list_action_rename)) },
+                                onClick = { listMenuOpen = false; renameDialog = true },
+                            )
+                            DropdownMenuItem(
+                                text = { Text(stringResource(MR.string.list_action_delete_list)) },
+                                onClick = { listMenuOpen = false; deleteListDialog = true },
+                            )
+                        }
+                    }
+                },
+            )
+        },
+        bottomBar = {
+            AddItemBar(
+                draft = draft,
+                onDraftChange = { draft = it },
+                onSend = {
+                    viewModel.addItem(draft)
+                    draft = ""
+                },
+            )
+        },
+    ) { innerPadding ->
+        when {
+            uiState.isLoading -> Box(Modifier.fillMaxSize().padding(innerPadding), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+            uiState.items.isEmpty() -> DetailEmptyState(Modifier.fillMaxSize().padding(innerPadding))
+            else -> LazyColumn(
+                modifier = Modifier.fillMaxSize().padding(innerPadding),
+                contentPadding = PaddingValues(vertical = 4.dp),
+            ) {
+                items(uiState.items, key = { it.itemId.toString() }) { item ->
+                    ListItemRow(
+                        item = item,
+                        onToggle = { viewModel.setChecked(item.itemId, !item.checked) },
+                        onEdit = { /* Task 6 */ },
+                        onDelete = { viewModel.deleteItem(item.itemId) },
+                    )
+                }
+            }
+        }
+    }
+
+    if (renameDialog) {
+        ListDetailTitleDialog(
+            initialValue = uiState.title,
+            onConfirm = { viewModel.renameList(it); renameDialog = false },
+            onDismiss = { renameDialog = false },
+        )
+    }
+    if (deleteListDialog) {
+        AlertDialog(
+            onDismissRequest = { deleteListDialog = false },
+            title = { Text(stringResource(MR.string.list_delete_title)) },
+            text = { Text(stringResource(MR.string.list_delete_body)) },
+            confirmButton = {
+                TextButton(onClick = { viewModel.deleteList(); deleteListDialog = false }) {
+                    Text(stringResource(MR.string.delete))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { deleteListDialog = false }) { Text(stringResource(MR.string.cancel)) }
+            },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ListItemRow(
+    item: ListDetailItem,
+    onToggle: () -> Unit,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    var menuOpen by remember { mutableStateOf(false) }
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Checkbox(
+            checked = item.checked,
+            onCheckedChange = { onToggle() },
+        )
+        Box(modifier = Modifier.weight(1f).padding(horizontal = 4.dp)) {
+            ChatMarkdown(
+                content = item.body,
+                color = if (item.checked) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.onSurface,
+                style = MaterialTheme.typography.bodyLarge.copy(
+                    textDecoration = if (item.checked) TextDecoration.LineThrough else null,
+                ),
+            )
+        }
+        Box {
+            IconButton(onClick = { menuOpen = true }) {
+                Icon(Icons.Filled.MoreVert, contentDescription = stringResource(MR.string.list_item_more))
+            }
+            DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(MR.string.edit)) },
+                    onClick = { menuOpen = false; onEdit() },
+                )
+                DropdownMenuItem(
+                    text = { Text(stringResource(MR.string.delete)) },
+                    onClick = { menuOpen = false; onDelete() },
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AddItemBar(
+    draft: String,
+    onDraftChange: (String) -> Unit,
+    onSend: () -> Unit,
+) {
+    val canSend = draft.isNotBlank()
+    Surface(tonalElevation = 2.dp) {
+        Column {
+            HorizontalDivider()
+            Row(
+                modifier = Modifier.fillMaxWidth().imePadding().navigationBarsPadding().padding(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedTextField(
+                    value = draft,
+                    onValueChange = onDraftChange,
+                    placeholder = { Text(stringResource(MR.string.list_detail_add_hint)) },
+                    modifier = Modifier.weight(1f),
+                )
+                IconButton(onClick = onSend, enabled = canSend) {
+                    Icon(Icons.AutoMirrored.Filled.Send, contentDescription = stringResource(MR.string.list_detail_add_action))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ListDetailTitleDialog(
+    initialValue: String,
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var text by remember { mutableStateOf(initialValue) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(MR.string.list_action_rename)) },
+        text = {
+            OutlinedTextField(
+                value = text,
+                onValueChange = { text = it },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(text) }, enabled = text.isNotBlank()) {
+                Text(stringResource(MR.string.save))
+            }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(MR.string.cancel)) } },
+    )
+}
+
+@Composable
+private fun DetailEmptyState(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.padding(horizontal = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Outlined.ListAlt,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(72.dp),
+        )
+        Text(
+            text = stringResource(MR.string.list_detail_empty_title),
+            style = MaterialTheme.typography.titleMedium,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(top = 16.dp),
+        )
+        Text(
+            text = stringResource(MR.string.list_detail_empty_body),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(top = 8.dp),
+        )
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListDetailUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListDetailUiState.kt
@@ -1,0 +1,22 @@
+package id.homebase.core.ui.screens.lists
+
+import kotlin.uuid.Uuid
+
+data class ListDetailItem(
+    val itemId: Uuid,
+    val body: String,
+    val checked: Boolean,
+    val sortKey: String,
+)
+
+data class ListDetailUiState(
+    val isLoading: Boolean = true,
+    val exists: Boolean = false,
+    val title: String = "",
+    val items: List<ListDetailItem> = emptyList(),
+)
+
+sealed interface ListDetailEvent {
+    /** The list was deleted (here or by a collaborator) — the screen should pop. */
+    data object ListDeleted : ListDetailEvent
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListDetailUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListDetailUiState.kt
@@ -15,8 +15,3 @@ data class ListDetailUiState(
     val title: String = "",
     val items: List<ListDetailItem> = emptyList(),
 )
-
-sealed interface ListDetailEvent {
-    /** The list was deleted (here or by a collaborator) — the screen should pop. */
-    data object ListDeleted : ListDetailEvent
-}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListDetailViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListDetailViewModel.kt
@@ -1,0 +1,100 @@
+package id.homebase.core.ui.screens.lists
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import id.homebase.core.lists.model.ListSortKeys
+import id.homebase.core.lists.services.ListItemSenderService
+import id.homebase.core.lists.services.ListService
+import id.homebase.core.lists.services.ListStream
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlin.uuid.Uuid
+
+/** Fractional key for an item dropped between [aboveSortKey] and [belowSortKey] (either may be null at an edge). */
+internal fun computeReorderKey(aboveSortKey: String?, belowSortKey: String?): String =
+    ListSortKeys.between(aboveSortKey, belowSortKey)
+
+class ListDetailViewModel(
+    private val listId: Uuid,
+    private val listStream: ListStream,
+    private val itemSender: ListItemSenderService,
+    private val listService: ListService,
+) : ViewModel() {
+
+    val uiState: StateFlow<ListDetailUiState> =
+        combine(listStream.lists, listStream.itemsByList) { data, itemsByList ->
+            val record = data.lists.find { it.listId == listId }
+            ListDetailUiState(
+                isLoading = !data.dataReady,
+                exists = record != null,
+                title = record?.definition?.title ?: "",
+                items = itemsByList[listId].orEmpty().map {
+                    ListDetailItem(
+                        itemId = it.itemId,
+                        body = it.item.body,
+                        checked = it.item.checked,
+                        sortKey = it.item.sortKey,
+                    )
+                },
+            )
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = ListDetailUiState(isLoading = true),
+        )
+
+    private val _events = MutableSharedFlow<ListDetailEvent>(extraBufferCapacity = 4)
+    val events: SharedFlow<ListDetailEvent> = _events.asSharedFlow()
+
+    fun addItem(body: String) {
+        val trimmed = body.trim()
+        if (trimmed.isEmpty()) return
+        viewModelScope.launch { itemSender.addItem(listId, trimmed) }
+    }
+
+    fun setChecked(itemId: Uuid, checked: Boolean) {
+        viewModelScope.launch { itemSender.setChecked(listId, itemId, checked) }
+    }
+
+    fun editItem(itemId: Uuid, newBody: String) {
+        val trimmed = newBody.trim()
+        if (trimmed.isEmpty()) return
+        viewModelScope.launch { itemSender.editItem(listId, itemId, trimmed) }
+    }
+
+    fun deleteItem(itemId: Uuid) {
+        viewModelScope.launch { itemSender.deleteItem(listId, itemId) }
+    }
+
+    /**
+     * Persist a drag-drop. [aboveItemId]/[belowItemId] are the items now directly above/below the
+     * moved item in the final visual order (null at an edge). Resolves their sortKeys against the
+     * latest state and issues ONE reorder write.
+     */
+    fun reorder(itemId: Uuid, aboveItemId: Uuid?, belowItemId: Uuid?) {
+        val items = uiState.value.items
+        val aboveKey = aboveItemId?.let { id -> items.find { it.itemId == id }?.sortKey }
+        val belowKey = belowItemId?.let { id -> items.find { it.itemId == id }?.sortKey }
+        val newKey = computeReorderKey(aboveKey, belowKey)
+        viewModelScope.launch { itemSender.reorderItem(listId, itemId, newKey) }
+    }
+
+    fun renameList(newTitle: String) {
+        val trimmed = newTitle.trim()
+        if (trimmed.isEmpty()) return
+        viewModelScope.launch { listService.renameList(listId, newTitle = trimmed) }
+    }
+
+    fun deleteList() {
+        viewModelScope.launch {
+            listService.deleteList(listId)
+            _events.tryEmit(ListDetailEvent.ListDeleted)
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListDetailViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListDetailViewModel.kt
@@ -6,14 +6,13 @@ import id.homebase.core.lists.model.ListSortKeys
 import id.homebase.core.lists.services.ListItemSenderService
 import id.homebase.core.lists.services.ListService
 import id.homebase.core.lists.services.ListStream
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.uuid.Uuid
 
 /** Fractional key for an item dropped between [aboveSortKey] and [belowSortKey] (either may be null at an edge). */
@@ -49,8 +48,27 @@ class ListDetailViewModel(
             initialValue = ListDetailUiState(isLoading = true),
         )
 
-    private val _events = MutableSharedFlow<ListDetailEvent>(extraBufferCapacity = 4)
-    val events: SharedFlow<ListDetailEvent> = _events.asSharedFlow()
+    // A reorder write merges back asynchronously (optimistic write -> BatchReceived -> re-sort), so
+    // two quick drags would otherwise both resolve neighbour keys from the SAME stale stream and
+    // could collide on an identical between-key. Serialize reorders and remember each issued key
+    // until the stream confirms it, so a follow-up drag resolves neighbours against the in-flight
+    // key. Mirrors the addMutex + lastIssuedSortKey hardening in ListItemSenderService.addItem.
+    private val reorderMutex = Mutex()
+    private val pendingSortKeys = mutableMapOf<Uuid, String>()
+
+    init {
+        // Drop a pending key once the stream confirms it (the item's sortKey == the key we issued).
+        // Collect the raw stream (not uiState) so this internal subscriber doesn't change uiState's
+        // WhileSubscribed sharing.
+        viewModelScope.launch {
+            listStream.itemsByList.collect { byList ->
+                if (pendingSortKeys.isEmpty()) return@collect
+                byList[listId].orEmpty().forEach { rec ->
+                    if (pendingSortKeys[rec.itemId] == rec.item.sortKey) pendingSortKeys.remove(rec.itemId)
+                }
+            }
+        }
+    }
 
     fun addItem(body: String) {
         val trimmed = body.trim()
@@ -74,15 +92,31 @@ class ListDetailViewModel(
 
     /**
      * Persist a drag-drop. [aboveItemId]/[belowItemId] are the items now directly above/below the
-     * moved item in the final visual order (null at an edge). Resolves their sortKeys against the
-     * latest state and issues ONE reorder write.
+     * moved item in the final visual order (null at an edge). Resolves their sortKeys (preferring an
+     * in-flight pending key over the possibly-stale stream), skips a no-op move, and issues ONE
+     * reorder write under [reorderMutex] so rapid successive drags can't collide on a shared key.
      */
     fun reorder(itemId: Uuid, aboveItemId: Uuid?, belowItemId: Uuid?) {
-        val items = uiState.value.items
-        val aboveKey = aboveItemId?.let { id -> items.find { it.itemId == id }?.sortKey }
-        val belowKey = belowItemId?.let { id -> items.find { it.itemId == id }?.sortKey }
-        val newKey = computeReorderKey(aboveKey, belowKey)
-        viewModelScope.launch { itemSender.reorderItem(listId, itemId, newKey) }
+        viewModelScope.launch {
+            reorderMutex.withLock {
+                val items = uiState.value.items
+                fun keyOf(id: Uuid): String? = pendingSortKeys[id] ?: items.find { it.itemId == id }?.sortKey
+                val aboveKey = aboveItemId?.let { keyOf(it) }
+                val belowKey = belowItemId?.let { keyOf(it) }
+                val currentKey = keyOf(itemId)
+                // No-op: the item already sits strictly between these neighbours (e.g. dropped in
+                // place, or the only item in the list) — don't churn an optimistic write + transit.
+                if (currentKey != null &&
+                    (aboveKey == null || currentKey > aboveKey) &&
+                    (belowKey == null || currentKey < belowKey)
+                ) {
+                    return@withLock
+                }
+                val newKey = computeReorderKey(aboveKey, belowKey)
+                pendingSortKeys[itemId] = newKey
+                itemSender.reorderItem(listId, itemId, newKey)
+            }
+        }
     }
 
     fun renameList(newTitle: String) {
@@ -92,9 +126,6 @@ class ListDetailViewModel(
     }
 
     fun deleteList() {
-        viewModelScope.launch {
-            listService.deleteList(listId)
-            _events.tryEmit(ListDetailEvent.ListDeleted)
-        }
+        viewModelScope.launch { listService.deleteList(listId) }
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListOverviewUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListOverviewUiState.kt
@@ -1,0 +1,21 @@
+package id.homebase.core.ui.screens.lists
+
+import kotlin.uuid.Uuid
+
+/** One row in the lists overview. [checkedCount]/[totalCount] drive the "3 / 7" progress label. */
+data class ListOverviewRow(
+    val listId: Uuid,
+    val title: String,
+    val totalCount: Int,
+    val checkedCount: Int,
+)
+
+data class ListOverviewUiState(
+    val isLoading: Boolean = true,
+    val rows: List<ListOverviewRow> = emptyList(),
+)
+
+/** One-time navigation effects (e.g. open the list the user just created). */
+sealed interface ListOverviewEvent {
+    data class OpenList(val listId: Uuid) : ListOverviewEvent
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListOverviewViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListOverviewViewModel.kt
@@ -1,0 +1,71 @@
+package id.homebase.core.ui.screens.lists
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import id.homebase.core.lists.services.ListItemRecord
+import id.homebase.core.lists.services.ListRecord
+import id.homebase.core.lists.services.ListService
+import id.homebase.core.lists.services.ListStream
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlin.uuid.Uuid
+
+/** Pure mapping: list records + their items -> overview rows. Extracted for unit testing. */
+internal fun mapOverviewRows(
+    lists: List<ListRecord>,
+    itemsByList: Map<Uuid, List<ListItemRecord>>,
+): List<ListOverviewRow> = lists.map { rec ->
+    val items = itemsByList[rec.listId].orEmpty()
+    ListOverviewRow(
+        listId = rec.listId,
+        title = rec.definition.title,
+        totalCount = items.size,
+        checkedCount = items.count { it.item.checked },
+    )
+}
+
+class ListOverviewViewModel(
+    private val listStream: ListStream,
+    private val listService: ListService,
+) : ViewModel() {
+
+    val uiState: StateFlow<ListOverviewUiState> =
+        combine(listStream.lists, listStream.itemsByList) { data, itemsByList ->
+            ListOverviewUiState(
+                isLoading = !data.dataReady,
+                rows = mapOverviewRows(data.lists, itemsByList),
+            )
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = ListOverviewUiState(isLoading = true),
+        )
+
+    private val _events = MutableSharedFlow<ListOverviewEvent>(extraBufferCapacity = 4)
+    val events: SharedFlow<ListOverviewEvent> = _events.asSharedFlow()
+
+    fun createList(title: String) {
+        val trimmed = title.trim()
+        if (trimmed.isEmpty()) return
+        viewModelScope.launch {
+            val listId = listService.createList(trimmed)
+            _events.tryEmit(ListOverviewEvent.OpenList(listId))
+        }
+    }
+
+    fun renameList(listId: Uuid, newTitle: String) {
+        val trimmed = newTitle.trim()
+        if (trimmed.isEmpty()) return
+        viewModelScope.launch { listService.renameList(listId, newTitle = trimmed) }
+    }
+
+    fun deleteList(listId: Uuid) {
+        viewModelScope.launch { listService.deleteList(listId) }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/lists/ListsScreen.kt
@@ -1,64 +1,245 @@
 package id.homebase.core.ui.screens.lists
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ListAlt
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.resources.MR
+import id.homebase.resources.cancel
+import id.homebase.resources.create
+import id.homebase.resources.delete
+import id.homebase.resources.list_action_delete_list
+import id.homebase.resources.list_action_rename
+import id.homebase.resources.list_delete_body
+import id.homebase.resources.list_delete_title
+import id.homebase.resources.list_overview_create_title
+import id.homebase.resources.list_overview_more
+import id.homebase.resources.list_overview_name_hint
+import id.homebase.resources.list_overview_new
+import id.homebase.resources.list_overview_progress
+import id.homebase.resources.list_overview_rename_title
 import id.homebase.resources.lists_empty_body
 import id.homebase.resources.lists_empty_title
 import id.homebase.resources.lists_label
+import id.homebase.resources.save
+import kotlinx.coroutines.flow.collectLatest
 import org.jetbrains.compose.resources.stringResource
+import kotlin.uuid.Uuid
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ListsScreen() {
+fun ListsScreen(
+    viewModel: ListOverviewViewModel,
+    onOpenList: (Uuid) -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    var showCreateDialog by remember { mutableStateOf(false) }
+    var renameTarget by remember { mutableStateOf<ListOverviewRow?>(null) }
+    var deleteTarget by remember { mutableStateOf<ListOverviewRow?>(null) }
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collectLatest { event ->
+            when (event) {
+                is ListOverviewEvent.OpenList -> onOpenList(event.listId)
+            }
+        }
+    }
+
     Scaffold(
-        topBar = {
-            TopAppBar(title = { Text(stringResource(MR.string.lists_label)) })
+        topBar = { TopAppBar(title = { Text(stringResource(MR.string.lists_label)) }) },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showCreateDialog = true }) {
+                Icon(Icons.Filled.Add, contentDescription = stringResource(MR.string.list_overview_new))
+            }
         },
     ) { innerPadding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-                .padding(horizontal = 32.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
-        ) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Outlined.ListAlt,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(72.dp),
-            )
-            Text(
-                text = stringResource(MR.string.lists_empty_title),
-                style = MaterialTheme.typography.titleMedium,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.padding(top = 16.dp),
-            )
-            Text(
-                text = stringResource(MR.string.lists_empty_body),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.padding(top = 8.dp),
-            )
+        when {
+            uiState.isLoading -> Box(Modifier.fillMaxSize().padding(innerPadding), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+            uiState.rows.isEmpty() -> ListsEmptyState(Modifier.fillMaxSize().padding(innerPadding))
+            else -> LazyColumn(
+                modifier = Modifier.fillMaxSize().padding(innerPadding),
+                contentPadding = PaddingValues(vertical = 8.dp),
+            ) {
+                items(uiState.rows, key = { it.listId.toString() }) { row ->
+                    ListOverviewRowItem(
+                        row = row,
+                        onClick = { onOpenList(row.listId) },
+                        onRename = { renameTarget = row },
+                        onDelete = { deleteTarget = row },
+                    )
+                }
+            }
         }
+    }
+
+    if (showCreateDialog) {
+        ListTitleDialog(
+            titleText = stringResource(MR.string.list_overview_create_title),
+            confirmText = stringResource(MR.string.create),
+            initialValue = "",
+            onConfirm = { viewModel.createList(it); showCreateDialog = false },
+            onDismiss = { showCreateDialog = false },
+        )
+    }
+    renameTarget?.let { target ->
+        ListTitleDialog(
+            titleText = stringResource(MR.string.list_overview_rename_title),
+            confirmText = stringResource(MR.string.save),
+            initialValue = target.title,
+            onConfirm = { viewModel.renameList(target.listId, it); renameTarget = null },
+            onDismiss = { renameTarget = null },
+        )
+    }
+    deleteTarget?.let { target ->
+        AlertDialog(
+            onDismissRequest = { deleteTarget = null },
+            title = { Text(stringResource(MR.string.list_delete_title)) },
+            text = { Text(stringResource(MR.string.list_delete_body)) },
+            confirmButton = {
+                TextButton(onClick = { viewModel.deleteList(target.listId); deleteTarget = null }) {
+                    Text(stringResource(MR.string.delete))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { deleteTarget = null }) { Text(stringResource(MR.string.cancel)) }
+            },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ListOverviewRowItem(
+    row: ListOverviewRow,
+    onClick: () -> Unit,
+    onRename: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    var menuOpen by remember { mutableStateOf(false) }
+    ListItem(
+        headlineContent = { Text(row.title) },
+        supportingContent = {
+            Text(stringResource(MR.string.list_overview_progress, row.checkedCount, row.totalCount))
+        },
+        leadingContent = {
+            Icon(Icons.AutoMirrored.Outlined.ListAlt, contentDescription = null)
+        },
+        trailingContent = {
+            Box {
+                IconButton(onClick = { menuOpen = true }) {
+                    Icon(Icons.Filled.MoreVert, contentDescription = stringResource(MR.string.list_overview_more))
+                }
+                DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(MR.string.list_action_rename)) },
+                        onClick = { menuOpen = false; onRename() },
+                    )
+                    DropdownMenuItem(
+                        text = { Text(stringResource(MR.string.list_action_delete_list)) },
+                        onClick = { menuOpen = false; onDelete() },
+                    )
+                }
+            }
+        },
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+    )
+}
+
+@Composable
+private fun ListTitleDialog(
+    titleText: String,
+    confirmText: String,
+    initialValue: String,
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var text by remember { mutableStateOf(initialValue) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(titleText) },
+        text = {
+            OutlinedTextField(
+                value = text,
+                onValueChange = { text = it },
+                singleLine = true,
+                label = { Text(stringResource(MR.string.list_overview_name_hint)) },
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(text) }, enabled = text.isNotBlank()) { Text(confirmText) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(MR.string.cancel)) }
+        },
+    )
+}
+
+@Composable
+private fun ListsEmptyState(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.padding(horizontal = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Outlined.ListAlt,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(72.dp),
+        )
+        Text(
+            text = stringResource(MR.string.lists_empty_title),
+            style = MaterialTheme.typography.titleMedium,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(top = 16.dp),
+        )
+        Text(
+            text = stringResource(MR.string.lists_empty_body),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(top = 8.dp),
+        )
     }
 }

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/lists/ListDetailReorderTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/lists/ListDetailReorderTest.kt
@@ -1,0 +1,31 @@
+package id.homebase.core.ui.screens.lists
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+class ListDetailReorderTest {
+
+    private fun item(sortKey: String) = ListDetailItem(Uuid.random(), "x", false, sortKey)
+
+    @Test
+    fun dropping_between_two_items_yields_a_key_strictly_between_them() {
+        val items = listOf(item("a"), item("g"), item("z"))
+        val moved = items[2] // "z"
+        // Drop it between items[0] ("a") and items[1] ("g").
+        val newKey = computeReorderKey(aboveSortKey = items[0].sortKey, belowSortKey = items[1].sortKey)
+        assertTrue(newKey > "a" && newKey < "g", "expected a < $newKey < g")
+    }
+
+    @Test
+    fun dropping_at_the_top_yields_a_key_below_the_first() {
+        val newKey = computeReorderKey(aboveSortKey = null, belowSortKey = "g")
+        assertTrue(newKey < "g", "expected $newKey < g")
+    }
+
+    @Test
+    fun dropping_at_the_bottom_yields_a_key_above_the_last() {
+        val newKey = computeReorderKey(aboveSortKey = "g", belowSortKey = null)
+        assertTrue(newKey > "g", "expected $newKey > g")
+    }
+}

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/lists/ListOverviewViewModelTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/lists/ListOverviewViewModelTest.kt
@@ -1,0 +1,38 @@
+package id.homebase.core.ui.screens.lists
+
+import id.homebase.core.lists.model.ListDefinition
+import id.homebase.core.lists.model.ListItem
+import id.homebase.core.lists.services.ListItemRecord
+import id.homebase.core.lists.services.ListRecord
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+
+class ListOverviewViewModelTest {
+
+    private fun rec(title: String): ListRecord {
+        val id = Uuid.random()
+        return ListRecord(id, Uuid.random(), null, null, ListDefinition(title = title))
+    }
+
+    private fun item(listId: Uuid, checked: Boolean): ListItemRecord =
+        ListItemRecord(Uuid.random(), listId, Uuid.random(), null, null, ListItem(body = "x", checked = checked, sortKey = "n"))
+
+    @Test
+    fun rows_carry_total_and_checked_counts() {
+        val a = rec("Groceries")
+        val b = rec("Chores")
+        val itemsByList = mapOf(
+            a.listId to listOf(item(a.listId, true), item(a.listId, false), item(a.listId, true)),
+            b.listId to emptyList(),
+        )
+        val rows = mapOverviewRows(listOf(a, b), itemsByList)
+        assertEquals(2, rows.size)
+        val groceries = rows.first { it.title == "Groceries" }
+        assertEquals(3, groceries.totalCount)
+        assertEquals(2, groceries.checkedCount)
+        val chores = rows.first { it.title == "Chores" }
+        assertEquals(0, chores.totalCount)
+        assertEquals(0, chores.checkedCount)
+    }
+}


### PR DESCRIPTION
## Shared Lists — Phase 3: Lists + Detail UI

Third PR in the Shared Lists feature, targeting the `feat-shared-lists` integration branch (merges to `main` as a whole after human testing). Builds the real user-facing UI on top of the Phase-2 data layer.

### What this adds
- **Overview (`ListsScreen`)** — replaces the Phase-1 placeholder: list of lists with a `3 / 7` checked/total progress label, FAB to create, per-row overflow to rename/delete, empty state. Driven by `combine(ListStream.lists, ListStream.itemsByList) → stateIn`.
- **Detail (`ListDetailScreen`)** — markdown items rendered read-only with the chat `ChatMarkdown`; checkbox toggle (checked = struck-through + dimmed); quick-add text field; per-item edit via a `RichTextEditor` bottom sheet (markdown round-trip through `applyMarkDownContent` / `.toMarkdown()`); per-item + per-list delete; list rename. `Route.ListDetail(listId)` carries the id as a String, parsed to `Uuid` at the NavHost edge (cloning `Route.LocationFindDevice`).
- **Drag-to-reorder** via `sh.calvin.reorderable` 3.1.0 (added to homebase-core commonMain — Desktop-safe). A drop resolves to a single fractional `ListSortKeys.between(...)` write; all sort-key math lives in the ViewModel.

### How it was built
Subagent-driven from a written plan (`docs/superpowers/plans/2026-06-15-shared-lists-phase3-ui.md`), one task per commit, each compiled on JVM + Android + iOS-sim and Konsist-checked before commit. Two new ViewModels with unit tests (overview row mapping; reorder neighbour-key math). No new user-facing string is hardcoded (Konsist enforced).

### Code review
High-effort review (3 finder angles: correctness/integration, Compose-Flow gotchas, reorder concurrency). The core reorder neighbour-key math was **confirmed correct** (a move only changes the moved item's key, so resolving neighbours from the stream is sound). Findings fixed in `aacb2169`:
1. **First-frame blank list** — the empty/list branch read `uiState.items` while the body rendered `localItems` (seeded post-composition). Now both read one `displayItems` source (stream order when idle, local order only mid-drag), which also bounds mid-drag staleness — the list re-syncs to the stream the instant a drag ends.
2. **Rapid-drag key collision** — two drags before the first write merged could collide on an identical between-key (the `reorderItem` analog of the `addItem` race already hardened in Phase 2). Now serialized with a `Mutex` + an in-flight pending-sort-key overlay.
3. **No-op reorder write** — drop-in-place / single-item drags issued a needless write + transit fan-out. Now skipped when the item already sits strictly between its target neighbours.
4. **List-gone handling** — generalized to a `!isLoading && !exists` pop guard (covers local delete, collaborator delete in Phase 4, and an invalid deep-linked listId), replacing the local-only delete event.
5. **Edit-sheet seed** — keyed on `initialBody` instead of `Unit`.

### Verification
- All targets compile (JVM + Android + iOS-sim), Lists unit tests + Konsist green as one unit.
- ⚠️ **Not yet device-verified:** the drag-reorder gesture and the markdown edit sheet need a manual pass on a device/simulator. (The server transit / cross-identity leg is still blocked by the Phase-1 activation read-grant bug, so live multi-user sync is out of scope here.)

### Deferred to Phase 4 (need transit / real-time first)
- Full reconciliation of `localItems` vs the stream under genuine concurrent external add/delete during a drag (today's guard bounds it; a complete reconcile is Phase-4 work alongside cross-identity real-time and write-failure rollback).
- Membership add/remove + backfill-on-join; the connected-circle write grant; the Phase-1 activation read-grant fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)