### PR TITLE
[EXPERIMENT] iOS cacheKind=none (do not merge)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -27,4 +27,7 @@ org.gradle.parallel=true
 org.gradle.configureondemand=false
 org.gradle.configuration-cache=true
 # --- Robolectric ---
-robolectric.enabledSdks=33
+robolectric.enabledSdks=33# EXPERIMENT: disable static klib caching for the simulator target to work around
+# the K/N "Failed to build cache ... Lowering ReturnsInsertion: phases [Coroutines]
+# are required, but not satisfied" crash on linkDebugTestIosSimulatorArm64.
+kotlin.native.cacheKind.iosSimulatorArm64=none

--- a/homebase-api/build.gradle.kts
+++ b/homebase-api/build.gradle.kts
@@ -159,6 +159,7 @@ kotlin {
     val wasmJsDbBackedTestClasses = listOf(
         "id.homebase.api.sync.database.ChatReadCountWrapperTest",
         "id.homebase.api.sync.database.CursorSyncTest",
+        "id.homebase.api.sync.database.DriveMainIndexCreateOrderTest",
         "id.homebase.api.sync.database.DriveLocalTagIndexTest",
         "id.homebase.api.sync.database.DriveMainIndexTest",
         "id.homebase.api.sync.database.DriveTagIndexTest",

--- a/homebase-api/src/androidHostTest/kotlin/id/homebase/api/sync/database/TestDatabaseHelper.androidHost.kt
+++ b/homebase-api/src/androidHostTest/kotlin/id/homebase/api/sync/database/TestDatabaseHelper.androidHost.kt
@@ -11,3 +11,7 @@ actual fun createInMemoryDatabase(): SqlDriver {
     OdinDatabase.Schema.create(driver)
     return driver
 }
+
+// Raw driver, no schema applied — the test stages its own DDL.
+actual fun createRawInMemoryDriver(): SqlDriver =
+    JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/DriveMainIndexCreateOrderTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/DriveMainIndexCreateOrderTest.kt
@@ -1,0 +1,167 @@
+package id.homebase.api.sync.database
+
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlDriver
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Regression coverage for the iOS launch crash:
+ *
+ * ```
+ * error while compiling: CREATE INDEX IF NOT EXISTS idx_unread_cover
+ *   ON DriveMainIndex(identityId, fileType, dataType, groupId, userDate,
+ *                     originalAuthor, fileState, archivalStatus)
+ * no such column: fileState
+ * ```
+ *
+ * Cause (platform-agnostic): `DatabaseManager.init {}` runs
+ * `OdinDatabase.Schema.create(driver)` *before* the `-- Version:` comment check
+ * that would otherwise `wipeAndRecreate()` a stale database. `fileState` was added
+ * to DriveMainIndex (schema v4→5) and a *new* covering index `idx_unread_cover`
+ * over it shipped afterwards. On a device whose DriveMainIndex predates `fileState`:
+ *   - `CREATE TABLE IF NOT EXISTS DriveMainIndex(...)` is a no-op (old table kept), and
+ *   - `CREATE INDEX IF NOT EXISTS idx_unread_cover ON DriveMainIndex(... fileState ...)`
+ *     throws `no such column: fileState`. The index is *new*, so `IF NOT EXISTS`
+ *     does not short-circuit it — it evaluates its column list against the stale table.
+ *
+ * These tests run on every disk-backed target (JVM, Android host, **iOS** via
+ * `nativeTest`/`iosSimulatorArm64Test`), pinning the root cause where the users
+ * actually hit it. wasmJs is excluded (no SQLDelight test driver) in build.gradle.kts.
+ *
+ * [staleSchemaThrowsOnNewFileStateIndex] characterizes the crash; [dropBeforeCreateRecoversCleanly]
+ * proves the intended `wipeAndRecreate()` mechanism (DROP every table, then create)
+ * is sound — i.e. the defect is purely the create-before-version-check ordering.
+ */
+class DriveMainIndexCreateOrderTest {
+
+    private val driver: SqlDriver = createRawInMemoryDriver()
+
+    @AfterTest
+    fun tearDown() {
+        driver.close()
+    }
+
+    @Test
+    fun staleSchemaThrowsOnNewFileStateIndex() {
+        stageOldDriveMainIndex(driver)
+
+        // Reproduce the production launch path: apply the current schema over the
+        // pre-fileState DriveMainIndex. The new idx_unread_cover is the only new
+        // index over fileState (the old Idx*/idx_chatmessage names already exist,
+        // so their `IF NOT EXISTS` creates are no-ops and never re-check columns).
+        val error = assertFailsWith<Throwable> {
+            OdinDatabase.Schema.create(driver)
+        }
+        val message = error.message ?: ""
+        assertTrue(
+            message.contains("no such column", ignoreCase = true) &&
+                message.contains("fileState"),
+            "Expected a 'no such column: fileState' compile error, got: $message",
+        )
+    }
+
+    @Test
+    fun dropBeforeCreateRecoversCleanly() {
+        stageOldDriveMainIndex(driver)
+
+        // What wipeAndRecreate() does: DROP every table first, THEN create. The DROP
+        // removes the stale DriveMainIndex (and its indexes) so the fresh CREATE TABLE
+        // builds the v5 shape with fileState before any index references it.
+        DatabaseManager.TABLE_NAMES.forEach { table ->
+            driver.execute(null, "DROP TABLE IF EXISTS $table", 0)
+        }
+
+        // Must not throw.
+        OdinDatabase.Schema.create(driver)
+
+        val columns = queryStrings(driver, "PRAGMA table_info(DriveMainIndex)", column = 1)
+        assertTrue(
+            columns.contains("fileState"),
+            "Recreated DriveMainIndex should carry fileState, has: $columns",
+        )
+
+        val indexes = queryStrings(
+            driver,
+            "SELECT name FROM sqlite_master WHERE type = 'index'",
+            column = 0,
+        )
+        assertTrue(
+            indexes.contains("idx_unread_cover"),
+            "Recreated schema should include idx_unread_cover, has: $indexes",
+        )
+        // Sanity: a fresh recreate leaves no rows behind.
+        val rowCount = queryStrings(driver, "SELECT COUNT(*) FROM DriveMainIndex", column = 0)
+        assertEquals(listOf("0"), rowCount, "Recreated DriveMainIndex should be empty")
+    }
+
+    /**
+     * Stage a pre-`fileState` DriveMainIndex exactly as an old install carries it:
+     * the v4 table plus its v4 indexes (Idx0..Idx3 — none reference fileState — and
+     * idx_chatmessage_convid_userDate). Because every old index name already exists,
+     * the current schema's `CREATE INDEX IF NOT EXISTS` for those names is a no-op and
+     * the failure lands on the genuinely new `idx_unread_cover`, matching the report.
+     *
+     * Plain SQLite types only (no SQLDelight `AS Uuid` adapter syntax) since this is
+     * raw DDL executed on the driver. Sourced from
+     * `git show f555d9816^:.../DriveMainIndex.sq`.
+     */
+    private fun stageOldDriveMainIndex(driver: SqlDriver) {
+        driver.execute(
+            null,
+            """
+            CREATE TABLE IF NOT EXISTS DriveMainIndex( -- Version: 4
+               rowId INTEGER PRIMARY KEY AUTOINCREMENT,
+               identityId BLOB NOT NULL,
+               driveId BLOB NOT NULL,
+               fileId BLOB NOT NULL,
+               uniqueId BLOB,
+               globalTransitId BLOB,
+               senderId TEXT,
+               originalAuthor TEXT,
+               groupId BLOB,
+               fileType INTEGER NOT NULL,
+               dataType INTEGER NOT NULL,
+               archivalStatus INTEGER NOT NULL,
+               historyStatus INTEGER NOT NULL,
+               userDate INTEGER NOT NULL,
+               created INTEGER NOT NULL,
+               modified INTEGER NOT NULL,
+               fileSystemType INTEGER NOT NULL,
+               jsonHeader TEXT NOT NULL,
+               UNIQUE(identityId,driveId,fileId),
+               UNIQUE(identityId,driveId,uniqueId),
+               UNIQUE(identityId,driveId,globalTransitId)
+            )
+            """.trimIndent(),
+            0,
+        )
+        listOf(
+            "CREATE INDEX IF NOT EXISTS Idx0DriveMainIndex ON DriveMainIndex(identityId,driveId,fileSystemType,created,rowId)",
+            "CREATE INDEX IF NOT EXISTS Idx1DriveMainIndex ON DriveMainIndex(identityId,driveId,fileSystemType,modified,rowId)",
+            "CREATE INDEX IF NOT EXISTS Idx2DriveMainIndex ON DriveMainIndex(identityId,driveId,fileSystemType,userDate,rowId)",
+            "CREATE INDEX IF NOT EXISTS Idx3DriveMainIndex ON DriveMainIndex(identityId,driveId,fileSystemType,groupId,fileType,userDate DESC,rowId)",
+            "CREATE INDEX IF NOT EXISTS idx_chatmessage_convid_userDate ON DriveMainIndex(groupId,fileType,userDate DESC)",
+        ).forEach { driver.execute(null, it, 0) }
+    }
+
+    /** Collect one text column from a query into a list (sync drivers only). */
+    private fun queryStrings(driver: SqlDriver, sql: String, column: Int): List<String> {
+        val out = mutableListOf<String>()
+        driver.executeQuery(
+            identifier = null,
+            sql = sql,
+            mapper = { cursor ->
+                while (cursor.next().value) {
+                    cursor.getString(column)?.let(out::add)
+                }
+                QueryResult.Value(Unit)
+            },
+            parameters = 0,
+        )
+        return out
+    }
+}

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/DriveMainIndexCreateOrderTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/DriveMainIndexCreateOrderTest.kt
@@ -2,10 +2,8 @@ package id.homebase.api.sync.database
 
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
-import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 /**
@@ -18,7 +16,7 @@ import kotlin.test.assertTrue
  * no such column: fileState
  * ```
  *
- * Cause (platform-agnostic): `DatabaseManager.init {}` runs
+ * Cause (platform-agnostic): `DatabaseManager`'s `init {}` block runs
  * `OdinDatabase.Schema.create(driver)` *before* the `-- Version:` comment check
  * that would otherwise `wipeAndRecreate()` a stale database. `fileState` was added
  * to DriveMainIndex (schema v4→5) and a *new* covering index `idx_unread_cover`
@@ -28,64 +26,78 @@ import kotlin.test.assertTrue
  *     throws `no such column: fileState`. The index is *new*, so `IF NOT EXISTS`
  *     does not short-circuit it — it evaluates its column list against the stale table.
  *
+ * The crash is in the **constructor's `init` block**, which runs *before* the
+ * companion `initialize()`'s version check — so the wipe net never fires.
+ *
  * These tests run on every disk-backed target (JVM, Android host, **iOS** via
  * `nativeTest`/`iosSimulatorArm64Test`), pinning the root cause where the users
  * actually hit it. wasmJs is excluded (no SQLDelight test driver) in build.gradle.kts.
- *
- * [staleSchemaThrowsOnNewFileStateIndex] characterizes the crash; [dropBeforeCreateRecoversCleanly]
- * proves the intended `wipeAndRecreate()` mechanism (DROP every table, then create)
- * is sound — i.e. the defect is purely the create-before-version-check ordering.
  */
 class DriveMainIndexCreateOrderTest {
 
-    private val driver: SqlDriver = createRawInMemoryDriver()
-
-    @AfterTest
-    fun tearDown() {
-        driver.close()
-    }
-
+    /**
+     * Drives the **production open path**: `DatabaseManager({ driver })` is the exact
+     * constructor `DatabaseManager.initialize()` (and the existing OutboxTest /
+     * LocationPointWrapperTest) use. Opening it over a pre-`fileState` DriveMainIndex
+     * must yield a usable, current-schema database.
+     *
+     * RED until the create/version-check ordering is fixed: today the `init {}`
+     * block's `Schema.create()` throws `no such column: fileState` on the stale table
+     * before the version check can wipe it, so the constructor — and the app launch —
+     * crashes. This is the regression that reproduces on the iOS toolchain in CI.
+     */
     @Test
-    fun staleSchemaThrowsOnNewFileStateIndex() {
-        stageOldDriveMainIndex(driver)
+    fun databaseManagerOpensOverStaleSchema() {
+        val raw = createRawInMemoryDriver()
+        stageOldDriveMainIndex(raw)
 
-        // Reproduce the production launch path: apply the current schema over the
-        // pre-fileState DriveMainIndex. The new idx_unread_cover is the only new
-        // index over fileState (the old Idx*/idx_chatmessage names already exist,
-        // so their `IF NOT EXISTS` creates are no-ops and never re-check columns).
-        val error = assertFailsWith<Throwable> {
-            OdinDatabase.Schema.create(driver)
+        // Constructor runs the production init path. Must not crash; the DB must come
+        // up on the current v5 schema (fileState present), via wipe-and-recreate.
+        DatabaseManager({ raw }).use { dbm ->
+            val columns = queryStrings(
+                dbm.driver,
+                "PRAGMA table_info(DriveMainIndex)",
+                column = 1,
+            )
+            assertTrue(
+                columns.contains("fileState"),
+                "Opened DriveMainIndex should carry fileState (v5 schema), has: $columns",
+            )
+            val indexes = queryStrings(
+                dbm.driver,
+                "SELECT name FROM sqlite_master WHERE type = 'index'",
+                column = 0,
+            )
+            assertTrue(
+                indexes.contains("idx_unread_cover"),
+                "Opened schema should include idx_unread_cover, has: $indexes",
+            )
         }
-        val message = error.message ?: ""
-        assertTrue(
-            message.contains("no such column", ignoreCase = true) &&
-                message.contains("fileState"),
-            "Expected a 'no such column: fileState' compile error, got: $message",
-        )
     }
 
+    /**
+     * The intended recovery is sound: doing what `wipeAndRecreate()` does — DROP every
+     * table, THEN create — turns a stale pre-`fileState` DriveMainIndex into the clean
+     * v5 schema. Confirms the defect is purely the create-before-version-check ordering,
+     * not the schema or the wipe routine itself. Passes today.
+     */
     @Test
     fun dropBeforeCreateRecoversCleanly() {
-        stageOldDriveMainIndex(driver)
+        val raw = createRawInMemoryDriver()
+        stageOldDriveMainIndex(raw)
 
-        // What wipeAndRecreate() does: DROP every table first, THEN create. The DROP
-        // removes the stale DriveMainIndex (and its indexes) so the fresh CREATE TABLE
-        // builds the v5 shape with fileState before any index references it.
         DatabaseManager.TABLE_NAMES.forEach { table ->
-            driver.execute(null, "DROP TABLE IF EXISTS $table", 0)
+            raw.execute(null, "DROP TABLE IF EXISTS $table", 0)
         }
+        OdinDatabase.Schema.create(raw) // must not throw
 
-        // Must not throw.
-        OdinDatabase.Schema.create(driver)
-
-        val columns = queryStrings(driver, "PRAGMA table_info(DriveMainIndex)", column = 1)
+        val columns = queryStrings(raw, "PRAGMA table_info(DriveMainIndex)", column = 1)
         assertTrue(
             columns.contains("fileState"),
             "Recreated DriveMainIndex should carry fileState, has: $columns",
         )
-
         val indexes = queryStrings(
-            driver,
+            raw,
             "SELECT name FROM sqlite_master WHERE type = 'index'",
             column = 0,
         )
@@ -93,9 +105,9 @@ class DriveMainIndexCreateOrderTest {
             indexes.contains("idx_unread_cover"),
             "Recreated schema should include idx_unread_cover, has: $indexes",
         )
-        // Sanity: a fresh recreate leaves no rows behind.
-        val rowCount = queryStrings(driver, "SELECT COUNT(*) FROM DriveMainIndex", column = 0)
+        val rowCount = queryStrings(raw, "SELECT COUNT(*) FROM DriveMainIndex", column = 0)
         assertEquals(listOf("0"), rowCount, "Recreated DriveMainIndex should be empty")
+        raw.close()
     }
 
     /**

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/TestDatabaseHelper.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/TestDatabaseHelper.kt
@@ -7,3 +7,15 @@ import app.cash.sqldelight.db.SqlDriver
  * Platform-specific implementations provide appropriate SQLDelight drivers
  */
 expect fun createInMemoryDatabase(): SqlDriver
+
+/**
+ * Creates an in-memory SQLite driver with **no schema applied** — the caller is
+ * responsible for laying down whatever DDL the test needs. Unlike
+ * [createInMemoryDatabase], this does NOT run `OdinDatabase.Schema.create`, so a
+ * test can stage an *old* on-disk schema (e.g. a pre-`fileState` DriveMainIndex)
+ * and then exercise the production create / wipe-and-recreate path against it.
+ *
+ * Not supported on wasmJs (no SQLDelight test driver wired up there); the wasmJs
+ * actual throws, and any test using this is excluded from the wasmJs test job.
+ */
+expect fun createRawInMemoryDriver(): SqlDriver

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/TestDatabaseHelper.jvm.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/TestDatabaseHelper.jvm.kt
@@ -8,3 +8,7 @@ actual fun createInMemoryDatabase(): SqlDriver {
     OdinDatabase.Schema.create(driver)
     return driver
 }
+
+// Raw driver, no schema applied — the test stages its own DDL.
+actual fun createRawInMemoryDriver(): SqlDriver =
+    JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)

--- a/homebase-api/src/nativeTest/kotlin/id/homebase/api/sync/database/TestDatabaseHelper.native.kt
+++ b/homebase-api/src/nativeTest/kotlin/id/homebase/api/sync/database/TestDatabaseHelper.native.kt
@@ -1,6 +1,8 @@
 package id.homebase.api.sync.database
 
+import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlSchema
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
 
 actual fun createInMemoryDatabase(): SqlDriver {
@@ -9,3 +11,22 @@ actual fun createInMemoryDatabase(): SqlDriver {
         name = "test.db",
         onConfiguration = { config -> config.copy(name = null, inMemory = true) })
 }
+
+// NativeSqliteDriver requires a schema argument, but for a *raw* driver we want
+// no tables created — so hand it a no-op schema. The test then stages its own DDL.
+private object EmptySchema : SqlSchema<QueryResult.Value<Unit>> {
+    override val version: Long = 1
+    override fun create(driver: SqlDriver): QueryResult.Value<Unit> = QueryResult.Unit
+    override fun migrate(
+        driver: SqlDriver,
+        oldVersion: Long,
+        newVersion: Long,
+        vararg callbacks: app.cash.sqldelight.db.AfterVersion,
+    ): QueryResult.Value<Unit> = QueryResult.Unit
+}
+
+actual fun createRawInMemoryDriver(): SqlDriver =
+    NativeSqliteDriver(
+        schema = EmptySchema,
+        name = "rawtest.db",
+        onConfiguration = { config -> config.copy(name = null, inMemory = true) })

--- a/homebase-api/src/wasmJsTest/kotlin/id/homebase/api/sync/database/TestDatabaseHelper.web.kt
+++ b/homebase-api/src/wasmJsTest/kotlin/id/homebase/api/sync/database/TestDatabaseHelper.web.kt
@@ -15,3 +15,9 @@ actual fun createInMemoryDatabase(): SqlDriver =
             "If you reached this from a new wasmJs test, run it on JVM / native / Android instead, " +
             "or add a sql.js-based test driver actual to wasmJsTest.",
     )
+
+actual fun createRawInMemoryDriver(): SqlDriver =
+    error(
+        "createRawInMemoryDriver is not supported on wasmJs — no test driver is wired up. " +
+            "Tests using it run on JVM / native / Android and are excluded from the wasmJs job.",
+    )


### PR DESCRIPTION
Probe for the pre-existing K/N `linkDebugTestIosSimulatorArm64` crash on main (`Failed to build cache for ...klib/homebase-api`, `Lowering ReturnsInsertion: phases [Coroutines] not satisfied`). Disables static klib caching for the sim target. Branched off the test branch so a green compile also runs DriveMainIndexCreateOrderTest on iOS. Throwaway — will close.