### PR TITLE
Redesign in-chat Event composer + timezone picker (Material 3)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventComposerSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventComposerSheet.kt
@@ -1,43 +1,52 @@
 package id.homebase.chat.event
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.automirrored.filled.Notes
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.MyLocation
+import androidx.compose.material.icons.filled.Public
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.Videocam
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TimePicker
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -46,10 +55,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import id.homebase.api.client.location.LocationPreviewProvider
 import id.homebase.api.util.truncateToCodePoints
 import id.homebase.chat.location.LocationResult
@@ -57,22 +67,19 @@ import id.homebase.chat.location.rememberCurrentLocationLauncher
 import id.homebase.chat.services.ChatMessageSenderService
 import id.homebase.chat.services.content.MessageContent
 import id.homebase.core.ui.theme.HomebaseTheme
+import id.homebase.core.util.rememberImeOffsetState
 import id.homebase.resources.MR
 import id.homebase.resources.cancel
-import id.homebase.resources.menu_back
-import id.homebase.resources.chat_event_add_end_time
-import id.homebase.resources.chat_event_create_title
-import id.homebase.resources.chat_event_remove_end_time
-import id.homebase.resources.chat_event_field_description
-import id.homebase.resources.chat_event_field_ends
-import id.homebase.resources.chat_event_field_location
-import id.homebase.resources.chat_event_field_meeting_url
-import id.homebase.resources.chat_event_field_starts
-import id.homebase.resources.chat_event_field_timezone
-import id.homebase.resources.chat_event_field_title
-import id.homebase.resources.chat_event_send
-import id.homebase.resources.chat_event_use_current_location
+import id.homebase.resources.close
 import id.homebase.resources.ok
+import id.homebase.resources.chat_event_add_end_time
+import id.homebase.resources.chat_event_description_hint
+import id.homebase.resources.chat_event_location_hint
+import id.homebase.resources.chat_event_meeting_url_hint
+import id.homebase.resources.chat_event_remove_end_time
+import id.homebase.resources.chat_event_send
+import id.homebase.resources.chat_event_title_hint
+import id.homebase.resources.chat_event_use_current_location
 import kotlin.time.Clock
 import kotlin.time.Instant
 import kotlin.uuid.ExperimentalUuidApi
@@ -91,25 +98,32 @@ import org.koin.compose.koinInject
 private const val MAX_TITLE_CODEPOINTS = 200
 private const val MAX_DESCRIPTION_CODEPOINTS = 4000
 
+/** Vertical gap reserved for the icon column so unlabeled sub-rows align under the row text. */
+private val RowIconGap = 20.dp
+
 /**
- * Fullscreen dialog that collects event details and sends the message.
+ * Bottom-sheet composer for an Event message, modeled on the Google Calendar
+ * quick-create screen: a borderless title, then flat icon-led rows.
  *
- * State is local — the composer is short-lived (open → fill → send → dismiss)
- * and doesn't survive process death meaningfully, so `remember` is enough.
+ * Presentation only — [EventDescriptor], the wire format and the send path are
+ * unchanged. State is local `remember` (the composer is short-lived:
+ * open → fill → send/dismiss).
  */
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalUuidApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EventComposerSheet(
     conversationId: Uuid,
     onDismiss: () -> Unit,
     onSent: () -> Unit,
 ) {
-    Dialog(
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
         onDismissRequest = onDismiss,
-        properties = DialogProperties(usePlatformDefaultWidth = false),
+        sheetState = sheetState,
     ) {
         EventComposerContent(
             conversationId = conversationId,
+            sheetState = sheetState,
             onDismiss = onDismiss,
             onSent = onSent,
         )
@@ -120,11 +134,20 @@ fun EventComposerSheet(
 @Composable
 private fun EventComposerContent(
     conversationId: Uuid,
+    sheetState: SheetState,
     onDismiss: () -> Unit,
     onSent: () -> Unit,
 ) {
     val sender: ChatMessageSenderService = koinInject()
     val scope = rememberCoroutineScope()
+    val brand = HomebaseTheme.extendedColors.bubbleSentSurface
+
+    // Keyboard inset — matches Vault/Chat. Pad by the PURE ime height (ime minus
+    // the home-indicator inset that WindowInsets.ime double-counts on iOS) so the
+    // last field sits flush above the keyboard. Raw imePadding() leaves a
+    // home-indicator-sized gray gap on iOS (see ImeOffsetUtils).
+    val imeState = rememberImeOffsetState()
+    val pureImeBottomDp = with(imeState.density) { imeState.pureImeBottomPx.toDp() }
 
     var title by remember { mutableStateOf("") }
     var description by remember { mutableStateOf("") }
@@ -134,11 +157,10 @@ private fun EventComposerContent(
     // Default start: next round hour. End: start + 1 hour.
     val defaultStart = remember {
         val now = Clock.System.now().toLocalDateTime(systemTz)
-        val rounded = LocalDateTime(
+        LocalDateTime(
             year = now.year, month = now.month, day = now.day,
             hour = (now.hour + 1).coerceAtMost(23), minute = 0, second = 0, nanosecond = 0,
         )
-        rounded
     }
     var startDateTime by remember { mutableStateOf(defaultStart) }
     var endDateTime by remember {
@@ -191,6 +213,13 @@ private fun EventComposerContent(
         derivedStateOf { title.isNotBlank() && !sending }
     }
 
+    val dismiss: () -> Unit = {
+        scope.launch {
+            sheetState.hide()
+            onDismiss()
+        }
+    }
+
     val doSend: () -> Unit = {
         if (isValid) {
             sending = true
@@ -217,113 +246,152 @@ private fun EventComposerContent(
                         previousMessageUniqueId = null,
                     )
                 }
-                sending = false
+                sheetState.hide()
                 onSent()
             }
         }
     }
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text(stringResource(MR.string.chat_event_create_title)) },
-                navigationIcon = {
-                    IconButton(onClick = onDismiss) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(MR.string.menu_back),
-                        )
+    Column(modifier = Modifier.fillMaxWidth().fillMaxHeight(0.92f)) {
+        // Top bar: close (start) · Send (end).
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 4.dp, end = 16.dp, bottom = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(onClick = dismiss) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = stringResource(MR.string.close),
+                )
+            }
+            Spacer(Modifier.weight(1f))
+            Button(
+                onClick = doSend,
+                enabled = isValid,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = brand,
+                    contentColor = HomebaseTheme.extendedColors.bubbleSentOnSurface,
+                ),
+            ) {
+                Text(stringResource(MR.string.chat_event_send))
+            }
+        }
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                // Pure-IME bottom inset OUTSIDE verticalScroll shrinks the scroll
+                // viewport by exactly the keyboard height; the focused-field
+                // auto-scroll then parks the last row just above the keyboard
+                // (matches Vault/Chat — no gray home-indicator gap on iOS).
+                .padding(bottom = pureImeBottomDp)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 20.dp),
+        ) {
+            // Title — borderless headline with a brand-blue underline indicator.
+            val titleInteraction = remember { MutableInteractionSource() }
+            val titleFocused by titleInteraction.collectIsFocusedAsState()
+            BasicTextField(
+                value = title,
+                onValueChange = { title = it },
+                singleLine = true,
+                textStyle = MaterialTheme.typography.headlineSmall.copy(
+                    color = MaterialTheme.colorScheme.onSurface,
+                ),
+                cursorBrush = SolidColor(brand),
+                interactionSource = titleInteraction,
+                modifier = Modifier.fillMaxWidth().padding(top = 8.dp, bottom = 6.dp),
+                decorationBox = { inner ->
+                    Box {
+                        if (title.isEmpty()) {
+                            Text(
+                                text = stringResource(MR.string.chat_event_title_hint),
+                                style = MaterialTheme.typography.headlineSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        inner()
                     }
                 },
             )
-        },
-        modifier = Modifier.fillMaxSize(),
-    ) { padding ->
-        Column(
-            modifier = Modifier
-                .padding(padding)
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            OutlinedTextField(
-                value = title,
-                onValueChange = { title = it },
-                label = { Text(stringResource(MR.string.chat_event_field_title)) },
-                singleLine = true,
-                modifier = Modifier.fillMaxWidth(),
-            )
-            OutlinedTextField(
-                value = description,
-                onValueChange = { description = it },
-                label = { Text(stringResource(MR.string.chat_event_field_description)) },
-                modifier = Modifier.fillMaxWidth().height(120.dp),
+            HorizontalDivider(
+                thickness = if (titleFocused) 2.dp else 1.dp,
+                color = if (titleFocused) brand else MaterialTheme.colorScheme.outlineVariant,
             )
 
-            DateTimeRow(
-                label = stringResource(MR.string.chat_event_field_starts),
-                local = startDateTime,
-                onPickDate = { showStartDate = true },
-                onPickTime = { showStartTime = true },
-            )
+            Spacer(Modifier.height(12.dp))
 
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                TextButton(onClick = { hasEndTime = !hasEndTime }) {
-                    Text(
-                        text = stringResource(
-                            if (hasEndTime) MR.string.chat_event_remove_end_time
-                            else MR.string.chat_event_add_end_time,
-                        ),
+            // WHEN group — clock row (start/end + toggle) and timezone row.
+            ComposerRow(icon = Icons.Default.Schedule, filled = true, verticalAlignment = Alignment.Top) {
+                Column(modifier = Modifier.weight(1f)) {
+                    DateTimeLine(
+                        local = startDateTime,
+                        onPickDate = { showStartDate = true },
+                        onPickTime = { showStartTime = true },
                     )
+                    if (hasEndTime) {
+                        DateTimeLine(
+                            local = endDateTime,
+                            onPickDate = { showEndDate = true },
+                            onPickTime = { showEndTime = true },
+                        )
+                    }
+                    TextButton(
+                        onClick = { hasEndTime = !hasEndTime },
+                        // Negative offset cancels the wider horizontal content
+                        // padding, so the label stays left-aligned with the date
+                        // above it while the hover/ripple splash reads wider.
+                        modifier = Modifier.offset(x = (-12).dp),
+                        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp),
+                    ) {
+                        Text(
+                            text = stringResource(
+                                if (hasEndTime) MR.string.chat_event_remove_end_time
+                                else MR.string.chat_event_add_end_time,
+                            ),
+                        )
+                    }
                 }
             }
-            if (hasEndTime) {
-                DateTimeRow(
-                    label = stringResource(MR.string.chat_event_field_ends),
-                    local = endDateTime,
-                    onPickDate = { showEndDate = true },
-                    onPickTime = { showEndTime = true },
+            ComposerRow(
+                icon = Icons.Default.Public,
+                filled = true,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(12.dp))
+                    .clickable(onClick = { tzExpanded = true }),
+            ) {
+                Text(
+                    text = friendlyZoneLabel(timezone),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.weight(1f),
                 )
             }
 
-            Box(modifier = Modifier.fillMaxWidth()) {
-                OutlinedTextField(
-                    value = friendlyZoneLabel(timezone),
-                    onValueChange = {},
-                    readOnly = true,
-                    label = { Text(stringResource(MR.string.chat_event_field_timezone)) },
-                    modifier = Modifier.fillMaxWidth(),
-                )
-                Box(
-                    modifier = Modifier
-                        .matchParentSize()
-                        .clickable(onClick = { tzExpanded = true })
-                )
-            }
-            if (tzExpanded) {
-                TimezonePickerSheet(
-                    currentZoneId = timezone,
-                    onPick = { picked ->
-                        timezone = picked
-                        tzExpanded = false
-                    },
-                    onDismiss = { tzExpanded = false },
+            HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+
+            // Meeting link.
+            ComposerRow(icon = Icons.Default.Videocam, filled = meetingUrl.isNotEmpty()) {
+                EditableField(
+                    value = meetingUrl,
+                    onValueChange = { meetingUrl = it },
+                    placeholder = stringResource(MR.string.chat_event_meeting_url_hint),
+                    singleLine = true,
+                    keyboardType = KeyboardType.Uri,
+                    cursorColor = brand,
                 )
             }
 
-            OutlinedTextField(
-                value = locationText,
-                onValueChange = {
-                    locationText = it
-                    // The user is hand-editing the address, so previously captured
-                    // coordinates no longer correspond. Drop them.
-                    locationLat = null
-                    locationLon = null
-                },
-                label = { Text(stringResource(MR.string.chat_event_field_location)) },
-                singleLine = true,
-                trailingIcon = {
+            HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+
+            // Location, with a current-location trailing action.
+            ComposerRow(
+                icon = Icons.Default.LocationOn,
+                filled = locationText.isNotEmpty(),
+                trailing = {
                     IconButton(
                         enabled = !fetchingLocation,
                         onClick = {
@@ -337,37 +405,52 @@ private fun EventComposerContent(
                         )
                     }
                 },
-                modifier = Modifier.fillMaxWidth(),
-            )
-            OutlinedTextField(
-                value = meetingUrl,
-                onValueChange = { meetingUrl = it },
-                label = { Text(stringResource(MR.string.chat_event_field_meeting_url)) },
-                singleLine = true,
-                modifier = Modifier.fillMaxWidth(),
-            )
-
-            Spacer(Modifier.height(8.dp))
-
-            Button(
-                onClick = doSend,
-                enabled = isValid,
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = HomebaseTheme.extendedColors.bubbleSentSurface,
-                    contentColor = HomebaseTheme.extendedColors.bubbleSentOnSurface,
-                ),
-                modifier = Modifier.fillMaxWidth(),
             ) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.Send,
-                    contentDescription = null,
+                EditableField(
+                    value = locationText,
+                    onValueChange = {
+                        locationText = it
+                        // The user is hand-editing the address, so previously captured
+                        // coordinates no longer correspond. Drop them.
+                        locationLat = null
+                        locationLon = null
+                    },
+                    placeholder = stringResource(MR.string.chat_event_location_hint),
+                    singleLine = true,
+                    cursorColor = brand,
                 )
-                Spacer(Modifier.width(8.dp))
-                Text(stringResource(MR.string.chat_event_send))
+            }
+
+            HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+
+            // Description.
+            ComposerRow(
+                icon = Icons.AutoMirrored.Filled.Notes,
+                filled = description.isNotEmpty(),
+                verticalAlignment = Alignment.Top,
+            ) {
+                EditableField(
+                    value = description,
+                    onValueChange = { description = it },
+                    placeholder = stringResource(MR.string.chat_event_description_hint),
+                    singleLine = false,
+                    cursorColor = brand,
+                )
             }
 
             Spacer(Modifier.height(24.dp))
         }
+    }
+
+    if (tzExpanded) {
+        TimezonePickerSheet(
+            currentZoneId = timezone,
+            onPick = { picked ->
+                timezone = picked
+                tzExpanded = false
+            },
+            onDismiss = { tzExpanded = false },
+        )
     }
 
     if (showStartDate) {
@@ -412,30 +495,101 @@ private fun EventComposerContent(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+/** A flat, icon-led row: leading icon + [content] + optional [trailing]. */
 @Composable
-private fun DateTimeRow(
-    label: String,
+private fun ComposerRow(
+    icon: ImageVector,
+    filled: Boolean,
+    modifier: Modifier = Modifier,
+    verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
+    trailing: @Composable (() -> Unit)? = null,
+    content: @Composable RowScope.() -> Unit,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth().padding(vertical = 10.dp),
+        verticalAlignment = verticalAlignment,
+        horizontalArrangement = Arrangement.spacedBy(RowIconGap),
+    ) {
+        Icon(
+            imageVector = icon,
+            // Decorative — the adjacent text/field conveys the row's meaning.
+            contentDescription = null,
+            tint = if (filled) MaterialTheme.colorScheme.onSurface
+            else MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        content()
+        trailing?.invoke()
+    }
+}
+
+/** Inline, borderless editable text used inside a [ComposerRow] (no box chrome). */
+@Composable
+private fun RowScope.EditableField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    singleLine: Boolean,
+    cursorColor: androidx.compose.ui.graphics.Color,
+    keyboardType: KeyboardType = KeyboardType.Text,
+) {
+    BasicTextField(
+        value = value,
+        onValueChange = onValueChange,
+        singleLine = singleLine,
+        textStyle = MaterialTheme.typography.bodyLarge.copy(
+            color = MaterialTheme.colorScheme.onSurface,
+        ),
+        cursorBrush = SolidColor(cursorColor),
+        keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+        modifier = Modifier.weight(1f),
+        decorationBox = { inner ->
+            Box {
+                if (value.isEmpty()) {
+                    Text(
+                        text = placeholder,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                inner()
+            }
+        },
+    )
+}
+
+/** One "date · time" line where the date and the time are independently tappable. */
+@Composable
+private fun DateTimeLine(
     local: LocalDateTime,
     onPickDate: () -> Unit,
     onPickTime: () -> Unit,
 ) {
-    val dateText = local.toString().substringBefore('T')
-    val timeText = local.hour.toString().padStart(2, '0') +
-        ":" + local.minute.toString().padStart(2, '0')
-    Column {
-        Text(text = label, style = MaterialTheme.typography.labelLarge)
-        Spacer(Modifier.height(4.dp))
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            OutlinedButton(onClick = onPickDate, modifier = Modifier.weight(1f)) {
-                Text(text = dateText)
-            }
-            OutlinedButton(onClick = onPickTime, modifier = Modifier.weight(1f)) {
-                Text(text = timeText)
-            }
-        }
+    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = formatFriendlyDate(local),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f).clip(RoundedCornerShape(8.dp)).clickable(onClick = onPickDate).padding(vertical = 6.dp),
+        )
+        Text(
+            text = formatTime(local),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.clip(RoundedCornerShape(8.dp)).clickable(onClick = onPickTime).padding(vertical = 6.dp, horizontal = 4.dp),
+        )
     }
 }
+
+/** e.g. "Tue, Jun 16, 2026". */
+private fun formatFriendlyDate(d: LocalDateTime): String {
+    val dow = d.dayOfWeek.name.lowercase().replaceFirstChar { it.uppercase() }.take(3)
+    val mon = d.month.name.lowercase().replaceFirstChar { it.uppercase() }.take(3)
+    return "$dow, $mon ${d.day}, ${d.year}"
+}
+
+/** 24h "HH:mm". */
+private fun formatTime(d: LocalDateTime): String =
+    d.hour.toString().padStart(2, '0') + ":" + d.minute.toString().padStart(2, '0')
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventDetailDialog.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventDetailDialog.kt
@@ -19,8 +19,11 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.QuestionMark
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.Videocam
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -40,6 +43,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
@@ -282,21 +286,21 @@ private fun EventDetailContent(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 RsvpButton(
-                    emoji = EventRsvp.GOING,
+                    icon = Icons.Default.Check,
                     label = stringResource(MR.string.chat_event_rsvp_yes),
                     selected = currentRsvp == EventRsvp.GOING,
                     onClick = { scope.launch { applyRsvp(actionService, conversationId, messageId, currentRsvp, EventRsvp.GOING) } },
                     modifier = Modifier.weight(1f),
                 )
                 RsvpButton(
-                    emoji = EventRsvp.MAYBE,
+                    icon = Icons.Default.QuestionMark,
                     label = stringResource(MR.string.chat_event_rsvp_maybe),
                     selected = currentRsvp == EventRsvp.MAYBE,
                     onClick = { scope.launch { applyRsvp(actionService, conversationId, messageId, currentRsvp, EventRsvp.MAYBE) } },
                     modifier = Modifier.weight(1f),
                 )
                 RsvpButton(
-                    emoji = EventRsvp.NOT_GOING,
+                    icon = Icons.Default.Close,
                     label = stringResource(MR.string.chat_event_rsvp_no),
                     selected = currentRsvp == EventRsvp.NOT_GOING,
                     onClick = { scope.launch { applyRsvp(actionService, conversationId, messageId, currentRsvp, EventRsvp.NOT_GOING) } },
@@ -333,21 +337,21 @@ private fun RsvpRoster(
     Column {
         RsvpSection(
             sectionLabel = stringResource(MR.string.chat_event_rsvp_yes),
-            emoji = EventRsvp.GOING,
+            icon = Icons.Default.Check,
             reactors = reactions.filter { it.emoji == EventRsvp.GOING },
             contactService = contactService,
             selfOdinId = selfOdinId,
         )
         RsvpSection(
             sectionLabel = stringResource(MR.string.chat_event_rsvp_maybe),
-            emoji = EventRsvp.MAYBE,
+            icon = Icons.Default.QuestionMark,
             reactors = reactions.filter { it.emoji == EventRsvp.MAYBE },
             contactService = contactService,
             selfOdinId = selfOdinId,
         )
         RsvpSection(
             sectionLabel = stringResource(MR.string.chat_event_rsvp_no),
-            emoji = EventRsvp.NOT_GOING,
+            icon = Icons.Default.Close,
             reactors = reactions.filter { it.emoji == EventRsvp.NOT_GOING },
             contactService = contactService,
             selfOdinId = selfOdinId,
@@ -358,18 +362,26 @@ private fun RsvpRoster(
 @Composable
 private fun RsvpSection(
     sectionLabel: String,
-    emoji: String,
+    icon: ImageVector,
     reactors: List<EmojiReaction>,
     contactService: ContactService,
     selfOdinId: OdinId?,
 ) {
     if (reactors.isEmpty()) return
     val youLabel = stringResource(MR.string.you)
-    // Format: "<emoji> <localized label> · <count>". The pieces are already
-    // localized; this is a presentational concat, not a translatable string.
-    val headerText = emoji + " " + sectionLabel + " · " + reactors.size.toString()
+    // "<localized label> · <count>", with a small leading vector icon. The
+    // pieces are already localized; this is a presentational concat, not a
+    // translatable string.
+    val headerText = sectionLabel + " · " + reactors.size.toString()
     Spacer(Modifier.height(12.dp))
     Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(16.dp),
+        )
+        Spacer(Modifier.width(6.dp))
         Text(
             text = headerText,
             style = MaterialTheme.typography.labelLarge,
@@ -629,7 +641,7 @@ private fun ActionRow(
 
 @Composable
 private fun RsvpButton(
-    emoji: String,
+    icon: ImageVector,
     label: String,
     selected: Boolean,
     onClick: () -> Unit,
@@ -651,8 +663,13 @@ private fun RsvpButton(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
         ) {
-            Text(text = emoji, style = MaterialTheme.typography.titleLarge)
-            Spacer(Modifier.height(2.dp))
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = onContainer,
+                modifier = Modifier.size(26.dp),
+            )
+            Spacer(Modifier.height(4.dp))
             Text(
                 text = label,
                 style = MaterialTheme.typography.labelSmall,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/TimezonePicker.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/TimezonePicker.kt
@@ -3,35 +3,46 @@ package id.homebase.chat.event
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Public
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import id.homebase.resources.MR
+import id.homebase.resources.menu_back
 import id.homebase.resources.chat_event_tz_picker_search
-import id.homebase.resources.chat_event_tz_picker_title
 import id.homebase.resources.chat_event_tz_region_africa
 import id.homebase.resources.chat_event_tz_region_americas
 import id.homebase.resources.chat_event_tz_region_antarctica
@@ -47,6 +58,7 @@ import kotlin.time.Clock
 import kotlin.time.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.offsetIn
+import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 
@@ -72,6 +84,13 @@ internal fun currentOffsetLabel(zoneId: String, now: Instant = Clock.System.now(
     val mins = absMin % 60
     return if (mins == 0) "GMT$sign$hours"
     else "GMT$sign$hours:${mins.toString().padStart(2, '0')}"
+}
+
+/** Current wall-clock time in `zoneId` at `now`, as 24h "HH:mm" (empty if the zone is invalid). */
+internal fun currentTimeInZone(zoneId: String, now: Instant = Clock.System.now()): String {
+    val tz = runCatching { TimeZone.of(zoneId) }.getOrNull() ?: return ""
+    val t = now.toLocalDateTime(tz).time
+    return t.hour.toString().padStart(2, '0') + ":" + t.minute.toString().padStart(2, '0')
 }
 
 /** Last IANA segment with underscores → spaces. UTC and other no-slash zones pass through. */
@@ -119,6 +138,15 @@ private val mainPrefixes = setOf(
     "Atlantic", "Australia", "Europe", "Indian", "Pacific",
 )
 
+/**
+ * Full-screen timezone picker that **appears in place** (no bottom-to-top slide):
+ * a top search bar (back + inline search) over a browsable, grouped list — modeled
+ * on the system "region or time zone" page. Rendered as a [Dialog] (which just
+ * shows, rather than sliding) sized to fill the screen.
+ *
+ * The search is not auto-focused, so the list is browsable immediately and the
+ * keyboard only appears when the user taps the field.
+ */
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun TimezonePickerSheet(
@@ -126,13 +154,10 @@ fun TimezonePickerSheet(
     onPick: (String) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val deviceZoneId = remember { TimeZone.currentSystemDefault().id }
     val now = remember { Clock.System.now() }
 
     var query by remember { mutableStateOf("") }
-    val focusRequester = remember { FocusRequester() }
-    LaunchedEffect(Unit) { focusRequester.requestFocus() }
 
     // All "main" zones sorted by city name within each continent. UTC is
     // surfaced separately in Suggested, not in the main grouped list.
@@ -153,66 +178,114 @@ fun TimezonePickerSheet(
         derivedStateOf { filtered.groupBy(::continentDisplayName) }
     }
 
-    ModalBottomSheet(
+    Dialog(
         onDismissRequest = onDismiss,
-        sheetState = sheetState,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
-        Column(modifier = Modifier.fillMaxWidth().heightIn(min = 320.dp, max = 640.dp)) {
-            Text(
-                text = stringResource(MR.string.chat_event_tz_picker_title),
-                style = MaterialTheme.typography.titleLarge,
-                modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
-            )
-            OutlinedTextField(
-                value = query,
-                onValueChange = { query = it },
-                singleLine = true,
-                placeholder = { Text(stringResource(MR.string.chat_event_tz_picker_search)) },
+        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surface) {
+            Column(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 4.dp)
-                    .focusRequester(focusRequester),
-            )
+                    .fillMaxSize()
+                    .statusBarsPadding()
+                    .navigationBarsPadding(),
+            ) {
+                SearchBar(
+                    query = query,
+                    onQueryChange = { query = it },
+                    onBack = onDismiss,
+                )
 
-            val lazyState = rememberLazyListState()
-            LazyColumn(modifier = Modifier.fillMaxWidth(), state = lazyState) {
-                if (query.isBlank()) {
-                    stickyHeader {
-                        SectionHeader(stringResource(MR.string.chat_event_tz_suggested))
+                val lazyState = rememberLazyListState()
+                LazyColumn(
+                    modifier = Modifier.fillMaxWidth().imePadding(),
+                    state = lazyState,
+                ) {
+                    if (query.isBlank()) {
+                        stickyHeader {
+                            SectionHeader(stringResource(MR.string.chat_event_tz_suggested))
+                        }
+                        item {
+                            ZoneRow(
+                                zoneId = deviceZoneId,
+                                selected = deviceZoneId == currentZoneId,
+                                now = now,
+                                onClick = { onPick(deviceZoneId) },
+                            )
+                        }
+                        item {
+                            ZoneRow(
+                                zoneId = "UTC",
+                                selected = currentZoneId == "UTC",
+                                now = now,
+                                onClick = { onPick("UTC") },
+                            )
+                        }
                     }
-                    item {
-                        ZoneRow(
-                            zoneId = deviceZoneId,
-                            selected = deviceZoneId == currentZoneId,
-                            now = now,
-                            onClick = { onPick(deviceZoneId) },
-                        )
-                    }
-                    item {
-                        ZoneRow(
-                            zoneId = "UTC",
-                            selected = currentZoneId == "UTC",
-                            now = now,
-                            onClick = { onPick("UTC") },
-                        )
-                    }
-                }
 
-                grouped.forEach { (continent, zones) ->
-                    stickyHeader(key = "h-$continent") {
-                        SectionHeader(localizedContinentName(continent))
-                    }
-                    items(zones, key = { it }) { zoneId ->
-                        ZoneRow(
-                            zoneId = zoneId,
-                            selected = zoneId == currentZoneId,
-                            now = now,
-                            onClick = { onPick(zoneId) },
-                        )
+                    grouped.forEach { (continent, zones) ->
+                        stickyHeader(key = "h-$continent") {
+                            SectionHeader(localizedContinentName(continent))
+                        }
+                        items(zones, key = { it }) { zoneId ->
+                            ZoneRow(
+                                zoneId = zoneId,
+                                selected = zoneId == currentZoneId,
+                                now = now,
+                                onClick = { onPick(zoneId) },
+                            )
+                        }
                     }
                 }
             }
         }
+    }
+}
+
+/** Top search bar: back arrow + a borderless inline search field with a leading search icon. */
+@Composable
+private fun SearchBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onBack: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 4.dp, end = 16.dp, top = 4.dp, bottom = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = stringResource(MR.string.menu_back),
+            )
+        }
+        Icon(
+            imageVector = Icons.Default.Search,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        BasicTextField(
+            value = query,
+            onValueChange = onQueryChange,
+            singleLine = true,
+            textStyle = MaterialTheme.typography.bodyLarge.copy(
+                color = MaterialTheme.colorScheme.onSurface,
+            ),
+            cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+            modifier = Modifier.fillMaxWidth(),
+            decorationBox = { inner ->
+                if (query.isEmpty()) {
+                    Text(
+                        text = stringResource(MR.string.chat_event_tz_picker_search),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                inner()
+            },
+        )
     }
 }
 
@@ -233,28 +306,36 @@ private fun SectionHeader(label: String) {
     }
 }
 
+/** A clean zone row: leading globe + city name + live "HH:mm · GMT±X". */
 @Composable
 private fun ZoneRow(zoneId: String, selected: Boolean, now: Instant, onClick: () -> Unit) {
     val bg = if (selected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surface
     val onBg = if (selected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface
-    Box(
+    Row(
         modifier = Modifier
             .fillMaxWidth()
             .background(bg)
             .clickable(onClick = onClick)
-            .padding(horizontal = 20.dp, vertical = 10.dp),
+            .padding(horizontal = 20.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(20.dp),
     ) {
-        val cityWithOffset = "${cityName(zoneId)} · ${currentOffsetLabel(zoneId, now)}"
+        Icon(
+            imageVector = Icons.Default.Public,
+            contentDescription = null,
+            tint = onBg.copy(alpha = 0.7f),
+        )
         Column {
             Text(
-                text = cityWithOffset,
+                text = cityName(zoneId),
                 style = MaterialTheme.typography.bodyLarge,
                 color = onBg,
             )
+            val timeWithOffset = "${currentTimeInZone(zoneId, now)} · ${currentOffsetLabel(zoneId, now)}"
             Text(
-                text = zoneId,
-                style = MaterialTheme.typography.labelSmall,
-                color = onBg.copy(alpha = 0.6f),
+                text = timeWithOffset,
+                style = MaterialTheme.typography.bodyMedium,
+                color = onBg.copy(alpha = 0.7f),
             )
         }
     }

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="share">Share</string>
     <string name="ok">Ok</string>
     <string name="cancel">Cancel</string>
+    <string name="close">Close</string>
     <string name="replying_to">Replying to %1$s</string>
     <string name="cancel_reply">Cancel reply</string>
     <string name="backspace">Backspace</string>
@@ -723,6 +724,10 @@
     <string name="chat_event_scheduled_in_zone">Scheduled: %1$s %2$s</string>
     <string name="chat_event_add_end_time">Add end time</string>
     <string name="chat_event_remove_end_time">Remove end time</string>
+    <string name="chat_event_title_hint">Add title</string>
+    <string name="chat_event_location_hint">Add location</string>
+    <string name="chat_event_meeting_url_hint">Add meeting link</string>
+    <string name="chat_event_description_hint">Add description</string>
     <string name="chat_event_organized_by">Organized by</string>
     <string name="chat_event_tz_picker_title">Time zone</string>
     <string name="chat_event_tz_picker_search">Search city or zone</string>


### PR DESCRIPTION
## Summary
Redesigns the in-chat **Event** composer and the **timezone** picker to Material 3, and cleans up the event detail RSVP UI. **Presentation-only** — `EventDescriptor`, the wire format, and the send path are unchanged.

### Event composer (`EventComposerSheet`)
- `ModalBottomSheet` (~92% height, drag handle) modeled on Google Calendar quick-create, replacing the fullscreen `Dialog` + flat `OutlinedTextField` stack.
- Borderless **Add title** with a brand-blue underline; flat icon-led rows (**When** / Meeting link / Location / Description) using inline `BasicTextField`s; **X** + brand-blue **Send** top bar.
- Friendly date format (`Tue, Jun 16, 2026`); existing M3 `DatePicker`/`TimePicker` dialogs.
- Keyboard: `pureImeBottomPx` (the Vault/Chat pattern) — the last field sits flush above the keyboard with no iOS home-indicator gap.
- Clickable rows get rounded hover/ripple corners; "Add end time" hover widened.

### Timezone picker (`TimezonePicker`)
- Full-screen page that just appears (no bottom-to-top slide); back + inline search bar (no auto-keyboard); globe-led rows showing live local time + offset.

### Event detail (`EventDetailDialog`)
- RSVP buttons + reactor roster render vector icons (Check / QuestionMark / Close) instead of emoji. `EventRsvp` emoji constants are unchanged (still the stored reaction values) — display-only swap.

### Strings
- 5 new strings (`close`, `chat_event_title_hint`, `…_location_hint`, `…_meeting_url_hint`, `…_description_hint`).

## Verification
- Compiles: JVM, Android, iOS (simulator).
- Konsist `ArchitectureTest` + `homebase-chat` JVM tests pass.
- Android device: composer renders, date/time/timezone pickers, send produces the event bubble.
- iOS sim: event bubble, detail RSVP icons, timezone redesign, app launches.
- Desktop: composer renders, hover states.

## Deferred (separate, app-wide)
- iOS full-screen **Dialog** safe-area gray bars (status bar / home indicator). Pre-existing for *all* dialogs (event / timezone / groodle / dice); CMP 1.10.2 removed the `platformLayers` toggle, so the fix needs inline-overlay rendering and will be handled in a dedicated change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)