### PR TITLE
Clear stuck video preload overlay on failure (#788)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPreloader.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPreloader.kt
@@ -59,14 +59,16 @@ class VideoPreloader(
             try {
                 val metadata = try {
                     resolveVideoMetadata(data, driveFileProvider)
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     Logger.d(tag = "VideoIO") { "preload skipped — no metadata for ${data.fileId}/${data.payloadKey}: ${e.message}" }
-                    return@withLock
+                    null
                 }
 
-                if (metadata.isSegmented) {
+                if (metadata?.isSegmented == true) {
                     preloadFirstHlsSegment(data, metadata, emit)
-                } else {
+                } else if (metadata != null) {
                     driveFileProvider.prefetchPayload(
                         driveId = data.driveId,
                         fileId = data.fileId,
@@ -75,12 +77,14 @@ class VideoPreloader(
                     )
                     Logger.d(tag = "VideoIO") { "preload complete (mp4, encrypted cache): ${data.fileId}/${data.payloadKey}" }
                 }
-                emit(1f)
             } catch (e: kotlinx.coroutines.CancellationException) {
                 throw e
             } catch (e: Exception) {
                 Logger.w(tag = "VideoIO") { "preload failed for ${data.fileId}/${data.payloadKey}: ${e.message}" }
             }
+            // Settle progress to done on every non-cancellation exit (metadata-miss,
+            // mp4 stall, hls throw) so the bubble overlay can't freeze (#788).
+            emit(1f)
         }
     }
 

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/video/FakeVideoPrefetchDriveAccess.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/video/FakeVideoPrefetchDriveAccess.kt
@@ -14,6 +14,7 @@ import kotlin.uuid.Uuid
 class FakeVideoPrefetchDriveAccess(
     private val getPayloadResponses: Map<String, String> = emptyMap(),
     private val prefetchDelayMs: Long = 0L,
+    private val prefetchError: Throwable? = null,
 ) : VideoPrefetchDriveAccess {
 
     sealed interface Call {
@@ -46,6 +47,7 @@ class FakeVideoPrefetchDriveAccess(
     ) {
         if (prefetchDelayMs > 0) delay(prefetchDelayMs)
         _calls.add(Call.PrefetchPayload(driveId, fileId, key))
+        prefetchError?.let { onDownloadProgress?.invoke(0.8f); throw it }
     }
 
     override suspend fun prefetchPayloadChunk(

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/video/VideoPreloaderTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/video/VideoPreloaderTest.kt
@@ -162,4 +162,40 @@ class VideoPreloaderTest {
         val prefetchChunkCalls = fake.calls.filterIsInstance<FakeVideoPrefetchDriveAccess.Call.PrefetchPayloadChunk>()
         assertEquals(2, prefetchChunkCalls.size, "concurrent preloads serialize — both run (calls=${fake.calls})")
     }
+
+    // -- #788: the MP4 download throws partway (reports 0.8 then fails). Progress must still
+    //    settle to 1f so the bubble overlay clears instead of freezing at ~80%.
+    @Test
+    fun mp4PrefetchThrows_progressStillSettlesTo1f() = runTest {
+        val stub = VideoMetadata(
+            mimeType = "video/mp4",
+            isDescriptorContentComplete = true,
+            isSegmented = false,
+            key = metadataKey,
+        )
+        val fake = FakeVideoPrefetchDriveAccess(prefetchError = RuntimeException("network died"))
+        val preloader = newPreloader(fake)
+
+        preloader.preload(playerData(stub))
+
+        assertEquals(1f, preloader.progressFlow(fileId, payloadKey).value)
+    }
+
+    // -- #788: metadata resolution fails (incomplete stub, no metadata payload). Progress must
+    //    settle to 1f so the bubble overlay clears instead of freezing at 0%.
+    @Test
+    fun metadataMiss_progressStillSettlesTo1f() = runTest {
+        val stub = VideoMetadata(
+            mimeType = "video/mp4",
+            isDescriptorContentComplete = false,
+            isSegmented = true,
+            key = metadataKey,
+        )
+        val fake = FakeVideoPrefetchDriveAccess()
+        val preloader = newPreloader(fake)
+
+        preloader.preload(playerData(stub))
+
+        assertEquals(1f, preloader.progressFlow(fileId, payloadKey).value)
+    }
 }


### PR DESCRIPTION
Fixes #788

## Problem
A preload progress overlay stays stuck over chat-bubble videos — MP4 frozen at ~80%, HLS at 0% — and never clears.

`VideoPreloader.preload()` emitted progress `1f` **only on the success path**. The bubble overlay (`MediaItem.kt`, `onPreloading(p < 1f)`) hides only when progress reaches exactly `1f`, so any path that skipped `emit(1f)` left it frozen:
- **Metadata-miss** → `return@withLock` skipped `emit(1f)` (HLS 0%).
- **Mid-download throw** (caught) → skipped `emit(1f)`; the last incremental MP4 value (~0.8) stuck.

## Fix
Settle progress to `1f` on **every non-cancellation exit**:
- Metadata resolution failure now yields `null` and falls through (instead of early-returning), with `CancellationException` rethrown.
- A single trailing `emit(1f)` runs after the try/catch — reached on success *and* caught failures, skipped on cancellation (which rethrows past it, so a shared in-flight progress flow isn't falsely marked done).
- Genuine failures stay logged (`Logger.d`/`Logger.w`) — the overlay clearing reveals the thumbnail + play button rather than hiding a frozen spinner.

commonMain, so all platforms benefit.

## Tests
`FakeVideoPrefetchDriveAccess` gains a `prefetchError` hook. Two regression tests assert the progress flow ends at `1f`:
- `mp4PrefetchThrows_progressStillSettlesTo1f` (reports 0.8 then throws)
- `metadataMiss_progressStillSettlesTo1f`

`:homebase-api:jvmTest --tests VideoPreloaderTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)