### PR TITLE
Sticker cutout: crop to subject so it fills the frame

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/StickerCreator.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/StickerCreator.kt
@@ -80,6 +80,8 @@ class StickerCreator(
     private val bgRemovalSupported: () -> Boolean = ::isBackgroundRemovalSupported,
     // removeBackground only — addWhiteOutline caps the working size internally, so no separate downscale here.
     private val cutOut: suspend (ByteArray) -> ByteArray? = { removeBackground(it) },
+    // Crop the full-frame mask to its subject BEFORE outline/512-resize, so the subject fills the frame.
+    private val cropToSubject: suspend (ByteArray) -> ByteArray = { StickerImageProcessor.cropToSubject(it) },
     private val addOutline: suspend (ByteArray) -> ByteArray = { StickerImageProcessor.addWhiteOutline(it) },
     private val normalize: suspend (ByteArray, String) -> Pair<ByteArray, String> = { bytes, contentType ->
         withContext(Dispatchers.Default) {
@@ -111,7 +113,7 @@ class StickerCreator(
             val outlined: ByteArray? = withContext(workDispatcher) {
                 when {
                     isTransparent(bytes) -> addOutline(bytes)
-                    bgRemovalSupported() -> cutOut(bytes)?.let { addOutline(it) }
+                    bgRemovalSupported() -> cutOut(bytes)?.let { addOutline(cropToSubject(it)) }
                     else -> null
                 }
             }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/image/StickerImageProcessor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/image/StickerImageProcessor.kt
@@ -7,6 +7,7 @@ import id.homebase.api.image.ImageUtils
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlin.math.roundToInt
 
 private const val TAG = "StickerImageProcessor"
 
@@ -129,6 +130,69 @@ object StickerImageProcessor {
                 throw e
             } catch (e: Exception) {
                 Logger.e(e, TAG) { "addWhiteOutline FAILED — returning un-outlined cut-out (in=${cutOutPng.size}B)" }
+                cutOutPng
+            }
+        }
+
+    /**
+     * Tightly crop a transparent cut-out to its alpha bounding box (plus a small margin) so the
+     * subject fills the sticker frame instead of being a tiny island in a full-frame transparent
+     * canvas. The segmenters emit a full-frame masked image, so without this the subject gets
+     * downscaled to 512 along with its transparent margins and renders small.
+     *
+     * Runs BEFORE [addWhiteOutline] so the outline radius and the final 512 cap are sized to the
+     * subject. Preserves natural aspect (no forced square). Pure PNG-in/PNG-out on
+     * Dispatchers.Default; returns the input unchanged on decode failure / fully-transparent input
+     * / any error so it can never block sticker creation.
+     */
+    suspend fun cropToSubject(cutOutPng: ByteArray, marginFraction: Float = 0.04f): ByteArray =
+        withContext(Dispatchers.Default) {
+            try {
+                val img = ImageUtils.decodeToArgb(cutOutPng) ?: return@withContext cutOutPng
+                val w = img.width; val h = img.height
+                if (w == 0 || h == 0) return@withContext cutOutPng
+
+                var minX = w; var minY = h; var maxX = -1; var maxY = -1
+                val px = img.pixels
+                for (y in 0 until h) {
+                    val row = y * w
+                    for (x in 0 until w) {
+                        if ((px[row + x] ushr 24 and 0xFF) > OUTLINE_ALPHA_THRESHOLD) {
+                            if (x < minX) minX = x
+                            if (x > maxX) maxX = x
+                            if (y < minY) minY = y
+                            if (y > maxY) maxY = y
+                        }
+                    }
+                }
+                if (maxX < minX || maxY < minY) {
+                    // Fully transparent (no subject) — nothing to crop to.
+                    return@withContext cutOutPng
+                }
+
+                val bw = maxX - minX + 1; val bh = maxY - minY + 1
+                // Small margin keeps the later white-outline halo from being clipped at the edge.
+                val pad = (maxOf(bw, bh) * marginFraction).roundToInt()
+                val x0 = (minX - pad).coerceAtLeast(0)
+                val y0 = (minY - pad).coerceAtLeast(0)
+                val x1 = (maxX + pad).coerceAtMost(w - 1)
+                val y1 = (maxY + pad).coerceAtMost(h - 1)
+                val cw = x1 - x0 + 1; val ch = y1 - y0 + 1
+                if (cw == w && ch == h) return@withContext cutOutPng // already tight
+
+                val cropped = IntArray(cw * ch)
+                for (y in 0 until ch) {
+                    val srcRow = (y0 + y) * w + x0
+                    val dstRow = y * cw
+                    px.copyInto(cropped, dstRow, srcRow, srcRow + cw)
+                }
+                val out = ImageUtils.encodeArgbToPng(ArgbImage(cropped, cw, ch))
+                Logger.d(tag = TAG) { "cropToSubject: ${w}x$h -> ${cw}x$ch (bbox ${bw}x$bh, pad=$pad)" }
+                out
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Logger.e(e, TAG) { "cropToSubject FAILED — returning un-cropped cut-out (in=${cutOutPng.size}B)" }
                 cutOutPng
             }
         }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/StickerCreatorTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/StickerCreatorTest.kt
@@ -37,6 +37,7 @@ private fun creator(
     isTransparent: (ByteArray) -> Boolean,
     bgSupported: () -> Boolean = { true },
     cutOut: suspend (ByteArray) -> ByteArray? = { byteArrayOf(7) },
+    crop: suspend (ByteArray) -> ByteArray = { it }, // identity by default; bg-removal branch crops before outline
     outline: suspend (ByteArray) -> ByteArray = { it + 9 },
     saveResult: Uuid? = Uuid.random(),
     normalize: suspend (ByteArray, String) -> Pair<ByteArray, String> = { b, ct -> b to ct },
@@ -49,6 +50,7 @@ private fun creator(
     isTransparent = isTransparent,
     bgRemovalSupported = bgSupported,
     cutOut = cutOut,
+    cropToSubject = crop,
     addOutline = outline,
     normalize = normalize,
     workDispatcher = scope.testDispatcher(),
@@ -66,6 +68,23 @@ class StickerCreatorTest {
         val cut = s.variants.first { it.kind == StickerVariant.CutOut }
         assertTrue(cut.bytes.contentEquals(byteArrayOf(2)))
         assertEquals(StickerVariant.CutOut, s.selected)
+    }
+
+    @Test fun opaque_with_subject_crops_before_outline() = runTest {
+        // bg-removal branch must run cropToSubject on the mask BEFORE addWhiteOutline, so the
+        // outline radius / 512 cap are sized to the cropped subject, not the full frame.
+        val rec = Rec(); var cropInput: ByteArray? = null; var outlineInput: ByteArray? = null
+        val c = creator(
+            this, rec, isTransparent = { false },
+            cutOut = { byteArrayOf(1) },
+            crop = { cropInput = it; byteArrayOf(2) },
+            outline = { outlineInput = it; byteArrayOf(3) },
+        )
+        c.create(byteArrayOf(0), "image/jpeg", convo); advanceUntilIdle()
+        val s = c.state.value as StickerCreateState.Choose
+        assertTrue(cropInput!!.contentEquals(byteArrayOf(1)), "crop receives the raw mask from cutOut")
+        assertTrue(outlineInput!!.contentEquals(byteArrayOf(2)), "outline receives the cropped bytes, not the raw mask")
+        assertTrue(s.variants.first { it.kind == StickerVariant.CutOut }.bytes.contentEquals(byteArrayOf(3)))
     }
 
     @Test fun transparent_source_skips_removal_outlines_source() = runTest {
@@ -175,7 +194,7 @@ class StickerCreatorTest {
             sendInfo = { rec.infos += it },
             awaitDriveGranted = {},
             isTransparent = { false }, bgRemovalSupported = { true },
-            cutOut = { byteArrayOf(1) }, addOutline = { byteArrayOf(2) },
+            cutOut = { byteArrayOf(1) }, cropToSubject = { it }, addOutline = { byteArrayOf(2) },
             normalize = { b, ct -> b to ct },
             workDispatcher = testDispatcher(),
         )

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/image/StickerImageProcessorTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/image/StickerImageProcessorTest.kt
@@ -68,6 +68,64 @@ class StickerImageProcessorTest {
         )
     }
 
+    @Test
+    fun cropToSubject_centeredOval_cropsToBboxPlusMargin_staysPngWithAlpha() = runTest {
+        // 1500x1000 with a centered opaque oval at (w/4, h/4, w/2, h/2) -> bbox ~750x500.
+        val src = transparentPng(1500, 1000)
+
+        val out = StickerImageProcessor.cropToSubject(src)
+
+        val size = ImageUtils.getNaturalSize(out)
+        // Cropped to roughly the oval bbox (~750x500) + a 4% margin — far smaller than the full frame.
+        assertTrue(
+            size.pixelWidth < 1500 && size.pixelHeight < 1000,
+            "must crop tighter than the full frame, was ${size.pixelWidth}x${size.pixelHeight}",
+        )
+        assertTrue(
+            size.pixelWidth in 700..900 && size.pixelHeight in 450..650,
+            "crop should be ~oval bbox + small margin, was ${size.pixelWidth}x${size.pixelHeight}",
+        )
+        assertEquals(
+            "image/png",
+            ImageFormatDetector.detectFormat(out),
+            "must stay PNG — the Android ImageUtils WebP branch crashes on API 28/29",
+        )
+        assertTrue(
+            ImageUtils.hasNonOpaquePixels(out),
+            "the transparent margin must survive so the bubble still drops its backdrop",
+        )
+    }
+
+    @Test
+    fun cropToSubject_fullyTransparent_returnsInputUnchanged() = runTest {
+        val blank = blankTransparentPng(400, 300)
+
+        assertContentEquals(
+            blank,
+            StickerImageProcessor.cropToSubject(blank),
+            "a fully transparent image has no subject to crop to — return it unchanged",
+        )
+    }
+
+    @Test
+    fun cropToSubject_undecodableBytes_fallsBackToInputUnchanged() = runTest {
+        val junk = byteArrayOf(1, 2, 3, 4, 5)
+
+        assertContentEquals(
+            junk,
+            StickerImageProcessor.cropToSubject(junk),
+            "a decode failure must fall back to the original bytes, never block sticker creation",
+        )
+    }
+
+    /** A fully transparent PNG of the given size (no subject). */
+    private fun blankTransparentPng(width: Int, height: Int): ByteArray {
+        val img = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+        val out = ByteArrayOutputStream()
+        ImageIO.write(img, "png", out)
+        return out.toByteArray()
+    }
+
     /** A PNG with a fully transparent canvas and one opaque blob — content + alpha. */
     private fun transparentPng(width: Int, height: Int): ByteArray {
         val img = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)


### PR DESCRIPTION
## What

The background-remover "cutout" sticker was too small: after removing the background, the subject sat as a tiny island in a transparent frame.

Adds a pure cross-platform `StickerImageProcessor.cropToSubject(cutOutPng, marginFraction = 0.04f)` and wires it into `StickerCreator` **before** `addWhiteOutline`, so the cut-out is tightly cropped to the subject before the outline radius and the final 512px cap are applied.

## Why

Both segmenters emit a **full-frame** masked image (Android returns `foregroundBitmap` as-is; iOS uses `croppedToInstancesExtent = false`). The subject therefore occupies a small region with large transparent margins. That whole frame was then downscaled to 512px and rendered at ~160dp, so the subject ended up tiny.

`cropToSubject` scans the alpha bounding box (reusing the existing `OUTLINE_ALPHA_THRESHOLD = 16`), crops to it plus a small symmetric margin (`max(w,h) * marginFraction`, clamped inside the frame), and re-encodes a lossless PNG. Natural aspect is preserved (no forced square). The single common-code seam fixes **both Android and iOS** at once — the native/android producers and `croppedToInstancesExtent = false` are left unchanged (single source of truth).

It runs **before** `addWhiteOutline` so the outline halo and the 512 resize are sized to the subject, not the full frame. PNG (not WebP) is required because the Android `ImageUtils` WebP encode path is API30-gated and crashes on minSdk 28.

Defensive throughout: decode failure, fully-transparent input, or any other error returns the input bytes unchanged (only `CancellationException` rethrows), so crop can never block sticker creation. The already-transparent (user-supplied PNG) branch is intentionally left alone to avoid over-cropping legitimately-padded stickers.

## Tests

- `StickerImageProcessorTest` (JVM, real Skia backend): a 1500×1000 transparent PNG with a centered oval crops to ~oval bbox + margin (far smaller than the full frame), stays PNG, keeps alpha; a fully-transparent input and an undecodable input both return the original bytes unchanged.
- `StickerCreatorTest`: new test asserts the bg-removal branch routes through `cropToSubject` before `addWhiteOutline`; existing tests updated to inject an identity crop seam (the default seam calls the real processor, which hops to `Dispatchers.Default` and isn't deterministic under `advanceUntilIdle`).

`:homebase-chat:compileKotlinJvm` clean; `:homebase-chat:jvmTest` for `*StickerImageProcessor*` + `*StickerCreator*` → 18 tests, 0 failures.

## Needs device test

The segmenters are no-ops on the iOS Simulator and need the GMS model downloaded on first use on Android, so the cutout path can only be exercised end-to-end on a real device. Please verify on-device that the cutout now fills the sticker frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)