### PR TITLE
Never crash on a transient network failure; record it as a Crashlytics non-fatal

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
@@ -23,8 +23,10 @@ import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.core.di.allModules
 import id.homebase.core.diagnostics.MainThreadWatchdog
 import id.homebase.core.location.tracking.LocationTrackingCoordinator
+import id.homebase.api.client.isTransientNetworkFailure
 import id.homebase.core.logging.CrashLogger
 import id.homebase.core.logging.LoggerConfig
+import id.homebase.core.logging.crashlyticsRecordException
 import id.homebase.core.logging.StartupLogger
 import id.homebase.core.util.PlatformInfo
 import chat_kmp.homebase_common.BuildConfig
@@ -217,6 +219,22 @@ class MainApplication : Application(), KoinComponent {
         val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
 
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            // A transient connectivity failure (timeout, dropped socket, DNS) that
+            // leaked from a network call on a scope without its own
+            // CoroutineExceptionHandler should NOT kill the app. Record it as a
+            // Crashlytics non-fatal — full stack, plus the coroutine-name/thread
+            // custom keys GlobalCoroutineExceptionHandler already stamped — so it
+            // stays debuggable, then return without invoking the default (killing)
+            // handler. Any non-network crash still terminates normally below.
+            if (throwable.isTransientNetworkFailure()) {
+                crashlyticsRecordException(throwable)
+                Logger.w(tag = "CrashHandler") {
+                    "Transient network failure leaked to '${thread.name}' (no local handler); " +
+                        "recorded as non-fatal, app not crashing: ${throwable.message}"
+                }
+                return@setDefaultUncaughtExceptionHandler
+            }
+
             try {
                 CrashLogger.logCrash(thread.name, throwable)
             } catch (e: Exception) {

--- a/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
+++ b/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
@@ -30,9 +30,11 @@ import id.homebase.core.App
 import id.homebase.core.auth.AuthConnectionCoordinator
 import id.homebase.core.di.allModules
 import id.homebase.core.diagnostics.MainThreadWatchdog
+import id.homebase.api.client.isTransientNetworkFailure
 import id.homebase.core.logging.CrashLogger
 import id.homebase.core.logging.LoggerConfig
 import id.homebase.core.logging.StartupLogger
+import id.homebase.core.logging.crashlyticsRecordException
 import id.homebase.core.settings.UserPreferences
 import id.homebase.core.settings.applyStoredLocale
 import id.homebase.core.ui.screens.appearance.getIconForTheme
@@ -270,6 +272,21 @@ private fun setupCrashHandler() {
     val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
 
     Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+        // A transient connectivity failure (timeout, dropped socket, DNS) that
+        // leaked from a network call on a scope without its own
+        // CoroutineExceptionHandler should not kill the app. Record it (no-op on
+        // Desktop, where no crash backend is wired) + log, then return without
+        // invoking the default (killing) handler. Non-network crashes still
+        // terminate normally below.
+        if (throwable.isTransientNetworkFailure()) {
+            crashlyticsRecordException(throwable)
+            Logger.w(tag = "CrashHandler") {
+                "Transient network failure leaked to '${thread.name}' (no local handler); " +
+                    "app not crashing: ${throwable.message}"
+            }
+            return@setDefaultUncaughtExceptionHandler
+        }
+
         try {
             CrashLogger.logCrash(thread.name, throwable)
         } catch (e: Exception) {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/NetworkException.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/NetworkException.kt
@@ -1,0 +1,42 @@
+package id.homebase.api.client
+
+import kotlinx.io.IOException
+
+/**
+ * Transport-level failure reaching the server — connect/socket/request timeout,
+ * connection refused, DNS failure, or a dropped socket mid-read. Distinct from
+ * [OdinApiException]'s HTTP-status subclasses ([NotFoundException], … ), which
+ * mean the server *did* respond. [status] is `0` to signal "no HTTP response".
+ *
+ * The raw Ktor/transport exception is preserved as [cause] so a crash report or
+ * log carries the real stack. Produced centrally by [OdinApiProviderBase.request]
+ * / [OdinApiProviderBase.requestBytes] so every REST call surfaces connectivity
+ * failures as one catchable, typed exception instead of a raw `IOException`.
+ */
+class NetworkException(
+    override val cause: Throwable,
+) : OdinApiException(
+    status = 0,
+    message = "Network failure: ${cause.message ?: cause::class.simpleName ?: "unknown"}",
+)
+
+/**
+ * True when [this] (or anything in its [Throwable.cause] chain) is a transient
+ * connectivity failure: a [NetworkException] from the API layer, or a raw
+ * [IOException] from a network path that bypasses it (e.g. the WebSocket).
+ *
+ * Used by the platform uncaught-exception handlers to keep a dropped connection
+ * from killing the process — a transient network error that leaks to a scope
+ * without its own `CoroutineExceptionHandler` is recorded as a non-fatal rather
+ * than crashing. Non-network failures return `false` and stay fatal. Walks the
+ * cause chain defensively (guards against a cyclic chain).
+ */
+fun Throwable.isTransientNetworkFailure(): Boolean {
+    val seen = HashSet<Throwable>()
+    var cur: Throwable? = this
+    while (cur != null && seen.add(cur)) {
+        if (cur is NetworkException || cur is IOException) return true
+        cur = cur.cause
+    }
+    return false
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/OdinApiProviderBase.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/OdinApiProviderBase.kt
@@ -28,6 +28,8 @@ import io.ktor.client.request.delete
 import io.ktor.client.request.parameter
 import io.ktor.utils.io.charsets.Charsets
 import io.ktor.utils.io.charsets.name
+import kotlinx.coroutines.CancellationException
+import kotlinx.io.IOException
 
 typealias UploadProgress = suspend (bytesSent: Long, totalBytes: Long?) -> Unit
 
@@ -80,12 +82,33 @@ abstract class OdinApiProviderBase(
     // Core request primitive
     // ------------------------------------------------------------
 
+    /**
+     * Run a network operation, mapping any transport failure (timeout,
+     * connection refused, DNS, dropped socket) to a typed [NetworkException].
+     * Cancellation is rethrown untouched so structured concurrency still works.
+     * Non-network failures (decrypt, parse) are NOT caught here — they fall
+     * outside [block] and propagate unchanged.
+     */
+    private suspend fun <T> networkCall(block: suspend () -> T): T =
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: IOException) {
+            throw NetworkException(e)
+        }
+
     protected suspend fun request(
         block: suspend () -> HttpResponse,
         secret: SecureByteArray?
     ): ApiResponse {
-        val response = block()
-        val rawBody = response.body<String>()
+        // The connect AND the body read are both network I/O — a socket can drop
+        // mid-read — so both run under networkCall, which maps transport failures
+        // to a typed NetworkException instead of leaking a raw IOException.
+        val (response, rawBody) = networkCall {
+            val r = block()
+            r to r.body<String>()
+        }
 
         // Decrypt when the server flags it (X-SSE) OR the body is unmistakably the shared-secret
         // envelope. The header is the fast path used on native; but browsers strip non-safelisted
@@ -128,8 +151,10 @@ abstract class OdinApiProviderBase(
         block: suspend () -> HttpResponse
     ): ByteApiResponse {
 
-        val response = block()
-        val bytes = response.readRawBytes()
+        val (response, bytes) = networkCall {
+            val r = block()
+            r to r.readRawBytes()
+        }
 
         val contentType =
             response.headers["decryptedcontenttype"]

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/NetworkExceptionTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/NetworkExceptionTest.kt
@@ -1,0 +1,63 @@
+package id.homebase.api.client
+
+import kotlinx.io.IOException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [NetworkException] and the [isTransientNetworkFailure] predicate the
+ * platform uncaught-exception handlers use to keep a dropped connection from
+ * killing the process. The predicate must be precise: transient transport
+ * failures classify true (recorded as non-fatals), every other failure classifies
+ * false (still fatal).
+ */
+class NetworkExceptionTest {
+
+    @Test
+    fun `NetworkException preserves cause and reports no-http status`() {
+        val cause = IOException("connect timeout")
+        val ex = NetworkException(cause)
+        assertSame(cause, ex.cause)
+        assertEquals(0, ex.status, "status 0 signals no HTTP response")
+    }
+
+    @Test
+    fun `NetworkException classifies as transient`() {
+        assertTrue(NetworkException(IOException("boom")).isTransientNetworkFailure())
+    }
+
+    @Test
+    fun `raw IOException classifies as transient`() {
+        // Covers network paths that bypass the API layer (e.g. the WebSocket),
+        // which throw a raw IOException rather than a wrapped NetworkException.
+        assertTrue(IOException("socket closed").isTransientNetworkFailure())
+    }
+
+    @Test
+    fun `NetworkException nested in a cause chain classifies as transient`() {
+        val wrapped = RuntimeException("thumb load failed", NetworkException(IOException("dns")))
+        assertTrue(wrapped.isTransientNetworkFailure())
+    }
+
+    @Test
+    fun `non-network failures classify as fatal`() {
+        assertFalse(IllegalStateException("bug").isTransientNetworkFailure())
+        assertFalse(NullPointerException().isTransientNetworkFailure())
+        // An HTTP-status API error means the server DID respond — not a transport failure.
+        assertFalse(NotFoundException().isTransientNetworkFailure())
+        assertFalse(UnauthorizedException().isTransientNetworkFailure())
+    }
+
+    @Test
+    fun `a cyclic cause chain does not loop forever`() {
+        val a = RuntimeException("a")
+        val b = RuntimeException("b", a)
+        a.initCause(b) // a -> b -> a cycle
+        // Must terminate (guarded by a visited set) and, with no network type
+        // present, classify as fatal.
+        assertFalse(a.isTransientNetworkFailure())
+    }
+}

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/upgrade/IdentityUpgradeProviderTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/upgrade/IdentityUpgradeProviderTest.kt
@@ -1,8 +1,10 @@
 package id.homebase.api.client.upgrade
 
+import id.homebase.api.client.NetworkException
 import id.homebase.api.client.UnauthorizedException
 import id.homebase.api.client.auth.ApiCredentials
 import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.isTransientNetworkFailure
 import id.homebase.api.common.OdinId
 import id.homebase.api.common.SecureByteArray
 import io.ktor.client.HttpClient
@@ -15,6 +17,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class IdentityUpgradeProviderTest {
 
@@ -106,10 +109,17 @@ class IdentityUpgradeProviderTest {
     }
 
     @Test
-    fun throwsOnNetworkError() = runTest {
+    fun throwsTypedNetworkExceptionOnTransportFailure() = runTest {
+        // A raw transport IOException from the engine must surface as the typed,
+        // catchable NetworkException (not a bare IOException), with the original
+        // exception preserved as the cause for diagnosis.
         val engine = MockEngine { throw java.io.IOException("timeout") }
-        assertFailsWith<java.io.IOException> {
+        val thrown = assertFailsWith<NetworkException> {
             createProvider(engine).checkUpgradeStatus()
         }
+        // Cause preserved (Ktor may rewrap the engine's IOException, so assert the
+        // type/chain rather than instance identity) so the real stack survives.
+        assertTrue(thrown.cause is java.io.IOException, "cause should be the transport IOException")
+        assertTrue(thrown.isTransientNetworkFailure())
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
@@ -561,8 +561,9 @@ fun MediaItem(
         }
 
         else -> {
-            // Unsupported media type
-            println("Unsupported media type: $contentType")
+            // Unsupported media type — log to the app log (Kermit) rather than
+            // stdout so it actually lands in homebase.log for diagnosis.
+            Logger.w(tag = "MediaItem") { "Unsupported media type: $contentType" }
             MediaPlaceholder(
                 emoji = "❓",
                 label = "Unknown",

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/logging/IOSCrashHandler.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/logging/IOSCrashHandler.kt
@@ -1,6 +1,7 @@
 package id.homebase.core.logging
 
 import co.touchlab.kermit.Logger
+import id.homebase.api.client.isTransientNetworkFailure
 import kotlin.experimental.ExperimentalNativeApi
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.staticCFunction
@@ -87,6 +88,25 @@ fun setupIOSCrashHandler() {
     // accessed-before-initialized ambiguity around setUnhandledExceptionHook's return.
     var previousHook: ((Throwable) -> Unit)? = null
     previousHook = setUnhandledExceptionHook { throwable ->
+        // Parity with the Android/Desktop uncaught handlers: a transient
+        // connectivity failure (timeout, dropped socket, DNS) that leaked from a
+        // network call on a scope without its own CoroutineExceptionHandler must
+        // NOT abort the app. Record it as a non-fatal (full stack + breadcrumb) so
+        // it stays debuggable, then return WITHOUT terminating. Any non-network
+        // throwable falls through and still crashes normally below.
+        if (throwable.isTransientNetworkFailure()) {
+            try {
+                crashlyticsRecordException(throwable)
+                crashlyticsLogFatalBreadcrumb(throwable)
+                Logger.w(tag = TAG) {
+                    "Transient network failure (no local handler); app not crashing: ${throwable.message}"
+                }
+            } catch (e: Throwable) {
+                println("IOSCrashHandler (network non-fatal) failed: ${e.message}")
+            }
+            return@setUnhandledExceptionHook
+        }
+
         try {
             // Record to Crashlytics — a Kotlin/Native exception aborts the process
             // without raising an NSException, so the SDK never sees it unless we


### PR DESCRIPTION
## Problem

A Ktor connect-timeout on a file-header fetch propagated to a coroutine on a **CEH-less scope** (`viewModelScope` → `Dispatchers.Main.immediate`) and **killed the process**. From an on-device `homebase.log`:

```
(CoroutineCrash) Uncaught coroutine exception (no local handler) coroutine='unnamed' thread='main' — process will terminate
vd1: Connect timeout has expired [url=…/files/by-uid/…/header, connect_timeout=30000 ms]
Caused by: java.net.SocketTimeoutException: failed to connect …
```

The crash class is systemic: there are **~206** `viewModelScope.launch` sites and only **2** `CoroutineExceptionHandler` scopes, no base ViewModel. The global ServiceLoader `GlobalCoroutineExceptionHandler` logs the leak but, by its own design, **cannot stop the kill** — only the thread's uncaught handler can. A dropped connection should never take down the app.

## Fix — two mount-agnostic layers

The specific Vault-mount launcher that triggered this is being reworked in #732; this PR fixes the **general** condition so *any* leaked transient network error is non-fatal, regardless of call site.

**1. Type it centrally.** `OdinApiProviderBase.request()`/`requestBytes()` now run the connect **and** the body read under a `networkCall` wrapper that maps transport failures (timeout, connection refused, DNS, dropped socket) to a typed, catchable **`NetworkException : OdinApiException`** (`status = 0`), preserving the original as `cause` and rethrowing `CancellationException` untouched. Non-network failures (decrypt/parse) live outside the wrapped block and propagate unchanged.

**2. Don't let it be fatal.** The **Android, Desktop, and iOS** uncaught-exception handlers now check `Throwable.isTransientNetworkFailure()` (walks the cause chain for `NetworkException` / raw `IOException`, cycle-guarded). If true → record a **Crashlytics non-fatal** (full stack + the coroutine-name/thread custom keys `GlobalCoroutineExceptionHandler` already stamps) and **return without invoking the killing default handler**. Every non-network crash still terminates normally.

This balances the three goals we set: minimal complexity (one typed exception + ~one classifier + a few lines per platform handler — no 206-site migration); easy to debug later (a *typed* failure recorded with full stack + the leaking scope's name); and it **registers with Crashlytics** as a non-fatal so nothing is lost.

Also: `MediaItem`'s unsupported-media-type `println` → `Logger.w` so it lands in `homebase.log` instead of only logcat.

## Cross-platform parity
- **Android** (`MainApplication`) and **Desktop** (`Main`) — JVM `Thread.setDefaultUncaughtExceptionHandler`; verified compiling + unit-tested locally.
- **iOS** (`IOSCrashHandler`, Kotlin/Native `setUnhandledExceptionHook`) — same guard for parity; compiled by CI (needs a macOS host).
- **Web** — N/A: no process to kill and no crash backend wired.

## Tests
- `IdentityUpgradeProviderTest` now asserts a transport `IOException` surfaces as `NetworkException` with the cause preserved (was: asserted a raw `IOException` — that documented the old, crashing behavior).
- New `NetworkExceptionTest` covers the classifier: `NetworkException`, a nested cause, and a raw `IOException` → transient (non-fatal); status errors (`NotFoundException`/`Unauthorized`) and plain bugs → fatal; a cyclic cause chain terminates.
- `homebase-api:jvmTest` + `homebase-chat:jvmTest` green locally; Android/Desktop/iOS compilation across all targets left to CI.

## Verification note (honest gap)
JVM uncaught-handler semantics (return-without-delegate ⇒ process continues) are well-defined, so Android/Desktop are solid. The iOS `setUnhandledExceptionHook` *return* path should be confirmed on a simulator to be sure it likewise continues rather than aborting — flagging for on-device verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)