### PR TITLE
Remove background-remover & send-as-sticker buttons from the attachment editor

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
@@ -360,14 +360,6 @@ fun ConversationMessagesPane(
                                     )
                                 )
                             },
-                            onRemoveBackground = { conversationId, attachmentId ->
-                                onUiAction(
-                                    id.homebase.chat.conversationlist.ConversationListUiAction.RemoveBackgroundAttachment(
-                                        conversationId,
-                                        attachmentId,
-                                    )
-                                )
-                            },
                             onTrimChange = { conversationId, attachmentId, startMs, endMs ->
                                 onUiAction(
                                     id.homebase.chat.conversationlist.ConversationListUiAction.ApplyTrimResult(
@@ -375,14 +367,6 @@ fun ConversationMessagesPane(
                                         attachmentId,
                                         startMs,
                                         endMs,
-                                    )
-                                )
-                            },
-                            onToggleSticker = { conversationId, attachmentId ->
-                                onUiAction(
-                                    id.homebase.chat.conversationlist.ConversationListUiAction.ToggleStickerAttachment(
-                                        conversationId,
-                                        attachmentId,
                                     )
                                 )
                             },

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenAttachmentEditor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenAttachmentEditor.kt
@@ -25,21 +25,17 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Crop
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Draw
-import androidx.compose.material.icons.filled.AutoFixHigh
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PhotoCamera
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.PlayCircle
 import androidx.compose.material.icons.filled.UploadFile
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilledIconToggleButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
@@ -59,8 +55,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import coil3.ImageLoader
 import coil3.compose.AsyncImage
@@ -69,7 +63,6 @@ import id.homebase.api.video.IndexedFrame
 import id.homebase.api.video.VideoThumbnailService
 import id.homebase.chat.conversationlist.AttachmentPendingFile
 import id.homebase.chat.conversationlist.FullScreenOverlay
-import id.homebase.chat.services.image.isBackgroundRemovalSupported
 import id.homebase.chat.widget.video.TrimDurationLabel
 import id.homebase.chat.widget.video.TrimmableVideoPlayerSurface
 import id.homebase.chat.widget.video.VideoTrimScrubber
@@ -79,13 +72,10 @@ import id.homebase.resources.cd_gallery_thumbnail
 import id.homebase.resources.cd_image_attachment
 import id.homebase.resources.cd_pause_video
 import id.homebase.resources.cd_play_video
-import id.homebase.resources.cd_send_as_sticker
 import id.homebase.resources.cd_send_to
 import id.homebase.resources.cd_video_thumbnail
 import id.homebase.resources.chat_message_add_gallery_image
 import id.homebase.resources.chat_message_remove_gallery_image
-import id.homebase.resources.chat_remove_background
-import id.homebase.resources.chat_removing_background
 import id.homebase.resources.crop
 import id.homebase.resources.draw
 import id.homebase.resources.menu_back
@@ -113,9 +103,7 @@ fun FullScreenAttachmentEditor(
     onDismiss: () -> Unit,
     onCropImage: (conversationId: Uuid, attachmentId: Uuid) -> Unit = { _, _ -> },
     onDrawImage: (conversationId: Uuid, attachmentId: Uuid) -> Unit = { _, _ -> },
-    onRemoveBackground: (conversationId: Uuid, attachmentId: Uuid) -> Unit = { _, _ -> },
     onTrimChange: (conversationId: Uuid, attachmentId: Uuid, startMs: Long?, endMs: Long?) -> Unit = { _, _, _, _ -> },
-    onToggleSticker: (conversationId: Uuid, attachmentId: Uuid) -> Unit = { _, _ -> },
 ) {
     val isFileMode = data.attachments.all { it is AttachmentPendingFile.File }
     val imageLoader: ImageLoader = koinInject()
@@ -507,10 +495,6 @@ fun FullScreenAttachmentEditor(
         // attachment — crop (image only), download. Future tools (filters,
         // markup) would join this row.
         val currentAttachment = data.attachments.getOrNull(pagerState.currentPage)
-        // Capability probe is a cheap, constant per-platform check (GMS present on
-        // Android, true on iOS, false on Desktop/Web); hold it so the tool button
-        // shows no dead control where removeBackground always returns null.
-        val backgroundRemovalSupported = remember { isBackgroundRemovalSupported() }
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -541,57 +525,6 @@ fun FullScreenAttachmentEditor(
                     Icon(
                         imageVector = Icons.Default.Draw,
                         contentDescription = stringResource(MR.string.draw),
-                    )
-                }
-                // Background remover — hidden on platforms where the on-device
-                // segmenter is unavailable (Desktop/Web) so there's no dead control.
-                if (backgroundRemovalSupported) {
-                    // Per-attachment so the spinner follows this image across pager swipes.
-                    val isRemovingBackground =
-                        currentAttachment.attachmentId in data.processingAttachmentIds
-                    IconButton(
-                        onClick = { onRemoveBackground(data.conversationId, currentAttachment.attachmentId) },
-                        enabled = !isRemovingBackground,
-                        colors = IconButtonDefaults.iconButtonColors(
-                            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest
-                        )
-                    ) {
-                        if (isRemovingBackground) {
-                            // First call can take ~1s (model download / warm-up); a spinner
-                            // keeps the wand from reading as a dead button.
-                            val removingDescription =
-                                stringResource(MR.string.chat_removing_background)
-                            CircularProgressIndicator(
-                                modifier = Modifier
-                                    .size(20.dp)
-                                    .semantics { contentDescription = removingDescription },
-                                strokeWidth = 2.dp,
-                            )
-                        } else {
-                            Icon(
-                                imageVector = Icons.Default.AutoFixHigh,
-                                contentDescription = stringResource(MR.string.chat_remove_background),
-                            )
-                        }
-                    }
-                }
-                // Send-as-sticker: render this image as a bare transparent cut-out
-                // (no rounded-card bubble) on the receiver. Always available — the
-                // source-of-truth is the per-image forceSticker flag on the model, so
-                // the checked state survives page swipes in the pager.
-                val isSticker = when (currentAttachment) {
-                    is AttachmentPendingFile.FileImage -> currentAttachment.forceSticker
-                    is AttachmentPendingFile.Gallery -> currentAttachment.forceSticker
-                }
-                FilledIconToggleButton(
-                    checked = isSticker,
-                    onCheckedChange = {
-                        onToggleSticker(data.conversationId, currentAttachment.attachmentId)
-                    },
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.AutoAwesome,
-                        contentDescription = stringResource(MR.string.cd_send_as_sticker),
                     )
                 }
             }


### PR DESCRIPTION
## What

Removes two buttons from `FullScreenAttachmentEditor`'s edit-tools row:

- **Remove background** (wand / `AutoFixHigh`)
- **Send as sticker** (sparkle / `AutoAwesome`)

The UX was confusing, and the sparkle icon collided visually with the Moments app icon. **Crop, draw, and download remain.**

## Why

Both were extra affordances on every shared/attached image with non-obvious behaviour. The send-as-sticker sparkle in particular reads as "Moments" to users.

## Scope of the change

- Drops the two buttons + the `backgroundRemovalSupported` capability probe from the editor.
- Removes the now-unused `onRemoveBackground` / `onToggleSticker` composable params and their call-site wiring in `ConversationMessagesPane`.
- Removes the now-unused imports (ktlint would flag them).

Left intentionally in place (not user-reachable from this UI anymore, low-risk to keep, avoids touching the send pipeline): the `forceSticker` flag on `FileImage`/`Gallery` and the `RemoveBackgroundAttachment` / `ToggleStickerAttachment` actions + their ViewModel handlers. `forceSticker` defaults to `false`, so images now always send as normal images from this editor.

## Testing

- ✅ `:homebase-chat:compileKotlinJvm` + `:androidApp:compileDebugKotlin` pass.
- ✅ Konsist `ArchitectureTest` passes (no new `Text("…")` literals — pure deletion).

Pure deletion: **83 lines removed, 0 added.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)