### PR TITLE
fix(ios): make saved files visible in the Files app

### DIFF
--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/FileUtilities.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/FileUtilities.native.kt
@@ -180,7 +180,10 @@ actual fun getUriHandler(): FileSystemHandler {
                             throw Exception("Failed to copy file to $destPath: $msg")
                         }
                     }
-                    onSuccess("Documents")
+                    // "Files" (not "Documents") — the saved file shows up in the
+                    // Files app under On My iPhone > Homebase, which is where this
+                    // points the user. Requires the Info.plist file-sharing keys.
+                    onSuccess("Files")
                 } catch (e: Exception) {
                     onError(e)
                 } finally {

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -48,5 +48,13 @@
 		<string>location</string>
 		<string>remote-notification</string>
 	</array>
+	<!-- Expose the app's Documents directory in the Files app ("On My iPhone > Homebase")
+	     so files saved via FileSystemHandler.saveFile (the "Saved to Documents" path in
+	     FileUtilities.native.kt) are actually visible to the user. The DB lives at
+	     ~/databases (excluded from backup), not here, so nothing sensitive is exposed. -->
+	<key>UIFileSharingEnabled</key>
+	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Problem

On iOS, saving a non-media file (e.g. a `.txt` or `.lock`) shows the toast **"Saved to Documents"**, but the file never appears anywhere the user can find it.

## Root cause

`FileSystemHandler.saveFile` on iOS (`FileUtilities.native.kt`) copies the file into the app's sandbox `NSDocumentDirectory` and reports success. iOS keeps that directory **private** unless the app opts in via Info.plist — and `iosApp/Info.plist` was missing the required keys. So the file *was* saved; it was just in a folder the user can't reach.

For comparison, Android saves these to `MediaStore.Downloads` (`FileUtilities.android.kt`), which is user-visible.

## Fix

- Add `UIFileSharingEnabled` and `LSSupportsOpeningDocumentsInPlace` to `iosApp/Info.plist`. Saved files now appear under **Files → On My iPhone → Homebase**. All three app build configs (Debug/Release/Dev) use this Info.plist; no conflicting `INFOPLIST_KEY_*` build settings.
- Report the save location as **"Files"** instead of "Documents" so the toast ("Saved to Files") points the user at the app that actually shows the file.

## Safety

The encrypted SQLite DB lives at `~/databases` (excluded from backup), **not** in Documents, so exposing the Documents directory leaks nothing sensitive. The only other content there is the app's own `logs/` folder.

## Verification

⚠️ Not yet verified on a device — this is a declarative Info.plist change with no unit test. Manual test: build → save a `.txt` from a chat → confirm it appears under **Files → On My iPhone → Homebase**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5MgRA9nBnYLhAUpbXDJ24