### PR TITLE
Location dashboard: directional emergency titles, tighter layout, "Who you can locate" placeholder

### DIFF
--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1274,10 +1274,12 @@
     <string name="location_menu_dashboard">Dashboard</string>
     <string name="location_dashboard_history_section">Location History</string>
     <string name="location_devices_section">Find my device</string>
-    <string name="location_emergency_access_section">Emergency Location Access:</string>
+    <string name="location_locatable_section">Who you can locate</string>
+    <string name="location_locatable_coming_soon">Coming soon…</string>
+    <string name="location_emergency_access_section">Who can locate you</string>
     <string name="location_emergency_access_manage">Add emergency contacts</string>
     <string name="location_emergency_access_missing">No Emergency Location Access circle yet. Tap + to set one up in your owner console.</string>
-    <string name="location_emergency_access_none">No one has emergency access yet. Tap + to add people.</string>
+    <string name="location_emergency_access_none">No one can locate you yet. Tap + to add people.</string>
     <string name="location_emergency_access_more">+%1$d</string>
     <string name="location_device_this_device">This device</string>
     <string name="location_device_no_fix">No recent location</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
@@ -31,7 +31,6 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Text
@@ -62,6 +61,8 @@ import id.homebase.resources.location_emergency_access_missing
 import id.homebase.resources.location_emergency_access_more
 import id.homebase.resources.location_emergency_access_none
 import id.homebase.resources.location_emergency_access_section
+import id.homebase.resources.location_locatable_coming_soon
+import id.homebase.resources.location_locatable_section
 import id.homebase.resources.location_status_pending
 import id.homebase.resources.location_status_points_today
 import kotlin.time.Instant
@@ -166,12 +167,26 @@ fun LocationDashboardContent(
             }
         }
 
-        // ── Emergency Location Access (members of that circle) ──
-        EmergencyAccessSection(
-            circleFound = uiState.emergencyCircleFound,
-            members = uiState.emergencyContacts,
+        // ── Who you can locate (placeholder — reciprocal list, not built yet) ──
+        DashboardSection(title = stringResource(MR.string.location_locatable_section)) {
+            Text(
+                text = stringResource(MR.string.location_locatable_coming_soon),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.fillMaxWidth().padding(16.dp),
+            )
+        }
+
+        // ── Who can locate you (members of the Emergency Location Access circle) ──
+        DashboardSection(
+            title = stringResource(MR.string.location_emergency_access_section),
             onManage = onManageEmergencyAccess,
-        )
+        ) {
+            EmergencyAccessBody(
+                circleFound = uiState.emergencyCircleFound,
+                members = uiState.emergencyContacts,
+            )
+        }
 
         // ── Footer ──
         Row(
@@ -238,57 +253,82 @@ fun DeviceRow(device: LocationDeviceInfo, onClick: () -> Unit) {
 }
 
 /**
- * Who can see this identity's location in an emergency: the members of the
- * "Emergency Location Access" circle. Always shown (with a manage "+" that opens
- * the owner console); collapses to an avatar stack that expands to a named list.
+ * A titled dashboard section: a tight title row (with an optional compact manage
+ * "+" affordance) hugging its content [Card]. Used for the two emergency lists so
+ * their layout matches.
  */
 @Composable
-private fun EmergencyAccessSection(
+private fun DashboardSection(
+    title: String,
+    modifier: Modifier = Modifier,
+    onManage: (() -> Unit)? = null,
+    content: @Composable () -> Unit,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.weight(1f),
+            )
+            if (onManage != null) {
+                // Compact tappable "+" (not a 48dp IconButton, which would balloon
+                // the title row and push the card away).
+                Icon(
+                    imageVector = Icons.Default.Add,
+                    contentDescription = stringResource(MR.string.location_emergency_access_manage),
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .clip(CircleShape)
+                        .clickable(onClick = onManage)
+                        .padding(4.dp)
+                        .size(22.dp),
+                )
+            }
+        }
+        Card(modifier = Modifier.fillMaxWidth()) { content() }
+    }
+}
+
+/**
+ * Body of the "Who can locate you" section: the members of the "Emergency Location
+ * Access" circle. Collapses to an avatar stack that expands to a named list.
+ */
+@Composable
+private fun EmergencyAccessBody(
     circleFound: Boolean?,
     members: List<ContactUiModel>,
-    onManage: () -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Text(
-            text = stringResource(MR.string.location_emergency_access_section),
-            style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.weight(1f),
-        )
-        IconButton(onClick = onManage) {
-            Icon(
-                imageVector = Icons.Default.Add,
-                contentDescription = stringResource(MR.string.location_emergency_access_manage),
-            )
+    when {
+        circleFound == null -> Box(
+            modifier = Modifier.fillMaxWidth().padding(24.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
         }
-    }
-    Card(modifier = Modifier.fillMaxWidth()) {
-        when {
-            circleFound == null -> Box(
-                modifier = Modifier.fillMaxWidth().padding(24.dp),
-                contentAlignment = Alignment.Center,
-            ) {
-                CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
-            }
 
-            !circleFound -> Text(
-                text = stringResource(MR.string.location_emergency_access_missing),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.fillMaxWidth().padding(16.dp),
-            )
+        !circleFound -> Text(
+            text = stringResource(MR.string.location_emergency_access_missing),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+        )
 
-            members.isEmpty() -> Text(
-                text = stringResource(MR.string.location_emergency_access_none),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.fillMaxWidth().padding(16.dp),
-            )
+        members.isEmpty() -> Text(
+            text = stringResource(MR.string.location_emergency_access_none),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+        )
 
-            else -> Column {
+        else -> Column {
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -331,7 +371,6 @@ private fun EmergencyAccessSection(
             }
         }
     }
-}
 
 /** Overlapping avatar stack with a "+N" overflow chip. */
 @Composable


### PR DESCRIPTION
## Summary

Follow-up polish (after #761) to the Location dashboard emergency sections.

1. **No colon** in the title — and renamed for a clear **directional pair**:
   - **"Who you can locate"** (new section, above) — people whose location you can check
     in an emergency.
   - **"Who can locate you"** (the existing circle section, was "Emergency Location Access:").
2. **Tighter title→card spacing.** A shared `DashboardSection` now groups each title row
   with its card (6 dp) and uses a compact tappable "+" instead of a 48 dp `IconButton`
   that was ballooning the title row and pushing the card down.
3. **New "Who you can locate" section** (same layout) with a **"Coming soon…"** placeholder —
   the reciprocal list (people who granted *you* access) isn't built yet, so no data wiring.

The "Who can locate you" section keeps everything from #761 (GUID-matched circle, always
shown, friendly "missing"/"none" messages, contact-service avatars, expand-to-list, "+" →
owner console).

## Test plan
- [x] `:homebase-core` compiles on JVM, Android, wasmJs
- [x] `homebase-core:jvmTest` green (incl. Konsist — all titles/strings are resources)
- [ ] Desktop: two stacked sections read clearly; "Who you can locate" shows "Coming soon…";
  "Who can locate you" title sits tight to its card

🤖 Generated with [Claude Code](https://claude.com/claude-code)