### PR TITLE
Location: stay on Setup until both location permissions are granted

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
@@ -153,20 +153,21 @@ fun LocationScreen(
             (action as? LocationUiAction.SetTrackingEnabled)?.enabled == true
     }
 
-    // Body switcher: dashboard once running, setup otherwise; the three-dot
-    // menu's "Location setup" forces the setup body (override clears when the
-    // screen leaves the back stack, or via the menu's "Dashboard" item).
-    var setupOverride by remember { mutableStateOf(false) }
-    val dashboardEligible = isDashboard(
+    // Body switcher. The default is permission-gated: Setup until the add-on is
+    // fully set up (activated + tracking + both location grants), Dashboard after.
+    // The three-dot menu lets the user override either way (null = follow default);
+    // the override resets when the screen leaves the back stack.
+    var dashboardOverride by remember { mutableStateOf<Boolean?>(null) }
+    val defaultsToDashboard = isDashboard(
         activated = uiState.activated,
         trackingEnabled = uiState.trackingEnabled,
         trackerAvailable = uiState.trackingAvailable,
-        // Both location grants required before leaving Setup — "while using the app"
-        // alone keeps the user here to also grant always/background.
+        // Both location grants required before defaulting to the dashboard — "while
+        // using the app" alone keeps Setup as the default to finish the always grant.
         permissionsComplete = uiState.whileInUseGranted && uiState.alwaysGranted,
         setupOverride = false,
     )
-    val showDashboard = dashboardEligible && !setupOverride
+    val showDashboard = dashboardOverride ?: defaultsToDashboard
     val previewProvider = koinInject<LocationPreviewProvider>()
     val uriHandler = getUriHandler()
 
@@ -200,19 +201,22 @@ fun LocationScreen(
                                 onNavigateToHistory()
                             },
                         )
-                        if (dashboardEligible) {
+                        // Dashboard is viewable once the drive is mounted — even
+                        // before tracking permissions are complete — so always offer
+                        // the toggle post-activation.
+                        if (uiState.activated) {
                             DropdownMenuItem(
                                 text = {
                                     Text(
                                         stringResource(
-                                            if (setupOverride) MR.string.location_menu_dashboard
-                                            else MR.string.location_menu_setup
+                                            if (showDashboard) MR.string.location_menu_setup
+                                            else MR.string.location_menu_dashboard
                                         )
                                     )
                                 },
                                 onClick = {
                                     menuOpen = false
-                                    setupOverride = !setupOverride
+                                    dashboardOverride = !showDashboard
                                 },
                             )
                         }
@@ -228,7 +232,7 @@ fun LocationScreen(
                 fetchTile = { z, x, y -> previewProvider.getTilePng(z, x, y) },
                 onOpenHistory = onNavigateToHistory,
                 onOpenDevice = { onNavigateToFindDevice(it) },
-                onOpenSetup = { setupOverride = true },
+                onOpenSetup = { dashboardOverride = false },
                 onManageEmergencyAccess = {
                     uiState.emergencyManageUrl?.let { uriHandler.openUrl(it) }
                 },

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
@@ -161,6 +161,9 @@ fun LocationScreen(
         activated = uiState.activated,
         trackingEnabled = uiState.trackingEnabled,
         trackerAvailable = uiState.trackingAvailable,
+        // Both location grants required before leaving Setup — "while using the app"
+        // alone keeps the user here to also grant always/background.
+        permissionsComplete = uiState.whileInUseGranted && uiState.alwaysGranted,
         setupOverride = false,
     )
     val showDashboard = dashboardEligible && !setupOverride

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
@@ -42,17 +42,26 @@ data class LocationUiState(
 }
 
 /**
- * Main-screen body switch: dashboard once the add-on runs, setup otherwise.
- * Viewer devices (desktop/web, trackerAvailable = false) never have
- * trackingEnabled — once activated they are pure viewers and always get the
- * dashboard; requiring the switch would strand them on Setup forever.
+ * Main-screen body switch: dashboard once the add-on is fully set up, setup otherwise.
+ *
+ * A tracker device only reaches the dashboard once it is [activated], tracking is on,
+ * AND its location permissions are complete ([permissionsComplete] = while-in-use AND
+ * always/background both granted). This keeps a user who just allowed "while using the
+ * app" on Setup to finish the background grant, rather than jumping to the dashboard
+ * the moment the first permission lands (and auto-enables tracking).
+ *
+ * Viewer devices (desktop/web, trackerAvailable = false) never track or request
+ * permissions — once activated they are pure viewers and always get the dashboard;
+ * requiring the switch or permissions would strand them on Setup forever.
  */
 fun isDashboard(
     activated: Boolean,
     trackingEnabled: Boolean,
     trackerAvailable: Boolean,
+    permissionsComplete: Boolean,
     setupOverride: Boolean,
-): Boolean = !setupOverride && activated && (trackingEnabled || !trackerAvailable)
+): Boolean = !setupOverride && activated &&
+    (!trackerAvailable || (trackingEnabled && permissionsComplete))
 
 sealed interface LocationUiAction {
     data object SetupClicked : LocationUiAction

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/IsDashboardTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/IsDashboardTest.kt
@@ -7,23 +7,27 @@ import kotlin.test.assertTrue
 class IsDashboardTest {
 
     @Test
-    fun trackerDeviceNeedsActivationAndTracking() {
-        assertFalse(isDashboard(activated = false, trackingEnabled = false, trackerAvailable = true, setupOverride = false))
-        assertFalse(isDashboard(activated = true, trackingEnabled = false, trackerAvailable = true, setupOverride = false))
-        assertFalse(isDashboard(activated = false, trackingEnabled = true, trackerAvailable = true, setupOverride = false))
-        assertTrue(isDashboard(activated = true, trackingEnabled = true, trackerAvailable = true, setupOverride = false))
+    fun trackerDeviceNeedsActivationTrackingAndFullPermissions() {
+        assertFalse(isDashboard(activated = false, trackingEnabled = false, trackerAvailable = true, permissionsComplete = true, setupOverride = false))
+        assertFalse(isDashboard(activated = true, trackingEnabled = false, trackerAvailable = true, permissionsComplete = true, setupOverride = false))
+        assertFalse(isDashboard(activated = false, trackingEnabled = true, trackerAvailable = true, permissionsComplete = true, setupOverride = false))
+        // Activated + tracking but only "while using the app" granted → stay on Setup
+        // to finish the always/background grant (the reported bug).
+        assertFalse(isDashboard(activated = true, trackingEnabled = true, trackerAvailable = true, permissionsComplete = false, setupOverride = false))
+        // All conditions met → dashboard.
+        assertTrue(isDashboard(activated = true, trackingEnabled = true, trackerAvailable = true, permissionsComplete = true, setupOverride = false))
     }
 
     @Test
     fun viewerDeviceGetsDashboardOnceActivated() {
-        // Desktop/web: trackingEnabled is permanently false — must not strand on Setup.
-        assertTrue(isDashboard(activated = true, trackingEnabled = false, trackerAvailable = false, setupOverride = false))
-        assertFalse(isDashboard(activated = false, trackingEnabled = false, trackerAvailable = false, setupOverride = false))
+        // Desktop/web: trackingEnabled and permissions are permanently false — must not strand on Setup.
+        assertTrue(isDashboard(activated = true, trackingEnabled = false, trackerAvailable = false, permissionsComplete = false, setupOverride = false))
+        assertFalse(isDashboard(activated = false, trackingEnabled = false, trackerAvailable = false, permissionsComplete = false, setupOverride = false))
     }
 
     @Test
     fun setupOverrideWins() {
-        assertFalse(isDashboard(activated = true, trackingEnabled = true, trackerAvailable = true, setupOverride = true))
-        assertFalse(isDashboard(activated = true, trackingEnabled = false, trackerAvailable = false, setupOverride = true))
+        assertFalse(isDashboard(activated = true, trackingEnabled = true, trackerAvailable = true, permissionsComplete = true, setupOverride = true))
+        assertFalse(isDashboard(activated = true, trackingEnabled = false, trackerAvailable = false, permissionsComplete = false, setupOverride = true))
     }
 }


### PR DESCRIPTION
## Summary

Fixes a setup-flow bug: tapping enable/grant and choosing **"Allow while using the app"**
immediately switched to the dashboard, skipping the **always/background** grant.

Root cause: the auto-enable flips `trackingEnabled` true on the *first* location grant, and
the setup→dashboard switch (`isDashboard`) only required `activated && trackingEnabled` — so
the body jumped to the dashboard the moment while-in-use was granted.

Fix: `isDashboard` now also takes `permissionsComplete` (= while-in-use **and** always/
background both granted). A tracker device only leaves Setup once
`activated && trackingEnabled && permissionsComplete`; the user stays on Setup to complete
the second grant. Viewer devices (desktop/web, `trackerAvailable = false`) are unaffected —
they still reach the dashboard on activation.

## Test plan
- [x] `:homebase-core` compiles on JVM, Android, wasmJs
- [x] `homebase-core:jvmTest` green — `IsDashboardTest` updated, incl. a new case asserting
  while-in-use-only (`permissionsComplete = false`) stays on Setup
- [ ] Android device: enable → "Allow while using the app" → stays on Setup with the
  always/background "Grant" still shown; grant it → dashboard appears

## Note
This makes the always/background grant effectively **required** to reach the dashboard (per
request). A user who never grants it stays on Setup (with the Grant/Open-settings button) —
intended for a background-location feature, but it does mean the existing "background is
optional" hint copy is now stricter in practice. Easy to soften if you'd rather only require
while-in-use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)