### PR TITLE
Show initials for self avatar in share picker (#793)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationEnricher.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationEnricher.kt
@@ -3,6 +3,7 @@ package id.homebase.chat.services.convo
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.auth.OwnerSession
+import id.homebase.api.client.auth.initials
 import id.homebase.api.client.connections.ConnectionStatus
 import id.homebase.api.client.drives.upload.EmbeddedThumb
 import id.homebase.api.client.connections.RedactedIdentityConnectionRegistration
@@ -119,10 +120,13 @@ class ConversationEnricher {
 internal fun ConversationUiModel.withOwnerProfileAvatar(
     ownerSession: OwnerSession,
 ): ConversationUiModel {
-    val previewContent = ownerSession.profileImagePreviewThumbnail?.takeIf { it.isNotBlank() }
-        ?: return this
-
     if (avatarModel.type != ConversationAvatarModel.Type.Owner) return this
+
+    // Owner's /pub/image is empty: without initials a missing/late photo shows blank.
+    val withInitials = copy(avatarModel = avatarModel.copy(initials = ownerSession.initials()))
+
+    val previewContent = ownerSession.profileImagePreviewThumbnail?.takeIf { it.isNotBlank() }
+        ?: return withInitials
 
     val ownerImageData = HomebaseImageData(
         driveId = Uuid.NIL,
@@ -139,5 +143,7 @@ internal fun ConversationUiModel.withOwnerProfileAvatar(
         keyHeader = KeyHeader.newRandom16(),
     )
 
-    return copy(avatarModel = avatarModel.copy(imageData = ownerImageData))
+    return withInitials.copy(
+        avatarModel = withInitials.avatarModel.copy(imageData = ownerImageData)
+    )
 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationEnricherTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationEnricherTest.kt
@@ -55,6 +55,15 @@ class ConversationEnricherTest {
         isGroup = false,
     )
 
+    private fun selfOwnerConvo() = oneOnOneConvo().copy(
+        id = ChatProtocol.ConversationWithYourselfId,
+        participants = listOf(me),
+        avatarModel = ConversationAvatarModel(
+            type = ConversationAvatarModel.Type.Owner,
+            odinId = me,
+        ),
+    )
+
     @Test
     fun enrich_withSelf_returnsEmptyParticipants() {
         val enricher = ConversationEnricher()
@@ -73,5 +82,22 @@ class ConversationEnricherTest {
         assertTrue(result.participants.isEmpty())
         assertTrue(result.missingConnections.isEmpty())
         assertEquals(null, result.oneOnOneConnectionStatus)
+    }
+
+    @Test
+    fun enrich_withSelf_ownerAvatar_alwaysHasInitials_whenNoProfileImage() {
+        // Regression for #793: with no preview image, the Owner avatar must
+        // still carry initials so it degrades to initials instead of a blank
+        // placeholder (the owner's /pub/image is empty).
+        val enricher = ConversationEnricher()
+
+        val result = enricher.enrich(
+            convo = selfOwnerConvo(),
+            contactMap = emptyMap(),
+            ownerSession = session.copy(profileImagePreviewThumbnail = null),
+        )
+
+        assertEquals("O", result.conversation.avatarModel.initials)
+        assertEquals(null, result.conversation.avatarModel.imageData)
     }
 }


### PR DESCRIPTION
Fixes #793

## Problem
On Android, the self ("note to self") entry in the share recipient picker shows a blank placeholder while every other contact renders. The note-to-self `Owner` avatar is built with no `initials` and no image; when the owner's profile photo isn't loaded (cold-start synthesized `OwnerSession` with `profileImagePreviewThumbnail = null`) or absent, it falls through `OwnerAvatar` → `PublicAvatar` → the owner's own `/pub/image` (empty) → `FallbackAvatar(initials = null)` → blank gray Person icon.

## Fix
`ConversationEnricher.withOwnerProfileAvatar` now **always** sets `initials` (via the existing `OwnerSession.initials()`) on the Owner avatar, then attaches the preview image when available. A missing/late photo now degrades to initials instead of a blank placeholder, and updates to the real photo once the live `OwnerSession` loads (the picker re-enriches when `ownerSession` emits).

One-line change in the enricher; no render-path change (the `PublicAvatar` error path already reached `FallbackAvatar`, it just had no initials).

## Test
Added `enrich_withSelf_ownerAvatar_alwaysHasInitials_whenNoProfileImage` to `ConversationEnricherTest` — asserts the Owner avatar gets initials with a null preview. `:homebase-chat:jvmTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)