### PR TITLE
fix(location): receive-collector lifecycle, tracking-off persistence, maps-off CTA, grant-based landing

### DIFF
--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1311,6 +1311,8 @@
     <string name="location_dashboard_live_section">Live location sharing</string>
     <string name="location_dashboard_live_open">Open live map</string>
     <string name="location_dashboard_live_empty">There's no live location data at the moment.</string>
+    <string name="location_maps_off_title">Maps are turned off</string>
+    <string name="location_maps_off_cta">Turn on maps</string>
     <string name="location_dashboard_sharing_with">Sharing with</string>
     <string name="location_dashboard_sharing_with_you">Sharing with you</string>
     <string name="location_dashboard_share_until">until %1$s</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationPointStore.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationPointStore.kt
@@ -25,6 +25,14 @@ class LocationPointStore(
     private val databaseManager: DatabaseManager,
     private val deviceSensors: DeviceSensors,
     /**
+     * Read at submit() time to decide whether to PERSIST a fix as history. A live share holds
+     * GPS on even with tracking off (the coordinator's wantsGps()), so fixes still arrive here —
+     * but with tracking off they must only be relayed, never recorded as the user's history
+     * (bug #823). Relay (onPointsBuffered + lastPoint) stays unconditional. Defaults to true so
+     * tests and any non-tracking caller persist as before; AppModule wires the live preference.
+     */
+    private val isTrackingEnabled: () -> Boolean = { true },
+    /**
      * Invoked after a non-empty batch lands in the buffer, on submit()'s
      * coroutine. Wired in AppModule to the uploader's rate-gated flushIfDue so
      * EVERY capture path triggers a drain — the Android background receiver AND
@@ -75,14 +83,22 @@ class LocationPointStore(
                 steps = if (i == lastIndex) sample?.deltaSteps else null,
             )
         }
-        databaseManager.locationPoint.insertPoints(buffered)
+        // Persist as history ONLY when tracking is on. With tracking off (fixes arriving solely
+        // because a live share holds GPS on), skip the DB insert so no history/trace/point-count
+        // is recorded — but still update _lastPoint and fire onPointsBuffered below so the live
+        // share keeps relaying (bug #823).
+        val persist = isTrackingEnabled()
+        if (persist) {
+            databaseManager.locationPoint.insertPoints(buffered)
+        }
         _lastPoint.value = last
         // Info (not debug) so the background capture/upload pipeline is auditable
         // in homebase.log — pending is the not-yet-uploaded backlog that the
         // iPhone stall would have shown climbing without a flush.
         val pending = runCatching { databaseManager.locationPoint.countUnmarked() }.getOrDefault(-1L)
         logger.i {
-            "Buffered ${accepted.size}/${points.size} points pending=$pending " +
+            val verb = if (persist) "Buffered" else "Relayed-only (tracking off)"
+            "$verb ${accepted.size}/${points.size} points pending=$pending " +
                 "(last src=${last?.src} bat=$battery steps=${sample?.deltaSteps})"
         }
         // Trigger a drain from common code so iOS gets the same background flush

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/tracking/LocationPointStoreTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/tracking/LocationPointStoreTest.kt
@@ -150,6 +150,35 @@ class LocationPointStoreTest {
     }
 
     @Test
+    fun trackingOffSkipsPersistButStillRelays() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val db = DatabaseManager(
+            { JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY) },
+            dispatcher = dispatcher,
+            readDispatcher = dispatcher,
+        )
+        try {
+            var relays = 0
+            // Tracking OFF: fixes arrive only because a live share holds GPS on (bug #823).
+            val store = LocationPointStore(
+                db,
+                FakeSensors(),
+                isTrackingEnabled = { false },
+                onPointsBuffered = { relays++ },
+            )
+            store.submit(listOf(point(t = 0), point(t = 60_000, lon = 13.01)))
+            // No history persisted: nothing buffered for upload, DB empty, point-count zero.
+            assertEquals(0, store.countPendingUpload())
+            assertEquals(0, db.locationPoint.selectByTimeRange(0, 3_600_000).size)
+            // But the relay seam still fired and lastPoint advanced, so the live share keeps sending.
+            assertEquals(1, relays)
+            assertEquals(60_000, assertNotNull(store.lastPoint.value).t)
+        } finally {
+            db.close()
+        }
+    }
+
+    @Test
     fun haversineSanity() {
         // One degree of longitude at the equator ≈ 111.3 km.
         val d = LocationPointStore.haversineMeters(0.0, 0.0, 0.0, 1.0)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -227,6 +227,9 @@ val appModule = module {
         LocationPointStore(
             databaseManager = get(),
             deviceSensors = get(),
+            // History persistence is gated on the tracking master switch; a live share's GPS
+            // fixes are relayed but not recorded as history when tracking is off (bug #823).
+            isTrackingEnabled = { get<LocationPreferences>().trackingEnabled.value },
             // Every buffered batch drains immediately (rate-gated by the
             // uploader). Lazy get() avoids the construction-time cycle; resolved
             // at flush time. This is the iOS background-flush fix — the Apple
@@ -420,6 +423,14 @@ val appModule = module {
             // a missing promoteToForeground() can't hang the app on "syncing".
             startsHeadless = get<PlatformInfo>().supportsBackgroundWake,
             onPostAuthenticated = {
+                // Live Relay receive store: clear any prior identity's positions for a clean
+                // slate (they rehydrate from the server's flush-on-connect). Resolved FIRST and
+                // independent of the other services so its app-lifetime init{} collector is
+                // guaranteed up — a throw in a later location reset() below can't prevent the
+                // consumer from existing when relay packets arrive (bug #824). The collector is
+                // never cancelled here; logout clears it in-stream via SessionEnded.
+                get<LiveLocationReceiveStore>().reset()
+
                 // Preload conversations and contacts from local DB while navigation
                 // and Compose composition are still in progress, saving ~800ms.
                 val conversationStream = get<ConversationStream>()
@@ -481,8 +492,6 @@ val appModule = module {
                 // the right GPS hold. reset() pokes the coordinator via refreshGpsHold().
                 get<LiveLocationShareService>().reset()
                 get<LocationTrackingCoordinator>().reset()
-                // In-memory receive store rehydrates from the server's flush-on-connect.
-                get<LiveLocationReceiveStore>().apply { reset(); start() }
             }
         )
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -1314,6 +1314,9 @@ fun AppNavHost(
                                 LiveLocationScreen(
                                     viewModel = koinViewModel(),
                                     onNavigateBack = { navController.popBackStack() },
+                                    // Maps-off CTA → location/maps setup (Route.Location when
+                                    // activated, else onboarding), reusing the shared nav lambda.
+                                    onOpenSetup = openLocation,
                                 )
                             }
                         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
@@ -154,14 +154,14 @@ fun LocationScreen(
             (action as? LocationUiAction.SetTrackingEnabled)?.enabled == true
     }
 
-    // Body switcher. The default is permission-gated: Setup until the add-on is
-    // fully set up (activated + tracking + both location grants), Dashboard after.
+    // Body switcher. The default is grant-gated: Setup until the add-on is activated
+    // with both location grants, Dashboard after — independent of the "Track my location"
+    // toggle (a granted user with tracking off still wants the dashboard, bug #822).
     // The three-dot menu lets the user override either way (null = follow default);
     // the override resets when the screen leaves the back stack.
     var dashboardOverride by remember { mutableStateOf<Boolean?>(null) }
     val defaultsToDashboard = isDashboard(
         activated = uiState.activated,
-        trackingEnabled = uiState.trackingEnabled,
         trackerAvailable = uiState.trackingAvailable,
         // Both location grants required before defaulting to the dashboard — "while
         // using the app" alone keeps Setup as the default to finish the always grant.

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
@@ -71,24 +71,26 @@ data class IncomingShareRow(
 /**
  * Main-screen body switch: dashboard once the add-on is fully set up, setup otherwise.
  *
- * A tracker device only reaches the dashboard once it is [activated], tracking is on,
- * AND its location permissions are complete ([permissionsComplete] = while-in-use AND
- * always/background both granted). This keeps a user who just allowed "while using the
- * app" on Setup to finish the background grant, rather than jumping to the dashboard
- * the moment the first permission lands (and auto-enables tracking).
+ * A tracker device reaches the dashboard once it is [activated] AND its location permissions
+ * are complete ([permissionsComplete] = while-in-use AND always/background both granted). The
+ * landing keys on the GRANTS, not the tracking master switch: a user with both grants but
+ * "Track my location" off still wants the dashboard (to view live shares / others), so gating
+ * on the toggle wrongly stranded them on Setup (bug #822). Conversely, with both grants denied,
+ * permissionsComplete is false and they land on Setup — where they can grant access. A
+ * while-in-use-only grant likewise keeps Setup as the default so the background grant can be
+ * finished.
  *
- * Viewer devices (desktop/web, trackerAvailable = false) never track or request
- * permissions — once activated they are pure viewers and always get the dashboard;
- * requiring the switch or permissions would strand them on Setup forever.
+ * Viewer devices (desktop/web, trackerAvailable = false) never track or request permissions —
+ * once activated they are pure viewers and always get the dashboard; requiring permissions
+ * would strand them on Setup forever.
  */
 fun isDashboard(
     activated: Boolean,
-    trackingEnabled: Boolean,
     trackerAvailable: Boolean,
     permissionsComplete: Boolean,
     setupOverride: Boolean,
 ): Boolean = !setupOverride && activated &&
-    (!trackerAvailable || (trackingEnabled && permissionsComplete))
+    (!trackerAvailable || permissionsComplete)
 
 sealed interface LocationUiAction {
     data object SetupClicked : LocationUiAction

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationReceiveStore.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationReceiveStore.kt
@@ -8,7 +8,6 @@ import id.homebase.api.client.liverelay.LiveLocationCodec
 import id.homebase.api.client.liverelay.LiveLocationPoint
 import id.homebase.api.common.OdinId
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -45,39 +44,63 @@ class LiveLocationReceiveStore(
     private val nowMs: () -> Long = { Clock.System.now().toEpochMilliseconds() },
 ) {
     private val logger = Logger.withTag(TAG)
-    private var job: Job? = null
 
     private val _positions = MutableStateFlow<Map<OdinId, LivePosition>>(emptyMap())
     val positions: StateFlow<Map<OdinId, LivePosition>> = _positions.asStateFlow()
 
-    fun start() {
-        if (job?.isActive == true) return
-        job = scope.launch {
-            eventBus.events.collect { event ->
-                if (event !is BackendEvent.LiveRelayReceived) return@collect
-                if (event.channelKey != LIVE_LOCATION_CHANNEL_KEY) return@collect
-                val pt = LiveLocationCodec.decode(event.blob)
-                if (pt == null) {
-                    logger.w {
-                        "RECV-DECODE-FAIL from=${event.senderOdinId.domainName} bytes=${event.blob.length}"
+    // The collector runs for the whole app lifetime on the app-scope (SupervisorJob, never
+    // cancelled on logout), so a received packet always has a live consumer — independent of
+    // whether the fragile onPostAuthenticated bootstrap ran, was deferred (headless), or a
+    // reconnect happened. Logout is handled in-stream via SessionEnded; see [reset]. (Bug #824:
+    // the old start()/reset()-job model left the collector dead whenever start() wasn't reached.)
+    init {
+        scope.launch { observeEvents() }
+    }
+
+    private suspend fun observeEvents() {
+        logger.i { "receive collector started" }
+        // Unlike ContactBookStream, we deliberately do NOT drop the replay buffer: EventBus
+        // replay=1 lets a slightly-late collector still catch the server's last flush-on-connect
+        // point, and a stale replayed position is harmless (overwritten; aged out by receivedAt).
+        eventBus.events.collect { event ->
+            when (event) {
+                is BackendEvent.SessionEnded -> reset()
+
+                is BackendEvent.LiveRelayReceived -> {
+                    if (event.channelKey != LIVE_LOCATION_CHANNEL_KEY) {
+                        logger.d {
+                            "RECV-DROP wrong-channel from=${event.senderOdinId.domainName} ch=${event.channelKey}"
+                        }
+                        return@collect
                     }
-                    return@collect
+                    val pt = LiveLocationCodec.decode(event.blob)
+                    if (pt == null) {
+                        logger.w {
+                            "RECV-DECODE-FAIL from=${event.senderOdinId.domainName} bytes=${event.blob.length}"
+                        }
+                        return@collect
+                    }
+                    _positions.update { current ->
+                        current + (event.senderOdinId to LivePosition(event.senderOdinId, pt, event.receivedAt))
+                    }
+                    logger.i {
+                        "RECV-DECODED from=${event.senderOdinId.domainName} lat=${pt.lat} lon=${pt.lon} " +
+                            "ageMs=${nowMs() - event.receivedAt} tracked=${_positions.value.size}"
+                    }
                 }
-                _positions.update { current ->
-                    current + (event.senderOdinId to LivePosition(event.senderOdinId, pt, event.receivedAt))
-                }
-                logger.i {
-                    "RECV-DECODED from=${event.senderOdinId.domainName} lat=${pt.lat} lon=${pt.lon} " +
-                        "ageMs=${nowMs() - event.receivedAt} tracked=${_positions.value.size}"
-                }
+
+                else -> {}
             }
         }
     }
 
-    /** Stop collecting and drop all positions (logout). They rehydrate from the server on next login. */
+    /**
+     * Drop all positions (logout / new identity). The collector is NOT cancelled — it stays
+     * subscribed for the app's lifetime; positions rehydrate from the server's flush-on-connect
+     * after the next login. Called in-stream on [BackendEvent.SessionEnded] and from the post-auth
+     * bootstrap for a clean slate.
+     */
     fun reset() {
-        job?.cancel()
-        job = null
         _positions.value = emptyMap()
     }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationScreen.kt
@@ -1,11 +1,18 @@
 package id.homebase.core.ui.screens.location.livelocation
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Map
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -17,12 +24,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.api.client.location.LocationPreviewProvider
 import id.homebase.resources.MR
 import id.homebase.resources.live_location_empty
 import id.homebase.resources.live_location_title
+import id.homebase.resources.location_maps_off_cta
+import id.homebase.resources.location_maps_off_title
 import id.homebase.resources.menu_back
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
@@ -32,6 +43,7 @@ import org.koin.compose.koinInject
 fun LiveLocationScreen(
     viewModel: LiveLocationViewModel,
     onNavigateBack: () -> Unit,
+    onOpenSetup: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val previewProvider = koinInject<LocationPreviewProvider>()
@@ -57,20 +69,63 @@ fun LiveLocationScreen(
                 .consumeWindowInsets(innerPadding)
                 .padding(innerPadding),
         ) {
-            if (uiState.markers.isEmpty()) {
-                Text(
+            when {
+                // Maps off → a tile-less canvas is just blank; show a tappable "turn on maps"
+                // state instead (#811). Takes precedence over the markers check.
+                !uiState.showMapTiles -> MapsOffState(
+                    onOpenSetup = onOpenSetup,
+                    modifier = Modifier.align(Alignment.Center),
+                )
+
+                uiState.markers.isEmpty() -> Text(
                     text = stringResource(MR.string.live_location_empty),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.align(Alignment.Center).padding(24.dp),
                 )
-            } else {
-                LiveLocationMap(
+
+                else -> LiveLocationMap(
                     markers = uiState.markers,
                     showMapTiles = uiState.showMapTiles,
                     fetchTile = { z, x, y -> previewProvider.getTilePng(z, x, y) },
                 )
             }
         }
+    }
+}
+
+/** Shown on the live map when no map provider is enabled: a tappable CTA into location setup. */
+@Composable
+private fun MapsOffState(
+    onOpenSetup: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.padding(horizontal = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Map,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(48.dp),
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(MR.string.location_maps_off_title),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = stringResource(MR.string.location_maps_off_cta),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.primary,
+            textDecoration = TextDecoration.Underline,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.clickable { onOpenSetup() },
+        )
     }
 }

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/IsDashboardTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/IsDashboardTest.kt
@@ -7,27 +7,33 @@ import kotlin.test.assertTrue
 class IsDashboardTest {
 
     @Test
-    fun trackerDeviceNeedsActivationTrackingAndFullPermissions() {
-        assertFalse(isDashboard(activated = false, trackingEnabled = false, trackerAvailable = true, permissionsComplete = true, setupOverride = false))
-        assertFalse(isDashboard(activated = true, trackingEnabled = false, trackerAvailable = true, permissionsComplete = true, setupOverride = false))
-        assertFalse(isDashboard(activated = false, trackingEnabled = true, trackerAvailable = true, permissionsComplete = true, setupOverride = false))
-        // Activated + tracking but only "while using the app" granted → stay on Setup
-        // to finish the always/background grant (the reported bug).
-        assertFalse(isDashboard(activated = true, trackingEnabled = true, trackerAvailable = true, permissionsComplete = false, setupOverride = false))
-        // All conditions met → dashboard.
-        assertTrue(isDashboard(activated = true, trackingEnabled = true, trackerAvailable = true, permissionsComplete = true, setupOverride = false))
+    fun trackerDeviceNeedsActivationAndFullPermissions() {
+        assertFalse(isDashboard(activated = false, trackerAvailable = true, permissionsComplete = true, setupOverride = false))
+        // Activated but only "while using the app" granted (or both denied → permissionsComplete
+        // false) → stay on Setup to grant access (the both-grants-denied → settings rule, #822).
+        assertFalse(isDashboard(activated = true, trackerAvailable = true, permissionsComplete = false, setupOverride = false))
+        // Activated + both grants → dashboard.
+        assertTrue(isDashboard(activated = true, trackerAvailable = true, permissionsComplete = true, setupOverride = false))
+    }
+
+    @Test
+    fun trackerWithGrantsButTrackingOffStillGetsDashboard() {
+        // Bug #822: the landing keys on grants, NOT the "Track my location" toggle. A device with
+        // both grants but tracking off must land on the dashboard (not Setup). isDashboard no longer
+        // takes trackingEnabled, so both-grants → dashboard regardless of the toggle's state.
+        assertTrue(isDashboard(activated = true, trackerAvailable = true, permissionsComplete = true, setupOverride = false))
     }
 
     @Test
     fun viewerDeviceGetsDashboardOnceActivated() {
-        // Desktop/web: trackingEnabled and permissions are permanently false — must not strand on Setup.
-        assertTrue(isDashboard(activated = true, trackingEnabled = false, trackerAvailable = false, permissionsComplete = false, setupOverride = false))
-        assertFalse(isDashboard(activated = false, trackingEnabled = false, trackerAvailable = false, permissionsComplete = false, setupOverride = false))
+        // Desktop/web: permissions are permanently false — must not strand on Setup.
+        assertTrue(isDashboard(activated = true, trackerAvailable = false, permissionsComplete = false, setupOverride = false))
+        assertFalse(isDashboard(activated = false, trackerAvailable = false, permissionsComplete = false, setupOverride = false))
     }
 
     @Test
     fun setupOverrideWins() {
-        assertFalse(isDashboard(activated = true, trackingEnabled = true, trackerAvailable = true, permissionsComplete = true, setupOverride = true))
-        assertFalse(isDashboard(activated = true, trackingEnabled = false, trackerAvailable = false, permissionsComplete = false, setupOverride = true))
+        assertFalse(isDashboard(activated = true, trackerAvailable = true, permissionsComplete = true, setupOverride = true))
+        assertFalse(isDashboard(activated = true, trackerAvailable = false, permissionsComplete = false, setupOverride = true))
     }
 }


### PR DESCRIPTION
Closes #824, #823, #811, #822 — four related Location fixes that dovetail: a user with location **grants but tracking off** should land on the **dashboard** (#822), that dashboard must **not** record history from a live share's GPS (#823), the map must show a **CTA instead of a blank canvas** when maps are off (#811), and an **incoming** live share must actually reach the dashboard (#824).

## #824 — incoming receive collector never ran
`LiveLocationReceiveStore`'s collector only started via `start()` in the fragile sequential `onPostAuthenticated` block (`AppModule`). An earlier line throwing, the headless/foreground-before-auth deferral, or a `reset()` without `start()` left it dead, so relay packets landed on the `EventBus` with **no consumer** (`RECV=11, RECV-DECODED=0`).

**Fix:** adopt `ContactBookStream`'s proven pattern — an **always-on collector launched in `init {}`** on the app-lifetime scope (`SupervisorJob`, never cancelled), cleared **in-stream on `SessionEnded`** instead of by `reset()` cancelling the job. Added diagnostics the issue asked for: log collector start + the previously-silent **channel-mismatch drop**. The store is resolved **first** in `onPostAuthenticated` so its collector comes up regardless of later failures. No reconnect/`onConnected` change needed — an app-scoped collector survives WS reconnects, and the server re-flushes retained points on connect.

## #823 — live-share GPS persisted as history while tracking off
A live share holds GPS on (correct), but `LocationPointStore.submit()` persisted every fix with no tracking check, so history/“Points today” climbed with tracking off.

**Fix:** gate **only the DB insert** on the tracking switch (`isTrackingEnabled` provider). `_lastPoint` and the `onPointsBuffered()` relay seam stay **unconditional**, so live-share relaying keeps working while tracking is off. Common `submit()` ⇒ covers Android + iOS.

## #811 — blank map when maps are off
**Fix:** a `MapsOffState` branch in `LiveLocationScreen` (precedence over the markers check) showing “Maps are turned off” + an underlined-primary **tappable CTA** into location/maps setup, wired to the existing `openLocation` nav. Reuses the CTA style from `DayPlaybackMap`.

## #822 — grants OK + tracking off wrongly opened Settings
Root cause (confirmed on Android): the dashboard default was gated on the **tracking toggle** (`trackingEnabled && permissionsComplete`).

**Fix:** key the landing on **grants**, not the toggle — drop `trackingEnabled` from `isDashboard()`. Granted users land on the dashboard regardless of the toggle; both-grants-denied keeps `permissionsComplete=false` → Settings; desktop/web viewers unchanged.

## Tests / verification
- `IsDashboardTest` updated for the new signature + a **tracking-off-but-granted → dashboard** case.
- `LocationPointStoreTest` gains a **tracking-off "skip persist but still relay"** case.
- Compiles JVM + Android (`:homebase-{common,api,chat,core}`); `homebase-core`/`api`/`common` jvmTest green; Konsist `ArchitectureTest` green (new strings resource-backed).
- Manual matrix (Android, then iOS) per the four acceptance criteria — receive-on-connect + reconnect/cold-wake, no history while tracking off (relay intact), maps-off CTA, and grant-based landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)