### PR TITLE
Global crash handler with native recovery screens (Android/iOS/Desktop)

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -149,6 +149,7 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.jetbrains.compose.material3)
     implementation(libs.jetbrains.compose.material.icons.extended)
+    implementation(libs.android.material)
 
     implementation(libs.koin.core)
     implementation(libs.koin.android)

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -159,6 +159,14 @@
             </intent-filter>
         </receiver>
 
+        <activity
+            android:name=".crash.CrashActivity"
+            android:process=":crash"
+            android:exported="false"
+            android:excludeFromRecents="true"
+            android:launchMode="singleTask"
+            android:theme="@style/Theme.Homebase.Crash" />
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainApplication.kt
@@ -23,11 +23,9 @@ import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.core.di.allModules
 import id.homebase.core.diagnostics.MainThreadWatchdog
 import id.homebase.core.location.tracking.LocationTrackingCoordinator
-import id.homebase.api.client.isTransientNetworkFailure
-import id.homebase.core.logging.CrashLogger
 import id.homebase.core.logging.LoggerConfig
-import id.homebase.core.logging.crashlyticsRecordException
 import id.homebase.core.logging.StartupLogger
+import id.homebase.feed.crash.GlobalCrashHandler
 import id.homebase.core.util.PlatformInfo
 import chat_kmp.homebase_common.BuildConfig
 import id.homebase.core.notifications.NotificationService
@@ -64,6 +62,11 @@ class MainApplication : Application(), KoinComponent {
         // way. Activity-scoped access still goes through ActivityProvider.initialize.
         ActivityProvider.initializeApplicationContext(this)
 
+        // Install the global crash handler as early as possible — before Koin/DB —
+        // so even an init-time crash gets a written report + the native recovery
+        // screen. It needs only Context + PackageManager + static BuildConfig.
+        GlobalCrashHandler.install(this)
+
         // Initialize storage (must be done before App() which may access storage)
         SecureStorage.initialize(this)
         SharedPreferences.initialize(this) // TODO: Maybe we should use injectable UserPreferences
@@ -99,9 +102,6 @@ class MainApplication : Application(), KoinComponent {
 
         val platformInfo = get<PlatformInfo>()
         StartupLogger.logAppStartupInfo(platformInfo.versionName, platformInfo.versionCode, BuildConfig.APP_BUILD_TIME)
-
-        // Set up uncaught exception handler for crash logging
-        setupCrashHandler()
 
         // Detect main-thread stalls before Android ANRs. Logs the main-thread stack to
         // homebase.log when a frame budget is exceeded by >4s — gives us a usable trace
@@ -215,35 +215,5 @@ class MainApplication : Application(), KoinComponent {
         }
     }
 
-    private fun setupCrashHandler() {
-        val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
 
-        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
-            // A transient connectivity failure (timeout, dropped socket, DNS) that
-            // leaked from a network call on a scope without its own
-            // CoroutineExceptionHandler should NOT kill the app. Record it as a
-            // Crashlytics non-fatal — full stack, plus the coroutine-name/thread
-            // custom keys GlobalCoroutineExceptionHandler already stamped — so it
-            // stays debuggable, then return without invoking the default (killing)
-            // handler. Any non-network crash still terminates normally below.
-            if (throwable.isTransientNetworkFailure()) {
-                crashlyticsRecordException(throwable)
-                Logger.w(tag = "CrashHandler") {
-                    "Transient network failure leaked to '${thread.name}' (no local handler); " +
-                        "recorded as non-fatal, app not crashing: ${throwable.message}"
-                }
-                return@setDefaultUncaughtExceptionHandler
-            }
-
-            try {
-                CrashLogger.logCrash(thread.name, throwable)
-            } catch (e: Exception) {
-                // If crash logging fails, still call the default handler
-                e.printStackTrace()
-            } finally {
-                // Call the original handler to let the app crash normally
-                defaultHandler?.uncaughtException(thread, throwable)
-            }
-        }
-    }
 }

--- a/androidApp/src/main/kotlin/id/homebase/feed/crash/CrashActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/crash/CrashActivity.kt
@@ -1,0 +1,58 @@
+package id.homebase.feed.crash
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.widget.Button
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.FileProvider
+import id.homebase.feed.R
+import java.io.File
+
+/** Runs in a separate `:crash` process so it survives the crashed main process. */
+class CrashActivity : AppCompatActivity() {
+    companion object { const val EXTRA_REPORT_PATH = "report_path" }
+
+    private var reportPath: String? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_crash)
+        reportPath = intent.getStringExtra(EXTRA_REPORT_PATH)
+
+        findViewById<TextView>(R.id.crash_details).text = reportPath
+            ?.let { runCatching { File(it).readText() }.getOrNull() }
+            ?: getString(R.string.crash_report_unavailable)
+
+        val card = findViewById<View>(R.id.crash_details_card)
+        findViewById<Button>(R.id.crash_details_toggle).setOnClickListener {
+            card.visibility = if (card.visibility == View.GONE) View.VISIBLE else View.GONE
+        }
+        findViewById<Button>(R.id.crash_restart).setOnClickListener { restart() }
+        findViewById<Button>(R.id.crash_share).setOnClickListener { share() }
+    }
+
+    private fun restart() {
+        runCatching {
+            packageManager.getLaunchIntentForPackage(packageName)?.apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            }?.let { startActivity(it) }
+        }
+        finish()
+        Runtime.getRuntime().exit(0)
+    }
+
+    private fun share() {
+        val path = reportPath ?: return
+        runCatching {
+            val uri = FileProvider.getUriForFile(this, "$packageName.fileprovider", File(path))
+            val send = Intent(Intent.ACTION_SEND).apply {
+                type = "text/plain"
+                putExtra(Intent.EXTRA_STREAM, uri)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            startActivity(Intent.createChooser(send, getString(R.string.crash_share)))
+        }
+    }
+}

--- a/androidApp/src/main/kotlin/id/homebase/feed/crash/GlobalCrashHandler.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/crash/GlobalCrashHandler.kt
@@ -1,0 +1,91 @@
+package id.homebase.feed.crash
+
+import android.app.Application
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ApplicationInfo
+import android.os.Build
+import android.os.Process
+import co.touchlab.kermit.Logger
+import com.google.firebase.Firebase
+import com.google.firebase.crashlytics.crashlytics
+import id.homebase.api.client.isTransientNetworkFailure
+import id.homebase.core.crash.CrashMetadata
+import id.homebase.core.crash.CrashReporting
+import id.homebase.core.logging.CrashLogger
+import kotlinx.io.files.Path
+import kotlin.system.exitProcess
+
+/**
+ * Installs CrashReporting + a global uncaught-exception handler that replaces the
+ * OS "app keeps stopping" dialog with a separate-process [CrashActivity]. Install
+ * EARLY in Application.onCreate (before Koin/DB) — it needs neither.
+ */
+object GlobalCrashHandler {
+    private const val TAG = "GlobalCrashHandler"
+    private const val CRASH_LOOP_PREFS = "crash_loop_guard"
+    private const val KEY_LAST_CRASH_MS = "last_crash_ms"
+    private const val CRASH_LOOP_WINDOW_MS = 10_000L
+
+    fun install(app: Application) {
+        CrashReporting.install(
+            metadata = CrashMetadata(
+                appVersion = runCatching {
+                    app.packageManager.getPackageInfo(app.packageName, 0).versionName
+                }.getOrNull() ?: "?",
+                buildType = if (app.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0) "debug" else "release",
+                platform = "Android ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})",
+                device = "${Build.MANUFACTURER} ${Build.MODEL}",
+                buildTime = chat_kmp.homebase_common.BuildConfig.APP_BUILD_TIME,
+            ),
+            logDir = Path(app.filesDir.resolve("logs").absolutePath),
+        )
+
+        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            try {
+                // Preserve PR #737: a transient network blip that leaked to the global
+                // handler must NOT crash the app or show the recovery screen.
+                if (throwable.isTransientNetworkFailure()) {
+                    runCatching { Firebase.crashlytics.recordException(throwable) }
+                    Logger.w(tag = TAG) {
+                        "Transient network failure on '${thread.name}'; not crashing: ${throwable.message}"
+                    }
+                    return@setDefaultUncaughtExceptionHandler
+                }
+
+                CrashLogger.logCrash(thread.name, throwable)
+                val reportPath = CrashReporting.writeReport(thread.name, throwable)
+                // Record as a non-fatal: the captured default handler is Crashlytics',
+                // and chaining to it would re-raise the OS dialog we're replacing.
+                runCatching { Firebase.crashlytics.recordException(throwable) }
+
+                if (!isCrashLooping(app) && reportPath != null) {
+                    launchCrashActivity(app, reportPath.toString())
+                }
+            } catch (t: Throwable) {
+                runCatching { Logger.e(tag = TAG, throwable = t) { "Crash handler itself failed" } }
+            } finally {
+                // We own termination: kill our own process to suppress the OS dialog.
+                Process.killProcess(Process.myPid())
+                exitProcess(10)
+            }
+        }
+    }
+
+    /** True if another crash happened < 10s ago (likely CrashActivity itself crashed). */
+    private fun isCrashLooping(app: Application): Boolean {
+        val prefs = app.getSharedPreferences(CRASH_LOOP_PREFS, Context.MODE_PRIVATE)
+        val now = System.currentTimeMillis()
+        val last = prefs.getLong(KEY_LAST_CRASH_MS, 0L)
+        prefs.edit().putLong(KEY_LAST_CRASH_MS, now).apply()
+        return now - last < CRASH_LOOP_WINDOW_MS
+    }
+
+    private fun launchCrashActivity(app: Application, reportPath: String) {
+        val intent = Intent(app, CrashActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            putExtra(CrashActivity.EXTRA_REPORT_PATH, reportPath)
+        }
+        app.startActivity(intent)
+    }
+}

--- a/androidApp/src/main/res/layout/activity_crash.xml
+++ b/androidApp/src/main/res/layout/activity_crash.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/colorSurface"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:paddingHorizontal="28dp"
+        android:paddingVertical="40dp">
+
+        <TextView
+            android:id="@+id/crash_emoji"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="?attr/colorPrimary"
+            android:textSize="34sp"
+            android:text="@string/crash_emoji" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="28dp"
+            android:gravity="center"
+            android:textAppearance="?attr/textAppearanceHeadlineSmall"
+            android:textColor="?attr/colorOnSurface"
+            android:text="@string/crash_title" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:gravity="center"
+            android:lineSpacingMultiplier="1.15"
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:textColor="?attr/colorOnSurfaceVariant"
+            android:text="@string/crash_body" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/crash_restart"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="40dp"
+            android:minHeight="56dp"
+            android:text="@string/crash_restart"
+            app:cornerRadius="18dp" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/crash_share"
+            style="@style/Widget.Material3.Button.TonalButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:minHeight="56dp"
+            android:text="@string/crash_share"
+            app:cornerRadius="18dp" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/crash_details_toggle"
+            style="@style/Widget.Material3.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/crash_details_toggle" />
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/crash_details_card"
+            style="@style/Widget.Material3.CardView.Filled"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:visibility="gone"
+            app:cardBackgroundColor="?attr/colorSurfaceVariant"
+            app:cardCornerRadius="16dp"
+            app:cardElevation="0dp">
+
+            <TextView
+                android:id="@+id/crash_details"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="16dp"
+                android:fontFamily="monospace"
+                android:textColor="?attr/colorOnSurfaceVariant"
+                android:textIsSelectable="true"
+                android:textSize="11sp" />
+        </com.google.android.material.card.MaterialCardView>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="28dp"
+            android:gravity="center"
+            android:textAppearance="?attr/textAppearanceBodySmall"
+            android:textColor="?attr/colorOnSurfaceVariant"
+            android:text="@string/crash_reassurance" />
+
+    </LinearLayout>
+</ScrollView>

--- a/androidApp/src/main/res/values-night/colors.xml
+++ b/androidApp/src/main/res/values-night/colors.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Homebase brand colors for the native crash screen (dark). Mirrors
+     homebase-common DarkColors. -->
+<resources>
+    <color name="crash_primary">#B6C5FA</color>
+    <color name="crash_on_primary">#1E2438</color>
+    <color name="crash_primary_container">#464B5C</color>
+    <color name="crash_on_primary_container">#DBE1FC</color>
+    <color name="crash_secondary_container">#414659</color>
+    <color name="crash_on_secondary_container">#DCE1F9</color>
+    <color name="crash_surface">#1B1C1F</color>
+    <color name="crash_on_surface">#E2E1E5</color>
+    <color name="crash_surface_variant">#303133</color>
+    <color name="crash_on_surface_variant">#BEBFC5</color>
+</resources>

--- a/androidApp/src/main/res/values-night/themes.xml
+++ b/androidApp/src/main/res/values-night/themes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Night variant: inherits Theme.Homebase.Crash.Base (colors come from
+         values-night/colors.xml); only the status-bar icon polarity flips. -->
+    <style name="Theme.Homebase.Crash" parent="Theme.Homebase.Crash.Base">
+        <item name="android:windowLightStatusBar">false</item>
+    </style>
+</resources>

--- a/androidApp/src/main/res/values/colors.xml
+++ b/androidApp/src/main/res/values/colors.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Homebase brand colors for the native crash screen (light). Mirrors
+     homebase-common LightColors so the recovery screen matches the app theme. -->
+<resources>
+    <color name="crash_primary">#2C58C3</color>
+    <color name="crash_on_primary">#FFFFFF</color>
+    <color name="crash_primary_container">#D2DFFB</color>
+    <color name="crash_on_primary_container">#051845</color>
+    <color name="crash_secondary_container">#DCE5F9</color>
+    <color name="crash_on_secondary_container">#151D2C</color>
+    <color name="crash_surface">#FBFCFF</color>
+    <color name="crash_on_surface">#1B1B1D</color>
+    <color name="crash_surface_variant">#E7EBF3</color>
+    <color name="crash_on_surface_variant">#545863</color>
+</resources>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -6,4 +6,12 @@
     <string name="share_sent_multiple">Sent to %1$d conversations</string>
     <string name="share_preview_title_single">Conversation</string>
     <string name="share_preview_title_others">%1$s +%2$d others</string>
+    <string name="crash_emoji">(╯°□°)╯︵ ┻━┻</string>
+    <string name="crash_title">Well, this is awkward.</string>
+    <string name="crash_body">Homebase tripped over its own feet and had to sit down for a second. You really shouldn\'t be seeing this — but here we are. Let\'s get you back.</string>
+    <string name="crash_reassurance">Your stuff is safe. Sharing the report helps us fix this.</string>
+    <string name="crash_restart">Restart</string>
+    <string name="crash_share">Share crash report</string>
+    <string name="crash_details_toggle">Technical details</string>
+    <string name="crash_report_unavailable">(crash report unavailable)</string>
 </resources>

--- a/androidApp/src/main/res/values/themes.xml
+++ b/androidApp/src/main/res/values/themes.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Branded Material 3 theme for CrashActivity. Color @refs adapt to dark via
+         values-night/colors.xml; windowLightStatusBar is flipped in values-night. -->
+    <style name="Theme.Homebase.Crash.Base" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/crash_primary</item>
+        <item name="colorOnPrimary">@color/crash_on_primary</item>
+        <item name="colorPrimaryContainer">@color/crash_primary_container</item>
+        <item name="colorOnPrimaryContainer">@color/crash_on_primary_container</item>
+        <item name="colorSecondaryContainer">@color/crash_secondary_container</item>
+        <item name="colorOnSecondaryContainer">@color/crash_on_secondary_container</item>
+        <item name="android:colorBackground">@color/crash_surface</item>
+        <item name="colorSurface">@color/crash_surface</item>
+        <item name="colorOnSurface">@color/crash_on_surface</item>
+        <item name="colorSurfaceVariant">@color/crash_surface_variant</item>
+        <item name="colorOnSurfaceVariant">@color/crash_on_surface_variant</item>
+        <item name="android:statusBarColor">@color/crash_surface</item>
+        <item name="android:navigationBarColor">@color/crash_surface</item>
+        <!-- Shown immediately while the :crash process cold-starts, so the user
+             sees the branded surface instead of a black/blank gap. -->
+        <item name="android:windowBackground">@color/crash_surface</item>
+    </style>
+
+    <style name="Theme.Homebase.Crash" parent="Theme.Homebase.Crash.Base">
+        <item name="android:windowLightStatusBar">true</item>
+    </style>
+</resources>

--- a/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
+++ b/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
@@ -31,6 +31,9 @@ import id.homebase.core.auth.AuthConnectionCoordinator
 import id.homebase.core.di.allModules
 import id.homebase.core.diagnostics.MainThreadWatchdog
 import id.homebase.api.client.isTransientNetworkFailure
+import id.homebase.app.crash.CrashRecoveryDialog
+import id.homebase.core.crash.CrashMetadata
+import id.homebase.core.crash.CrashReporting
 import id.homebase.core.logging.CrashLogger
 import id.homebase.core.logging.LoggerConfig
 import id.homebase.core.logging.StartupLogger
@@ -70,6 +73,16 @@ fun main() {
             logsDir.mkdirs()
         }
         LoggerConfig.initialize(logDirectory = Path(logsDir.absolutePath))
+        CrashReporting.install(
+            metadata = CrashMetadata(
+                appVersion = System.getProperty("jpackage.app-version") ?: "dev",
+                buildType = "desktop",
+                platform = "${System.getProperty("os.name")} ${System.getProperty("os.version")}",
+                device = System.getProperty("os.arch") ?: "?",
+                buildTime = BuildConfig.APP_BUILD_TIME,
+            ),
+            logDir = Path(File(JvmFileSystemUtil.getAppDataDirectory(), "logs").absolutePath),
+        )
     } catch (e: Exception) {
         Logger.e("Main", e, "Failed to initialize file logging")
     }
@@ -269,15 +282,8 @@ fun main() {
 }
 
 private fun setupCrashHandler() {
-    val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
-
     Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
-        // A transient connectivity failure (timeout, dropped socket, DNS) that
-        // leaked from a network call on a scope without its own
-        // CoroutineExceptionHandler should not kill the app. Record it (no-op on
-        // Desktop, where no crash backend is wired) + log, then return without
-        // invoking the default (killing) handler. Non-network crashes still
-        // terminate normally below.
+        // Preserve PR #737: don't crash on a transient network blip.
         if (throwable.isTransientNetworkFailure()) {
             crashlyticsRecordException(throwable)
             Logger.w(tag = "CrashHandler") {
@@ -286,14 +292,14 @@ private fun setupCrashHandler() {
             }
             return@setDefaultUncaughtExceptionHandler
         }
-
         try {
             CrashLogger.logCrash(thread.name, throwable)
-        } catch (e: Exception) {
+            val reportPath = CrashReporting.writeReport(thread.name, throwable)
+            // Modal dialog; it handles Restart/Reveal/Quit and owns termination.
+            CrashRecoveryDialog.showAndBlock(reportPath?.toString())
+        } catch (e: Throwable) {
             e.printStackTrace()
-        } finally {
-            // Call the original handler to let the app crash normally
-            defaultHandler?.uncaughtException(thread, throwable)
+            kotlin.system.exitProcess(1)
         }
     }
 }

--- a/desktopApp/src/jvmMain/kotlin/id/homebase/app/crash/CrashRecoveryDialog.kt
+++ b/desktopApp/src/jvmMain/kotlin/id/homebase/app/crash/CrashRecoveryDialog.kt
@@ -1,0 +1,147 @@
+package id.homebase.app.crash
+
+import java.awt.BorderLayout
+import java.awt.Color
+import java.awt.Cursor
+import java.awt.Desktop
+import java.awt.Dimension
+import java.awt.FlowLayout
+import java.awt.Font
+import java.awt.Graphics
+import java.awt.Graphics2D
+import java.awt.RenderingHints
+import java.io.File
+import javax.swing.BorderFactory
+import javax.swing.JButton
+import javax.swing.JDialog
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.JScrollPane
+import javax.swing.JTextArea
+import javax.swing.SwingUtilities
+import kotlin.system.exitProcess
+
+/** Native Swing crash recovery dialog (no Compose/Skia). Blocks on the EDT. */
+object CrashRecoveryDialog {
+
+    private val SURFACE = Color(0xFB, 0xFC, 0xFF)
+    private val SURFACE_VARIANT = Color(0xE7, 0xEB, 0xF3)
+    private val ON_SURFACE_VARIANT = Color(0x54, 0x58, 0x63)
+    private val PRIMARY = Color(0x2C, 0x58, 0xC3)
+    private val ON_PRIMARY = Color.WHITE
+    private val SECONDARY_CONTAINER = Color(0xDC, 0xE5, 0xF9)
+    private val ON_SECONDARY_CONTAINER = Color(0x15, 0x1D, 0x2C)
+
+    private const val MESSAGE_HTML =
+        "<html><body style='width:420px;font-family:sans-serif'>" +
+        "<h2 style='color:#2C58C3'>Well, this is awkward.</h2>" +
+        "<p style='color:#1B1B1D'>Homebase tripped over its own feet and had to sit down for a second. " +
+        "You really shouldn't be seeing this — but here we are.</p>" +
+        "<p style='color:#545863'>Your stuff is safe. Sharing the report helps us fix this.</p>" +
+        "</body></html>"
+
+    fun showAndBlock(reportPath: String?) {
+        try {
+            val r = Runnable { buildAndShow(reportPath) }
+            if (SwingUtilities.isEventDispatchThread()) r.run() else SwingUtilities.invokeAndWait(r)
+        } catch (t: Throwable) {
+            t.printStackTrace()
+        }
+        exitProcess(1)
+    }
+
+    /** Rounded (pill) button; [fill] null = a text button that only tints on hover. */
+    private fun pillButton(text: String, fill: Color?, fg: Color): JButton =
+        object : JButton(text) {
+            init {
+                isContentAreaFilled = false
+                isFocusPainted = false
+                isBorderPainted = false
+                isOpaque = false
+                foreground = fg
+                font = font.deriveFont(Font.BOLD, 13f)
+                border = BorderFactory.createEmptyBorder(11, 22, 11, 22)
+                cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+            }
+
+            override fun paintComponent(g: Graphics) {
+                val g2 = g.create() as Graphics2D
+                g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+                val arc = height
+                when {
+                    fill != null -> {
+                        g2.color = if (model.isPressed) fill.darker() else fill
+                        g2.fillRoundRect(0, 0, width, height, arc, arc)
+                    }
+                    model.isRollover -> {
+                        g2.color = Color(fg.red, fg.green, fg.blue, 22)
+                        g2.fillRoundRect(0, 0, width, height, arc, arc)
+                    }
+                }
+                g2.dispose()
+                super.paintComponent(g)
+            }
+        }
+
+    private fun buildAndShow(reportPath: String?) {
+        val report = reportPath?.let { runCatching { File(it).readText() }.getOrNull() }
+            ?: "(crash report unavailable)"
+
+        val dialog = JDialog(null as java.awt.Frame?, "Homebase", true)
+        val root = JPanel(BorderLayout(0, 16)).apply {
+            background = SURFACE
+            border = BorderFactory.createEmptyBorder(24, 28, 20, 28)
+        }
+        root.add(JLabel(MESSAGE_HTML).apply { isOpaque = true; background = SURFACE }, BorderLayout.NORTH)
+
+        val area = JTextArea(report, 14, 56).apply {
+            isEditable = false; lineWrap = true; wrapStyleWord = true
+            background = SURFACE_VARIANT; foreground = ON_SURFACE_VARIANT
+            font = Font(Font.MONOSPACED, Font.PLAIN, 11)
+            border = BorderFactory.createEmptyBorder(12, 12, 12, 12)
+        }
+        val scroll = JScrollPane(area).apply {
+            preferredSize = Dimension(560, 240)
+            isVisible = false
+            border = BorderFactory.createEmptyBorder()
+        }
+        root.add(scroll, BorderLayout.CENTER)
+
+        val buttons = JPanel(FlowLayout(FlowLayout.RIGHT, 8, 0)).apply { background = SURFACE }
+        val details = pillButton("Technical details", null, PRIMARY).apply {
+            addActionListener { scroll.isVisible = !scroll.isVisible; dialog.pack() }
+        }
+        val quit = pillButton("Quit", null, ON_SURFACE_VARIANT).apply {
+            addActionListener { exitProcess(1) }
+        }
+        val reveal = pillButton("Reveal crash report", SECONDARY_CONTAINER, ON_SECONDARY_CONTAINER).apply {
+            addActionListener { revealReport(reportPath) }
+        }
+        val restart = pillButton("Restart", PRIMARY, ON_PRIMARY).apply {
+            addActionListener { relaunch(); exitProcess(0) }
+        }
+        buttons.add(details); buttons.add(quit); buttons.add(reveal); buttons.add(restart)
+        root.add(buttons, BorderLayout.SOUTH)
+
+        dialog.contentPane = root
+        dialog.defaultCloseOperation = JDialog.DISPOSE_ON_CLOSE
+        dialog.pack()
+        dialog.setLocationRelativeTo(null)
+        dialog.isVisible = true
+    }
+
+    private fun revealReport(reportPath: String?) {
+        val path = reportPath ?: return
+        runCatching {
+            val parent = File(path).parentFile ?: return
+            if (Desktop.isDesktopSupported()) Desktop.getDesktop().open(parent)
+        }
+    }
+
+    private fun relaunch() {
+        runCatching {
+            val cmd = ProcessHandle.current().info().commandLine().orElse(null) ?: return
+            ProcessBuilder(cmd.split(" ").filter { it.isNotBlank() }).inheritIO().start()
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ jetbrains-compose-material3-adaptive = "1.2.0"
 kotlinxHtmlJvm = "0.12.0"
 kotlinxSerializationJson = "1.11.0"
 materialIconsExtended = "1.7.3"
+materialComponents = "1.11.0"
 multiplatformSettings = "1.3.0"
 coil3 = "3.4.0"
 zoomimage = "1.4.0"
@@ -120,6 +121,7 @@ androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-te
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-testExt" }
 androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-espresso" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
+android-material = { module = "com.google.android.material:material", version.ref = "materialComponents" }
 androidx-biometric = { module = "androidx.biometric:biometric", version.ref = "androidx-biometric" }
 androidx-exifinterface = { module = "androidx.exifinterface:exifinterface", version.ref = "androidx-exifinterface" }
 androidx-sharetarget = { module = "androidx.sharetarget:sharetarget", version.ref = "sharetarget" }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/crash/CrashMetadata.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/crash/CrashMetadata.kt
@@ -1,0 +1,14 @@
+package id.homebase.core.crash
+
+/**
+ * Static, platform-supplied crash context captured at [CrashReporting.install] time.
+ * Built from values cheaply available before Koin/DB (PackageManager / NSBundle /
+ * system properties) so it is valid even for an init-time crash.
+ */
+data class CrashMetadata(
+    val appVersion: String,
+    val buildType: String,
+    val platform: String,
+    val device: String,
+    val buildTime: String,
+)

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/crash/CrashReport.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/crash/CrashReport.kt
@@ -1,0 +1,32 @@
+package id.homebase.core.crash
+
+/** Pure rendering of a crash report (no I/O) so it is unit-testable. */
+internal object CrashReport {
+    fun render(
+        metadata: CrashMetadata?,
+        timeIso: String,
+        thread: String,
+        exceptionLine: String,
+        stackText: String,
+        logTail: String?,
+    ): String = buildString {
+        appendLine("===== Homebase crash report =====")
+        appendLine("Time:      $timeIso")
+        if (metadata != null) {
+            appendLine("App:       ${metadata.appVersion} (${metadata.buildType}, built ${metadata.buildTime})")
+            appendLine("Platform:  ${metadata.platform}")
+            appendLine("Device:    ${metadata.device}")
+        }
+        appendLine("Thread:    $thread")
+        appendLine("Exception: $exceptionLine")
+        appendLine()
+        appendLine("----- Stack trace -----")
+        appendLine(stackText)
+        if (logTail != null) {
+            appendLine()
+            appendLine("----- Recent log (tail) -----")
+            appendLine(logTail)
+        }
+        appendLine("=================================")
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/crash/CrashReporting.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/crash/CrashReporting.kt
@@ -1,0 +1,169 @@
+package id.homebase.core.crash
+
+import co.touchlab.kermit.Logger
+import id.homebase.core.logging.LogFileExporter
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.readString
+import kotlinx.io.writeString
+import kotlin.concurrent.Volatile
+import kotlin.time.Clock
+
+/**
+ * Dependency-free crash report persistence. Safe to call from inside a crashing
+ * process: no Koin, no coroutines, no DB — only kotlinx-io file ops, each wrapped
+ * so nothing here ever throws into a caller that is already crashing.
+ *
+ * [install] must run as the FIRST startup step on each platform (before Koin/DB),
+ * with values from the static BuildConfig / platform APIs.
+ */
+object CrashReporting {
+    private const val TAG = "CrashReporting"
+    private const val PENDING_FILE = "PENDING"
+    private const val LOG_TAIL_CHARS = 32_000
+    private const val DEFAULT_KEEP = 5
+    private const val LAUNCH_FILE = "launch_failures"
+    // iOS only: show next-launch recovery once this many consecutive launches have
+    // crashed before reaching a usable state (a startup crash loop). One silent retry.
+    private const val STARTUP_FAILURE_THRESHOLD = 2
+
+    @Volatile private var metadata: CrashMetadata? = null
+    @Volatile private var logDir: Path? = null
+    @Volatile private var crashDir: Path? = null
+
+    /** @param logDir the existing homebase.log directory; crash reports go in logDir/crash. */
+    fun install(metadata: CrashMetadata, logDir: Path) {
+        this.metadata = metadata
+        this.logDir = logDir
+        val dir = Path(logDir, "crash")
+        this.crashDir = dir
+        runCatching { SystemFileSystem.createDirectories(dir) }
+    }
+
+    /**
+     * iOS launch entry. Returns the pending crash report to recover from ONLY when the
+     * app is stuck failing to start — at least [STARTUP_FAILURE_THRESHOLD] consecutive
+     * launches crashed before [markStartupComplete]. Otherwise records this launch
+     * attempt and returns null so startup proceeds normally. A mid-session crash never
+     * trips this: startup completed, so the counter was reset.
+     */
+    fun beginLaunchCheckRecovery(): Path? {
+        val dir = crashDir ?: return null
+        val failures = readLaunchCount()
+        val report = pendingReport()
+        if (failures >= STARTUP_FAILURE_THRESHOLD && report != null) return report
+        runCatching {
+            SystemFileSystem.sink(Path(dir, LAUNCH_FILE)).buffered().use { it.writeString((failures + 1).toString()) }
+        }
+        return null
+    }
+
+    /** App reached a usable state — reset the consecutive-startup-failure counter. */
+    fun markStartupComplete() {
+        val dir = crashDir ?: return
+        runCatching {
+            SystemFileSystem.sink(Path(dir, LAUNCH_FILE)).buffered().use { it.writeString("0") }
+        }
+    }
+
+    private fun readLaunchCount(): Int {
+        val dir = crashDir ?: return 0
+        return try {
+            val f = Path(dir, LAUNCH_FILE)
+            if (SystemFileSystem.metadataOrNull(f) == null) 0
+            else SystemFileSystem.source(f).buffered().use { it.readString() }.trim().toIntOrNull() ?: 0
+        } catch (t: Throwable) {
+            0
+        }
+    }
+
+    fun writeReport(thread: String, throwable: Throwable): Path? = writeInternal(
+        thread = thread,
+        exceptionLine = buildString {
+            append(throwable::class.qualifiedName ?: throwable::class.simpleName ?: "Throwable")
+            append(": ")
+            append(throwable.message ?: "")
+        },
+        stackText = throwable.stackTraceToString(),
+    )
+
+    /** For the iOS ObjC channel, where there is no Kotlin [Throwable]. */
+    fun writeReportRaw(thread: String, name: String, reason: String, stack: List<String>): Path? = writeInternal(
+        thread = thread,
+        exceptionLine = if (reason.isBlank()) name else "$name: $reason",
+        stackText = stack.joinToString("\n"),
+    )
+
+    private fun writeInternal(thread: String, exceptionLine: String, stackText: String): Path? {
+        val dir = crashDir ?: return null
+        return try {
+            runCatching { SystemFileSystem.createDirectories(dir) }
+            val now = Clock.System.now()
+            val report = CrashReport.render(
+                metadata = metadata,
+                timeIso = now.toString(),
+                thread = thread,
+                exceptionLine = exceptionLine,
+                stackText = stackText,
+                logTail = readLogTail(),
+            )
+            val base = now.toEpochMilliseconds()
+            var file = Path(dir, "crash-$base.txt")
+            var suffix = 1
+            while (SystemFileSystem.metadataOrNull(file) != null) {
+                file = Path(dir, "crash-$base-${suffix++}.txt")
+            }
+            SystemFileSystem.sink(file).buffered().use { it.writeString(report) }
+            runCatching {
+                SystemFileSystem.sink(Path(dir, PENDING_FILE)).buffered().use { it.writeString(file.name) }
+            }
+            runCatching { pruneOld() }
+            file
+        } catch (t: Throwable) {
+            runCatching { Logger.e(tag = TAG) { "Failed to write crash report: ${t.message}" } }
+            null
+        }
+    }
+
+    private fun readLogTail(): String? {
+        val ld = logDir ?: return null
+        return try {
+            val logFile = LogFileExporter.getMostRecentLogFile(ld) ?: return null
+            val content = SystemFileSystem.source(logFile).buffered().use { it.readString() }
+            if (content.length > LOG_TAIL_CHARS) content.takeLast(LOG_TAIL_CHARS) else content
+        } catch (t: Throwable) {
+            null
+        }
+    }
+
+    fun pendingReport(): Path? {
+        val dir = crashDir ?: return null
+        return try {
+            val pending = Path(dir, PENDING_FILE)
+            if (SystemFileSystem.metadataOrNull(pending) == null) return null
+            val name = SystemFileSystem.source(pending).buffered().use { it.readString() }.trim()
+            if (name.isEmpty()) return null
+            val report = Path(dir, name)
+            if (SystemFileSystem.metadataOrNull(report) == null) null else report
+        } catch (t: Throwable) {
+            null
+        }
+    }
+
+    fun clearPending() {
+        val dir = crashDir ?: return
+        runCatching { SystemFileSystem.delete(Path(dir, PENDING_FILE), mustExist = false) }
+    }
+
+    fun pruneOld(keep: Int = DEFAULT_KEEP) {
+        val dir = crashDir ?: return
+        runCatching {
+            SystemFileSystem.list(dir)
+                .filter { it.name.startsWith("crash-") && it.name.endsWith(".txt") }
+                .sortedByDescending { it.name }
+                .drop(keep)
+                .forEach { runCatching { SystemFileSystem.delete(it, mustExist = false) } }
+        }
+    }
+}

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/crash/CrashReportTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/crash/CrashReportTest.kt
@@ -1,0 +1,50 @@
+package id.homebase.core.crash
+
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertTrue
+
+class CrashReportTest {
+    private val meta = CrashMetadata(
+        appVersion = "1.2.3",
+        buildType = "release",
+        platform = "Android 14 (API 34)",
+        device = "Google Pixel 7",
+        buildTime = "2026-06-10 09:00:00",
+    )
+
+    @Test
+    fun render_includes_all_sections() {
+        val out = CrashReport.render(
+            metadata = meta,
+            timeIso = "2026-06-16T08:31:04Z",
+            thread = "main",
+            exceptionLine = "kotlin.IllegalStateException: boom",
+            stackText = "at Foo.bar(Foo.kt:1)",
+            logTail = "10:00 some log line",
+        )
+        assertContains(out, "Homebase crash report")
+        assertContains(out, "1.2.3 (release, built 2026-06-10 09:00:00)")
+        assertContains(out, "Android 14 (API 34)")
+        assertContains(out, "Google Pixel 7")
+        assertContains(out, "Thread:    main")
+        assertContains(out, "kotlin.IllegalStateException: boom")
+        assertContains(out, "----- Stack trace -----")
+        assertContains(out, "at Foo.bar(Foo.kt:1)")
+        assertContains(out, "----- Recent log (tail) -----")
+        assertContains(out, "10:00 some log line")
+    }
+
+    @Test
+    fun render_omits_log_section_when_null() {
+        val out = CrashReport.render(meta, "t", "main", "E: x", "stack", logTail = null)
+        assertTrue("Recent log" !in out)
+    }
+
+    @Test
+    fun render_tolerates_null_metadata() {
+        val out = CrashReport.render(null, "t", "bg", "E: x", "stack", null)
+        assertContains(out, "Thread:    bg")
+        assertTrue("App:" !in out)
+    }
+}

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/crash/CrashReportingTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/crash/CrashReportingTest.kt
@@ -1,0 +1,110 @@
+package id.homebase.core.crash
+
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.files.SystemTemporaryDirectory
+import kotlinx.io.readString
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class CrashReportingTest {
+    private lateinit var logDir: Path
+
+    private val meta = CrashMetadata("1.0", "debug", "JVM", "test", "2026-06-10")
+
+    @BeforeTest
+    fun setup() {
+        // Unique per-run dir name (no Math.random in commonTest — use nanoTime).
+        logDir = Path(SystemTemporaryDirectory, "crashtest-${System.nanoTime()}")
+        SystemFileSystem.createDirectories(logDir)
+        CrashReporting.install(meta, logDir)
+    }
+
+    @AfterTest
+    fun teardown() {
+        runCatching {
+            val crashDir = Path(logDir, "crash")
+            SystemFileSystem.list(crashDir).forEach { SystemFileSystem.delete(it, mustExist = false) }
+            SystemFileSystem.delete(crashDir, mustExist = false)
+            SystemFileSystem.delete(logDir, mustExist = false)
+        }
+    }
+
+    @Test
+    fun writeReport_writes_file_and_sets_pending() {
+        val path = CrashReporting.writeReport("main", IllegalStateException("boom"))
+        assertNotNull(path)
+        val text = SystemFileSystem.source(path).buffered().use { it.readString() }
+        assertTrue("boom" in text)
+        assertTrue("Stack trace" in text)
+        val pending = CrashReporting.pendingReport()
+        assertEquals(path.name, pending?.name)
+    }
+
+    @Test
+    fun clearPending_removes_marker_keeps_report() {
+        val path = CrashReporting.writeReport("main", RuntimeException("x"))
+        assertNotNull(CrashReporting.pendingReport())
+        CrashReporting.clearPending()
+        assertNull(CrashReporting.pendingReport())
+        // report file itself still exists
+        assertTrue(SystemFileSystem.metadataOrNull(path!!) != null)
+    }
+
+    @Test
+    fun pruneOld_keeps_newest_n() {
+        repeat(8) { CrashReporting.writeReport("main", RuntimeException("e$it")) }
+        CrashReporting.pruneOld(keep = 5)
+        val crashDir = Path(logDir, "crash")
+        val reports = SystemFileSystem.list(crashDir)
+            .filter { it.name.startsWith("crash-") && it.name.endsWith(".txt") }
+        assertEquals(5, reports.size)
+    }
+
+    @Test
+    fun writeReportRaw_renders_objc_style() {
+        val path = CrashReporting.writeReportRaw("ObjC", "NSRangeException", "out of bounds", listOf("frame0", "frame1"))
+        assertNotNull(path)
+        val text = SystemFileSystem.source(path).buffered().use { it.readString() }
+        assertTrue("NSRangeException: out of bounds" in text)
+        assertTrue("frame0" in text)
+    }
+
+    @Test
+    fun stuck_startup_shows_recovery_after_two_failures() {
+        // Launch 1: begin (no recovery), then crash before startup completes.
+        assertNull(CrashReporting.beginLaunchCheckRecovery())
+        CrashReporting.writeReport("main", RuntimeException("startup-1"))
+        // Launch 2: silent retry (no recovery), crash again.
+        assertNull(CrashReporting.beginLaunchCheckRecovery())
+        CrashReporting.writeReport("main", RuntimeException("startup-2"))
+        // Launch 3: two consecutive startup failures -> recovery shows.
+        assertNotNull(CrashReporting.beginLaunchCheckRecovery())
+    }
+
+    @Test
+    fun mid_session_crash_does_not_show_recovery() {
+        // Launch: startup completes, then a mid-session crash.
+        assertNull(CrashReporting.beginLaunchCheckRecovery())
+        CrashReporting.markStartupComplete()
+        CrashReporting.writeReport("main", RuntimeException("mid-session"))
+        // Next launch: report exists but the failure counter was reset -> no recovery.
+        assertNull(CrashReporting.beginLaunchCheckRecovery())
+    }
+
+    @Test
+    fun successful_start_resets_failure_count() {
+        assertNull(CrashReporting.beginLaunchCheckRecovery())
+        CrashReporting.writeReport("main", RuntimeException("startup-1"))
+        assertNull(CrashReporting.beginLaunchCheckRecovery())
+        CrashReporting.markStartupComplete() // recovered on the retry
+        // Even though a report exists, the reset counter means no recovery next launch.
+        assertNull(CrashReporting.beginLaunchCheckRecovery())
+    }
+}

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/logging/IOSCrashHandler.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/logging/IOSCrashHandler.kt
@@ -2,6 +2,7 @@ package id.homebase.core.logging
 
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.isTransientNetworkFailure
+import id.homebase.core.crash.CrashReporting
 import kotlin.experimental.ExperimentalNativeApi
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.staticCFunction
@@ -73,6 +74,13 @@ fun setupIOSCrashHandler() {
                     }
                 )
 
+                CrashReporting.writeReportRaw(
+                    thread = "ObjC/NSException",
+                    name = objcName,
+                    reason = objcReason,
+                    stack = objcStack,
+                )
+
                 // Give the file log writer a moment to flush before the process dies.
                 NSThread.sleepForTimeInterval(0.1)
             } catch (e: Exception) {
@@ -121,6 +129,7 @@ fun setupIOSCrashHandler() {
             crashlyticsRecordException(throwable)
             crashlyticsLogFatalBreadcrumb(throwable)
             CrashLogger.logCrash(thread = "Kotlin/Native", exception = throwable)
+            CrashReporting.writeReport(thread = "Kotlin/Native", throwable = throwable)
             // Give the file log writer a moment to flush before the process dies.
             NSThread.sleepForTimeInterval(0.1)
         } catch (e: Throwable) {

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/MainViewController.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/MainViewController.kt
@@ -22,6 +22,8 @@ import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.core.di.allModules
 import id.homebase.core.diagnostics.MainThreadWatchdog
 import id.homebase.core.diagnostics.installGpuTextDiagnostics
+import id.homebase.core.crash.CrashMetadata
+import id.homebase.core.crash.CrashReporting
 import id.homebase.core.logging.LoggerConfig
 import id.homebase.core.logging.StartupLogger
 import id.homebase.core.logging.setErrorCollectionEnabled
@@ -32,6 +34,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.io.files.Path
 import org.koin.core.context.startKoin
 import platform.Foundation.NSBundle
+import platform.UIKit.UIDevice
 import platform.Foundation.NSDocumentDirectory
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSUserDomainMask
@@ -39,6 +42,47 @@ import platform.UIKit.UIViewController
 
 private var koinInitialized = false
 private var appInitialized = false
+private var crashHandlingInstalled = false
+
+@OptIn(ExperimentalForeignApi::class)
+private fun buildIosCrashMetadata(): CrashMetadata {
+    val info = NSBundle.mainBundle.infoDictionary
+    val version = info?.get("CFBundleShortVersionString") as? String ?: "?"
+    val build = info?.get("CFBundleVersion") as? String ?: "?"
+    val device = UIDevice.currentDevice
+    return CrashMetadata(
+        appVersion = "$version ($build)",
+        buildType = "ios",
+        platform = "${device.systemName} ${device.systemVersion}",
+        device = device.model,
+        buildTime = BuildConfig.APP_BUILD_TIME,
+    )
+}
+
+/** Idempotent: installs CrashReporting + the iOS crash hooks. No Koin/DB. */
+@OptIn(ExperimentalForeignApi::class)
+private fun installCrashReportingAndHandlers() {
+    if (crashHandlingInstalled) return
+    crashHandlingInstalled = true
+    CrashReporting.install(buildIosCrashMetadata(), getLogDirectory())
+    setupIOSCrashHandler()
+}
+
+/**
+ * Swift calls this FIRST in didFinishLaunching (before initializeApp): arms crash
+ * handling (no Koin/DB) and returns the path of a pending crash report from the
+ * previous run, or null.
+ */
+@OptIn(ExperimentalForeignApi::class)
+fun armCrashHandlingAndCheckPending(): String? {
+    installCrashReportingAndHandlers()
+    return CrashReporting.beginLaunchCheckRecovery()?.toString()
+}
+
+/** Swift calls this when the user taps Continue on the recovery screen. */
+fun clearPendingCrash() {
+    CrashReporting.clearPending()
+}
 
 /** Start Koin early so it's available before any Compose UI renders (e.g. on background push). */
 fun initKoin() {
@@ -58,6 +102,10 @@ fun initKoin() {
 fun initializeApp() {
     if (appInitialized) return
     appInitialized = true
+
+    // Arm crash handling as the VERY FIRST step — even before Koin/DB — so
+    // an init-time crash gets a written report even if Swift didn't arm first.
+    installCrashReportingAndHandlers()
 
     val startMark = kotlin.time.TimeSource.Monotonic.markNow()
     Logger.i(tag = "TextRendering") { "initializeApp() started" }
@@ -80,9 +128,6 @@ fun initializeApp() {
     // Configure Crashlytics based on user preference
     // Note: Koin must be initialized before accessing UserPreferences
     setErrorCollectionEnabled(UserPreferencesHelper.errorCollectionEnabled)
-
-    // Set up crash handler
-    setupIOSCrashHandler()
 
     // Detect main-thread stalls and log them to homebase.log. On iOS the stack itself can't be
     // captured from a background thread, but the "stalled for Nms" breadcrumb is still recorded.
@@ -110,6 +155,7 @@ fun initializeApp() {
         .get<id.homebase.core.location.tracking.LocationTrackingCoordinator>()
         .onProcessStart()
 
+    CrashReporting.markStartupComplete()
     Logger.i(tag = "TextRendering") { "initializeApp() total: ${startMark.elapsedNow().inWholeMilliseconds}ms" }
 }
 

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -36,8 +36,20 @@ struct ContentView: View {
     // fontCacheUsed=6889 count=4, 3/3 field captures). Latched true forever after — backgrounding
     // later must NOT tear the view down.
     @State private var hasBeenActive = false
+    // Crash recovery: when a crash report from the previous run is pending, show the
+    // native SwiftUI recovery screen INSTEAD of Compose until the user taps Continue
+    // (which runs the deferred heavy init and flips pendingReportPath back to nil).
+    @ObservedObject private var crashModel = CrashRecoveryModel.shared
 
     var body: some View {
+        if let reportPath = crashModel.pendingReportPath {
+            CrashRecoveryView(reportPath: reportPath)
+        } else {
+            mainContent
+        }
+    }
+
+    private var mainContent: some View {
         ZStack {
             if hasBeenActive || scenePhase == .active {
                 ComposeView()

--- a/iosApp/iosApp/CrashRecovery.swift
+++ b/iosApp/iosApp/CrashRecovery.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+import ComposeApp
+import UIKit
+
+/// Holds the pending crash report path so ContentView can gate Compose until the
+/// user taps Continue. Set during didFinishLaunching's arm-and-check step.
+final class CrashRecoveryModel: ObservableObject {
+    static let shared = CrashRecoveryModel()
+    @Published var pendingReportPath: String?
+    private init() {}
+}
+
+private enum CrashBrand {
+    static let primary = dyn(0x2C58C3, 0xB6C5FA)
+    static let onPrimary = dyn(0xFFFFFF, 0x1E2438)
+    static let surface = dyn(0xFBFCFF, 0x1B1C1F)
+    static let onSurface = dyn(0x1B1B1D, 0xE2E1E5)
+    static let onSurfaceVariant = dyn(0x545863, 0xBEBFC5)
+    static let secondaryContainer = dyn(0xDCE5F9, 0x414659)
+    static let onSecondaryContainer = dyn(0x151D2C, 0xDCE1F9)
+    static let surfaceVariant = dyn(0xE7EBF3, 0x303133)
+
+    private static func dyn(_ light: UInt32, _ dark: UInt32) -> Color {
+        Color(UIColor { $0.userInterfaceStyle == .dark ? rgb(dark) : rgb(light) })
+    }
+    private static func rgb(_ hex: UInt32) -> UIColor {
+        UIColor(
+            red: CGFloat((hex >> 16) & 0xFF) / 255.0,
+            green: CGFloat((hex >> 8) & 0xFF) / 255.0,
+            blue: CGFloat(hex & 0xFF) / 255.0,
+            alpha: 1.0
+        )
+    }
+}
+
+struct CrashRecoveryView: View {
+    let reportPath: String
+    @State private var showDetails = false
+    @State private var showShare = false
+
+    var body: some View {
+        ZStack {
+            CrashBrand.surface.ignoresSafeArea()
+            ScrollView {
+                VStack(spacing: 18) {
+                    Text("(╯°□°)╯︵ ┻━┻")
+                        .font(.system(size: 36))
+                        .foregroundColor(CrashBrand.primary)
+                        .padding(.top, 64)
+                    Text("Well, this is awkward.")
+                        .font(.title2.weight(.semibold))
+                        .foregroundColor(CrashBrand.onSurface)
+                        .multilineTextAlignment(.center)
+                    Text("Homebase tripped over its own feet and had to sit down for a second. You really shouldn't be seeing this — but here we are. Let's get you back.")
+                        .multilineTextAlignment(.center)
+                        .foregroundColor(CrashBrand.onSurfaceVariant)
+                        .padding(.horizontal, 24)
+
+                    VStack(spacing: 12) {
+                        Button { continueToApp() } label: {
+                            Text("Continue")
+                                .font(.headline)
+                                .foregroundColor(CrashBrand.onPrimary)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 16)
+                                .background(CrashBrand.primary)
+                                .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                        }
+                        .buttonStyle(.plain)
+
+                        Button { showShare = true } label: {
+                            Text("Share crash report")
+                                .font(.headline)
+                                .foregroundColor(CrashBrand.onSecondaryContainer)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 16)
+                                .background(CrashBrand.secondaryContainer)
+                                .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .padding(.horizontal, 28)
+                    .padding(.top, 12)
+
+                    DisclosureGroup("Technical details", isExpanded: $showDetails) {
+                        CrashReportTextView(text: reportText)
+                            .frame(height: 320)
+                            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                            .background(
+                                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                    .fill(CrashBrand.surfaceVariant)
+                            )
+                            .padding(.top, 8)
+                    }
+                    .tint(CrashBrand.primary)
+                    .padding(.horizontal, 24)
+                    .padding(.top, 4)
+
+                    Text("Your stuff is safe. Sharing the report helps us fix this.")
+                        .font(.footnote)
+                        .foregroundColor(CrashBrand.onSurfaceVariant)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 24)
+                        .padding(.bottom, 24)
+                }
+            }
+        }
+        .sheet(isPresented: $showShare) {
+            CrashShareSheet(items: [URL(fileURLWithPath: reportPath)])
+        }
+    }
+
+    private var reportText: String {
+        (try? String(contentsOfFile: reportPath, encoding: .utf8)) ?? "(report unavailable)"
+    }
+
+    private func continueToApp() {
+        MainViewControllerKt.clearPendingCrash()
+        MainViewControllerKt.initializeApp()
+        CrashRecoveryModel.shared.pendingReportPath = nil
+    }
+}
+
+struct CrashShareSheet: UIViewControllerRepresentable {
+    let items: [Any]
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+    func updateUIViewController(_ vc: UIActivityViewController, context: Context) {}
+}
+
+struct CrashReportTextView: UIViewRepresentable {
+    let text: String
+
+    func makeUIView(context: Context) -> UITextView {
+        let tv = UITextView()
+        tv.isEditable = false
+        tv.isSelectable = true
+        tv.isScrollEnabled = true
+        tv.alwaysBounceVertical = true
+        tv.backgroundColor = .clear
+        tv.font = UIFont.monospacedSystemFont(ofSize: 11, weight: .regular)
+        tv.textColor = UIColor(CrashBrand.onSurfaceVariant)
+        tv.textContainerInset = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
+        tv.text = text
+        return tv
+    }
+
+    func updateUIView(_ uiView: UITextView, context: Context) {
+        uiView.text = text
+    }
+}

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -23,7 +23,15 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
       // Run Koin, logging, and database init before any UI framework setup.
       // This keeps the main-thread run-loop free between heavy init and the
       // first Compose frame, preventing the iOS text-rendering race condition.
-      MainViewControllerKt.initializeApp()
+      //
+      // Arm crash handling FIRST (no Koin/DB) and check for a crash from last run.
+      // If there is one, DEFER heavy init until the user taps Continue (avoids an
+      // init-time crash loop). Otherwise initialize normally.
+      if let pending = MainViewControllerKt.armCrashHandlingAndCheckPending() {
+          CrashRecoveryModel.shared.pendingReportPath = pending
+      } else {
+          MainViewControllerKt.initializeApp()
+      }
 
       //By default showPushNotification value is true.
       //When set showPushNotification to false foreground push  notification will not be shown.


### PR DESCRIPTION
## Global crash handler — native recovery on Android, iOS & Desktop

A safety net for otherwise-fatal uncaught exceptions. Every crash is captured to a readable on-disk report (independent of Crashlytics, which has been unreliable at recording these), and the user gets a native, brand-themed recovery screen instead of a silent/hard crash.

### Per platform
- **Android** — `GlobalCrashHandler` (installed early in `Application.onCreate`) writes the report, records a Crashlytics non-fatal, launches a separate `:crash`-process **Material 3 `CrashActivity`** (Homebase brand theme, light/dark), then kills the crashed process so the OS "app keeps stopping" dialog never appears. **Restart** + **Share crash report** + collapsible details. Crash-loop guard.
- **iOS** — process death is unavoidable, so recovery is **next-launch**, shown **only when the app is stuck in a startup crash loop** (≥2 consecutive startup failures, one silent retry). A one-off / mid-session crash is captured + shareable via Help with **no nag** on reopen. Native SwiftUI screen (brand colors, scrollable report); hooks armed first in `initializeApp`; heavy init deferred while recovery shows (avoids the init-crash loop).
- **Desktop** — native **Swing** recovery dialog (brand colors, rounded buttons): Restart / Reveal report / Quit.

### Shared core
`homebase-common/commonMain` `CrashReporting`: dependency-free (no Koin/coroutines/DB), safe to call mid-crash. Writes `exception + stack/cause + thread + app/device/OS/version + tail of homebase.log` to `<appData>/logs/crash/`. Unit-tested (incl. the startup-crash-loop detection).

### Preserved
Crashlytics where it works; the #737 transient-network carve-out on all platforms; the existing `homebase.log` pipeline.

### Known gap (documented)
iOS crashes **before** `application(_:didFinishLaunching)` (dyld load/link, ObjC/C++ static initializers) can't be caught by any runtime handler — a deployment-target / weak-linking matter, out of scope here.

### Verification
- JVM unit tests + Konsist, `androidApp:assembleDebug`, Desktop compile, iOS `xcodebuild` — all green.
- Runtime-verified: iPhone 17 sim (startup crash loop → recovery; mid-session → none; Continue + Share sheet), Redmi Note 5 Pro (`CrashActivity` after a real crash), Desktop Swing dialog on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)