### PR TITLE
Live location map: shared TiledMapView + live screen + dashboard section

### DIFF
--- a/CREATING_GITHUB_ISSUES.md
+++ b/CREATING_GITHUB_ISSUES.md
@@ -1,0 +1,199 @@
+# Creating GitHub Issues for chat-kmp
+
+This is the playbook Claude follows when the user asks it to file a bug or feature
+issue against the **`homebase-id/chat-kmp`** repository. The user describes the
+problem in chat; Claude turns it into a well-structured, plan-ready GitHub issue and
+creates it with the `gh` CLI.
+
+The goal: every issue body should read like a **`/plan` prompt** — enough context,
+evidence, and scope that a Claude agent (or a human) could open the repo and produce a
+reasonable implementation plan without a back-and-forth.
+
+---
+
+## Quick reference
+
+- **Repo:** `homebase-id/chat-kmp`
+- **Tool:** `gh issue create`
+- **Issue author (current gh login):** `Seifert69`
+- **Assignable users:** `2002Bishwajeet`, `acarlsen`, `odindevops`, `sebbarg`,
+  `Seifert69`, `stef-coenen`, `toddmitchell`, `xcarpentier`
+- **Labels in use:** `bug`, `enhancement`, `documentation`, `question`,
+  `help wanted`, `good first issue`, `duplicate`, `invalid`, `wontfix`
+
+---
+
+## The process (what Claude does each time)
+
+1. **Read this file first.** It defines the body format, labels, and assignee rules.
+2. **Classify** the request: bug, enhancement, or other. Pick the matching label(s)
+   and body template below.
+3. **Draft the body** as a `/plan`-ready prompt (see template). Fill every section
+   that applies; omit sections that genuinely don't (don't leave empty headings).
+4. **Resolve the assignee.** If the user did **not** say who to assign, **ask** —
+   never guess or leave it unassigned silently. (See "Assignees".)
+5. **Handle attachments.** If the user attached files, process them per the
+   "Attachments" section before creating the issue.
+6. **Confirm the title + labels + assignee** in chat (one line), then create the
+   issue with `gh`.
+7. **Report back** the issue URL that `gh` prints.
+
+---
+
+## Assignees
+
+> **If the user forgets to say who to assign an issue to, ask before creating it.**
+
+Phrase it simply, e.g. *"Who should I assign this to?"* and offer the known
+assignable users. Do not invent usernames; only use names from the assignable list
+above (refresh it with `gh api repos/homebase-id/chat-kmp/assignees --jq '.[].login'`
+if someone new joined).
+
+Pass the chosen user with `--assignee <login>`. Multiple assignees are allowed
+(`--assignee a --assignee b`).
+
+---
+
+## Attachments
+
+When the user attaches files to the chat, include them in the issue.
+
+- **Text-ish files** — stack traces, `homebase.log` excerpts, `adb logcat` dumps,
+  JSON descriptors, crash tombstones, diffs:
+  **embed inline** in the issue body inside a fenced code block, under a
+  `<details>` block if long. This is the most reliable path and keeps the evidence
+  with the issue.
+
+  ```
+  <details><summary>homebase.log (relevant excerpt)</summary>
+
+  ```text
+  ...paste...
+  ```
+  </details>
+  ```
+
+- **Images / screenshots / binary files:**
+  GitHub's drag-and-drop attachment CDN (`user-attachments`) is **not** reachable
+  from the `gh` CLI, and raw repo URLs do **not** render inline for a private repo.
+  So Claude will:
+  1. Save the attached file into the working tree under
+     `docs/issue-assets/<short-issue-slug>/<filename>`.
+  2. Reference it in the body by repo-relative path, e.g.
+     `See ![screenshot](docs/issue-assets/live-map-crash/crash.png).`
+  3. Tell the user in chat: *"The image is saved at `<path>`. For it to render
+     inline in the issue, drag it into the issue on github.com — GitHub doesn't let
+     the CLI upload to its attachment CDN for a private repo."*
+
+  Commit/push of the asset happens **only if the user asks** (per repo norms about
+  not committing without being told). Default is to leave it in the working tree and
+  point at it.
+
+If you're unsure whether an attachment is text or binary, prefer inline embedding for
+anything human-readable.
+
+---
+
+## Body template — Bug
+
+Use label `bug` (add others as relevant). Title: short, specific, imperative or
+symptom-first — e.g. *"Live location map freezes UI when conversation has 0 items"*.
+
+```markdown
+## Summary
+<One or two sentences: what's broken and the user-visible impact.>
+
+## Environment
+- Platform(s): <Android / iOS / Desktop (macOS|Windows|Linux) / Web>
+- Build: <debug|release>, version / commit if known
+- Device / OS: <e.g. Pixel 7, Android 14 — or "all platforms">
+
+## Steps to reproduce
+1. …
+2. …
+3. …
+
+## Expected vs actual
+- **Expected:** …
+- **Actual:** …
+
+## Evidence
+<Stack trace, ANR dump, logcat/homebase.log excerpt, screenshot path, profiler
+sample. Per CLAUDE.md's "Debugging & root cause" rule, an issue is stronger with
+concrete evidence than with a guessed cause. If no evidence is captured yet, name the
+instrumentation that would capture it.>
+
+## Suspected area (optional)
+<Module + file(s) you suspect, e.g. homebase-chat ConversationContent.kt. Don't
+assert a root cause you haven't proven — frame as a lead.>
+
+## Scope for the plan
+<What a fix should and shouldn't touch. Constraints (KMP targets affected, must not
+regress X). This is the part that makes it a good `/plan` prompt.>
+```
+
+## Body template — Enhancement / Feature
+
+Use label `enhancement`. Title: capability-framed — e.g. *"Add tap-to-share live
+location duration picker"*.
+
+```markdown
+## Problem / motivation
+<What can't the user do today, or what's awkward? Why does it matter?>
+
+## Proposed behaviour
+<Describe the desired UX/flow. Reference existing patterns in the app where
+relevant — e.g. "like the Event composer in ADDING_TYPED_MESSAGE_KIND.md".>
+
+## Affected modules / targets
+<homebase-api / common / chat / core; which platforms.>
+
+## Design / constraints
+<Material 3 requirements, string-resource rules, descriptor size budgets, etc. —
+call out the CLAUDE.md rules the implementer must respect.>
+
+## Acceptance criteria
+- [ ] …
+- [ ] …
+
+## Scope for the plan
+<Boundaries: what's in, what's explicitly out of scope for this issue.>
+```
+
+---
+
+## Creating the issue with `gh`
+
+Write the body to a temp file (avoids shell-quoting pain with multi-line markdown),
+then:
+
+```bash
+gh issue create \
+  --repo homebase-id/chat-kmp \
+  --title "<title>" \
+  --label bug \
+  --assignee <login> \
+  --body-file /tmp/issue-body.md
+```
+
+Notes:
+- Use `--body-file`, not `--body`, for anything longer than one line.
+- Multiple labels: repeat `--label`. Multiple assignees: repeat `--assignee`.
+- `gh` prints the new issue URL on success — relay it to the user.
+- To verify afterward: `gh issue view <number> --repo homebase-id/chat-kmp`.
+
+---
+
+## Conventions / house style
+
+- **Title:** specific and searchable. Lead with the symptom for bugs, the capability
+  for features. No trailing period.
+- **One issue per problem.** Don't bundle unrelated bugs.
+- **Plan-ready over terse.** Err toward more context. The "Scope for the plan"
+  section is what separates a filed ticket from a `/plan` prompt.
+- **Evidence over guesses** (see CLAUDE.md). Prefer a stack trace to a hunch; if the
+  cause is unproven, label it a lead, not a conclusion.
+- **Respect repo rules** when describing fixes: Material 3, `stringResource()` for all
+  user-facing text, RTL padding, no duplicated envelope fields in descriptors, etc.
+- Don't create labels or milestones on the fly; if a new label seems needed, ask the
+  user first.

--- a/CREATING_GITHUB_ISSUES.md
+++ b/CREATING_GITHUB_ISSUES.md
@@ -75,19 +75,32 @@ When the user attaches files to the chat, include them in the issue.
 
 - **Images / screenshots / binary files:**
   GitHub's drag-and-drop attachment CDN (`user-attachments`) is **not** reachable
-  from the `gh` CLI, and raw repo URLs do **not** render inline for a private repo.
-  So Claude will:
-  1. Save the attached file into the working tree under
-     `docs/issue-assets/<short-issue-slug>/<filename>`.
-  2. Reference it in the body by repo-relative path, e.g.
-     `See ![screenshot](docs/issue-assets/live-map-crash/crash.png).`
-  3. Tell the user in chat: *"The image is saved at `<path>`. For it to render
-     inline in the issue, drag it into the issue on github.com — GitHub doesn't let
-     the CLI upload to its attachment CDN for a private repo."*
+  from the `gh` CLI. But **`homebase-id/chat-kmp` is a public repo**, so a committed
+  file's `raw.githubusercontent.com` URL **renders inline** in the issue body with no
+  auth. The working method:
 
-  Commit/push of the asset happens **only if the user asks** (per repo norms about
-  not committing without being told). Default is to leave it in the working tree and
-  point at it.
+  1. Copy the attachment into a worktree on a dedicated long-lived **`issue-assets`**
+     branch (keeps `main` and feature branches clean), under
+     `docs/issue-assets/<short-issue-slug>/<filename>`:
+     ```bash
+     # create the branch from main the first time, or check out the existing one
+     git worktree add -B issue-assets /tmp/issue-assets-wt origin/main   # first time
+     # (if it already exists on origin: git worktree add /tmp/issue-assets-wt issue-assets)
+     cp <uploaded-file> /tmp/issue-assets-wt/docs/issue-assets/<slug>/<filename>
+     cd /tmp/issue-assets-wt && git add -A && git commit -m "issue-assets: <slug> ..." && git push -u origin issue-assets
+     git worktree remove /tmp/issue-assets-wt   # clean up; return to the original branch
+     ```
+  2. Embed it in the issue body via the raw URL (verify it returns HTTP 200 with
+     `curl -so /dev/null -w '%{http_code}'` before creating the issue):
+     ```
+     ![description](https://raw.githubusercontent.com/homebase-id/chat-kmp/issue-assets/docs/issue-assets/<slug>/<filename>)
+     ```
+
+  Pushing to the `issue-assets` branch is authorized by the standing "upload any files
+  I attach" instruction — it never touches `main` or the working feature branch. If
+  the repo ever goes private, this stops rendering (raw URLs would then need auth); in
+  that case fall back to telling the user to drag the image into the issue on
+  github.com.
 
 If you're unsure whether an attachment is text or binary, prefer inline embedding for
 anything human-readable.

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/liverelay/LiveShareRoster.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/liverelay/LiveShareRoster.kt
@@ -38,6 +38,20 @@ object LiveShareRoster {
     ): List<TimedRecipient> =
         current.filter { it.endTimeMs > nowMs } + add.map { TimedRecipient(it, endTimeMs) }
 
+    /**
+     * Remove exactly the entries belonging to one share — those whose [TimedRecipient.odinId] is in
+     * [recipients] **and** whose [TimedRecipient.endTimeMs] equals [endTimeMs]. The `{recipient,
+     * end-time}` pair is the share's key: a chat bubble stores its share's absolute end-time, and
+     * "stop sharing" passes that exact end-time back here so only this share's entries drop — any other
+     * live share to the same person (a different end-time) is left untouched. No-op if nothing matches.
+     */
+    fun remove(
+        current: List<TimedRecipient>,
+        recipients: List<String>,
+        endTimeMs: Long,
+    ): List<TimedRecipient> =
+        current.filterNot { it.endTimeMs == endTimeMs && it.odinId in recipients }
+
     /** The still-live entries at [nowMs] (end-time strictly in the future). May contain duplicates. */
     fun live(roster: List<TimedRecipient>, nowMs: Long): List<TimedRecipient> =
         roster.filter { it.endTimeMs > nowMs }

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/client/liverelay/LiveShareRosterTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/client/liverelay/LiveShareRosterTest.kt
@@ -59,4 +59,26 @@ class LiveShareRosterTest {
         assertEquals(listOf(TimedRecipient("a", 100)), LiveShareRoster.live(roster, nowMs = 75))
         assertTrue(LiveShareRoster.live(roster, nowMs = 200).isEmpty())
     }
+
+    @Test
+    fun remove_dropsOnlyTheMatchingShare() {
+        // Two overlapping shares sharing recipient "b": share1 {a,b}@100, share2 {b,c}@300.
+        val share1 = LiveShareRoster.add(emptyList(), listOf("a", "b"), endTimeMs = 100, nowMs = 0)
+        val roster = LiveShareRoster.add(share1, listOf("b", "c"), endTimeMs = 300, nowMs = 0)
+        // Stop share1 ({a,b}@100): only its entries drop; share2's "b"@300 and "c"@300 stay.
+        val out = LiveShareRoster.remove(roster, recipients = listOf("a", "b"), endTimeMs = 100)
+        assertEquals(listOf(TimedRecipient("b", 300), TimedRecipient("c", 300)), out)
+    }
+
+    @Test
+    fun remove_matchesOnBothRecipientAndEndTime() {
+        val roster = listOf(TimedRecipient("a", 100), TimedRecipient("a", 300))
+        // Right identity, wrong end-time -> no-op; the other "a" entry survives.
+        assertEquals(roster, LiveShareRoster.remove(roster, recipients = listOf("a"), endTimeMs = 200))
+        // Exact {recipient, end-time} match removes just that one.
+        assertEquals(
+            listOf(TimedRecipient("a", 300)),
+            LiveShareRoster.remove(roster, recipients = listOf("a"), endTimeMs = 100),
+        )
+    }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -117,6 +117,7 @@ fun ConversationListScreen(
     onNavigateBack: () -> Unit,
     onNavigateToSettingsScreen: () -> Unit,
     onNavigateToNewConversation: () -> Unit,
+    onNavigateToLiveLocationMap: () -> Unit = {},
     onNavigateToContactInfo: (odinId: String) -> Unit,
     onNavigateToConversationSettings: (conversationId: String) -> Unit,
     onNavigateToGroupSettings: (conversationId: String) -> Unit,
@@ -177,6 +178,11 @@ fun ConversationListScreen(
             is ConversationListUiEvent.NavigateToNewConversation -> {
                 viewModel.eventConsumed()
                 onNavigateToNewConversation()
+            }
+
+            is ConversationListUiEvent.NavigateToLiveLocationMap -> {
+                viewModel.eventConsumed()
+                onNavigateToLiveLocationMap()
             }
 
             is ConversationListUiEvent.NavigateToContactInfo -> {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
@@ -343,4 +343,22 @@ sealed interface ConversationListUiAction {
     data object EnsureStickerDriveMounted : ConversationListUiAction
 
     // endregion
+
+    // region Live location sharing
+
+    /** Start (or extend) a live share on [messageId]'s location: sets liveShareUntilMs = now + duration. */
+    data class StartLiveLocationShare(
+        val messageId: Uuid,
+        val durationMs: Long,
+    ) : ConversationListUiAction
+
+    /** Stop the live share on [messageId]'s location: sets liveShareUntilMs = now (ENDED). */
+    data class StopLiveLocationShare(
+        val messageId: Uuid,
+    ) : ConversationListUiAction
+
+    /** Open the Live Location map (tap a live location bubble's map). */
+    data object OpenLiveLocationMap : ConversationListUiAction
+
+    // endregion
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiEvent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiEvent.kt
@@ -31,4 +31,7 @@ sealed interface ConversationListUiEvent {
      * should navigate to the draw editor.
      */
     data class NavigateToDrawer(val requestId: kotlin.uuid.Uuid) : ConversationListUiEvent
+
+    /** Open the Live Location map (from tapping a live location bubble's map). */
+    data object NavigateToLiveLocationMap : ConversationListUiEvent
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -146,6 +146,7 @@ class ConversationListViewModel(
     private val stickerStream: id.homebase.chat.services.sticker.StickerStream,
     private val stickerService: id.homebase.chat.services.sticker.StickerService,
     private val stickerPermissionViewModel: ExtendPermissionViewModel,
+    private val liveLocationShareService: id.homebase.chat.services.livelocation.LiveLocationShareService,
 ) : ViewModel() {
 
     companion object {
@@ -840,17 +841,26 @@ class ConversationListViewModel(
                 sendEvent(ConversationListUiEvent.NavigateToLiveLocationMap)
             }
 
-            // Live share = a header-descriptor edit. Location is a raw-header typed kind, so
-            // updateMessage(content = descriptorJson) sets/clears liveShareUntilMs and syncs to both
-            // sides (sender via optimistic write, receiver via fileModified).
+            // Live share has two linked halves: the synced *declaration* (the message's
+            // liveShareUntilMs header descriptor — Location is a raw-header typed kind, so
+            // updateMessage(content = descriptorJson) sets it and syncs to both sides) AND the local
+            // *relay* roster that actually streams GPS. Both use the SAME absolute end-time so stop can
+            // later remove exactly this share's {recipient, end-time} roster entries.
             is ConversationListUiAction.StartLiveLocationShare -> viewModelScope.launch {
-                updateLocationLiveShare(
-                    action.messageId,
-                    Clock.System.now().toEpochMilliseconds() + action.durationMs,
-                )
+                val untilMs = Clock.System.now().toEpochMilliseconds() + action.durationMs
+                val msg = chatMessageStream.getMessage(action.messageId) ?: return@launch
+                val recipients = conversationStream.getRecipients(msg.conversationId, emptyList(), null)
+                updateLocationLiveShare(action.messageId, untilMs) // synced declaration → bubbles flip LIVE
+                liveLocationShareService.start(recipients, untilMs) // local relay → GPS arms + streams
             }
 
             is ConversationListUiAction.StopLiveLocationShare -> viewModelScope.launch {
+                val msg = chatMessageStream.getMessage(action.messageId) ?: return@launch
+                // The share's end-time off the descriptor BEFORE we overwrite it — the key that targets
+                // just this share's roster entries, leaving any other live share running.
+                val untilMs = (msg.messageContent as? MessageContent.Location)?.descriptor?.liveShareUntilMs
+                val recipients = conversationStream.getRecipients(msg.conversationId, emptyList(), null)
+                if (untilMs != null) liveLocationShareService.stop(recipients, untilMs)
                 updateLocationLiveShare(action.messageId, Clock.System.now().toEpochMilliseconds())
             }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -30,6 +30,8 @@ import id.homebase.chat.services.ChatMessageStream
 import id.homebase.chat.services.ChatMessagesData
 import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.LocalAttachmentContextStore
+import id.homebase.chat.services.content.MessageContent
+import id.homebase.chat.services.content.MessageContentParser
 import id.homebase.chat.services.convo.ConversationEnricher
 import id.homebase.chat.services.convo.ConversationService
 import id.homebase.chat.services.convo.ConversationStream
@@ -82,6 +84,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Instant
 import kotlin.time.TimeSource
+import kotlin.time.Clock
 import kotlin.uuid.Uuid
 
 private data class ConnectionStatusContext(
@@ -784,6 +787,24 @@ class ConversationListViewModel(
         loadMessagesForConversation(conversationId, messageId, scrollToBottom, trigger)
     }
 
+    /**
+     * Set/clear the live-share window on a location message by editing its header descriptor
+     * ([LocationPreviewDescriptor.liveShareUntilMs]). Only applies to new-format (typed) location
+     * messages; a no-op otherwise.
+     */
+    private suspend fun updateLocationLiveShare(messageId: Uuid, untilMs: Long) {
+        val msg = chatMessageStream.getMessage(messageId) ?: return
+        val descriptor = (msg.messageContent as? MessageContent.Location)?.descriptor ?: return
+        val updated = descriptor.copy(liveShareUntilMs = untilMs)
+        runCatching {
+            chatMessageSenderService.updateMessage(
+                messageId = messageId,
+                versionTag = msg.versionTag,
+                content = MessageContentParser.serialize(MessageContent.Location(updated)),
+            )
+        }.onFailure { Logger.e(throwable = it, tag = "LiveRelay") { "live-share update failed" } }
+    }
+
     fun eventConsumed() {
         _uiState.update { it.copy(uiEvent = null) }
     }
@@ -813,6 +834,24 @@ class ConversationListViewModel(
 
             is ConversationListUiAction.SearchClicked -> {
                 _uiState.update { it.copy(isSearchActive = true) }
+            }
+
+            is ConversationListUiAction.OpenLiveLocationMap -> {
+                sendEvent(ConversationListUiEvent.NavigateToLiveLocationMap)
+            }
+
+            // Live share = a header-descriptor edit. Location is a raw-header typed kind, so
+            // updateMessage(content = descriptorJson) sets/clears liveShareUntilMs and syncs to both
+            // sides (sender via optimistic write, receiver via fileModified).
+            is ConversationListUiAction.StartLiveLocationShare -> viewModelScope.launch {
+                updateLocationLiveShare(
+                    action.messageId,
+                    Clock.System.now().toEpochMilliseconds() + action.durationMs,
+                )
+            }
+
+            is ConversationListUiAction.StopLiveLocationShare -> viewModelScope.launch {
+                updateLocationLiveShare(action.messageId, Clock.System.now().toEpochMilliseconds())
             }
 
             is ConversationListUiAction.SearchBackClicked -> {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -1028,11 +1028,14 @@ internal class MessageActionsHandler(
                 val locationPreview =
                     payloadRenderers.filterIsInstance<LocationPreviewRenderer>().firstOrNull()?.preview
                 if (locationPreview != null && payloadRenderers.size == 1) {
+                    // Carry the user's typed caption in the descriptor (a typed message has no separate
+                    // text body); cap it so the header descriptor stays well under the 7 KB budget.
+                    val caption = content.trim().ifBlank { null }?.truncateToCodePoints(2000)
                     chatMessageSenderService.sendNewTypedMessage(
                         messageUniqueId = newMessageId,
                         conversationId = conversationId,
                         content = MessageContent.Location(
-                            LocationPreviewPayloadBuilder.descriptorFor(locationPreview)
+                            LocationPreviewPayloadBuilder.descriptorFor(locationPreview).copy(caption = caption)
                         ),
                         previousMessageUniqueId = null,
                         payloadBundle = payloadBundle,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -28,6 +28,8 @@ import id.homebase.chat.services.builder.MessageAttachmentBuilder
 import id.homebase.chat.services.builder.toImageAttachmentInput
 import id.homebase.chat.services.convo.ConversationService
 import id.homebase.chat.services.convo.contact.ContactService
+import id.homebase.chat.services.builder.LocationPreviewPayloadBuilder
+import id.homebase.chat.services.renderer.LocationPreviewRenderer
 import id.homebase.chat.services.renderer.PayloadRenderer
 import id.homebase.chat.services.renderer.toCombinedPayloadBundle
 import id.homebase.chat.services.renderer.toMessageDataType
@@ -1020,14 +1022,31 @@ internal class MessageActionsHandler(
                 registerLocalPreviewContexts(newMessageId, payloadBundle)
                 Logger.d(tag = TAG) { "addMessage: message=$newMessageId conversation=$conversationId" }
 
-                chatMessageSenderService.sendNewMessage(
-                    messageUniqueId = newMessageId,
-                    conversationId = conversationId,
-                    messageText = content,
-                    previousMessageUniqueId = null,
-                    payloadBundle = payloadBundle,
-                    dataType = payloadRenderers.toMessageDataType(),
-                )
+                // Location is a typed kind (= Event): the coordinate descriptor rides in the header
+                // (appData), the map PNG stays a chat_loc payload. Sending it through the typed path
+                // is what lets a live-share toggle edit the descriptor via updateMessage().
+                val locationPreview =
+                    payloadRenderers.filterIsInstance<LocationPreviewRenderer>().firstOrNull()?.preview
+                if (locationPreview != null && payloadRenderers.size == 1) {
+                    chatMessageSenderService.sendNewTypedMessage(
+                        messageUniqueId = newMessageId,
+                        conversationId = conversationId,
+                        content = MessageContent.Location(
+                            LocationPreviewPayloadBuilder.descriptorFor(locationPreview)
+                        ),
+                        previousMessageUniqueId = null,
+                        payloadBundle = payloadBundle,
+                    )
+                } else {
+                    chatMessageSenderService.sendNewMessage(
+                        messageUniqueId = newMessageId,
+                        conversationId = conversationId,
+                        messageText = content,
+                        previousMessageUniqueId = null,
+                        payloadBundle = payloadBundle,
+                        dataType = payloadRenderers.toMessageDataType(),
+                    )
+                }
                 messageInputTextState.clear()
                 jumpToLatestAfterOwnSend(conversationId)
                 Logger.d(tag = TAG) { "addMessage: complete message=$newMessageId" }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/LocationPreviewDescriptor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/LocationPreviewDescriptor.kt
@@ -3,11 +3,12 @@ package id.homebase.chat.services.builder
 import kotlinx.serialization.Serializable
 
 /**
- * Wire-format metadata for a location-share payload. Stored as JSON in
- * `PayloadDescriptor.descriptorContent` for payloads keyed `PAYLOAD_KEY_LOCATION`. The map PNG
- * lives in the encrypted payload bytes; this descriptor only carries the small fields the
- * receiver needs to render the bubble (and the `geo:` deep-link) without first downloading the
- * PNG.
+ * The coordinate metadata for a location message. New messages carry this in the message **header**
+ * (`appData.content`) — location is a typed kind (`MessageContent.Location`), like Event — which makes
+ * it the source of truth and lets a live-share toggle edit it via `updateMessage`. The map PNG lives
+ * in the encrypted `chat_loc` payload bytes; a copy of this JSON is also kept on that payload's
+ * `descriptorContent` (per-payload "image + its own GPS" sidecar) for the "See all → Locations" list
+ * and older clients. The header copy is authoritative; the payload copy is not updated on live-share.
  */
 @Serializable
 data class LocationPreviewDescriptor(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/LocationPreviewDescriptor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/LocationPreviewDescriptor.kt
@@ -17,4 +17,12 @@ data class LocationPreviewDescriptor(
     val hasImage: Boolean,
     val imageWidth: Int?,
     val imageHeight: Int?,
+    /**
+     * Absolute UTC epoch-ms at which a live-location share window ends, or null for a plain static
+     * location. The bubble derives its state from this: null = STATIC, now < value = LIVE,
+     * now >= value = ENDED. Set/cleared by updating this message's descriptor (see the live-share UX).
+     * Defaults null + `explicitNulls = false` ⇒ omitted from JSON for static shares and ignored by
+     * older clients.
+     */
+    val liveShareUntilMs: Long? = null,
 )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/LocationPreviewDescriptor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/LocationPreviewDescriptor.kt
@@ -26,4 +26,10 @@ data class LocationPreviewDescriptor(
      * older clients.
      */
     val liveShareUntilMs: Long? = null,
+    /**
+     * The user's optional caption typed alongside the location. Lives in the descriptor (like Event's
+     * title/description) because a typed location message has no separate text body. Preserved across
+     * live-share edits.
+     */
+    val caption: String? = null,
 )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/LocationPreviewPayloadBuilder.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/LocationPreviewPayloadBuilder.kt
@@ -79,6 +79,25 @@ object LocationPreviewPayloadBuilder {
         )
     }
 
+    /**
+     * The [LocationPreviewDescriptor] for a preview — used as the message HEADER content for location
+     * messages (the coordinate data lives in appData, like Event; the PNG stays a payload). `hasImage`
+     * is computed the same way [build] does (a decodable base64 image).
+     */
+    fun descriptorFor(locationPreview: LocationPreview): LocationPreviewDescriptor {
+        val imageUrl = locationPreview.imageUrl
+        val hasImage = imageUrl != null && imageUrl.contains("base64,") &&
+            runCatching { Base64.decode(imageUrl.substringAfter("base64,")).isNotEmpty() }.getOrDefault(false)
+        return LocationPreviewDescriptor(
+            lat = locationPreview.lat,
+            lon = locationPreview.lon,
+            address = locationPreview.address.truncateToCodePoints(200),
+            hasImage = hasImage,
+            imageWidth = if (hasImage) locationPreview.imageWidth else null,
+            imageHeight = if (hasImage) locationPreview.imageHeight else null,
+        )
+    }
+
     private fun buildDescriptorJson(
         locationPreview: LocationPreview,
         hasImage: Boolean,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/content/MessageContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/content/MessageContent.kt
@@ -139,8 +139,10 @@ sealed interface MessageContent {
             allowInlineReactions = true,
             allowReactionDetails = true,
         )
-        override val displayLabel: String get() = descriptor?.address?.ifBlank { UNPARSEABLE_LOCATION_LABEL }
-            ?: UNPARSEABLE_LOCATION_LABEL
+        override val displayLabel: String get() =
+            descriptor?.caption?.ifBlank { null }
+                ?: descriptor?.address?.ifBlank { null }
+                ?: UNPARSEABLE_LOCATION_LABEL
     }
 
     /**

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/content/MessageContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/content/MessageContent.kt
@@ -4,6 +4,7 @@ import id.homebase.chat.dice.DiceRollDescriptor
 import id.homebase.chat.event.EventDescriptor
 import id.homebase.chat.groodle.GroodleDescriptor
 import id.homebase.chat.poll.PollDescriptor
+import id.homebase.chat.services.builder.LocationPreviewDescriptor
 import id.homebase.notifshared.EVENT_NOTIF_SENTINEL
 
 /**
@@ -123,6 +124,26 @@ sealed interface MessageContent {
     }
 
     /**
+     * A shared location (static pin, or a live share via [LocationPreviewDescriptor.liveShareUntilMs]).
+     * The coordinate descriptor rides in the header (`appData.content`) — like Event — so editing it
+     * (start/stop a live share) goes through the raw-header `updateMessage` path. The map PNG stays a
+     * `chat_loc` payload. The bubble renders via the existing media path (this kind falls through), so
+     * keep a media-like action surface. [descriptor] follows the [Event.descriptor] nullability contract.
+     */
+    data class Location(val descriptor: LocationPreviewDescriptor?) : MessageContent {
+        override val actions: ActionPolicy = ActionPolicy(
+            allowEdit = false,            // no free-text edit; the live-share toggle lives on the bubble
+            allowReply = true,
+            allowForward = false,
+            allowShare = true,
+            allowInlineReactions = true,
+            allowReactionDetails = true,
+        )
+        override val displayLabel: String get() = descriptor?.address?.ifBlank { UNPARSEABLE_LOCATION_LABEL }
+            ?: UNPARSEABLE_LOCATION_LABEL
+    }
+
+    /**
      * A typed message whose [dataType] this client doesn't recognize — typically
      * a newer kind (poll, doodle, …) sent from a more up-to-date peer. The
      * receiver can't render the content itself; the bubble shows an
@@ -144,6 +165,7 @@ sealed interface MessageContent {
         const val UNPARSEABLE_DICE_LABEL = "Dice roll"
         const val UNPARSEABLE_GROODLE_LABEL = "Groodle"
         const val UNPARSEABLE_POLL_LABEL = "Poll"
+        const val UNPARSEABLE_LOCATION_LABEL = "Location"
         const val UNKNOWN_LABEL = "Unknown message"
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/content/MessageContentParser.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/content/MessageContentParser.kt
@@ -7,6 +7,7 @@ import id.homebase.chat.event.EventDescriptor
 import id.homebase.chat.groodle.GroodleDescriptor
 import id.homebase.chat.poll.PollDescriptor
 import id.homebase.chat.services.ChatProtocol
+import id.homebase.chat.services.builder.LocationPreviewDescriptor
 
 /**
  * Parses the `appData.content` JSON for a typed rich-content message.
@@ -47,9 +48,13 @@ object MessageContentParser {
             // before reaching us — it's listed here so the Defragmenter probe
             // (which calls this parser too) doesn't false-positive on
             // historical status messages.
+            // Location: NEW messages carry the LocationPreviewDescriptor verbatim in the header
+            // (like Event) → MessageContent.Location. OLD messages have a MessageAppData header
+            // (descriptor on the chat_loc payload) → parseLocation fails and returns null, so they
+            // flow through the media path unchanged.
+            ChatProtocol.ChatLocationMessageDataType -> parseLocation(content)
             0,
-            ChatProtocol.ChatStatusMessageDataType,
-            ChatProtocol.ChatLocationMessageDataType -> null
+            ChatProtocol.ChatStatusMessageDataType -> null
             // Any other non-zero dataType is a typed kind a future version of
             // the app will know about. Surface it so the user sees a visible
             // "update the app" chip instead of a silently-dropped message.
@@ -108,6 +113,17 @@ object MessageContentParser {
         MessageContent.Groodle(descriptor = null)
     }
 
+    /**
+     * NEW-format location: the header IS a [LocationPreviewDescriptor]. Returns null when the header
+     * isn't a descriptor (old MessageAppData-shaped location messages) so the caller treats it as
+     * MessageAppData and the bubble renders off the chat_loc payload — the back-compat path.
+     */
+    private fun parseLocation(content: String): MessageContent? = try {
+        MessageContent.Location(OdinSystemSerializer.deserialize<LocationPreviewDescriptor>(content))
+    } catch (_: Exception) {
+        null
+    }
+
     private fun parsePoll(content: String): MessageContent.Poll = try {
         val descriptor = OdinSystemSerializer.deserialize<PollDescriptor>(content)
         if (descriptor.isValid()) {
@@ -143,6 +159,10 @@ object MessageContentParser {
             OdinSystemSerializer.serialize(
                 requireNotNull(content.descriptor) { "Poll descriptor must be non-null on send" }
             )
+        is MessageContent.Location ->
+            OdinSystemSerializer.serialize(
+                requireNotNull(content.descriptor) { "Location descriptor must be non-null on send" }
+            )
         is MessageContent.Unknown ->
             error("Unknown message kind (dataType=${content.dataType}) cannot be serialized")
     }
@@ -152,6 +172,7 @@ object MessageContentParser {
         is MessageContent.DiceRoll -> ChatProtocol.ChatDiceRollMessageDataType
         is MessageContent.Groodle -> ChatProtocol.ChatGroodleMessageDataType
         is MessageContent.Poll -> ChatProtocol.ChatPollMessageDataType
+        is MessageContent.Location -> ChatProtocol.ChatLocationMessageDataType
         is MessageContent.Unknown ->
             error("Unknown message kind (dataType=${content.dataType}) cannot be re-sent")
     }
@@ -171,7 +192,8 @@ object MessageContentParser {
         is MessageContent.Event,
         is MessageContent.DiceRoll,
         is MessageContent.Groodle,
-        is MessageContent.Poll -> true
+        is MessageContent.Poll,
+        is MessageContent.Location -> true
         is MessageContent.Unknown, null -> false
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/livelocation/LiveLocationShareService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/livelocation/LiveLocationShareService.kt
@@ -13,6 +13,7 @@ import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.core.location.tracking.LocationPointStore
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.Serializable
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
@@ -67,30 +68,72 @@ class LiveLocationShareService(
     fun isActive(): Boolean = hasLiveShare()
 
     /**
-     * Share live location with [recipients] for [durationMs] from now. Appends to the roster (each
-     * share is a distinct entry), so starting a second share never drops the first's recipients.
+     * Share live location with [recipients] until the absolute [endTimeMs] (UTC epoch-ms). Appends to
+     * the roster (each share is a distinct entry), so starting a second share never drops the first's
+     * recipients. The caller MUST pass the SAME absolute end-time it wrote onto the message descriptor
+     * — that `{recipient, end-time}` identity is what lets [stop] later remove exactly this share.
+     *
+     * Immediately relays the current GPS fix (if any) to [recipients] so the server's retained
+     * last-point is fresh from the first second — a recipient opening the map mid-share is hydrated by
+     * the server with that point without waiting for the next OS fix.
      */
-    suspend fun start(recipients: List<OdinId>, durationMs: Long = DEFAULT_DURATION_MS) {
+    suspend fun start(recipients: List<OdinId>, endTimeMs: Long) {
         val now = nowMs()
+        val recipientIds = recipients.map { it.domainName }
         val roster = LiveShareRoster.add(
             current = state.value.recipients,
-            add = recipients.map { it.domainName },
-            endTimeMs = now + durationMs,
+            add = recipientIds,
+            endTimeMs = endTimeMs,
             nowMs = now,
         )
         update(LiveShareState(roster))
         onLiveShareChanged() // coordinator arms GPS for the share
         logger.i {
             "START +${recipients.size} entries=${roster.size} " +
-                "uniqueLive=${LiveShareRoster.liveRecipientIds(roster, now).size} until=${now + durationMs}"
+                "uniqueLive=${LiveShareRoster.liveRecipientIds(roster, now).size} until=$endTimeMs"
         }
+        pushCurrentPointNow(recipientIds)
     }
 
-    /** Stop ALL live sharing now (manual stop). Per-conversation stop is a UX-plan concern. */
-    suspend fun stop() {
+    /**
+     * Stop exactly the share identified by `{[recipients], [endTimeMs]}` — the same absolute end-time
+     * the matching chat bubble stored. Other live shares (to other people, or to the same people with a
+     * different end-time) are left running. No-op if nothing matches.
+     */
+    suspend fun stop(recipients: List<OdinId>, endTimeMs: Long) {
+        val roster = LiveShareRoster.remove(
+            current = state.value.recipients,
+            recipients = recipients.map { it.domainName },
+            endTimeMs = endTimeMs,
+        )
+        update(LiveShareState(roster))
+        onLiveShareChanged() // coordinator stops GPS if nothing else needs it
+        logger.i { "STOP -${recipients.size} until=$endTimeMs entries=${roster.size}" }
+    }
+
+    /** Stop ALL live sharing now. Reserved for logout/reset paths — not the per-bubble stop. */
+    suspend fun stopAll() {
         update(LiveShareState())
         onLiveShareChanged() // coordinator stops GPS if nothing else needs it
-        logger.i { "STOP" }
+        logger.i { "STOP ALL" }
+    }
+
+    /**
+     * Relay the latest GPS fix to [recipientIds] right now, ignoring the throttle window — used on
+     * [start] so the just-added recipients (and the server's retained point) get a position without
+     * waiting for the next OS fix. No-op if no fix is available yet (cold GPS) or the set is empty.
+     */
+    private suspend fun pushCurrentPointNow(recipientIds: List<String>) {
+        if (recipientIds.isEmpty()) return
+        val p = locationPointStore.lastPoint.value ?: return
+        sendLock.withLock {
+            val blob = LiveLocationCodec.encode(
+                LiveLocationPoint(lat = p.lat, lon = p.lon, acc = p.acc, spd = p.spd, hdg = p.hdg, ts = p.t)
+            )
+            runCatching { liveRelayProvider.relay(LIVE_LOCATION_CHANNEL_KEY, recipientIds.distinct(), blob) }
+                .onFailure { logger.w(it) { "immediate push failed" } }
+            lastSentMs = nowMs()
+        }
     }
 
     /**
@@ -180,9 +223,6 @@ class LiveLocationShareService(
         /** Coalesce cadence — last-value-wins. Only really exercised in the foreground; background
          *  GPS delivery is itself OS-throttled to roughly 1/min. */
         private const val MIN_INTERVAL_MS = 3_000L
-
-        /** Default share window for the debug toggle (no duration UI yet). */
-        private const val DEFAULT_DURATION_MS = 60 * 60 * 1000L // 1 hour
 
         // Location preferences own the 0a03xx namespace; 0a0307 is the next free slot.
         private val STATE_KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0307")

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LiveLocationBubbleControls.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LiveLocationBubbleControls.kt
@@ -1,0 +1,18 @@
+package id.homebase.chat.widget
+
+/**
+ * Live-share controls attached to a location chat bubble. Present for every location message in a real
+ * conversation (both sender and receiver); null only for the pre-send staging preview. The bubble's
+ * LIVE/ENDED state is NOT carried here — it's read from the message's own descriptor
+ * (`LocationPreviewDescriptor.liveShareUntilMs`). This only carries the side + the action callbacks.
+ *
+ * - [sentByYou] gates the start/stop links (you can only share/stop your own location message).
+ * - [onStart]/[onStop] update this message's descriptor (set/clear the live window).
+ * - [onOpenMap] opens the Live Location map (used by either side when the share is live).
+ */
+data class LiveLocationBubbleControls(
+    val sentByYou: Boolean,
+    val onStart: (durationMs: Long) -> Unit,
+    val onStop: () -> Unit,
+    val onOpenMap: () -> Unit,
+)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LocationPreview.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LocationPreview.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalUriHandler
@@ -77,8 +78,9 @@ import kotlin.uuid.Uuid
 private fun LocationPreviewTextContent(
     address: String,
     maxAddressLines: Int = 2,
+    color: Color = MaterialTheme.colorScheme.onSurfaceVariant,
 ) {
-    // Address only — raw lat/lon coordinates aren't human-readable, so we don't show them. Muted grey
+    // Address only — raw lat/lon coordinates aren't human-readable, so we don't show them. Muted
     // (Event-style) because the address is fixed/auto-generated location metadata, not user content.
     if (address.isNotEmpty()) {
         Text(
@@ -86,7 +88,7 @@ private fun LocationPreviewTextContent(
             style = MaterialTheme.typography.bodyMedium,
             maxLines = maxAddressLines,
             overflow = TextOverflow.Ellipsis,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            color = color,
         )
     }
 }
@@ -243,6 +245,8 @@ fun LocationPreviewCard(
     onLongPress: (() -> Unit)? = null,
     /** Live-share side + actions; null only for the pre-send staging preview. */
     liveControls: LiveLocationBubbleControls? = null,
+    /** Bubble foreground color so text/links stay legible on both grey (received) and tinted (sent) bubbles. */
+    contentColor: Color = MaterialTheme.colorScheme.onSurface,
 ) {
     val uriHandler = LocalUriHandler.current
     val geoUri = remember(descriptor.lat, descriptor.lon, descriptor.address) {
@@ -302,22 +306,24 @@ fun LocationPreviewCard(
             )
         } else {
             Box(
-                modifier = Modifier.fillMaxWidth().height(100.dp)
-                    .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+                modifier = Modifier.fillMaxWidth().height(100.dp),
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(
                     imageVector = Icons.Default.LocationOn,
                     contentDescription = stringResource(MR.string.cd_location_pin),
-                    tint = MaterialTheme.colorScheme.primary,
+                    tint = contentColor,
                     modifier = Modifier.size(40.dp),
                 )
             }
         }
 
         Column(modifier = Modifier.padding(12.dp)) {
-            // ── Fixed location metadata (muted grey): address, then the share-live affordance ──
-            LocationPreviewTextContent(address = descriptor.address)
+            // ── Fixed location metadata (muted): address, then the share-live affordance ──
+            LocationPreviewTextContent(
+                address = descriptor.address,
+                color = contentColor.copy(alpha = 0.7f),
+            )
             if (liveControls != null) {
                 if (descriptor.address.isNotEmpty()) Spacer(modifier = Modifier.height(6.dp))
                 LiveShareActionArea(
@@ -325,15 +331,16 @@ fun LocationPreviewCard(
                     isLive = isLive,
                     isEnded = isEnded,
                     remainingMs = remainingMs,
+                    contentColor = contentColor,
                 )
             }
-            // ── The user's own typed caption, in the regular message text color, below the fixed parts ──
+            // ── The user's own typed caption, in the full bubble text color, below the fixed parts ──
             if (!descriptor.caption.isNullOrBlank()) {
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(
                     text = descriptor.caption,
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
+                    color = contentColor,
                 )
             }
         }
@@ -352,7 +359,9 @@ private fun LiveShareActionArea(
     isLive: Boolean,
     isEnded: Boolean,
     remainingMs: Long,
+    contentColor: Color,
 ) {
+    val mutedColor = contentColor.copy(alpha = 0.7f)
     Box {
         when {
             isLive -> {
@@ -380,7 +389,7 @@ private fun LiveShareActionArea(
                     Text(
                         text = stringResource(MR.string.live_share_active, formatRemaining(remainingMs)),
                         style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        color = mutedColor,
                     )
                 }
             }
@@ -390,12 +399,13 @@ private fun LiveShareActionArea(
                 Text(
                     text = stringResource(MR.string.live_share_ended),
                     style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    color = mutedColor,
                 )
             }
 
             controls.sentByYou -> {
-                // STATIC, my own message: offer to share live.
+                // STATIC, my own message: offer to share live. Uses the bubble's content color so the
+                // link is visible on both the grey (received) and tinted (sent) bubble.
                 var menuExpanded by remember { mutableStateOf(false) }
                 Column {
                     Row(
@@ -405,14 +415,14 @@ private fun LiveShareActionArea(
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.Send,
                             contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary,
+                            tint = contentColor,
                             modifier = Modifier.size(18.dp),
                         )
                         Spacer(modifier = Modifier.size(6.dp))
                         Text(
                             text = stringResource(MR.string.share_live_location),
                             style = MaterialTheme.typography.labelLarge,
-                            color = MaterialTheme.colorScheme.primary,
+                            color = contentColor,
                         )
                     }
                     DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LocationPreview.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LocationPreview.kt
@@ -78,15 +78,15 @@ private fun LocationPreviewTextContent(
     address: String,
     maxAddressLines: Int = 2,
 ) {
-    // Address only — raw lat/lon coordinates aren't human-readable, so we don't show them.
+    // Address only — raw lat/lon coordinates aren't human-readable, so we don't show them. Muted grey
+    // (Event-style) because the address is fixed/auto-generated location metadata, not user content.
     if (address.isNotEmpty()) {
         Text(
             text = address,
-            style = MaterialTheme.typography.titleSmall,
-            fontWeight = FontWeight.Bold,
+            style = MaterialTheme.typography.bodyMedium,
             maxLines = maxAddressLines,
             overflow = TextOverflow.Ellipsis,
-            color = MaterialTheme.colorScheme.onSurface,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
 }
@@ -316,24 +316,24 @@ fun LocationPreviewCard(
         }
 
         Column(modifier = Modifier.padding(12.dp)) {
+            // ── Fixed location metadata (muted grey): address, then the share-live affordance ──
             LocationPreviewTextContent(address = descriptor.address)
-            // The user's typed caption (if any), below the address.
-            if (!descriptor.caption.isNullOrBlank()) {
-                if (descriptor.address.isNotEmpty()) Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = descriptor.caption,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
-            }
-            // Share-live action is the LAST line of the caption.
             if (liveControls != null) {
-                Spacer(modifier = Modifier.height(6.dp))
+                if (descriptor.address.isNotEmpty()) Spacer(modifier = Modifier.height(6.dp))
                 LiveShareActionArea(
                     controls = liveControls,
                     isLive = isLive,
                     isEnded = isEnded,
                     remainingMs = remainingMs,
+                )
+            }
+            // ── The user's own typed caption, in the regular message text color, below the fixed parts ──
+            if (!descriptor.caption.isNullOrBlank()) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = descriptor.caption,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
                 )
             }
         }
@@ -380,7 +380,7 @@ private fun LiveShareActionArea(
                     Text(
                         text = stringResource(MR.string.live_share_active, formatRemaining(remainingMs)),
                         style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.primary,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
             }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LocationPreview.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LocationPreview.kt
@@ -76,9 +76,9 @@ import kotlin.uuid.Uuid
 @Composable
 private fun LocationPreviewTextContent(
     address: String,
-    coordinatesLabel: String,
     maxAddressLines: Int = 2,
 ) {
+    // Address only — raw lat/lon coordinates aren't human-readable, so we don't show them.
     if (address.isNotEmpty()) {
         Text(
             text = address,
@@ -88,16 +88,7 @@ private fun LocationPreviewTextContent(
             overflow = TextOverflow.Ellipsis,
             color = MaterialTheme.colorScheme.onSurface,
         )
-        Spacer(modifier = Modifier.height(4.dp))
     }
-
-    Text(
-        text = coordinatesLabel,
-        style = MaterialTheme.typography.labelSmall,
-        color = MaterialTheme.colorScheme.primary,
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
-    )
 }
 
 // ─── Sender-side card (base64 image from LocationPreview) ────────────────────
@@ -117,9 +108,6 @@ fun LocationPreviewCard(
     val uriHandler = LocalUriHandler.current
     val geoUri = remember(locationPreview.lat, locationPreview.lon, locationPreview.address) {
         buildGeoUri(locationPreview.lat, locationPreview.lon, locationPreview.address)
-    }
-    val coordinatesLabel = remember(locationPreview.lat, locationPreview.lon) {
-        formatLatLon(locationPreview.lat, locationPreview.lon)
     }
 
     val imageBitmap = remember(locationPreview.imageUrl) {
@@ -142,7 +130,6 @@ fun LocationPreviewCard(
             Column(modifier = Modifier.weight(1f).padding(12.dp)) {
                 LocationPreviewTextContent(
                     address = locationPreview.address,
-                    coordinatesLabel = coordinatesLabel,
                     maxAddressLines = 1,
                 )
             }
@@ -230,7 +217,6 @@ fun LocationPreviewCard(
             Column(modifier = Modifier.padding(12.dp)) {
                 LocationPreviewTextContent(
                     address = locationPreview.address,
-                    coordinatesLabel = coordinatesLabel,
                 )
             }
         }
@@ -261,9 +247,6 @@ fun LocationPreviewCard(
     val uriHandler = LocalUriHandler.current
     val geoUri = remember(descriptor.lat, descriptor.lon, descriptor.address) {
         buildGeoUri(descriptor.lat, descriptor.lon, descriptor.address)
-    }
-    val coordinatesLabel = remember(descriptor.lat, descriptor.lon) {
-        formatLatLon(descriptor.lat, descriptor.lon)
     }
 
     // Derive STATIC / LIVE / ENDED from the descriptor's window vs now. While live, a coarse ticker
@@ -310,20 +293,16 @@ fun LocationPreviewCard(
                     loadFullPayload = true,
                 )
             }
+            // Fill the bubble width (no letterbox borders); the outer container rounds the corners.
             HomebaseImage(
                 imageData = imageData,
-                modifier = Modifier.fillMaxWidth().heightIn(max = 180.dp).clip(
-                    RoundedCornerShape(
-                        topStart = Dimens.Message.cornerRadius,
-                        topEnd = Dimens.Message.cornerRadius,
-                    )
-                ),
-                contentScale = ContentScale.Fit,
+                modifier = Modifier.fillMaxWidth().height(160.dp),
+                contentScale = ContentScale.Crop,
                 contentDescription = descriptor.address,
             )
         } else {
             Box(
-                modifier = Modifier.fillMaxWidth().heightIn(min = 100.dp)
+                modifier = Modifier.fillMaxWidth().height(100.dp)
                     .background(MaterialTheme.colorScheme.surfaceContainerHigh),
                 contentAlignment = Alignment.Center,
             ) {
@@ -336,20 +315,18 @@ fun LocationPreviewCard(
             }
         }
 
-        if (liveControls != null) {
-            LiveShareActionArea(
-                controls = liveControls,
-                isLive = isLive,
-                isEnded = isEnded,
-                remainingMs = remainingMs,
-            )
-        }
-
         Column(modifier = Modifier.padding(12.dp)) {
-            LocationPreviewTextContent(
-                address = descriptor.address,
-                coordinatesLabel = coordinatesLabel,
-            )
+            LocationPreviewTextContent(address = descriptor.address)
+            // Share-live action is the LAST line of the caption.
+            if (liveControls != null) {
+                if (descriptor.address.isNotEmpty()) Spacer(modifier = Modifier.height(6.dp))
+                LiveShareActionArea(
+                    controls = liveControls,
+                    isLive = isLive,
+                    isEnded = isEnded,
+                    remainingMs = remainingMs,
+                )
+            }
         }
     }
 }
@@ -367,7 +344,7 @@ private fun LiveShareActionArea(
     isEnded: Boolean,
     remainingMs: Long,
 ) {
-    Box(modifier = Modifier.padding(start = 12.dp, end = 12.dp, top = 8.dp)) {
+    Box {
         when {
             isLive -> {
                 // Both sides show the live caption + time left; only the sender gets the Stop link.

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LocationPreview.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LocationPreview.kt
@@ -317,9 +317,18 @@ fun LocationPreviewCard(
 
         Column(modifier = Modifier.padding(12.dp)) {
             LocationPreviewTextContent(address = descriptor.address)
+            // The user's typed caption (if any), below the address.
+            if (!descriptor.caption.isNullOrBlank()) {
+                if (descriptor.address.isNotEmpty()) Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = descriptor.caption,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
             // Share-live action is the LAST line of the caption.
             if (liveControls != null) {
-                if (descriptor.address.isNotEmpty()) Spacer(modifier = Modifier.height(6.dp))
+                Spacer(modifier = Modifier.height(6.dp))
                 LiveShareActionArea(
                     controls = liveControls,
                     isLive = isLive,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LocationPreview.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LocationPreview.kt
@@ -3,6 +3,7 @@ package id.homebase.chat.widget
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -15,23 +16,33 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import kotlin.time.Clock
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.drives.upload.EmbeddedThumb
 import id.homebase.api.client.location.LocationPreview
@@ -44,6 +55,15 @@ import id.homebase.resources.MR
 import id.homebase.resources.cancel
 import id.homebase.resources.cd_location_pin
 import id.homebase.resources.chat_location_attachment
+import id.homebase.resources.live_share_15m
+import id.homebase.resources.live_share_1h
+import id.homebase.resources.live_share_2h
+import id.homebase.resources.live_share_30m
+import id.homebase.resources.live_share_4h
+import id.homebase.resources.live_share_active
+import id.homebase.resources.live_share_ended
+import id.homebase.resources.share_live_location
+import id.homebase.resources.stop_sharing
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.decodeToImageBitmap
 import org.jetbrains.compose.resources.stringResource
@@ -233,6 +253,10 @@ fun LocationPreviewCard(
     keyHeader: KeyHeader,
     previewThumbnail: EmbeddedThumb? = null,
     modifier: Modifier = Modifier,
+    /** Forwarded to the message actions menu — fixes long-press being swallowed by the old `.clickable`. */
+    onLongPress: (() -> Unit)? = null,
+    /** Live-share side + actions; null only for the pre-send staging preview. */
+    liveControls: LiveLocationBubbleControls? = null,
 ) {
     val uriHandler = LocalUriHandler.current
     val geoUri = remember(descriptor.lat, descriptor.lon, descriptor.address) {
@@ -242,7 +266,37 @@ fun LocationPreviewCard(
         formatLatLon(descriptor.lat, descriptor.lon)
     }
 
-    Column(modifier = modifier.fillMaxWidth().clickable { uriHandler.openUri(geoUri) }) {
+    // Derive STATIC / LIVE / ENDED from the descriptor's window vs now. While live, a coarse ticker
+    // (<=30s) refreshes the "time left" caption; the loop lands exactly on `until` to flip to ENDED.
+    val until = descriptor.liveShareUntilMs
+    var nowMs by remember(until) { mutableStateOf(Clock.System.now().toEpochMilliseconds()) }
+    LaunchedEffect(until) {
+        val u = until ?: return@LaunchedEffect
+        while (true) {
+            val now = Clock.System.now().toEpochMilliseconds()
+            nowMs = now
+            if (now >= u) break
+            delay(minOf(u - now, 30_000L) + 50)
+        }
+    }
+    val isLive = until != null && nowMs < until
+    val isEnded = until != null && nowMs >= until
+    val remainingMs = if (until != null) (until - nowMs).coerceAtLeast(0L) else 0L
+
+    val onCardTap = {
+        if (isLive && liveControls != null) liveControls.onOpenMap() else uriHandler.openUri(geoUri)
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .pointerInput(isLive, onLongPress) {
+                detectTapGestures(
+                    onTap = { onCardTap() },
+                    onLongPress = { onLongPress?.invoke() },
+                )
+            },
+    ) {
         if (descriptor.hasImage) {
             val imageData = remember(driveId, fileId, payloadKey) {
                 HomebaseImageData(
@@ -282,6 +336,15 @@ fun LocationPreviewCard(
             }
         }
 
+        if (liveControls != null) {
+            LiveShareActionArea(
+                controls = liveControls,
+                isLive = isLive,
+                isEnded = isEnded,
+                remainingMs = remainingMs,
+            )
+        }
+
         Column(modifier = Modifier.padding(12.dp)) {
             LocationPreviewTextContent(
                 address = descriptor.address,
@@ -289,6 +352,116 @@ fun LocationPreviewCard(
             )
         }
     }
+}
+
+/**
+ * The live-share action area shown directly below the map image. Sender (own message) sees a
+ * "Share live location" link with a duration menu, or "Stop sharing" while live. Receiver sees a
+ * read-only "sharing live / ended" caption. State (LIVE/ENDED) comes from the descriptor; this only
+ * renders affordances.
+ */
+@Composable
+private fun LiveShareActionArea(
+    controls: LiveLocationBubbleControls,
+    isLive: Boolean,
+    isEnded: Boolean,
+    remainingMs: Long,
+) {
+    Box(modifier = Modifier.padding(start = 12.dp, end = 12.dp, top = 8.dp)) {
+        when {
+            isLive -> {
+                // Both sides show the live caption + time left; only the sender gets the Stop link.
+                Column {
+                    if (controls.sentByYou) {
+                        Row(
+                            modifier = Modifier.clickable { controls.onStop() },
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.LocationOn,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.error,
+                                modifier = Modifier.size(18.dp),
+                            )
+                            Spacer(modifier = Modifier.size(6.dp))
+                            Text(
+                                text = stringResource(MR.string.stop_sharing),
+                                style = MaterialTheme.typography.labelLarge,
+                                color = MaterialTheme.colorScheme.error,
+                            )
+                        }
+                    }
+                    Text(
+                        text = stringResource(MR.string.live_share_active, formatRemaining(remainingMs)),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+
+            isEnded -> {
+                // Finished — no re-share option.
+                Text(
+                    text = stringResource(MR.string.live_share_ended),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            controls.sentByYou -> {
+                // STATIC, my own message: offer to share live.
+                var menuExpanded by remember { mutableStateOf(false) }
+                Column {
+                    Row(
+                        modifier = Modifier.clickable { menuExpanded = true },
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.Send,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Spacer(modifier = Modifier.size(6.dp))
+                        Text(
+                            text = stringResource(MR.string.share_live_location),
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                    DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
+                        DURATION_OPTIONS.forEach { (labelRes, durationMs) ->
+                            DropdownMenuItem(
+                                text = { Text(stringResource(labelRes)) },
+                                onClick = {
+                                    menuExpanded = false
+                                    controls.onStart(durationMs)
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+            // Receiver + STATIC: no action area.
+        }
+    }
+}
+
+private val DURATION_OPTIONS = listOf(
+    MR.string.live_share_15m to 15 * 60_000L,
+    MR.string.live_share_30m to 30 * 60_000L,
+    MR.string.live_share_1h to 60 * 60_000L,
+    MR.string.live_share_2h to 2 * 60 * 60_000L,
+    MR.string.live_share_4h to 4 * 60 * 60_000L,
+)
+
+/** Compact "time left" label: "42m", "1h", "1h 20m". */
+private fun formatRemaining(remainingMs: Long): String {
+    val totalMin = (remainingMs / 60_000L).coerceAtLeast(0L)
+    if (totalMin < 60) return "${totalMin}m"
+    val h = totalMin / 60
+    val m = totalMin % 60
+    return if (m == 0L) "${h}h" else "${h}h ${m}m"
 }
 
 // ─── Compact list row (the "See all" locations tab) ──────────────────────────

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
@@ -112,6 +112,8 @@ fun MediaItem(
     onClick: (() -> Unit)? = null,
     onLongPress: ((Offset) -> Unit)? = null,
     onRequestDecryptedFile: (() -> Unit)? = null,
+    liveControls: LiveLocationBubbleControls? = null,
+    locationHeaderDescriptor: LocationPreviewDescriptor? = null,
     shape: Shape =
         RoundedCornerShape(
             topStart = Dimens.Message.cornerRadius,
@@ -199,23 +201,26 @@ fun MediaItem(
         }
 
         payload.key == ChatProtocol.PAYLOAD_KEY_LOCATION -> {
-            val locationDescriptors = remember(payload.descriptorContent) {
+            // NEW messages carry the descriptor in the header (locationHeaderDescriptor); OLD ones
+            // parse it from the payload's descriptorContent. Header wins when present.
+            val payloadDescriptor = remember(payload.descriptorContent) {
                 payload.descriptorContent?.let { content ->
                     try {
                         OdinSystemSerializer.deserialize<List<LocationPreviewDescriptor>>(
                             content
-                        )
+                        ).firstOrNull()
                     } catch (_: Exception) {
                         null
                     }
                 }
             }
+            val descriptor = locationHeaderDescriptor ?: payloadDescriptor
 
             val payloadIv = payload.iv?.let { Base64.decode(it) }
 
-            if (payloadIv != null && locationDescriptors != null) {
+            if (payloadIv != null && descriptor != null) {
                 LocationPreviewCard(
-                    descriptor = locationDescriptors[0],
+                    descriptor = descriptor,
                     fileId = fileId,
                     driveId = driveId,
                     payloadKey = payload.key,
@@ -223,6 +228,10 @@ fun MediaItem(
                     previewThumbnail = payload.previewThumbnail?.toEmbeddedThumb()
                         ?: previewThumbnail,
                     modifier = baseModifier,
+                    onLongPress = onLongPress?.let { lp -> { lp(Offset.Zero) } },
+                    // Live-share only on new-format (header-descriptor) messages; an old payload-only
+                    // location can't be edited via updateMessage, so don't offer the toggle there.
+                    liveControls = liveControls.takeIf { locationHeaderDescriptor != null },
                 )
             } else {
                 MediaPlaceholder(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
@@ -32,6 +32,7 @@ import id.homebase.api.video.VideoProcessingPhase
 import id.homebase.chat.conversationlist.DecryptedFileKey
 import id.homebase.chat.conversationlist.UploadStatus
 import id.homebase.chat.services.ChatProtocol
+import id.homebase.chat.services.builder.LocationPreviewDescriptor
 import id.homebase.core.image.ImageSize
 import id.homebase.core.ui.theme.Dimens
 import id.homebase.resources.MR
@@ -76,6 +77,8 @@ fun MediaMessage(
     onMediaClick: ((PayloadDescriptor) -> Unit)? = null,
     onMediaLongPress: ((PayloadDescriptor, Offset) -> Unit)? = null,
     onRequestDecryptedFile: ((PayloadDescriptor) -> Unit)? = null,
+    liveControls: LiveLocationBubbleControls? = null,
+    locationHeaderDescriptor: LocationPreviewDescriptor? = null,
     shape: Shape = RoundedCornerShape(
         topStart = Dimens.Message.cornerRadius,
         topEnd = Dimens.Message.cornerRadius
@@ -144,6 +147,8 @@ fun MediaMessage(
                     isDownloading = downloadingFiles.contains("${messageId}_${payloads[0].key}"),
                     messageId = messageId,
                     isUploading = uploadStatus != null,
+                    liveControls = liveControls,
+                    locationHeaderDescriptor = locationHeaderDescriptor,
                 )
             }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -156,6 +156,7 @@ private val GroupMessageAvatarOptions = AvatarOptions(size = Dimens.Conversation
 @Composable
 fun SentMessageBubble(
     message: MessageUiModel,
+    liveControls: LiveLocationBubbleControls? = null,
     userDefaultReactions: ImmutableList<String>,
     decryptedFiles: ImmutableMap<DecryptedFileKey, String>,
     currentOdinId: String = "",
@@ -341,6 +342,7 @@ fun SentMessageBubble(
                             .onSizeChanged { bubbleWidthPx = it.width },
                         message = message,
                         decryptedFiles = decryptedFiles,
+                        liveControls = liveControls,
                         sentByYou = true,
                         currentOdinId = currentOdinId,
                         clusterPosition = clusterPosition,
@@ -452,6 +454,7 @@ fun SentMessageBubbleDisplayOnly(
 @Composable
 fun ReceivedMessageBubble(
     message: MessageUiModel,
+    liveControls: LiveLocationBubbleControls? = null,
     userDefaultReactions: ImmutableList<String>,
     decryptedFiles: ImmutableMap<DecryptedFileKey, String>,
     currentOdinId: String = "",
@@ -581,6 +584,7 @@ fun ReceivedMessageBubble(
                                 .onSizeChanged { bubbleWidthPx = it.width },
                             message = message,
                             decryptedFiles = decryptedFiles,
+                        liveControls = liveControls,
                             sentByYou = false,
                             currentOdinId = currentOdinId,
                             clusterPosition = clusterPosition,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -224,12 +224,11 @@ fun MessageBubbleRaw(
                     it.key == ChatProtocol.PAYLOAD_KEY_LOCATION
                 }
                 val pIv = mapPayload?.iv?.let { Base64.decode(it) }
-                val locContainerColor =
-                    if (sentByYou) HomebaseTheme.extendedColors.bubbleSentSurface
-                    else MaterialTheme.colorScheme.surfaceContainerHigh
-                val locContentColor =
-                    if (sentByYou) HomebaseTheme.extendedColors.bubbleSentOnSurface
-                    else MaterialTheme.colorScheme.onSurface
+                // Match the Event bubble: a neutral card (NOT a blue "sent" bubble) with grey fixed
+                // text + normal-color caption, the same for sender and receiver. Tinting the card blue
+                // for sentByYou put blue text on a blue background in dark theme.
+                val locContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+                val locContentColor = MaterialTheme.colorScheme.onSurface
                 LocationPreviewCard(
                     descriptor = d,
                     fileId = message.fileId,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -224,9 +224,12 @@ fun MessageBubbleRaw(
                     it.key == ChatProtocol.PAYLOAD_KEY_LOCATION
                 }
                 val pIv = mapPayload?.iv?.let { Base64.decode(it) }
-                val containerColor =
+                val locContainerColor =
                     if (sentByYou) HomebaseTheme.extendedColors.bubbleSentSurface
                     else MaterialTheme.colorScheme.surfaceContainerHigh
+                val locContentColor =
+                    if (sentByYou) HomebaseTheme.extendedColors.bubbleSentOnSurface
+                    else MaterialTheme.colorScheme.onSurface
                 LocationPreviewCard(
                     descriptor = d,
                     fileId = message.fileId,
@@ -237,9 +240,10 @@ fun MessageBubbleRaw(
                     modifier = modifier
                         .widthIn(min = 240.dp, max = 320.dp)
                         .clip(RoundedCornerShape(16.dp))
-                        .background(containerColor),
+                        .background(locContainerColor),
                     onLongPress = onLongClick,
                     liveControls = liveControls,
+                    contentColor = locContentColor,
                 )
             }
             return

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -127,6 +127,7 @@ fun MessageBubbleRaw(
     onMediaClick: (PayloadDescriptor) -> Unit,
     onClickMessageId: (Uuid) -> Unit,
     onRequestDecryptedFile: ((PayloadDescriptor) -> Unit)? = null,
+    liveControls: LiveLocationBubbleControls? = null,
     sharedTransitionScope: SharedTransitionScope?,
     animatedVisibilityScope: AnimatedVisibilityScope?,
     downloadingFiles: Set<String>,
@@ -210,8 +211,14 @@ fun MessageBubbleRaw(
             )
             return
         }
+        // Location renders via the media path (chat_loc payload + the header descriptor); fall through.
+        is MessageContent.Location -> Unit
         null -> Unit // fall through to text + media rendering
     }
+
+    // New location messages carry the descriptor in the header; pass it to the media path (MediaItem
+    // reads it for the chat_loc bubble, falling back to the payload descriptor for old messages).
+    val locationDescriptor = (message.messageContent as? MessageContent.Location)?.descriptor
 
     val filteredPayloads = message.payloads?.filter {
         it.key != ChatProtocol.DefaultPayloadKey &&
@@ -424,6 +431,8 @@ fun MessageBubbleRaw(
                         previewThumbnail = message.previewThumbnail,
                         onMediaClick = onMediaClick,
                         onMediaLongPress = { _, _ -> handleLongClick() },
+                        liveControls = liveControls,
+                        locationHeaderDescriptor = locationDescriptor,
                         onRequestDecryptedFile = onRequestDecryptedFile,
                         shape = RoundedCornerShape(Dimens.Message.cornerRadius),
                         sharedTransitionScope = sharedTransitionScope,
@@ -462,6 +471,8 @@ fun MessageBubbleRaw(
                                 previewThumbnail = message.previewThumbnail,
                                 onMediaClick = onMediaClick,
                                 onMediaLongPress = { _, _ -> handleLongClick() },
+                        liveControls = liveControls,
+                        locationHeaderDescriptor = locationDescriptor,
                                 onRequestDecryptedFile = onRequestDecryptedFile,
                                 shape = RoundedCornerShape(0.dp),
                                 sharedTransitionScope = sharedTransitionScope,
@@ -545,6 +556,8 @@ fun MessageBubbleRaw(
                                 topEnd = Dimens.Message.cornerRadius
                             ) else RoundedCornerShape(0.dp),
                             onMediaLongPress = { _, _ -> handleLongClick() },
+                        liveControls = liveControls,
+                        locationHeaderDescriptor = locationDescriptor,
                             onRequestDecryptedFile = onRequestDecryptedFile,
                             sharedTransitionScope = sharedTransitionScope,
                             animatedVisibilityScope = animatedVisibilityScope,
@@ -651,6 +664,8 @@ fun MessageBubbleRaw(
                                         topEnd = Dimens.Message.cornerRadius
                                     ) else RoundedCornerShape(0.dp),
                                     onMediaLongPress = { _, _ -> handleLongClick() },
+                        liveControls = liveControls,
+                        locationHeaderDescriptor = locationDescriptor,
                                     onRequestDecryptedFile = onRequestDecryptedFile,
                                     sharedTransitionScope = sharedTransitionScope,
                                     animatedVisibilityScope = animatedVisibilityScope,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -51,6 +52,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.drives.files.DescriptorContent
 import id.homebase.api.client.drives.files.PayloadDescriptor
 import id.homebase.api.util.markdownHasBlockElements
@@ -80,6 +82,7 @@ import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
+import kotlin.io.encoding.Base64
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
 
@@ -211,13 +214,40 @@ fun MessageBubbleRaw(
             )
             return
         }
-        // Location renders via the media path (chat_loc payload + the header descriptor); fall through.
-        is MessageContent.Location -> Unit
+        // Location renders as a self-contained typed bubble (like Event) so the generic text line —
+        // which would duplicate the address (MessageMapper sets it to displayLabel) — is skipped, and
+        // the bubble is Event-sized. Old payload-format messages (messageContent == null) fall through
+        // to the media path instead.
+        is MessageContent.Location -> {
+            content.descriptor?.let { d ->
+                val mapPayload = message.payloads?.firstOrNull {
+                    it.key == ChatProtocol.PAYLOAD_KEY_LOCATION
+                }
+                val pIv = mapPayload?.iv?.let { Base64.decode(it) }
+                val containerColor =
+                    if (sentByYou) HomebaseTheme.extendedColors.bubbleSentSurface
+                    else MaterialTheme.colorScheme.surfaceContainerHigh
+                LocationPreviewCard(
+                    descriptor = d,
+                    fileId = message.fileId,
+                    driveId = chatTargetDrive.alias,
+                    payloadKey = ChatProtocol.PAYLOAD_KEY_LOCATION,
+                    keyHeader = KeyHeader(pIv ?: ByteArray(16), message.keyHeader.aesKey),
+                    previewThumbnail = mapPayload?.previewThumbnail?.toEmbeddedThumb(),
+                    modifier = modifier
+                        .widthIn(min = 240.dp, max = 320.dp)
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(containerColor),
+                    onLongPress = onLongClick,
+                    liveControls = liveControls,
+                )
+            }
+            return
+        }
         null -> Unit // fall through to text + media rendering
     }
 
-    // New location messages carry the descriptor in the header; pass it to the media path (MediaItem
-    // reads it for the chat_loc bubble, falling back to the payload descriptor for old messages).
+    // Old payload-format location messages (no header descriptor) still render via the media path.
     val locationDescriptor = (message.messageContent as? MessageContent.Location)?.descriptor
 
     val filteredPayloads = message.payloads?.filter {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageContentLabel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageContentLabel.kt
@@ -54,6 +54,7 @@ fun typedMessageContentLabel(messageContent: MessageContent?): ContentLabel? = w
     is MessageContent.Event -> ContentLabel(messageContent.displayLabel, Icons.Default.Event)
     is MessageContent.DiceRoll -> ContentLabel(messageContent.displayLabel, Icons.Default.Casino)
     is MessageContent.Groodle -> ContentLabel(messageContent.displayLabel, Icons.Default.CalendarMonth)
+    is MessageContent.Location -> ContentLabel(messageContent.displayLabel, Icons.Default.LocationOn)
     is MessageContent.Unknown -> ContentLabel(messageContent.displayLabel, Icons.AutoMirrored.Outlined.HelpOutline)
     null -> null
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageItem.kt
@@ -57,6 +57,20 @@ fun MessageItem(
     // disables edit/reply/forward/share/inline-reactions/reactor-details.
     val policy = message.messageContent?.actions ?: ActionPolicy.Standard
 
+    // Live-location controls for the location bubble (ignored by non-location media). State (LIVE/
+    // ENDED) is read from the message descriptor in the bubble; this only carries side + actions.
+    val sentByYou = message.isAuthoredBy(odinId)
+    val liveLocationControls = remember(message.id, sentByYou) {
+        LiveLocationBubbleControls(
+            sentByYou = sentByYou,
+            onStart = { durationMs ->
+                onUiAction(ConversationListUiAction.StartLiveLocationShare(message.id, durationMs))
+            },
+            onStop = { onUiAction(ConversationListUiAction.StopLiveLocationShare(message.id)) },
+            onOpenMap = { onUiAction(ConversationListUiAction.OpenLiveLocationMap) },
+        )
+    }
+
     // Memoize all callbacks with message.id as key. Disabled actions get
     // null callbacks; the bubble subcomposables already gate on non-null.
     val onMessageInfo =
@@ -144,6 +158,7 @@ fun MessageItem(
         ) {
             SentMessageBubble(
                 message = message,
+                liveControls = liveLocationControls,
                 userDefaultReactions = userDefaultReactions,
                 decryptedFiles = decryptedFiles,
                 currentOdinId = currentOdinId,
@@ -198,6 +213,7 @@ fun MessageItem(
         ) {
             ReceivedMessageBubble(
                 message = message,
+                liveControls = liveLocationControls,
                 userDefaultReactions = userDefaultReactions,
                 decryptedFiles = decryptedFiles,
                 currentOdinId = currentOdinId,

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1301,6 +1301,13 @@
     <string name="location_consent_decline">No thanks</string>
     <string name="location_history_title">History</string>
     <string name="location_history_you">(you)</string>
+    <string name="live_location_title">Live location</string>
+    <string name="live_location_empty">No one is sharing their live location right now.</string>
+    <string name="live_location_marker_cd">%1$s's live location</string>
+    <string name="live_location_you">You</string>
+    <string name="live_location_age_minutes">%1$dm</string>
+    <string name="location_dashboard_live_section">Live location sharing</string>
+    <string name="location_dashboard_live_open">Open live map</string>
     <string name="location_history_empty">No locations recorded on this day</string>
     <string name="location_history_map_disclosure">Map tiles are fetched from OpenStreetMap — the viewed area becomes visible to their servers.</string>
     <string name="location_history_previous_day">Previous day</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1309,6 +1309,15 @@
     <string name="location_dashboard_live_section">Live location sharing</string>
     <string name="location_dashboard_live_open">Open live map</string>
     <string name="location_dashboard_live_empty">There's no live location data at the moment.</string>
+    <string name="share_live_location">Share live location</string>
+    <string name="stop_sharing">Stop sharing</string>
+    <string name="live_share_active">Live location · %1$s left</string>
+    <string name="live_share_ended">Live share ended</string>
+    <string name="live_share_15m">15 minutes</string>
+    <string name="live_share_30m">30 minutes</string>
+    <string name="live_share_1h">1 hour</string>
+    <string name="live_share_2h">2 hours</string>
+    <string name="live_share_4h">4 hours</string>
     <string name="location_history_empty">No locations recorded on this day</string>
     <string name="location_history_map_disclosure">Map tiles are fetched from OpenStreetMap — the viewed area becomes visible to their servers.</string>
     <string name="location_history_previous_day">Previous day</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1308,6 +1308,7 @@
     <string name="live_location_age_minutes">%1$dm</string>
     <string name="location_dashboard_live_section">Live location sharing</string>
     <string name="location_dashboard_live_open">Open live map</string>
+    <string name="location_dashboard_live_empty">There's no live location data at the moment.</string>
     <string name="location_history_empty">No locations recorded on this day</string>
     <string name="location_history_map_disclosure">Map tiles are fetched from OpenStreetMap — the viewed area becomes visible to their servers.</string>
     <string name="location_history_previous_day">Previous day</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
@@ -196,6 +196,10 @@ sealed class Route {
     data object LocationHistory : Route()
 
     @Serializable
+    @SerialName("location-live")
+    data object LocationLive : Route()
+
+    @Serializable
     @SerialName("location-find-device")
     data class LocationFindDevice(val deviceId: String? = null) : Route()
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -683,6 +683,7 @@ val appModule = module {
             stickerStream = get(),
             stickerService = get(),
             stickerPermissionViewModel = get(StickerPermissionQualifier),
+            liveLocationShareService = get(),
         )
     }
     viewModelOf(::ArchivedConversationsViewModel)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -158,6 +158,7 @@ import id.homebase.core.ui.screens.location.LocationViewModel
 import id.homebase.core.ui.screens.location.devices.FindDeviceViewModel
 import id.homebase.core.ui.screens.location.devices.LocationDeviceDirectory
 import id.homebase.core.ui.screens.location.history.LocationHistoryViewModel
+import id.homebase.core.ui.screens.location.livelocation.LiveLocationViewModel
 
 val VaultPermissionQualifier = named("vaultPermission")
 
@@ -729,9 +730,12 @@ val appModule = module {
             contactService = get(),
             credentialsManager = get(),
             tracker = get(),
+            receiveStore = get(),
+            liveShareService = get(),
         )
     }
     viewModelOf(::LocationHistoryViewModel)
+    viewModelOf(::LiveLocationViewModel)
     viewModelOf(::ContactBookViewModel)
     viewModelOf(::ContactDetailViewModel)
     viewModelOf(::ContactBookSettingsViewModel)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -735,7 +735,17 @@ val appModule = module {
         )
     }
     viewModelOf(::LocationHistoryViewModel)
-    viewModelOf(::LiveLocationViewModel)
+    // Manual block (not viewModelOf): the constructor has a `nowMs: () -> Long` param with a default;
+    // viewModelOf would try to autowire that Function0 from Koin and fail at creation time.
+    viewModel {
+        LiveLocationViewModel(
+            receiveStore = get(),
+            contactService = get(),
+            locationPreferences = get(),
+            pointStore = get(),
+            credentialsManager = get(),
+        )
+    }
     viewModelOf(::ContactBookViewModel)
     viewModelOf(::ContactDetailViewModel)
     viewModelOf(::ContactBookSettingsViewModel)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -113,6 +113,7 @@ import id.homebase.core.ui.screens.location.LocationUiEvent
 import id.homebase.core.ui.screens.location.LocationViewModel
 import id.homebase.core.ui.screens.location.devices.FindDeviceScreen
 import id.homebase.core.ui.screens.location.history.LocationHistoryScreen
+import id.homebase.core.ui.screens.location.livelocation.LiveLocationScreen
 import id.homebase.core.ui.screens.location.onboarding.LocationOnboardingScreen
 import id.homebase.core.ui.screens.notifications.NotificationSettingsScreen
 import id.homebase.core.ui.screens.settings.SettingsScreen
@@ -1277,6 +1278,9 @@ fun AppNavHost(
                                             Route.LocationFindDevice(deviceId?.toString())
                                         )
                                     },
+                                    onNavigateToLiveMap = {
+                                        navController.navigate(Route.LocationLive)
+                                    },
                                 )
                             }
                         }
@@ -1284,6 +1288,15 @@ fun AppNavHost(
                         composable<Route.LocationHistory> {
                             if (isAuthenticated) {
                                 LocationHistoryScreen(
+                                    viewModel = koinViewModel(),
+                                    onNavigateBack = { navController.popBackStack() },
+                                )
+                            }
+                        }
+
+                        composable<Route.LocationLive> {
+                            if (isAuthenticated) {
+                                LiveLocationScreen(
                                     viewModel = koinViewModel(),
                                     onNavigateBack = { navController.popBackStack() },
                                 )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -882,6 +882,9 @@ fun AppNavHost(
                                     onNavigateToNewConversation = {
                                         navController.navigate(Route.CreateConversation)
                                     },
+                                    onNavigateToLiveLocationMap = {
+                                        navController.navigate(Route.LocationLive)
+                                    },
                                     onNavigateToContactInfo = {
                                         navController.navigate(Route.ContactInfo(it))
                                     },

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.outlined.Computer
 import androidx.compose.material.icons.outlined.Language
 import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material.icons.outlined.LocationSearching
 import androidx.compose.material.icons.outlined.Smartphone
 import androidx.compose.material.icons.outlined.WarningAmber
 import androidx.compose.material3.Card
@@ -53,6 +54,7 @@ import id.homebase.core.widget.AvatarImage
 import id.homebase.resources.MR
 import id.homebase.resources.location_dashboard_empty_today
 import id.homebase.resources.location_dashboard_history_section
+import id.homebase.resources.location_dashboard_live_empty
 import id.homebase.resources.location_dashboard_live_open
 import id.homebase.resources.location_dashboard_live_section
 import id.homebase.resources.location_dashboard_perm_banner
@@ -127,12 +129,12 @@ fun LocationDashboardContent(
             }
         }
 
-        // ── Live location sharing (visible when sharing or a recent inbound point exists) → live map ──
+        // ── Live location sharing (title always shown; card opens the map or shows an empty state) ──
+        Text(
+            text = stringResource(MR.string.location_dashboard_live_section),
+            style = MaterialTheme.typography.titleMedium,
+        )
         if (uiState.liveSharingVisible) {
-            Text(
-                text = stringResource(MR.string.location_dashboard_live_section),
-                style = MaterialTheme.typography.titleMedium,
-            )
             Card(
                 modifier = Modifier.fillMaxWidth().clickable(onClick = onOpenLiveMap),
             ) {
@@ -155,6 +157,25 @@ fun LocationDashboardContent(
                         imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                         contentDescription = null,
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        } else {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Row(
+                    modifier = Modifier.padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.LocationSearching,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = stringResource(MR.string.location_dashboard_live_empty),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
             }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
@@ -19,11 +19,13 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.outlined.Computer
 import androidx.compose.material.icons.outlined.Language
+import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material.icons.outlined.Smartphone
 import androidx.compose.material.icons.outlined.WarningAmber
 import androidx.compose.material3.Card
@@ -51,6 +53,8 @@ import id.homebase.core.widget.AvatarImage
 import id.homebase.resources.MR
 import id.homebase.resources.location_dashboard_empty_today
 import id.homebase.resources.location_dashboard_history_section
+import id.homebase.resources.location_dashboard_live_open
+import id.homebase.resources.location_dashboard_live_section
 import id.homebase.resources.location_dashboard_perm_banner
 import id.homebase.resources.location_device_no_fix
 import id.homebase.resources.location_device_this_device
@@ -80,6 +84,7 @@ fun LocationDashboardContent(
     innerPadding: PaddingValues,
     fetchTile: suspend (zoom: Int, x: Int, y: Int) -> ByteArray?,
     onOpenHistory: () -> Unit,
+    onOpenLiveMap: () -> Unit,
     onOpenDevice: (Uuid) -> Unit,
     onOpenSetup: () -> Unit,
     onManageEmergencyAccess: () -> Unit,
@@ -117,6 +122,39 @@ fun LocationDashboardContent(
                         text = stringResource(MR.string.location_dashboard_perm_banner),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onErrorContainer,
+                    )
+                }
+            }
+        }
+
+        // ── Live location sharing (visible when sharing or a recent inbound point exists) → live map ──
+        if (uiState.liveSharingVisible) {
+            Text(
+                text = stringResource(MR.string.location_dashboard_live_section),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Card(
+                modifier = Modifier.fillMaxWidth().clickable(onClick = onOpenLiveMap),
+            ) {
+                Row(
+                    modifier = Modifier.padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.LocationOn,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                    Text(
+                        text = stringResource(MR.string.location_dashboard_live_open),
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
             }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
@@ -50,6 +50,7 @@ fun LocationScreen(
     viewModel: LocationViewModel,
     onNavigateToHistory: () -> Unit,
     onNavigateToFindDevice: (Uuid?) -> Unit,
+    onNavigateToLiveMap: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -231,6 +232,7 @@ fun LocationScreen(
                 innerPadding = innerPadding,
                 fetchTile = { z, x, y -> previewProvider.getTilePng(z, x, y) },
                 onOpenHistory = onNavigateToHistory,
+                onOpenLiveMap = onNavigateToLiveMap,
                 onOpenDevice = { onNavigateToFindDevice(it) },
                 onOpenSetup = { dashboardOverride = false },
                 onManageEmergencyAccess = {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
@@ -36,6 +36,8 @@ data class LocationUiState(
     /** Owner-console deep link to manage the circle's members; null until the identity is known. */
     val emergencyManageUrl: String? = null,
     val mapProvider: LocationMapProvider = LocationMapProvider.DEFAULT,
+    /** Show the "Live location sharing" dashboard section: I'm sharing, or a recent inbound point exists. */
+    val liveSharingVisible: Boolean = false,
 ) {
     /** Only OSM tiles are implemented today; the canvas takes a boolean. */
     val showMapTiles: Boolean get() = mapProvider == LocationMapProvider.OpenStreetMap

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
@@ -7,6 +7,7 @@ import id.homebase.api.client.connections.ConnectionNetworkProvider
 import id.homebase.chat.conversationlist.ExtendPermissionUiState
 import id.homebase.chat.conversationlist.ExtendPermissionViewModel
 import id.homebase.chat.services.convo.contact.ContactService
+import id.homebase.chat.services.livelocation.LiveLocationShareService
 import id.homebase.core.config.locationLabeledDrive
 import id.homebase.core.location.LocationPreferences
 import id.homebase.core.location.tracking.LocationPointStore
@@ -16,6 +17,9 @@ import id.homebase.core.sync.OptionalDriveActivation
 import id.homebase.core.ui.screens.location.devices.LocationDeviceDirectory
 import id.homebase.core.ui.screens.location.history.localDayStart
 import id.homebase.core.ui.screens.location.history.shiftDay
+import id.homebase.core.ui.screens.location.livelocation.LIVE_STALE_MS
+import id.homebase.core.ui.screens.location.livelocation.LiveLocationReceiveStore
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -23,7 +27,9 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -47,6 +53,8 @@ class LocationViewModel(
     private val connectionNetworkProvider: ConnectionNetworkProvider,
     private val contactService: ContactService,
     private val credentialsManager: CredentialsManager,
+    private val receiveStore: LiveLocationReceiveStore,
+    private val liveShareService: LiveLocationShareService,
     tracker: LocationTracker,
 ) : ViewModel() {
 
@@ -163,6 +171,25 @@ class LocationViewModel(
             uploaderService.pendingCount.collect { n ->
                 _uiState.update { it.copy(pendingUploadCount = n.toInt()) }
             }
+        }
+        // "Live location sharing" dashboard section is visible when I'm sharing OR someone's recent
+        // position is in the receive store. isActive() is a plain getter (no flow), so the 30 s ticker
+        // re-evaluates it; the receive store flow covers inbound updates.
+        viewModelScope.launch {
+            combine(receiveStore.positions, liveTicker()) { positions, _ ->
+                val now = Clock.System.now().toEpochMilliseconds()
+                liveShareService.isActive() ||
+                    positions.values.any { now - it.receivedAtMs <= LIVE_STALE_MS }
+            }.collect { visible ->
+                _uiState.update { it.copy(liveSharingVisible = visible) }
+            }
+        }
+    }
+
+    private fun liveTicker() = flow {
+        while (true) {
+            emit(Unit)
+            delay(30_000L)
         }
     }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationTraceCanvas.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationTraceCanvas.kt
@@ -1,37 +1,20 @@
 package id.homebase.core.ui.screens.location.history
 
-import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.gestures.detectTransformGestures
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateMapOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import id.homebase.api.client.location.WebMercator
-import kotlinx.coroutines.launch
-import org.jetbrains.compose.resources.decodeToImageBitmap
-import kotlin.math.ceil
-import kotlin.math.floor
-import kotlin.math.ln
+import id.homebase.core.ui.screens.location.map.TiledMapView
 import kotlin.math.max
 import kotlin.math.min
-import kotlin.math.roundToInt
 
 /**
  * Trace colors for drawing on the map. Deliberately NOT theme colors: the OSM
@@ -47,13 +30,11 @@ val mapTraceColors = listOf(
 )
 
 /**
- * Viewport over Web-Mercator unit space (0..1 world): a center point plus the
- * unit-width of one screen pixel. Pure data so gestures and tile math share it.
+ * History/Find-Device map: GPS traces (and optional playback + dwell dots) drawn over an OSM basemap.
+ * A thin wrapper over the shared [TiledMapView] — this composable owns only the History-specific
+ * overlay (trace polylines, playhead, dwell dots); all viewport/zoom/tile behaviour lives in
+ * [TiledMapView]/[id.homebase.core.ui.screens.location.map].
  */
-private data class Viewport(val centerX: Double, val centerY: Double, val unitsPerPx: Double)
-
-private data class TileKey(val zoom: Int, val x: Int, val y: Int)
-
 @Composable
 fun LocationTraceCanvas(
     traces: List<DeviceTrace>,
@@ -74,10 +55,6 @@ fun LocationTraceCanvas(
     /** Places the user lingered; drawn as dots sized by dwell length (see [dwellRadiusDp]). */
     dwellStops: List<DwellStop> = emptyList(),
 ) {
-    var canvasSize by remember { mutableStateOf(IntSize.Zero) }
-    // User pan/zoom override; null = fit the day's bbox. Reset when the day's data changes.
-    var userViewport by remember(traces) { mutableStateOf<Viewport?>(null) }
-
     // Project once per data change: trace -> segments -> unit-space points.
     val unitTraces = remember(traces) {
         traces.map { trace ->
@@ -103,75 +80,46 @@ fun LocationTraceCanvas(
         if (minX > maxX) null else doubleArrayOf(minX, minY, maxX, maxY)
     }
 
-    val viewport = userViewport ?: fitViewport(bbox, canvasSize)
-
-    // ── Tile layer state ──
-    val tileBitmaps = remember { mutableStateMapOf<TileKey, ImageBitmap>() }
-    val visibleTiles = if (showMapTiles && viewport != null && canvasSize != IntSize.Zero) {
-        visibleTileKeys(viewport, canvasSize)
-    } else emptyList()
-    LaunchedEffect(visibleTiles, showMapTiles) {
-        if (!showMapTiles) return@LaunchedEffect
-        // Concurrent fetches: the provider single-flights and runs downloads on
-        // its own scope, so restarts of this effect (pan/zoom) neither cancel
-        // nor duplicate them. Failures are simply retried on the next restart.
-        for (key in visibleTiles) {
-            if (tileBitmaps.containsKey(key)) continue
-            launch {
-                val bytes = fetchTile(key.zoom, key.x, key.y)
-                val bitmap = bytes?.let { runCatching { it.decodeToImageBitmap() }.getOrNull() }
-                if (bitmap != null) tileBitmaps[key] = bitmap
-            }
-        }
-    }
-
-    val gestureModifier = if (!interactive) Modifier else {
-        Modifier.pointerInput(traces) {
-            detectTransformGestures { centroid, pan, zoom, _ ->
-                val current = userViewport ?: fitViewport(bbox, canvasSize) ?: return@detectTransformGestures
-                val newUnitsPerPx = (current.unitsPerPx / zoom)
-                    .coerceIn(MIN_UNITS_PER_PX, MAX_UNITS_PER_PX)
-                // Keep the gesture centroid anchored while zooming, then pan.
-                val cx = centroid.x - size.width / 2f
-                val cy = centroid.y - size.height / 2f
-                val anchoredX = current.centerX + cx * (current.unitsPerPx - newUnitsPerPx)
-                val anchoredY = current.centerY + cy * (current.unitsPerPx - newUnitsPerPx)
-                userViewport = Viewport(
-                    centerX = anchoredX - pan.x * newUnitsPerPx,
-                    centerY = anchoredY - pan.y * newUnitsPerPx,
-                    unitsPerPx = newUnitsPerPx,
-                )
-            }
-        }
-    }
-
-    Canvas(
-        modifier = modifier
-            .fillMaxSize()
-            .onSizeChanged { canvasSize = it }
-            .then(gestureModifier),
-    ) {
-        val vp = viewport ?: return@Canvas
-        fun toPx(unit: Pair<Double, Double>): Offset = Offset(
-            x = ((unit.first - vp.centerX) / vp.unitsPerPx + size.width / 2.0).toFloat(),
-            y = ((unit.second - vp.centerY) / vp.unitsPerPx + size.height / 2.0).toFloat(),
-        )
-
-        // ── Basemap tiles (under the traces) ──
-        for (key in visibleTiles) {
-            val bitmap = tileBitmaps[key] ?: continue
-            val b = WebMercator.tileToUnitBounds(key.x, key.y, key.zoom)
-            val topLeft = toPx(b[0] to b[1])
-            val bottomRight = toPx(b[2] to b[3])
-            drawImage(
-                image = bitmap,
-                dstOffset = IntOffset(topLeft.x.roundToInt(), topLeft.y.roundToInt()),
-                dstSize = IntSize(
-                    width = (bottomRight.x - topLeft.x).roundToInt().coerceAtLeast(1),
-                    height = (bottomRight.y - topLeft.y).roundToInt().coerceAtLeast(1),
-                ),
+    TiledMapView(
+        bbox = bbox,
+        showMapTiles = showMapTiles,
+        fetchTile = fetchTile,
+        modifier = modifier,
+        interactive = interactive,
+        resetViewportOn = traces,
+        onDrawOverlay = { project ->
+            drawTraceOverlay(
+                project = project,
+                traces = traces,
+                unitTraces = unitTraces,
+                unitStops = unitStops,
+                dwellStops = dwellStops,
+                traceColors = traceColors,
+                showMapTiles = showMapTiles,
+                highlightLast = highlightLast,
+                playbackClockMs = playbackClockMs,
             )
-        }
+        },
+    )
+}
+
+/**
+ * The History-specific overlay: trace polylines (with optional playback clipping + playhead), start/
+ * end markers, and dwell dots. Pulled out of [LocationTraceCanvas] as a [DrawScope] extension so the
+ * `onDrawOverlay` slot stays a thin call.
+ */
+private fun DrawScope.drawTraceOverlay(
+    project: (Double, Double) -> Offset,
+    traces: List<DeviceTrace>,
+    unitTraces: List<List<List<Pair<Double, Double>>>>,
+    unitStops: List<Pair<Double, Double>>,
+    dwellStops: List<DwellStop>,
+    traceColors: List<Color>,
+    showMapTiles: Boolean,
+    highlightLast: Boolean,
+    playbackClockMs: Long?,
+) {
+    fun toPx(unit: Pair<Double, Double>): Offset = project(unit.first, unit.second)
 
         // ── Traces ──
         val strokeWidth = 3.dp.toPx()
@@ -278,62 +226,4 @@ fun LocationTraceCanvas(
             drawCircle(Color.White, dotRadius * 1.5f, center)
             drawCircle(color, dotRadius * 1.1f, center)
         }
-    }
 }
-
-private fun fitViewport(bbox: DoubleArray?, canvasSize: IntSize): Viewport? {
-    if (bbox == null || canvasSize.width == 0 || canvasSize.height == 0) return null
-    val minX = bbox[0]; val minY = bbox[1]; val maxX = bbox[2]; val maxY = bbox[3]
-    val spanX = max(maxX - minX, MIN_FIT_SPAN_UNITS)
-    val spanY = max(maxY - minY, MIN_FIT_SPAN_UNITS)
-    val unitsPerPx = max(
-        spanX * FIT_PADDING / canvasSize.width,
-        spanY * FIT_PADDING / canvasSize.height,
-    ).coerceIn(MIN_UNITS_PER_PX, MAX_UNITS_PER_PX)
-    return Viewport(
-        centerX = (minX + maxX) / 2,
-        centerY = (minY + maxY) / 2,
-        unitsPerPx = unitsPerPx,
-    )
-}
-
-private fun visibleTileKeys(vp: Viewport, canvasSize: IntSize): List<TileKey> {
-    // Start at the zoom where one tile (256px-native) renders ~1:1, then step
-    // DOWN until the full visible grid fits the tile budget — a portrait phone
-    // at 1:1 needs ~30-40 tiles, so coverage beats crispness: coarser tiles are
-    // upscaled but the whole view gets a basemap (truncating the grid instead
-    // left the bottom of the screen bare).
-    val idealZoom = (-ln(vp.unitsPerPx * WebMercator.TILE_SIZE_PX) / ln(2.0))
-        .roundToInt().coerceIn(MIN_TILE_ZOOM, MAX_TILE_ZOOM)
-    val halfW = canvasSize.width / 2.0 * vp.unitsPerPx
-    val halfH = canvasSize.height / 2.0 * vp.unitsPerPx
-    for (zoom in idealZoom downTo MIN_TILE_ZOOM) {
-        val n = 1 shl zoom
-        val x0 = floor((vp.centerX - halfW) * n).toInt().coerceIn(0, n - 1)
-        val x1 = ceil((vp.centerX + halfW) * n).toInt().coerceIn(0, n - 1)
-        val y0 = floor((vp.centerY - halfH) * n).toInt().coerceIn(0, n - 1)
-        val y1 = ceil((vp.centerY + halfH) * n).toInt().coerceIn(0, n - 1)
-        val count = (x1 - x0 + 1) * (y1 - y0 + 1)
-        if (count > MAX_TILES_PER_VIEW && zoom > MIN_TILE_ZOOM) continue
-        return buildList {
-            for (y in y0..y1) {
-                for (x in x0..x1) {
-                    add(TileKey(zoom, x, y))
-                    if (size >= MAX_TILES_PER_VIEW) return@buildList
-                }
-            }
-        }
-    }
-    return emptyList()
-}
-
-private const val FIT_PADDING = 1.2
-private const val MIN_FIT_SPAN_UNITS = 1e-5 // ~ city block; avoids infinite zoom on 1 point
-private const val MIN_UNITS_PER_PX = 1e-9
-private const val MAX_UNITS_PER_PX = 1.0 / 256.0
-private const val MIN_TILE_ZOOM = 3
-private const val MAX_TILE_ZOOM = 19
-
-// Budget per view. 24 fits a portrait phone one zoom step below 1:1 (×2
-// upscale worst case) while keeping per-view OSM traffic modest.
-private const val MAX_TILES_PER_VIEW = 24

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationMap.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationMap.kt
@@ -10,9 +10,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.geometry.Offset
 import id.homebase.api.client.location.WebMercator
 import id.homebase.core.ui.screens.location.map.TiledMapView
+import kotlin.math.cos
+import kotlin.math.PI
 import kotlin.math.roundToInt
+import kotlin.math.sin
 
 /**
  * The live-location map: a zoomable OSM basemap ([TiledMapView]) with one avatar dot per [LiveMarker].
@@ -64,7 +68,11 @@ fun LiveLocationMap(
                                 .offset {
                                     val o = project(unit.first, unit.second)
                                     val half = (LiveMarkerSize / 2).toPx()
-                                    IntOffset((o.x - half).roundToInt(), (o.y - half).roundToInt())
+                                    val fan = fanOffset(marker.clusterIndex, marker.clusterSize, half)
+                                    IntOffset(
+                                        (o.x - half + fan.x).roundToInt(),
+                                        (o.y - half + fan.y).roundToInt(),
+                                    )
                                 }
                                 .clearAndSetSemantics { contentDescription = cd },
                         ) {
@@ -75,4 +83,16 @@ fun LiveLocationMap(
             }
         },
     )
+}
+
+/**
+ * Spread for co-located markers: places slot [index] of a group of [size] evenly around a circle of
+ * radius ~[markerHalfPx], so overlapping dots fan out and stay individually visible. No spread for a
+ * lone marker.
+ */
+private fun fanOffset(index: Int, size: Int, markerHalfPx: Float): Offset {
+    if (size <= 1) return Offset.Zero
+    val angle = 2.0 * PI * index / size
+    val radius = markerHalfPx * 1.1f
+    return Offset(radius * cos(angle).toFloat(), radius * sin(angle).toFloat())
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationMap.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationMap.kt
@@ -1,0 +1,78 @@
+package id.homebase.core.ui.screens.location.livelocation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.unit.IntOffset
+import id.homebase.api.client.location.WebMercator
+import id.homebase.core.ui.screens.location.map.TiledMapView
+import kotlin.math.roundToInt
+
+/**
+ * The live-location map: a zoomable OSM basemap ([TiledMapView]) with one avatar dot per [LiveMarker].
+ * Markers are composables positioned with `Modifier.offset` reading the live viewport projection, so a
+ * pan/zoom frame re-runs only placement math — no recomposition, no avatar reload. `key(marker.key)`
+ * keeps each avatar instance stable as positions update.
+ */
+@Composable
+fun LiveLocationMap(
+    markers: List<LiveMarker>,
+    showMapTiles: Boolean,
+    fetchTile: suspend (zoom: Int, x: Int, y: Int) -> ByteArray?,
+    modifier: Modifier = Modifier,
+) {
+    // Precompute unit-space coords once per emission (cheap; N is small).
+    val unitByKey = remember(markers) {
+        markers.associate { it.key to WebMercator.latLonToUnit(it.lat, it.lon) }
+    }
+    val bbox = remember(unitByKey) {
+        if (unitByKey.isEmpty()) {
+            null
+        } else {
+            var minX = Double.MAX_VALUE; var minY = Double.MAX_VALUE
+            var maxX = -Double.MAX_VALUE; var maxY = -Double.MAX_VALUE
+            unitByKey.values.forEach { (x, y) ->
+                if (x < minX) minX = x; if (x > maxX) maxX = x
+                if (y < minY) minY = y; if (y > maxY) maxY = y
+            }
+            doubleArrayOf(minX, minY, maxX, maxY)
+        }
+    }
+
+    TiledMapView(
+        bbox = bbox,
+        showMapTiles = showMapTiles,
+        fetchTile = fetchTile,
+        modifier = modifier,
+        interactive = true,
+        resetViewportOn = Unit, // preserve pan/zoom across store updates
+        markerContent = { project, ready ->
+            if (ready) {
+                markers.forEach { marker ->
+                    val unit = unitByKey[marker.key] ?: return@forEach
+                    val cd = liveMarkerContentDescription(marker)
+                    key(marker.key) {
+                        Box(
+                            modifier = Modifier
+                                .wrapContentSize()
+                                .offset {
+                                    val o = project(unit.first, unit.second)
+                                    val half = (LiveMarkerSize / 2).toPx()
+                                    IntOffset((o.x - half).roundToInt(), (o.y - half).roundToInt())
+                                }
+                                .clearAndSetSemantics { contentDescription = cd },
+                        ) {
+                            LiveLocationMarker(marker)
+                        }
+                    }
+                }
+            }
+        },
+    )
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationMarker.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationMarker.kt
@@ -1,0 +1,65 @@
+package id.homebase.core.ui.screens.location.livelocation
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import id.homebase.core.widget.AvatarImage
+import id.homebase.resources.MR
+import id.homebase.resources.live_location_age_minutes
+import id.homebase.resources.live_location_marker_cd
+import id.homebase.resources.live_location_you
+import org.jetbrains.compose.resources.stringResource
+
+/** Diameter of a live-location avatar dot. */
+val LiveMarkerSize = 40.dp
+
+/**
+ * One map dot: a ringed avatar (self gets a primary-color ring, others a white ring for contrast
+ * over tiles) plus, when the position is older than [AGE_LABEL_AFTER_MS], a small "Nm" age pill.
+ */
+@Composable
+fun LiveLocationMarker(marker: LiveMarker, modifier: Modifier = Modifier) {
+    val ringColor = if (marker.isSelf) MaterialTheme.colorScheme.primary else Color.White
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        AvatarImage(
+            modifier = Modifier.border(2.dp, ringColor, CircleShape).clip(CircleShape),
+            avatarUrl = marker.avatarUrl,
+            avatarInitials = marker.initials,
+            size = LiveMarkerSize,
+        )
+        val ageMinutes = (marker.ageMs / 60_000L).toInt()
+        if (marker.ageMs > AGE_LABEL_AFTER_MS && ageMinutes >= 1) {
+            Text(
+                text = stringResource(MR.string.live_location_age_minutes, ageMinutes),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.85f))
+                    .padding(horizontal = 6.dp, vertical = 2.dp),
+            )
+        }
+    }
+}
+
+/** contentDescription for a marker — "You" for self, "<name>'s live location" otherwise. */
+@Composable
+fun liveMarkerContentDescription(marker: LiveMarker): String =
+    if (marker.isSelf) stringResource(MR.string.live_location_you)
+    else stringResource(MR.string.live_location_marker_cd, marker.key)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationScreen.kt
@@ -1,0 +1,76 @@
+package id.homebase.core.ui.screens.location.livelocation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.homebase.api.client.location.LocationPreviewProvider
+import id.homebase.resources.MR
+import id.homebase.resources.live_location_empty
+import id.homebase.resources.live_location_title
+import id.homebase.resources.menu_back
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LiveLocationScreen(
+    viewModel: LiveLocationViewModel,
+    onNavigateBack: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val previewProvider = koinInject<LocationPreviewProvider>()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(MR.string.live_location_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(MR.string.menu_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(innerPadding)
+                .padding(innerPadding),
+        ) {
+            if (uiState.markers.isEmpty()) {
+                Text(
+                    text = stringResource(MR.string.live_location_empty),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.align(Alignment.Center).padding(24.dp),
+                )
+            } else {
+                LiveLocationMap(
+                    markers = uiState.markers,
+                    showMapTiles = uiState.showMapTiles,
+                    fetchTile = { z, x, y -> previewProvider.getTilePng(z, x, y) },
+                )
+            }
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationUiState.kt
@@ -14,6 +14,13 @@ data class LiveMarker(
     /** Age of this position (now − receivedAt) in ms; drives the staleness label. */
     val ageMs: Long,
     val isSelf: Boolean = false,
+    /**
+     * De-overlap fan-out: markers sharing (near-)identical coordinates are spread around a small
+     * circle so each stays visible. [clusterIndex] is this marker's slot in its co-located group of
+     * [clusterSize]; size 1 = no spread.
+     */
+    val clusterIndex: Int = 0,
+    val clusterSize: Int = 1,
 )
 
 data class LiveLocationUiState(

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationUiState.kt
@@ -1,0 +1,31 @@
+package id.homebase.core.ui.screens.location.livelocation
+
+/**
+ * A friend you're sharing with (or yourself), reduced to what the live map renders. [key] is stable
+ * across store emissions (the OdinId domain, or "self") so each avatar composable instance — and its
+ * Coil image load — survives position updates without reloading/flicker.
+ */
+data class LiveMarker(
+    val key: String,
+    val lat: Double,
+    val lon: Double,
+    val avatarUrl: String?,
+    val initials: String,
+    /** Age of this position (now − receivedAt) in ms; drives the staleness label. */
+    val ageMs: Long,
+    val isSelf: Boolean = false,
+)
+
+data class LiveLocationUiState(
+    val markers: List<LiveMarker> = emptyList(),
+    val showMapTiles: Boolean = true,
+)
+
+/**
+ * A live position is shown for up to 30 minutes after receipt; past that it's dropped from the map
+ * and the dashboard "Live location sharing" section. Same window for both, by design.
+ */
+const val LIVE_STALE_MS: Long = 30 * 60 * 1000L
+
+/** A dot older than 2 minutes gets a small "Nm" age label beside it. Fresher dots show none. */
+const val AGE_LABEL_AFTER_MS: Long = 2 * 60 * 1000L

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationViewModel.kt
@@ -1,0 +1,99 @@
+package id.homebase.core.ui.screens.location.livelocation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.common.OdinId
+import id.homebase.chat.services.convo.contact.ContactService
+import id.homebase.chat.services.livelocation.LiveLocationShareService
+import id.homebase.core.location.LocationMapProvider
+import id.homebase.core.location.LocationPreferences
+import id.homebase.core.location.tracking.LocationPointStore
+import id.homebase.core.util.initials
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.time.Clock
+
+/**
+ * Drives the live-location map: turns the in-memory [LiveLocationReceiveStore] into a list of
+ * [LiveMarker]s (others + an optional "you"), filtering out positions older than [LIVE_STALE_MS] and
+ * resolving each sender's avatar. Recomputes on every store emission and on a 30 s ticker (so dots
+ * age-label and drop even with no new packets).
+ */
+class LiveLocationViewModel(
+    private val receiveStore: LiveLocationReceiveStore,
+    private val contactService: ContactService,
+    private val locationPreferences: LocationPreferences,
+    private val liveShareService: LiveLocationShareService,
+    private val pointStore: LocationPointStore,
+    private val credentialsManager: CredentialsManager,
+    private val nowMs: () -> Long = { Clock.System.now().toEpochMilliseconds() },
+) : ViewModel() {
+
+    private val ownOdinId = MutableStateFlow<OdinId?>(null)
+
+    init {
+        viewModelScope.launch {
+            ownOdinId.value = runCatching { credentialsManager.getActiveCredentials()?.domain }.getOrNull()
+        }
+    }
+
+    // Re-emits so age labels update and stale dots drop without a new store packet.
+    private val ticker = flow {
+        while (true) {
+            emit(Unit)
+            delay(TICK_MS)
+        }
+    }
+
+    val uiState: StateFlow<LiveLocationUiState> =
+        combine(receiveStore.positions, ownOdinId, ticker) { positions, ownId, _ ->
+            val now = nowMs()
+            val others = positions.values
+                .filter { now - it.receivedAtMs <= LIVE_STALE_MS }
+                .map { lp ->
+                    val contact = contactService.resolveByOdinId(lp.senderOdinId)
+                    LiveMarker(
+                        key = lp.senderOdinId.domainName,
+                        lat = lp.point.lat,
+                        lon = lp.point.lon,
+                        avatarUrl = contact?.avatarUrl?.ifEmpty { null },
+                        initials = contact?.avatarInitials?.ifEmpty { null }
+                            ?: lp.senderOdinId.domainName.initials(),
+                        ageMs = now - lp.receivedAtMs,
+                    )
+                }
+            // Include myself when I'm actively sharing and have a fix — a distinct "you" dot.
+            val self = selfMarker(ownId, now)
+            LiveLocationUiState(
+                markers = listOfNotNull(self) + others,
+                showMapTiles = locationPreferences.mapProvider.value == LocationMapProvider.OpenStreetMap,
+            )
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), LiveLocationUiState())
+
+    private fun selfMarker(ownId: OdinId?, now: Long): LiveMarker? {
+        if (!liveShareService.isActive()) return null
+        val p = pointStore.lastPoint.value ?: return null
+        val contact = ownId?.let { contactService.resolveByOdinId(it) }
+        return LiveMarker(
+            key = "self",
+            lat = p.lat,
+            lon = p.lon,
+            avatarUrl = contact?.avatarUrl?.ifEmpty { null },
+            initials = contact?.avatarInitials?.ifEmpty { null }
+                ?: ownId?.domainName?.initials().orEmpty(),
+            ageMs = now - p.t,
+            isSelf = true,
+        )
+    }
+
+    private companion object {
+        const val TICK_MS = 30_000L
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.common.OdinId
 import id.homebase.chat.services.convo.contact.ContactService
-import id.homebase.chat.services.livelocation.LiveLocationShareService
 import id.homebase.core.location.LocationMapProvider
 import id.homebase.core.location.LocationPreferences
 import id.homebase.core.location.tracking.LocationPointStore
@@ -18,6 +17,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlin.math.roundToLong
 import kotlin.time.Clock
 
 /**
@@ -30,7 +30,6 @@ class LiveLocationViewModel(
     private val receiveStore: LiveLocationReceiveStore,
     private val contactService: ContactService,
     private val locationPreferences: LocationPreferences,
-    private val liveShareService: LiveLocationShareService,
     private val pointStore: LocationPointStore,
     private val credentialsManager: CredentialsManager,
     private val nowMs: () -> Long = { Clock.System.now().toEpochMilliseconds() },
@@ -53,7 +52,7 @@ class LiveLocationViewModel(
     }
 
     val uiState: StateFlow<LiveLocationUiState> =
-        combine(receiveStore.positions, ownOdinId, ticker) { positions, ownId, _ ->
+        combine(receiveStore.positions, ownOdinId, pointStore.lastPoint, ticker) { positions, ownId, myFix, _ ->
             val now = nowMs()
             val others = positions.values
                 .filter { now - it.receivedAtMs <= LIVE_STALE_MS }
@@ -69,26 +68,50 @@ class LiveLocationViewModel(
                         ageMs = now - lp.receivedAtMs,
                     )
                 }
-            // Include myself when I'm actively sharing and have a fix — a distinct "you" dot.
-            val self = selfMarker(ownId, now)
+            // Always show myself (a distinct "you" dot) whenever this device has a known position —
+            // not only while sharing. Listed first so it stays slot 0 of any co-located cluster.
+            val self = selfMarker(ownId, myFix?.lat, myFix?.lon, myFix?.t, now)
             LiveLocationUiState(
-                markers = listOfNotNull(self) + others,
+                markers = assignClusters(listOfNotNull(self) + others),
                 showMapTiles = locationPreferences.mapProvider.value == LocationMapProvider.OpenStreetMap,
             )
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), LiveLocationUiState())
 
-    private fun selfMarker(ownId: OdinId?, now: Long): LiveMarker? {
-        if (!liveShareService.isActive()) return null
-        val p = pointStore.lastPoint.value ?: return null
+    /**
+     * Tag markers that sit at (near-)identical coordinates so the map can fan them out instead of
+     * stacking them invisibly. Co-location is keyed on lat/lon rounded to ~1.1 m, so this only fires
+     * for genuine overlap (e.g. two people testing from the same spot), not for friends a street
+     * apart. Preserves input order (self stays first).
+     */
+    private fun assignClusters(markers: List<LiveMarker>): List<LiveMarker> {
+        fun key(m: LiveMarker): Pair<Long, Long> =
+            (m.lat * 1e5).roundToLong() to (m.lon * 1e5).roundToLong()
+        val sizes = markers.groupingBy { key(it) }.eachCount()
+        val nextIndex = HashMap<Pair<Long, Long>, Int>()
+        return markers.map { m ->
+            val k = key(m)
+            val idx = nextIndex.getOrElse(k) { 0 }
+            nextIndex[k] = idx + 1
+            m.copy(clusterIndex = idx, clusterSize = sizes[k] ?: 1)
+        }
+    }
+
+    /**
+     * Your own dot — shown whenever this device has a known position ([lat]/[lon] non-null),
+     * regardless of whether you're actively sharing. Returns null when there's no fix (e.g. location
+     * permission not granted, or a viewer device with no GPS), so the map just omits it.
+     */
+    private fun selfMarker(ownId: OdinId?, lat: Double?, lon: Double?, fixTimeMs: Long?, now: Long): LiveMarker? {
+        if (lat == null || lon == null) return null
         val contact = ownId?.let { contactService.resolveByOdinId(it) }
         return LiveMarker(
             key = "self",
-            lat = p.lat,
-            lon = p.lon,
+            lat = lat,
+            lon = lon,
             avatarUrl = contact?.avatarUrl?.ifEmpty { null },
             initials = contact?.avatarInitials?.ifEmpty { null }
                 ?: ownId?.domainName?.initials().orEmpty(),
-            ageMs = now - p.t,
+            ageMs = if (fixTimeMs != null) now - fixTimeMs else 0L,
             isSelf = true,
         )
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/map/MapProjection.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/map/MapProjection.kt
@@ -1,0 +1,99 @@
+package id.homebase.core.ui.screens.location.map
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.IntSize
+import id.homebase.api.client.location.WebMercator
+import kotlin.math.ceil
+import kotlin.math.floor
+import kotlin.math.ln
+import kotlin.math.max
+import kotlin.math.roundToInt
+
+/**
+ * Pure viewport/tile math shared by every map surface (History traces, the dashboard preview, Find
+ * Device, the live-location map). Extracted verbatim from the former `LocationTraceCanvas` privates
+ * so all surfaces share one zoom/pan/tile heuristic. No Compose state, no side effects — trivially
+ * testable.
+ *
+ * Coordinates are Web-Mercator **unit space** (0..1 world), the same space [WebMercator.latLonToUnit]
+ * produces.
+ */
+
+/**
+ * Viewport over unit space: a center point plus the unit-width of one screen pixel. Pure data so
+ * gestures and tile math share it.
+ */
+internal data class MapViewport(val centerX: Double, val centerY: Double, val unitsPerPx: Double)
+
+internal data class MapTileKey(val zoom: Int, val x: Int, val y: Int)
+
+/** Project a unit-space point to screen pixels for a canvas of [widthPx] x [heightPx]. */
+internal fun MapViewport.toPx(ux: Double, uy: Double, widthPx: Float, heightPx: Float): Offset =
+    Offset(
+        x = ((ux - centerX) / unitsPerPx + widthPx / 2.0).toFloat(),
+        y = ((uy - centerY) / unitsPerPx + heightPx / 2.0).toFloat(),
+    )
+
+/**
+ * Fit [bbox] (unit-space `[minX,minY,maxX,maxY]`) into [canvasSize] with padding. Returns null until
+ * there's both data and a measured canvas. A zero-span bbox (a single point) is widened to
+ * [MIN_FIT_SPAN_UNITS] so one point lands at a sensible city-block zoom instead of infinite zoom.
+ */
+internal fun fitViewport(bbox: DoubleArray?, canvasSize: IntSize): MapViewport? {
+    if (bbox == null || canvasSize.width == 0 || canvasSize.height == 0) return null
+    val minX = bbox[0]; val minY = bbox[1]; val maxX = bbox[2]; val maxY = bbox[3]
+    val spanX = max(maxX - minX, MIN_FIT_SPAN_UNITS)
+    val spanY = max(maxY - minY, MIN_FIT_SPAN_UNITS)
+    val unitsPerPx = max(
+        spanX * FIT_PADDING / canvasSize.width,
+        spanY * FIT_PADDING / canvasSize.height,
+    ).coerceIn(MIN_UNITS_PER_PX, MAX_UNITS_PER_PX)
+    return MapViewport(
+        centerX = (minX + maxX) / 2,
+        centerY = (minY + maxY) / 2,
+        unitsPerPx = unitsPerPx,
+    )
+}
+
+/**
+ * The tile keys covering the current viewport. Starts at the zoom where one 256px-native tile renders
+ * ~1:1, then steps DOWN until the full visible grid fits [MAX_TILES_PER_VIEW] — a portrait phone at
+ * 1:1 needs ~30-40 tiles, so coverage beats crispness: coarser tiles are upscaled but the whole view
+ * gets a basemap (truncating the grid instead left the bottom of the screen bare).
+ */
+internal fun visibleTileKeys(vp: MapViewport, canvasSize: IntSize): List<MapTileKey> {
+    val idealZoom = (-ln(vp.unitsPerPx * WebMercator.TILE_SIZE_PX) / ln(2.0))
+        .roundToInt().coerceIn(MIN_TILE_ZOOM, MAX_TILE_ZOOM)
+    val halfW = canvasSize.width / 2.0 * vp.unitsPerPx
+    val halfH = canvasSize.height / 2.0 * vp.unitsPerPx
+    for (zoom in idealZoom downTo MIN_TILE_ZOOM) {
+        val n = 1 shl zoom
+        val x0 = floor((vp.centerX - halfW) * n).toInt().coerceIn(0, n - 1)
+        val x1 = ceil((vp.centerX + halfW) * n).toInt().coerceIn(0, n - 1)
+        val y0 = floor((vp.centerY - halfH) * n).toInt().coerceIn(0, n - 1)
+        val y1 = ceil((vp.centerY + halfH) * n).toInt().coerceIn(0, n - 1)
+        val count = (x1 - x0 + 1) * (y1 - y0 + 1)
+        if (count > MAX_TILES_PER_VIEW && zoom > MIN_TILE_ZOOM) continue
+        return buildList {
+            for (y in y0..y1) {
+                for (x in x0..x1) {
+                    add(MapTileKey(zoom, x, y))
+                    if (size >= MAX_TILES_PER_VIEW) return@buildList
+                }
+            }
+        }
+    }
+    return emptyList()
+}
+
+internal const val MIN_UNITS_PER_PX = 1e-9
+internal const val MAX_UNITS_PER_PX = 1.0 / 256.0
+
+private const val FIT_PADDING = 1.2
+private const val MIN_FIT_SPAN_UNITS = 1e-5 // ~ city block; avoids infinite zoom on 1 point
+private const val MIN_TILE_ZOOM = 3
+private const val MAX_TILE_ZOOM = 19
+
+// Budget per view. 24 fits a portrait phone one zoom step below 1:1 (×2
+// upscale worst case) while keeping per-view OSM traffic modest.
+private const val MAX_TILES_PER_VIEW = 24

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/map/TiledMapView.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/map/TiledMapView.kt
@@ -1,0 +1,141 @@
+package id.homebase.core.ui.screens.location.map
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import id.homebase.api.client.location.WebMercator
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.decodeToImageBitmap
+import kotlin.math.roundToInt
+
+/**
+ * Generic zoomable, pannable map: an OSM tile basemap plus a caller-supplied overlay. The single
+ * shared map core — History traces, the dashboard preview card, Find Device, and the live-location
+ * map all render through this, so they share one viewport/zoom/tile heuristic ([MapProjection]).
+ *
+ * Two overlay slots, both reading the SAME live viewport so they stay pixel-anchored during zoom/pan:
+ *  - [onDrawOverlay] — Canvas drawing on top of the tiles (History uses it for trace polylines,
+ *    playheads, dwell dots). Receives `project(unitX, unitY) -> Offset`.
+ *  - [markerContent] — composables on top of the canvas (the live map uses it for avatar dots).
+ *    Receives the same `project` plus `ready` (false until the viewport/canvas are measured). Markers
+ *    should position themselves with `Modifier.offset { project(...) }` so a gesture frame re-runs
+ *    only placement math — no recomposition, no image reload.
+ *
+ * Coordinates are Web-Mercator unit space; convert lat/lon with [WebMercator.latLonToUnit].
+ *
+ * @param bbox unit-space `[minX,minY,maxX,maxY]` to fit on first layout (and re-fit until the first
+ *   user gesture); null = nothing to fit yet.
+ * @param resetViewportOn when this key changes the user's pan/zoom is dropped and the view re-fits to
+ *   [bbox]. History passes its `traces` (new day re-fits); the live map passes `Unit` (preserve
+ *   pan/zoom across store updates).
+ */
+@Composable
+fun TiledMapView(
+    bbox: DoubleArray?,
+    showMapTiles: Boolean,
+    fetchTile: suspend (zoom: Int, x: Int, y: Int) -> ByteArray?,
+    modifier: Modifier = Modifier,
+    interactive: Boolean = true,
+    resetViewportOn: Any? = Unit,
+    onDrawOverlay: (DrawScope.(project: (Double, Double) -> Offset) -> Unit)? = null,
+    markerContent: (@Composable (project: (Double, Double) -> Offset, ready: Boolean) -> Unit)? = null,
+) {
+    var canvasSize by remember { mutableStateOf(IntSize.Zero) }
+    // User pan/zoom override; null = fit the bbox. Reset when resetViewportOn changes.
+    var userViewport by remember(resetViewportOn) { mutableStateOf<MapViewport?>(null) }
+
+    val viewport = userViewport ?: fitViewport(bbox, canvasSize)
+
+    // ── Tile layer state ──
+    val tileBitmaps = remember { mutableStateMapOf<MapTileKey, ImageBitmap>() }
+    val visibleTiles = if (showMapTiles && viewport != null && canvasSize != IntSize.Zero) {
+        visibleTileKeys(viewport, canvasSize)
+    } else emptyList()
+    LaunchedEffect(visibleTiles, showMapTiles) {
+        if (!showMapTiles) return@LaunchedEffect
+        // Concurrent fetches: the provider single-flights and runs downloads on
+        // its own scope, so restarts of this effect (pan/zoom) neither cancel
+        // nor duplicate them. Failures are simply retried on the next restart.
+        for (key in visibleTiles) {
+            if (tileBitmaps.containsKey(key)) continue
+            launch {
+                val bytes = fetchTile(key.zoom, key.x, key.y)
+                val bitmap = bytes?.let { runCatching { it.decodeToImageBitmap() }.getOrNull() }
+                if (bitmap != null) tileBitmaps[key] = bitmap
+            }
+        }
+    }
+
+    val gestureModifier = if (!interactive) Modifier else {
+        Modifier.pointerInput(resetViewportOn) {
+            detectTransformGestures { centroid, pan, zoom, _ ->
+                val current = userViewport ?: fitViewport(bbox, canvasSize) ?: return@detectTransformGestures
+                val newUnitsPerPx = (current.unitsPerPx / zoom)
+                    .coerceIn(MIN_UNITS_PER_PX, MAX_UNITS_PER_PX)
+                // Keep the gesture centroid anchored while zooming, then pan.
+                val cx = centroid.x - size.width / 2f
+                val cy = centroid.y - size.height / 2f
+                val anchoredX = current.centerX + cx * (current.unitsPerPx - newUnitsPerPx)
+                val anchoredY = current.centerY + cy * (current.unitsPerPx - newUnitsPerPx)
+                userViewport = MapViewport(
+                    centerX = anchoredX - pan.x * newUnitsPerPx,
+                    centerY = anchoredY - pan.y * newUnitsPerPx,
+                    unitsPerPx = newUnitsPerPx,
+                )
+            }
+        }
+    }
+
+    Box(modifier = modifier.fillMaxSize().onSizeChanged { canvasSize = it }.then(gestureModifier)) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val vp = viewport ?: return@Canvas
+            fun project(ux: Double, uy: Double): Offset = vp.toPx(ux, uy, size.width, size.height)
+
+            // ── Basemap tiles (under the overlay) ──
+            for (key in visibleTiles) {
+                val bitmap = tileBitmaps[key] ?: continue
+                val b = WebMercator.tileToUnitBounds(key.x, key.y, key.zoom)
+                val topLeft = project(b[0], b[1])
+                val bottomRight = project(b[2], b[3])
+                drawImage(
+                    image = bitmap,
+                    dstOffset = IntOffset(topLeft.x.roundToInt(), topLeft.y.roundToInt()),
+                    dstSize = IntSize(
+                        width = (bottomRight.x - topLeft.x).roundToInt().coerceAtLeast(1),
+                        height = (bottomRight.y - topLeft.y).roundToInt().coerceAtLeast(1),
+                    ),
+                )
+            }
+
+            // ── Caller overlay (traces, playheads, dwell dots, …) ──
+            onDrawOverlay?.invoke(this) { ux, uy -> project(ux, uy) }
+        }
+
+        // ── Composable marker overlay (avatar dots, …) ──
+        if (markerContent != null) {
+            val vp = viewport
+            val ready = vp != null && canvasSize != IntSize.Zero
+            val w = canvasSize.width.toFloat()
+            val h = canvasSize.height.toFloat()
+            markerContent({ ux, uy ->
+                vp?.toPx(ux, uy, w, h) ?: Offset.Zero
+            }, ready)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Builds the **live-location map** on top of the merged Live Relay plumbing (#778), and first **streamlines the map code** into a shared core (the user's explicit "first order of business").

### Phase 1 — refactor (behaviour-preserving)
Extract the zoom/pan/tile/projection core out of `LocationTraceCanvas` so the History map, dashboard preview card, Find Device, and the new live map all share one viewport heuristic.
- `location/map/MapProjection.kt` — `MapViewport`/`MapTileKey`/`fitViewport`/`visibleTileKeys`/`toPx` + constants (extracted verbatim).
- `location/map/TiledMapView.kt` — generic tiled basemap + gestures, with two overlay slots: `onDrawOverlay` (Canvas, for traces) and `markerContent` (composables, for avatar dots), both reading the same live viewport.
- `LocationTraceCanvas` keeps its **public signature unchanged** and delegates to `TiledMapView` (trace/playhead/dwell drawing moved into `onDrawOverlay`). **All existing call sites untouched.**

### Phase 2 — feature
A separate, zoomable live map: one avatar dot per identity in the in-memory receive store, plus a distinct **"you"** dot when sharing; updates as the store updates.
- `livelocation/`: `LiveLocationUiState` (+ `LIVE_STALE_MS` 30 min / `AGE_LABEL_AFTER_MS` 2 min), `LiveLocationViewModel` (positions + 30 s ticker, self dot, staleness filter, avatar resolve), `LiveLocationMarker` (ringed avatar + "Nm" age label when >2 min), `LiveLocationMap` (keyed, offset-positioned markers), `LiveLocationScreen`.
- `Route.LocationLive` + `AppNavHost`; `viewModelOf(::LiveLocationViewModel)`.
- Dashboard: **"Live location sharing"** section ABOVE Location History, visible when sharing OR a ≤30 min inbound point exists; links to the live map.

Dots older than 30 min drop; older than 2 min show a minute label. **Chat-bubble entry deferred** to the future live-share message kind (Dashboard is the v1 entry, per decision).

## Verification
- ✅ Compiles: `homebase-core` on **JVM, Android, wasmJs**; **Konsist** (hardcoded-`Text`) green; this PR's CI verifies **iOS** + Desktop.
- ✅ Desktop smoke launch: Koin DI graph builds (no `NoBeanDefinition`), app authenticates and enters Compose with the new wiring.
- ⏳ **Interactive visual check (recommended on a real device/desktop):** History/Dashboard-preview/Find-Device pan-zoom-playback unchanged after the refactor; and with a second identity sharing, avatar dots render on the live map (driven via `LiveLocationShareService.start` per #778's "How to activate" note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)