### PR TITLE
Fix immediate startup crash: LiveShareReadiness resolved unregistered PermissionsManager from Koin

### DIFF
--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/permissions/LocationPermissionCheck.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/permissions/LocationPermissionCheck.android.kt
@@ -1,0 +1,19 @@
+package id.homebase.core.permissions
+
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+import id.homebase.api.ActivityProvider
+
+// Mirrors AndroidPermissionsManager.isPermissionGranted(PermissionType.LOCATION): coarse-only
+// ("approximate") still counts as while-in-use access. checkSelfPermission needs only the
+// application context — no Activity or launcher — so it is safe to call off the composition.
+actual fun isLocationPermissionGranted(): Boolean {
+    val context = ActivityProvider.requireApplicationContext()
+    return ContextCompat.checkSelfPermission(
+        context, Manifest.permission.ACCESS_FINE_LOCATION
+    ) == PackageManager.PERMISSION_GRANTED ||
+        ContextCompat.checkSelfPermission(
+            context, Manifest.permission.ACCESS_COARSE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/permissions/LocationPermissionCheck.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/permissions/LocationPermissionCheck.kt
@@ -1,0 +1,16 @@
+package id.homebase.core.permissions
+
+/**
+ * Read-only check of whether foreground ("while in use") location is currently granted, without an
+ * Activity or a permission launcher.
+ *
+ * [createPermissionsManager] is a `@Composable` that can only run inside composition (it needs
+ * `LocalActivity` + a `rememberLauncherForActivityResult` launcher), so it cannot be a Koin
+ * singleton. Non-UI code that only needs to *read* the location grant — DI singletons, services —
+ * uses this instead. The grant is a process-wide system state, so no instance/context needs to be
+ * threaded through: each platform reads it from the OS (Android via the application context,
+ * iOS via the shared CLLocationManager authorization status).
+ *
+ * See `id.homebase.chat.services.livelocation.LiveShareReadiness`.
+ */
+expect fun isLocationPermissionGranted(): Boolean

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/permissions/LocationPermissionCheck.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/permissions/LocationPermissionCheck.jvm.kt
@@ -1,0 +1,5 @@
+package id.homebase.core.permissions
+
+// Desktop has no runtime location-permission model; PermissionsManager.jvm reports every
+// permission as granted, so the readiness gate matches.
+actual fun isLocationPermissionGranted(): Boolean = true

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/permissions/LocationPermissionCheck.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/permissions/LocationPermissionCheck.native.kt
@@ -1,0 +1,12 @@
+package id.homebase.core.permissions
+
+import platform.CoreLocation.kCLAuthorizationStatusAuthorizedAlways
+import platform.CoreLocation.kCLAuthorizationStatusAuthorizedWhenInUse
+
+// Mirrors IOSPermissionsManager.isPermissionGranted(PermissionType.LOCATION), reading the same
+// process-wide CLLocationManager authorization status (a synchronous OS read — no prompt).
+actual fun isLocationPermissionGranted(): Boolean {
+    val status = LocationPermissionRequester.status
+    return status == kCLAuthorizationStatusAuthorizedWhenInUse ||
+        status == kCLAuthorizationStatusAuthorizedAlways
+}

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/permissions/PermissionsManager.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/permissions/PermissionsManager.native.kt
@@ -57,7 +57,7 @@ actual fun createPermissionsManager(onPermissionResult: (PermissionType, Permiss
  * must stay alive until the user answers the system prompt, while
  * [createPermissionsManager] returns a fresh manager on every composition.
  */
-private object LocationPermissionRequester {
+internal object LocationPermissionRequester {
     private var pending: ((CLAuthorizationStatus) -> Unit)? = null
 
     private val delegate = object : NSObject(), CLLocationManagerDelegateProtocol {

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/permissions/LocationPermissionCheck.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/permissions/LocationPermissionCheck.web.kt
@@ -1,0 +1,5 @@
+package id.homebase.core.permissions
+
+// Web's PermissionsManager reports every permission as granted; match that here so the readiness
+// gate behaves consistently with the existing web stub.
+actual fun isLocationPermissionGranted(): Boolean = true

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -37,8 +37,7 @@ import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.chat.services.livelocation.LiveLocationShareService
 import id.homebase.chat.services.livelocation.LiveShareReadiness
 import id.homebase.core.config.locationLabeledDrive
-import id.homebase.core.permissions.PermissionsManager
-import id.homebase.core.permissions.PermissionType
+import id.homebase.core.permissions.isLocationPermissionGranted
 import id.homebase.core.ui.screens.location.livelocation.LiveLocationReceiveStore
 import id.homebase.chat.services.ChatMessageActionService
 import id.homebase.chat.services.ChatMessageSenderService
@@ -255,10 +254,9 @@ val appModule = module {
     // layer can prompt to set up location instead of starting a share that captures nothing.
     single<LiveShareReadiness> {
         val activation = get<OptionalDriveActivation>()
-        val permissions = get<PermissionsManager>()
         LiveShareReadiness {
             activation.isActivated(locationLabeledDrive) &&
-                permissions.isPermissionGranted(PermissionType.LOCATION)
+                isLocationPermissionGranted()
         }
     }
     single<LocationTracker> { createLocationTracker(get<LocationPointStore>()) }


### PR DESCRIPTION
## Symptom

The release app (`id.homebase.feed`, v1.4.1735) crashes **immediately on launch**, every time, landing on `CrashActivity`. Captured from device logcat:

```
CoroutineCrash: Could not create instance for '[Factory: ConversationListViewModel]'
  Caused by: Could not create instance for '[Singleton: LiveShareReadiness]'
    Caused by: No definition found for type 'PermissionsManager' on scope '_root_'.
```

(Names deobfuscated from the DI graph — the crash fires on the first Compose frame, inside `Choreographer.doFrame`, while building the conversation-list home screen's ViewModel.)

## Root cause

**PR #801** added a `single<LiveShareReadiness>` whose lambda calls `get<PermissionsManager>()`, and made `LiveShareReadiness` a constructor dependency of `ConversationListViewModel`.

But `PermissionsManager` is **never registered in Koin**. It's a `@Composable`, Activity-scoped type created on demand via `createPermissionsManager { }` inside composition (it needs `LocalActivity` + a `rememberLauncherForActivityResult` launcher), so it structurally cannot be a singleton. Every other caller creates it inside a composable.

The first composition of the conversation list resolves the singleton → `get<PermissionsManager>()` → `NoBeanDefFoundException` on the main thread inside a coroutine → process killed.

### Why CI stayed green
The bad `get()` lives inside a `single { }` lambda body, which is resolved lazily — invisible to compile checks and to Koin's `module.verify()` (which only reflects over constructor refs like `viewModelOf`). build-check CI only compiles; no test instantiates this VM through Koin.

## Fix

The readiness gate only needs to **read** whether foreground location is granted — no Activity or launcher required. Introduce a parameterless `expect fun isLocationPermissionGranted(): Boolean`, answered per platform from process-wide OS state:

- **Android** — `ContextCompat.checkSelfPermission` (fine-or-coarse) on the application context via `ActivityProvider`; mirrors `AndroidPermissionsManager.isPermissionGranted(LOCATION)`.
- **iOS** — the shared `CLLocationManager` authorization status; mirrors `IOSPermissionsManager` (`LocationPermissionRequester` is now `internal` so the check reuses the same process-wide manager).
- **Desktop / Web** — `true`, matching their existing permission stubs.

`LiveShareReadiness` now depends on `isLocationPermissionGranted()` instead of the container, removing the unregistered dependency entirely.

## Testing

- [ ] CI green (compile all targets + JVM tests)
- [ ] Manual: release build launches past the home screen
- [ ] Manual: "Share live location" with location off still shows the set-up prompt (the #801 behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)