### PR TITLE
chore: gitignore locally-installed agent skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ gradle/local-repo/id/homebase/libs/ffmpeg-kit/1.0/ffmpeg-kit-1.0.aar.*.bak
 
 # Brainstorming visual-companion mockups (local only)
 .superpowers/
+
+# Locally-installed agent skills (argent, kotlin, etc.) — installed per-machine, not part of the repo
+/.agents/
+/skills-lock.json


### PR DESCRIPTION
`.agents/` and `skills-lock.json` are dropped into the repo per-machine by agent-skill tooling (argent, etc.) and aren't part of the project. Ignore them so they can't be committed by accident.

Scoped intentionally to just the skill install artifacts — team-shareable MCP/editor configs (`.mcp.json`, `.vscode/`, `.cursor/`, etc.) are **not** ignored here.

One file changed (`.gitignore`, +3 lines).