### PR TITLE
docs(sticker): clarify StickerHandler KDoc (sibling handler, not same DI)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/StickerHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/StickerHandler.kt
@@ -29,8 +29,8 @@ private const val TAG = "StickerHandler"
 
 /**
  * Handles the sticker-library action arms (send a saved sticker, save a received
- * sticker, remove a sticker), extracted from `ConversationListViewModel.onAction` in the
- * same handler-class style as [AttachmentHandler] / [MediaDownloadHandler].
+ * sticker, remove a sticker), extracted from `ConversationListViewModel.onAction` as a
+ * sibling handler class to [AttachmentHandler] / [MediaDownloadHandler].
  *
  * Collaborators are injected as functions (mirroring [StickerCreator]) so the handler is
  * unit-testable without standing up [id.homebase.chat.services.sticker.StickerService] and


### PR DESCRIPTION
One-line KDoc clarity tweak on `StickerHandler`.

The class doc said it follows the "same handler-class style as AttachmentHandler / MediaDownloadHandler" — but those take their services directly, whereas StickerHandler takes function lambdas (mirroring `StickerCreator`, as the very next sentence already explains). The word "style" could momentarily read as "same DI". Changed to "sibling handler class" so the first line is purely about class organization; the DI distinction stays where it belongs in the following paragraph.

Comment-only; no behavior change. Follow-up to #754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)