### PR TITLE
Live share: prompt to set up location when it can't capture GPS

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -76,6 +76,9 @@ import id.homebase.resources.cancel
 import id.homebase.resources.chat_delete
 import id.homebase.resources.chat_delete_conversation_title
 import id.homebase.resources.chat_message_delete_dialog_title
+import id.homebase.resources.live_share_enable_location_body
+import id.homebase.resources.live_share_enable_location_cta
+import id.homebase.resources.live_share_enable_location_title
 import id.homebase.resources.chat_message_delete_for_everyone
 import id.homebase.resources.chat_message_delete_for_me
 import id.homebase.resources.chat_message_discard_draft
@@ -118,6 +121,7 @@ fun ConversationListScreen(
     onNavigateToSettingsScreen: () -> Unit,
     onNavigateToNewConversation: () -> Unit,
     onNavigateToLiveLocationMap: () -> Unit = {},
+    onNavigateToLocationSetup: () -> Unit = {},
     onNavigateToContactInfo: (odinId: String) -> Unit,
     onNavigateToConversationSettings: (conversationId: String) -> Unit,
     onNavigateToGroupSettings: (conversationId: String) -> Unit,
@@ -183,6 +187,11 @@ fun ConversationListScreen(
             is ConversationListUiEvent.NavigateToLiveLocationMap -> {
                 viewModel.eventConsumed()
                 onNavigateToLiveLocationMap()
+            }
+
+            is ConversationListUiEvent.NavigateToLocationSetup -> {
+                viewModel.eventConsumed()
+                onNavigateToLocationSetup()
             }
 
             is ConversationListUiEvent.NavigateToContactInfo -> {
@@ -331,6 +340,27 @@ fun ConversationListScreen(
                     DialogTitle(
                         text = stringResource(MR.string.chat_message_delete_dialog_title),
                     )
+                }
+            }
+        }
+
+        is ConversationListUiDialog.EnableLocationForShare -> {
+            Dialog(onDismissRequest = { viewModel.dialogClosed() }) {
+                DialogCard(
+                    buttons = {
+                        DialogButtons(
+                            primaryText = stringResource(MR.string.live_share_enable_location_cta),
+                            onPrimaryClick = {
+                                viewModel.onAction(ConversationListUiAction.OpenLocationSetup)
+                                viewModel.dialogClosed()
+                            },
+                            tertiaryText = stringResource(MR.string.cancel),
+                            onTertiaryClick = { viewModel.dialogClosed() },
+                            showButtonsVertically = true,
+                        )
+                    }) {
+                    DialogTitle(text = stringResource(MR.string.live_share_enable_location_title))
+                    DialogText(text = stringResource(MR.string.live_share_enable_location_body))
                 }
             }
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
@@ -360,5 +360,9 @@ sealed interface ConversationListUiAction {
     /** Open the Live Location map (tap a live location bubble's map). */
     data object OpenLiveLocationMap : ConversationListUiAction
 
+    /** Open the location setup screen — from the "set up location" prompt shown when a live share
+     *  can't start because location isn't ready. */
+    data object OpenLocationSetup : ConversationListUiAction
+
     // endregion
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiDialog.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiDialog.kt
@@ -11,6 +11,10 @@ sealed interface ConversationListUiDialog {
 
     data class DeleteConversation(val conversationId: Uuid) : ConversationListUiDialog
 
+    /** Shown when the user tries to start a live-location share but location isn't set up to capture
+     *  GPS (add-on not activated or permission not granted). Offers to open the location setup screen. */
+    data object EnableLocationForShare : ConversationListUiDialog
+
     /** Surfaced when a preflight check before [IntroductionSender.sendIntroductions]
      *  reports any recipient as non-Ready. The user picks one of three outcomes:
      *  send anyway with the original list, send only to the Ready subset, or cancel.

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiEvent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiEvent.kt
@@ -34,4 +34,7 @@ sealed interface ConversationListUiEvent {
 
     /** Open the Live Location map (from tapping a live location bubble's map). */
     data object NavigateToLiveLocationMap : ConversationListUiEvent
+
+    /** Open the location setup screen (from the "set up location" prompt before a live share). */
+    data object NavigateToLocationSetup : ConversationListUiEvent
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -147,6 +147,7 @@ class ConversationListViewModel(
     private val stickerService: id.homebase.chat.services.sticker.StickerService,
     private val stickerPermissionViewModel: ExtendPermissionViewModel,
     private val liveLocationShareService: id.homebase.chat.services.livelocation.LiveLocationShareService,
+    private val liveShareReadiness: id.homebase.chat.services.livelocation.LiveShareReadiness,
 ) : ViewModel() {
 
     companion object {
@@ -841,12 +842,23 @@ class ConversationListViewModel(
                 sendEvent(ConversationListUiEvent.NavigateToLiveLocationMap)
             }
 
+            is ConversationListUiAction.OpenLocationSetup -> {
+                sendEvent(ConversationListUiEvent.NavigateToLocationSetup)
+            }
+
             // Live share has two linked halves: the synced *declaration* (the message's
             // liveShareUntilMs header descriptor — Location is a raw-header typed kind, so
             // updateMessage(content = descriptorJson) sets it and syncs to both sides) AND the local
             // *relay* roster that actually streams GPS. Both use the SAME absolute end-time so stop can
             // later remove exactly this share's {recipient, end-time} roster entries.
             is ConversationListUiAction.StartLiveLocationShare -> viewModelScope.launch {
+                // Guard: a live share is pointless if location can't actually capture GPS (add-on not
+                // set up / permission not granted) — prompt the user to set it up instead of silently
+                // broadcasting nothing.
+                if (!liveShareReadiness.isReady()) {
+                    _uiState.update { it.copy(uiDialog = ConversationListUiDialog.EnableLocationForShare) }
+                    return@launch
+                }
                 val untilMs = Clock.System.now().toEpochMilliseconds() + action.durationMs
                 val msg = chatMessageStream.getMessage(action.messageId) ?: return@launch
                 val recipients = conversationStream.getRecipients(msg.conversationId, emptyList(), null)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/livelocation/LiveShareReadiness.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/livelocation/LiveShareReadiness.kt
@@ -1,0 +1,14 @@
+package id.homebase.chat.services.livelocation
+
+/**
+ * Whether the current identity can actually start a live-location share — i.e. a share would capture
+ * and relay GPS rather than silently send nothing.
+ *
+ * Implemented in homebase-core (where the location add-on's `locationLabeledDrive` lives) and injected
+ * into the chat layer: `ConversationListViewModel` can't reach homebase-core, so this thin seam lets it
+ * gate "Share live location" on the location feature being set up + location permission granted, and
+ * otherwise prompt the user to set it up first.
+ */
+fun interface LiveShareReadiness {
+    suspend fun isReady(): Boolean
+}

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1319,6 +1319,9 @@
     <string name="live_share_1h">1 hour</string>
     <string name="live_share_2h">2 hours</string>
     <string name="live_share_4h">4 hours</string>
+    <string name="live_share_enable_location_title">Turn on location to share</string>
+    <string name="live_share_enable_location_body">To share your live location, set up location on this device first so it can send your position.</string>
+    <string name="live_share_enable_location_cta">Set up location</string>
     <string name="location_history_empty">No locations recorded on this day</string>
     <string name="location_history_map_disclosure">Map tiles are fetched from OpenStreetMap — the viewed area becomes visible to their servers.</string>
     <string name="location_history_previous_day">Previous day</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -35,6 +35,10 @@ import id.homebase.chat.messageinfo.MessageInfoViewModel
 import id.homebase.chat.selectmembers.SelectMembersViewModel
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.chat.services.livelocation.LiveLocationShareService
+import id.homebase.chat.services.livelocation.LiveShareReadiness
+import id.homebase.core.config.locationLabeledDrive
+import id.homebase.core.permissions.PermissionsManager
+import id.homebase.core.permissions.PermissionType
 import id.homebase.core.ui.screens.location.livelocation.LiveLocationReceiveStore
 import id.homebase.chat.services.ChatMessageActionService
 import id.homebase.chat.services.ChatMessageSenderService
@@ -247,6 +251,16 @@ val appModule = module {
         )
     }
     single { LiveLocationReceiveStore(eventBus = get(), scope = get()) }
+    // Readiness gate for "Share live location": activated add-on + location permission, so the chat
+    // layer can prompt to set up location instead of starting a share that captures nothing.
+    single<LiveShareReadiness> {
+        val activation = get<OptionalDriveActivation>()
+        val permissions = get<PermissionsManager>()
+        LiveShareReadiness {
+            activation.isActivated(locationLabeledDrive) &&
+                permissions.isPermissionGranted(PermissionType.LOCATION)
+        }
+    }
     single<LocationTracker> { createLocationTracker(get<LocationPointStore>()) }
     single {
         LocationTrackUploaderService(
@@ -684,6 +698,7 @@ val appModule = module {
             stickerService = get(),
             stickerPermissionViewModel = get(StickerPermissionQualifier),
             liveLocationShareService = get(),
+            liveShareReadiness = get(),
         )
     }
     viewModelOf(::ArchivedConversationsViewModel)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -885,6 +885,10 @@ fun AppNavHost(
                                     onNavigateToLiveLocationMap = {
                                         navController.navigate(Route.LocationLive)
                                     },
+                                    // Reuse the same entry the Location nav icon uses: onboarding when
+                                    // the add-on isn't activated, else the dashboard (which requests
+                                    // permission) — covers both "not set up" gate-fail cases.
+                                    onNavigateToLocationSetup = openLocation,
                                     onNavigateToContactInfo = {
                                         navController.navigate(Route.ContactInfo(it))
                                     },


### PR DESCRIPTION
## Problem
Tapping a location bubble's **Share live location** → picking a duration started a live share even when the sender's location wasn't set up — so it silently captured/relayed nothing and the recipient's map stayed empty.

## Fix
The `StartLiveLocationShare` handler now checks readiness first. If not ready, it shows an explanatory dialog ("Set up location") **instead of** starting a dead share:
- **Primary "Set up location"** → reuses `AppNavHost.openLocation` (→ onboarding when the add-on isn't activated, else the dashboard, which requests permission). Covers both gate-fail cases.
- **Cancel** → dismisses; no share starts.

**Readiness** = location add-on **activated** AND **foreground location permission** granted (`!isActivated || !permission` → prompt). The master tracking switch is intentionally *not* in the gate — starting a share arms GPS itself, so permission + activation is what actually matters.

## Module-boundary note
`ConversationListViewModel` (homebase-chat) can't import homebase-core (where `locationLabeledDrive` lives), so the check is a tiny `LiveShareReadiness` fun-interface in homebase-chat, **implemented in homebase-core's `AppModule`** (`OptionalDriveActivation.isActivated(locationLabeledDrive) && PermissionsManager.isPermissionGranted(LOCATION)`) and injected into the VM.

## Static "share location" — unchanged
That sibling only needs the foreground "while using" permission for a one-off fix, and `LocationLauncher` already requests it inline and snackbars on `PermissionDenied`/`Unavailable` (`ConversationContent.kt`). No change.

## Out of scope (noted)
- Auto-resuming the pending share after setup (v1: user re-taps Share).
- Prompting on the first tap (before the duration menu) — needs readiness plumbed into the bubble; the handler-time check is simpler and always reads fresh permission.
- Background/ALWAYS-permission gating — the setup screen handles escalation.

## Test
- `:homebase-chat:compileKotlinJvm` + `:homebase-core:compileKotlinJvm` + both `compileAndroidMain` green; Konsist green.
- Device, location not set up: Share live location → pick duration → dialog appears → "Set up location" opens onboarding/dashboard; Cancel → no share. Location set up + permission: starts immediately, no dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)