### PR TITLE
feat(location): dashboard live-share lists with per-person + all cancel (#812)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/liverelay/LiveShareRoster.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/liverelay/LiveShareRoster.kt
@@ -52,6 +52,19 @@ object LiveShareRoster {
     ): List<TimedRecipient> =
         current.filterNot { it.endTimeMs == endTimeMs && it.odinId in recipients }
 
+    /**
+     * Remove **every** entry belonging to any of [recipients], regardless of end-time — the
+     * "stop sharing with this person entirely" primitive. Unlike [remove] (which keys on a single
+     * `{recipient, end-time}` share), this drops all of a recipient's overlapping shares at once, so
+     * the deduped Dashboard row that represents a person disappears in one action. No-op for
+     * recipients with no entries.
+     */
+    fun removeRecipients(
+        current: List<TimedRecipient>,
+        recipients: List<String>,
+    ): List<TimedRecipient> =
+        current.filterNot { it.odinId in recipients }
+
     /** The still-live entries at [nowMs] (end-time strictly in the future). May contain duplicates. */
     fun live(roster: List<TimedRecipient>, nowMs: Long): List<TimedRecipient> =
         roster.filter { it.endTimeMs > nowMs }

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/client/liverelay/LiveShareRosterTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/client/liverelay/LiveShareRosterTest.kt
@@ -81,4 +81,31 @@ class LiveShareRosterTest {
             LiveShareRoster.remove(roster, recipients = listOf("a"), endTimeMs = 100),
         )
     }
+
+    @Test
+    fun removeRecipients_dropsAllOfAPersonsEntriesRegardlessOfEndTime() {
+        // "a" has two overlapping shares (@100 and @300); "b" has one. The Dashboard's per-person
+        // stop on "a" must drop BOTH of "a"'s entries while leaving "b" untouched.
+        val roster = listOf(
+            TimedRecipient("a", 100),
+            TimedRecipient("a", 300),
+            TimedRecipient("b", 200),
+        )
+        assertEquals(
+            listOf(TimedRecipient("b", 200)),
+            LiveShareRoster.removeRecipients(roster, recipients = listOf("a")),
+        )
+    }
+
+    @Test
+    fun removeRecipients_removesSeveralPeopleAndIsNoOpForUnknown() {
+        val roster = listOf(TimedRecipient("a", 100), TimedRecipient("b", 200), TimedRecipient("c", 300))
+        // A subset of people drops all their entries...
+        assertEquals(
+            listOf(TimedRecipient("c", 300)),
+            LiveShareRoster.removeRecipients(roster, recipients = listOf("a", "b")),
+        )
+        // ...and a recipient with no entries is a no-op.
+        assertEquals(roster, LiveShareRoster.removeRecipients(roster, recipients = listOf("zzz")))
+    }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/livelocation/LiveLocationShareService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/livelocation/LiveLocationShareService.kt
@@ -15,6 +15,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -65,6 +69,14 @@ class LiveLocationShareService(
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     private val state = MutableStateFlow(readPersisted())
+
+    /**
+     * The current share roster (all entries, including not-yet-expired ones) for UI to observe —
+     * e.g. the Location Dashboard's "Sharing with" list, which dedups by identity and shows the
+     * longest end-time. Read-only; mutate only through [start]/[stop]/[stopAll].
+     */
+    val recipients: StateFlow<List<TimedRecipient>> =
+        state.map { it.recipients }.stateIn(scope, SharingStarted.Eagerly, state.value.recipients)
 
     // Authoritative throttle bookkeeping — only touched under [sendLock].
     private val sendLock = Mutex()
@@ -119,12 +131,32 @@ class LiveLocationShareService(
         logger.i { "STOP -${recipients.size} until=$endTimeMs entries=${roster.size}" }
     }
 
-    /** Stop ALL live sharing now. Reserved for logout/reset paths — not the per-bubble stop. */
+    /** Stop ALL live sharing now. The Dashboard's "stop sharing with everyone" and logout/reset. */
     suspend fun stopAll() {
         update(LiveShareState())
         onLiveShareChanged() // coordinator stops GPS if nothing else needs it
         logger.i { "STOP ALL" }
     }
+
+    /**
+     * Stop **every** live share to any of [recipients] — all their roster entries, regardless of
+     * end-time. This is the Dashboard's per-person "stop sharing with this person" (the list is
+     * deduped to one row per identity), distinct from [stop] which targets a single
+     * `{recipient, end-time}` share (the per-bubble stop). No-op on an empty list.
+     */
+    suspend fun stopAll(recipients: List<OdinId>) {
+        if (recipients.isEmpty()) return
+        val roster = LiveShareRoster.removeRecipients(
+            current = state.value.recipients,
+            recipients = recipients.map { it.domainName },
+        )
+        update(LiveShareState(roster))
+        onLiveShareChanged() // coordinator stops GPS if nothing else needs it
+        logger.i { "STOP recipients=${recipients.size} entries=${roster.size}" }
+    }
+
+    /** Stop all of one person's live shares. Convenience over [stopAll]`(List<OdinId>)`. */
+    suspend fun stopAll(odinId: OdinId) = stopAll(listOf(odinId))
 
     /**
      * Relay the latest GPS fix to [recipientIds] right now, ignoring the throttle window — used on

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1311,6 +1311,13 @@
     <string name="location_dashboard_live_section">Live location sharing</string>
     <string name="location_dashboard_live_open">Open live map</string>
     <string name="location_dashboard_live_empty">There's no live location data at the moment.</string>
+    <string name="location_dashboard_sharing_with">Sharing with</string>
+    <string name="location_dashboard_sharing_with_you">Sharing with you</string>
+    <string name="location_dashboard_share_until">until %1$s</string>
+    <string name="location_dashboard_stop_one_cd">Stop sharing with %1$s</string>
+    <string name="location_dashboard_stop_everyone">Stop sharing with everyone</string>
+    <string name="location_dashboard_stop_confirm_title">Stop all sharing?</string>
+    <string name="location_dashboard_stop_confirm_body">This ends every live location share you've started.</string>
     <string name="share_live_location">Share live location</string>
     <string name="stop_sharing">Stop sharing</string>
     <string name="live_share_active">Live location · %1$s left</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/util/TimeFormatter.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/util/TimeFormatter.kt
@@ -69,6 +69,24 @@ fun formatMomentDate(timestamp: Instant): String {
     }
 }
 
+/**
+ * Forward-looking label for a future moment (e.g. a live-share expiry): the clock time when it
+ * lands on the current local day, otherwise a date + clock time (year added only across years).
+ * Unlike [formatTimestamp], this never collapses a near-future instant to "Just now".
+ */
+@Composable
+fun formatUntilTime(timestamp: Instant): String {
+    val zone = TimeZone.currentSystemDefault()
+    val nowDate = Clock.System.now().toLocalDateTime(zone).date
+    val tsDate = timestamp.toLocalDateTime(zone).date
+    val time = formatTime(timestamp)
+    return when {
+        nowDate == tsDate -> time
+        nowDate.year == tsDate.year -> formatMediumDateNoYear(timestamp) + " " + time
+        else -> formatMediumDate(timestamp) + " " + time
+    }
+}
+
 @Composable
 fun formatMessageTimestamp(timestamp: Instant): String {
     val now = Clock.System.now()

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.outlined.Computer
@@ -29,14 +30,17 @@ import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material.icons.outlined.LocationSearching
 import androidx.compose.material.icons.outlined.Smartphone
 import androidx.compose.material.icons.outlined.WarningAmber
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -49,15 +53,26 @@ import androidx.compose.ui.unit.dp
 import id.homebase.chat.data.ContactUiModel
 import id.homebase.core.ui.screens.location.devices.LocationDeviceInfo
 import id.homebase.core.ui.screens.location.history.LocationTraceCanvas
+import id.homebase.core.ui.screens.location.livelocation.AGE_LABEL_AFTER_MS
 import id.homebase.core.util.formatTimestamp
+import id.homebase.core.util.formatUntilTime
 import id.homebase.core.widget.AvatarImage
 import id.homebase.resources.MR
+import id.homebase.resources.cancel
+import id.homebase.resources.live_location_age_minutes
 import id.homebase.resources.location_dashboard_empty_today
 import id.homebase.resources.location_dashboard_history_section
 import id.homebase.resources.location_dashboard_live_empty
 import id.homebase.resources.location_dashboard_live_open
 import id.homebase.resources.location_dashboard_live_section
 import id.homebase.resources.location_dashboard_perm_banner
+import id.homebase.resources.location_dashboard_share_until
+import id.homebase.resources.location_dashboard_sharing_with
+import id.homebase.resources.location_dashboard_sharing_with_you
+import id.homebase.resources.location_dashboard_stop_confirm_body
+import id.homebase.resources.location_dashboard_stop_confirm_title
+import id.homebase.resources.location_dashboard_stop_everyone
+import id.homebase.resources.location_dashboard_stop_one_cd
 import id.homebase.resources.location_device_no_fix
 import id.homebase.resources.location_device_this_device
 import id.homebase.resources.location_device_unnamed
@@ -71,6 +86,7 @@ import id.homebase.resources.location_locatable_coming_soon
 import id.homebase.resources.location_locatable_section
 import id.homebase.resources.location_status_pending
 import id.homebase.resources.location_status_points_today
+import id.homebase.resources.stop_sharing
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
 import org.jetbrains.compose.resources.stringResource
@@ -87,6 +103,8 @@ fun LocationDashboardContent(
     fetchTile: suspend (zoom: Int, x: Int, y: Int) -> ByteArray?,
     onOpenHistory: () -> Unit,
     onOpenLiveMap: () -> Unit,
+    onStopSharingWith: (String) -> Unit,
+    onStopSharingWithEveryone: () -> Unit,
     onOpenDevice: (Uuid) -> Unit,
     onOpenSetup: () -> Unit,
     onManageEmergencyAccess: () -> Unit,
@@ -129,12 +147,13 @@ fun LocationDashboardContent(
             }
         }
 
-        // ── Live location sharing (title always shown; card opens the map or shows an empty state) ──
+        // ── Live location sharing (title always shown; below it the map link + who's sharing) ──
         Text(
             text = stringResource(MR.string.location_dashboard_live_section),
             style = MaterialTheme.typography.titleMedium,
         )
         if (uiState.liveSharingVisible) {
+            // Map link — opens the live map (Route.LocationLive).
             Card(
                 modifier = Modifier.fillMaxWidth().clickable(onClick = onOpenLiveMap),
             ) {
@@ -158,6 +177,62 @@ fun LocationDashboardContent(
                         contentDescription = null,
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
+                }
+            }
+
+            // People I'm sharing with — one row per person (longest "until"), per-row + all stop.
+            if (uiState.outgoingShares.isNotEmpty()) {
+                var confirmStopAll by remember { mutableStateOf(false) }
+                Text(
+                    text = stringResource(MR.string.location_dashboard_sharing_with),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column {
+                        uiState.outgoingShares.forEachIndexed { index, row ->
+                            if (index > 0) HorizontalDivider()
+                            OutgoingShareRowItem(row = row, onStop = { onStopSharingWith(row.odinId) })
+                        }
+                    }
+                }
+                TextButton(onClick = { confirmStopAll = true }) {
+                    Text(text = stringResource(MR.string.location_dashboard_stop_everyone))
+                }
+                if (confirmStopAll) {
+                    AlertDialog(
+                        onDismissRequest = { confirmStopAll = false },
+                        title = { Text(stringResource(MR.string.location_dashboard_stop_confirm_title)) },
+                        text = { Text(stringResource(MR.string.location_dashboard_stop_confirm_body)) },
+                        confirmButton = {
+                            TextButton(onClick = {
+                                confirmStopAll = false
+                                onStopSharingWithEveryone()
+                            }) { Text(stringResource(MR.string.stop_sharing)) }
+                        },
+                        dismissButton = {
+                            TextButton(onClick = { confirmStopAll = false }) {
+                                Text(stringResource(MR.string.cancel))
+                            }
+                        },
+                    )
+                }
+            }
+
+            // People sharing with me — name + live-updating age (shown only past 2 minutes stale).
+            if (uiState.incomingShares.isNotEmpty()) {
+                Text(
+                    text = stringResource(MR.string.location_dashboard_sharing_with_you),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column {
+                        uiState.incomingShares.forEachIndexed { index, row ->
+                            if (index > 0) HorizontalDivider()
+                            IncomingShareRowItem(row = row)
+                        }
+                    }
                 }
             }
         } else {
@@ -476,6 +551,78 @@ private fun EmergencyAvatarStack(
                     color = MaterialTheme.colorScheme.onSurface,
                 )
             }
+        }
+    }
+}
+
+/** One row in the "Sharing with" list: avatar, name, "until …", and a per-person stop button. */
+@Composable
+private fun OutgoingShareRowItem(
+    row: OutgoingShareRow,
+    onStop: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, top = 8.dp, bottom = 8.dp, end = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        AvatarImage(
+            avatarUrl = row.avatarUrl,
+            avatarInitials = row.avatarInitials,
+            size = 40.dp,
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = row.name,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Text(
+                text = stringResource(
+                    MR.string.location_dashboard_share_until,
+                    formatUntilTime(Instant.fromEpochMilliseconds(row.untilMs)),
+                ),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        IconButton(onClick = onStop) {
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = stringResource(MR.string.location_dashboard_stop_one_cd, row.name),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+/** One row in the "Sharing with you" list: avatar, name, and the last-fix age (only past 2 min). */
+@Composable
+private fun IncomingShareRowItem(row: IncomingShareRow) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        AvatarImage(
+            avatarUrl = row.avatarUrl,
+            avatarInitials = row.avatarInitials,
+            size = 40.dp,
+        )
+        Text(
+            text = row.name,
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.weight(1f),
+        )
+        if (row.ageMs > AGE_LABEL_AFTER_MS) {
+            Text(
+                text = stringResource(MR.string.live_location_age_minutes, (row.ageMs / 60_000L).toInt()),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
@@ -233,6 +233,8 @@ fun LocationScreen(
                 fetchTile = { z, x, y -> previewProvider.getTilePng(z, x, y) },
                 onOpenHistory = onNavigateToHistory,
                 onOpenLiveMap = onNavigateToLiveMap,
+                onStopSharingWith = { execute(LocationUiAction.StopSharingWith(it)) },
+                onStopSharingWithEveryone = { execute(LocationUiAction.StopSharingWithEveryone) },
                 onOpenDevice = { onNavigateToFindDevice(it) },
                 onOpenSetup = { dashboardOverride = false },
                 onManageEmergencyAccess = {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
@@ -38,10 +38,35 @@ data class LocationUiState(
     val mapProvider: LocationMapProvider = LocationMapProvider.DEFAULT,
     /** Show the "Live location sharing" dashboard section: I'm sharing, or a recent inbound point exists. */
     val liveSharingVisible: Boolean = false,
+    /** People I'm sharing my live location with — deduped by identity, longest end-time. */
+    val outgoingShares: List<OutgoingShareRow> = emptyList(),
+    /** People sharing their live location with me — with the age of their last fix. */
+    val incomingShares: List<IncomingShareRow> = emptyList(),
 ) {
     /** Only OSM tiles are implemented today; the canvas takes a boolean. */
     val showMapTiles: Boolean get() = mapProvider == LocationMapProvider.OpenStreetMap
 }
+
+/** One row in the "Sharing with" list: a person and the latest time my share to them lasts. */
+data class OutgoingShareRow(
+    /** Identity domain string (OdinId.domainName) — stable list key and stop target. */
+    val odinId: String,
+    val name: String,
+    val avatarInitials: String,
+    val avatarUrl: String?,
+    /** Longest end-time across this person's overlapping shares (UTC epoch-ms). */
+    val untilMs: Long,
+)
+
+/** One row in the "Sharing with you" list: a person and how stale their last fix is. */
+data class IncomingShareRow(
+    val odinId: String,
+    val name: String,
+    val avatarInitials: String,
+    val avatarUrl: String?,
+    /** Age of their last received fix (ms); the label only shows past AGE_LABEL_AFTER_MS. */
+    val ageMs: Long,
+)
 
 /**
  * Main-screen body switch: dashboard once the add-on is fully set up, setup otherwise.
@@ -71,6 +96,10 @@ sealed interface LocationUiAction {
     data class SetTrackingEnabled(val enabled: Boolean) : LocationUiAction
     data class SetIconVisible(val visible: Boolean) : LocationUiAction
     data class SetMapProvider(val provider: LocationMapProvider) : LocationUiAction
+    /** Stop all of one person's outgoing live shares (Dashboard per-row stop). */
+    data class StopSharingWith(val odinId: String) : LocationUiAction
+    /** Stop every outgoing live share (Dashboard "stop sharing with everyone"). */
+    data object StopSharingWithEveryone : LocationUiAction
     data object RequestWhileInUseClicked : LocationUiAction
     data object RequestAlwaysClicked : LocationUiAction
     data object OpenSystemSettingsClicked : LocationUiAction

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.connections.ConnectionNetworkProvider
+import id.homebase.api.common.OdinId
 import id.homebase.chat.conversationlist.ExtendPermissionUiState
 import id.homebase.chat.conversationlist.ExtendPermissionViewModel
 import id.homebase.chat.services.convo.contact.ContactService
@@ -19,6 +20,7 @@ import id.homebase.core.ui.screens.location.history.localDayStart
 import id.homebase.core.ui.screens.location.history.shiftDay
 import id.homebase.core.ui.screens.location.livelocation.LIVE_STALE_MS
 import id.homebase.core.ui.screens.location.livelocation.LiveLocationReceiveStore
+import id.homebase.core.util.initials
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -172,16 +174,58 @@ class LocationViewModel(
                 _uiState.update { it.copy(pendingUploadCount = n.toInt()) }
             }
         }
-        // "Live location sharing" dashboard section is visible when I'm sharing OR someone's recent
-        // position is in the receive store. isActive() is a plain getter (no flow), so the 30 s ticker
-        // re-evaluates it; the receive store flow covers inbound updates.
+        // "Live location sharing" dashboard section: who I'm sharing with (deduped, longest until),
+        // who's sharing with me (with age), and whether to show the section/map-link at all. Recomputed
+        // on the 30 s ticker so the live entries prune and ages/until stay fresh without a second timer.
         viewModelScope.launch {
-            combine(receiveStore.positions, liveTicker()) { positions, _ ->
+            combine(
+                liveShareService.recipients,
+                receiveStore.positions,
+                liveTicker(),
+            ) { roster, positions, _ ->
                 val now = Clock.System.now().toEpochMilliseconds()
-                liveShareService.isActive() ||
-                    positions.values.any { now - it.receivedAtMs <= LIVE_STALE_MS }
-            }.collect { visible ->
-                _uiState.update { it.copy(liveSharingVisible = visible) }
+
+                // Outgoing: one row per identity, longest end-time across overlapping shares.
+                val outgoing = roster
+                    .filter { it.endTimeMs > now }
+                    .groupBy { it.odinId }
+                    .map { (id, entries) ->
+                        val contact = contactService.resolveByOdinId(OdinId(id))
+                        OutgoingShareRow(
+                            odinId = id,
+                            name = contact?.name?.ifEmpty { null } ?: id,
+                            avatarInitials = contact?.avatarInitials?.ifEmpty { null } ?: id.initials(),
+                            avatarUrl = contact?.avatarUrl?.ifEmpty { null },
+                            untilMs = entries.maxOf { it.endTimeMs },
+                        )
+                    }
+                    .sortedBy { it.name.lowercase() }
+
+                // Incoming: people whose last fix is still fresh, with its age.
+                val incoming = positions.values
+                    .filter { now - it.receivedAtMs <= LIVE_STALE_MS }
+                    .map { lp ->
+                        val id = lp.senderOdinId.domainName
+                        val contact = contactService.resolveByOdinId(lp.senderOdinId)
+                        IncomingShareRow(
+                            odinId = id,
+                            name = contact?.name?.ifEmpty { null } ?: id,
+                            avatarInitials = contact?.avatarInitials?.ifEmpty { null } ?: id.initials(),
+                            avatarUrl = contact?.avatarUrl?.ifEmpty { null },
+                            ageMs = now - lp.receivedAtMs,
+                        )
+                    }
+                    .sortedBy { it.name.lowercase() }
+
+                Triple(outgoing.isNotEmpty() || incoming.isNotEmpty(), outgoing, incoming)
+            }.collect { (visible, outgoing, incoming) ->
+                _uiState.update {
+                    it.copy(
+                        liveSharingVisible = visible,
+                        outgoingShares = outgoing,
+                        incomingShares = incoming,
+                    )
+                }
             }
         }
     }
@@ -240,6 +284,14 @@ class LocationViewModel(
 
             is LocationUiAction.SetMapProvider -> {
                 viewModelScope.launch { locationPreferences.setMapProvider(action.provider) }
+            }
+
+            is LocationUiAction.StopSharingWith -> {
+                viewModelScope.launch { liveShareService.stopAll(OdinId(action.odinId)) }
+            }
+
+            LocationUiAction.StopSharingWithEveryone -> {
+                viewModelScope.launch { liveShareService.stopAll() }
             }
 
             // Permission requests are dispatched at the screen level (the


### PR DESCRIPTION
Closes #812.

## What

Expands the Location Dashboard's live-share section from a single card into two readable lists, per-person + all-at-once cancel of outgoing shares, and the existing map link.

### Sharing with (outgoing)
- Unique people you're sharing with — **deduped by odinId**, showing the **longest "until"** across overlapping shares (no duplicate rows).
- Per-row stop removes **all** of that person's live shares.
- Section-level **"Stop sharing with everyone"** with a confirm dialog.

### Sharing with you (incoming)
- People sharing with you, each with a **live-updating age** label — shorthand (`5m`, reusing `live_location_age_minutes`), shown **only past 2 minutes** (`AGE_LABEL_AFTER_MS`), and dropped after 30 min stale (`LIVE_STALE_MS`).

### Map link
- The existing "Open live map" card (→ `Route.LocationLive`) stays, shown whenever anything is live.

Empty sub-states omit a subsection when its list is empty; the prior empty card shows when nothing is live.

## How

- **`LiveShareRoster.removeRecipients()`** — drops all of a recipient's entries regardless of end-time (pure roster math).
- **`LiveLocationShareService`** — exposes a read-only `recipients: StateFlow`, adds `stopAll(odinId)` / `stopAll(recipients: List<OdinId>)` overloads (no-arg `stopAll()` already meant "everyone"). Stop logic stays in the service so GPS-relay pruning stays in one place.
- **`LocationViewModel`** — one combine over `recipients` + `positions` + the existing 30s `liveTicker()` builds both lists (contacts resolved via `ContactService.resolveByOdinId` with domain-name/`initials()` fallback) and `liveSharingVisible`. New `StopSharingWith` / `StopSharingWithEveryone` actions.
- **`LocationDashboardContent`** — renders the two lists, per-row stop, stop-all confirm dialog; reuses `AvatarImage`. New `formatUntilTime()` helper (forward-looking clock/date time) in `TimeFormatter`.

### Cancel semantics (per review discussion)
These are **additive** — the per-bubble `stop(recipients, endTimeMs)` path (`ConversationListViewModel.StopLiveLocationShare`) is **untouched**. Stopping one share from a chat bubble still removes only that `{recipient, end-time}` instance and leaves overlapping shares to the same person running. The Dashboard's deduped per-person row is the only caller of the new "remove all of a person" behavior.

## Tests / verification
- `LiveShareRosterTest` extended: `removeRecipients` drops all of a person's entries across end-times, handles a subset of people, and is a no-op for unknown recipients.
- Compiles JVM + Android (`:homebase-{api,common,chat,core}`); `homebase-api` / `homebase-chat` jvmTest green; `homebase-common` Konsist `ArchitectureTest` gate green (all new strings resource-backed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)