### PR TITLE
fix(ios): chat camera opens then closes instantly

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -572,6 +572,22 @@ fun ConversationContent(
             )
         }
     }
+
+    // iOS: present the camera/recorder only AFTER the attachment dropdown menu has dismissed.
+    // The camera button is a DropdownMenu item; launching synchronously from its onClick
+    // presents the picker while the menu is still tearing down, and iOS dismisses the picker
+    // instantly along with the menu — the "camera opens then closes" bug (chat only; Vault and
+    // Moments don't launch from a dropdown, and the video path already async-defers). Deferring
+    // the launch via this effect lets the menu finish dismissing first — mirrors VaultScreen's
+    // deferred picker launch.
+    var pendingPickerLaunch by remember { mutableStateOf<(() -> Unit)?>(null) }
+    LaunchedEffect(pendingPickerLaunch) {
+        pendingPickerLaunch?.let { launchPicker ->
+            launchPicker()
+            pendingPickerLaunch = null
+        }
+    }
+
     val fileLauncher = rememberFilePickerLauncher { file ->
         file?.let {
             onUiAction(
@@ -1543,8 +1559,8 @@ fun ConversationContent(
                                     showAttachmentSheet = false
                                 },
                                 onAddAttachmentClick = { toggleAttachmentSheet() },
-                                onCameraClick = { cameraLauncher.launch() },
-                                onVideoRecordClick = { videoRecorderLauncher.launch() },
+                                onCameraClick = { pendingPickerLaunch = { cameraLauncher.launch() } },
+                                onVideoRecordClick = { pendingPickerLaunch = { videoRecorderLauncher.launch() } },
                                 onRecordingStarted = {
                                     onUiAction(
                                         ConversationListUiAction.StartRecording(

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/CameraUtil.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/CameraUtil.native.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.compose.rememberCameraPickerLauncher
 import platform.AVFoundation.AVAuthorizationStatusAuthorized
 import platform.AVFoundation.AVAuthorizationStatusNotDetermined
 import platform.AVFoundation.AVCaptureDevice
@@ -11,80 +12,43 @@ import platform.AVFoundation.AVMediaTypeAudio
 import platform.AVFoundation.AVMediaTypeVideo
 import platform.AVFoundation.authorizationStatusForMediaType
 import platform.AVFoundation.requestAccessForMediaType
-import platform.Foundation.NSTemporaryDirectory
 import platform.Foundation.NSURL
-import platform.Foundation.NSUUID
-import platform.Foundation.writeToFile
 import platform.UIKit.UIApplication
-import platform.UIKit.UIImage
-import platform.UIKit.UIImageJPEGRepresentation
 import platform.UIKit.UIImagePickerController
 import platform.UIKit.UIImagePickerControllerDelegateProtocol
 import platform.UIKit.UIImagePickerControllerMediaURL
-import platform.UIKit.UIImagePickerControllerOriginalImage
 import platform.UIKit.UIImagePickerControllerSourceType
 import platform.UIKit.UINavigationControllerDelegateProtocol
 import platform.darwin.NSObject
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
 
-/**
- * iOS camera (photo). Presents a native [UIImagePickerController] with the camera source —
- * the same approach as [rememberVideoRecorderManager] below. We deliberately do NOT use
- * FileKit's `rememberCameraPickerLauncher` here: its camera presentation opened and then
- * dismissed instantly in-chat on iOS, so the photo path mirrors the working video path.
- *
- * The captured [UIImage] is JPEG-encoded to a temp file and returned as a [PlatformFile];
- * a camera capture has no source URL ([UIImagePickerControllerMediaURL] is movie-only and
- * [UIImagePickerControllerImageURL] is null for fresh captures), so we encode it ourselves.
- */
 @Composable
 actual fun rememberCameraManager(onResult: (PlatformFile?) -> Unit): PlatformCameraManager {
-    // Result lambda is recreated each recomposition (it captures conversation state); keep
-    // the latest so a capture that finishes after a recomposition reports to the live one.
-    val currentOnResult = rememberUpdatedState(onResult)
+    val launcher = rememberCameraPickerLauncher { file ->
+        onResult(file)
+    }
     return remember {
         object : PlatformCameraManager {
-            // UIImagePickerController.delegate is a weak reference — hold a strong ref here
-            // or it would be deallocated and no pick/cancel callback would ever fire.
-            private var delegate: PhotoPickerDelegate? = null
-
             override fun launch() {
-                ensureCameraPermission { presentPhotoPicker() }
-            }
-
-            private fun ensureCameraPermission(onGranted: () -> Unit) {
-                when (AVCaptureDevice.authorizationStatusForMediaType(AVMediaTypeVideo)) {
-                    AVAuthorizationStatusAuthorized ->
-                        dispatch_async(dispatch_get_main_queue()) { onGranted() }
-
-                    AVAuthorizationStatusNotDetermined ->
+                val status = AVCaptureDevice.authorizationStatusForMediaType(AVMediaTypeVideo)
+                when (status) {
+                    AVAuthorizationStatusAuthorized -> launcher.launch()
+                    AVAuthorizationStatusNotDetermined -> {
                         AVCaptureDevice.requestAccessForMediaType(AVMediaTypeVideo) { granted ->
-                            if (granted) dispatch_async(dispatch_get_main_queue()) { onGranted() }
+                            if (granted) {
+                                dispatch_async(dispatch_get_main_queue()) {
+                                    launcher.launch()
+                                }
+                            }
                         }
-
-                    else ->
+                    }
+                    else -> {
                         NSURL.URLWithString(platform.UIKit.UIApplicationOpenSettingsURLString)?.let {
                             UIApplication.sharedApplication.openURL(it, emptyMap<Any?, String>()) {}
                         }
+                    }
                 }
-            }
-
-            private fun presentPhotoPicker() {
-                val rootVC = UIApplication.sharedApplication.keyWindow?.rootViewController ?: return
-
-                val picker = UIImagePickerController()
-                picker.sourceType = UIImagePickerControllerSourceType.UIImagePickerControllerSourceTypeCamera
-                picker.mediaTypes = listOf("public.image")
-
-                val d = PhotoPickerDelegate { file ->
-                    currentOnResult.value(file)
-                    delegate = null
-                }
-                delegate = d
-                picker.delegate = d
-
-                rootVC.presentViewController(picker, animated = true, completion = null)
             }
         }
     }
@@ -164,38 +128,6 @@ actual fun rememberVideoRecorderManager(onResult: (PlatformFile?) -> Unit): Plat
 
                 rootVC.presentViewController(picker, animated = true, completion = null)
             }
-        }
-    }
-}
-
-/** Encodes a captured [UIImage] to a JPEG temp file and wraps it as a [PlatformFile], or null. */
-private fun saveImageToTempFile(image: UIImage): PlatformFile? {
-    val data = UIImageJPEGRepresentation(image, 0.9) ?: return null
-    val path = NSTemporaryDirectory() + "camera_" + NSUUID().UUIDString + ".jpg"
-    return if (data.writeToFile(path, atomically = true)) {
-        PlatformFile(NSURL.fileURLWithPath(path))
-    } else {
-        null
-    }
-}
-
-private class PhotoPickerDelegate(
-    private val onResult: (PlatformFile?) -> Unit
-) : NSObject(), UIImagePickerControllerDelegateProtocol, UINavigationControllerDelegateProtocol {
-
-    override fun imagePickerController(
-        picker: UIImagePickerController,
-        didFinishPickingMediaWithInfo: Map<Any?, *>
-    ) {
-        val image = didFinishPickingMediaWithInfo[UIImagePickerControllerOriginalImage] as? UIImage
-        picker.dismissViewControllerAnimated(true) {
-            onResult(image?.let { saveImageToTempFile(it) })
-        }
-    }
-
-    override fun imagePickerControllerDidCancel(picker: UIImagePickerController) {
-        picker.dismissViewControllerAnimated(true) {
-            onResult(null)
         }
     }
 }

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/CameraUtil.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/CameraUtil.native.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import io.github.vinceglb.filekit.PlatformFile
-import io.github.vinceglb.filekit.dialogs.compose.rememberCameraPickerLauncher
 import platform.AVFoundation.AVAuthorizationStatusAuthorized
 import platform.AVFoundation.AVAuthorizationStatusNotDetermined
 import platform.AVFoundation.AVCaptureDevice
@@ -12,43 +11,80 @@ import platform.AVFoundation.AVMediaTypeAudio
 import platform.AVFoundation.AVMediaTypeVideo
 import platform.AVFoundation.authorizationStatusForMediaType
 import platform.AVFoundation.requestAccessForMediaType
+import platform.Foundation.NSTemporaryDirectory
 import platform.Foundation.NSURL
+import platform.Foundation.NSUUID
+import platform.Foundation.writeToFile
 import platform.UIKit.UIApplication
+import platform.UIKit.UIImage
+import platform.UIKit.UIImageJPEGRepresentation
 import platform.UIKit.UIImagePickerController
 import platform.UIKit.UIImagePickerControllerDelegateProtocol
 import platform.UIKit.UIImagePickerControllerMediaURL
+import platform.UIKit.UIImagePickerControllerOriginalImage
 import platform.UIKit.UIImagePickerControllerSourceType
 import platform.UIKit.UINavigationControllerDelegateProtocol
 import platform.darwin.NSObject
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
 
+/**
+ * iOS camera (photo). Presents a native [UIImagePickerController] with the camera source —
+ * the same approach as [rememberVideoRecorderManager] below. We deliberately do NOT use
+ * FileKit's `rememberCameraPickerLauncher` here: its camera presentation opened and then
+ * dismissed instantly in-chat on iOS, so the photo path mirrors the working video path.
+ *
+ * The captured [UIImage] is JPEG-encoded to a temp file and returned as a [PlatformFile];
+ * a camera capture has no source URL ([UIImagePickerControllerMediaURL] is movie-only and
+ * [UIImagePickerControllerImageURL] is null for fresh captures), so we encode it ourselves.
+ */
 @Composable
 actual fun rememberCameraManager(onResult: (PlatformFile?) -> Unit): PlatformCameraManager {
-    val launcher = rememberCameraPickerLauncher { file ->
-        onResult(file)
-    }
+    // Result lambda is recreated each recomposition (it captures conversation state); keep
+    // the latest so a capture that finishes after a recomposition reports to the live one.
+    val currentOnResult = rememberUpdatedState(onResult)
     return remember {
         object : PlatformCameraManager {
+            // UIImagePickerController.delegate is a weak reference — hold a strong ref here
+            // or it would be deallocated and no pick/cancel callback would ever fire.
+            private var delegate: PhotoPickerDelegate? = null
+
             override fun launch() {
-                val status = AVCaptureDevice.authorizationStatusForMediaType(AVMediaTypeVideo)
-                when (status) {
-                    AVAuthorizationStatusAuthorized -> launcher.launch()
-                    AVAuthorizationStatusNotDetermined -> {
+                ensureCameraPermission { presentPhotoPicker() }
+            }
+
+            private fun ensureCameraPermission(onGranted: () -> Unit) {
+                when (AVCaptureDevice.authorizationStatusForMediaType(AVMediaTypeVideo)) {
+                    AVAuthorizationStatusAuthorized ->
+                        dispatch_async(dispatch_get_main_queue()) { onGranted() }
+
+                    AVAuthorizationStatusNotDetermined ->
                         AVCaptureDevice.requestAccessForMediaType(AVMediaTypeVideo) { granted ->
-                            if (granted) {
-                                dispatch_async(dispatch_get_main_queue()) {
-                                    launcher.launch()
-                                }
-                            }
+                            if (granted) dispatch_async(dispatch_get_main_queue()) { onGranted() }
                         }
-                    }
-                    else -> {
+
+                    else ->
                         NSURL.URLWithString(platform.UIKit.UIApplicationOpenSettingsURLString)?.let {
                             UIApplication.sharedApplication.openURL(it, emptyMap<Any?, String>()) {}
                         }
-                    }
                 }
+            }
+
+            private fun presentPhotoPicker() {
+                val rootVC = UIApplication.sharedApplication.keyWindow?.rootViewController ?: return
+
+                val picker = UIImagePickerController()
+                picker.sourceType = UIImagePickerControllerSourceType.UIImagePickerControllerSourceTypeCamera
+                picker.mediaTypes = listOf("public.image")
+
+                val d = PhotoPickerDelegate { file ->
+                    currentOnResult.value(file)
+                    delegate = null
+                }
+                delegate = d
+                picker.delegate = d
+
+                rootVC.presentViewController(picker, animated = true, completion = null)
             }
         }
     }
@@ -128,6 +164,38 @@ actual fun rememberVideoRecorderManager(onResult: (PlatformFile?) -> Unit): Plat
 
                 rootVC.presentViewController(picker, animated = true, completion = null)
             }
+        }
+    }
+}
+
+/** Encodes a captured [UIImage] to a JPEG temp file and wraps it as a [PlatformFile], or null. */
+private fun saveImageToTempFile(image: UIImage): PlatformFile? {
+    val data = UIImageJPEGRepresentation(image, 0.9) ?: return null
+    val path = NSTemporaryDirectory() + "camera_" + NSUUID().UUIDString + ".jpg"
+    return if (data.writeToFile(path, atomically = true)) {
+        PlatformFile(NSURL.fileURLWithPath(path))
+    } else {
+        null
+    }
+}
+
+private class PhotoPickerDelegate(
+    private val onResult: (PlatformFile?) -> Unit
+) : NSObject(), UIImagePickerControllerDelegateProtocol, UINavigationControllerDelegateProtocol {
+
+    override fun imagePickerController(
+        picker: UIImagePickerController,
+        didFinishPickingMediaWithInfo: Map<Any?, *>
+    ) {
+        val image = didFinishPickingMediaWithInfo[UIImagePickerControllerOriginalImage] as? UIImage
+        picker.dismissViewControllerAnimated(true) {
+            onResult(image?.let { saveImageToTempFile(it) })
+        }
+    }
+
+    override fun imagePickerControllerDidCancel(picker: UIImagePickerController) {
+        picker.dismissViewControllerAnimated(true) {
+            onResult(null)
         }
     }
 }


### PR DESCRIPTION
## Bug
**iOS only** — in a chat, tapping the camera ("Take Photo") opens the camera then it closes instantly. Vault camera, Moments camera, and chat **video** recording all work.

## Root cause (chat-specific)
The chat camera button is a **DropdownMenu** item, and it launched the picker **synchronously from the menu item's `onClick`** (`ConversationContent.kt`). On iOS, presenting the picker while the dropdown is still dismissing makes the OS dismiss the picker instantly along with the menu → "opens then closes". Confirmed by the asymmetry: Vault/Moments don't launch from a dropdown (Vault even *defers* on purpose), and chat **video** uses the same dropdown but its native path async-defers the present — which is why only chat Take-Photo broke. The shared `rememberCameraManager` util is fine (it works in Vault/Moments) and is **not** touched.

## Fix
`ConversationContent.kt` — defer the camera/recorder launch via a `LaunchedEffect` (pending-launch lambda) so the DropdownMenu fully dismisses before the picker presents. Mirrors `VaultScreen`'s deferred picker launch. **Net diff: +18 lines, one file.**

(An earlier revision of this PR also rewrote the iOS photo util FileKit→native; that was reverted — it wasn't the fix, added ~85 lines, and risked saving rotated photos.)

## Verification
- `:homebase-chat:compileKotlinIosSimulatorArm64` green.
- **Needs on-device check**: chat → camera → Take Photo → confirm it opens, you can capture, and it attaches.
🤖 Generated with [Claude Code](https://claude.com/claude-code)