### PR TITLE
fix(chat): attachment-tray Send→Next button — blue, right-aligned, relabeled (#820)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/AttachmentOptions.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/AttachmentOptions.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Casino
@@ -35,6 +36,8 @@ import androidx.compose.material.icons.filled.PlayCircle
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.UploadFile
 import androidx.compose.material.icons.outlined.Circle
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ElevatedButton
@@ -65,6 +68,7 @@ import id.homebase.core.gallery.GalleryCache
 import id.homebase.core.gallery.GalleryImage
 import id.homebase.core.gallery.rememberGalleryPermissionState
 import id.homebase.core.ui.theme.Dimens
+import id.homebase.core.ui.theme.HomebaseTheme
 import id.homebase.core.util.isMobile
 import id.homebase.core.util.noRippleClickable
 import id.homebase.resources.MR
@@ -82,7 +86,7 @@ import id.homebase.resources.cd_gallery_thumbnail
 import id.homebase.resources.cd_not_selected
 import id.homebase.resources.cd_play_video
 import id.homebase.resources.chat_gallery_selection_index
-import id.homebase.resources.chat_gallery_send_count
+import id.homebase.resources.chat_gallery_next_count
 import id.homebase.resources.chat_select_more_photos
 import id.homebase.resources.go_to_settings
 import id.homebase.resources.manage
@@ -335,18 +339,30 @@ fun AttachmentGallery(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.End
                 ) {
-                    ElevatedButton(
+                    // "Next", not "Send": tapping opens the full-screen attachment editor.
+                    // Reuse the "+" button's blue so it reads as the primary action.
+                    Button(
                         onClick = {
                             val ordered = selectedIds.mapNotNull { byId[it] }
                             resetSelection()
                             if (ordered.isNotEmpty()) {
                                 onImagesSelected(ordered)
                             }
-                        }
+                        },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = HomebaseTheme.extendedColors.bubbleSentSurface,
+                            contentColor = HomebaseTheme.extendedColors.bubbleSentOnSurface
+                        )
                     ) {
-                        Text(stringResource(MR.string.chat_gallery_send_count, sendCount))
+                        Text(stringResource(MR.string.chat_gallery_next_count, sendCount))
+                        Spacer(Modifier.width(4.dp))
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                            contentDescription = null
+                        )
                     }
                 }
             }

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -311,7 +311,7 @@
     <string name="chat_no_gallery_items">Ingen elementer</string>
     <string name="chat_select_more_photos">Vælg flere billeder</string>
     <string name="chat_gallery_selection_index">%1$d</string>
-    <string name="chat_gallery_send_count">Send (%1$d)</string>
+    <string name="chat_gallery_next_count">Næste (%1$d)</string>
 
     <!-- Conversation new -->
     <string name="chat_new_conversation">Ny samtale</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -509,7 +509,7 @@
     <string name="chat_no_gallery_items">No items</string>
     <string name="chat_select_more_photos">Select more photos</string>
     <string name="chat_gallery_selection_index">%1$d</string>
-    <string name="chat_gallery_send_count">Send (%1$d)</string>
+    <string name="chat_gallery_next_count">Next (%1$d)</string>
 
     <!-- Conversation new -->
     <string name="chat_new_conversation">New conversation</string>


### PR DESCRIPTION
## What
In the chat attachment gallery tray (multi-select), the confirm button:
1. **Recolored** to the same blue as the "+" button — `bubbleSentSurface` / `bubbleSentOnSurface` (was a low-contrast `ElevatedButton`).
2. **Right-aligned** in its row (`Arrangement.End`).
3. **Relabeled** "Send (N)" → "Next (N)" with a forward chevron (`Icons.AutoMirrored.Filled.ArrowForward`), reflecting that it opens the full-screen attachment **editor**, not a direct send.

String key `chat_gallery_send_count` → `chat_gallery_next_count` ("Next (%1\$d)" / da "Næste (%1\$d)").

## Verified
Built `androidApp:installDebug` and confirmed on a physical Android (Redmi Note 5 Pro): multi-select shows a blue, right-aligned **"Next (1) →"** button with the chevron. Light theme confirmed; tokens are theme-aware so dark follows.

Closes #820

🤖 Generated with [Claude Code](https://claude.com/claude-code)