### PR TITLE
DriveRegistry: reconcile local registry with server on bootstrap

### DIFF
--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/DriveRegistry.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/DriveRegistry.kt
@@ -115,14 +115,20 @@ class DriveRegistry(
         loadDrives().any { it.drive.alias == driveId }
 
     /**
-     * Resolve the registry on login: try the local index first (fast, offline-safe,
-     * covers cold boot of returning users), then fall back to a single
-     * `getFileHeaderByUid` HTTP call (covers fresh login on a new device or one whose
-     * local DB was wiped). On both-empty or any fetch failure, returns an empty list
-     * so the caller proceeds with mandatory drives only — the observer will pick the
-     * file up on the next chat-drive sync.
+     * Resolve the registry on login by reconciling the local index with the server.
+     * Reads the local index (fast, offline-safe) AND issues a single `getFileHeaderByUid`
+     * HTTP call for the authoritative server copy, returning the **union** of the two.
+     * On any fetch failure (offline) or when the server has no registry file, falls back
+     * to the local list — so a failed fetch never drops the user's drives.
      *
-     * This eliminates the "first WS connect subscribes to mandatory only, then
+     * Reconciling on every login (not just when local is empty) is what lets a drive
+     * activated on ANOTHER device be mounted here at login: it's in the server registry
+     * file but not necessarily in this device's local index yet. Returning the local list
+     * whenever it was non-empty left such a device stuck on its stale cache until some
+     * later chat-drive sync happened to redeliver the registry file — the reconciliation
+     * bug this method now fixes.
+     *
+     * This also eliminates the "first WS connect subscribes to mandatory only, then
      * reconnects after the first sync delivers the registry file" race on fresh
      * login. Callers should pass the result to both [AuthConnectionCoordinator.connect]
      * (so the WS subscribes to the full set on the first connect) and [start]'s
@@ -171,29 +177,55 @@ class DriveRegistry(
         Logger.i(tag = TAG) { "bootstrap() begin" }
         val local = loadDrives()
         Logger.i(tag = TAG) { "bootstrap local-DB returned ${local.size} drive(s)" }
-        if (local.isNotEmpty()) {
-            Logger.i(tag = TAG) { "bootstrap() end (local, ${local.size} drive(s))" }
-            return local
-        }
+
+        // Always reconcile against the server, even when the local cache is non-empty.
+        // The local index is only as fresh as the last chat-drive sync delivered: a drive
+        // activated on ANOTHER device lives in the server registry file but may not be in
+        // this device's local index yet, and nothing would mount it at login. (Returning
+        // local-when-non-empty was the reconciliation bug — a stale cache never caught up
+        // until some later chat-drive sync happened to redeliver the registry file.)
         val chatDriveId = SystemDriveConstants.chatDrive.alias
-        Logger.i(tag = TAG) { "bootstrap falling back to server fetch" }
-        val server = try {
-            getFileHeaderByUid(chatDriveId, REGISTRY_UNIQUE_ID)
+        val server: List<LabeledDrive>? = try {
+            getFileHeaderByUid(chatDriveId, REGISTRY_UNIQUE_ID)?.let { parseRegistryContent(it) }
         } catch (e: CancellationException) {
             // Don't swallow cancellation — let the caller's scope tear down cleanly.
             throw e
         } catch (e: Exception) {
             Logger.w(tag = TAG, throwable = e) {
-                "bootstrap server fetch failed — falling back to empty (observer will pick up after first sync)"
+                "bootstrap server fetch failed — using local registry only (${local.size} drive(s))"
             }
-            return emptyList()
-        } ?: run {
-            Logger.i(tag = TAG) { "bootstrap() end (server returned no registry file, 0 drives)" }
-            return emptyList()
+            null
         }
-        val parsed = parseRegistryContent(server)
-        Logger.i(tag = TAG) { "bootstrap() end (server, ${parsed.size} drive(s))" }
-        return parsed
+
+        if (server == null) {
+            // Offline / fetch error / no registry file on the server yet. Trust the local
+            // cache (empty on a fresh install — the observer picks the file up on the first
+            // chat-drive sync). Offline-safe: a failed fetch never drops the user's drives.
+            Logger.i(tag = TAG) { "bootstrap() end (local-only, ${local.size} drive(s))" }
+            return local
+        }
+
+        // Union local with the server list so a drive activated elsewhere (server-only, not
+        // yet synced locally) is mounted at login, while a drive just activated on THIS
+        // device (local-only, not yet reflected by a stale server replica read) is never
+        // dropped. The post-login observer ([start]/[reconcile]) keeps the two converging
+        // thereafter, including propagating removals once the local index catches up.
+        val merged = unionByAlias(local, server)
+        Logger.i(tag = TAG) {
+            "bootstrap() end (reconciled local=${local.size} + server=${server.size} -> ${merged.size} drive(s))"
+        }
+        return merged
+    }
+
+    private fun unionByAlias(
+        primary: List<LabeledDrive>,
+        secondary: List<LabeledDrive>,
+    ): List<LabeledDrive> {
+        val seen = HashSet<Uuid>(primary.size + secondary.size)
+        val result = ArrayList<LabeledDrive>(primary.size + secondary.size)
+        for (drive in primary) if (seen.add(drive.drive.alias)) result.add(drive)
+        for (drive in secondary) if (seen.add(drive.drive.alias)) result.add(drive)
+        return result
     }
 
     /**

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/sync/DriveRegistryTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/sync/DriveRegistryTest.kt
@@ -289,16 +289,43 @@ class DriveRegistryTest {
     // ---------- bootstrap ----------
 
     @Test
-    fun bootstrapReturnsLocalDrivesWithoutFetchingServerWhenLocalAvailable() = runTest {
+    fun bootstrapReconcilesLocalWithServerMountingDriveActivatedElsewhere() = runTest {
+        // Regression: local index has only the drive activated on this device, but the
+        // server registry also lists a drive activated on ANOTHER device. bootstrap must
+        // fetch the server and return the union so the other drive is mounted at login —
+        // it used to short-circuit on the non-empty local cache and never reconcile.
+        val activatedElsewhere = makeLabeledDrive("activated-elsewhere")
         val db = createTestDatabaseManager()
         seedRegistryFile(db, listOf(feedLabeledDrive))
-        val recorder = WriteRecorder()
+        val serverFile = buildRegistryFile(listOf(feedLabeledDrive, activatedElsewhere))
+        val recorder = WriteRecorder(existingServerFile = serverFile)
+        val registry = buildRegistry(db, recorder = recorder)
+
+        val drives = registry.bootstrap()
+
+        assertEquals(
+            listOf(feedLabeledDrive.drive.alias, activatedElsewhere.drive.alias),
+            drives.map { it.drive.alias },
+        )
+        assertEquals(1, recorder.fetchCount, "bootstrap must reconcile against the server even when local has the file")
+        db.close()
+    }
+
+    @Test
+    fun bootstrapFallsBackToLocalWhenServerFetchThrowsAndLocalPresent() = runTest {
+        // Offline-safe: a failed server fetch must never drop the user's already-activated
+        // drives — fall back to the local cache rather than returning empty.
+        val db = createTestDatabaseManager()
+        seedRegistryFile(db, listOf(feedLabeledDrive))
+        val recorder = WriteRecorder(
+            fetchResolver = { throw RuntimeException("simulated network failure") },
+        )
         val registry = buildRegistry(db, recorder = recorder)
 
         val drives = registry.bootstrap()
 
         assertEquals(listOf(feedLabeledDrive.drive.alias), drives.map { it.drive.alias })
-        assertEquals(0, recorder.fetchCount, "bootstrap must not hit the server when local DB has the file")
+        assertEquals(1, recorder.fetchCount)
         db.close()
     }
 


### PR DESCRIPTION
Why:
A drive activated on one device could stay invisible on another. The cross- device registry is a single file on the chat drive, and bootstrap() — which resolves the mounted-drive set at login — returned the LOCAL index whenever it was non-empty, only hitting the server when local was empty. So a device whose local cache already held some drives (e.g. Vault) never reconciled with the server: a drive activated elsewhere (e.g. Moments) lived in the server registry file but was never mounted at login, and the feature's feed stayed empty until some later chat-drive sync happened to redeliver the registry file. Observed in the field: Moments shared with a user delivered a push but never appeared, because the moments drive was never in driveSyncs.

What changed:
- runBootstrap() now ALWAYS issues the single getFileHeaderByUid fetch and returns the UNION of the local and server drive lists, instead of short- circuiting on a non-empty local cache.
- Union (not server-wins) so a drive just activated on THIS device — local- only, possibly not yet reflected by a stale server replica read — is never dropped, while a drive activated elsewhere — server-only — is mounted at login. The post-login observer (start/reconcile) keeps the two converging thereafter, including propagating removals once the local index catches up.
- Offline-safe: on any fetch failure or when the server has no registry file, fall back to the local list — a failed fetch never drops the user's drives.
- Updated the bootstrap() kdoc to describe the reconcile model.
- Tests: replaced the obsolete "must not hit server when local present" test with bootstrapReconcilesLocalWithServerMountingDriveActivatedElsewhere, and added bootstrapFallsBackToLocalWhenServerFetchThrowsAndLocalPresent. The empty-local cases are unchanged and still pass.

Tradeoff:
Every login now performs one extra getFileHeaderByUid GET (coalesced across concurrent callers via the existing in-flight dedupe). On fresh login that call already happened, so no change there; for a returning user's cold boot it adds one round-trip before drives mount + WS connect. When offline the GET fast-fails (e.g. UnknownHostException) and we fall back to local, so the correctness win costs at most one quick failed request on the login path.

Note: this fixes the propagation/reconciliation side only. If an activated drive is missing from the SERVER registry file too, the bug is on the write side (activation never persisted addDrive's upload) and is not addressed here.