### PR TITLE
ContactBook: fix infinite spinner from replayed SessionEnded at login

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/ClientNotificationType.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/ClientNotificationType.kt
@@ -18,6 +18,8 @@ enum class ClientNotificationType {
     deviceDisconnected,
     inboxItemReceived,
     newFollower,
+    connectionChanged,
+    circleDefinitionChanged,
     statisticsChanged,
     reactionContentAdded,
     reactionContentDeleted,

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/ConnectionAndCircleNotifications.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/ConnectionAndCircleNotifications.kt
@@ -6,32 +6,16 @@ import kotlinx.serialization.Serializable
  * Server push notifications for connection & circle state changes, delivered to all of the
  * owner's sessions whenever connection/circle state changes from any device.
  *
- * Transport: these ride inside the [ClientNotificationType.appNotificationAdded] websocket
- * notification. That notification's `data` is the app-notification envelope below, whose int
- * [AppNotificationEnvelope.notificationType] selects the concrete payload and whose `data` is a
- * second, double-encoded JSON string carrying it (parsed again). The wire is camelCase (the
- * server's CamelCase policy), so the Kotlin camelCase field names match via
- * [id.homebase.api.serialization.OdinSystemSerializer]'s naming strategy; enum names are decoded
- * case-insensitively, and unknown values coerce to [ConnectionChangeType.Unknown] /
- * [CircleDefinitionChangeType.Unknown] so a newer server kind never throws here.
+ * Transport (confirmed on the wire): each arrives as its own top-level
+ * [ClientNotificationType] — `connectionChanged` / `circleDefinitionChanged` — exactly like
+ * `connectionRequestReceived` et al. The notification's `data` is a (double-encoded) JSON string
+ * carrying the payload directly; deserialize it into the types below. Field names are camelCase;
+ * enum names decode case-insensitively (server sends e.g. `"CircleGranted"`), and unknown values
+ * coerce to [ConnectionChangeType.Unknown] / [CircleDefinitionChangeType.Unknown] so a newer
+ * server kind never throws here.
  */
 
-/** App-notification envelope: int type id + a double-encoded payload string. */
-@Serializable
-data class AppNotificationEnvelope(
-    val notificationType: Int = 0,
-    val data: String = "",
-)
-
-object AppNotificationType {
-    /** [ConnectionChangedNotification] */
-    const val CONNECTION_CHANGED: Int = 5002
-
-    /** [CircleDefinitionChangedNotification] */
-    const val CIRCLE_DEFINITION_CHANGED: Int = 5003
-}
-
-/** What happened to an existing connection (5002). */
+/** What happened to an existing connection. */
 @Serializable
 enum class ConnectionChangeType {
     Disconnected,
@@ -44,7 +28,7 @@ enum class ConnectionChangeType {
     Unknown,
 }
 
-/** What happened to a circle definition itself — not its membership (5003). */
+/** What happened to a circle definition itself — not its membership. */
 @Serializable
 enum class CircleDefinitionChangeType {
     Created,
@@ -58,8 +42,9 @@ enum class CircleDefinitionChangeType {
 }
 
 /**
- * 5002 — an existing connection's state changed, or a circle was granted/revoked to it.
- * [circleId] is only present for [ConnectionChangeType.CircleGranted] / [ConnectionChangeType.CircleRevoked].
+ * `connectionChanged` — an existing connection's state changed, or a circle was granted/revoked
+ * to it. [circleId] is only present for [ConnectionChangeType.CircleGranted] /
+ * [ConnectionChangeType.CircleRevoked].
  */
 @Serializable
 data class ConnectionChangedNotification(
@@ -68,7 +53,7 @@ data class ConnectionChangedNotification(
     val circleId: String? = null,
 )
 
-/** 5003 — a circle definition was created/renamed/re-permissioned/deleted/enabled/disabled. */
+/** `circleDefinitionChanged` — a circle definition was created/renamed/re-permissioned/deleted/enabled/disabled. */
 @Serializable
 data class CircleDefinitionChangedNotification(
     val circleId: String = "",

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
@@ -542,8 +542,32 @@ class OdinWebSocketClient(
             }
 
 
+            ClientNotificationType.connectionChanged -> {
+                val d = OdinSystemSerializer.deserialize<ConnectionChangedNotification>(
+                    notification.data
+                )
+                eventBus.emit(
+                    BackendEvent.CircleNetworkEvent.ConnectionChanged(
+                        identity = d.identity,
+                        change = d.change,
+                        circleId = d.circleId,
+                    )
+                )
+            }
+
+            ClientNotificationType.circleDefinitionChanged -> {
+                val d = OdinSystemSerializer.deserialize<CircleDefinitionChangedNotification>(
+                    notification.data
+                )
+                eventBus.emit(
+                    BackendEvent.CircleNetworkEvent.CircleDefinitionChanged(
+                        circleId = d.circleId,
+                        change = d.change,
+                    )
+                )
+            }
+
             ClientNotificationType.appNotificationAdded -> {
-                handleAppNotification(notification)
             }
 
 
@@ -560,62 +584,6 @@ class OdinWebSocketClient(
             }
 
             else -> {
-            }
-        }
-    }
-
-    /**
-     * App-notification fan-out. We only act on the connection/circle state-change kinds (5002/5003);
-     * every other app-notification id is intentionally ignored here. The payload is double-encoded:
-     * parse the envelope, then parse its inner `data` string into the concrete notification. Parse
-     * failures are swallowed (logged) so one malformed/unknown payload can't kill the dispatch loop.
-     *
-     * These fire for any origin of the change — including an echo of this device's own mutation — so
-     * the downstream consumer ([id.homebase.chat.services.convo.contact.ConnectionService]) debounces
-     * and re-fetches idempotently rather than trusting the event to be unique.
-     */
-    private suspend fun handleAppNotification(notification: ClientNotificationPayload) {
-        val envelope = runCatching {
-            OdinSystemSerializer.deserialize<AppNotificationEnvelope>(notification.data)
-        }.getOrElse {
-            Logger.w(it) { "appNotification: envelope parse failed, data=${notification.data.take(200)}" }
-            return
-        }
-
-        when (envelope.notificationType) {
-            AppNotificationType.CONNECTION_CHANGED -> {
-                val d = runCatching {
-                    OdinSystemSerializer.deserialize<ConnectionChangedNotification>(envelope.data)
-                }.getOrElse {
-                    Logger.w(it) { "appNotification 5002 parse failed" }
-                    return
-                }
-                eventBus.emit(
-                    BackendEvent.CircleNetworkEvent.ConnectionChanged(
-                        identity = d.identity,
-                        change = d.change,
-                        circleId = d.circleId,
-                    )
-                )
-            }
-
-            AppNotificationType.CIRCLE_DEFINITION_CHANGED -> {
-                val d = runCatching {
-                    OdinSystemSerializer.deserialize<CircleDefinitionChangedNotification>(envelope.data)
-                }.getOrElse {
-                    Logger.w(it) { "appNotification 5003 parse failed" }
-                    return
-                }
-                eventBus.emit(
-                    BackendEvent.CircleNetworkEvent.CircleDefinitionChanged(
-                        circleId = d.circleId,
-                        change = d.change,
-                    )
-                )
-            }
-
-            else -> {
-                // Other app-notification kinds are not handled by this client.
             }
         }
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -786,8 +786,8 @@ fun AppNavHost(
                                 } else {
                                     ContactBookScreen(
                                         viewModel = contactBookViewModel,
-                                        onNavigateToSettings = {
-                                            navController.navigate(Route.ContactBookSettings)
+                                        onProfileClick = {
+                                            navController.navigate(Route.Settings)
                                         },
                                     )
                                 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookScreen.kt
@@ -1,17 +1,23 @@
 package id.homebase.core.ui.screens.contactbook
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.PersonAddAlt1
-import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -32,13 +38,19 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.backhandler.BackHandler
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.homebase.api.client.auth.initials
+import id.homebase.core.avatars.AvatarOptions
+import id.homebase.core.avatars.OwnerAvatar
 import id.homebase.core.permissions.PermissionStatus
 import id.homebase.core.permissions.PermissionType
 import id.homebase.core.permissions.createPermissionsManager
@@ -48,7 +60,6 @@ import id.homebase.core.ui.screens.contactbook.deviceimport.ContactImportSheet
 import id.homebase.resources.MR
 import id.homebase.resources.contactbook_action_add
 import id.homebase.resources.contactbook_action_import
-import id.homebase.resources.contactbook_action_settings
 import id.homebase.resources.contactbook_error_delete
 import id.homebase.resources.contactbook_error_forbidden
 import id.homebase.resources.contactbook_error_import
@@ -68,7 +79,7 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun ContactBookScreen(
     viewModel: ContactBookViewModel,
-    onNavigateToSettings: () -> Unit,
+    onProfileClick: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -175,7 +186,40 @@ fun ContactBookScreen(
                 )
             } else {
                 TopAppBar(
-                    title = { Text(stringResource(MR.string.contactbook_label)) },
+                    // Owner avatar on the left links to settings — mirrors the Moments header.
+                    title = {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Spacer(modifier = Modifier.width(4.dp))
+                            AnimatedVisibility(
+                                visible = uiState.ownerSession != null,
+                                enter = fadeIn(animationSpec = tween(300, delayMillis = 200)),
+                                exit = fadeOut(animationSpec = tween(150)),
+                            ) {
+                                uiState.ownerSession?.let { session ->
+                                    OwnerAvatar(
+                                        odinId = session.odinId,
+                                        profileImageData = null,
+                                        initials = session.initials(),
+                                        connectionStatus = uiState.connectionStatus,
+                                        driveIsSyncing = uiState.driveIsSyncing,
+                                        hasDriveError = uiState.hasDriveError,
+                                        options = AvatarOptions(
+                                            size = 32.dp,
+                                            fontSize = 12.sp,
+                                            onClick = onProfileClick,
+                                        ),
+                                        animatedVisibilityScope = this@AnimatedVisibility,
+                                        sharedTransitionScope = null,
+                                    )
+                                }
+                            }
+                            Spacer(modifier = Modifier.width(16.dp))
+                            Text(stringResource(MR.string.contactbook_label))
+                        }
+                    },
                     actions = {
                         IconButton(onClick = { searchActive = true }) {
                             Icon(
@@ -190,12 +234,6 @@ fun ContactBookScreen(
                                     contentDescription = stringResource(MR.string.contactbook_action_import),
                                 )
                             }
-                        }
-                        IconButton(onClick = onNavigateToSettings) {
-                            Icon(
-                                Icons.Outlined.Settings,
-                                contentDescription = stringResource(MR.string.contactbook_action_settings),
-                            )
                         }
                     },
                 )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookStream.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookStream.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.uuid.ExperimentalUuidApi
@@ -102,7 +103,21 @@ class ContactBookStream(
     }
 
     private suspend fun observeEvents() {
-        eventBus.events.collect { event ->
+        // The EventBus replays its last event (replay=1) to every new subscriber.
+        // This stream is a lazily-constructed singleton whose collector subscribes
+        // the first time it is resolved — which is inside onPostAuthenticated() at
+        // login. If a SessionEnded is sitting in the replay buffer from the
+        // pre-login Unauthenticated state (cold start lands on the login screen,
+        // which emits SessionEnded), it would be redelivered here and call reset()
+        // (_isLoaded=false), racing start()'s loadAll() (_isLoaded=true). When that
+        // replayed reset() lands AFTER loadAll(), the contact list spins forever
+        // until the next logout/login. A replayed event is stale by construction
+        // here, so skip whatever is already buffered and act on live events only.
+        val replayed = eventBus.events.replayCache.size
+        if (replayed > 0) {
+            Logger.d(tag = TAG) { "observeEvents: skipping $replayed replayed event(s) at startup" }
+        }
+        eventBus.events.drop(replayed).collect { event ->
             when (event) {
                 is BackendEvent.SessionEnded -> reset()
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookStream.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookStream.kt
@@ -22,6 +22,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -57,6 +59,10 @@ class ContactBookStream(
     // before the server-confirmed delete syncs down.
     private val deletedIds = mutableSetOf<Uuid>()
 
+    // Serializes loadAll so concurrent ensureLoaded() callers (the screen) don't run
+    // overlapping queries, and so ensureLoaded's check-then-load is atomic.
+    private val loadMutex = Mutex()
+
     init {
         scope.launch { observeEvents() }
     }
@@ -64,6 +70,21 @@ class ContactBookStream(
     /** Load from the local DB. Called from onPostAuthenticated, never from init. */
     fun start() {
         scope.launch { loadAll() }
+    }
+
+    /**
+     * Guarantees the contact list has been loaded for the current session, on demand.
+     * The screen calls this on entry so it never depends on the post-auth bootstrap
+     * (onPostAuthenticated -> start()) having actually run: that chain can be skipped by
+     * the headless/foreground promotion race, leaving [isLoaded] stuck false and the list
+     * spinning forever. Idempotent and cheap once loaded.
+     */
+    suspend fun ensureLoaded() {
+        if (_isLoaded.value) return
+        loadMutex.withLock {
+            if (_isLoaded.value) return
+            loadAll()
+        }
     }
 
     /** Clear all in-memory state for a clean login as a different identity. */

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookUiState.kt
@@ -1,7 +1,9 @@
 package id.homebase.core.ui.screens.contactbook
 
 import androidx.compose.runtime.Immutable
+import id.homebase.api.client.auth.OwnerSession
 import id.homebase.api.client.connections.CircleWithMembers
+import id.homebase.core.avatars.AppConnectionStatus
 import id.homebase.core.contactbook.DeviceContact
 import id.homebase.core.ui.screens.contactbook.model.ContactBookEntry
 import io.github.vinceglb.filekit.PlatformFile
@@ -100,6 +102,14 @@ data class ContactBookUiState(
     val overlay: ContactBookOverlay? = null,
     val importState: ImportUiState? = null,
     val importSupported: Boolean = false,
+    /** Logged-in owner, for the header avatar that links to settings. Null until loaded. */
+    val ownerSession: OwnerSession? = null,
+    /** Connection state surfaced as the avatar's status dot. */
+    val connectionStatus: AppConnectionStatus = AppConnectionStatus.Disconnected,
+    /** A sync pass is in flight — the avatar shows a spinner instead of the dot. */
+    val driveIsSyncing: Boolean = false,
+    /** The last sync pass failed — the avatar dot turns amber. */
+    val hasDriveError: Boolean = false,
 )
 
 sealed interface ContactBookUiAction {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookViewModel.kt
@@ -5,17 +5,24 @@ package id.homebase.core.ui.screens.contactbook
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
+import id.homebase.api.client.auth.OwnerSession
+import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.api.client.connections.CircleWithMembers
 import id.homebase.api.client.connections.ConnectionNetworkProvider
 import id.homebase.api.client.connections.ConnectionRequestOrigin
 import id.homebase.api.client.connections.ConnectionStatus
 import id.homebase.api.client.contacts.ContactContent
+import id.homebase.api.client.eventbus.BackendEvent
+import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.common.OdinId
 import id.homebase.api.crypto.Md5
 import id.homebase.chat.services.convo.ConversationService
 import id.homebase.chat.services.convo.contact.CircleMembershipState
 import id.homebase.chat.services.convo.contact.ConnectionService
 import id.homebase.chat.services.convo.contact.ConnectionState
+import id.homebase.core.auth.AuthConnectionCoordinator
+import id.homebase.core.auth.toConnectionStatus
+import id.homebase.core.avatars.AppConnectionStatus
 import id.homebase.core.config.CONFIRMED_CONNECTIONS_CIRCLE_ID
 import id.homebase.api.client.contacts.ContactEmail
 import id.homebase.api.client.contacts.ContactName
@@ -34,7 +41,9 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -62,6 +71,9 @@ class ContactBookViewModel(
     private val conversationService: ConversationService,
     private val connectionService: ConnectionService,
     private val connectionNetworkProvider: ConnectionNetworkProvider,
+    ownerSessionRepository: OwnerSessionRepository,
+    authConnectionCoordinator: AuthConnectionCoordinator,
+    eventBus: EventBus,
 ) : ViewModel() {
 
     private val _selectedTab = MutableStateFlow(ContactTab.CONTACTS)
@@ -72,6 +84,52 @@ class ContactBookViewModel(
     private val _circles = MutableStateFlow<List<CircleWithMembers>>(emptyList())
     private val _circlesLoading = MutableStateFlow(false)
     private val _circleMembers = MutableStateFlow<CircleMembersUi?>(null)
+
+    /** Owner avatar + connection/sync status for the header (mirrors the Moments header). */
+    private data class HeaderBundle(
+        val ownerSession: OwnerSession? = null,
+        val connectionStatus: AppConnectionStatus = AppConnectionStatus.Disconnected,
+        val driveIsSyncing: Boolean = false,
+        val hasDriveError: Boolean = false,
+    )
+
+    private val _header = MutableStateFlow(HeaderBundle())
+
+    init {
+        // Make the screen self-sufficient: load the contact list on entry rather than
+        // relying on the post-auth bootstrap (onPostAuthenticated -> start()), which can be
+        // skipped by the headless/foreground promotion race and leave the list spinning.
+        // Idempotent once loaded.
+        viewModelScope.launch { stream.ensureLoaded() }
+        viewModelScope.launch {
+            ownerSessionRepository.user.collect { session ->
+                _header.update { it.copy(ownerSession = session) }
+            }
+        }
+        viewModelScope.launch {
+            authConnectionCoordinator.connectionState.collectLatest { state ->
+                _header.update { it.copy(connectionStatus = state.toConnectionStatus()) }
+            }
+        }
+        viewModelScope.launch {
+            eventBus.events
+                .filter { it is BackendEvent.SyncAllStarted || it is BackendEvent.SyncAllStopped }
+                .collectLatest { event ->
+                    when (event) {
+                        is BackendEvent.SyncAllStarted -> _header.update {
+                            it.copy(driveIsSyncing = true, hasDriveError = false)
+                        }
+                        is BackendEvent.SyncAllStopped -> _header.update {
+                            it.copy(
+                                driveIsSyncing = false,
+                                hasDriveError = event.result is BackendEvent.SyncAllResult.Failure,
+                            )
+                        }
+                        else -> Unit
+                    }
+                }
+        }
+    }
 
     private data class ContactsBundle(
         val contacts: List<ContactBookEntry>,
@@ -107,7 +165,8 @@ class ContactBookViewModel(
             UiBits(q, f, tab, o, i)
         },
         combine(_circles, _circlesLoading, _circleMembers) { c, l, m -> CirclesBundle(c, l, m) },
-    ) { contactsData, ui, circlesData ->
+        _header,
+    ) { contactsData, ui, circlesData, header ->
         val connectedRegs = contactsData.connections.map
             .filterValues { it.status == ConnectionStatus.Connected }
         val connectedDomains = connectedRegs.keys.map { it.domainName.lowercase() }.toSet()
@@ -172,6 +231,10 @@ class ContactBookViewModel(
             overlay = ui.overlay,
             importState = ui.importState,
             importSupported = isDeviceContactsSupported(),
+            ownerSession = header.ownerSession,
+            connectionStatus = header.connectionStatus,
+            driveIsSyncing = header.driveIsSyncing,
+            hasDriveError = header.hasDriveError,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ContactBookUiState())
 


### PR DESCRIPTION
ContactBookStream is a lazily-constructed singleton; its observeEvents() collector subscribes the first time it is resolved, inside onPostAuthenticated() at login. The EventBus has replay=1, so a SessionEnded left in the buffer from the pre-login Unauthenticated state (cold start lands on the login screen, which emits SessionEnded) gets redelivered to the new collector and calls reset() (_isLoaded=false) — racing start()'s loadAll() (_isLoaded=true). When the replayed reset() lands after loadAll(), the contact list spins forever until the next logout/login (which doesn't re-subscribe, so the next loadAll() wins uncontested).

Skip whatever is already buffered at subscription time and act on live events only. A replayed event is stale by construction here — the stream is built because we just authenticated — and start()/loadAll() reads the DB fresh, so nothing is lost.