### PR TITLE
Feed: fetch followed-post media over peer by globalTransitId (WIP)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProvider.kt
@@ -20,8 +20,18 @@ import kotlin.uuid.Uuid
  * case).
  *
  * Routes mirror dotyoucore-js `get{Payload,Thumb}BytesOverPeerByGlobalTransitId`:
- * `/transit/query/{payload,thumb}_byglobaltransitid` with the peer + drive (alias+type) + gtid as
- * query params (NOT the `/peer/.../files/...` path form, which only exposes `exists` by gtid).
+ * `/api/apps/v1/transit/query/{payload,thumb}_byglobaltransitid` (PeerQueryControllerBase) with the
+ * peer + drive (alias+type) + gtid as query params.
+ *
+ * KNOWN LIMITATION (verified against the odin backend): these `*_byglobaltransitid` endpoints live
+ * ONLY under the classic App/Owner/Guest API v1 surface, which authenticates a classic app
+ * ClientAuthToken (cookie). chat-kmp logs in via the unified v2 API and sends a v2 bearer token, so
+ * these v1 routes reject it with 401. The unified v2 peer surface exposes payload/thumb over peer
+ * ONLY by **fileId** (`/api/v2/peer/{odinId}/drives/{driveId}/files/{fileId}/payload/{key}[/thumb]`,
+ * V2DrivePeerFileReadonlyController) — never by gtid (v2 by-gtid is `exists` only). So the v2-native
+ * path is: resolve gtid→author-fileId via an over-peer query-batch (FileQueryParams.globalTransitId
+ * filter, supported), then fetch payload/thumb by that fileId. TODO: implement that resolve step;
+ * until then followed-post media falls back to the embedded preview thumbnail (no regression).
  */
 class PeerFileByGlobalTransitProvider(
     httpClient: HttpClient,
@@ -41,7 +51,7 @@ class PeerFileByGlobalTransitProvider(
         val creds = requireCreds()
         val query = "odinId=$peer&alias=$driveAlias&type=$driveType" +
             "&globalTransitId=$globalTransitId&key=$payloadKey"
-        val url = apiUrl(creds.domain, "/transit/query/payload_byglobaltransitid?$query")
+        val url = transitQueryUrl(creds.domain, "payload_byglobaltransitid", query)
         Logger.i(tag = TAG) {
             "getPayload: GET peer=${peer.domainName} alias=$driveAlias gtid=$globalTransitId key=$payloadKey"
         }
@@ -62,14 +72,21 @@ class PeerFileByGlobalTransitProvider(
         require(width > 0 && height > 0) { "width/height must be positive" }
         val creds = requireCreds()
         val query = "odinId=$peer&alias=$driveAlias&type=$driveType" +
-            "&globalTransitId=$globalTransitId&payloadKey=$payloadKey&width=$width&height=$height"
-        val url = apiUrl(creds.domain, "/transit/query/thumb_byglobaltransitid?$query")
+            "&globalTransitId=$globalTransitId&payloadKey=$payloadKey" +
+            "&width=$width&height=$height&directMatchOnly=false"
+        val url = transitQueryUrl(creds.domain, "thumb_byglobaltransitid", query)
         Logger.i(tag = TAG) {
             "getThumb: GET peer=${peer.domainName} alias=$driveAlias gtid=$globalTransitId " +
                 "key=$payloadKey ${width}x$height"
         }
         return fetchAndDecrypt(url)
     }
+
+    // PeerQueryControllerBase routes the *_byglobaltransitid endpoints under the App API v1
+    // transit/query path. The unified /api/v2 peer surface only exposes `exists` by gtid (no
+    // payload/thumb), so [apiUrl]'s /api/v2 base 404s here — build the App-API-v1 URL directly.
+    private fun transitQueryUrl(domain: OdinId, endpoint: String, query: String): String =
+        "https://$domain/api/apps/v1/transit/query/$endpoint?$query"
 
     private suspend fun fetchAndDecrypt(url: String): BytesResponse? {
         val creds = requireCreds()

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProvider.kt
@@ -12,20 +12,16 @@ import io.ktor.client.request.get
 import kotlin.uuid.Uuid
 
 /**
- * Reads a payload (or its thumbnail) of a file that lives on a **followed identity's** drive,
- * addressed by [globalTransitId]. The user's own host ([requireCreds]`.domain`) brokers the read
- * to the peer server-side and re-encrypts the response under the caller's shared secret, so the
- * decode/decrypt path is identical to a local read (it reuses [DriveFileProvider.decryptBytes],
- * which returns plaintext bytes untouched when the server marks the payload `payloadencrypted=false`
- * — the public-feed case).
+ * Reads a payload (or its thumbnail) of a file on a **followed identity's** drive, addressed by
+ * [globalTransitId]. The user's own host ([requireCreds]`.domain`) brokers the transit query to the
+ * peer server-side and re-encrypts the response under the caller's shared secret, so the
+ * decode/decrypt path is identical to a local read (reuses [DriveFileProvider.decryptBytes], which
+ * returns plaintext bytes untouched when the server marks `payloadencrypted=false` — the public-feed
+ * case).
  *
- * Why a new provider rather than [TemporalDriveReadProvider]: that one is the *time-boxed
- * emergency* API (needs a `ConditionalTemporalRead` circle grant, clamps to a recent window,
- * notifies the author's owner, and keys by **fileId**). Feed posts need none of that and the
- * Feed-drive reference only carries a **globalTransitId**, never the author's fileId — hence the
- * by-gtid route here, extending the `/peer/.../files/by-gtid/{gtid}/exists` route
- * [PeerDriveQueryProvider] already uses. Mirrors dotyoucore-js
- * `get{Payload,Thumb}BytesOverPeerByGlobalTransitId`.
+ * Routes mirror dotyoucore-js `get{Payload,Thumb}BytesOverPeerByGlobalTransitId`:
+ * `/transit/query/{payload,thumb}_byglobaltransitid` with the peer + drive (alias+type) + gtid as
+ * query params (NOT the `/peer/.../files/...` path form, which only exposes `exists` by gtid).
  */
 class PeerFileByGlobalTransitProvider(
     httpClient: HttpClient,
@@ -33,21 +29,21 @@ class PeerFileByGlobalTransitProvider(
     private val driveFileProvider: DriveFileProvider,
 ) : OdinApiProviderBase(httpClient, credentialsManager) {
 
-    /** Full payload bytes of [globalTransitId]'s [payloadKey] on [peer]'s [driveId]. Null on 404. */
+    /** Full payload bytes of [globalTransitId]'s [payloadKey] on [peer]'s drive. Null on 404. */
     suspend fun getPayloadOverPeerByGlobalTransitId(
         peer: OdinId,
-        driveId: Uuid,
+        driveAlias: Uuid,
+        driveType: Uuid,
         globalTransitId: Uuid,
         payloadKey: String,
     ): BytesResponse? {
         require(payloadKey.isNotBlank()) { "payloadKey must be defined" }
         val creds = requireCreds()
-        val url = apiUrl(
-            creds.domain,
-            "/peer/$peer/drives/$driveId/files/by-gtid/$globalTransitId/payload/$payloadKey",
-        )
+        val query = "odinId=$peer&alias=$driveAlias&type=$driveType" +
+            "&globalTransitId=$globalTransitId&key=$payloadKey"
+        val url = apiUrl(creds.domain, "/transit/query/payload_byglobaltransitid?$query")
         Logger.i(tag = TAG) {
-            "getPayload: GET peer=${peer.domainName} drive=$driveId gtid=$globalTransitId key=$payloadKey"
+            "getPayload: GET peer=${peer.domainName} alias=$driveAlias gtid=$globalTransitId key=$payloadKey"
         }
         return fetchAndDecrypt(url)
     }
@@ -55,7 +51,8 @@ class PeerFileByGlobalTransitProvider(
     /** A server thumbnail ([width]x[height]) of [globalTransitId]'s [payloadKey]. Null on 404. */
     suspend fun getThumbOverPeerByGlobalTransitId(
         peer: OdinId,
-        driveId: Uuid,
+        driveAlias: Uuid,
+        driveType: Uuid,
         globalTransitId: Uuid,
         payloadKey: String,
         width: Int,
@@ -64,12 +61,11 @@ class PeerFileByGlobalTransitProvider(
         require(payloadKey.isNotBlank()) { "payloadKey must be defined" }
         require(width > 0 && height > 0) { "width/height must be positive" }
         val creds = requireCreds()
-        val url = apiUrl(
-            creds.domain,
-            "/peer/$peer/drives/$driveId/files/by-gtid/$globalTransitId/payload/$payloadKey/thumb/$width/$height",
-        )
+        val query = "odinId=$peer&alias=$driveAlias&type=$driveType" +
+            "&globalTransitId=$globalTransitId&payloadKey=$payloadKey&width=$width&height=$height"
+        val url = apiUrl(creds.domain, "/transit/query/thumb_byglobaltransitid?$query")
         Logger.i(tag = TAG) {
-            "getThumb: GET peer=${peer.domainName} drive=$driveId gtid=$globalTransitId " +
+            "getThumb: GET peer=${peer.domainName} alias=$driveAlias gtid=$globalTransitId " +
                 "key=$payloadKey ${width}x$height"
         }
         return fetchAndDecrypt(url)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProvider.kt
@@ -1,0 +1,88 @@
+package id.homebase.api.client.peer
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.client.OdinApiProviderBase
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.files.BytesResponse
+import id.homebase.api.client.drives.files.DriveFileProvider
+import id.homebase.api.common.OdinId
+import io.ktor.client.HttpClient
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.get
+import kotlin.uuid.Uuid
+
+/**
+ * Reads a payload (or its thumbnail) of a file that lives on a **followed identity's** drive,
+ * addressed by [globalTransitId]. The user's own host ([requireCreds]`.domain`) brokers the read
+ * to the peer server-side and re-encrypts the response under the caller's shared secret, so the
+ * decode/decrypt path is identical to a local read (it reuses [DriveFileProvider.decryptBytes],
+ * which returns plaintext bytes untouched when the server marks the payload `payloadencrypted=false`
+ * — the public-feed case).
+ *
+ * Why a new provider rather than [TemporalDriveReadProvider]: that one is the *time-boxed
+ * emergency* API (needs a `ConditionalTemporalRead` circle grant, clamps to a recent window,
+ * notifies the author's owner, and keys by **fileId**). Feed posts need none of that and the
+ * Feed-drive reference only carries a **globalTransitId**, never the author's fileId — hence the
+ * by-gtid route here, extending the `/peer/.../files/by-gtid/{gtid}/exists` route
+ * [PeerDriveQueryProvider] already uses. Mirrors dotyoucore-js
+ * `get{Payload,Thumb}BytesOverPeerByGlobalTransitId`.
+ */
+class PeerFileByGlobalTransitProvider(
+    httpClient: HttpClient,
+    credentialsManager: CredentialsManager,
+    private val driveFileProvider: DriveFileProvider,
+) : OdinApiProviderBase(httpClient, credentialsManager) {
+
+    /** Full payload bytes of [globalTransitId]'s [payloadKey] on [peer]'s [driveId]. Null on 404. */
+    suspend fun getPayloadOverPeerByGlobalTransitId(
+        peer: OdinId,
+        driveId: Uuid,
+        globalTransitId: Uuid,
+        payloadKey: String,
+    ): BytesResponse? {
+        require(payloadKey.isNotBlank()) { "payloadKey must be defined" }
+        val creds = requireCreds()
+        val url = apiUrl(
+            creds.domain,
+            "/peer/$peer/drives/$driveId/files/by-gtid/$globalTransitId/payload/$payloadKey",
+        )
+        Logger.i(tag = TAG) {
+            "getPayload: GET peer=${peer.domainName} drive=$driveId gtid=$globalTransitId key=$payloadKey"
+        }
+        return fetchAndDecrypt(url)
+    }
+
+    /** A server thumbnail ([width]x[height]) of [globalTransitId]'s [payloadKey]. Null on 404. */
+    suspend fun getThumbOverPeerByGlobalTransitId(
+        peer: OdinId,
+        driveId: Uuid,
+        globalTransitId: Uuid,
+        payloadKey: String,
+        width: Int,
+        height: Int,
+    ): BytesResponse? {
+        require(payloadKey.isNotBlank()) { "payloadKey must be defined" }
+        require(width > 0 && height > 0) { "width/height must be positive" }
+        val creds = requireCreds()
+        val url = apiUrl(
+            creds.domain,
+            "/peer/$peer/drives/$driveId/files/by-gtid/$globalTransitId/payload/$payloadKey/thumb/$width/$height",
+        )
+        Logger.i(tag = TAG) {
+            "getThumb: GET peer=${peer.domainName} drive=$driveId gtid=$globalTransitId " +
+                "key=$payloadKey ${width}x$height"
+        }
+        return fetchAndDecrypt(url)
+    }
+
+    private suspend fun fetchAndDecrypt(url: String): BytesResponse? {
+        val creds = requireCreds()
+        val response = requestBytes { httpClient.get(url) { bearerAuth(creds.accessToken) } }
+        if (response.status == 404) return null
+        throwForFailure(response)
+        val decrypted = driveFileProvider.decryptBytes(response.headers, response.bytes)
+        return BytesResponse(bytes = decrypted, contentType = response.contentType)
+    }
+
+    companion object { private const val TAG = "PeerFileByGtid" }
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
@@ -27,6 +27,7 @@ import id.homebase.api.client.link.LinkPreviewProvider
 import id.homebase.api.client.location.LocationPreviewProvider
 import id.homebase.api.client.notifications.PushNotificationApi
 import id.homebase.api.client.peer.PeerDriveQueryProvider
+import id.homebase.api.client.peer.PeerFileByGlobalTransitProvider
 import id.homebase.api.client.peer.PeerDriveUploadProvider
 import id.homebase.api.client.peer.PeerNotificationProvider
 import id.homebase.api.client.peer.PeerWebSocketManager
@@ -98,6 +99,7 @@ val apiModule = module {
 
     factoryOf(::ConnectionNetworkProvider)
     factoryOf(::PeerDriveQueryProvider)
+    factoryOf(::PeerFileByGlobalTransitProvider)
     factoryOf(::TemporalDriveReadProvider)
     factoryOf(::PeerDriveUploadProvider)
     factoryOf(::PeerNotificationProvider)

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProviderTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProviderTest.kt
@@ -12,6 +12,7 @@ import id.homebase.api.common.SecureByteArray
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpRequestData
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -23,17 +24,17 @@ import kotlin.test.assertNull
 import kotlin.uuid.Uuid
 
 /**
- * Covers the by-globalTransitId over-peer payload/thumb fetch: route shape, the plaintext
- * passthrough (public feed posts come back `payloadencrypted=false` and are returned untouched),
- * 404 → null, and the input guards. The encrypted-decrypt branch is [DriveFileProvider.decryptBytes]'
- * own responsibility (tested there); this provider only delegates to it.
+ * Covers the by-globalTransitId over-peer payload/thumb fetch: the transit/query route shape
+ * + query params, the plaintext passthrough (public feed posts come back `payloadencrypted=false`
+ * and are returned untouched), 404 → null, and the input guards. The encrypted-decrypt branch is
+ * [DriveFileProvider.decryptBytes]' own responsibility (tested there); this provider only delegates.
  */
 class PeerFileByGlobalTransitProviderTest {
 
-    // 16-byte zero shared secret — same harness as FollowProviderTest.
     private val sharedSecret = ByteArray(16)
     private val peer = OdinId("frodo.baggins.demo.rocks")
-    private val driveId = Uuid.parse("e8475dc4-6cb4-b665-1c2d-0dbd0f3aad5f")
+    private val driveAlias = Uuid.parse("e8475dc4-6cb4-b665-1c2d-0dbd0f3aad5f")
+    private val driveType = Uuid.parse("a3227ffb-a876-08be-eb24-fee9b70d92a6")
     private val gtid = Uuid.parse("2c8cdd19-009d-a000-007d-eb88b8f218bd")
 
     private suspend fun creds(): CredentialsManager {
@@ -56,13 +57,15 @@ class PeerFileByGlobalTransitProviderTest {
         return PeerFileByGlobalTransitProvider(client, cm, driveFileProvider)
     }
 
+    private fun HttpRequestData.param(name: String): String? = url.parameters[name]
+
     @Test
-    fun getPayload_hitsByGtidPayloadRoute_andReturnsPlaintextBytes() = runTest {
-        var path: String? = null
+    fun getPayload_hitsTransitPayloadRoute_withParams_andReturnsPlaintextBytes() = runTest {
+        var request: HttpRequestData? = null
         val payload = byteArrayOf(1, 2, 3, 4)
         val cm = creds()
-        val engine = MockEngine { request ->
-            path = request.url.encodedPath
+        val engine = MockEngine { req ->
+            request = req
             respond(
                 content = payload,
                 status = HttpStatusCode.OK,
@@ -74,33 +77,37 @@ class PeerFileByGlobalTransitProviderTest {
         }
 
         val result = provider(engine, cm)
-            .getPayloadOverPeerByGlobalTransitId(peer, driveId, gtid, "pst_mdi0")
+            .getPayloadOverPeerByGlobalTransitId(peer, driveAlias, driveType, gtid, "pst_mdi0")
 
-        assertEquals(
-            "/api/v2/peer/$peer/drives/$driveId/files/by-gtid/$gtid/payload/pst_mdi0",
-            path,
-        )
+        val req = requireNotNull(request)
+        assertEquals("/api/v2/transit/query/payload_byglobaltransitid", req.url.encodedPath)
+        assertEquals(peer.toString(), req.param("odinId"))
+        assertEquals(driveAlias.toString(), req.param("alias"))
+        assertEquals(driveType.toString(), req.param("type"))
+        assertEquals(gtid.toString(), req.param("globalTransitId"))
+        assertEquals("pst_mdi0", req.param("key"))
         assertEquals(payload.toList(), result!!.bytes.toList())
         assertEquals("image/webp", result.contentType)
     }
 
     @Test
-    fun getThumb_hitsByGtidThumbRoute_withDimensions() = runTest {
-        var path: String? = null
+    fun getThumb_hitsTransitThumbRoute_withDimensions() = runTest {
+        var request: HttpRequestData? = null
         val thumb = byteArrayOf(9, 8, 7)
         val cm = creds()
-        val engine = MockEngine { request ->
-            path = request.url.encodedPath
+        val engine = MockEngine { req ->
+            request = req
             respond(thumb, HttpStatusCode.OK, headersOf("payloadencrypted" to listOf("false")))
         }
 
         val result = provider(engine, cm)
-            .getThumbOverPeerByGlobalTransitId(peer, driveId, gtid, "pst_mdi0", 320, 480)
+            .getThumbOverPeerByGlobalTransitId(peer, driveAlias, driveType, gtid, "pst_mdi0", 320, 480)
 
-        assertEquals(
-            "/api/v2/peer/$peer/drives/$driveId/files/by-gtid/$gtid/payload/pst_mdi0/thumb/320/480",
-            path,
-        )
+        val req = requireNotNull(request)
+        assertEquals("/api/v2/transit/query/thumb_byglobaltransitid", req.url.encodedPath)
+        assertEquals("pst_mdi0", req.param("payloadKey"))
+        assertEquals("320", req.param("width"))
+        assertEquals("480", req.param("height"))
         assertEquals(thumb.toList(), result!!.bytes.toList())
     }
 
@@ -109,7 +116,8 @@ class PeerFileByGlobalTransitProviderTest {
         val cm = creds()
         val engine = MockEngine { respond(ByteArray(0), HttpStatusCode.NotFound) }
         assertNull(
-            provider(engine, cm).getPayloadOverPeerByGlobalTransitId(peer, driveId, gtid, "pst_mdi0"),
+            provider(engine, cm)
+                .getPayloadOverPeerByGlobalTransitId(peer, driveAlias, driveType, gtid, "pst_mdi0"),
         )
     }
 
@@ -119,7 +127,7 @@ class PeerFileByGlobalTransitProviderTest {
         val engine = MockEngine { respond(ByteArray(0), HttpStatusCode.NotFound) }
         assertNull(
             provider(engine, cm)
-                .getThumbOverPeerByGlobalTransitId(peer, driveId, gtid, "pst_mdi0", 320, 480),
+                .getThumbOverPeerByGlobalTransitId(peer, driveAlias, driveType, gtid, "pst_mdi0", 320, 480),
         )
     }
 
@@ -128,7 +136,8 @@ class PeerFileByGlobalTransitProviderTest {
         val cm = creds()
         val engine = MockEngine { respond(ByteArray(0), HttpStatusCode.OK) }
         assertFailsWith<IllegalArgumentException> {
-            provider(engine, cm).getPayloadOverPeerByGlobalTransitId(peer, driveId, gtid, "")
+            provider(engine, cm)
+                .getPayloadOverPeerByGlobalTransitId(peer, driveAlias, driveType, gtid, "")
         }
     }
 
@@ -138,7 +147,7 @@ class PeerFileByGlobalTransitProviderTest {
         val engine = MockEngine { respond(ByteArray(0), HttpStatusCode.OK) }
         assertFailsWith<IllegalArgumentException> {
             provider(engine, cm)
-                .getThumbOverPeerByGlobalTransitId(peer, driveId, gtid, "pst_mdi0", 0, 480)
+                .getThumbOverPeerByGlobalTransitId(peer, driveAlias, driveType, gtid, "pst_mdi0", 0, 480)
         }
     }
 }

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProviderTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProviderTest.kt
@@ -80,7 +80,7 @@ class PeerFileByGlobalTransitProviderTest {
             .getPayloadOverPeerByGlobalTransitId(peer, driveAlias, driveType, gtid, "pst_mdi0")
 
         val req = requireNotNull(request)
-        assertEquals("/api/v2/transit/query/payload_byglobaltransitid", req.url.encodedPath)
+        assertEquals("/api/apps/v1/transit/query/payload_byglobaltransitid", req.url.encodedPath)
         assertEquals(peer.toString(), req.param("odinId"))
         assertEquals(driveAlias.toString(), req.param("alias"))
         assertEquals(driveType.toString(), req.param("type"))
@@ -104,10 +104,11 @@ class PeerFileByGlobalTransitProviderTest {
             .getThumbOverPeerByGlobalTransitId(peer, driveAlias, driveType, gtid, "pst_mdi0", 320, 480)
 
         val req = requireNotNull(request)
-        assertEquals("/api/v2/transit/query/thumb_byglobaltransitid", req.url.encodedPath)
+        assertEquals("/api/apps/v1/transit/query/thumb_byglobaltransitid", req.url.encodedPath)
         assertEquals("pst_mdi0", req.param("payloadKey"))
         assertEquals("320", req.param("width"))
         assertEquals("480", req.param("height"))
+        assertEquals("false", req.param("directMatchOnly"))
         assertEquals(thumb.toList(), result!!.bytes.toList())
     }
 

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProviderTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProviderTest.kt
@@ -1,0 +1,144 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package id.homebase.api.client.peer
+
+import id.homebase.api.client.auth.ApiCredentials
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.cache.DriveFileProviderCached
+import id.homebase.api.client.drives.files.DriveFileProvider
+import id.homebase.api.client.profile.FakeFileOperationsProvider
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.SecureByteArray
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.uuid.Uuid
+
+/**
+ * Covers the by-globalTransitId over-peer payload/thumb fetch: route shape, the plaintext
+ * passthrough (public feed posts come back `payloadencrypted=false` and are returned untouched),
+ * 404 → null, and the input guards. The encrypted-decrypt branch is [DriveFileProvider.decryptBytes]'
+ * own responsibility (tested there); this provider only delegates to it.
+ */
+class PeerFileByGlobalTransitProviderTest {
+
+    // 16-byte zero shared secret — same harness as FollowProviderTest.
+    private val sharedSecret = ByteArray(16)
+    private val peer = OdinId("frodo.baggins.demo.rocks")
+    private val driveId = Uuid.parse("e8475dc4-6cb4-b665-1c2d-0dbd0f3aad5f")
+    private val gtid = Uuid.parse("2c8cdd19-009d-a000-007d-eb88b8f218bd")
+
+    private suspend fun creds(): CredentialsManager {
+        val cm = CredentialsManager()
+        cm.setActiveCredentials(
+            ApiCredentials.create(
+                domain = OdinId("test.homebase.id"),
+                clientAccessToken = "fake-token",
+                sharedSecret = SecureByteArray(sharedSecret.copyOf()),
+            )
+        )
+        return cm
+    }
+
+    private fun provider(engine: MockEngine, cm: CredentialsManager): PeerFileByGlobalTransitProvider {
+        val client = HttpClient(engine)
+        val driveFileProvider = DriveFileProvider(
+            client, cm, DriveFileProviderCached(client, cm, FakeFileOperationsProvider()),
+        )
+        return PeerFileByGlobalTransitProvider(client, cm, driveFileProvider)
+    }
+
+    @Test
+    fun getPayload_hitsByGtidPayloadRoute_andReturnsPlaintextBytes() = runTest {
+        var path: String? = null
+        val payload = byteArrayOf(1, 2, 3, 4)
+        val cm = creds()
+        val engine = MockEngine { request ->
+            path = request.url.encodedPath
+            respond(
+                content = payload,
+                status = HttpStatusCode.OK,
+                headers = headersOf(
+                    "payloadencrypted" to listOf("false"),
+                    "decryptedcontenttype" to listOf("image/webp"),
+                ),
+            )
+        }
+
+        val result = provider(engine, cm)
+            .getPayloadOverPeerByGlobalTransitId(peer, driveId, gtid, "pst_mdi0")
+
+        assertEquals(
+            "/api/v2/peer/$peer/drives/$driveId/files/by-gtid/$gtid/payload/pst_mdi0",
+            path,
+        )
+        assertEquals(payload.toList(), result!!.bytes.toList())
+        assertEquals("image/webp", result.contentType)
+    }
+
+    @Test
+    fun getThumb_hitsByGtidThumbRoute_withDimensions() = runTest {
+        var path: String? = null
+        val thumb = byteArrayOf(9, 8, 7)
+        val cm = creds()
+        val engine = MockEngine { request ->
+            path = request.url.encodedPath
+            respond(thumb, HttpStatusCode.OK, headersOf("payloadencrypted" to listOf("false")))
+        }
+
+        val result = provider(engine, cm)
+            .getThumbOverPeerByGlobalTransitId(peer, driveId, gtid, "pst_mdi0", 320, 480)
+
+        assertEquals(
+            "/api/v2/peer/$peer/drives/$driveId/files/by-gtid/$gtid/payload/pst_mdi0/thumb/320/480",
+            path,
+        )
+        assertEquals(thumb.toList(), result!!.bytes.toList())
+    }
+
+    @Test
+    fun getPayload_returnsNullOn404() = runTest {
+        val cm = creds()
+        val engine = MockEngine { respond(ByteArray(0), HttpStatusCode.NotFound) }
+        assertNull(
+            provider(engine, cm).getPayloadOverPeerByGlobalTransitId(peer, driveId, gtid, "pst_mdi0"),
+        )
+    }
+
+    @Test
+    fun getThumb_returnsNullOn404() = runTest {
+        val cm = creds()
+        val engine = MockEngine { respond(ByteArray(0), HttpStatusCode.NotFound) }
+        assertNull(
+            provider(engine, cm)
+                .getThumbOverPeerByGlobalTransitId(peer, driveId, gtid, "pst_mdi0", 320, 480),
+        )
+    }
+
+    @Test
+    fun getPayload_blankKey_throws() = runTest {
+        val cm = creds()
+        val engine = MockEngine { respond(ByteArray(0), HttpStatusCode.OK) }
+        assertFailsWith<IllegalArgumentException> {
+            provider(engine, cm).getPayloadOverPeerByGlobalTransitId(peer, driveId, gtid, "")
+        }
+    }
+
+    @Test
+    fun getThumb_nonPositiveDimensions_throws() = runTest {
+        val cm = creds()
+        val engine = MockEngine { respond(ByteArray(0), HttpStatusCode.OK) }
+        assertFailsWith<IllegalArgumentException> {
+            provider(engine, cm)
+                .getThumbOverPeerByGlobalTransitId(peer, driveId, gtid, "pst_mdi0", 0, 480)
+        }
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageData.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageData.kt
@@ -3,6 +3,7 @@ package id.homebase.core.image
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.drives.files.ThumbnailDescriptor
 import id.homebase.api.client.drives.upload.EmbeddedThumb
+import id.homebase.api.common.OdinId
 import kotlin.math.max
 import kotlin.uuid.Uuid
 
@@ -52,6 +53,14 @@ data class HomebaseImageData(
     val payloadContentType: String? = null,
     /** KeyHeader for decryption of the payload */
     val keyHeader: KeyHeader,
+    /**
+     * When non-null, the payload lives on a FOLLOWED identity's drive and is fetched over peer
+     * (by [globalTransitId]) instead of locally — see [HomebaseImageLoader]. [driveId] is then the
+     * author's channel drive and [remoteOdinId] is the author. Null for ordinary local reads.
+     */
+    val remoteOdinId: OdinId? = null,
+    /** Global transit id of a remote post, required alongside [remoteOdinId] for the over-peer fetch. */
+    val globalTransitId: Uuid? = null,
 ) {
     companion object {
         /** Create data for a pending (not yet uploaded) image */

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageData.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageData.kt
@@ -61,6 +61,8 @@ data class HomebaseImageData(
     val remoteOdinId: OdinId? = null,
     /** Global transit id of a remote post, required alongside [remoteOdinId] for the over-peer fetch. */
     val globalTransitId: Uuid? = null,
+    /** Type of the author's drive ([driveId] is the alias) — both go in the over-peer transit query. */
+    val remoteDriveType: Uuid? = null,
 ) {
     companion object {
         /** Create data for a pending (not yet uploaded) image */

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
@@ -131,15 +131,17 @@ class HomebaseImageLoader(
         val nativeSize = selectThumbSize(targetSize, data.availableThumbSizes)
 
         // Fetch from server with retry
-        return withRetry(retryConfig, TAG) {
+        val thumb = withRetry(retryConfig, TAG) {
             val response = try {
                 val remoteOdinId = data.remoteOdinId
                 val gtid = data.globalTransitId
-                if (remoteOdinId != null && gtid != null) {
+                val driveType = data.remoteDriveType
+                if (remoteOdinId != null && gtid != null && driveType != null) {
                     // Followed-identity post: bytes live on the author's drive — fetch over peer.
                     peerFileProvider.getThumbOverPeerByGlobalTransitId(
                         peer = remoteOdinId,
-                        driveId = data.driveId,
+                        driveAlias = data.driveId,
+                        driveType = driveType,
                         globalTransitId = gtid,
                         payloadKey = data.payloadKey,
                         width = nativeSize.pixelWidth,
@@ -177,6 +179,13 @@ class HomebaseImageLoader(
                 bytes = response.bytes, contentType = response.contentType, size = nativeSize
             )
         }
+        // A followed identity's post often has no server thumbnail at the requested size (its
+        // feed-drive reference carries no thumbnail descriptor, so we ask for an odd size → 404).
+        // Fall back to the full payload over peer, like dotyoucore-js getDecryptedMediaUrlOverPeer*.
+        if (thumb == null && data.remoteOdinId != null && data.globalTransitId != null) {
+            return loadFullPayload(data, retryConfig)
+        }
+        return thumb
     }
 
     /**
@@ -228,10 +237,12 @@ class HomebaseImageLoader(
             val response = try {
                 val remoteOdinId = data.remoteOdinId
                 val gtid = data.globalTransitId
-                if (remoteOdinId != null && gtid != null) {
+                val driveType = data.remoteDriveType
+                if (remoteOdinId != null && gtid != null && driveType != null) {
                     peerFileProvider.getPayloadOverPeerByGlobalTransitId(
                         peer = remoteOdinId,
-                        driveId = data.driveId,
+                        driveAlias = data.driveId,
+                        driveType = driveType,
                         globalTransitId = gtid,
                         payloadKey = data.payloadKey,
                     )

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
@@ -4,6 +4,7 @@ import co.touchlab.kermit.Logger
 import id.homebase.api.client.NotFoundException
 import id.homebase.api.client.RetryConfig
 import id.homebase.api.client.drives.files.DriveFileProvider
+import id.homebase.api.client.peer.PeerFileByGlobalTransitProvider
 import id.homebase.api.client.withRetry
 import id.homebase.api.coroutines.supervisedScope
 import id.homebase.api.file.FileOperationsProvider
@@ -40,6 +41,7 @@ data class CachedImage(val bytes: ByteArray, val contentType: String, val size: 
 class HomebaseImageLoader(
     private val driveFileProvider: DriveFileProvider,
     private val fileOperationsProvider: FileOperationsProvider,
+    private val peerFileProvider: PeerFileByGlobalTransitProvider,
 ) {
     // Durable scope hosting full-payload loads so a cancelled caller (e.g. a
     // prefetch whose grid item left composition) does not abort a load that
@@ -131,15 +133,29 @@ class HomebaseImageLoader(
         // Fetch from server with retry
         return withRetry(retryConfig, TAG) {
             val response = try {
-                driveFileProvider.getThumbBytesDecrypted(
-                    driveId = data.driveId,
-                    fileId = data.fileId,
-                    payloadKey = data.payloadKey,
-                    keyHeader = data.keyHeader,
-                    width = nativeSize.pixelWidth,
-                    height = nativeSize.pixelHeight,
-                    lastModified = data.lastModified,
-                )
+                val remoteOdinId = data.remoteOdinId
+                val gtid = data.globalTransitId
+                if (remoteOdinId != null && gtid != null) {
+                    // Followed-identity post: bytes live on the author's drive — fetch over peer.
+                    peerFileProvider.getThumbOverPeerByGlobalTransitId(
+                        peer = remoteOdinId,
+                        driveId = data.driveId,
+                        globalTransitId = gtid,
+                        payloadKey = data.payloadKey,
+                        width = nativeSize.pixelWidth,
+                        height = nativeSize.pixelHeight,
+                    )
+                } else {
+                    driveFileProvider.getThumbBytesDecrypted(
+                        driveId = data.driveId,
+                        fileId = data.fileId,
+                        payloadKey = data.payloadKey,
+                        keyHeader = data.keyHeader,
+                        width = nativeSize.pixelWidth,
+                        height = nativeSize.pixelHeight,
+                        lastModified = data.lastModified,
+                    )
+                }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
@@ -210,12 +226,23 @@ class HomebaseImageLoader(
     ): CachedImage? {
         return withRetry(retryConfig, TAG) {
             val response = try {
-                driveFileProvider.getPayloadBytesDecrypted(
-                    driveId = data.driveId,
-                    fileId = data.fileId,
-                    key = data.payloadKey,
-                    keyHeader = data.keyHeader
-                )
+                val remoteOdinId = data.remoteOdinId
+                val gtid = data.globalTransitId
+                if (remoteOdinId != null && gtid != null) {
+                    peerFileProvider.getPayloadOverPeerByGlobalTransitId(
+                        peer = remoteOdinId,
+                        driveId = data.driveId,
+                        globalTransitId = gtid,
+                        payloadKey = data.payloadKey,
+                    )
+                } else {
+                    driveFileProvider.getPayloadBytesDecrypted(
+                        driveId = data.driveId,
+                        fileId = data.fileId,
+                        key = data.payloadKey,
+                        keyHeader = data.keyHeader,
+                    )
+                }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/feed/services/FeedModels.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/feed/services/FeedModels.kt
@@ -52,6 +52,14 @@ data class FeedPostItem(
     val ownReactions: List<String>,
     /** Comment count from the embedded reaction/comment preview. */
     val commentCount: Int,
+    /**
+     * Author whose drive hosts this post when it's a followed-identity reference on the feed
+     * drive — its media bytes are remote and fetched over peer (with [globalTransitId]). Null for
+     * the user's own posts, whose media is local.
+     */
+    val remoteOdinId: OdinId? = null,
+    /** Cross-identity global id of the post, used with [remoteOdinId] for the over-peer media fetch. */
+    val globalTransitId: Uuid? = null,
 )
 
 /**
@@ -93,7 +101,8 @@ fun HomebaseFile.toFeedPostItem(): FeedPostItem? {
     // feed drive as references that carry only a globalTransitId (no uniqueId) — fall back to it
     // so followed/public posts surface in the timeline instead of being dropped. Both values
     // stably identify the post for dedup; they never collide (own posts aren't feed references).
-    val uniqueId = appData.uniqueId ?: fileMetadata.globalTransitId ?: return null
+    val isReference = appData.uniqueId == null
+    val id = appData.uniqueId ?: fileMetadata.globalTransitId ?: return null
     val content = appData.content?.let { raw ->
         runCatching { OdinSystemSerializer.deserialize<PostContent>(raw) }
             .onFailure { Logger.w(tag = "FeedModels") { "PostContent parse failed: ${it.message}" } }
@@ -103,7 +112,7 @@ fun HomebaseFile.toFeedPostItem(): FeedPostItem? {
         ?.mapNotNull { raw -> decodeOwnReactionEmoji(raw) }
         .orEmpty()
     return FeedPostItem(
-        id = uniqueId,
+        id = id,
         fileId = fileId,
         driveId = driveId,
         keyHeader = keyHeader,
@@ -123,6 +132,10 @@ fun HomebaseFile.toFeedPostItem(): FeedPostItem? {
         versionTag = fileMetadata.versionTag,
         ownReactions = ownReactions,
         commentCount = fileMetadata.reactionPreview?.totalCommentCount ?: 0,
+        // A reference (no uniqueId) is a followed identity's post: its media lives on the author's
+        // drive and is fetched over peer. senderOdinId is the author who hosts it.
+        remoteOdinId = if (isReference) (fileMetadata.senderOdinId ?: fileMetadata.originalAuthor) else null,
+        globalTransitId = fileMetadata.globalTransitId,
     )
 }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/feed/widget/PostCard.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/feed/widget/PostCard.kt
@@ -143,5 +143,8 @@ private fun PostMedia(
         downloadingFiles = emptySet(),
         remoteOdinId = post.remoteOdinId,
         globalTransitId = post.globalTransitId,
+        // Drive type pairs with mediaDriveId (alias) for the over-peer transit query; inert unless
+        // remoteOdinId is set (own posts read locally).
+        remoteDriveType = SystemDriveConstants.publicPostChannelDrive.type,
     )
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/feed/widget/PostCard.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/feed/widget/PostCard.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
+import id.homebase.api.client.drives.SystemDriveConstants
 import id.homebase.api.client.drives.files.PayloadDescriptor
 import id.homebase.core.feed.services.FeedPostItem
 import id.homebase.core.feed.services.FeedProtocol
@@ -115,10 +116,19 @@ private fun PostMedia(
         post.payloads.filter { it.key.startsWith(FeedProtocol.MediaPayloadKeyPrefix) }
     if (mediaPayloads.isEmpty()) return
 
+    // A followed identity's post (remoteOdinId set) keeps its payload bytes on the author's drive:
+    // fetch over peer (by globalTransitId) from the author's public-channel drive instead of the
+    // local feed-drive reference, whose bytes are "marked as remote".
+    // ponytail: assumes the default public-channel drive; posts on a custom channel would need the
+    // channel-specific drive derived from PostContent.channelId — add that if such posts appear.
+    val mediaDriveId =
+        if (post.remoteOdinId != null) SystemDriveConstants.publicPostChannelDrive.alias
+        else post.driveId
+
     MomentMediaGallery(
         payloads = mediaPayloads,
         fileId = post.fileId,
-        driveId = post.driveId,
+        driveId = mediaDriveId,
         previewThumbnail = post.previewThumbnail,
         keyHeader = post.keyHeader,
         modifier = modifier,
@@ -131,5 +141,7 @@ private fun PostMedia(
         animatedVisibilityScope = null,
         messageId = post.id,
         downloadingFiles = emptySet(),
+        remoteOdinId = post.remoteOdinId,
+        globalTransitId = post.globalTransitId,
     )
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaCarousel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaCarousel.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.KeyHeader
+import id.homebase.api.common.OdinId
 import id.homebase.api.client.drives.files.PayloadDescriptor
 import id.homebase.api.client.drives.upload.EmbeddedThumb
 import id.homebase.core.image.ImageSize
@@ -98,6 +99,9 @@ fun MomentMediaCarousel(
     // Force the whole video frame to show (fit) instead of crop-to-fill —
     // set while the host card is shrunk for the comments sheet.
     fitToContent: Boolean = false,
+    // When set, media lives on a followed identity's drive — fetched over peer (by gtid).
+    remoteOdinId: OdinId? = null,
+    globalTransitId: Uuid? = null,
 ) {
     if (payloads.isEmpty()) return
 
@@ -230,6 +234,8 @@ fun MomentMediaCarousel(
                     isDownloading = downloadingFiles.contains("${messageId}_${payload.key}"),
                     messageId = messageId,
                     isUploading = isUploading,
+                    remoteOdinId = remoteOdinId,
+                    globalTransitId = globalTransitId,
                 )
             }
         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaCarousel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaCarousel.kt
@@ -102,6 +102,7 @@ fun MomentMediaCarousel(
     // When set, media lives on a followed identity's drive — fetched over peer (by gtid).
     remoteOdinId: OdinId? = null,
     globalTransitId: Uuid? = null,
+    remoteDriveType: Uuid? = null,
 ) {
     if (payloads.isEmpty()) return
 
@@ -236,6 +237,7 @@ fun MomentMediaCarousel(
                     isUploading = isUploading,
                     remoteOdinId = remoteOdinId,
                     globalTransitId = globalTransitId,
+                    remoteDriveType = remoteDriveType,
                 )
             }
         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaGallery.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaGallery.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
 import id.homebase.api.client.KeyHeader
+import id.homebase.api.common.OdinId
 import id.homebase.api.client.drives.files.PayloadDescriptor
 import id.homebase.api.client.drives.upload.EmbeddedThumb
 import id.homebase.core.image.ImageSize
@@ -70,6 +71,10 @@ fun MomentMediaGallery(
     // Force carousel videos to show the whole frame (fit) — set while the host
     // card is shrunk for the comments sheet.
     fitToContent: Boolean = false,
+    // When set, this gallery's media lives on a followed identity's drive and is fetched over peer
+    // (by [globalTransitId]). Null for local media (moments, chat, own posts).
+    remoteOdinId: OdinId? = null,
+    globalTransitId: Uuid? = null,
 ) {
     if (payloads.isEmpty()) return
 
@@ -90,6 +95,8 @@ fun MomentMediaGallery(
                 downloadingFiles = downloadingFiles,
                 isUploading = isUploading,
                 fitToContent = fitToContent,
+                remoteOdinId = remoteOdinId,
+                globalTransitId = globalTransitId,
             )
         } else {
             MomentMediaCarousel(
@@ -111,6 +118,8 @@ fun MomentMediaGallery(
                 autoplayActive = autoplayActive,
                 onVisiblePayloadChanged = onVisiblePayloadChanged,
                 fitToContent = fitToContent,
+                remoteOdinId = remoteOdinId,
+                globalTransitId = globalTransitId,
             )
         }
     }
@@ -134,6 +143,8 @@ private fun SingleImageLayout(
     // aspect-locked crop — used while the card is shrunk to a band above the
     // comments sheet so the entire photo is visible.
     fitToContent: Boolean = false,
+    remoteOdinId: OdinId? = null,
+    globalTransitId: Uuid? = null,
 ) {
     // Compute aspect from the payload's thumbnail metadata so the cell sizes
     // before the (possibly remote, encrypted) full image is decoded. Falls
@@ -176,6 +187,8 @@ private fun SingleImageLayout(
         isDownloading = downloadingFiles.contains("${messageId}_${payload.key}"),
         messageId = messageId,
         isUploading = isUploading,
+        remoteOdinId = remoteOdinId,
+        globalTransitId = globalTransitId,
     )
 }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaGallery.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaGallery.kt
@@ -75,6 +75,7 @@ fun MomentMediaGallery(
     // (by [globalTransitId]). Null for local media (moments, chat, own posts).
     remoteOdinId: OdinId? = null,
     globalTransitId: Uuid? = null,
+    remoteDriveType: Uuid? = null,
 ) {
     if (payloads.isEmpty()) return
 
@@ -97,6 +98,7 @@ fun MomentMediaGallery(
                 fitToContent = fitToContent,
                 remoteOdinId = remoteOdinId,
                 globalTransitId = globalTransitId,
+                remoteDriveType = remoteDriveType,
             )
         } else {
             MomentMediaCarousel(
@@ -120,6 +122,7 @@ fun MomentMediaGallery(
                 fitToContent = fitToContent,
                 remoteOdinId = remoteOdinId,
                 globalTransitId = globalTransitId,
+                remoteDriveType = remoteDriveType,
             )
         }
     }
@@ -145,6 +148,7 @@ private fun SingleImageLayout(
     fitToContent: Boolean = false,
     remoteOdinId: OdinId? = null,
     globalTransitId: Uuid? = null,
+    remoteDriveType: Uuid? = null,
 ) {
     // Compute aspect from the payload's thumbnail metadata so the cell sizes
     // before the (possibly remote, encrypted) full image is decoded. Falls
@@ -189,6 +193,7 @@ private fun SingleImageLayout(
         isUploading = isUploading,
         remoteOdinId = remoteOdinId,
         globalTransitId = globalTransitId,
+        remoteDriveType = remoteDriveType,
     )
 }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaItem.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaItem.kt
@@ -116,6 +116,7 @@ fun MomentMediaItem(
     // (by [globalTransitId]). Null for ordinary local media (chat, moments, own posts).
     remoteOdinId: OdinId? = null,
     globalTransitId: Uuid? = null,
+    remoteDriveType: Uuid? = null,
 ) {
     val contentType = payload.contentType ?: ""
     val imageContentScale = if (preserveAspectRatio || fitBounds) ContentScale.Fit else ContentScale.Crop
@@ -277,6 +278,7 @@ fun MomentMediaItem(
                                 ?: KeyHeader.empty(),
                             remoteOdinId = remoteOdinId,
                             globalTransitId = globalTransitId,
+                            remoteDriveType = remoteDriveType,
                         )
                     }
 
@@ -336,6 +338,7 @@ fun MomentMediaItem(
                         keyHeader = perPayloadKeyHeader,
                         remoteOdinId = remoteOdinId,
                         globalTransitId = globalTransitId,
+                        remoteDriveType = remoteDriveType,
                     )
                 }
                 val videoLocalContext = localContext as? LocalAttachmentContext.Video

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaItem.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaItem.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import id.homebase.api.client.KeyHeader
+import id.homebase.api.common.OdinId
 import id.homebase.api.client.drives.files.DescriptorContent
 import id.homebase.api.client.drives.files.PayloadDescriptor
 import id.homebase.api.client.drives.upload.EmbeddedThumb
@@ -111,6 +112,10 @@ fun MomentMediaItem(
     isDownloading: Boolean = false,
     messageId: Uuid? = null,
     isUploading: Boolean = false,
+    // When set, this payload's bytes live on a followed identity's drive and are fetched over peer
+    // (by [globalTransitId]). Null for ordinary local media (chat, moments, own posts).
+    remoteOdinId: OdinId? = null,
+    globalTransitId: Uuid? = null,
 ) {
     val contentType = payload.contentType ?: ""
     val imageContentScale = if (preserveAspectRatio || fitBounds) ContentScale.Fit else ContentScale.Crop
@@ -270,6 +275,8 @@ fun MomentMediaItem(
                             keyHeader = payloadIv
                                 ?.let { KeyHeader(iv = it, aesKey = keyHeader.aesKey) }
                                 ?: KeyHeader.empty(),
+                            remoteOdinId = remoteOdinId,
+                            globalTransitId = globalTransitId,
                         )
                     }
 
@@ -327,6 +334,8 @@ fun MomentMediaItem(
                         lastModified = payload.lastModified,
                         isEncrypted = true,
                         keyHeader = perPayloadKeyHeader,
+                        remoteOdinId = remoteOdinId,
+                        globalTransitId = globalTransitId,
                     )
                 }
                 val videoLocalContext = localContext as? LocalAttachmentContext.Video


### PR DESCRIPTION
**WIP / Draft — stacked on #802.**

Followed-identity posts on the feed drive are references whose media bytes live on the **author's** drive ("marked as remote"). This adds the pipeline to fetch them over peer:
- `PeerFileByGlobalTransitProvider` + `HomebaseImageData.{remoteOdinId, globalTransitId, remoteDriveType}` + a `HomebaseImageLoader` over-peer branch (thumb→payload fallback) + threading through the media widgets + `FeedPostItem`/`PostCard`.
- 6 provider unit tests (route shape, plaintext passthrough, 404→null, guards).

## Known blocker (traced against the odin backend, `DotYouCore`)
The `*_byglobaltransitid` payload/thumb endpoints exist **only** under the classic App/Owner/Guest **API v1** (`/api/apps/v1/transit/query/...`), which authenticates a classic app *cookie* token — chat-kmp uses the unified **v2** API with a bearer token, so v1 returns **401** (verified on device: route resolves, 401 not 404). Unified v2 exposes over-peer payload/thumb **only by fileId** (`/api/v2/peer/{id}/drives/{drive}/files/{fileId}/payload/{key}[/thumb]`), where the bearer works.

**v2-native path (TODO):** resolve `gtid → author-fileId` via an over-peer query-batch (`FileQueryParams.globalTransitId` filter — confirmed present), then fetch payload/thumb by fileId. Until then, followed-post media falls back to the embedded preview thumbnail — **no regression**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01KrYXfXQGNZQXbrQvk6bzJ7