### PR TITLE
Location History: inset map in a Card so it clears day-nav and stats

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
@@ -131,22 +132,31 @@ fun LocationHistoryScreen(
             }
 
             // ── Trace canvas ──
-            Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
-                LocationTraceCanvas(
-                    traces = uiState.traces,
-                    showMapTiles = uiState.showMapTiles,
-                    fetchTile = { z, x, y -> previewProvider.getTilePng(z, x, y) },
-                    traceColors = mapTraceColors,
-                )
-                if (uiState.isLoading) {
-                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-                } else if (uiState.isEmpty) {
-                    Text(
-                        text = stringResource(MR.string.location_history_empty),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.align(Alignment.Center).padding(24.dp),
+            // Card clips and insets the map so it doesn't run into the day-nav
+            // controls above or the stats row below.
+            Card(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+            ) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    LocationTraceCanvas(
+                        traces = uiState.traces,
+                        showMapTiles = uiState.showMapTiles,
+                        fetchTile = { z, x, y -> previewProvider.getTilePng(z, x, y) },
+                        traceColors = mapTraceColors,
                     )
+                    if (uiState.isLoading) {
+                        CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                    } else if (uiState.isEmpty) {
+                        Text(
+                            text = stringResource(MR.string.location_history_empty),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.align(Alignment.Center).padding(24.dp),
+                        )
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

Follow-up polish to the Location add-on (after #746). On the **History** screen the
trace map filled all the space between the day-navigation row and the stats row as a
full-bleed `Box(Modifier.weight(1f).fillMaxWidth())`, running flush into — and visually
covering — the controls above and the stats below (especially with map tiles on).

Wrap the canvas in an inset `Card` (`padding(horizontal = 16.dp, vertical = 8.dp)`) —
the same treatment applied to the Find-device screen in #746 — so the map is a clipped,
rounded, clearly-separated panel. `weight(1f)` is retained, so it still occupies the
main area and pan/zoom keeps working within the Card bounds. Single-file change; no
string/state changes.

## Test plan
- [x] `:homebase-core` compiles on JVM, Android, wasmJs
- [x] `homebase-core:jvmTest` green (incl. Konsist `ArchitectureTest`)
- [ ] Desktop: Location → History shows the map as an inset rounded panel with gaps above the day-nav and below the stats; day switching, date picker, and pan/zoom still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)