### PR TITLE
fix(sticker): guard against multi-send on rapid taps

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -253,11 +253,20 @@ class ConversationListViewModel(
     private val stickerHandler = StickerHandler(
         scope = viewModelScope,
         messagesUiState = _messagesUiState,
-        stickerService = stickerService,
-        stickerStream = stickerStream,
-        chatMessageActionService = chatMessageActionService,
         sendEvent = ::sendEvent,
         addMessageWithFiles = messageActionsHandler::addMessageWithFiles,
+        resolveStickerForSend = stickerService::resolveForSend,
+        saveStickerBytes = { bytes, contentType, sourceFileId ->
+            stickerService.saveSticker(
+                bytes = bytes,
+                contentType = contentType,
+                scope = viewModelScope,
+                sourceFileId = sourceFileId,
+            )
+        },
+        deleteSticker = stickerService::deleteSticker,
+        getPayloadBytes = chatMessageActionService::getPayloadBytes,
+        savedStickers = { stickerStream.stickers.value },
         awaitDriveGranted = ::ensureStickerDriveReady,
     )
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/StickerHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/StickerHandler.kt
@@ -5,10 +5,7 @@ package id.homebase.chat.conversationlist
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.KeyHeader
 import id.homebase.chat.conversationlist.ConversationListUiEvent.ShowInfoMessage
-import id.homebase.chat.services.ChatMessageActionService
 import id.homebase.chat.services.sticker.SavedSticker
-import id.homebase.chat.services.sticker.StickerService
-import id.homebase.chat.services.sticker.StickerStream
 import id.homebase.core.clipboard.platformFileFromPath
 import id.homebase.core.config.chatTargetDrive
 import id.homebase.core.image.HomebaseImageData
@@ -32,36 +29,60 @@ private const val TAG = "StickerHandler"
 
 /**
  * Handles the sticker-library action arms (send a saved sticker, save a received
- * sticker, import a transparent image, remove a sticker), extracted from
- * `ConversationListViewModel.onAction` in the same handler-class style as
- * [AttachmentHandler] / [MediaDownloadHandler].
+ * sticker, remove a sticker), extracted from `ConversationListViewModel.onAction` in the
+ * same handler-class style as [AttachmentHandler] / [MediaDownloadHandler].
  *
- * Reuses the existing send pipeline: tapping a saved sticker re-stages it as a
- * normal [AttachmentPendingFile.FileImage] with `forceSticker = true` and calls
- * [addMessageWithFiles] — no new send code. Saving a received sticker decrypts the
- * payload via the same `getPayloadBytes` path [MediaDownloadHandler] uses.
+ * Collaborators are injected as functions (mirroring [StickerCreator]) so the handler is
+ * unit-testable without standing up [id.homebase.chat.services.sticker.StickerService] and
+ * its drive/database dependencies.
+ *
+ * Reuses the existing send pipeline: tapping a saved sticker re-stages it as a normal
+ * [AttachmentPendingFile.FileImage] with `forceSticker = true` and calls [addMessageWithFiles].
  */
 internal class StickerHandler(
     private val scope: CoroutineScope,
     private val messagesUiState: MutableStateFlow<MessageListUiState>,
-    private val stickerService: StickerService,
-    private val stickerStream: StickerStream,
-    private val chatMessageActionService: ChatMessageActionService,
     private val sendEvent: (ConversationListUiEvent) -> Unit,
     private val addMessageWithFiles: (conversationId: Uuid, content: String, files: List<AttachmentPendingFile>) -> Unit,
     /**
+     * Resolve a saved sticker's image to a local temp path so it can be re-staged as a
+     * normal image attachment. This is a (possibly slow, cold) drive fetch the first time.
+     */
+    private val resolveStickerForSend: suspend (SavedSticker) -> String?,
+    /** Persist raw sticker bytes to the Stickers drive; returns the new uniqueId or null. */
+    private val saveStickerBytes: suspend (bytes: ByteArray, contentType: String, sourceFileId: Uuid?) -> Uuid?,
+    /** Enqueue a delete for a saved sticker. */
+    private val deleteSticker: suspend (SavedSticker) -> Boolean,
+    /** Decrypt a chat message payload's bytes (used when saving a received sticker). */
+    private val getPayloadBytes: suspend (fileId: Uuid, key: String, keyHeader: KeyHeader) -> ByteArray?,
+    /** Snapshot of the user's saved stickers (for matching a received sticker's source file). */
+    private val savedStickers: () -> List<SavedSticker>,
+    /**
      * Suspends until the optional Stickers drive is granted (instant when it already is;
      * waits for the extend-permissions dialog on first use). The write paths
-     * (import / save-from-message) gate on this so they never enqueue an upload to an
-     * ungranted drive — which the sync engine wouldn't push, silently losing the sticker.
+     * (save-from-message) gate on this so they never enqueue an upload to an ungranted
+     * drive — which the sync engine wouldn't push, silently losing the sticker.
      */
     private val awaitDriveGranted: suspend () -> Unit,
 ) {
 
+    /**
+     * uniqueIds of stickers whose send is currently in flight. A saved-sticker send first
+     * does a cold drive fetch ([resolveStickerForSend]) that can take seconds; without this
+     * guard every tap during that window launched another full send (the "each press sends
+     * a sticker" bug). Accessed only on [scope]'s dispatcher (taps and the resetting
+     * `finally` both run there), so a plain set needs no extra synchronisation.
+     */
+    private val sendingStickerIds = mutableSetOf<Uuid>()
+
     fun handleSendSavedSticker(action: ConversationListUiAction.SendSavedSticker) {
+        val stickerId = action.sticker.uniqueId
+        // Ignore repeated taps on the same sticker while its send is in flight. Reset in
+        // `finally` so a later, deliberate re-send of the same sticker still works.
+        if (!sendingStickerIds.add(stickerId)) return
         scope.launch {
             try {
-                val path = stickerService.resolveForSend(action.sticker)
+                val path = resolveStickerForSend(action.sticker)
                 if (path == null) {
                     sendEvent(ShowInfoMessage(MR.string.chat_sticker_save_failed))
                     return@launch
@@ -75,6 +96,8 @@ internal class StickerHandler(
             } catch (e: Exception) {
                 Logger.e(e, TAG) { "Failed to send saved sticker" }
                 sendEvent(ShowInfoMessage(MR.string.chat_sticker_send_failed))
+            } finally {
+                sendingStickerIds.remove(stickerId)
             }
         }
     }
@@ -91,7 +114,7 @@ internal class StickerHandler(
                     sendEvent(ShowInfoMessage(MR.string.chat_sticker_save_failed))
                     return@launch
                 }
-                val bytes = chatMessageActionService.getPayloadBytes(
+                val bytes = getPayloadBytes(
                     message.fileId,
                     action.payloadKey,
                     KeyHeader(Base64.decode(iv), message.keyHeader.aesKey),
@@ -103,13 +126,12 @@ internal class StickerHandler(
                 // Don't enqueue the upload until the Stickers drive is granted, or the
                 // sync engine would drop it (ungranted drives aren't pushed).
                 awaitDriveGranted()
-                val saved = stickerService.saveSticker(
-                    bytes = bytes,
-                    contentType = payload.contentType ?: "image/png",
-                    scope = scope,
+                val saved = saveStickerBytes(
+                    bytes,
+                    payload.contentType ?: "image/png",
                     // Record which message this sticker came from, so a later sheet open can
                     // detect it's already saved and offer "Remove" instead of "Add".
-                    sourceFileId = message.fileId,
+                    message.fileId,
                 )
                 sendEvent(
                     ShowInfoMessage(
@@ -127,7 +149,7 @@ internal class StickerHandler(
     fun handleRemoveSticker(action: ConversationListUiAction.RemoveSticker) {
         scope.launch {
             try {
-                val ok = stickerService.deleteSticker(action.sticker)
+                val ok = deleteSticker(action.sticker)
                 if (ok) sendEvent(ShowInfoMessage(MR.string.chat_sticker_removed))
             } catch (e: Exception) {
                 Logger.e(e, TAG) { "Failed to remove sticker" }
@@ -194,7 +216,7 @@ internal class StickerHandler(
                     sendEvent(ShowInfoMessage(MR.string.chat_sticker_remove_failed))
                     return@launch
                 }
-                val ok = stickerService.deleteSticker(saved)
+                val ok = deleteSticker(saved)
                 if (ok) sendEvent(ShowInfoMessage(MR.string.chat_sticker_removed))
                 else sendEvent(ShowInfoMessage(MR.string.chat_sticker_remove_failed))
             } catch (e: Exception) {
@@ -205,5 +227,5 @@ internal class StickerHandler(
     }
 
     private fun findSavedFromMessage(sourceFileId: Uuid): SavedSticker? =
-        stickerStream.stickers.value.firstOrNull { it.sourceFileId == sourceFileId }
+        savedStickers().firstOrNull { it.sourceFileId == sourceFileId }
 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/StickerSendGuardTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/StickerSendGuardTest.kt
@@ -1,0 +1,109 @@
+package id.homebase.chat.conversationlist
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.drives.files.PayloadDescriptor
+import id.homebase.chat.services.sticker.SavedSticker
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+
+/**
+ * Guards the sticker-send fix (bug: "takes 5 seconds and each press sends a sticker").
+ *
+ * The slow part of a send is [StickerHandler]'s `resolveStickerForSend` — a cold drive
+ * fetch that can take seconds the first time. Without an in-flight guard, every tap during
+ * that window launched another full send. These tests pin the guard's three behaviours:
+ * repeated taps on the SAME sticker while one is in flight send once; a deliberate re-send
+ * after completion works; different stickers are not blocked by each other.
+ *
+ * Uses [UnconfinedTestDispatcher] so the handler's fire-and-forget `scope.launch` runs
+ * eagerly up to its first real suspension — making the in-flight window deterministic
+ * without manual scheduler advancement.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class StickerSendGuardTest {
+
+    private fun savedSticker(uniqueId: Uuid = Uuid.random()) = SavedSticker(
+        fileId = Uuid.random(),
+        uniqueId = uniqueId,
+        driveId = Uuid.random(),
+        payloadKey = "stk",
+        contentType = "image/png",
+        keyHeader = KeyHeader.newRandom16(),
+        previewThumbnail = null,
+        payloadDescriptor = PayloadDescriptor(key = "stk", contentType = "image/png"),
+        createdAt = 0L,
+    )
+
+    private fun handler(
+        scope: CoroutineScope,
+        resolve: suspend (SavedSticker) -> String?,
+        onSend: () -> Unit,
+    ) = StickerHandler(
+        scope = scope,
+        messagesUiState = MutableStateFlow(MessageListUiState()),
+        sendEvent = {},
+        addMessageWithFiles = { _, _, _ -> onSend() },
+        resolveStickerForSend = resolve,
+        saveStickerBytes = { _, _, _ -> null },
+        deleteSticker = { false },
+        getPayloadBytes = { _, _, _ -> null },
+        savedStickers = { emptyList() },
+        awaitDriveGranted = {},
+    )
+
+    private fun send(h: StickerHandler, sticker: SavedSticker) =
+        h.handleSendSavedSticker(ConversationListUiAction.SendSavedSticker(Uuid.random(), sticker))
+
+    @Test
+    fun rapidTaps_sameSticker_inFlight_sendOnce() = runTest {
+        var sends = 0
+        val gate = CompletableDeferred<Unit>()
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val h = handler(scope, resolve = { gate.await(); "/tmp/s.png" }, onSend = { sends++ })
+        val sticker = savedSticker()
+
+        send(h, sticker)       // runs eagerly, suspends in resolve at the gate
+        send(h, sticker)       // second tap while the first is in flight -> guarded
+        gate.complete(Unit)    // first resolve completes -> send proceeds
+
+        assertEquals(1, sends, "rapid taps on the same sticker while in flight should send once")
+        scope.cancel()
+    }
+
+    @Test
+    fun resend_afterCompletion_allowed() = runTest {
+        var sends = 0
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val h = handler(scope, resolve = { "/tmp/s.png" }, onSend = { sends++ })
+        val sticker = savedSticker()
+
+        send(h, sticker)       // completes eagerly (no suspension)
+        send(h, sticker)       // deliberate re-send after the first completed
+
+        assertEquals(2, sends, "a deliberate re-send after completion should work")
+        scope.cancel()
+    }
+
+    @Test
+    fun differentStickers_notGuarded() = runTest {
+        var sends = 0
+        val gate = CompletableDeferred<Unit>()
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val h = handler(scope, resolve = { gate.await(); "/tmp/s.png" }, onSend = { sends++ })
+
+        send(h, savedSticker())
+        send(h, savedSticker()) // different sticker, also in flight
+        gate.complete(Unit)
+
+        assertEquals(2, sends, "different stickers should each send")
+        scope.cancel()
+    }
+}


### PR DESCRIPTION
## Bug
Sending a saved sticker had two reported problems: it takes ~5 seconds, and **each press sends a sticker**.

## Root cause
`StickerHandler.handleSendSavedSticker` launched a send coroutine on every tap with **no in-flight guard**. Because the send first does a cold drive fetch of the full sticker payload (`resolveForSend` → `getPayloadBytesDecrypted`, which can take seconds the first time), every tap during that window launched another full send → multiple sticker messages.

## Fix
- Add an **in-flight guard** keyed by the sticker's `uniqueId` (`sendingStickerIds`), reset in `finally` so a deliberate re-send after the first completes still works. Repeated taps on the *same* sticker while it's in flight are ignored; *different* stickers are unaffected (correct Signal/WhatsApp-style behaviour — the sticker keyboard stays open).
- Refactor `StickerHandler` to **function-injected collaborators** (mirroring the sibling `StickerCreator`) so it's unit-testable without standing up `StickerService` and its drive/database dependencies.
- Add `StickerSendGuardTest` (3 cases): in-flight dedupe, re-send-after-completion, different-stickers-independent. Uses `UnconfinedTestDispatcher` so the fire-and-forget launch runs deterministically.

## On the ~5s latency
Profiled from the code: it's an **inherent cold fetch** of the full sticker payload from the Stickers drive. Subsequent sends of the same sticker hit the disk cache (`payloadDiskCache`) and are fast. Per the repo's debugging rules I did **not** guess-fix this; eliminating the first-send latency would need either a local sticker-bytes cache or an optimistic-bubble send path (and on-device profiling to confirm where the time goes) — a separate change. The guard already removes the user-visible damage (no more accidental multi-send during that window).

## Tests
- `:homebase-chat:jvmTest --tests StickerSendGuardTest` — green (3/3)
- Full `:homebase-chat:jvmTest` — green (no existing test broken by the refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)