### PR TITLE
fix(ios): share extension silently fails (dev+prod URL-scheme collision)

### DIFF
--- a/iosApp/Configuration/Config.xcconfig
+++ b/iosApp/Configuration/Config.xcconfig
@@ -7,6 +7,9 @@ CURRENT_PROJECT_VERSION=804
 MARKETING_VERSION=1.2.0
 
 APP_GROUP_IDENTIFIER = group.id.homebase.feed
+// Variant-specific share URL scheme (see Dev.xcconfig). Prod keeps the original
+// `homebase-share`; the dev build overrides this to `homebase-share-dev`.
+SHARE_URL_SCHEME = homebase-share
 
 OTHER_LDFLAGS = $(inherited) -lsqlite3 -lz -lbz2 -liconv
 

--- a/iosApp/Configuration/Dev.xcconfig
+++ b/iosApp/Configuration/Dev.xcconfig
@@ -3,4 +3,7 @@
 PRODUCT_NAME=Homebase Dev
 PRODUCT_BUNDLE_IDENTIFIER=id.homebase.feed.dev
 APP_GROUP_IDENTIFIER = group.id.homebase.feed.dev
+// Variant-specific so a dev + prod build installed side by side don't both register the
+// same share URL scheme (which let the share extension's openURL hand off to the wrong app).
+SHARE_URL_SCHEME = homebase-share-dev
 KOTLIN_FRAMEWORK_BUILD_TYPE=release

--- a/iosApp/ShareExtension/ShareViewController.swift
+++ b/iosApp/ShareExtension/ShareViewController.swift
@@ -129,9 +129,18 @@ class ShareViewController: UIViewController {
         }
     }
 
+    /// Variant-specific share URL scheme. A dev + prod build installed side by side must NOT
+    /// both register the same scheme, or this extension's openURL hand-off can be claimed by
+    /// the wrong app — which then reads a different App Group than the one we wrote to, so the
+    /// share silently vanishes. Derived from the (already variant-specific) App Group id; must
+    /// stay in sync with SHARE_URL_SCHEME in the xcconfigs that the main app registers.
+    private var shareUrlScheme: String {
+        SharedContentSaver.appGroupId.hasSuffix(".dev") ? "homebase-share-dev" : "homebase-share"
+    }
+
     /// Open the main app's moments composer via URL scheme.
     private func openMainAppForMoment() {
-        guard let url = URL(string: "homebase-share://moment") else {
+        guard let url = URL(string: "\(shareUrlScheme)://moment") else {
             cancelExtension()
             return
         }
@@ -141,7 +150,7 @@ class ShareViewController: UIViewController {
 
     /// Open the main app via URL scheme to complete the send.
     private func openMainApp(conversationIds: String) {
-        guard let url = URL(string: "homebase-share://send?conversationIds=\(conversationIds)") else {
+        guard let url = URL(string: "\(shareUrlScheme)://send?conversationIds=\(conversationIds)") else {
             cancelExtension()
             return
         }

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -13,7 +13,7 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>homebase-share</string>
+				<string>$(SHARE_URL_SCHEME)</string>
 				<string>homebase-fchat</string>
 			</array>
 		</dict>

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -219,7 +219,9 @@ struct iOSApp: App {
 
     private func handleIncomingURL(_ url: URL) {
         switch url.scheme {
-        case "homebase-share":
+        // Accept both the prod scheme and the dev build's variant (see SHARE_URL_SCHEME /
+        // ShareViewController.shareUrlScheme) — the app only ever receives its own.
+        case "homebase-share", "homebase-share-dev":
             if url.host == "moment" {
                 ShareHandlerBridge.shared.handleIncomingMomentShare()
             } else {


### PR DESCRIPTION
## Bug
**iOS only** — sharing into the app via the Share Extension fails silently. Reported flow: pick Homebase in the share sheet → the extension's picker opens → tap Send → "that's it", nothing arrives. Specifically reproduced with **a dev and a prod build installed at the same time**.

## Root cause
The hand-off scheme `homebase-share` was **hardcoded and not namespaced per build variant** — in the extension's `openURL` (`ShareViewController`), the app's `CFBundleURLSchemes` (Info.plist), and the app's `onOpenURL` handler. With dev + prod both installed, **both apps register `homebase-share`**, so the dev extension's `homebase-share://send?…` hand-off can be claimed by the **prod** app. Prod then reads the **prod** App Group, but the dev extension wrote the shared payload to the **dev** App Group (`…feed.dev`) — so the receiver finds nothing and the share silently vanishes. (The App Groups were already correctly variant-split; the URL scheme was the one piece that wasn't.)

## Fix
Namespace the scheme per variant, mirroring the existing `$(APP_GROUP_IDENTIFIER)` pattern:
- **`SHARE_URL_SCHEME`** build var in the xcconfigs — `Dev.xcconfig` = `homebase-share-dev`, `Config.xcconfig` = `homebase-share`. The app registers `$(SHARE_URL_SCHEME)` in `CFBundleURLSchemes`.
- The **extension** target inlines its build settings (no xcconfig base), so instead of editing `project.pbxproj` it **derives** its scheme from the already-variant-specific App Group id (`…feed.dev` → `homebase-share-dev`, else `homebase-share`).
- The app's `onOpenURL` accepts **both** schemes.

Now the dev extension opens `homebase-share-dev://` → only the dev app handles it → reads the dev App Group it wrote to. **Prod-only installs are unchanged** (`homebase-share` end to end).

## Scope note
`homebase-fchat` (owner-console permission / data-upgrade callbacks) has the same latent cross-variant collision, but its redirect URL is built server-side, so it's left out of this PR.

## Verification
- Compile is validated by this PR's **"Build iOS on macos-latest"** CI check (the changed code is in the Xcode targets, not built by Gradle).
- **Needs your on-device check** (can't be done headlessly / needs dev+prod coexistence): with both builds installed, share a photo/text from another app into the **dev** build, tap Send, and confirm it lands in the chosen conversation (and that the **dev** app — not prod — comes to the foreground).

🤖 Generated with [Claude Code](https://claude.com/claude-code)