### PR TITLE
Contact detail: sync button + danger zone; lock Homebase ID for conne…

### DIFF
--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1361,12 +1361,14 @@
     <string name="contactbook_detail_disconnect_message">This permanently removes your connection and the access it granted. They won't be notified. To reconnect, you'll need to send a new connection request.</string>
     <string name="contactbook_detail_delete_title">Delete contact?</string>
     <string name="contactbook_detail_delete_message">This removes the contact from your address book.</string>
+    <string name="contactbook_detail_danger_zone">Danger zone</string>
 
     <string name="contactbook_edit_title_new">New contact</string>
     <string name="contactbook_edit_title_edit">Edit contact</string>
     <string name="contactbook_edit_given_name">First name</string>
     <string name="contactbook_edit_surname">Last name</string>
     <string name="contactbook_edit_odinid">Homebase ID</string>
+    <string name="contactbook_edit_odinid_locked">Homebase ID can't be changed for a connected contact.</string>
     <string name="contactbook_edit_phone">Phone</string>
     <string name="contactbook_country_search">Search countries</string>
     <string name="contactbook_edit_email">Email</string>
@@ -1408,5 +1410,6 @@
     <string name="contactbook_action_blocked">Contact blocked.</string>
     <string name="contactbook_action_unblocked">Contact unblocked.</string>
     <string name="contactbook_action_disconnected">Disconnected.</string>
+    <string name="contactbook_action_sync_started">Syncing this contact from their profile…</string>
 
 </resources>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookScreen.kt
@@ -253,6 +253,7 @@ fun ContactBookScreen(
                 viewModel.onAction(ContactBookUiAction.SaveContact(draft, overlay.entry, photo))
             },
             onDismiss = { viewModel.onAction(ContactBookUiAction.CloseOverlay) },
+            odinIdLocked = overlay.entry?.odinId?.lowercase() in uiState.connectedOdinIds,
         )
         null -> {}
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/ContactEditSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/ContactEditSheet.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AddAPhoto
+import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
@@ -48,6 +49,7 @@ import id.homebase.resources.contactbook_edit_country
 import id.homebase.resources.contactbook_edit_email
 import id.homebase.resources.contactbook_edit_given_name
 import id.homebase.resources.contactbook_edit_odinid
+import id.homebase.resources.contactbook_edit_odinid_locked
 import id.homebase.resources.contactbook_edit_phone
 import id.homebase.resources.contactbook_edit_save
 import id.homebase.resources.contactbook_edit_surname
@@ -66,6 +68,7 @@ fun ContactEditSheet(
     editing: ContactBookEntry?,
     onSave: (ContactDraft, PlatformFile?) -> Unit,
     onDismiss: () -> Unit,
+    odinIdLocked: Boolean = false,
 ) {
     var draft by remember { mutableStateOf(editing?.toDraft() ?: ContactDraft()) }
     var photo by remember { mutableStateOf<PlatformFile?>(null) }
@@ -112,12 +115,19 @@ fun ContactEditSheet(
             Field(draft.surname, stringResource(MR.string.contactbook_edit_surname)) {
                 draft = draft.copy(surname = it)
             }
+            val odinIdLockNote =
+                if (odinIdLocked) stringResource(MR.string.contactbook_edit_odinid_locked) else null
             Field(
                 value = draft.odinId,
                 label = stringResource(MR.string.contactbook_edit_odinid),
                 isError = !draft.odinIdValid,
                 errorText = stringResource(MR.string.contactbook_error_odinid),
                 keyboardType = KeyboardType.Uri,
+                readOnly = odinIdLocked,
+                helperText = odinIdLockNote,
+                trailingIcon = if (odinIdLocked) {
+                    { Icon(Icons.Outlined.Lock, contentDescription = odinIdLockNote) }
+                } else null,
             ) { draft = draft.copy(odinId = it) }
             PhoneNumberField(
                 e164Value = draft.phone,
@@ -198,6 +208,9 @@ private fun Field(
     isError: Boolean = false,
     errorText: String? = null,
     keyboardType: KeyboardType = KeyboardType.Text,
+    readOnly: Boolean = false,
+    helperText: String? = null,
+    trailingIcon: (@Composable () -> Unit)? = null,
     onChange: (String) -> Unit,
 ) {
     val showError = isError && value.isNotBlank()
@@ -207,10 +220,14 @@ private fun Field(
         label = { Text(label) },
         singleLine = true,
         isError = showError,
+        readOnly = readOnly,
+        trailingIcon = trailingIcon,
         keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(keyboardType = keyboardType),
-        supportingText = if (showError && errorText != null) {
-            { Text(errorText) }
-        } else null,
+        supportingText = when {
+            showError && errorText != null -> { { Text(errorText) } }
+            helperText != null -> { { Text(helperText) } }
+            else -> null
+        },
         modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
     )
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailScreen.kt
@@ -60,6 +60,7 @@ import id.homebase.core.ui.screens.contactbook.components.ContactEditSheet
 import id.homebase.resources.MR
 import id.homebase.resources.cancel
 import id.homebase.resources.contactbook_action_blocked
+import id.homebase.resources.contactbook_action_sync_started
 import id.homebase.resources.contactbook_action_disconnected
 import id.homebase.resources.contactbook_action_unblocked
 import id.homebase.resources.contactbook_connected
@@ -108,6 +109,7 @@ fun ContactDetailScreen(
     val msgBlocked = stringResource(MR.string.contactbook_action_blocked)
     val msgUnblocked = stringResource(MR.string.contactbook_action_unblocked)
     val msgDisconnected = stringResource(MR.string.contactbook_action_disconnected)
+    val msgSyncStarted = stringResource(MR.string.contactbook_action_sync_started)
 
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
@@ -126,6 +128,7 @@ fun ContactDetailScreen(
                 ContactDetailEvent.Blocked -> snackbarHostState.showSnackbar(msgBlocked)
                 ContactDetailEvent.Unblocked -> snackbarHostState.showSnackbar(msgUnblocked)
                 ContactDetailEvent.Disconnected -> snackbarHostState.showSnackbar(msgDisconnected)
+                ContactDetailEvent.SyncStarted -> snackbarHostState.showSnackbar(msgSyncStarted)
             }
         }
     }
@@ -256,6 +259,7 @@ fun ContactDetailScreen(
             editing = uiState.entry,
             onSave = { draft, photo -> viewModel.onAction(ContactDetailAction.SaveContact(draft, photo)) },
             onDismiss = { viewModel.onAction(ContactDetailAction.CloseEdit) },
+            odinIdLocked = uiState.isConnected,
         )
     }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailSections.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailSections.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Email
 import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material.icons.outlined.PersonRemove
+import androidx.compose.material.icons.outlined.Sync
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
@@ -52,6 +53,7 @@ import id.homebase.resources.contactbook_detail_circles
 import id.homebase.resources.contactbook_detail_circles_connect
 import id.homebase.resources.contactbook_detail_circles_empty
 import id.homebase.resources.contactbook_detail_contact_details
+import id.homebase.resources.contactbook_detail_danger_zone
 import id.homebase.resources.contactbook_detail_groups_connect
 import id.homebase.resources.contactbook_detail_groups_empty
 import id.homebase.resources.contactbook_detail_delete
@@ -61,6 +63,7 @@ import id.homebase.resources.contactbook_detail_more
 import id.homebase.resources.contactbook_detail_none
 import id.homebase.resources.contactbook_detail_no_recent_media
 import id.homebase.resources.contactbook_detail_recent_media
+import id.homebase.resources.contactbook_detail_sync
 import id.homebase.resources.contactbook_detail_unblock
 import id.homebase.resources.conversation_groups_in_common
 import id.homebase.resources.conversation_media_see_all
@@ -259,11 +262,28 @@ fun ManagementSection(
     uiState: ContactDetailUiState,
     onAction: (ContactDetailAction) -> Unit,
 ) {
+    // Pull the latest public profile into this contact — only meaningful for Homebase identities.
+    if (uiState.hasOdinId) {
+        ManagementAction(
+            Icons.Outlined.Sync,
+            stringResource(MR.string.contactbook_detail_sync),
+        ) { onAction(ContactDetailAction.SyncClicked) }
+    }
+
+    // Danger zone — disconnect / block / delete.
+    Spacer(modifier = Modifier.height(8.dp))
+    Text(
+        text = stringResource(MR.string.contactbook_detail_danger_zone),
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.error,
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+    )
     if (uiState.hasOdinId) {
         if (uiState.isConnected) {
             ManagementAction(
                 Icons.Outlined.PersonRemove,
                 stringResource(MR.string.contactbook_detail_disconnect),
+                destructive = true,
             ) { onAction(ContactDetailAction.DisconnectClicked) }
         }
         if (uiState.isBlocked) {
@@ -275,6 +295,7 @@ fun ManagementSection(
             ManagementAction(
                 Icons.Outlined.Block,
                 stringResource(MR.string.contactbook_detail_block),
+                destructive = true,
             ) { onAction(ContactDetailAction.BlockClicked) }
         }
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailUiState.kt
@@ -41,6 +41,7 @@ data class ContactDetailUiState(
 
 sealed interface ContactDetailAction {
     data object MessageClicked : ContactDetailAction
+    data object SyncClicked : ContactDetailAction
     data object EditClicked : ContactDetailAction
     data class SaveContact(val draft: ContactDraft, val photo: io.github.vinceglb.filekit.PlatformFile?) :
         ContactDetailAction
@@ -76,4 +77,6 @@ sealed interface ContactDetailEvent {
     data object Blocked : ContactDetailEvent
     data object Unblocked : ContactDetailEvent
     data object Disconnected : ContactDetailEvent
+    /** Best-effort profile sync was requested; the enriched contact lands later via drive sync. */
+    data object SyncStarted : ContactDetailEvent
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailViewModel.kt
@@ -154,6 +154,7 @@ class ContactDetailViewModel(
     fun onAction(action: ContactDetailAction) {
         when (action) {
             ContactDetailAction.MessageClicked -> handleMessage()
+            ContactDetailAction.SyncClicked -> handleSync()
             ContactDetailAction.EditClicked -> _uiState.update { it.copy(editOpen = true) }
             ContactDetailAction.CloseEdit -> _uiState.update { it.copy(editOpen = false) }
             is ContactDetailAction.SaveContact -> handleSave(action)
@@ -189,6 +190,17 @@ class ContactDetailViewModel(
             }
             _events.tryEmit(ContactDetailEvent.OpenConversation(id))
         }
+    }
+
+    /**
+     * Best-effort server-side enrichment from the identity's public profile. The endpoint is
+     * fire-and-forget (202 Accepted) and the enriched contact lands later via drive sync, so we
+     * just acknowledge the request — there's no success/failure to report back synchronously.
+     */
+    private fun handleSync() {
+        val domain = odinId ?: return
+        _events.tryEmit(ContactDetailEvent.SyncStarted)
+        viewModelScope.launch { contactBookService.syncFromIdentity(domain) }
     }
 
     private fun handleSave(action: ContactDetailAction.SaveContact) {


### PR DESCRIPTION
…cted contacts

Add a Sync action (gated to Homebase identities) above a new "Danger zone" section grouping Disconnect / Block / Delete. Sync fires the best-effort ContactsProvider.syncContact via ContactBookService and acknowledges with a snackbar (server returns 202; enriched contact lands later via drive sync).

Make the Homebase ID field read-only in the edit sheet when the contact is connected, with a lock icon and explanatory helper text.