### PR TITLE
Fix app-start crash: LiveShareReadiness resolved un-registered Permis…

### DIFF
--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/permissions/LocationPermissionQuery.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/permissions/LocationPermissionQuery.android.kt
@@ -1,0 +1,25 @@
+package id.homebase.core.permissions
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+
+/**
+ * App-context-backed location permission read. Needs only a [Context]
+ * (`ContextCompat.checkSelfPermission`), not the Compose `ActivityResult`
+ * launcher that [createPermissionsManager] sets up for *requesting* — so it is
+ * safe to construct from Koin's `platformModule()` with `androidContext()`.
+ *
+ * Mirrors `AndroidPermissionsManager.isPermissionGranted(PermissionType.LOCATION)`:
+ * coarse-only ("approximate") still counts as while-in-use access.
+ */
+fun androidLocationPermissionQuery(context: Context): LocationPermissionQuery =
+    LocationPermissionQuery {
+        ContextCompat.checkSelfPermission(
+            context, Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED ||
+            ContextCompat.checkSelfPermission(
+                context, Manifest.permission.ACCESS_COARSE_LOCATION
+            ) == PackageManager.PERMISSION_GRANTED
+    }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/permissions/LocationPermissionQuery.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/permissions/LocationPermissionQuery.kt
@@ -1,0 +1,20 @@
+package id.homebase.core.permissions
+
+/**
+ * Non-composable, off-composition read of whether the app currently holds
+ * while-in-use location permission.
+ *
+ * [createPermissionsManager] is `@Composable` only because *requesting* a
+ * permission needs a Compose-scoped `ActivityResult` launcher on Android.
+ * Reading the current grant state needs no launcher, so this thin seam can be
+ * provided from Koin (`platformModule()`) and consumed by plain singletons and
+ * services such as [id.homebase.chat.services.livelocation.LiveShareReadiness].
+ *
+ * Resolving the full [PermissionsManager] from Koin is impossible — it has no
+ * non-composable constructor — and attempting it (`get<PermissionsManager>()`)
+ * is what crashed `ConversationListViewModel` at app start on every platform.
+ */
+fun interface LocationPermissionQuery {
+    /** True if ACCESS_FINE or ACCESS_COARSE (while-in-use) location is granted. */
+    suspend fun isGranted(): Boolean
+}

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/permissions/LocationPermissionQuery.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/permissions/LocationPermissionQuery.native.kt
@@ -1,0 +1,20 @@
+package id.homebase.core.permissions
+
+import platform.CoreLocation.CLLocationManager
+import platform.CoreLocation.kCLAuthorizationStatusAuthorizedAlways
+import platform.CoreLocation.kCLAuthorizationStatusAuthorizedWhenInUse
+
+/**
+ * CoreLocation-backed location permission read. `authorizationStatus` is a plain
+ * instance property (no delegate, no prompt), so reading it off-composition is
+ * safe and needs none of the request machinery in [IOSPermissionsManager].
+ *
+ * Mirrors `IOSPermissionsManager.isPermissionGranted(PermissionType.LOCATION)`:
+ * both while-in-use and always count as granted.
+ */
+fun iosLocationPermissionQuery(): LocationPermissionQuery =
+    LocationPermissionQuery {
+        val status = CLLocationManager().authorizationStatus
+        status == kCLAuthorizationStatusAuthorizedWhenInUse ||
+            status == kCLAuthorizationStatusAuthorizedAlways
+    }

--- a/homebase-core/src/androidMain/kotlin/id/homebase/core/di/AppModule.android.kt
+++ b/homebase-core/src/androidMain/kotlin/id/homebase/core/di/AppModule.android.kt
@@ -30,6 +30,8 @@ import id.homebase.core.image.HomebaseImageKeyer
 import id.homebase.core.image.PublicImageFetcher
 import id.homebase.core.notifications.KMPNotifierBackend
 import id.homebase.core.notifications.NotificationBackend
+import id.homebase.core.permissions.LocationPermissionQuery
+import id.homebase.core.permissions.androidLocationPermissionQuery
 import id.homebase.core.settings.createSettings
 import id.homebase.core.share.ShareCacheStorage
 import id.homebase.core.updater.AndroidUpdateAppManager
@@ -41,6 +43,7 @@ import org.koin.core.module.Module
 import org.koin.dsl.module
 
 actual fun platformModule(): Module = module {
+    single<LocationPermissionQuery> { androidLocationPermissionQuery(androidContext()) }
     single<FileOperationsProvider> { AndroidFileOperationsProvider(androidContext()) }
     single { ShareCacheStorage(androidContext()) }
     single { createSettings(androidContext()) }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -37,8 +37,7 @@ import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.chat.services.livelocation.LiveLocationShareService
 import id.homebase.chat.services.livelocation.LiveShareReadiness
 import id.homebase.core.config.locationLabeledDrive
-import id.homebase.core.permissions.PermissionsManager
-import id.homebase.core.permissions.PermissionType
+import id.homebase.core.permissions.LocationPermissionQuery
 import id.homebase.core.ui.screens.location.livelocation.LiveLocationReceiveStore
 import id.homebase.chat.services.ChatMessageActionService
 import id.homebase.chat.services.ChatMessageSenderService
@@ -255,10 +254,14 @@ val appModule = module {
     // layer can prompt to set up location instead of starting a share that captures nothing.
     single<LiveShareReadiness> {
         val activation = get<OptionalDriveActivation>()
-        val permissions = get<PermissionsManager>()
+        // Off-composition location-permission read (LocationPermissionQuery,
+        // provided per-platform in platformModule()). PermissionsManager itself
+        // is @Composable-only, so resolving it here is impossible — doing so
+        // crashed ConversationListViewModel at app start on every platform.
+        val locationPermission = get<LocationPermissionQuery>()
         LiveShareReadiness {
             activation.isActivated(locationLabeledDrive) &&
-                permissions.isPermissionGranted(PermissionType.LOCATION)
+                locationPermission.isGranted()
         }
     }
     single<LocationTracker> { createLocationTracker(get<LocationPointStore>()) }

--- a/homebase-core/src/jvmMain/kotlin/id/homebase/core/di/AppModule.desktop.kt
+++ b/homebase-core/src/jvmMain/kotlin/id/homebase/core/di/AppModule.desktop.kt
@@ -28,6 +28,7 @@ import id.homebase.core.image.PublicImageFetcher
 import id.homebase.core.notifications.DesktopChatNotificationBridge
 import id.homebase.core.notifications.KMPNotifierBackend
 import id.homebase.core.notifications.NotificationBackend
+import id.homebase.core.permissions.LocationPermissionQuery
 import id.homebase.core.settings.createSettings
 import id.homebase.core.share.ShareCacheStorage
 import id.homebase.core.updater.JvmUpdateAppManager
@@ -38,6 +39,10 @@ import org.koin.core.module.Module
 import org.koin.dsl.module
 
 actual fun platformModule(): Module = module {
+    // Desktop has no runtime location permission model — JvmPermissionsManager
+    // grants everything; mirror that here so live-share readiness gates on
+    // add-on activation alone.
+    single<LocationPermissionQuery> { LocationPermissionQuery { true } }
     single<FileOperationsProvider> { JvmFileOperationsProvider() }
     single { ShareCacheStorage() }
     single { createSettings() }

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/di/AppModule.native.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/di/AppModule.native.kt
@@ -30,6 +30,8 @@ import id.homebase.core.image.PHAssetFetcher
 import id.homebase.core.image.PublicImageFetcher
 import id.homebase.core.notifications.KMPNotifierBackend
 import id.homebase.core.notifications.NotificationBackend
+import id.homebase.core.permissions.LocationPermissionQuery
+import id.homebase.core.permissions.iosLocationPermissionQuery
 import id.homebase.core.settings.createSettings
 import id.homebase.core.share.ShareCacheStorage
 import id.homebase.core.updater.IOSUpdateAppManager
@@ -40,6 +42,7 @@ import org.koin.core.module.Module
 import org.koin.dsl.module
 
 actual fun platformModule(): Module = module {
+    single<LocationPermissionQuery> { iosLocationPermissionQuery() }
     single<FileOperationsProvider> { IOSFileOperationsProvider() }
     single { ShareCacheStorage() }
     single { createSettings() }

--- a/homebase-core/src/wasmJsMain/kotlin/id/homebase/core/di/AppModule.web.kt
+++ b/homebase-core/src/wasmJsMain/kotlin/id/homebase/core/di/AppModule.web.kt
@@ -18,6 +18,7 @@ import id.homebase.core.image.HomebaseImageFetcher
 import id.homebase.core.image.HomebaseImageKeyer
 import id.homebase.core.notifications.NoopNotificationBackend
 import id.homebase.core.notifications.NotificationBackend
+import id.homebase.core.permissions.LocationPermissionQuery
 import id.homebase.core.settings.createSettings
 import id.homebase.core.share.ShareCacheStorage
 import id.homebase.core.updater.UpdateAppManager
@@ -27,6 +28,9 @@ import org.koin.dsl.module
 
 actual fun platformModule(): Module = module {
     single { createSettings() }
+    // Web's PermissionsManager grants everything (see WebPlatformStubs); mirror
+    // that so live-share readiness gates on add-on activation alone.
+    single<LocationPermissionQuery> { LocationPermissionQuery { true } }
     single<FileOperationsProvider> { WebFileOperationsProvider() }
     single { ShareCacheStorage() }
     single<NotificationBackend> { NoopNotificationBackend() }


### PR DESCRIPTION
…sionsManager

LiveShareReadiness (added in e9f70490) did get<PermissionsManager>() in its Koin singleton factory, but PermissionsManager has no Koin definition — it is only constructible via the @Composable createPermissionsManager (Android needs a Compose-scoped ActivityResult launcher). The unsatisfiable dependency threw NoDefinitionFoundException while creating ConversationListViewModel, crashing NavHost composition at app start on every platform. It compiled green because Koin resolution is a runtime, not compile-time, failure.

Introduce LocationPermissionQuery — a non-composable, off-composition read of while-in-use location permission — provided per platform in platformModule() (Android: ContextCompat.checkSelfPermission via androidContext(); iOS: CLLocationManager.authorizationStatus; Desktop/Web: granted, matching their PermissionsManager actuals). LiveShareReadiness now gates on this seam instead of the composition-scoped PermissionsManager.

Verified: compiles on JVM, Android, and wasmJs.