### PR TITLE
fix(ios): animate GIFs from the quick-switch gallery preview

### DIFF
--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/image/PHAssetFetcher.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/image/PHAssetFetcher.kt
@@ -4,9 +4,11 @@ import coil3.ImageLoader
 import coil3.Uri
 import coil3.asImage
 import coil3.decode.DataSource
+import coil3.decode.ImageSource
 import coil3.fetch.FetchResult
 import coil3.fetch.Fetcher
 import coil3.fetch.ImageFetchResult
+import coil3.fetch.SourceFetchResult
 import coil3.request.Options
 import coil3.size.Dimension
 import id.homebase.api.lib.image.ImageFormatDetector
@@ -15,6 +17,7 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.usePinned
 import kotlinx.coroutines.suspendCancellableCoroutine
+import okio.Buffer
 import org.jetbrains.skia.Bitmap
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skia.impl.use
@@ -132,6 +135,25 @@ class PHAssetFetcher(
             header.usePinned { pinned ->
                 memcpy(pinned.addressOf(0), nsData.bytes, header.size.toULong())
             }
+        }
+
+        // Animated containers (GIF / animated WebP): hand the raw bytes to the Coil
+        // decoder chain as a SourceFetchResult so AnimatedSkiaDecoder can animate
+        // multi-frame images. Decoding to a single Bitmap here (the static path below)
+        // freezes a GIF on its first frame — the bug for quick-switch gallery previews.
+        // Single-frame GIF/WebP fall through to the default static Skia decoder inside
+        // the chain, so non-animated images are unaffected.
+        val format = ImageFormatDetector.detectFormat(header)
+        if (format == "image/gif" || format == "image/webp") {
+            val bytes = ByteArray(nsData.length.toInt())
+            bytes.usePinned { pinned ->
+                memcpy(pinned.addressOf(0), nsData.bytes, nsData.length)
+            }
+            return SourceFetchResult(
+                source = ImageSource(Buffer().apply { write(bytes) }, options.fileSystem),
+                mimeType = format,
+                dataSource = DataSource.DISK,
+            )
         }
 
         val skiaImage = if (ImageFormatDetector.isHeic(header)) {


### PR DESCRIPTION
## Problem

On iOS, a GIF picked from the **quick-switch gallery** grid showed only its **first frame** (frozen) in the FullScreenAttachmentEditor preview. GIFs received in messages animate fine — so this was specific to the local PHAsset preview path.

## Root cause

`PHAssetFetcher` (the Coil fetcher for `ph://` / `/L0/` PHAsset URIs) decoded **every** image — GIF and WebP included — to a single Skia `Bitmap` and returned an `ImageFetchResult`. Coil only runs its **decoder chain** on a `SourceFetchResult` (raw source); a pre-decoded `ImageFetchResult` skips decoders entirely. So the in-house `AnimatedSkiaDecoder` — which already animates multi-frame GIF/WebP for every other fetcher — never saw the bytes, and the GIF was flattened to frame 0.

Received GIFs work because their fetchers (`HomebaseImageFetcher`, `PublicImageFetcher`, `PlatformFileFetcher`) return raw bytes as a `SourceFetchResult`.

## Fix

In `PHAssetFetcher.imageFromNSData`, detect animatable containers via the existing `ImageFormatDetector.detectFormat()` (`image/gif` / `image/webp`) and return the **raw bytes as a `SourceFetchResult`** instead of a decoded bitmap — so the decoder chain runs and `AnimatedSkiaDecoder` animates multi-frame images. Single-frame GIF/WebP and all other formats (JPEG/PNG/HEIC) keep the existing decoded path, so there's no regression for non-animated images (the static HEIC native-decode path is untouched).

One file changed (`homebase-common/.../image/PHAssetFetcher.kt`).

## Verification

- Native compile (`:homebase-common:compileKotlinIosSimulatorArm64`) clean.
- On device (iPhone 15, iOS 26.5): GIF picked from the quick-switch grid animates in the editor preview.

## Notes

Independent of the gallery-video send fix (PR #755); branched off `main`.
