### PR TITLE
fix(vault): don't flash the loading spinner when data is cached

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
@@ -74,6 +74,40 @@ class VaultViewModel(
         _syncingState,
         _checkingPermissions,
     ) { (sections, entriesBySection, isLoaded), overlay, syncing, checkingPermissions ->
+        buildUiState(sections, entriesBySection, isLoaded, overlay, syncing, checkingPermissions)
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        // Seed the initial value from VaultStream's CURRENT cached snapshot. VaultStream is a
+        // singleton that keeps its loaded sections across screen re-entry, but a freshly created
+        // VaultViewModel's stateIn would otherwise emit the empty + loading default VaultUiState()
+        // (isLoading = true, no sections) for the frame before the combine's first emission —
+        // flashing the full-screen spinner (VaultContent shows it on
+        // `(isLoading || isSyncing) && sections.isEmpty()`) on every Vault entry even though the
+        // data is already cached. Seeding from cache renders the cached sections immediately and
+        // spins only on a genuine cold load (stream not loaded yet → isLoaded = false, empty).
+        buildUiState(
+            sections = vaultStream.sections.value,
+            entriesBySection = vaultStream.entriesBySection.value,
+            isLoaded = vaultStream.isLoaded.value,
+            overlay = _overlayState.value,
+            syncing = _syncingState.value,
+            checkingPermissions = _checkingPermissions.value,
+        ),
+    )
+
+    /**
+     * Builds the [VaultUiState] from the stream + overlay inputs. Shared by the [uiState] combine
+     * and the cache-seeded `stateIn` initial value above so the two can never drift.
+     */
+    private fun buildUiState(
+        sections: List<VaultSection>,
+        entriesBySection: Map<Uuid, List<VaultEntry>>,
+        isLoaded: Boolean,
+        overlay: VaultOverlay?,
+        syncing: Boolean,
+        checkingPermissions: Boolean,
+    ): VaultUiState {
         val sectionModels = sections.mapIndexed { index, section ->
             section.copy(
                 entries = entriesBySection[section.sectionId] ?: emptyList(),
@@ -85,14 +119,14 @@ class VaultViewModel(
             val freshFile = sectionModels.flatMap { it.entries }.find { it.uniqueId == gallery.file.uniqueId }
             if (freshFile != null) gallery.copy(file = freshFile) else gallery
         }
-        VaultUiState(
+        return VaultUiState(
             sections = sectionModels,
             isLoading = !isLoaded,
             isSyncing = syncing,
             isCheckingPermissions = checkingPermissions,
             fullScreenOverlay = refreshedOverlay ?: overlay,
         )
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), VaultUiState())
+    }
 
     private val _events = MutableSharedFlow<VaultUiEvent>(extraBufferCapacity = 4)
     val events: SharedFlow<VaultUiEvent> = _events.asSharedFlow()


### PR DESCRIPTION
## Bug
The Vault screen flashes the full-screen circular progress indicator on (re)entry **even when the data is already cached** — it should render cached content immediately and only spin on a genuine first load.

## Root cause
`VaultContent` shows the spinner on `(isLoading || isSyncing) && sections.isEmpty()`. In `VaultViewModel`, `uiState` is a `stateIn(... WhileSubscribed(5_000), VaultUiState())` whose **initial/seed value is the default `VaultUiState()`** — `isLoading = true` (`VaultUiState.kt:12`) with empty `sections`. A freshly created `VaultViewModel` (re-entering the Vault screen) emits that empty+loading default for the frame **before** the combine reads the cached data, so the spinner flashes on every entry — even though `VaultStream` (an app singleton) still holds the loaded sections (`isLoaded` only flips false on logout, `VaultStream.kt:88`).

## Fix
Seed the `stateIn` initial value from `VaultStream`'s **current cached snapshot** instead of the empty default:
- Extracted the UiState mapping into a private `buildUiState(...)`, shared by the combine and the seed so they can't drift.
- The seed reads `vaultStream.sections.value` / `entriesBySection.value` / `isLoaded.value`, so a fresh VM renders cached sections immediately (`isLoading = !isLoaded` → false when already loaded). The spinner now appears only on a true cold load (stream not yet loaded → `isLoaded = false`, sections empty).

No behaviour change for the genuine cold-load case; reactive updates via the combine are unchanged.

## Verification
- `:homebase-core:compileKotlinJvm` — green.
- No unit test: `VaultViewModel` has 11 heavy constructor deps with no existing fakes (and `VaultStream` is a concrete class with its own deps), so a VM-level test is disproportionately expensive; this is a UI-timing flash best confirmed on device.
- **Needs your on-device check**: load Vault, navigate away and back — confirm cached entries show immediately with no spinner flash; first-ever load still shows the spinner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)