### PR TITLE
ContactDetail: harden block/unblock/disconnect handling and copy

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/connections/ConnectionNetworkProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/connections/ConnectionNetworkProvider.kt
@@ -1,5 +1,6 @@
 package id.homebase.api.client.connections
 
+import co.touchlab.kermit.Logger
 import id.homebase.api.client.OdinApiProviderBase
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.common.OdinId
@@ -24,6 +25,10 @@ class ConnectionNetworkProvider(
 
     suspend fun disconnect(odinId: OdinId) {
         postOdinId("/connections/disconnect", odinId)
+    }
+
+    private companion object {
+        const val TAG = "ConnectionNetworkProvider"
     }
 
     suspend fun confirmConnection(odinId: OdinId) {
@@ -151,26 +156,56 @@ class ConnectionNetworkProvider(
     }
 
     private suspend fun postOdinId(endpoint: String, odinId: OdinId) {
+        Logger.i(tag = TAG) { "POST $endpoint odinId=$odinId" }
         post(endpoint, OdinIdRequest(odinId))
     }
 
-    private suspend fun post(endpoint: String, body: Any) {
-        val creds = requireCreds()
-
-        val response = encryptedPostJson(
-            url = apiUrl(creds.domain, endpoint),
-            token = creds.accessToken,
-            jsonBody = OdinSystemSerializer.serialize(body),
-            secret = creds.secret
-        )
-
-        throwForFailure(response)
+    /**
+     * Serialize [body] with its concrete (reified) type, then POST. Serializing through a
+     * `body: Any` parameter erases the type and makes kotlinx.serialization look for an
+     * `Any` serializer (which doesn't exist) — so the reified type must be captured here.
+     */
+    private suspend inline fun <reified T> post(endpoint: String, body: T) {
+        postJson(endpoint, OdinSystemSerializer.serialize(body))
     }
 
-    private suspend inline fun <reified T> postAndDeserialize(
+    /** Shared transport + logging. Takes an already-serialized [jsonBody]. */
+    private suspend fun postJson(endpoint: String, jsonBody: String) {
+        val creds = requireCreds()
+        val url = apiUrl(creds.domain, endpoint)
+
+        val response = try {
+            encryptedPostJson(
+                url = url,
+                token = creds.accessToken,
+                jsonBody = jsonBody,
+                secret = creds.secret
+            )
+        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Logger.w(e, TAG) { "POST $endpoint threw before a response (${e::class.simpleName})" }
+            throw e
+        }
+
+        Logger.i(tag = TAG) {
+            "POST $endpoint -> status=${response.status} body=${response.body.take(500)}"
+        }
+
+        try {
+            throwForFailure(response)
+        } catch (e: Exception) {
+            Logger.w(e, TAG) {
+                "POST $endpoint FAILED status=${response.status} (${e::class.simpleName})"
+            }
+            throw e
+        }
+    }
+
+    private suspend inline fun <reified Req, reified Res> postAndDeserialize(
         endpoint: String,
-        body: Any
-    ): T {
+        body: Req
+    ): Res {
         val creds = requireCreds()
 
         val response = encryptedPostJson(

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1366,8 +1366,13 @@
     <string name="contactbook_error_forbidden">Couldn't save — this app doesn't have permission to manage your contacts. Re-grant access by extending permissions in the owner console, then try again.</string>
     <string name="contactbook_error_connection_forbidden">Couldn't update this connection — this app doesn't have permission to manage your connections. Re-grant access by extending permissions in the owner console, then try again.</string>
     <string name="contactbook_error_delete">Couldn't delete the contact.</string>
+    <string name="contactbook_error_delete_forbidden">Couldn't delete — this app doesn't have permission to manage your contacts. Re-grant access by extending permissions in the owner console, then try again.</string>
     <string name="contactbook_error_import">Couldn't import contacts.</string>
     <string name="contactbook_error_photo">The contact was saved, but the photo couldn't be uploaded.</string>
     <string name="contactbook_error_message">Couldn't open the chat.</string>
+
+    <string name="contactbook_action_blocked">Contact blocked.</string>
+    <string name="contactbook_action_unblocked">Contact unblocked.</string>
+    <string name="contactbook_action_disconnected">Disconnected.</string>
 
 </resources>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1322,9 +1322,9 @@
     <string name="contactbook_detail_more">More</string>
     <string name="contactbook_detail_less">Less</string>
     <string name="contactbook_detail_block_title">Block this contact?</string>
-    <string name="contactbook_detail_block_message">They won't be able to reach you. You can unblock them later.</string>
+    <string name="contactbook_detail_block_message">They won't be able to reach you, and they won't be notified. You can unblock them later to restore the connection.</string>
     <string name="contactbook_detail_disconnect_title">Disconnect?</string>
-    <string name="contactbook_detail_disconnect_message">This removes your connection. You can reconnect later.</string>
+    <string name="contactbook_detail_disconnect_message">This permanently removes your connection and the access it granted. They won't be notified. To reconnect, you'll need to send a new connection request.</string>
     <string name="contactbook_detail_delete_title">Delete contact?</string>
     <string name="contactbook_detail_delete_message">This removes the contact from your address book.</string>
 
@@ -1364,6 +1364,7 @@
 
     <string name="contactbook_error_save">Couldn't save the contact.</string>
     <string name="contactbook_error_forbidden">Couldn't save — this app doesn't have permission to manage your contacts. Re-grant access by extending permissions in the owner console, then try again.</string>
+    <string name="contactbook_error_connection_forbidden">Couldn't update this connection — this app doesn't have permission to manage your connections. Re-grant access by extending permissions in the owner console, then try again.</string>
     <string name="contactbook_error_delete">Couldn't delete the contact.</string>
     <string name="contactbook_error_import">Couldn't import contacts.</string>
     <string name="contactbook_error_photo">The contact was saved, but the photo couldn't be uploaded.</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookService.kt
@@ -52,11 +52,17 @@ class ContactBookService(
         null
     }
 
-    /** Soft-delete. Returns true on success (or already-gone), false on error. */
+    /**
+     * Soft-delete. Returns true on success (or already-gone), false on a generic/transient
+     * error. Rethrows [ForbiddenException] (403) so callers can explain the missing-permission
+     * cause distinctly — mirrors [save].
+     */
     suspend fun delete(uniqueId: Uuid): Boolean = try {
         contactsProvider.deleteContact(uniqueId)
         true
     } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+        throw e
+    } catch (e: ForbiddenException) {
         throw e
     } catch (e: Exception) {
         Logger.w(e, TAG) { "deleteContact failed for $uniqueId" }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailScreen.kt
@@ -73,6 +73,7 @@ import id.homebase.resources.contactbook_detail_edit
 import id.homebase.resources.contactbook_detail_message
 import id.homebase.resources.contactbook_detail_not_connected
 import id.homebase.resources.contactbook_detail_pending
+import id.homebase.resources.contactbook_error_connection_forbidden
 import id.homebase.resources.contactbook_error_forbidden
 import id.homebase.resources.contactbook_error_photo
 import id.homebase.resources.contactbook_error_save
@@ -94,6 +95,7 @@ fun ContactDetailScreen(
     val errSave = stringResource(MR.string.contactbook_error_save)
     val errPhoto = stringResource(MR.string.contactbook_error_photo)
     val errForbidden = stringResource(MR.string.contactbook_error_forbidden)
+    val errConnectionForbidden = stringResource(MR.string.contactbook_error_connection_forbidden)
 
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
@@ -103,6 +105,8 @@ fun ContactDetailScreen(
                 ContactDetailEvent.Back -> onBack()
                 ContactDetailEvent.Error -> snackbarHostState.showSnackbar(errSave)
                 ContactDetailEvent.Forbidden -> snackbarHostState.showSnackbar(errForbidden)
+                ContactDetailEvent.ConnectionForbidden ->
+                    snackbarHostState.showSnackbar(errConnectionForbidden)
                 ContactDetailEvent.PhotoError -> snackbarHostState.showSnackbar(errPhoto)
             }
         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailScreen.kt
@@ -2,6 +2,7 @@
 
 package id.homebase.core.ui.screens.contactbook.detail
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -43,6 +44,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -57,6 +59,9 @@ import id.homebase.core.ui.screens.contactbook.components.ContactBookAvatar
 import id.homebase.core.ui.screens.contactbook.components.ContactEditSheet
 import id.homebase.resources.MR
 import id.homebase.resources.cancel
+import id.homebase.resources.contactbook_action_blocked
+import id.homebase.resources.contactbook_action_disconnected
+import id.homebase.resources.contactbook_action_unblocked
 import id.homebase.resources.contactbook_connected
 import id.homebase.resources.contactbook_detail_block
 import id.homebase.resources.contactbook_detail_block_message
@@ -74,6 +79,8 @@ import id.homebase.resources.contactbook_detail_message
 import id.homebase.resources.contactbook_detail_not_connected
 import id.homebase.resources.contactbook_detail_pending
 import id.homebase.resources.contactbook_error_connection_forbidden
+import id.homebase.resources.contactbook_error_delete
+import id.homebase.resources.contactbook_error_delete_forbidden
 import id.homebase.resources.contactbook_error_forbidden
 import id.homebase.resources.contactbook_error_photo
 import id.homebase.resources.contactbook_error_save
@@ -95,7 +102,12 @@ fun ContactDetailScreen(
     val errSave = stringResource(MR.string.contactbook_error_save)
     val errPhoto = stringResource(MR.string.contactbook_error_photo)
     val errForbidden = stringResource(MR.string.contactbook_error_forbidden)
+    val errDelete = stringResource(MR.string.contactbook_error_delete)
+    val errDeleteForbidden = stringResource(MR.string.contactbook_error_delete_forbidden)
     val errConnectionForbidden = stringResource(MR.string.contactbook_error_connection_forbidden)
+    val msgBlocked = stringResource(MR.string.contactbook_action_blocked)
+    val msgUnblocked = stringResource(MR.string.contactbook_action_unblocked)
+    val msgDisconnected = stringResource(MR.string.contactbook_action_disconnected)
 
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
@@ -105,9 +117,15 @@ fun ContactDetailScreen(
                 ContactDetailEvent.Back -> onBack()
                 ContactDetailEvent.Error -> snackbarHostState.showSnackbar(errSave)
                 ContactDetailEvent.Forbidden -> snackbarHostState.showSnackbar(errForbidden)
+                ContactDetailEvent.DeleteError -> snackbarHostState.showSnackbar(errDelete)
+                ContactDetailEvent.DeleteForbidden ->
+                    snackbarHostState.showSnackbar(errDeleteForbidden)
                 ContactDetailEvent.ConnectionForbidden ->
                     snackbarHostState.showSnackbar(errConnectionForbidden)
                 ContactDetailEvent.PhotoError -> snackbarHostState.showSnackbar(errPhoto)
+                ContactDetailEvent.Blocked -> snackbarHostState.showSnackbar(msgBlocked)
+                ContactDetailEvent.Unblocked -> snackbarHostState.showSnackbar(msgUnblocked)
+                ContactDetailEvent.Disconnected -> snackbarHostState.showSnackbar(msgDisconnected)
             }
         }
     }
@@ -211,6 +229,25 @@ fun ContactDetailScreen(
                 snackbarHostState = snackbarHostState,
                 onDismiss = { viewModel.onAction(ContactDetailAction.CloseMedia) },
             )
+
+            if (uiState.actionInProgress) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.32f))
+                        .pointerInput(Unit) {
+                            // Swallow taps so the action can't be re-triggered while it runs.
+                            awaitPointerEventScope {
+                                while (true) {
+                                    awaitPointerEvent().changes.forEach { it.consume() }
+                                }
+                            }
+                        },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
         }
     }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailUiState.kt
@@ -63,5 +63,7 @@ sealed interface ContactDetailEvent {
     data object Error : ContactDetailEvent
     /** 403 — app lacks manage-contacts permission. */
     data object Forbidden : ContactDetailEvent
+    /** 403 on block/unblock/disconnect — app lacks manage-connections permission. */
+    data object ConnectionForbidden : ContactDetailEvent
     data object PhotoError : ContactDetailEvent
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailUiState.kt
@@ -31,6 +31,8 @@ data class ContactDetailUiState(
     val fullScreenMedia: SharedMediaItem? = null,
     val editOpen: Boolean = false,
     val confirm: ContactDetailConfirm? = null,
+    /** A management action (delete/block/disconnect/unblock) is running — show a blocking spinner. */
+    val actionInProgress: Boolean = false,
 ) {
     val hasOdinId: Boolean get() = !entry?.odinId.isNullOrBlank()
     val isConnected: Boolean get() = connectionStatus == ConnectionStatus.Connected
@@ -63,7 +65,15 @@ sealed interface ContactDetailEvent {
     data object Error : ContactDetailEvent
     /** 403 — app lacks manage-contacts permission. */
     data object Forbidden : ContactDetailEvent
+    /** Generic/transient failure while deleting the contact. */
+    data object DeleteError : ContactDetailEvent
+    /** 403 on delete — app lacks manage-contacts permission. */
+    data object DeleteForbidden : ContactDetailEvent
     /** 403 on block/unblock/disconnect — app lacks manage-connections permission. */
     data object ConnectionForbidden : ContactDetailEvent
     data object PhotoError : ContactDetailEvent
+    /** Success confirmations for connection actions. */
+    data object Blocked : ContactDetailEvent
+    data object Unblocked : ContactDetailEvent
+    data object Disconnected : ContactDetailEvent
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailViewModel.kt
@@ -214,10 +214,18 @@ class ContactDetailViewModel(
 
     private fun handleUnblock() {
         val domain = odinId ?: return
+        _uiState.update { it.copy(actionInProgress = true) }
         viewModelScope.launch {
-            runCatching { connectionNetworkProvider.unblock(OdinId(domain)) }
-                .onSuccess { connectionService.refresh() }
-                .onFailure { emitConnectionError(it) }
+            try {
+                runCatching { connectionNetworkProvider.unblock(OdinId(domain)) }
+                    .onSuccess {
+                        connectionService.refresh()
+                        _events.tryEmit(ContactDetailEvent.Unblocked)
+                    }
+                    .onFailure { emitConnectionError(it) }
+            } finally {
+                _uiState.update { it.copy(actionInProgress = false) }
+            }
         }
     }
 
@@ -237,32 +245,54 @@ class ContactDetailViewModel(
         val confirm = _uiState.value.confirm ?: return
         val entry = _uiState.value.entry
         val domain = odinId
-        _uiState.update { it.copy(confirm = null) }
+        _uiState.update { it.copy(confirm = null, actionInProgress = true) }
         viewModelScope.launch {
-            when (confirm) {
-                ContactDetailConfirm.DELETE -> {
-                    if (entry != null) {
+            try {
+                when (confirm) {
+                    ContactDetailConfirm.DELETE -> {
+                        if (entry == null) {
+                            _events.tryEmit(ContactDetailEvent.Back)
+                            return@launch
+                        }
                         contactBookStream.removeOptimistic(entry.uniqueId)
-                        if (!contactBookService.delete(entry.uniqueId)) {
-                            _events.tryEmit(ContactDetailEvent.Error)
+                        val event = try {
+                            if (contactBookService.delete(entry.uniqueId)) {
+                                ContactDetailEvent.Back
+                            } else {
+                                // Generic/transient failure — restore the contact and stay put.
+                                contactBookStream.insertOrUpdateOptimistic(entry)
+                                ContactDetailEvent.DeleteError
+                            }
+                        } catch (e: ForbiddenException) {
+                            // 403 — app lacks manage-contacts permission. Restore and explain.
+                            contactBookStream.insertOrUpdateOptimistic(entry)
+                            ContactDetailEvent.DeleteForbidden
+                        }
+                        _events.tryEmit(event)
+                    }
+                    ContactDetailConfirm.BLOCK -> {
+                        if (domain != null) {
+                            runCatching { connectionNetworkProvider.block(OdinId(domain)) }
+                                .onSuccess {
+                                    connectionService.refresh()
+                                    _events.tryEmit(ContactDetailEvent.Blocked)
+                                }
+                                .onFailure { emitConnectionError(it) }
                         }
                     }
-                    _events.tryEmit(ContactDetailEvent.Back)
-                }
-                ContactDetailConfirm.BLOCK -> {
-                    if (domain != null) {
-                        runCatching { connectionNetworkProvider.block(OdinId(domain)) }
-                            .onSuccess { connectionService.refresh() }
-                            .onFailure { emitConnectionError(it) }
+                    ContactDetailConfirm.DISCONNECT -> {
+                        if (domain != null) {
+                            runCatching { connectionNetworkProvider.disconnect(OdinId(domain)) }
+                                .onSuccess {
+                                    connectionService.refresh()
+                                    _events.tryEmit(ContactDetailEvent.Disconnected)
+                                }
+                                .onFailure { emitConnectionError(it) }
+                        }
                     }
                 }
-                ContactDetailConfirm.DISCONNECT -> {
-                    if (domain != null) {
-                        runCatching { connectionNetworkProvider.disconnect(OdinId(domain)) }
-                            .onSuccess { connectionService.refresh() }
-                            .onFailure { emitConnectionError(it) }
-                    }
-                }
+            } finally {
+                _uiState.update { it.copy(actionInProgress = false) }
             }
         }
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import co.touchlab.kermit.Logger
+import id.homebase.api.client.ForbiddenException
 import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.api.client.connections.ConnectionNetworkProvider
 import id.homebase.api.common.OdinId
@@ -215,9 +216,21 @@ class ContactDetailViewModel(
         val domain = odinId ?: return
         viewModelScope.launch {
             runCatching { connectionNetworkProvider.unblock(OdinId(domain)) }
-                .onFailure { _events.tryEmit(ContactDetailEvent.Error) }
-            connectionService.refresh()
+                .onSuccess { connectionService.refresh() }
+                .onFailure { emitConnectionError(it) }
         }
+    }
+
+    /**
+     * The server returns 200 for no-ops and never echoes the new state, so we only refresh
+     * after a successful call. A 403 means this app wasn't granted manage-connections
+     * permission — surface that distinctly from a generic/transient failure.
+     */
+    private fun emitConnectionError(error: Throwable) {
+        _events.tryEmit(
+            if (error is ForbiddenException) ContactDetailEvent.ConnectionForbidden
+            else ContactDetailEvent.Error
+        )
     }
 
     private fun handleConfirm() {
@@ -239,15 +252,15 @@ class ContactDetailViewModel(
                 ContactDetailConfirm.BLOCK -> {
                     if (domain != null) {
                         runCatching { connectionNetworkProvider.block(OdinId(domain)) }
-                            .onFailure { _events.tryEmit(ContactDetailEvent.Error) }
-                        connectionService.refresh()
+                            .onSuccess { connectionService.refresh() }
+                            .onFailure { emitConnectionError(it) }
                     }
                 }
                 ContactDetailConfirm.DISCONNECT -> {
                     if (domain != null) {
                         runCatching { connectionNetworkProvider.disconnect(OdinId(domain)) }
-                            .onFailure { _events.tryEmit(ContactDetailEvent.Error) }
-                        connectionService.refresh()
+                            .onSuccess { connectionService.refresh() }
+                            .onFailure { emitConnectionError(it) }
                     }
                 }
             }


### PR DESCRIPTION
- Differentiate a 403 (app lacks manage-connections permission) from generic failures via a new ConnectionForbidden event + dedicated string, instead of collapsing every error into the contacts-save message.
- Only refresh connection state on a successful call. The server returns 200 for no-ops and never echoes the new state, so refreshing after a failure was a wasted round-trip that repainted "no change".
- Correct the confirm-dialog copy: disconnect is permanent and requires a fresh connection request to reconnect; block is reversible via unblock; neither notifies the other party.