### PR TITLE
fix(android): don't crash on ML Kit/MediaPipe background-removal failures

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/crash/GlobalCrashHandler.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/crash/GlobalCrashHandler.kt
@@ -9,6 +9,7 @@ import android.os.Process
 import co.touchlab.kermit.Logger
 import com.google.firebase.Firebase
 import com.google.firebase.crashlytics.crashlytics
+import id.homebase.api.client.isMlKitTeardownFailure
 import id.homebase.api.client.isTransientNetworkFailure
 import id.homebase.core.crash.CrashMetadata
 import id.homebase.core.crash.CrashReporting
@@ -49,6 +50,18 @@ object GlobalCrashHandler {
                     runCatching { Firebase.crashlytics.recordException(throwable) }
                     Logger.w(tag = TAG) {
                         "Transient network failure on '${thread.name}'; not crashing: ${throwable.message}"
+                    }
+                    return@setDefaultUncaughtExceptionHandler
+                }
+
+                // Same class as the network case: ML Kit / MediaPipe background-removal runs on
+                // native threads we don't own, so a teardown/callback failure can leak here that
+                // no local try/catch could reach. Background removal is best-effort — degrade to
+                // "no cutout", record a non-fatal, and keep the app alive.
+                if (throwable.isMlKitTeardownFailure()) {
+                    runCatching { Firebase.crashlytics.recordException(throwable) }
+                    Logger.w(tag = TAG) {
+                        "ML Kit/MediaPipe failure on '${thread.name}'; not crashing (background removal degrades to no cutout): ${throwable.message}"
                     }
                     return@setDefaultUncaughtExceptionHandler
                 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/MlKitFailure.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/MlKitFailure.kt
@@ -1,0 +1,33 @@
+package id.homebase.api.client
+
+/**
+ * True when [this] (or anything in its [Throwable.cause] chain) is a failure from the
+ * on-device ML Kit / MediaPipe image-segmentation subsystem used for background removal.
+ *
+ * ML Kit Subject Segmentation runs on MediaPipe's native pipeline. Its teardown/`close()`
+ * and late result callbacks run on threads we don't own, so a failure there can surface as
+ * an *uncaught* exception that no local `try/catch` around `removeBackground()` can reach —
+ * the same class of problem as a dropped-socket leaking to the global handler (see
+ * [isTransientNetworkFailure], PR #737). Background removal is a best-effort enhancement: a
+ * failure must degrade to "no cutout", never kill the app.
+ *
+ * The platform uncaught-exception handlers consult this (alongside
+ * [isTransientNetworkFailure]) and record a Crashlytics non-fatal instead of crashing.
+ *
+ * Matched narrowly to avoid masking unrelated crashes: an exception class in the
+ * `com.google.mlkit` / `com.google.mediapipe` packages (qualified name carries the
+ * marker), or a `mediapipe` marker in the message. Walks the cause chain defensively
+ * (guards against a cyclic chain).
+ */
+fun Throwable.isMlKitTeardownFailure(): Boolean {
+    val seen = HashSet<Throwable>()
+    var cur: Throwable? = this
+    while (cur != null && seen.add(cur)) {
+        val className = cur::class.qualifiedName?.lowercase()
+        if (className != null && ("mediapipe" in className || "mlkit" in className)) return true
+        val message = cur.message?.lowercase()
+        if (message != null && "mediapipe" in message) return true
+        cur = cur.cause
+    }
+    return false
+}

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/MlKitFailureTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/MlKitFailureTest.kt
@@ -1,0 +1,49 @@
+package id.homebase.api.client
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests the [isMlKitTeardownFailure] predicate the platform uncaught-exception handlers use
+ * to keep an ML Kit / MediaPipe background-removal failure from killing the app.
+ */
+class MlKitFailureTest {
+
+    // qualifiedName of this class contains "mediapipe" (case-insensitive), standing in for a
+    // real com.google.mediapipe.* exception we can't instantiate here.
+    private class MediaPipeNativeException(message: String? = null) : RuntimeException(message)
+
+    @Test
+    fun mediaPipeExceptionClass_isMatch() {
+        assertTrue(MediaPipeNativeException().isMlKitTeardownFailure())
+    }
+
+    @Test
+    fun mediaPipeInMessage_isMatch() {
+        assertTrue(RuntimeException("CalculatorGraph::Run failed in mediapipe pipeline").isMlKitTeardownFailure())
+    }
+
+    @Test
+    fun wrappedCause_isMatch() {
+        val wrapped = IllegalStateException("teardown", MediaPipeNativeException("graph closed"))
+        assertTrue(wrapped.isMlKitTeardownFailure())
+    }
+
+    @Test
+    fun unrelatedExceptions_areNotMatched() {
+        assertFalse(IllegalStateException("some app bug").isMlKitTeardownFailure())
+        assertFalse(NullPointerException().isMlKitTeardownFailure())
+        assertFalse(RuntimeException("network timeout").isMlKitTeardownFailure())
+    }
+
+    @Test
+    fun cyclicCauseChain_terminates() {
+        val a = RuntimeException("a")
+        val b = RuntimeException("b")
+        a.initCause(b)
+        b.initCause(a)
+        // No mediapipe/mlkit marker anywhere; the important thing is it returns (doesn't loop).
+        assertFalse(a.isMlKitTeardownFailure())
+    }
+}


### PR DESCRIPTION
## Bug
A failure in on-device background removal (ML Kit Subject Segmentation, backed by MediaPipe's native pipeline) could **crash the whole app**. Its teardown/`close()` and late result callbacks run on threads we don't own, so an exception there surfaces as an *uncaught* exception that no local `try/catch` around `removeBackground()` can reach — the same class of problem as the network-crash work (PR #737). Background removal is a best-effort enhancement; a failure should degrade to "no cutout", not kill the app.

## Fix
- New `Throwable.isMlKitTeardownFailure()` in `homebase-api` commonMain, **alongside `isTransientNetworkFailure`**. Matches narrowly — an exception class in `com.google.mlkit` / `com.google.mediapipe` (qualified name carries the marker) or a `mediapipe` marker in the message — walking the cause chain with a cycle guard.
- The Android `GlobalCrashHandler` consults it right after the network check: records a Crashlytics **non-fatal** and returns, instead of crashing / showing the recovery screen.

Scoped to Android (where ML Kit/MediaPipe runs); iOS/Desktop background removal use other backends, so their handlers are untouched.

## Why string-matching (not `is MlKitException`)
The classifier lives in `homebase-api` (core), which has no ML Kit dependency, and the exception can be a native MediaPipe one. Matching the `com.google.mlkit`/`com.google.mediapipe` package (or a `mediapipe` message marker) is tight enough to avoid masking unrelated crashes.

## Tests
`MlKitFailureTest` (homebase-api jvmTest): mediapipe exception class matches, message marker matches, wrapped cause matches, unrelated exceptions don't, cyclic cause chain terminates. `:homebase-api:jvmTest` green; `:androidApp:compileDebugKotlin` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)