### PR TITLE
Moments: allow deleting a moment from the feed

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
@@ -48,7 +48,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.AddReaction
-import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Group
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
@@ -2141,6 +2140,7 @@ private fun CommentsPanelContent(
                     onDraftChanged = { onAction(MomentDetailUiAction.DescriptionDraftChanged(it)) },
                     onSave = { onAction(MomentDetailUiAction.SaveDescriptionEdit) },
                     onCancel = { onAction(MomentDetailUiAction.CancelDescriptionEdit) },
+                    onDelete = { onAction(MomentDetailUiAction.RequestDeleteMoment) },
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp, vertical = 12.dp),
@@ -2288,6 +2288,23 @@ internal fun MomentCommentsSheet(
         scrimColor = Color.Transparent,
         sheetState = sheetState,
     )
+
+    // The description menu's Delete lands here. Wired in this entry point (the
+    // timeline feed sheet) the same way DetailContent wires it for reels — this
+    // path doesn't go through DetailContent, so without this the RequestDelete
+    // action would toggle showDeleteDialog with no dialog ever rendered.
+    if (uiState.showDeleteDialog) {
+        DeleteMomentDialog(
+            allowDeleteForEveryone = uiState.isMine,
+            onDeleteForMe = {
+                onAction(MomentDetailUiAction.ConfirmDeleteMoment(forEveryone = false))
+            },
+            onDeleteForEveryone = {
+                onAction(MomentDetailUiAction.ConfirmDeleteMoment(forEveryone = true))
+            },
+            onDismiss = { onAction(MomentDetailUiAction.DismissDeleteDialog) },
+        )
+    }
 
     val deleteCommentTarget = uiState.deleteCommentDialogTarget
     if (deleteCommentTarget != null) {
@@ -2926,6 +2943,7 @@ private fun MomentDescriptionSection(
     onDraftChanged: (String) -> Unit,
     onSave: () -> Unit,
     onCancel: () -> Unit,
+    onDelete: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -2987,16 +3005,55 @@ private fun MomentDescriptionSection(
                         .padding(top = 8.dp),
                 )
                 if (isMine) {
-                    IconButton(onClick = onStartEdit) {
-                        Icon(
-                            imageVector = Icons.Default.Edit,
-                            contentDescription = stringResource(
-                                MR.string.moments_detail_edit_description,
-                            ),
-                        )
-                    }
+                    MomentDescriptionMenu(
+                        onEdit = onStartEdit,
+                        onDelete = onDelete,
+                    )
                 }
             }
+        }
+    }
+}
+
+/**
+ * Author-only overflow next to a moment's description. Replaces the standalone
+ * edit pencil with a [MoreVert] menu so the same surface offers both **Edit
+ * description** and **Delete** — and because this description section is shown
+ * from both the reels detail pane and the timeline's [MomentCommentsSheet],
+ * surfacing delete here is what gives the feed a delete path (the reels-only
+ * immersive top-bar [MomentOverflowMenu] never appears over the feed).
+ */
+@Composable
+private fun MomentDescriptionMenu(
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        IconButton(onClick = { expanded = true }) {
+            Icon(
+                imageVector = Icons.Default.MoreVert,
+                contentDescription = stringResource(MR.string.moments_detail_menu_more),
+            )
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            DropdownMenuItem(
+                text = { Text(stringResource(MR.string.moments_detail_edit_description)) },
+                onClick = {
+                    expanded = false
+                    onEdit()
+                },
+            )
+            DropdownMenuItem(
+                text = { Text(stringResource(MR.string.moments_detail_menu_delete)) },
+                onClick = {
+                    expanded = false
+                    onDelete()
+                },
+            )
         }
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsScreen.kt
@@ -793,6 +793,15 @@ private fun MomentCommentsSheetHost(
             key = "moment-comments-sheet-$momentId",
         ) { parametersOf(momentId, null) }
         val uiState by detailVm.uiState.collectAsStateWithLifecycle()
+        // Deleting the moment from the sheet's description menu does an
+        // optimistic local remove, so the feed card vanishes on its own. There's
+        // no nav target to pop here (unlike the reels view), so just close the
+        // sheet so it doesn't linger over the now-deleted moment.
+        LaunchedEffect(detailVm) {
+            detailVm.events.collect { event ->
+                if (event is MomentDetailUiEvent.MomentDeleted) onDismiss()
+            }
+        }
         MomentCommentsSheet(
             uiState = uiState,
             onAction = detailVm::onAction,


### PR DESCRIPTION
## Why

Deleting a moment was only reachable from the reels/detail view's immersive top-bar overflow menu (`MomentOverflowMenu`), which **never appears over the timeline feed**. So a user browsing the feed had no way to delete their own moment without first opening it in the full-screen reels view.

## Approach

The description section of the comments/description bottom sheet (`MomentDescriptionSection`) is shown from **both** the reels detail pane and the feed (`MomentCommentsSheet` via `MomentCommentsSheetHost`), and both back it with the same `MomentDetailViewModel`. The entire delete path — `deleteMoment(forEveryone)`, `DeleteMomentDialog`, the `isMine` ownership gate, optimistic local delete + outbox enqueue — already exists in that VM/service. So surfacing delete on that shared surface gives the feed a delete path with **no new card gesture and no new business logic**.

## Changes

- **Replace the author-only edit pencil** in `MomentDescriptionSection` with a `MoreVert` overflow menu offering **Edit description** + **Delete** (still gated by `isMine`, so only the author sees it).
- **Wire `DeleteMomentDialog` into the feed's `MomentCommentsSheet`**, the same way `DetailContent` does for reels — this entry point doesn't route through `DetailContent`, so the `RequestDeleteMoment` action would otherwise toggle `showDeleteDialog` with no dialog ever rendered. Keeps the "Delete for me" / "Delete for everyone" choice identical to reels.
- **Dismiss the feed sheet on the `MomentDeleted` event** in `MomentCommentsSheetHost`. The optimistic local delete already removes the card from the feed; unlike reels there's no nav target to pop, so the sheet just closes.

## Notes

- Reuses existing strings (`moments_detail_edit_description`, `moments_detail_menu_delete`, `moments_detail_menu_more`) — no new strings.
- Removed the now-unused `Icons.Default.Edit` import.
- `:homebase-core:compileKotlinJvm` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)