### PR TITLE
Handle connection & circle state-change push notifications (5002/5003)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/eventbus/BackendEvent.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/eventbus/BackendEvent.kt
@@ -1,6 +1,8 @@
 package id.homebase.api.client.eventbus
 
 import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.client.websockets.CircleDefinitionChangeType
+import id.homebase.api.client.websockets.ConnectionChangeType
 import id.homebase.api.client.websockets.Introduction
 import id.homebase.api.common.OdinId
 import id.homebase.api.video.VideoProcessingPhase
@@ -51,6 +53,24 @@ sealed interface BackendEvent {
         data class IntroductionsReceived(
             val introducerOdinId: OdinId,
             val introduction: Introduction
+        ) : CircleNetworkEvent
+
+        /**
+         * An existing connection's state changed elsewhere (disconnect/block/unblock) or a circle
+         * was granted/revoked to it. Pushed to all the owner's sessions for any origin — including
+         * an echo of this device's own mutation, so consumers must be idempotent. [circleId] is
+         * non-null only for [ConnectionChangeType.CircleGranted] / [ConnectionChangeType.CircleRevoked].
+         */
+        data class ConnectionChanged(
+            val identity: String,
+            val change: ConnectionChangeType,
+            val circleId: String?,
+        ) : CircleNetworkEvent
+
+        /** A circle definition itself changed elsewhere (not its membership). Echoes like above. */
+        data class CircleDefinitionChanged(
+            val circleId: String,
+            val change: CircleDefinitionChangeType,
         ) : CircleNetworkEvent
 
     }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/ConnectionAndCircleNotifications.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/ConnectionAndCircleNotifications.kt
@@ -1,0 +1,76 @@
+package id.homebase.api.client.websockets
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Server push notifications for connection & circle state changes, delivered to all of the
+ * owner's sessions whenever connection/circle state changes from any device.
+ *
+ * Transport: these ride inside the [ClientNotificationType.appNotificationAdded] websocket
+ * notification. That notification's `data` is the app-notification envelope below, whose int
+ * [AppNotificationEnvelope.notificationType] selects the concrete payload and whose `data` is a
+ * second, double-encoded JSON string carrying it (parsed again). The wire is camelCase (the
+ * server's CamelCase policy), so the Kotlin camelCase field names match via
+ * [id.homebase.api.serialization.OdinSystemSerializer]'s naming strategy; enum names are decoded
+ * case-insensitively, and unknown values coerce to [ConnectionChangeType.Unknown] /
+ * [CircleDefinitionChangeType.Unknown] so a newer server kind never throws here.
+ */
+
+/** App-notification envelope: int type id + a double-encoded payload string. */
+@Serializable
+data class AppNotificationEnvelope(
+    val notificationType: Int = 0,
+    val data: String = "",
+)
+
+object AppNotificationType {
+    /** [ConnectionChangedNotification] */
+    const val CONNECTION_CHANGED: Int = 5002
+
+    /** [CircleDefinitionChangedNotification] */
+    const val CIRCLE_DEFINITION_CHANGED: Int = 5003
+}
+
+/** What happened to an existing connection (5002). */
+@Serializable
+enum class ConnectionChangeType {
+    Disconnected,
+    Blocked,
+    Unblocked,
+    CircleGranted,
+    CircleRevoked,
+
+    /** Fallback for a value this client build doesn't recognize. */
+    Unknown,
+}
+
+/** What happened to a circle definition itself — not its membership (5003). */
+@Serializable
+enum class CircleDefinitionChangeType {
+    Created,
+    Updated,
+    Deleted,
+    Enabled,
+    Disabled,
+
+    /** Fallback for a value this client build doesn't recognize. */
+    Unknown,
+}
+
+/**
+ * 5002 — an existing connection's state changed, or a circle was granted/revoked to it.
+ * [circleId] is only present for [ConnectionChangeType.CircleGranted] / [ConnectionChangeType.CircleRevoked].
+ */
+@Serializable
+data class ConnectionChangedNotification(
+    val identity: String = "",
+    val change: ConnectionChangeType = ConnectionChangeType.Unknown,
+    val circleId: String? = null,
+)
+
+/** 5003 — a circle definition was created/renamed/re-permissioned/deleted/enabled/disabled. */
+@Serializable
+data class CircleDefinitionChangedNotification(
+    val circleId: String = "",
+    val change: CircleDefinitionChangeType = CircleDefinitionChangeType.Unknown,
+)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
@@ -543,6 +543,7 @@ class OdinWebSocketClient(
 
 
             ClientNotificationType.appNotificationAdded -> {
+                handleAppNotification(notification)
             }
 
 
@@ -559,6 +560,62 @@ class OdinWebSocketClient(
             }
 
             else -> {
+            }
+        }
+    }
+
+    /**
+     * App-notification fan-out. We only act on the connection/circle state-change kinds (5002/5003);
+     * every other app-notification id is intentionally ignored here. The payload is double-encoded:
+     * parse the envelope, then parse its inner `data` string into the concrete notification. Parse
+     * failures are swallowed (logged) so one malformed/unknown payload can't kill the dispatch loop.
+     *
+     * These fire for any origin of the change — including an echo of this device's own mutation — so
+     * the downstream consumer ([id.homebase.chat.services.convo.contact.ConnectionService]) debounces
+     * and re-fetches idempotently rather than trusting the event to be unique.
+     */
+    private suspend fun handleAppNotification(notification: ClientNotificationPayload) {
+        val envelope = runCatching {
+            OdinSystemSerializer.deserialize<AppNotificationEnvelope>(notification.data)
+        }.getOrElse {
+            Logger.w(it) { "appNotification: envelope parse failed, data=${notification.data.take(200)}" }
+            return
+        }
+
+        when (envelope.notificationType) {
+            AppNotificationType.CONNECTION_CHANGED -> {
+                val d = runCatching {
+                    OdinSystemSerializer.deserialize<ConnectionChangedNotification>(envelope.data)
+                }.getOrElse {
+                    Logger.w(it) { "appNotification 5002 parse failed" }
+                    return
+                }
+                eventBus.emit(
+                    BackendEvent.CircleNetworkEvent.ConnectionChanged(
+                        identity = d.identity,
+                        change = d.change,
+                        circleId = d.circleId,
+                    )
+                )
+            }
+
+            AppNotificationType.CIRCLE_DEFINITION_CHANGED -> {
+                val d = runCatching {
+                    OdinSystemSerializer.deserialize<CircleDefinitionChangedNotification>(envelope.data)
+                }.getOrElse {
+                    Logger.w(it) { "appNotification 5003 parse failed" }
+                    return
+                }
+                eventBus.emit(
+                    BackendEvent.CircleNetworkEvent.CircleDefinitionChanged(
+                        circleId = d.circleId,
+                        change = d.change,
+                    )
+                )
+            }
+
+            else -> {
+                // Other app-notification kinds are not handled by this client.
             }
         }
     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ConnectionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ConnectionService.kt
@@ -11,6 +11,7 @@ import id.homebase.api.common.OdinId
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -18,6 +19,10 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import co.touchlab.kermit.Logger
+
+/** Debounce window for push-driven refreshes — long enough to swallow a fan-out burst, short
+ *  enough that the contact-detail / circles UI updates promptly after an external change. */
+private const val REFRESH_DEBOUNCE_MS = 300L
 
 data class ConnectionState(
     val isLoaded: Boolean,
@@ -78,9 +83,23 @@ class ConnectionService(
     // actions, CircleNetworkEvents) bypass this guard so they always re-fetch.
     private var refreshJob: Job? = null
 
+    // Trailing-debounce for push-driven invalidation (ConnectionChanged / CircleDefinitionChanged).
+    // Each event reschedules, so a burst (bulk circle edit, or the echo of our own mutation plus the
+    // real change) collapses into a single refresh once the events go quiet.
+    private var debouncedRefreshJob: Job? = null
+
     private fun launchRefresh() {
         if (refreshJob?.isActive == true) return
         refreshJob = scope.launch { refresh() }
+    }
+
+    /** Coalesces a burst of push events into one refresh [REFRESH_DEBOUNCE_MS] after the last one. */
+    private fun scheduleRefresh() {
+        debouncedRefreshJob?.cancel()
+        debouncedRefreshJob = scope.launch {
+            delay(REFRESH_DEBOUNCE_MS)
+            refresh()
+        }
     }
 
     init {
@@ -109,6 +128,19 @@ class ConnectionService(
                     // When the websocket comes back after an offline window, reconcile
                     // against the server — covers the airplane-mode-off case.
                     is BackendEvent.ConnectionOnline -> launchRefresh()
+                    // Connection/circle state changed somewhere (another device, owner-console,
+                    // server-side). These fan out to every session and echo our own mutations, so
+                    // a single connection edit or a bulk circle change can arrive as a burst —
+                    // collapse them into one re-fetch. refresh() already reloads connections AND
+                    // circles, so both event kinds are covered by the same scheduled refresh.
+                    is BackendEvent.CircleNetworkEvent.ConnectionChanged -> {
+                        Logger.d { "ConnectionChanged: ${event.identity} ${event.change} ${event.circleId ?: ""}" }
+                        scheduleRefresh()
+                    }
+                    is BackendEvent.CircleNetworkEvent.CircleDefinitionChanged -> {
+                        Logger.d { "CircleDefinitionChanged: ${event.circleId} ${event.change}" }
+                        scheduleRefresh()
+                    }
                     // Logout: drop the previous identity's connection map.
                     is BackendEvent.SessionEnded -> reset()
                     else -> {}
@@ -135,6 +167,8 @@ class ConnectionService(
     fun reset() {
         refreshJob?.cancel()
         refreshJob = null
+        debouncedRefreshJob?.cancel()
+        debouncedRefreshJob = null
         started = false
         _connections.value = ConnectionState(isLoaded = false, map = emptyMap())
         _circles.value = CircleMembershipState()


### PR DESCRIPTION
Wire the previously no-op appNotificationAdded websocket branch to parse the new server app-notifications: ConnectionChanged (5002 — disconnect/block/ unblock/circle grant/revoke on an existing connection) and CircleDefinitionChanged (5003 — circle created/renamed/re-permissioned/ deleted/enabled/disabled). Parses the double-encoded envelope, emits typed BackendEvent.CircleNetworkEvent variants; enums carry an Unknown fallback and decode case-insensitively so a newer server kind never throws.

ConnectionService consumes both with a 300ms trailing-debounced refresh. The events fan out to every session and echo this device's own mutations, so a single edit or a bulk circle change can arrive as a burst — debouncing collapses them into one re-fetch. refresh() already reloads connections AND circles, so both kinds are covered. Fixes stale circle membership / connection state on the contact-detail screen after a change made from another device or the owner console.