### PR TITLE
fix(chat): typed messages can be a conversation's last-message preview

### DIFF
--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ChatReadCount.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ChatReadCount.sq
@@ -48,7 +48,7 @@ LEFT JOIN DriveMainIndex AS m
     WHERE m2.identityId = d.identityId
       AND m2.groupId = d.uniqueId
       AND m2.fileType = 7878
-      AND m2.dataType = 0
+      AND m2.dataType != 202
     ORDER BY m2.userDate DESC
     LIMIT 1
   )


### PR DESCRIPTION
## Problem

After an app restart, a conversation whose **newest message is a typed kind** (poll/event/dice/groodle/location) showed a **stale or blank** last-message preview in the conversation list. Example: a 1:1 whose last message was a dice roll rendered an empty preview line.

## Root cause

The boot/cold-load query `selectAllConversationPlusLastMessage` selects each conversation's last message with:

```sql
WHERE m2.fileType = 7878
  AND m2.dataType = 0      -- ← excludes all typed kinds
ORDER BY m2.userDate DESC LIMIT 1
```

That `dataType = 0` filter was written when **every** chat message was dataType 0. Typed messages use dataType **210** (event), **211** (location), **212** (dice), **213** (groodle), **214** (poll) — so they can never be chosen as the "last message", and the query falls back to an older/empty `dataType=0` row.

The live **bump** path (`applyIncomingMessageBump`) uses the fully-mapped `MessageUiModel`, so freshly-arriving typed messages previewed fine — masking the bug until a restart.

Confirmed with instrumentation: `applyLastMessage` saw `dataType=0` for **every** conversation regardless of its true last message.

## Fix

```sql
AND m2.dataType != 202   -- include text + all typed kinds; exclude only status (202)
```

- `0` = text/media, `210–214` = typed kinds → all valid last messages.
- `202` = `ChatStatusMessageDataType` (system/status lines) → still excluded, matching prior behavior.
- Forward-compatible: future typed kinds (215+) work automatically.
- `idx_chatmessage_convid_userDate` (groupId-leading) keeps this a fast `LIMIT 1` seek.

Query-only change; no schema migration.

## Verification

Built + run on a physical Android device. A conversation whose last message is a dice roll now previews **"Rolled 13 (3d6)"** with its kind icon; an event conversation shows the event title — both previously blank on cold load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)