### PR TITLE
Add client-side Conditional Temporal Read API + dev-menu probe

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/query/DriveQueryProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/query/DriveQueryProvider.kt
@@ -92,8 +92,13 @@ class DriveQueryProvider(
      * Decode a query-batch response body into a [QueryBatchResponse], salvaging individually
      * corrupt file metadata rather than failing the whole batch. Shared by the own-host and
      * over-peer query paths — both receive headers encrypted under the caller's [secret].
+     *
+     * `internal` so the temporal-read path
+     * ([id.homebase.api.client.peer.temporal.TemporalDriveReadProvider.temporalQueryBatch]) reuses the
+     * exact same salvage-decode instead of duplicating it — its `/temporal/query-batch` response has
+     * the identical [QueryBatchResponse] shape.
      */
-    private suspend fun mapQueryBatchResponse(
+    internal suspend fun mapQueryBatchResponse(
         body: String,
         secret: SecureByteArray,
     ): QueryBatchResponse {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/temporal/TemporalAccessStatus.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/temporal/TemporalAccessStatus.kt
@@ -1,6 +1,7 @@
 package id.homebase.api.client.peer.temporal
 
 import id.homebase.api.client.drives.TargetDrive
+import id.homebase.api.common.time.UnixTimeUtc
 import kotlinx.serialization.Serializable
 
 /**
@@ -13,10 +14,17 @@ import kotlinx.serialization.Serializable
  * @property targetDrive the drive that was checked.
  * @property windowSeconds the effective lookback window (seconds) the caller is clamped to, or null
  *   when the caller has unconstrained read access (no time clamp). Only meaningful when [hasAccess].
+ * @property newestFileModified the `modified` timestamp of the newest active file on the drive — a
+ *   "is data still flowing?" signal (e.g. has tracking been turned off?). It is **not** clamped to
+ *   [windowSeconds]: if data stopped longer ago than the window you still get the real last-update
+ *   time, not zero. [UnixTimeUtc.ZeroTime] (0 ms) means the drive has no files OR the caller has no
+ *   access — so only treat it as a real timestamp when [hasAccess] is true; otherwise render it as
+ *   "no data / unknown".
  */
 @Serializable
 data class TemporalAccessStatus(
     val hasAccess: Boolean = false,
     val targetDrive: TargetDrive? = null,
     val windowSeconds: Long? = null,
+    val newestFileModified: UnixTimeUtc = UnixTimeUtc.ZeroTime,
 )

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/temporal/TemporalAccessStatus.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/temporal/TemporalAccessStatus.kt
@@ -1,0 +1,22 @@
+package id.homebase.api.client.peer.temporal
+
+import id.homebase.api.client.drives.TargetDrive
+import kotlinx.serialization.Serializable
+
+/**
+ * Result of the temporal-read `verify` preflight ("can I use the temporal API on this peer's drive,
+ * and is it working?"). Mirrors the server `TemporalAccessStatus` (odin-core PR #1567). Lets a caller
+ * render a live "you have access" indicator without reading data or firing an access notification.
+ *
+ * @property hasAccess true when the caller currently holds temporal (or full) read access and the
+ *   drive exists.
+ * @property targetDrive the drive that was checked.
+ * @property windowSeconds the effective lookback window (seconds) the caller is clamped to, or null
+ *   when the caller has unconstrained read access (no time clamp). Only meaningful when [hasAccess].
+ */
+@Serializable
+data class TemporalAccessStatus(
+    val hasAccess: Boolean = false,
+    val targetDrive: TargetDrive? = null,
+    val windowSeconds: Long? = null,
+)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/temporal/TemporalDriveReadProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/temporal/TemporalDriveReadProvider.kt
@@ -73,7 +73,7 @@ class TemporalDriveReadProvider(
         }
         val body: TemporalAccessStatus = deserialize(response.body)
         Logger.i(tag = TAG) {
-            "verifyTemporalAccess: OK peer=${peer.domainName} drive=$driveId → hasAccess=${body.hasAccess} windowSeconds=${body.windowSeconds}"
+            "verifyTemporalAccess: OK peer=${peer.domainName} drive=$driveId → hasAccess=${body.hasAccess} windowSeconds=${body.windowSeconds} newestFileModified=${body.newestFileModified.milliseconds}"
         }
         return body
     }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/temporal/TemporalDriveReadProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/temporal/TemporalDriveReadProvider.kt
@@ -1,0 +1,220 @@
+package id.homebase.api.client.peer.temporal
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.client.OdinApiProviderBase
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.client.drives.QueryBatchRequest
+import id.homebase.api.client.drives.QueryBatchResponse
+import id.homebase.api.client.drives.ServerFile
+import id.homebase.api.client.drives.files.BytesResponse
+import id.homebase.api.client.drives.files.DriveFileProvider
+import id.homebase.api.client.drives.query.DriveQueryProvider
+import id.homebase.api.common.OdinId
+import id.homebase.api.serialization.OdinSystemSerializer
+import io.ktor.client.HttpClient
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.get
+import kotlin.uuid.Uuid
+
+/**
+ * Client for the **temporal (time-boxed / "emergency") read** API a peer identity hosts for its
+ * sensitive drives (odin-core PR #1567). The caller's access derives from
+ * `DrivePermission.ConditionalTemporalRead` granted via a circle on the peer; the peer clamps every
+ * read to a recent window and notifies its owner. Used by the Location App's family-emergency feature
+ * to pull a relative's recent location history.
+ *
+ * Like the rest of the peer API, every call hits the **user's own host** (`creds.domain`) with
+ * `bearerAuth` + shared-secret encryption; the own host brokers to the peer server-side and
+ * re-encrypts the response under the caller's shared secret, so the decode path is identical to the
+ * non-temporal providers. Mirrors [id.homebase.api.client.peer.PeerDriveQueryProvider]'s style and
+ * reuses [DriveQueryProvider.mapQueryBatchResponse] / [DriveFileProvider.decryptBytes] so no decode
+ * or decrypt logic is duplicated.
+ *
+ * Routes (all under `/peer/{odinId}/drives/{driveId}/temporal`):
+ * - `POST verify`                                  → [TemporalAccessStatus]
+ * - `POST query-batch`                             → [QueryBatchResponse]
+ * - `GET  files/{fileId}/header`                   → [HomebaseFile] (null outside the window / missing)
+ * - `GET  files/{fileId}/payload/{payloadKey}`     → payload bytes (null outside the window / missing)
+ * - `GET  files/{fileId}/payload/{payloadKey}/thumb/{w}/{h}` → thumbnail bytes
+ */
+class TemporalDriveReadProvider(
+    httpClient: HttpClient,
+    credentialsManager: CredentialsManager,
+    private val driveQueryProvider: DriveQueryProvider,
+    private val driveFileProvider: DriveFileProvider,
+) : OdinApiProviderBase(httpClient, credentialsManager) {
+
+    /**
+     * Preflight: does the caller currently hold temporal read access to [driveId] on [peer], and what
+     * window? Reads no data and fires no access notification on the peer. Returns
+     * `hasAccess = false` when no grant exists (does not throw).
+     */
+    suspend fun verifyTemporalAccess(peer: OdinId, driveId: Uuid): TemporalAccessStatus {
+        val creds = requireCreds()
+        val url = apiUrl(creds.domain, "/peer/$peer/drives/$driveId/temporal/verify")
+        Logger.i(tag = TAG) { "verifyTemporalAccess: POST peer=${peer.domainName} drive=$driveId" }
+
+        // No request body on the server; send an encrypted empty JSON object so the shared-secret
+        // perimeter is satisfied (the endpoint is OwnerOrApp, not [NoSharedSecret]).
+        val response = encryptedPostJson(
+            url = url,
+            token = creds.accessToken,
+            jsonBody = "{}",
+            secret = creds.secret,
+        )
+        try {
+            throwForFailure(response)
+        } catch (e: Exception) {
+            Logger.w(throwable = e, tag = TAG) {
+                "verifyTemporalAccess: FAIL peer=${peer.domainName} drive=$driveId status=${response.status}"
+            }
+            throw e
+        }
+        val body: TemporalAccessStatus = deserialize(response.body)
+        Logger.i(tag = TAG) {
+            "verifyTemporalAccess: OK peer=${peer.domainName} drive=$driveId → hasAccess=${body.hasAccess} windowSeconds=${body.windowSeconds}"
+        }
+        return body
+    }
+
+    /**
+     * Time-clamped query-batch against the peer's drive. The peer derives the [TargetDrive] from the
+     * route and clamps results to the resolved window; an out-of-window file simply isn't returned.
+     * Reuses [QueryBatchRequest] (its `queryParams` needs no drive field — the route carries it).
+     */
+    suspend fun temporalQueryBatch(
+        peer: OdinId,
+        driveId: Uuid,
+        request: QueryBatchRequest,
+    ): QueryBatchResponse {
+        val creds = requireCreds()
+        val url = apiUrl(creds.domain, "/peer/$peer/drives/$driveId/temporal/query-batch")
+        Logger.i(tag = TAG) { "temporalQueryBatch: POST peer=${peer.domainName} drive=$driveId" }
+
+        val response = encryptedPostJson(
+            url = url,
+            token = creds.accessToken,
+            jsonBody = OdinSystemSerializer.serialize(request),
+            secret = creds.secret,
+        )
+        try {
+            throwForFailure(response)
+        } catch (e: Exception) {
+            Logger.w(throwable = e, tag = TAG) {
+                "temporalQueryBatch: FAIL peer=${peer.domainName} drive=$driveId status=${response.status}"
+            }
+            throw e
+        }
+        val batch = driveQueryProvider.mapQueryBatchResponse(response.body, creds.secret)
+        Logger.i(tag = TAG) {
+            "temporalQueryBatch: OK peer=${peer.domainName} drive=$driveId → ${batch.searchResults.size} files (hasMore=${batch.hasMoreRows})"
+        }
+        return batch
+    }
+
+    /**
+     * Fetch one file's header through the temporal API. Returns null when the file is outside the
+     * window or doesn't exist (the peer answers 404 either way — fail-closed).
+     */
+    suspend fun temporalGetFileHeader(peer: OdinId, driveId: Uuid, fileId: Uuid): HomebaseFile? {
+        val creds = requireCreds()
+        val url = apiUrl(creds.domain, "/peer/$peer/drives/$driveId/temporal/files/$fileId/header")
+        Logger.i(tag = TAG) { "temporalGetFileHeader: GET peer=${peer.domainName} drive=$driveId file=$fileId" }
+
+        val response = encryptedGet(url = url, token = creds.accessToken, secret = creds.secret)
+        if (response.status == 404) {
+            Logger.i(tag = TAG) { "temporalGetFileHeader: 404 (outside window / missing) file=$fileId" }
+            return null
+        }
+        try {
+            throwForFailure(response)
+        } catch (e: Exception) {
+            Logger.w(throwable = e, tag = TAG) {
+                "temporalGetFileHeader: FAIL peer=${peer.domainName} drive=$driveId file=$fileId status=${response.status}"
+            }
+            throw e
+        }
+        return deserialize<ServerFile>(response.body).asHomebaseFile(creds.secret)
+    }
+
+    /**
+     * Fetch (and decrypt) a payload through the temporal API. The payload endpoint carries no
+     * shared-secret on the wire — it returns the still-encrypted bytes plus the
+     * `sharedsecretencryptedheader64` header, which [DriveFileProvider.decryptBytes] uses to recover
+     * the key header and decrypt. Returns null when the file is outside the window or missing.
+     *
+     * [chunkStart]/[chunkLength] request a byterange (both or neither).
+     */
+    suspend fun temporalGetPayload(
+        peer: OdinId,
+        driveId: Uuid,
+        fileId: Uuid,
+        payloadKey: String,
+        chunkStart: Long? = null,
+        chunkLength: Long? = null,
+    ): BytesResponse? {
+        require(payloadKey.isNotBlank()) { "payloadKey must be defined" }
+        val creds = requireCreds()
+        val base = "/peer/$peer/drives/$driveId/temporal/files/$fileId/payload/$payloadKey"
+        val path = if (chunkStart != null) "$base/$chunkStart/${chunkLength ?: ""}" else base
+        val url = apiUrl(creds.domain, path)
+        Logger.i(tag = TAG) { "temporalGetPayload: GET peer=${peer.domainName} drive=$driveId file=$fileId key=$payloadKey" }
+
+        val response = requestBytes {
+            httpClient.get(url) { bearerAuth(creds.accessToken) }
+        }
+        if (response.status == 404) {
+            Logger.i(tag = TAG) { "temporalGetPayload: 404 (outside window / missing) file=$fileId key=$payloadKey" }
+            return null
+        }
+        throwForFailure(response)
+
+        val decrypted = driveFileProvider.decryptBytes(response.headers, response.bytes)
+        Logger.i(tag = TAG) {
+            "temporalGetPayload: OK file=$fileId key=$payloadKey → ${decrypted.size} bytes (${response.contentType})"
+        }
+        return BytesResponse(bytes = decrypted, contentType = response.contentType)
+    }
+
+    /**
+     * Fetch (and decrypt) a payload thumbnail through the temporal API. Same wire shape as
+     * [temporalGetPayload]. Returns null when the file/thumbnail is outside the window or missing.
+     */
+    suspend fun temporalGetThumbnail(
+        peer: OdinId,
+        driveId: Uuid,
+        fileId: Uuid,
+        payloadKey: String,
+        width: Int,
+        height: Int,
+    ): BytesResponse? {
+        require(payloadKey.isNotBlank()) { "payloadKey must be defined" }
+        require(width > 0 && height > 0) { "width/height must be positive" }
+        val creds = requireCreds()
+        val url = apiUrl(
+            creds.domain,
+            "/peer/$peer/drives/$driveId/temporal/files/$fileId/payload/$payloadKey/thumb/$width/$height",
+        )
+        Logger.i(tag = TAG) {
+            "temporalGetThumbnail: GET peer=${peer.domainName} drive=$driveId file=$fileId key=$payloadKey ${width}x$height"
+        }
+
+        val response = requestBytes {
+            httpClient.get(url) { bearerAuth(creds.accessToken) }
+        }
+        if (response.status == 404) {
+            Logger.i(tag = TAG) { "temporalGetThumbnail: 404 (outside window / missing) file=$fileId key=$payloadKey" }
+            return null
+        }
+        throwForFailure(response)
+
+        val decrypted = driveFileProvider.decryptBytes(response.headers, response.bytes)
+        Logger.i(tag = TAG) {
+            "temporalGetThumbnail: OK file=$fileId key=$payloadKey → ${decrypted.size} bytes (${response.contentType})"
+        }
+        return BytesResponse(bytes = decrypted, contentType = response.contentType)
+    }
+
+    companion object { private const val TAG = "TemporalRead" }
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
@@ -27,6 +27,7 @@ import id.homebase.api.client.peer.PeerDriveQueryProvider
 import id.homebase.api.client.peer.PeerDriveUploadProvider
 import id.homebase.api.client.peer.PeerNotificationProvider
 import id.homebase.api.client.peer.PeerWebSocketManager
+import id.homebase.api.client.peer.temporal.TemporalDriveReadProvider
 import id.homebase.api.client.profile.PublicProfileProvider
 import id.homebase.api.client.profile.PublicProfileProviderCached
 import id.homebase.api.client.upgrade.IdentityUpgradeProvider
@@ -93,6 +94,7 @@ val apiModule = module {
 
     factoryOf(::ConnectionNetworkProvider)
     factoryOf(::PeerDriveQueryProvider)
+    factoryOf(::TemporalDriveReadProvider)
     factoryOf(::PeerDriveUploadProvider)
     factoryOf(::PeerNotificationProvider)
     // Single: one set of peer (owner-hosted) websocket connections per app session; reset on logout

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1172,6 +1172,7 @@
     <string name="dev_menu_force_sync">Force Sync All</string>
     <string name="dev_menu_clear_data">Clear All Data</string>
     <string name="dev_menu_test_notification">Test Rich Notification</string>
+    <string name="dev_menu_test_temporal_read">Test temporal location read (Frodo)</string>
     <string name="dev_menu_allow_ten_bit_video">Allow 10-bit video</string>
     <string name="dev_menu_allow_ten_bit_video_description">Keep uploaded 10-bit videos at 10-bit (High 10) instead of downconverting to 8-bit. For testing only — the result may not play on all devices.</string>
     <string name="dev_menu_section_crashlytics">Crashlytics</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/devmenu/DeveloperMenuScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/devmenu/DeveloperMenuScreen.kt
@@ -54,6 +54,7 @@ import id.homebase.resources.dev_menu_section_sync
 import id.homebase.resources.dev_menu_section_testing
 import id.homebase.resources.dev_menu_section_video
 import id.homebase.resources.dev_menu_test_notification
+import id.homebase.resources.dev_menu_test_temporal_read
 import id.homebase.resources.dev_menu_title
 import id.homebase.resources.dev_menu_trigger_test_crash
 import id.homebase.resources.dev_menu_trigger_test_crash_description
@@ -204,6 +205,11 @@ fun DeveloperMenuUi(
                         label = stringResource(MR.string.dev_menu_test_notification),
                         showChevron = false,
                         onClick = { onAction(DeveloperMenuUiAction.TestRichNotification) }
+                    )
+                    HelpClickableRow(
+                        label = stringResource(MR.string.dev_menu_test_temporal_read),
+                        showChevron = false,
+                        onClick = { onAction(DeveloperMenuUiAction.TestTemporalLocationRead) }
                     )
                 }
             }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/devmenu/DeveloperMenuViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/devmenu/DeveloperMenuViewModel.kt
@@ -5,11 +5,21 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.QueryBatchRequest
+import id.homebase.api.client.drives.QueryBatchResultOptionsRequest
+import id.homebase.api.client.drives.QueryBatchSortOrder
+import id.homebase.api.client.drives.query.FileQueryParams
+import id.homebase.api.client.peer.temporal.TemporalDriveReadProvider
+import id.homebase.api.common.OdinId
 import id.homebase.api.sync.DriveSyncManager
 import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.core.config.locationLabeledDrive
 import id.homebase.core.notifications.RichNotificationData
 import id.homebase.core.notifications.RichNotificationDisplayer
 import id.homebase.core.settings.UserPreferences
+import id.homebase.core.ui.screens.location.model.LOCATION_POINTS_PAYLOAD_KEY
+import id.homebase.core.ui.screens.location.model.LOCATION_TRACK_FILE_TYPE
+import id.homebase.core.ui.screens.location.model.LocationTrackCodec
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -22,7 +32,17 @@ class DeveloperMenuViewModel(
     private val databaseManager: DatabaseManager,
     private val credentialsManager: CredentialsManager,
     private val userPreferences: UserPreferences,
+    private val temporalDriveReadProvider: TemporalDriveReadProvider,
 ) : ViewModel() {
+
+    companion object {
+        private const val TEMPORAL_TAG = "TemporalRead"
+
+        // Temporary hardcoded test target — the peer whose location drive we read. For a non-empty
+        // result this identity must grant our logged-in identity ConditionalTemporalRead on the
+        // location drive (via an emergency circle); `verify` works regardless.
+        private const val TEST_PEER = "frodo.baggins.demo.rocks"
+    }
 
     private val _uiState = MutableStateFlow(
         DeveloperMenuUiState(allowTenBitVideo = userPreferences.allowTenBitVideo)
@@ -37,6 +57,10 @@ class DeveloperMenuViewModel(
 
             is DeveloperMenuUiAction.TestRichNotification -> {
                 testRichNotification()
+            }
+
+            is DeveloperMenuUiAction.TestTemporalLocationRead -> {
+                testTemporalLocationRead()
             }
 
             is DeveloperMenuUiAction.ForceSyncAll -> {
@@ -83,6 +107,71 @@ class DeveloperMenuViewModel(
         )
 
         RichNotificationDisplayer().show(richData)
+    }
+
+    /**
+     * Temporary dev probe for the new temporal (time-boxed / emergency) read API against
+     * [TEST_PEER]'s location drive. Exercises verify → query-batch → header → payload, logging each
+     * step under tag [TEMPORAL_TAG] and surfacing a snackbar. Safe to run without a grant: `verify`
+     * reports `hasAccess=false` and the data calls return 404/403 (logged, not fatal).
+     */
+    private fun testTemporalLocationRead() {
+        viewModelScope.launch {
+            try {
+                val peer = OdinId(TEST_PEER)
+                val driveId = locationLabeledDrive.drive.alias
+                Logger.i(tag = TEMPORAL_TAG) { "Temporal read test → peer=$TEST_PEER drive=$driveId" }
+
+                val access = temporalDriveReadProvider.verifyTemporalAccess(peer, driveId)
+                Logger.i(tag = TEMPORAL_TAG) {
+                    "verify → hasAccess=${access.hasAccess} windowSeconds=${access.windowSeconds}"
+                }
+
+                val request = QueryBatchRequest(
+                    queryParams = FileQueryParams(fileType = listOf(LOCATION_TRACK_FILE_TYPE)),
+                    resultOptionsRequest = QueryBatchResultOptionsRequest(
+                        maxRecords = 50,
+                        includeMetadataHeader = true,
+                        ordering = QueryBatchSortOrder.NewestFirst,
+                    ),
+                )
+                val batch = temporalDriveReadProvider.temporalQueryBatch(peer, driveId, request)
+                Logger.i(tag = TEMPORAL_TAG) { "query-batch → ${batch.searchResults.size} hour files" }
+                for (file in batch.searchResults.take(5)) {
+                    Logger.i(tag = TEMPORAL_TAG) { "  file=${file.fileId} created=${file.fileMetadata.created}" }
+                }
+
+                val newest = batch.searchResults.firstOrNull()
+                if (newest != null) {
+                    val header = temporalDriveReadProvider.temporalGetFileHeader(peer, driveId, newest.fileId)
+                    val content = header?.fileMetadata?.appData?.content
+                    val hour = content?.let { LocationTrackCodec.decodeHeader(it) }
+                    Logger.i(tag = TEMPORAL_TAG) {
+                        "header → file=${newest.fileId} points=${hour?.points?.size} full=${hour?.fullCount}"
+                    }
+
+                    val hasOverflow = header?.fileMetadata?.payloads
+                        ?.any { it.keyEquals(LOCATION_POINTS_PAYLOAD_KEY) } == true
+                    if (hasOverflow) {
+                        val payload = temporalDriveReadProvider.temporalGetPayload(
+                            peer, driveId, newest.fileId, LOCATION_POINTS_PAYLOAD_KEY,
+                        )
+                        Logger.i(tag = TEMPORAL_TAG) { "payload($LOCATION_POINTS_PAYLOAD_KEY) → ${payload?.bytes?.size} bytes" }
+                    } else {
+                        Logger.i(tag = TEMPORAL_TAG) { "payload → newest hour file has no '$LOCATION_POINTS_PAYLOAD_KEY' overflow" }
+                    }
+                }
+
+                sendEvent(
+                    DeveloperMenuUiEvent.Success(
+                        "Temporal read OK — access=${access.hasAccess}, ${batch.searchResults.size} files (see log tag $TEMPORAL_TAG)"
+                    )
+                )
+            } catch (e: Exception) {
+                Logger.e(throwable = e, tag = TEMPORAL_TAG) { "Temporal read test failed" }
+                sendEvent(DeveloperMenuUiEvent.Error("Temporal read failed: ${e.message}"))
+            }
+        }
     }
 
     private fun forceSyncAll() {
@@ -158,6 +247,7 @@ sealed interface DeveloperMenuUiEvent {
 sealed interface DeveloperMenuUiAction {
     data object BackClicked : DeveloperMenuUiAction
     data object TestRichNotification : DeveloperMenuUiAction
+    data object TestTemporalLocationRead : DeveloperMenuUiAction
     data object ForceSyncAll : DeveloperMenuUiAction
     data object ClearAllData : DeveloperMenuUiAction
     data object TriggerTestCrash : DeveloperMenuUiAction

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/devmenu/DeveloperMenuViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/devmenu/DeveloperMenuViewModel.kt
@@ -123,8 +123,12 @@ class DeveloperMenuViewModel(
                 Logger.i(tag = TEMPORAL_TAG) { "Temporal read test → peer=$TEST_PEER drive=$driveId" }
 
                 val access = temporalDriveReadProvider.verifyTemporalAccess(peer, driveId)
+                // newestFileModified is the "is data still flowing?" signal — 0 (ZeroTime) means
+                // no files / no access, so only meaningful when hasAccess is true.
+                val newestMs = access.newestFileModified.milliseconds
                 Logger.i(tag = TEMPORAL_TAG) {
-                    "verify → hasAccess=${access.hasAccess} windowSeconds=${access.windowSeconds}"
+                    "verify → hasAccess=${access.hasAccess} windowSeconds=${access.windowSeconds} " +
+                        "newestFileModified=${if (access.hasAccess && newestMs > 0) newestMs.toString() else "none"}"
                 }
 
                 val request = QueryBatchRequest(


### PR DESCRIPTION
## Summary

Server [odin-core PR #1567](https://github.com/homebase-id/odin-core/pull/1567) added a fail-safe, time-boxed **"emergency" read** API for sensitive peer drives — `DrivePermission.ConditionalTemporalRead`, granted via a circle, honored only through a dedicated temporal endpoint family and clamped to a recent window. This wires up the chat-kmp **client** for it. The dev-menu button is throwaway scaffolding to exercise the calls; the real consumer is the **Location App**'s family-emergency feature (pulling a relative's recent location-history day).

## `homebase-api`
- **`TemporalDriveReadProvider`** (`client/peer/temporal`) covering all five endpoints under `/peer/{odinId}/drives/{driveId}/temporal`: `verify`, `query-batch`, `files/{id}/header`, `payload`, `thumbnail`. Follows the existing peer-provider conventions exactly (own-host broker URL, `bearerAuth` + shared-secret crypto, per-call Kermit logging under tag `TemporalRead`).
- **`TemporalAccessStatus`** model mirroring the server DTO (`hasAccess` / `targetDrive` / `windowSeconds`).
- **Reuse over duplication**: `QueryBatchRequest` for the body, `DriveQueryProvider.mapQueryBatchResponse` for the corrupt-metadata-salvaging decode (bumped `private` → `internal`), `ServerFile.asHomebaseFile` for the header, and `DriveFileProvider.decryptBytes` for payload/thumbnail.
- Registered `factoryOf(::TemporalDriveReadProvider)` in `ApiModule`.

## `homebase-core` / `homebase-common`
- Temporary dev-menu probe **"Test temporal location read (Frodo)"** running verify → query-batch → header → payload against a hardcoded peer (`frodo.baggins.demo.rocks`) and the known location drive alias, logging each step and showing a Success/Error snackbar.
- New `dev_menu_test_temporal_read` string (the Konsist `ArchitectureTest` forbids `Text` literals).

## Verification
- Compiles on **JVM / Android / wasmJs**; `ArchitectureTest` + `homebase-api` JVM tests pass.
- Manually exercised on desktop: `verify` and `query-batch` round-trip correctly — fail-closed **403** without a grant, **`hasAccess=true`** once Frodo grants the caller via the emergency circle.

## Notes
- The dev button is scaffolding (hardcoded `TEST_PEER` in `DeveloperMenuViewModel`); the only non-throwaway production change is `DriveQueryProvider.mapQueryBatchResponse` going `private` → `internal`.
- Full header+payload path is unexercised until a Frodo device has real location hour files on the drive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)