### PR TITLE
fix(ios): video sends as a few-KB file instead of the movie

### DIFF
--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/IOSFileOperationsProvider.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/IOSFileOperationsProvider.kt
@@ -26,6 +26,12 @@ import platform.Foundation.seekToEndOfFile
 import platform.Foundation.writeData
 import platform.Foundation.writeToFile
 import platform.Photos.PHAsset
+import platform.Photos.PHAssetMediaTypeVideo
+import platform.Photos.PHAssetResource
+import platform.Photos.PHAssetResourceManager
+import platform.Photos.PHAssetResourceRequestOptions
+import platform.Photos.PHAssetResourceTypeFullSizeVideo
+import platform.Photos.PHAssetResourceTypeVideo
 import platform.Photos.PHImageRequestOptions
 import platform.Photos.PHImageRequestOptionsDeliveryModeHighQualityFormat
 import platform.posix.memcpy
@@ -184,6 +190,17 @@ class IOSFileOperationsProvider : FileOperationsProvider {
     @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
     override suspend fun resolveToFilePath(path: String): String {
         if (path.startsWith("ph://") || path.contains("/L0/")) {
+            // A video PHAsset must be read via PHAssetResourceManager: requestImageDataForAsset
+            // (used by readPhotoLibraryAsset) is image-only and returns a tiny poster frame for
+            // videos — that's the "video sends as a few-KB file" bug. Stream the original movie
+            // resource straight to the temp file (also avoids holding the whole video in memory).
+            val videoAsset = phVideoAssetOrNull(path)
+            if (videoAsset != null) {
+                val tmpPath = "${NSTemporaryDirectory()}resolved_${NSUUID().UUIDString}.mov"
+                writeVideoAssetToFile(videoAsset, tmpPath)
+                return tmpPath
+            }
+
             val bytes = readPhotoLibraryAsset(path)
             val tmpPath = "${NSTemporaryDirectory()}resolved_${NSUUID().UUIDString}.mov"
             val data = bytes.usePinned { pinned ->
@@ -195,6 +212,49 @@ class IOSFileOperationsProvider : FileOperationsProvider {
 
         return path
     }
+
+    /** The [PHAsset] for a `ph://` path iff it is a video, else null (images/`/L0/` paths). */
+    @OptIn(ExperimentalForeignApi::class)
+    private fun phVideoAssetOrNull(path: String): PHAsset? {
+        if (!path.startsWith("ph://")) return null
+        val assetId = path.removePrefix("ph://")
+        val fetchResult = PHAsset.fetchAssetsWithLocalIdentifiers(listOf(assetId), options = null)
+        if (fetchResult.count.toInt() == 0) return null
+        val asset = fetchResult.objectAtIndex(0u) as PHAsset
+        return if (asset.mediaType == PHAssetMediaTypeVideo) asset else null
+    }
+
+    /** Streams a video PHAsset's original movie resource to [destPath] via PHAssetResourceManager. */
+    @OptIn(ExperimentalForeignApi::class)
+    private suspend fun writeVideoAssetToFile(asset: PHAsset, destPath: String): Unit =
+        suspendCancellableCoroutine { continuation ->
+            val videoResource = PHAssetResource.assetResourcesForAsset(asset)
+                .filterIsInstance<PHAssetResource>()
+                .firstOrNull { it.type == PHAssetResourceTypeVideo || it.type == PHAssetResourceTypeFullSizeVideo }
+            if (videoResource == null) {
+                continuation.resumeWithException(
+                    IllegalStateException("No video resource for asset ${asset.localIdentifier}")
+                )
+                return@suspendCancellableCoroutine
+            }
+
+            val options = PHAssetResourceRequestOptions().apply { setNetworkAccessAllowed(true) }
+            val destUrl = NSURL.fileURLWithPath(destPath)
+            PHAssetResourceManager.defaultManager().writeDataForAssetResource(
+                videoResource,
+                toFile = destUrl,
+                options = options,
+                completionHandler = { error ->
+                    if (error != null) {
+                        continuation.resumeWithException(
+                            IllegalStateException("Failed to export video resource: ${error.localizedDescription}")
+                        )
+                    } else {
+                        continuation.resume(Unit)
+                    }
+                },
+            )
+        }
 
     @OptIn(ExperimentalForeignApi::class, kotlinx.cinterop.BetaInteropApi::class)
     private suspend fun readPhotoLibraryAsset(phUri: String): ByteArray = suspendCancellableCoroutine { continuation ->

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/IOSFileOperationsProvider.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/IOSFileOperationsProvider.kt
@@ -213,11 +213,21 @@ class IOSFileOperationsProvider : FileOperationsProvider {
         return path
     }
 
-    /** The [PHAsset] for a `ph://` path iff it is a video, else null (images/`/L0/` paths). */
+    /**
+     * The [PHAsset] for a Photos-library video path iff it is a video, else null (images, or a
+     * non-library path). Accepts BOTH a `ph://<id>` URI and the raw PHAsset localIdentifier
+     * (`<uuid>/L0/nnn`): the gallery picker hands the send path the raw localIdentifier — never a
+     * `ph://` URI — so gating on `ph://` alone left gallery video picks falling through to the
+     * image-only `requestImageDataForAsset` path, which returns a few-KB poster frame for `.mp4`
+     * (the "mp4 sends as a tiny file" bug). Mirrors the `ph:// || /L0/` guard used above.
+     */
     @OptIn(ExperimentalForeignApi::class)
     private fun phVideoAssetOrNull(path: String): PHAsset? {
-        if (!path.startsWith("ph://")) return null
-        val assetId = path.removePrefix("ph://")
+        val assetId = when {
+            path.startsWith("ph://") -> path.removePrefix("ph://")
+            path.contains("/L0/") -> path
+            else -> return null
+        }
         val fetchResult = PHAsset.fetchAssetsWithLocalIdentifiers(listOf(assetId), options = null)
         if (fetchResult.count.toInt() == 0) return null
         val asset = fetchResult.objectAtIndex(0u) as PHAsset

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentHandler.kt
@@ -254,7 +254,18 @@ internal class AttachmentHandler(
                     if (pending is AttachmentPendingFile.FileVideo) {
                         // Cheap playable handle (blob: URL on web, real path on native); see
                         // handleAttachPlatformFile. Send-time materialization is separate.
-                        extractThumbnailAsync(pending.attachmentId, gallery.file.toPlayableUrl())
+                        val rawPath = gallery.file.toPlayableUrl()
+                        // iOS quick-switch hands a bare PHAsset localIdentifier (ph://… / …/L0/…)
+                        // that AVPlayer (the editor preview) and the thumbnail/duration probe can't
+                        // open — materialize it to a real temp file first. Other platforms
+                        // (Android content://, desktop real path) are already playable; pass through.
+                        // The send path resolves file (the identifier) on its own, so it's untouched.
+                        val playable = if (rawPath.startsWith("ph://") || rawPath.contains("/L0/")) {
+                            fileOperationsProvider.resolveToFilePath(rawPath)
+                        } else {
+                            rawPath
+                        }
+                        extractThumbnailAsync(pending.attachmentId, playable)
                     }
                 }
             } catch (e: Exception) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentHandler.kt
@@ -211,6 +211,9 @@ internal class AttachmentHandler(
                         AttachmentPendingFile.FileVideo(
                             Uuid.generateV7(),
                             it.file,
+                            // The gallery PlatformFile path is a bare PHAsset localIdentifier on iOS
+                            // (no extension), so carry the real filename for content-type resolution.
+                            sourceFileName = it.fileName,
                             thumbnailBytes = null,
                         )
                     } else {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -341,6 +341,13 @@ sealed class AttachmentPendingFile(val attachmentId: Uuid) {
     data class FileVideo(
         val id: Uuid,
         val file: PlatformFile,
+        // Real source filename (with extension) for when [file]'s own name is uninformative — e.g.
+        // an iOS quick-switch gallery pick whose PlatformFile path is a bare PHAsset localIdentifier
+        // ("<uuid>/L0/001", no extension). Used at send time to resolve the video content-type and
+        // display name; null falls back to file.name. Without it the content-type resolves to
+        // application/octet-stream and the video is uploaded as a generic file instead of routing
+        // through the video pipeline (the "quick-switch video sends as a file" bug).
+        val sourceFileName: String? = null,
         val thumbnailBytes: ByteArray? = null,
         val durationMs: Long? = null,
         val trimStartMs: Long? = null,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -650,10 +650,10 @@ internal class MessageActionsHandler(
                             AttachmentInput(
                                 filePath = attachment.file.toUploadPath(fileOperationsProvider),
                                 contentType = resolveContentType(
-                                    fileName = attachment.file.name,
+                                    fileName = attachment.sourceFileName ?: attachment.file.name,
                                     platformMimeType = attachment.file.mimeType()?.toString(),
                                 ),
-                                displayName = attachment.file.name,
+                                displayName = attachment.sourceFileName ?: attachment.file.name,
                                 trimStartMs = attachment.trimStartMs,
                                 trimEndMs = attachment.trimEndMs,
                                 // Web: the blob: URL becomes the ffmpeg compress INPUT (read in JS,


### PR DESCRIPTION
## Problem

On iOS, a video picked from the **quick-switch gallery** (the in-app grid in the attachment sheet) sent as a tiny few-KB file instead of the real movie, and couldn't be previewed/played in the attachment editor. Videos chosen through the system **gallery picker** worked fine — which is the clue.

## Root cause

The quick-switch grid (`IOSGalleryManager`) hands the send path a `PlatformFile` whose path is the **bare PHAsset localIdentifier** (`<uuid>/L0/001`) — not a real file. Three failures stacked on that:

1. **Wrong export API.** `resolveToFilePath` only routed `ph://`-prefixed paths to `PHAssetResourceManager`; the gallery passes the raw `/L0/` identifier, so videos fell back to the image-only `requestImageDataForAsset` — which returns the full bytes for a self-contained `.mov` but only a poster frame for `.mp4` (why mov looked fine and mp4 didn't).
2. **Misclassified content-type.** `PlatformFile(localIdentifier).name` is `"001"` (no extension), so `resolveContentType` returned `application/octet-stream` → the clip skipped `VideoPayloadProcessor` and uploaded as a generic file.
3. **Unplayable preview.** The editor's `AVPlayer` (and the thumbnail/duration probe) got the same bare identifier, which they can't open → no preview/playback.

The system picker avoided all of this because `materializeForUpload` copies a real file up front.

## Fix

- `phVideoAssetOrNull` now accepts the raw `/L0/` localIdentifier (not just `ph://`), so gallery picks stream the full original via `PHAssetResourceManager`.
- `FileVideo.sourceFileName` carries the asset's real filename (`PHAssetResource.originalFilename`), so the content-type resolves to `video/*` and the clip enters the video pipeline.
- The editor preview materializes the PHAsset to a real temp file before the player/probe read it — guarded to PHAsset identifiers, so Android `content://` and desktop paths pass through unchanged. The send path is untouched (it resolves the identifier itself).

## Verification — on device (iPhone 15, iOS 26.5)

- Quick-switch `.mp4`: previously a few-KB poster → now an **8.35 MB clip segments to HLS** and uploads the full video (confirmed in `homebase.log`: `compression … input=8352814B`).
- Editor preview now plays quick-switch videos.

## Out of scope / follow-up

Animated **GIF** preview from the quick-switch grid is a separate, pre-existing issue — it needs the in-house animated-GIF decoder in the Coil pipeline (`PHAssetFetcher` returns static image data), not the localIdentifier handling fixed here. Tracked separately.
