### PR TITLE
feat(vault): move an image from one section to another (#784)

### DIFF
--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -693,4 +693,9 @@
     <string name="moments_push_new_post">Et øjeblik er blevet delt med dig…</string>
     <string name="moments_push_new_comment">Kommenterede på et øjeblik, du er en del af</string>
 
+    <!-- Vault Move to section -->
+    <string name="vault_move_to_section">Flyt til sektion…</string>
+    <string name="vault_move_to_section_target">Flyt til %1$s</string>
+    <string name="vault_move_to_section_failed">Kunne ikke flytte filen. Prøv igen.</string>
+
 </resources>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1062,6 +1062,11 @@
     <string name="vault_gallery_delete_file">Delete file</string>
     <string name="vault_gallery_delete_all">Delete all</string>
 
+    <!-- Vault Move to section -->
+    <string name="vault_move_to_section">Move to section…</string>
+    <string name="vault_move_to_section_target">Move to %1$s</string>
+    <string name="vault_move_to_section_failed">Couldn't move the file. Please try again.</string>
+
     <!-- Vault Notes -->
     <string name="vault_notes_label">Notes</string>
     <string name="vault_notes_placeholder">Add notes about this entry…</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultScreen.kt
@@ -74,6 +74,7 @@ import id.homebase.resources.vault_error_save_notes
 import id.homebase.resources.vault_error_update_label
 import id.homebase.resources.vault_error_upload
 import id.homebase.resources.vault_label
+import id.homebase.resources.vault_move_to_section_failed
 import id.homebase.resources.vault_permission_cancel
 import id.homebase.resources.vault_rename_action
 import id.homebase.resources.vault_rename_title
@@ -357,6 +358,12 @@ fun VaultScreen(
                             onDeleteEntry = {
                                 viewModel.onAction(VaultUiAction.DeleteFile(overlay.file))
                             },
+                            sections = uiState.sections,
+                            onMoveToSection = { targetSectionId ->
+                                viewModel.onAction(
+                                    VaultUiAction.MoveEntryToSection(overlay.file, targetSectionId),
+                                )
+                            },
                             sharedTransitionScope = this@SharedTransitionLayout,
                             animatedVisibilityScope = this@AnimatedContent,
                         )
@@ -517,6 +524,7 @@ private fun resolveVaultError(error: VaultError): String = when (error) {
     VaultError.DownloadFailed -> stringResource(MR.string.vault_error_download)
     is VaultError.RenameFileFailed -> stringResource(MR.string.vault_error_rename_file, error.fileName)
     is VaultError.DeleteFileFailed -> stringResource(MR.string.vault_error_delete_file, error.fileName)
+    VaultError.MoveEntryFailed -> stringResource(MR.string.vault_move_to_section_failed)
     VaultError.AppendPagesFailed -> stringResource(MR.string.vault_error_append_pages)
     VaultError.DeletePageFailed -> stringResource(MR.string.vault_error_delete_page)
     VaultError.SaveNotesFailed -> stringResource(MR.string.vault_error_save_notes)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultService.kt
@@ -273,6 +273,29 @@ class VaultService(
         }
     }
 
+    suspend fun moveEntryToSection(
+        entry: VaultEntry,
+        targetSectionId: Uuid,
+    ): Boolean {
+        return try {
+            enqueueFileContentUpdate(
+                uniqueId = entry.uniqueId,
+                fileContent = VaultFileContent(
+                    name = entry.fileName,
+                    label = entry.label,
+                    notes = entry.notes,
+                    pdfPageCount = entry.pdfPageCount,
+                ),
+                groupId = targetSectionId,
+                versionTag = entry.versionTag,
+                keyHeader = entry.keyHeader,
+            )
+        } catch (e: Exception) {
+            Logger.e(e, TAG) { "Failed to enqueue move for ${entry.uniqueId} -> $targetSectionId" }
+            false
+        }
+    }
+
     suspend fun updateNotes(
         entry: VaultEntry,
         notes: String?,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultStream.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultStream.kt
@@ -373,6 +373,31 @@ class VaultStream(
     }
 
     /**
+     * Move an entry to a different section optimistically: drop it from whichever
+     * section currently holds it and add it (with [targetSectionId] as its new
+     * groupId) to the target section's list. No-op if the entry isn't found or is
+     * already in the target section.
+     */
+    fun moveOptimisticEntry(uniqueId: Uuid, targetSectionId: Uuid) {
+        if (targetSectionId in deletedSectionIds) return
+        _entriesBySection.update { current ->
+            val sourceSectionId = current.entries
+                .firstOrNull { (_, list) -> list.any { it.uniqueId == uniqueId } }
+                ?.key ?: return@update current
+            if (sourceSectionId == targetSectionId) return@update current
+
+            val entry = current[sourceSectionId]
+                ?.firstOrNull { it.uniqueId == uniqueId }
+                ?.copy(groupId = targetSectionId)
+                ?: return@update current
+
+            val sourceList = current[sourceSectionId].orEmpty().filterNot { it.uniqueId == uniqueId }
+            val targetList = current[targetSectionId].orEmpty() + entry
+            current + (sourceSectionId to sourceList) + (targetSectionId to targetList)
+        }
+    }
+
+    /**
      * Remove an entry from all sections. Called after a delete is enqueued.
      */
     fun removeEntry(uniqueId: Uuid) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultUiState.kt
@@ -54,6 +54,11 @@ sealed interface VaultUiAction {
         val label: String?,
     ) : VaultUiAction
 
+    data class MoveEntryToSection(
+        val entry: VaultEntry,
+        val targetSectionId: Uuid,
+    ) : VaultUiAction
+
     data class EntryClicked(val file: VaultEntry) : VaultUiAction
     data class ShareFile(val file: VaultEntry) : VaultUiAction
     data class SharePage(val file: VaultEntry, val payloadKey: String) : VaultUiAction
@@ -88,6 +93,7 @@ sealed interface VaultError {
     data object DownloadFailed : VaultError
     data class RenameFileFailed(val fileName: String) : VaultError
     data class DeleteFileFailed(val fileName: String) : VaultError
+    data object MoveEntryFailed : VaultError
     data object AppendPagesFailed : VaultError
     data object DeletePageFailed : VaultError
     data object SaveNotesFailed : VaultError

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
@@ -239,6 +239,7 @@ class VaultViewModel(
             is VaultUiAction.DeletePage,
             is VaultUiAction.UpdateNotes,
             is VaultUiAction.UpdateLabel,
+            is VaultUiAction.MoveEntryToSection,
             is VaultUiAction.SharePage,
             is VaultUiAction.SavePage,
             is VaultUiAction.ShareFile,
@@ -275,6 +276,7 @@ class VaultViewModel(
             is VaultUiAction.DeletePage -> handleDeletePage(action)
             is VaultUiAction.UpdateNotes -> handleUpdateNotes(action)
             is VaultUiAction.UpdateLabel -> handleUpdateLabel(action)
+            is VaultUiAction.MoveEntryToSection -> handleMoveEntryToSection(action)
             is VaultUiAction.SharePage -> handleSharePage(action)
             is VaultUiAction.SavePage -> handleSavePage(action)
             is VaultUiAction.EntryClicked -> handleEntryClicked(action)
@@ -653,6 +655,24 @@ class VaultViewModel(
             )
             if (!success) {
                 _events.tryEmit(VaultUiEvent.Error(VaultError.UpdateLabelFailed(action.file.fileName)))
+            }
+        }
+    }
+
+    private fun handleMoveEntryToSection(action: VaultUiAction.MoveEntryToSection) {
+        val sourceSectionId = action.entry.groupId
+        if (sourceSectionId == action.targetSectionId) return
+
+        _overlayState.update { null }
+        vaultStream.moveOptimisticEntry(action.entry.uniqueId, action.targetSectionId)
+
+        viewModelScope.launch {
+            val success = vaultService.moveEntryToSection(action.entry, action.targetSectionId)
+            if (!success) {
+                if (sourceSectionId != null) {
+                    vaultStream.moveOptimisticEntry(action.entry.uniqueId, sourceSectionId)
+                }
+                _events.tryEmit(VaultUiEvent.Error(VaultError.MoveEntryFailed))
             }
         }
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/components/VaultFileIcon.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/components/VaultFileIcon.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.InsertDriveFile
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.automirrored.outlined.Article
+import androidx.compose.material.icons.automirrored.outlined.DriveFileMove
 import androidx.compose.material.icons.outlined.AudioFile
 import androidx.compose.material.icons.outlined.Code
 import androidx.compose.material.icons.automirrored.outlined.NoteAdd
@@ -26,9 +27,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import id.homebase.core.ui.screens.vault.model.VaultEntry
+import id.homebase.core.ui.screens.vault.model.VaultSection
 import id.homebase.core.util.CONTENT_TYPE_MARKDOWN
 import id.homebase.core.util.formatFileSize
 import id.homebase.core.util.formatShortDate
@@ -37,9 +42,13 @@ import id.homebase.resources.vault_delete_confirm_action
 import id.homebase.resources.vault_gallery_delete_all
 import id.homebase.resources.vault_gallery_delete_file
 import id.homebase.resources.vault_more_options
+import id.homebase.resources.vault_move_to_section
+import id.homebase.resources.vault_move_to_section_target
 import id.homebase.resources.vault_rename_action
 import id.homebase.resources.vault_share
 import kotlin.time.Instant
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 import org.jetbrains.compose.resources.stringResource
 
 /**
@@ -95,15 +104,23 @@ fun formatFileInfo(sizeBytes: Long, createdAt: Long): String {
 /**
  * Three-dot dropdown menu for vault file actions (share, delete).
  */
+@OptIn(ExperimentalUuidApi::class)
 @Composable
 fun VaultFileDropdownMenu(
     file: VaultEntry,
     onShare: (VaultEntry) -> Unit,
     onDelete: (VaultEntry) -> Unit,
     onDeletePage: (() -> Unit)? = null,
+    sections: List<VaultSection> = emptyList(),
+    onMoveToSection: ((Uuid) -> Unit)? = null,
     iconTint: Color = MaterialTheme.colorScheme.onSurfaceVariant,
 ) {
     var expanded by remember { mutableStateOf(false) }
+    var moveExpanded by remember { mutableStateOf(false) }
+    // Sections other than the one this file lives in — the valid move targets.
+    val otherSections = remember(sections, file.groupId) {
+        sections.filter { it.sectionId != file.groupId }
+    }
 
     Box {
         IconButton(onClick = { expanded = true }) {
@@ -123,6 +140,21 @@ fun VaultFileDropdownMenu(
                     onClick = {
                         expanded = false
                         onShare(file)
+                    },
+                )
+            }
+            if (onMoveToSection != null && otherSections.isNotEmpty()) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(MR.string.vault_move_to_section)) },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Outlined.DriveFileMove,
+                            contentDescription = null,
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        moveExpanded = true
                     },
                 )
             }
@@ -156,6 +188,23 @@ fun VaultFileDropdownMenu(
                     onDelete(file)
                 },
             )
+        }
+        // Section picker, shown after "Move to section…" is chosen.
+        DropdownMenu(
+            expanded = moveExpanded,
+            onDismissRequest = { moveExpanded = false },
+        ) {
+            otherSections.forEach { section ->
+                val itemLabel = stringResource(MR.string.vault_move_to_section_target, section.title)
+                DropdownMenuItem(
+                    text = { Text(section.title) },
+                    onClick = {
+                        moveExpanded = false
+                        onMoveToSection?.invoke(section.sectionId)
+                    },
+                    modifier = Modifier.semantics { contentDescription = itemLabel },
+                )
+            }
         }
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/components/VaultFileIcon.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/components/VaultFileIcon.kt
@@ -1,6 +1,10 @@
 package id.homebase.core.ui.screens.vault.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.InsertDriveFile
 import androidx.compose.material.icons.filled.MoreVert
@@ -16,12 +20,14 @@ import androidx.compose.material.icons.outlined.PictureAsPdf
 import androidx.compose.material.icons.outlined.Slideshow
 import androidx.compose.material.icons.outlined.TableChart
 import androidx.compose.material.icons.outlined.VideoFile
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -32,12 +38,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
 import id.homebase.core.ui.screens.vault.model.VaultEntry
 import id.homebase.core.ui.screens.vault.model.VaultSection
 import id.homebase.core.util.CONTENT_TYPE_MARKDOWN
 import id.homebase.core.util.formatFileSize
 import id.homebase.core.util.formatShortDate
 import id.homebase.resources.MR
+import id.homebase.resources.cancel
 import id.homebase.resources.vault_delete_confirm_action
 import id.homebase.resources.vault_gallery_delete_all
 import id.homebase.resources.vault_gallery_delete_file
@@ -189,22 +197,42 @@ fun VaultFileDropdownMenu(
                 },
             )
         }
-        // Section picker, shown after "Move to section…" is chosen.
-        DropdownMenu(
-            expanded = moveExpanded,
+    }
+
+    // Section picker dialog, shown after "Move to section…" is chosen. A simple
+    // tap-to-move list (M3 basic dialog) — sections are few, so a dialog is lighter
+    // and more focused than a nested menu or a bottom sheet.
+    if (moveExpanded) {
+        AlertDialog(
             onDismissRequest = { moveExpanded = false },
-        ) {
-            otherSections.forEach { section ->
-                val itemLabel = stringResource(MR.string.vault_move_to_section_target, section.title)
-                DropdownMenuItem(
-                    text = { Text(section.title) },
-                    onClick = {
-                        moveExpanded = false
-                        onMoveToSection?.invoke(section.sectionId)
-                    },
-                    modifier = Modifier.semantics { contentDescription = itemLabel },
-                )
-            }
-        }
+            title = { Text(stringResource(MR.string.vault_move_to_section)) },
+            text = {
+                Column {
+                    otherSections.forEach { section ->
+                        val itemLabel = stringResource(
+                            MR.string.vault_move_to_section_target,
+                            section.title,
+                        )
+                        Text(
+                            text = section.title,
+                            style = MaterialTheme.typography.bodyLarge,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    moveExpanded = false
+                                    onMoveToSection?.invoke(section.sectionId)
+                                }
+                                .semantics { contentDescription = itemLabel }
+                                .padding(vertical = 12.dp),
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { moveExpanded = false }) {
+                    Text(stringResource(MR.string.cancel))
+                }
+            },
+        )
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/components/VaultFileIcon.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/components/VaultFileIcon.kt
@@ -3,8 +3,11 @@ package id.homebase.core.ui.screens.vault.components
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.InsertDriveFile
 import androidx.compose.material.icons.filled.MoreVert
@@ -14,6 +17,7 @@ import androidx.compose.material.icons.outlined.AudioFile
 import androidx.compose.material.icons.outlined.Code
 import androidx.compose.material.icons.automirrored.outlined.NoteAdd
 import androidx.compose.material.icons.outlined.Description
+import androidx.compose.material.icons.outlined.Folder
 import androidx.compose.material.icons.outlined.FolderZip
 import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material.icons.outlined.PictureAsPdf
@@ -33,6 +37,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -213,9 +218,7 @@ fun VaultFileDropdownMenu(
                             MR.string.vault_move_to_section_target,
                             section.title,
                         )
-                        Text(
-                            text = section.title,
-                            style = MaterialTheme.typography.bodyLarge,
+                        Row(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .clickable {
@@ -223,8 +226,21 @@ fun VaultFileDropdownMenu(
                                     onMoveToSection?.invoke(section.sectionId)
                                 }
                                 .semantics { contentDescription = itemLabel }
-                                .padding(vertical = 12.dp),
-                        )
+                                .padding(vertical = 14.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Icon(
+                                imageVector = Icons.Outlined.Folder,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Spacer(Modifier.width(16.dp))
+                            Text(
+                                text = section.title,
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+                        }
                     }
                 }
             },

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultGalleryDetailSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultGalleryDetailSheet.kt
@@ -1,4 +1,4 @@
-@file:OptIn(ExperimentalEncodingApi::class, ExperimentalComposeUiApi::class)
+@file:OptIn(ExperimentalEncodingApi::class, ExperimentalComposeUiApi::class, ExperimentalUuidApi::class)
 
 package id.homebase.core.ui.screens.vault.gallery
 
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -17,6 +18,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -28,8 +30,12 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.automirrored.outlined.DriveFileMove
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -49,6 +55,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
@@ -63,13 +71,18 @@ import id.homebase.core.image.HomebaseImageData
 import id.homebase.core.image.thumbSizesFrom
 import id.homebase.core.ui.screens.vault.components.fileTypeIcon
 import id.homebase.core.ui.screens.vault.model.VaultEntry
+import id.homebase.core.ui.screens.vault.model.VaultSection
 import id.homebase.resources.MR
 import id.homebase.resources.vault_gallery_add_page
 import id.homebase.resources.vault_gallery_page_counter
 import id.homebase.resources.vault_label_placeholder
+import id.homebase.resources.vault_move_to_section
+import id.homebase.resources.vault_move_to_section_target
 import id.homebase.resources.vault_notes_placeholder
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 
@@ -83,6 +96,8 @@ fun VaultGalleryDetailSheet(
     onAppendPages: () -> Unit,
     onUpdateLabel: (String?) -> Unit,
     onUpdateNotes: (String?) -> Unit,
+    sections: List<VaultSection>,
+    onMoveToSection: (Uuid) -> Unit,
     localAttachmentStore: LocalAttachmentContextStore,
 ) {
     val scope = rememberCoroutineScope()
@@ -318,6 +333,81 @@ fun VaultGalleryDetailSheet(
             },
         )
 
+        val otherSections = remember(sections, file.groupId) {
+            sections.filter { it.sectionId != file.groupId }
+        }
+        if (otherSections.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(16.dp))
+            MoveToSectionRow(
+                sections = otherSections,
+                onMoveToSection = onMoveToSection,
+            )
+        }
+
         Spacer(modifier = Modifier.height(24.dp))
+    }
+}
+
+@Composable
+private fun MoveToSectionRow(
+    sections: List<VaultSection>,
+    onMoveToSection: (Uuid) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val moveLabel = stringResource(MR.string.vault_move_to_section)
+
+    Box {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClickLabel = moveLabel) { expanded = true }
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Outlined.DriveFileMove,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp),
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = moveLabel,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.weight(1f),
+            )
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            sections.forEach { section ->
+                val itemLabel = stringResource(
+                    MR.string.vault_move_to_section_target,
+                    section.title,
+                )
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = section.title,
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        onMoveToSection(section.sectionId)
+                    },
+                    modifier = Modifier.semantics { contentDescription = itemLabel },
+                )
+            }
+        }
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultGalleryDetailSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultGalleryDetailSheet.kt
@@ -1,4 +1,4 @@
-@file:OptIn(ExperimentalEncodingApi::class, ExperimentalComposeUiApi::class, ExperimentalUuidApi::class)
+@file:OptIn(ExperimentalEncodingApi::class, ExperimentalComposeUiApi::class)
 
 package id.homebase.core.ui.screens.vault.gallery
 
@@ -30,12 +30,8 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
-import androidx.compose.material.icons.automirrored.outlined.DriveFileMove
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -56,7 +52,6 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
@@ -71,18 +66,13 @@ import id.homebase.core.image.HomebaseImageData
 import id.homebase.core.image.thumbSizesFrom
 import id.homebase.core.ui.screens.vault.components.fileTypeIcon
 import id.homebase.core.ui.screens.vault.model.VaultEntry
-import id.homebase.core.ui.screens.vault.model.VaultSection
 import id.homebase.resources.MR
 import id.homebase.resources.vault_gallery_add_page
 import id.homebase.resources.vault_gallery_page_counter
 import id.homebase.resources.vault_label_placeholder
-import id.homebase.resources.vault_move_to_section
-import id.homebase.resources.vault_move_to_section_target
 import id.homebase.resources.vault_notes_placeholder
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
-import kotlin.uuid.ExperimentalUuidApi
-import kotlin.uuid.Uuid
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 
@@ -96,8 +86,6 @@ fun VaultGalleryDetailSheet(
     onAppendPages: () -> Unit,
     onUpdateLabel: (String?) -> Unit,
     onUpdateNotes: (String?) -> Unit,
-    sections: List<VaultSection>,
-    onMoveToSection: (Uuid) -> Unit,
     localAttachmentStore: LocalAttachmentContextStore,
 ) {
     val scope = rememberCoroutineScope()
@@ -333,81 +321,6 @@ fun VaultGalleryDetailSheet(
             },
         )
 
-        val otherSections = remember(sections, file.groupId) {
-            sections.filter { it.sectionId != file.groupId }
-        }
-        if (otherSections.isNotEmpty()) {
-            Spacer(modifier = Modifier.height(16.dp))
-            MoveToSectionRow(
-                sections = otherSections,
-                onMoveToSection = onMoveToSection,
-            )
-        }
-
         Spacer(modifier = Modifier.height(24.dp))
-    }
-}
-
-@Composable
-private fun MoveToSectionRow(
-    sections: List<VaultSection>,
-    onMoveToSection: (Uuid) -> Unit,
-) {
-    var expanded by remember { mutableStateOf(false) }
-    val moveLabel = stringResource(MR.string.vault_move_to_section)
-
-    Box {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable(onClickLabel = moveLabel) { expanded = true }
-                .padding(horizontal = 16.dp, vertical = 12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Outlined.DriveFileMove,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(20.dp),
-            )
-            Spacer(modifier = Modifier.width(12.dp))
-            Text(
-                text = moveLabel,
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.weight(1f),
-            )
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.ArrowForward,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(20.dp),
-            )
-        }
-
-        DropdownMenu(
-            expanded = expanded,
-            onDismissRequest = { expanded = false },
-        ) {
-            sections.forEach { section ->
-                val itemLabel = stringResource(
-                    MR.string.vault_move_to_section_target,
-                    section.title,
-                )
-                DropdownMenuItem(
-                    text = {
-                        Text(
-                            text = section.title,
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
-                    },
-                    onClick = {
-                        expanded = false
-                        onMoveToSection(section.sectionId)
-                    },
-                    modifier = Modifier.semantics { contentDescription = itemLabel },
-                )
-            }
-        }
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultGalleryScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultGalleryScreen.kt
@@ -1,4 +1,4 @@
-@file:OptIn(ExperimentalComposeUiApi::class)
+@file:OptIn(ExperimentalComposeUiApi::class, ExperimentalUuidApi::class)
 
 package id.homebase.core.ui.screens.vault.gallery
 
@@ -60,6 +60,7 @@ import id.homebase.core.ui.screens.vault.VaultUploaderService
 import id.homebase.core.ui.screens.vault.components.VaultFileDropdownMenu
 import id.homebase.core.ui.screens.vault.components.fileTypeIcon
 import id.homebase.core.ui.screens.vault.model.VaultEntry
+import id.homebase.core.ui.screens.vault.model.VaultSection
 import id.homebase.resources.MR
 import id.homebase.resources.menu_back
 import id.homebase.resources.vault_delete_confirm_action
@@ -73,6 +74,8 @@ import id.homebase.resources.vault_gallery_save_page
 import id.homebase.resources.vault_gallery_share_page
 import id.homebase.resources.vault_permission_cancel
 import id.homebase.chat.services.LocalAttachmentContextStore
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
@@ -90,6 +93,8 @@ fun VaultGalleryScreen(
     onUpdateLabel: (String?) -> Unit,
     onUpdateNotes: (String?) -> Unit,
     onDeleteEntry: () -> Unit,
+    sections: List<VaultSection>,
+    onMoveToSection: (Uuid) -> Unit,
     sharedTransitionScope: SharedTransitionScope? = null,
     animatedVisibilityScope: AnimatedVisibilityScope? = null,
 ) {
@@ -162,6 +167,8 @@ fun VaultGalleryScreen(
                     onAppendPages = onAppendPages,
                     onUpdateLabel = onUpdateLabel,
                     onUpdateNotes = onUpdateNotes,
+                    sections = sections,
+                    onMoveToSection = onMoveToSection,
                     localAttachmentStore = localAttachmentStore,
                 )
             },

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultGalleryScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultGalleryScreen.kt
@@ -167,8 +167,6 @@ fun VaultGalleryScreen(
                     onAppendPages = onAppendPages,
                     onUpdateLabel = onUpdateLabel,
                     onUpdateNotes = onUpdateNotes,
-                    sections = sections,
-                    onMoveToSection = onMoveToSection,
                     localAttachmentStore = localAttachmentStore,
                 )
             },
@@ -301,6 +299,8 @@ fun VaultGalleryScreen(
                                 onShare = { currentDescriptor?.let { onSharePage(it.key) } },
                                 onDelete = { showDeleteEntryConfirm = true },
                                 onDeletePage = { currentDescriptor?.let { pageToDelete = it.key } },
+                                sections = sections,
+                                onMoveToSection = onMoveToSection,
                                 iconTint = MaterialTheme.colorScheme.onSurface,
                             )
                         },


### PR DESCRIPTION
## What
Adds a **"Move to section…"** action so a Vault image can be relocated between sections without the old delete-and-re-upload dance.

It lives in the image viewer's **⋮ More options** menu (next to Share / Delete). Selecting it opens an **M3 dialog** listing the *other* sections as folder-icon rows; tapping one moves the image — optimistically in the grid, with the change synced to the drive in the background.

| ⋮ More options | Move-to-section dialog |
|:---:|:---:|
| <img src="https://raw.githubusercontent.com/homebase-id/chat-kmp/issue-assets/docs/issue-assets/vault-move-section/overflow-menu.png" width="270"> | <img src="https://raw.githubusercontent.com/homebase-id/chat-kmp/issue-assets/docs/issue-assets/vault-move-section/move-dialog.png" width="270"> |

## How
- **UI:** `VaultFileDropdownMenu` (the ⋮ menu) gains a "Move to section…" item, shown only when ≥1 other section exists. It opens an `AlertDialog` with a tap-to-move list of sections (folder icon + title) plus Cancel. *(Earlier iterations placed this in the bottom detail sheet, then a nested dropdown — both replaced per review. A dialog is the lightest, most focused M3 fit for the handful of sections a vault has; nested menus aren't an M3 mobile pattern.)*
- **Move = metadata update:** `VaultService.moveEntryToSection` enqueues an update-file-by-uniqueId with the new `groupId`, reusing the existing optimistic-writer + outbox path (identical to rename/label/notes). No payload re-upload; name / label / notes / versionTag / keyHeader are preserved.
- **Optimistic UI:** `VaultStream.moveOptimisticEntry` relocates the entry between section maps immediately; the ViewModel rolls back and shows a snackbar (`vault_move_to_section_failed`) on enqueue failure.

## Verified
On a physical Android: moved an image between sections — it leaves the old section, appears in the new one immediately, and **persists across an app reinstall** (drive sync). Dialog renders as shown above. Compiles (`:homebase-core:compileAndroidMain`).

> Note: this PR is independent of the Vault biometric-load fix (#833); testing used a combined build so the Vault could open. Land #833 first for the Vault to load reliably on a fresh launch.

Closes #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)
