### PR TITLE
Location history: 'Turn on location tracking' link on empty days when tracking is off

### DIFF
--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1323,6 +1323,7 @@
     <string name="live_share_enable_location_body">To share your live location, set up location on this device first so it can send your position.</string>
     <string name="live_share_enable_location_cta">Set up location</string>
     <string name="location_history_empty">No locations recorded on this day</string>
+    <string name="location_history_enable_tracking">Turn on location tracking</string>
     <string name="location_history_map_disclosure">Map tiles are fetched from OpenStreetMap — the viewed area becomes visible to their servers.</string>
     <string name="location_history_previous_day">Previous day</string>
     <string name="location_history_next_day">Next day</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -1297,6 +1297,14 @@ fun AppNavHost(
                                 LocationHistoryScreen(
                                     viewModel = koinViewModel(),
                                     onNavigateBack = { navController.popBackStack() },
+                                    // Empty-day "turn on location tracking" link → the dashboard, where
+                                    // the tracking toggle lives (reuse the existing instance).
+                                    onNavigateToDashboard = {
+                                        navController.navigate(Route.Location) {
+                                            launchSingleTop = true
+                                            popUpTo(Route.Location) { inclusive = false }
+                                        }
+                                    },
                                 )
                             }
                         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/DayPlaybackMap.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/DayPlaybackMap.kt
@@ -1,11 +1,14 @@
 package id.homebase.core.ui.screens.location.history
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
@@ -24,6 +27,7 @@ import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import id.homebase.api.client.location.LocationPreviewProvider
 import id.homebase.api.sync.database.BufferedLocationPoint
@@ -32,6 +36,7 @@ import id.homebase.resources.MR
 import id.homebase.resources.location_history_devices
 import id.homebase.resources.location_history_distance
 import id.homebase.resources.location_history_empty
+import id.homebase.resources.location_history_enable_tracking
 import id.homebase.resources.location_history_points
 import id.homebase.resources.location_history_span
 import org.jetbrains.compose.resources.stringResource
@@ -66,6 +71,11 @@ fun DayPlaybackMap(
     modifier: Modifier = Modifier,
     subjectName: String? = null,
     isLoading: Boolean = false,
+    /** Whether personal location tracking is on. Drives the empty-state "turn on tracking" hint. */
+    trackingEnabled: Boolean = true,
+    /** Tap target for the empty-state "turn on location tracking" link. Null ⇒ no link (the link is
+     *  only meaningful for one's own history, so non-history callers leave it null). */
+    onEnableTracking: (() -> Unit)? = null,
 ) {
     val previewProvider = koinInject<LocationPreviewProvider>()
     // Playback model + stats derive from the day's points (cheap, O(points)).
@@ -130,12 +140,30 @@ fun DayPlaybackMap(
                 if (isLoading) {
                     CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
                 } else if (isEmpty) {
-                    Text(
-                        text = stringResource(MR.string.location_history_empty),
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    Column(
                         modifier = Modifier.align(Alignment.Center).padding(24.dp),
-                    )
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Text(
+                            text = stringResource(MR.string.location_history_empty),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center,
+                        )
+                        // Only when this is the user's own history (onEnableTracking provided) and the
+                        // day is empty *because* tracking is off — nudge them to turn it on.
+                        if (onEnableTracking != null && !trackingEnabled) {
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text(
+                                text = stringResource(MR.string.location_history_enable_tracking),
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.primary,
+                                textDecoration = TextDecoration.Underline,
+                                textAlign = TextAlign.Center,
+                                modifier = Modifier.clickable { onEnableTracking() },
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryScreen.kt
@@ -58,6 +58,7 @@ import kotlin.time.Instant
 fun LocationHistoryScreen(
     viewModel: LocationHistoryViewModel,
     onNavigateBack: () -> Unit,
+    onNavigateToDashboard: () -> Unit = {},
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var showPicker by remember { mutableStateOf(false) }
@@ -126,6 +127,8 @@ fun LocationHistoryScreen(
                 showMapTiles = uiState.showMapTiles,
                 isLoading = uiState.isLoading,
                 subjectName = stringResource(MR.string.location_history_you),
+                trackingEnabled = uiState.trackingEnabled,
+                onEnableTracking = onNavigateToDashboard,
                 modifier = Modifier.weight(1f),
             )
         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryUiState.kt
@@ -6,6 +6,8 @@ data class LocationHistoryUiState(
     val traces: List<DeviceTrace> = emptyList(),
     val isLoading: Boolean = true,
     val showMapTiles: Boolean = false,
+    /** Whether personal location tracking is on — drives the empty-state "turn on tracking" hint. */
+    val trackingEnabled: Boolean = false,
 )
 
 sealed interface LocationHistoryUiAction {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryViewModel.kt
@@ -24,6 +24,7 @@ class LocationHistoryViewModel(
         LocationHistoryUiState(
             dayStartMs = localDayStart(Clock.System.now().toEpochMilliseconds()),
             showMapTiles = locationPreferences.mapProvider.value == LocationMapProvider.OpenStreetMap,
+            trackingEnabled = locationPreferences.trackingEnabled.value,
         )
     )
     val uiState: StateFlow<LocationHistoryUiState> = _uiState.asStateFlow()
@@ -34,6 +35,11 @@ class LocationHistoryViewModel(
                 _uiState.update {
                     it.copy(showMapTiles = provider == LocationMapProvider.OpenStreetMap)
                 }
+            }
+        }
+        viewModelScope.launch {
+            locationPreferences.trackingEnabled.collect { enabled ->
+                _uiState.update { it.copy(trackingEnabled = enabled) }
             }
         }
         loadDay(_uiState.value.dayStartMs)


### PR DESCRIPTION
## Problem
An empty location-history day was a dead end — just "No locations recorded on this day", with no hint that the reason is *location tracking is off* and no way to fix it.

## Fix
When a history day is empty **and** `trackingEnabled` is false, show an underlined **"Turn on location tracking"** link beneath the message. Tapping it navigates to the location dashboard (`Route.Location`), where the tracking toggle lives.

- When tracking is **on** but a day simply has no fixes → only the plain message (no link).
- The link is gated on `onEnableTracking != null && !trackingEnabled`, so the points-based `DayPlaybackMap` delegation / any non-history caller never shows it.

## Changes
- `DayPlaybackMap` (empty state): new `trackingEnabled` + nullable `onEnableTracking`; renders the link in a centered column under the empty message.
- `LocationHistoryUiState` / `LocationHistoryViewModel`: collect `LocationPreferences.trackingEnabled` into state (mirrors the existing `mapProvider` collector; `LocationPreferences` already injected).
- `LocationHistoryScreen`: threads `trackingEnabled` + a new `onNavigateToDashboard` callback.
- `AppNavHost`: wires it to `Route.Location` (reusing the existing dashboard instance via `launchSingleTop` + `popUpTo`).
- New string `location_history_enable_tracking`.

## Out of scope
- Auto-enabling tracking from the link (navigates to the dashboard toggle instead, as requested).
- Per-day "was tracking on that date" logic — gate is the current `trackingEnabled`.

## Test
- `:homebase-core:compileKotlinJvm` + `:homebase-core:compileAndroidMain` + Konsist green.
- Device: dashboard → tracking off → History → empty day shows the message + link → tap returns to dashboard. Tracking on + empty day → message only. Day with data → normal track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)