### PR TITLE
Location History: time-warped day playback + dwell dots + 24h scrubber

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationDayPlayback.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationDayPlayback.kt
@@ -1,0 +1,202 @@
+package id.homebase.core.ui.screens.location.history
+
+import id.homebase.api.sync.database.BufferedLocationPoint
+import id.homebase.core.location.tracking.LocationPointStore
+import kotlin.math.sqrt
+
+private const val DWELL_MIN_R_DP = 7f
+private const val DWELL_MAX_R_DP = 22f
+private const val DWELL_SATURATE_MS = 4 * 60 * 60_000L // 4h — longer stays all render at max
+
+/**
+ * Screen-space dwell-dot radius (dp, not map-scaled, so zoom never bloats it): grows
+ * on a saturating sqrt curve from [DWELL_MIN_R_DP] at the 15-minute floor to
+ * [DWELL_MAX_R_DP], maxing out at [DWELL_SATURATE_MS] — so a 24-hour stay is the same
+ * capped size as a 4-hour one, never absurd. Pure (testable); the canvas converts to px.
+ */
+fun dwellRadiusDp(durationMs: Long): Float {
+    val span = (DWELL_SATURATE_MS - DayPlayback.DWELL_MIN_MS).toDouble()
+    val f = ((durationMs - DayPlayback.DWELL_MIN_MS).toDouble() / span).coerceIn(0.0, 1.0)
+    return DWELL_MIN_R_DP + (DWELL_MAX_R_DP - DWELL_MIN_R_DP) * sqrt(f).toFloat()
+}
+
+/**
+ * A place the user lingered: a cluster of consecutive fixes that stayed within
+ * [DWELL_RADIUS_M] of a running centroid for at least [DWELL_MIN_MS]. [lat]/[lon]
+ * are the cluster centroid; [durationMs] drives the dwell-dot size.
+ */
+data class DwellStop(
+    val deviceIndex: Int,
+    val lat: Double,
+    val lon: Double,
+    val startMs: Long,
+    val endMs: Long,
+) {
+    val durationMs: Long get() = endMs - startMs
+}
+
+/**
+ * Time-warped playback model for one day's traces. The single animated quantity
+ * is `clock` (an epoch-ms instant into the day): [clockAtProgress] maps a uniform
+ * playback progress 0..1 onto real time so that **movement is slow and idle is
+ * fast** — an 8-hour stay collapses to one [IDLE_BEAT_MS] beat instead of a third
+ * of the runtime. Everything on the canvas then renders as "the day as of clock",
+ * which also makes multi-device days correct and lets the scrubber set clock directly.
+ *
+ * Built once per loaded day off the main thread (pure, O(points)); see [build].
+ */
+class DayPlayback internal constructor(
+    val firstFixMs: Long,
+    val lastFixMs: Long,
+    val totalAnimMillis: Int,
+    val stops: List<DwellStop>,
+    // Parallel warp tables (size = event count): real epoch ms at each event, and the
+    // cumulative animation ms when the warped playhead reaches it. animCumMs is
+    // non-decreasing, animCumMs[0] = 0, animCumMs.last() = totalAnimMillis.
+    private val realAtStep: LongArray,
+    private val animCumMs: LongArray,
+) {
+    /** Warped: a uniform progress 0..1 → real epoch ms (lerped within the active step). */
+    fun clockAtProgress(progress: Float): Long {
+        if (realAtStep.size == 1) return realAtStep[0]
+        val target = (progress.coerceIn(0f, 1f).toDouble() * totalAnimMillis).toLong()
+        // Largest i with animCumMs[i] <= target.
+        var lo = 0
+        var hi = animCumMs.size - 1
+        while (lo < hi) {
+            val mid = (lo + hi + 1) ushr 1
+            if (animCumMs[mid] <= target) lo = mid else hi = mid - 1
+        }
+        if (lo >= animCumMs.size - 1) return realAtStep.last()
+        val span = animCumMs[lo + 1] - animCumMs[lo]
+        val frac = if (span > 0) (target - animCumMs[lo]).toDouble() / span else 0.0
+        return realAtStep[lo] + ((realAtStep[lo + 1] - realAtStep[lo]) * frac).toLong()
+    }
+
+    companion object {
+        const val DWELL_RADIUS_M = 75.0
+        const val DWELL_MIN_MS = 15 * 60_000L
+        private const val MOVE_EPS_M = 30.0
+        private const val IDLE_BEAT_MS = 450L
+        private const val MOVING_BUDGET_MS = 9_000.0
+        private const val MOVING_STEP_CAP_MS = 600.0
+        private const val MIN_ANIM_MS = 5_000L
+        private const val MAX_ANIM_MS = 18_000L
+
+        /** Returns null when the day has no fixes. */
+        fun build(traces: List<DeviceTrace>): DayPlayback? {
+            val events = buildList {
+                traces.forEachIndexed { di, trace ->
+                    trace.segments.forEachIndexed { si, segment ->
+                        segment.forEach { p -> add(Event(p.t, p.lat, p.lon, di, si)) }
+                    }
+                }
+            }.sortedBy { it.t }
+            if (events.isEmpty()) return null
+
+            val stops = detectDwells(traces)
+            if (events.size == 1) {
+                val t = events[0].t
+                return DayPlayback(t, t, MIN_ANIM_MS.toInt(), stops, longArrayOf(t), longArrayOf(0L))
+            }
+
+            val n = events.size - 1
+            val moving = BooleanArray(n)
+            val movedM = DoubleArray(n)
+            for (k in 0 until n) {
+                val a = events[k]
+                val b = events[k + 1]
+                val sameLeg = a.deviceIndex == b.deviceIndex && a.segIndex == b.segIndex
+                val moved = if (sameLeg) {
+                    LocationPointStore.haversineMeters(a.lat, a.lon, b.lat, b.lon)
+                } else 0.0
+                moving[k] = sameLeg && moved > MOVE_EPS_M
+                if (moving[k]) movedM[k] = moved
+            }
+
+            // Moving steps: anim time ∝ distance (constant screen-speed trail), each
+            // capped so a single sparse/teleport step can't dominate the budget.
+            val animStep = DoubleArray(n)
+            val totalMoved = movedM.sum()
+            if (totalMoved > 0) {
+                for (k in 0 until n) if (moving[k]) {
+                    animStep[k] = (movedM[k] / totalMoved * MOVING_BUDGET_MS)
+                        .coerceAtMost(MOVING_STEP_CAP_MS)
+                }
+            }
+            // Each maximal run of idle steps collapses to a single beat.
+            var k = 0
+            while (k < n) {
+                if (!moving[k]) {
+                    val runStart = k
+                    while (k < n && !moving[k]) k++
+                    animStep[runStart] = IDLE_BEAT_MS.toDouble()
+                } else k++
+            }
+
+            val rawTotal = animStep.sum().coerceAtLeast(1.0)
+            val total = rawTotal.toLong().coerceIn(MIN_ANIM_MS, MAX_ANIM_MS)
+            val scale = total / rawTotal
+
+            val real = LongArray(events.size)
+            val animCum = LongArray(events.size)
+            real[0] = events[0].t
+            var acc = 0.0
+            for (i in 0 until n) {
+                acc += animStep[i] * scale
+                real[i + 1] = events[i + 1].t
+                animCum[i + 1] = acc.toLong()
+            }
+            animCum[animCum.size - 1] = total // pin the end exactly
+
+            return DayPlayback(events.first().t, events.last().t, total.toInt(), stops, real, animCum)
+        }
+
+        private fun detectDwells(traces: List<DeviceTrace>): List<DwellStop> {
+            val out = mutableListOf<DwellStop>()
+            traces.forEachIndexed { di, trace ->
+                // Segments are time-ordered and non-overlapping, so flattening keeps
+                // chronological order; clustering across a segment break lets a stay
+                // that was split by a tracking gap still register as one dwell.
+                val pts = trace.segments.flatten()
+                var i = 0
+                while (i < pts.size) {
+                    var sumLat = pts[i].lat
+                    var sumLon = pts[i].lon
+                    var cLat = pts[i].lat
+                    var cLon = pts[i].lon
+                    var count = 1
+                    val startT = pts[i].t
+                    var endT = pts[i].t
+                    var j = i + 1
+                    while (j < pts.size &&
+                        LocationPointStore.haversineMeters(cLat, cLon, pts[j].lat, pts[j].lon) <= DWELL_RADIUS_M
+                    ) {
+                        sumLat += pts[j].lat
+                        sumLon += pts[j].lon
+                        count++
+                        cLat = sumLat / count
+                        cLon = sumLon / count
+                        endT = pts[j].t
+                        j++
+                    }
+                    if (endT - startT >= DWELL_MIN_MS) {
+                        out.add(DwellStop(di, cLat, cLon, startT, endT))
+                        i = j
+                    } else {
+                        i++
+                    }
+                }
+            }
+            return out
+        }
+    }
+
+    private data class Event(
+        val t: Long,
+        val lat: Double,
+        val lon: Double,
+        val deviceIndex: Int,
+        val segIndex: Int,
+    )
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
@@ -24,17 +25,22 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.api.client.location.LocationPreviewProvider
@@ -75,6 +81,30 @@ fun LocationHistoryScreen(
     val previewProvider = koinInject<LocationPreviewProvider>()
     var showPicker by remember { mutableStateOf(false) }
     val deviceTz = remember { TimeZone.currentSystemDefault() }
+
+    // ── Playback / scrubber state (reset per day) ──
+    val playback = uiState.playback
+    val dayMs = 24L * 60 * 60 * 1000
+    // `clockMs` is the single source of truth: the day-instant the map renders.
+    var clockMs by remember(uiState.dayStartMs) { mutableLongStateOf(uiState.dayStartMs) }
+    var isScrubbing by remember(uiState.dayStartMs) { mutableStateOf(false) }
+    var autoPlayed by remember(uiState.dayStartMs) { mutableStateOf(false) }
+
+    // Auto-play once per day: a warped sweep (slow through movement, fast through idle).
+    LaunchedEffect(uiState.dayStartMs, playback) {
+        if (playback == null || autoPlayed || isScrubbing) return@LaunchedEffect
+        autoPlayed = true
+        clockMs = playback.firstFixMs
+        val total = playback.totalAnimMillis.toLong().coerceAtLeast(1L)
+        val startNanos = withFrameNanos { it }
+        while (!isScrubbing) {
+            val now = withFrameNanos { it }
+            val progress = (((now - startNanos) / 1_000_000).toFloat() / total).coerceIn(0f, 1f)
+            clockMs = playback.clockAtProgress(progress)
+            if (progress >= 1f) break
+        }
+        if (!isScrubbing) clockMs = playback.lastFixMs
+    }
 
     Scaffold(
         topBar = {
@@ -131,22 +161,33 @@ fun LocationHistoryScreen(
             }
 
             // ── Trace canvas ──
-            Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
-                LocationTraceCanvas(
-                    traces = uiState.traces,
-                    showMapTiles = uiState.showMapTiles,
-                    fetchTile = { z, x, y -> previewProvider.getTilePng(z, x, y) },
-                    traceColors = mapTraceColors,
-                )
-                if (uiState.isLoading) {
-                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-                } else if (uiState.isEmpty) {
-                    Text(
-                        text = stringResource(MR.string.location_history_empty),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.align(Alignment.Center).padding(24.dp),
+            // Card clips and insets the map so it doesn't run into the day-nav
+            // controls above or the stats/scrubber below.
+            Card(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+            ) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    LocationTraceCanvas(
+                        traces = uiState.traces,
+                        showMapTiles = uiState.showMapTiles,
+                        fetchTile = { z, x, y -> previewProvider.getTilePng(z, x, y) },
+                        traceColors = mapTraceColors,
+                        playbackClockMs = if (playback != null) clockMs else null,
+                        dwellStops = playback?.stops ?: emptyList(),
                     )
+                    if (uiState.isLoading) {
+                        CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                    } else if (uiState.isEmpty) {
+                        Text(
+                            text = stringResource(MR.string.location_history_empty),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.align(Alignment.Center).padding(24.dp),
+                        )
+                    }
                 }
             }
 
@@ -186,6 +227,28 @@ fun LocationHistoryScreen(
                 }
             }
 
+            // ── 24h scrubber (the only playback control) ──
+            if (playback != null) {
+                Text(
+                    text = formatTime(Instant.fromEpochMilliseconds(clockMs)),
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                    textAlign = TextAlign.Center,
+                )
+                Slider(
+                    value = ((clockMs - uiState.dayStartMs).toFloat() / dayMs).coerceIn(0f, 1f),
+                    onValueChange = { v ->
+                        isScrubbing = true
+                        clockMs = uiState.dayStartMs + (v * dayMs).toLong()
+                    },
+                    onValueChangeFinished = { isScrubbing = false },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 4.dp),
+                )
+            }
         }
     }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryUiState.kt
@@ -7,6 +7,8 @@ data class LocationHistoryUiState(
     val stats: DayStats? = null,
     val isLoading: Boolean = true,
     val showMapTiles: Boolean = false,
+    /** Time-warped playback model + dwell stops for the shown day; null while empty/loading. */
+    val playback: DayPlayback? = null,
 ) {
     val isEmpty: Boolean get() = !isLoading && traces.isEmpty()
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryViewModel.kt
@@ -54,10 +54,16 @@ class LocationHistoryViewModel(
             val traces = runCatching { deviceDirectory.loadDayTraces(dayStartMs, dayEndMs) }
                 .onFailure { logger.e(it) { "loadDayTraces failed for $dayStartMs" } }
                 .getOrDefault(emptyList())
+            val playback = DayPlayback.build(traces)
             _uiState.update {
                 // Drop stale results if the user already moved to another day.
                 if (it.dayStartMs != dayStartMs) it
-                else it.copy(traces = traces, stats = LocationHistoryAssembler.stats(traces), isLoading = false)
+                else it.copy(
+                    traces = traces,
+                    stats = LocationHistoryAssembler.stats(traces),
+                    playback = playback,
+                    isLoading = false,
+                )
             }
         }
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationTraceCanvas.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationTraceCanvas.kt
@@ -65,6 +65,14 @@ fun LocationTraceCanvas(
     interactive: Boolean = true,
     /** Emphasize each trace's final position (Find device): bigger dot + halo. */
     highlightLast: Boolean = false,
+    /**
+     * Playback: when set, each trace is drawn only up to this instant (with an
+     * interpolated leading edge + a playhead marker on the active segment). Null =
+     * the static full-day view.
+     */
+    playbackClockMs: Long? = null,
+    /** Places the user lingered; drawn as dots sized by dwell length (see [dwellRadiusDp]). */
+    dwellStops: List<DwellStop> = emptyList(),
 ) {
     var canvasSize by remember { mutableStateOf(IntSize.Zero) }
     // User pan/zoom override; null = fit the day's bbox. Reset when the day's data changes.
@@ -77,6 +85,9 @@ fun LocationTraceCanvas(
                 segment.map { p -> WebMercator.latLonToUnit(p.lat, p.lon) }
             }
         }
+    }
+    val unitStops = remember(dwellStops) {
+        dwellStops.map { WebMercator.latLonToUnit(it.lat, it.lon) }
     }
     val bbox = remember(unitTraces) {
         var minX = Double.MAX_VALUE; var minY = Double.MAX_VALUE
@@ -165,19 +176,46 @@ fun LocationTraceCanvas(
         // ── Traces ──
         val strokeWidth = 3.dp.toPx()
         val dotRadius = 5.dp.toPx()
+        val clock = playbackClockMs
+        // Playhead positions to draw on top after the dwell dots (one per active trace).
+        val playheads = mutableListOf<Pair<Offset, Color>>()
         unitTraces.forEachIndexed { traceIndex, segments ->
             val color = traceColors[traceIndex % traceColors.size]
-            for (segment in segments) {
-                if (segment.isEmpty()) continue
-                if (segment.size == 1) {
-                    drawCircle(color, radius = strokeWidth, center = toPx(segment.first()))
-                    continue
+            val tsegs = traces[traceIndex].segments
+            var tracePlayhead: Pair<Double, Double>? = null
+            segments.forEachIndexed { segIndex, unitSeg ->
+                if (unitSeg.isEmpty()) return@forEachIndexed
+                val times = tsegs[segIndex]
+                // Clip the segment to `clock`: keep points already reached, then
+                // interpolate one leading edge to the exact instant (= the playhead).
+                val drawPts: List<Pair<Double, Double>> = if (clock == null) {
+                    unitSeg
+                } else {
+                    if (clock < times.first().t) return@forEachIndexed // not started yet
+                    val cutoff = times.count { it.t <= clock }
+                    if (cutoff >= unitSeg.size) {
+                        unitSeg
+                    } else {
+                        val p0 = unitSeg[cutoff - 1]
+                        val p1 = unitSeg[cutoff]
+                        val t0 = times[cutoff - 1].t
+                        val t1 = times[cutoff].t
+                        val f = if (t1 > t0) (clock - t0).toDouble() / (t1 - t0) else 0.0
+                        val head = p0.first + (p1.first - p0.first) * f to
+                            p0.second + (p1.second - p0.second) * f
+                        tracePlayhead = head
+                        unitSeg.subList(0, cutoff) + head
+                    }
+                }
+                if (drawPts.size == 1) {
+                    drawCircle(color, radius = strokeWidth, center = toPx(drawPts.first()))
+                    return@forEachIndexed
                 }
                 val path = Path()
-                val first = toPx(segment.first())
+                val first = toPx(drawPts.first())
                 path.moveTo(first.x, first.y)
-                for (i in 1 until segment.size) {
-                    val p = toPx(segment[i])
+                for (i in 1 until drawPts.size) {
+                    val p = toPx(drawPts[i])
                     path.lineTo(p.x, p.y)
                 }
                 if (showMapTiles) {
@@ -195,13 +233,17 @@ fun LocationTraceCanvas(
                     style = Stroke(width = strokeWidth, cap = StrokeCap.Round, join = StrokeJoin.Round),
                 )
             }
-            // Start dot (filled) and end marker (ring) for the whole trace.
-            segments.firstOrNull()?.firstOrNull()?.let {
+            // Start dot once the trace has begun.
+            val started = clock == null || (tsegs.firstOrNull()?.firstOrNull()?.let { clock >= it.t } ?: false)
+            if (started) segments.firstOrNull()?.firstOrNull()?.let {
                 val start = toPx(it)
                 if (showMapTiles) drawCircle(Color.White, dotRadius * 1.4f, start)
                 drawCircle(color, dotRadius, start)
             }
-            segments.lastOrNull()?.lastOrNull()?.let {
+            // End marker only once the whole trace is in the past (or static view).
+            val lastT = tsegs.lastOrNull()?.lastOrNull()?.t
+            val finished = clock == null || (lastT != null && clock >= lastT)
+            if (finished) segments.lastOrNull()?.lastOrNull()?.let {
                 val end = toPx(it)
                 if (highlightLast) {
                     // Find-device emphasis: soft halo + solid dot + ring.
@@ -212,6 +254,29 @@ fun LocationTraceCanvas(
                     drawCircle(color, dotRadius, end, style = Stroke(width = strokeWidth))
                 }
             }
+            tracePlayhead?.let { playheads.add(toPx(it) to color) }
+        }
+
+        // ── Dwell dots (always drawn when present; grow as the clock sweeps the stay) ──
+        unitStops.forEachIndexed { i, unit ->
+            val stop = dwellStops[i]
+            val effDur = if (clock == null) {
+                stop.durationMs
+            } else {
+                if (clock < stop.startMs) return@forEachIndexed // not reached yet
+                minOf(clock, stop.endMs) - stop.startMs
+            }
+            val r = dwellRadiusDp(effDur).dp.toPx()
+            val c = traceColors[stop.deviceIndex % traceColors.size]
+            val center = toPx(unit)
+            drawCircle(c.copy(alpha = 0.20f), r, center)
+            drawCircle(c, r, center, style = Stroke(width = 2.dp.toPx()))
+        }
+
+        // ── Playheads (on top) ──
+        playheads.forEach { (center, color) ->
+            drawCircle(Color.White, dotRadius * 1.5f, center)
+            drawCircle(color, dotRadius * 1.1f, center)
         }
     }
 }

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/history/LocationDayPlaybackTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/history/LocationDayPlaybackTest.kt
@@ -1,0 +1,133 @@
+package id.homebase.core.ui.screens.location.history
+
+import id.homebase.api.sync.database.BufferedLocationPoint
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+class LocationDayPlaybackTest {
+
+    private val dev = Uuid.parse("00000000-0000-0000-0000-000000000001")
+
+    private fun pt(t: Long, lat: Double = 52.0, lon: Double = 13.0) =
+        BufferedLocationPoint(t = t, lat = lat, lon = lon, acc = 10.0, src = "gps", fg = true)
+
+    private fun trace(vararg segments: List<BufferedLocationPoint>) =
+        DeviceTrace(deviceId = dev, segments = segments.toList())
+
+    private val min = 60_000L
+
+    // ── Dwell detection ──
+
+    @Test
+    fun dwell_detected_for_stay_of_at_least_15_min() {
+        // Four fixes at one spot spanning 16 minutes.
+        val seg = listOf(pt(0), pt(5 * min), pt(10 * min), pt(16 * min))
+        val pb = DayPlayback.build(listOf(trace(seg)))
+        assertNotNull(pb)
+        assertEquals(1, pb.stops.size)
+        val stop = pb.stops.single()
+        assertEquals(16 * min, stop.durationMs)
+        assertTrue(kotlin.math.abs(stop.lat - 52.0) < 1e-6)
+        assertTrue(kotlin.math.abs(stop.lon - 13.0) < 1e-6)
+    }
+
+    @Test
+    fun no_dwell_for_stay_under_15_min() {
+        val seg = listOf(pt(0), pt(5 * min), pt(10 * min))
+        val pb = DayPlayback.build(listOf(trace(seg)))
+        assertNotNull(pb)
+        assertTrue(pb.stops.isEmpty())
+    }
+
+    @Test
+    fun dwell_spanning_a_tracking_gap_still_counts() {
+        // Same spot, but split into two segments by a tracking gap (20 min apart).
+        val pb = DayPlayback.build(listOf(trace(listOf(pt(0)), listOf(pt(20 * min)))))
+        assertNotNull(pb)
+        assertEquals(1, pb.stops.size)
+        assertEquals(20 * min, pb.stops.single().durationMs)
+    }
+
+    @Test
+    fun empty_day_has_no_playback() {
+        assertNull(DayPlayback.build(emptyList()))
+        assertNull(DayPlayback.build(listOf(trace(emptyList()))))
+    }
+
+    // ── Warp ──
+
+    /** Leg A (moving 5 min) → 8 h parked → leg B (moving 5 min), one continuous segment. */
+    private fun warpDay(): DayPlayback {
+        val seg = buildList {
+            // Leg A: 5 fixes, ~111 m apart, 1 min steps.
+            for (i in 0..4) add(pt(i * min, lat = 52.000 + 0.001 * i, lon = 13.0))
+            // Parked: same spot as A's end, every 30 min for 8 h.
+            val parkLat = 52.004
+            for (i in 1..16) add(pt(4 * min + i * 30 * min, lat = parkLat, lon = 13.0))
+            // Leg B: resume moving from the parked spot.
+            val bStart = 4 * min + 16 * 30 * min
+            for (i in 1..5) add(pt(bStart + i * min, lat = 52.004 + 0.001 * i, lon = 13.0))
+        }
+        return DayPlayback.build(listOf(trace(seg)))!!
+    }
+
+    @Test
+    fun warp_endpoints_and_bounds() {
+        val pb = warpDay()
+        assertEquals(pb.firstFixMs, pb.clockAtProgress(0f))
+        assertEquals(pb.lastFixMs, pb.clockAtProgress(1f))
+        assertTrue(pb.totalAnimMillis in 5_000..18_000)
+    }
+
+    @Test
+    fun warp_is_monotonic() {
+        val pb = warpDay()
+        var prev = pb.clockAtProgress(0f)
+        var p = 0.05f
+        while (p <= 1f) {
+            val c = pb.clockAtProgress(p)
+            assertTrue(c >= prev, "clock went backwards at p=$p ($c < $prev)")
+            prev = c
+            p += 0.05f
+        }
+    }
+
+    @Test
+    fun idle_is_compressed_so_movement_gets_the_budget() {
+        val pb = warpDay()
+        val legAEndT = 4 * min               // last moving fix of leg A
+        val parkedEndT = 4 * min + 16 * 30 * min // last parked fix (leg B starts after)
+
+        // A quarter through the animation we're still in leg A (the 8 h park hasn't
+        // eaten the budget); three-quarters through we're already past it into leg B.
+        assertTrue(
+            pb.clockAtProgress(0.25f) <= legAEndT,
+            "expected to still be in leg A at 25%, was ${pb.clockAtProgress(0.25f)}",
+        )
+        assertTrue(
+            pb.clockAtProgress(0.75f) >= parkedEndT,
+            "expected to be past the 8 h park at 75%, was ${pb.clockAtProgress(0.75f)}",
+        )
+    }
+
+    // ── Dwell-dot size curve ──
+
+    @Test
+    fun dwell_radius_curve_is_capped_and_monotonic() {
+        val atFloor = dwellRadiusDp(DayPlayback.DWELL_MIN_MS)
+        val at30m = dwellRadiusDp(30 * min)
+        val at2h = dwellRadiusDp(2 * 60 * min)
+        val at4h = dwellRadiusDp(4 * 60 * min)
+        val at24h = dwellRadiusDp(24 * 60 * min)
+
+        assertEquals(7f, atFloor, 0.01f)        // MIN_R at the 15-min floor
+        assertTrue(at30m in atFloor..at2h)      // monotonic up
+        assertTrue(at2h < at4h)
+        assertEquals(at4h, at24h, 0.001f)       // saturates by 4 h — 24 h is no bigger
+        assertEquals(22f, at24h, 0.01f)         // MAX_R cap
+    }
+}


### PR DESCRIPTION
## Summary

Brings a day's GPS history to life on the History map, designed to **not be boring**:
the only animated quantity is a **warped clock** that advances slowly while you're moving
and fast while everything is idle, so an 8-hour stay collapses to one ~450 ms beat instead
of a third of the runtime. Everything renders as "the day as of `clock`", which also makes
multi-device days correct and lets the scrubber set the clock directly.

- **`LocationDayPlayback`** (new, pure, unit-tested): `clockAtProgress(0..1) → epoch ms`.
  Moving legs get animation time ∝ distance (constant screen-speed trail), each capped so a
  sparse/teleport step can't dominate; idle runs collapse to a single beat; total clamped to
  5–18 s. Reuses `LocationPointStore.haversineMeters`.
- **Dwell dots**: places you lingered ≥15 min within ~75 m (clustering across tracking
  gaps). Always visible on the static map, sized on a **saturating sqrt curve** in dp
  (7 dp at 15 min → 22 dp cap at 4 h) — screen-space so zoom never bloats them and a 24 h
  stay is no bigger than a 4 h one. During playback each dot grows as the clock sweeps the stay.
- **Canvas**: additive `playbackClockMs` + `dwellStops` params — clips each trace to the
  clock with an interpolated leading edge + a playhead, draws the dwell dots. Static callers
  (dashboard, find-device) unchanged via defaults. Whole-day fit kept (no playhead-follow),
  so the trail draws within view and tiles don't refetch per frame.
- **History screen**: auto-plays the warped sweep **once** per day, then the **24 h slider
  is the only control** — thumb sweeps forward during playback; grabbing it ends auto-play
  and scrubs the day linearly with a live "3:42 PM" label; releasing rests there; drag back
  across to replay. Map wrapped in the inset `Card` so it clears the day-nav and the scrubber.

## Note on overlap with #748
This branch is off `main` (which doesn't yet have the open map-inset PR #748). It restructures
the same History trace-canvas block and includes the inset `Card`, so it **supersedes #748** —
recommend merging this and closing #748 (or merge #748 first; the conflict resolves to this
version).

## Test plan
- [x] `:homebase-core` compiles on JVM, Android, wasmJs
- [x] `homebase-core:jvmTest` green — new `LocationDayPlaybackTest` (dwell detection incl.
  gap-split stays, warp monotonicity + idle compression, size-curve cap) + Konsist `ArchitectureTest`
- [ ] Desktop: History on a day with movement + a long stay — auto-plays once (fast through
  the stay, slow through movement), rests on full day; dwell dots sized by stay length; slider
  scrubs the 24 h day with a live time label; drag-left-and-across replays; day switch + pan/zoom work

🤖 Generated with [Claude Code](https://claude.com/claude-code)