### PR TITLE
Keep line numbers in obfuscated release crash traces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,31 @@ adb logcat -d --pid=$(adb shell pidof id.homebase.feed.dev)
 adb logcat -c
 ```
 
+### De-obfuscating release crash stack traces
+
+Release and `dev` builds run R8 with `isMinifyEnabled = true`, so on-device
+traces (logcat, `homebase.log`, the crash-recovery screen, a tester's
+screenshot) show obfuscated names like `a.b.c`. **Do not disable obfuscation** —
+it's defense-in-depth for a crypto/E2E app and keeps the AAB small. Instead,
+translate the trace with the `mapping.txt` R8 emits each build.
+
+- **Crashlytics / Play Console** de-obfuscate automatically: the Crashlytics
+  Gradle plugin uploads `mapping.txt` on every minified build. `proguard-rules.pro`
+  keeps `SourceFile,LineNumberTable`, so these show the exact original file + line.
+- **A raw trace** (logcat / log file / screenshot) — retrace it locally against
+  the mapping for the exact build that produced it:
+
+```bash
+# mapping.txt is written per variant by the release build:
+#   androidApp/build/outputs/mapping/release/mapping.txt   (release)
+#   androidApp/build/outputs/mapping/dev/mapping.txt       (dev)
+# Save the obfuscated trace to trace.txt, then:
+retrace androidApp/build/outputs/mapping/release/mapping.txt trace.txt
+# `retrace` ships in the Android SDK (build-tools / cmdline-tools). `r8 retrace`
+# also works. Keep the mapping.txt from each shipped build — a stale mapping
+# from a different build produces wrong line numbers.
+```
+
 ## Desktop App Logs (JVM / Android Studio `desktopApp:run`)
 
 The Desktop App writes its `homebase.log` to the platform-specific app data directory

--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -12,13 +12,16 @@
 #   public *;
 #}
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# Keep line numbers in release stack traces. Obfuscation stays ON — this only
+# preserves the line-number table so Crashlytics / Play Console (which have the
+# uploaded mapping.txt) and `retrace` resolve crashes to the exact original
+# file + line instead of showing "Unknown Source".
+-keepattributes SourceFile,LineNumberTable
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# Replace the original .kt file name with a constant ("SourceFile") in the
+# bytecode — keeps the line numbers above while still hiding source file names.
+# The mapping file maps everything back during retrace/Crashlytics.
+-renamesourcefileattribute SourceFile
 
 # Filekit
 -keep class com.sun.jna.** { *; }


### PR DESCRIPTION
## Problem

Release crashes show obfuscated stack traces, and even where they're translated they lack line numbers — "Unknown Source" / `:0` — making them hard to act on.

## Why it happens

`androidApp` release & `dev` build types run R8 with `isMinifyEnabled = true` (shrink + obfuscate + optimize). The two standard line-number directives in `proguard-rules.pro` were left **commented out**, so R8 strips the `SourceFile`/`LineNumberTable` attributes. The Crashlytics Gradle plugin already uploads `mapping.txt` (default on), so class/method names *can* be de-obfuscated — but without the line table you don't get exact lines.

## Fix (keep obfuscation, make traces readable)

Uncomment the two directives:

```proguard
-keepattributes SourceFile,LineNumberTable
-renamesourcefileattribute SourceFile
```

- `SourceFile,LineNumberTable` — preserves the line-number table so traces resolve to the **exact original file + line**.
- `-renamesourcefileattribute SourceFile` — replaces the original `.kt` filename with a constant, so source file names stay hidden while line numbers are kept.

**Obfuscation, shrinking, and optimization all stay ON** — only the line table is preserved (negligible DEX size cost).

## Why not just disable obfuscation?

Considered and rejected. For this crypto/E2E chat app (SQLCipher, YouAuth, key handling) obfuscation is meaningful defense-in-depth; disabling it also drops R8 shrinking/optimization and bloats the AAB. The crash-readability problem is fully solvable without it.

## How to read crashes now

- **Crashlytics / Play Console** — de-obfuscated automatically via the uploaded `mapping.txt`, now with exact lines.
- **Raw on-device trace** (logcat / `homebase.log` / screenshot) — `retrace mapping.txt trace.txt` locally. Documented in `CLAUDE.md` (new "De-obfuscating release crash stack traces" section), including where the per-variant `mapping.txt` lives and the caveat to keep the mapping from each shipped build.

## Testing

ProGuard config + docs only; no app code change. These are the standard Android template directives, so R8 accepts them as-is. The full release build (which validates R8 end-to-end) needs the signing keystore and runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)