### PR TITLE
fix(chat): deleted-bubble timestamp overlap + "You:" before preview icon

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationItem.kt
@@ -56,7 +56,7 @@ import id.homebase.resources.chat_group_legacy
 import id.homebase.resources.chat_group_rejoin_pending
 import id.homebase.resources.chat_no_messages
 import id.homebase.resources.chat_note_to_self
-import id.homebase.resources.chat_preview_sender_prefix
+import id.homebase.resources.chat_preview_sender_label
 import id.homebase.resources.chat_search_result_pinned
 import id.homebase.resources.you
 import org.jetbrains.compose.resources.stringResource
@@ -189,15 +189,18 @@ fun ConversationItem(
                     enrichedData.conversation.lastMessageIsFromActiveUser -> stringResource(MR.string.you)
                     else -> groupSenderName
                 }
-                val previewText = if (senderLabel != null && rawPreview.isNotBlank()) {
-                    stringResource(MR.string.chat_preview_sender_prefix, senderLabel, rawPreview)
+                // Render the sender prefix ("You:" / a group member's name) BEFORE the
+                // content-type icon so it reads "You: <icon> Image", not "<icon> You: Image".
+                val senderPrefix = if (senderLabel != null && rawPreview.isNotBlank()) {
+                    stringResource(MR.string.chat_preview_sender_label, senderLabel)
                 } else {
-                    rawPreview
+                    null
                 }
                 val iconRes = if (pendingSubtitle != null) null else contentLabel?.icon
 
                 ConversationMessagePreview(
-                    text = previewText,
+                    text = rawPreview,
+                    prefix = senderPrefix,
                     iconRes = iconRes,
                     isDeleted = enrichedData.conversation.lastMessageIsDeleted,
                     modifier = Modifier.weight(1f)
@@ -342,12 +345,24 @@ fun ConversationMessagePreview(
     iconRes: ImageVector?,
     isDeleted: Boolean,
     modifier: Modifier = Modifier,
+    prefix: String? = null,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp),
         modifier = modifier
     ) {
+        if (prefix != null) {
+            Text(
+                text = prefix,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(
+                    alpha = if (isDeleted) 0.5f else 1f
+                ),
+                maxLines = 1,
+            )
+        }
+
         if (iconRes != null) {
             Icon(
                 imageVector = iconRes,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -733,12 +733,10 @@ fun MessageBubbleRaw(
                                 } else {
                                     // Mirror the conversation-list preview's deleted marker
                                     // (MessageContentLabel: Block icon + the same string).
-                                    // ponytail: safe only because it sits beside the short fixed
-                                    // "deleted" string. The timestamp-tuck Layout below measures
-                                    // lastLineRight from the text's own origin and assumes it starts
-                                    // at textRowPadding; this icon shifts that origin right by ~20dp.
-                                    // If this icon is ever shown next to variable/long body text,
-                                    // add its width to lastLineEnd or the tucked time can overlap.
+                                    // This icon (16dp) + the row's 4dp gap shift the text's
+                                    // visual origin right; the timestamp-tuck Layout below adds
+                                    // that same offset (leadingIconOffset) to lastLineEnd so the
+                                    // tucked time clears the text instead of overlapping it.
                                     if (message.isDeleted) {
                                         Icon(
                                             imageVector = Icons.Default.Block,
@@ -822,6 +820,13 @@ fun MessageBubbleRaw(
                             }
                         }
                     ) { measurables, constraints ->
+                        // The deleted-message Block icon sits left of the body inside the text
+                        // row (icon 16dp + the row's 4dp gap), shifting the text's visual origin
+                        // right. lastLineRight is measured from the text's own origin, so add this
+                        // offset to lastLineEnd below or the tucked timestamp overlaps the text.
+                        val leadingIconOffset =
+                            if (message.isDeleted) (16.dp + 4.dp).roundToPx() else 0
+
                         // Find MediaMessage index (after author and reply preview)
                         var mediaIndex = 0
                         if (authorName != null) mediaIndex++
@@ -888,7 +893,7 @@ fun MessageBubbleRaw(
                             val textRowPadding = 12.dp.roundToPx()
                             val availableWidth =
                                 if (mediaWidth > 0) mediaWidth else constraints.maxWidth
-                            val lastLineEnd = textRowPadding + lastLineRight.toInt()
+                            val lastLineEnd = textRowPadding + leadingIconOffset + lastLineRight.toInt()
                             val fitsOnLastLine =
                                 (lastLineEnd + horizontalGap + infoPlaceable.width + textRowPadding) <= availableWidth
 
@@ -947,7 +952,7 @@ fun MessageBubbleRaw(
                             val textRowPadding = 12.dp.roundToPx()
                             val availableWidth =
                                 if (mediaWidth > 0) mediaWidth else constraints.maxWidth
-                            val lastLineEnd = textRowPadding + lastLineRight.toInt()
+                            val lastLineEnd = textRowPadding + leadingIconOffset + lastLineRight.toInt()
                             val fitsOnLastLine =
                                 (lastLineEnd + horizontalGap + infoPlaceable.width + textRowPadding) <= availableWidth
 

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -690,6 +690,7 @@
     <string name="chat_message_location">Location</string>
     <string name="chat_message_multiple_media">Media</string>
     <string name="chat_preview_sender_prefix">%1$s: %2$s</string>
+    <string name="chat_preview_sender_label">%1$s:</string>
 
     <string name="chat_location_share">Location</string>
     <string name="chat_location_attachment">Location map</string>


### PR DESCRIPTION
Two small conversation-UI fixes.

## 1. Deleted-message timestamp overlap
The deleted-message bubble renders a leading `Block` icon. The timestamp-tuck `Layout` measured `lastLineRight` from the text's own origin and assumed the text started at `textRowPadding` — but the icon shifts the text's visual origin right by 20dp (16dp icon + 4dp row gap). That offset was unaccounted for, so the tucked time landed ~20dp too far left and overlapped the body (only on deleted messages, since they're the only bubble with a leading icon). Fixed by adding `leadingIconOffset` to `lastLineEnd` in both measure passes. The existing code comment had literally predicted this exact failure.

## 2. "You:" rendered after the content-type icon
The conversation-list preview baked the `You:` / group-sender prefix into the preview text, so it rendered *after* the content-type icon (`<icon> You: Image`). Now the prefix is a standalone leading `Text` so it reads `You: <icon> Image`, via a new `chat_preview_sender_label` string.

## Testing
- `:homebase-chat:compileKotlinJvm` ✅
- `:homebase-common:jvmTest` (Konsist architecture) ✅
- Built + installed debug APK, verified both fixes on a physical Android device ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)