### PR TITLE
Chat: detect own messages by null==self so updated messages stay "mine"

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -191,8 +191,11 @@ internal class MessageActionsHandler(
             if (it is MessageListContentModel.Message) it.message else null
         }
         val message = messages.firstOrNull { it.id == action.messageId } ?: return
+        // isFromActiveUser (null == self), NOT a strict originalAuthor compare: an own message that
+        // was updated + re-synced (e.g. a location live-share PATCH) comes back with originalAuthor
+        // null, which a strict compare reads as "not mine" — wrongly hiding "delete for everyone".
         val isCurrentUserMessage =
-            message.originalAuthor?.domainName == uiState.value.ownerSession?.odinId?.domainName
+            message.isFromActiveUser(uiState.value.ownerSession?.odinId)
         val isWithSelf =
             message.conversationId == ChatProtocol.ConversationWithYourselfId
         uiState.update {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageItem.kt
@@ -59,7 +59,13 @@ fun MessageItem(
 
     // Live-location controls for the location bubble (ignored by non-location media). State (LIVE/
     // ENDED) is read from the message descriptor in the bubble; this only carries side + actions.
-    val sentByYou = message.isAuthoredBy(odinId)
+    //
+    // isFromActiveUser (null == self), NOT isAuthoredBy (strict): the server doesn't stamp
+    // originalAuthor on own messages, so after an own message is updated+re-synced (e.g. starting a
+    // live-location share PATCHes the message, then it syncs back) originalAuthor comes back null.
+    // The strict check then mis-rendered an own message as received (left-aligned, "delete for me"
+    // only, no edit). The conversation list already uses isFromActiveUser for this exact reason.
+    val sentByYou = message.isFromActiveUser(odinId)
     val liveLocationControls = remember(message.id, sentByYou) {
         LiveLocationBubbleControls(
             sentByYou = sentByYou,
@@ -136,7 +142,7 @@ fun MessageItem(
     val onReport =
         remember(message.id) { { onUiAction(ConversationListUiAction.ReportContent) } }
 
-    if (message.isAuthoredBy(odinId)) {
+    if (sentByYou) {
         val onEdit = if (policy.allowEdit) {
             remember(message.id) {
                 {


### PR DESCRIPTION
## Symptom

A sent **location** message rendered as if it were *received* on the sender's own device — left/"centered", and the long-press menu offered **"delete for me" only** (no "delete for everyone", no edit).

## Root cause

The server doesn't stamp `originalAuthor` on own messages, so an own message that's **updated and re-synced** comes back with `originalAuthor == null` — this is documented on `MessageUiModel.isFromActiveUser` (*"null author == self"*).

- At **send**, the optimistic write stamps `originalAuthor = self` → correct (verified in a device log: `isAuthoredBy(self)=true`).
- **Starting a live-location share** PATCHes the message (`updateMessage`), which **re-syncs** the file via WSPush; the synced header has `originalAuthor == null`.
- The bubble used the **strict** `isAuthoredBy` (`null != self`) for the sent/received branch (`MessageItem`), and the delete dialog used a strict `originalAuthor` compare (`MessageActionsHandler`) — so the own message was now classified as received.

Normal text messages never hit this (they're never updated). Location is the first kind the **owner updates**, so it's the first to expose the latent bug. An edited own text message would hit the same path.

## Fix

Use `isFromActiveUser` (`null == self`) for:
- the bubble's sent/received branch + live-controls `sentByYou` (`MessageItem`)
- the delete dialog's "delete for everyone" gate (`MessageActionsHandler`)

This matches what the conversation list already does (`ConversationStream`, `ConversationMessageBump`). Status/system messages are unaffected — they render via a separate `MessagesSystemMessage` path, not `MessageItem`.

## Test
- `:homebase-chat:compileKotlinJvm` + `:homebase-chat:compileAndroidMain` green
- Needs on-device confirm: send a location → it's right-aligned with "delete for everyone"; **start a live share** → it stays right-aligned and keeps "delete for everyone" (previously flipped to received style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)