### PR TITLE
feat(chat): hide per-bubble timestamp/delivery footer except last in cluster (#814)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LocationPreview.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LocationPreview.kt
@@ -275,6 +275,7 @@ fun LocationPreviewCard(
     isPendingSend: Boolean = false,
     deliveryStatus: Int = 0,
     pendingSince: Instant? = null,
+    showTimestamp: Boolean = true,
 ) {
     val uriHandler = LocalUriHandler.current
     val geoUri = remember(descriptor.lat, descriptor.lon, descriptor.address) {
@@ -383,7 +384,7 @@ fun LocationPreviewCard(
                         )
                     }
                     // No caption ⇒ the timestamp (+ delivery status) sits muted at the bottom of the card.
-                    if (showCardTimestamp) {
+                    if (showCardTimestamp && showTimestamp) {
                         if (descriptor.address.isNotEmpty() || liveControls != null) {
                             Spacer(modifier = Modifier.height(6.dp))
                         }
@@ -414,7 +415,7 @@ fun LocationPreviewCard(
                     style = MaterialTheme.typography.bodyLarge,
                     color = captionContentColor,
                 )
-                if (timestamp != null) {
+                if (timestamp != null && showTimestamp) {
                     Spacer(modifier = Modifier.height(2.dp))
                     MessageTimestampFooter(
                         infoText = timestamp,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -839,7 +839,9 @@ fun MessageTimestampFooter(
     deliveryStatus: Int,
     pendingSince: Instant?,
     modifier: Modifier = Modifier,
+    visible: Boolean = true,
 ) {
+    if (!visible) return
     Row(
         modifier = modifier,
         verticalAlignment = Alignment.Bottom,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -63,6 +63,7 @@ import id.homebase.api.util.markdownHasBlockElements
 import id.homebase.chat.conversationlist.DecryptedFileKey
 import id.homebase.chat.conversationlist.MessageClusterPosition
 import id.homebase.chat.conversationlist.UploadStatus
+import id.homebase.chat.services.ChatDeliveryStatus
 import id.homebase.chat.data.MessageUiModel
 import id.homebase.chat.dice.DiceRollBubble
 import id.homebase.chat.event.EventBubble
@@ -146,6 +147,12 @@ fun MessageBubbleRaw(
     isCurrentSearchResult: Boolean = false,
     chainCap: Int? = null,
 ) {
+
+    // #814: render the timestamp + delivery footer only on the last bubble of a
+    // same-sender cluster (END/ALONE), or whenever a sent message failed to deliver.
+    val showMessageFooter = clusterPosition == MessageClusterPosition.END ||
+        clusterPosition == MessageClusterPosition.ALONE ||
+        (sentByYou && message.messageAppData.deliveryStatus == ChatDeliveryStatus.Failed.value)
 
     // Typed rich-content (event today; poll/doodle later) bypasses the text+media
     // path entirely — each kind paints its own bubble, with its own background and
@@ -256,6 +263,7 @@ fun MessageBubbleRaw(
                     timestamp = locInfoText,
                     captionBackgroundColor = captionBg,
                     captionContentColor = captionContent,
+                    showTimestamp = showMessageFooter,
                     showDeliveryStatus = sentByYou && !message.isDeleted,
                     isPendingSend = message.isPendingSend,
                     deliveryStatus = message.messageAppData.deliveryStatus,
@@ -462,6 +470,7 @@ fun MessageBubbleRaw(
                     deliveryStatus = message.messageAppData.deliveryStatus,
                     contentColor = contentColor,
                     pendingSince = message.userDate,
+                    showTimestamp = showMessageFooter,
                     onMediaClick = onMediaClick,
                     onMediaLongPress = { handleLongClick() },
                     onRequestDecryptedFile = onRequestDecryptedFile,
@@ -492,6 +501,7 @@ fun MessageBubbleRaw(
                         uploadStatus = uploadStatus,
                     )
                     MediaTimestampOverlay(
+                        showTimestamp = showMessageFooter,
                         messageInfoText = messageInfoText,
                         sentByYou = sentByYou,
                         isPendingSend = isPendingSend,
@@ -532,6 +542,7 @@ fun MessageBubbleRaw(
                                 uploadStatus = uploadStatus,
                             )
                             MediaTimestampOverlay(
+                                showTimestamp = showMessageFooter,
                                 messageInfoText = messageInfoText,
                                 sentByYou = sentByYou,
                                 isPendingSend = isPendingSend,
@@ -649,6 +660,7 @@ fun MessageBubbleRaw(
                         }
                     }
                     MessageTimestampFooter(
+                        visible = showMessageFooter,
                         infoText = messageInfoText,
                         contentColor = contentColor,
                         showDeliveryStatus = sentByYou && !message.isDeleted,
@@ -803,19 +815,24 @@ fun MessageBubbleRaw(
                                 verticalAlignment = Alignment.Bottom,
                                 horizontalArrangement = Arrangement.End,
                             ) {
-                                Text(
-                                    text = messageInfoText,
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = contentColor.copy(alpha = 0.7f)
-                                )
-                                if (sentByYou && !message.isDeleted) {
-                                    Spacer(modifier = Modifier.width(4.dp))
-                                    DeliveryStatus(
-                                        isPendingSend = isPendingSend,
-                                        deliveryStatus = message.messageAppData.deliveryStatus,
-                                        contentColor = contentColor.copy(alpha = 0.7f),
-                                        pendingSince = message.userDate,
+                                // #814: keep this Row child present (the timestamp-tuck
+                                // Layout indexes children by position) but hide its
+                                // contents on non-terminal cluster bubbles.
+                                if (showMessageFooter) {
+                                    Text(
+                                        text = messageInfoText,
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = contentColor.copy(alpha = 0.7f)
                                     )
+                                    if (sentByYou && !message.isDeleted) {
+                                        Spacer(modifier = Modifier.width(4.dp))
+                                        DeliveryStatus(
+                                            isPendingSend = isPendingSend,
+                                            deliveryStatus = message.messageAppData.deliveryStatus,
+                                            contentColor = contentColor.copy(alpha = 0.7f),
+                                            pendingSince = message.userDate,
+                                        )
+                                    }
                                 }
                             }
                         }
@@ -1055,7 +1072,9 @@ private fun BoxScope.MediaTimestampOverlay(
     deliveryStatus: Int,
     contentColor: Color,
     pendingSince: Instant?,
+    showTimestamp: Boolean = true,
 ) {
+    if (!showTimestamp) return
     Box(modifier = Modifier.matchParentSize().align(Alignment.BottomStart)) {
         Box(
             modifier = Modifier.fillMaxWidth().height(40.dp)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/StickerMessage.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/StickerMessage.kt
@@ -68,6 +68,7 @@ fun StickerMessage(
     animatedVisibilityScope: AnimatedVisibilityScope?,
     downloadingFiles: Set<String>,
     uploadStatus: UploadStatus? = null,
+    showTimestamp: Boolean = true,
     modifier: Modifier = Modifier,
 ) {
     if (payloads.isEmpty()) return
@@ -108,20 +109,24 @@ fun StickerMessage(
 
             // Subtle timestamp + delivery status — identical styling to the emoji-only
             // footer (labelSmall, contentColor @ 0.7 alpha), no scrim, no background.
+            // #814: keep this Row child (measurables[1]) but hide its contents on
+            // non-terminal cluster bubbles; the gap below collapses when it's empty.
             Row(verticalAlignment = Alignment.Bottom) {
-                Text(
-                    text = messageInfoText,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = contentColor.copy(alpha = 0.7f),
-                )
-                if (sentByYou) {
-                    Spacer(modifier = Modifier.width(4.dp))
-                    DeliveryStatus(
-                        isPendingSend = isPendingSend,
-                        deliveryStatus = deliveryStatus,
-                        contentColor = contentColor.copy(alpha = 0.7f),
-                        pendingSince = pendingSince,
+                if (showTimestamp) {
+                    Text(
+                        text = messageInfoText,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = contentColor.copy(alpha = 0.7f),
                     )
+                    if (sentByYou) {
+                        Spacer(modifier = Modifier.width(4.dp))
+                        DeliveryStatus(
+                            isPendingSend = isPendingSend,
+                            deliveryStatus = deliveryStatus,
+                            contentColor = contentColor.copy(alpha = 0.7f),
+                            pendingSince = pendingSince,
+                        )
+                    }
                 }
             }
         },
@@ -132,7 +137,7 @@ fun StickerMessage(
             constraints.copy(minWidth = 0, maxWidth = imagePlaceable.width)
         )
 
-        val gap = 4.dp.roundToPx()
+        val gap = if (infoPlaceable.height > 0) 4.dp.roundToPx() else 0
         val width = imagePlaceable.width
         val height = imagePlaceable.height + gap + infoPlaceable.height
 


### PR DESCRIPTION
## What
Signal-style clustering follow-up to #458. In a same-sender, time-proximate cluster, the timestamp + delivery-status footer now renders **only on the last bubble** (`END`) and on **standalone** bubbles (`ALONE`); it's hidden on `START`/`MIDDLE`. A **failed** send always shows its footer regardless of position, so a failure is never hidden mid-cluster.

A single `showMessageFooter` flag is computed once in `MessageBubbleRaw` and threaded to every footer-rendering site:
- block-body `MessageTimestampFooter` (`visible` param)
- inline text-Layout footer Row — child kept (the timestamp-tuck `Layout` indexes children by position), only its **contents** are gated
- `MediaTimestampOverlay` — media-only **and** reply-media sites (early-return param)
- `StickerMessage` — gated, and the 4dp footer gap collapses when hidden
- `LocationPreviewCard` — both caption and no-caption footers (`showTimestamp` param)

No change to cluster spacing or corner radii (those still come from `clusterPosition`).

## Verified
`:homebase-chat:compileAndroidMain` — BUILD SUCCESSFUL. Device verification on a physical Android in progress (cluster of consecutive sent messages → only the last shows time/✓✓).

Closes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)