### PR TITLE
chore(android): disable R8 identifier obfuscation, keep shrink/optimize (#831)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,30 +178,24 @@ adb logcat -d --pid=$(adb shell pidof id.homebase.feed.dev)
 adb logcat -c
 ```
 
-### De-obfuscating release crash stack traces
+### Reading release crash stack traces
 
-Release and `dev` builds run R8 with `isMinifyEnabled = true`, so on-device
-traces (logcat, `homebase.log`, the crash-recovery screen, a tester's
-screenshot) show obfuscated names like `a.b.c`. **Do not disable obfuscation** —
-it's defense-in-depth for a crypto/E2E app and keeps the AAB small. Instead,
-translate the trace with the `mapping.txt` R8 emits each build.
+Release and `dev` builds run R8 with `isMinifyEnabled = true` for shrinking and
+optimization, but `proguard-rules.pro` sets `-dontobfuscate`, so identifier
+renaming is **off**. On-device traces (logcat, `homebase.log`, the crash-recovery
+screen, a tester's screenshot) already show the real class/method names — e.g.
+`id.homebase.feed.MainActivity` — with exact line numbers (`-keepattributes
+SourceFile,LineNumberTable`). No `retrace` and no per-build `mapping.txt` is
+needed to read names; a raw trace is directly triageable.
 
-- **Crashlytics / Play Console** de-obfuscate automatically: the Crashlytics
-  Gradle plugin uploads `mapping.txt` on every minified build. `proguard-rules.pro`
-  keeps `SourceFile,LineNumberTable`, so these show the exact original file + line.
-- **A raw trace** (logcat / log file / screenshot) — retrace it locally against
-  the mapping for the exact build that produced it:
+- **Crashlytics / Play Console** still work as before: the Crashlytics Gradle
+  plugin uploads `mapping.txt` on every minified build, and these show the exact
+  original file + line. Harmless to keep.
 
-```bash
-# mapping.txt is written per variant by the release build:
-#   androidApp/build/outputs/mapping/release/mapping.txt   (release)
-#   androidApp/build/outputs/mapping/dev/mapping.txt       (dev)
-# Save the obfuscated trace to trace.txt, then:
-retrace androidApp/build/outputs/mapping/release/mapping.txt trace.txt
-# `retrace` ships in the Android SDK (build-tools / cmdline-tools). `r8 retrace`
-# also works. Keep the mapping.txt from each shipped build — a stale mapping
-# from a different build produces wrong line numbers.
-```
+(Renaming was disabled because the app is open-source — obfuscating names that
+are public on GitHub anyway protected nothing, while readable raw traces make
+real-world crash triage from logs/screenshots far easier. Shrinking and
+optimization, which is where R8's size win actually comes from, stay on.)
 
 ## Desktop App Logs (JVM / Android Studio `desktopApp:run`)
 

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -80,8 +80,8 @@ android {
 
     buildTypes {
         release {
-            // Enables code shrinking, obfuscation, and optimization for only
-            // your project's release build type.
+            // Enables code shrinking and optimization. Identifier obfuscation is
+            // turned off via -dontobfuscate in proguard-rules.pro.
             isMinifyEnabled = true
 
             // Enables resource shrinking, which is performed by the
@@ -99,8 +99,8 @@ android {
         create("dev") {
             applicationIdSuffix = ".dev"
 
-            // Enables code shrinking, obfuscation, and optimization for only
-            // your project's release build type.
+            // Enables code shrinking and optimization. Identifier obfuscation is
+            // turned off via -dontobfuscate in proguard-rules.pro.
             isMinifyEnabled = true
 
             // Enables resource shrinking, which is performed by the

--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -12,15 +12,19 @@
 #   public *;
 #}
 
-# Keep line numbers in release stack traces. Obfuscation stays ON — this only
-# preserves the line-number table so Crashlytics / Play Console (which have the
-# uploaded mapping.txt) and `retrace` resolve crashes to the exact original
-# file + line instead of showing "Unknown Source".
+# Disable identifier renaming only. R8 shrinking + optimization stay on (the AAB
+# size wins are theirs, not renaming's). The app is open-source, so renamed
+# identifiers protect nothing public; leaving names intact makes raw traces
+# (logcat / homebase.log / crash-recovery screen / screenshots) directly readable
+# with no retrace / per-build mapping.txt.
+-dontobfuscate
+
+# Keep line numbers in release stack traces so Crashlytics / Play Console and
+# `retrace` resolve crashes to the exact original file + line instead of
+# "Unknown Source".
 -keepattributes SourceFile,LineNumberTable
 
-# Replace the original .kt file name with a constant ("SourceFile") in the
-# bytecode — keeps the line numbers above while still hiding source file names.
-# The mapping file maps everything back during retrace/Crashlytics.
+# Moot with -dontobfuscate (no renaming happens); kept to minimise the diff.
 -renamesourcefileattribute SourceFile
 
 # Filekit


### PR DESCRIPTION
## What

Add `-dontobfuscate` to `androidApp/proguard-rules.pro` so R8 stops **renaming identifiers**, while keeping `isMinifyEnabled = true` and `isShrinkResources = true` for both `release` and `dev` — i.e. **shrinking + optimization stay on**, only the renaming is turned off. Plus the CLAUDE.md correction the issue asks for.

## Measured AAB size delta (the deciding fact)

**Variant measured: `release`** — built locally with `./gradlew androidApp:bundleRelease`. The release signing config in `build.gradle.kts` falls back to the bundled `debug.keystore` when `SIGNING_KEYSTORE_FILE_PATH` is unset, so the **release** AAB built and signed fine without secrets (I did *not* need the `dev` fallback). Exact `.aab` byte sizes (`wc -c`):

| Build | `.aab` bytes |
|---|---|
| Obfuscation **ON** (baseline, as-is) | `69,362,626` |
| **`-dontobfuscate`** (renaming off) | `69,405,251` |
| **Delta (OFF − ON)** | **`+42,625` bytes (~41.6 KiB, +0.061%)** |

The AAB grew by **~42 KB (+0.061%)** — an order of magnitude *smaller* than the issue's "low single-digit % / few hundred KB" expectation. Verdict: shipping `-dontobfuscate` is clearly acceptable. (The tiny delta also confirms shrink/optimize are doing the real size work, not renaming.)

I verified renaming is genuinely off by inspecting `mapping.txt`: classes map to themselves (`id.homebase.feed.MainActivity -> id.homebase.feed.MainActivity`), and there are **zero** single-letter obfuscated names. The only `source -> target` differences are `R8$$REMOVED$$CLASS$$N` entries — that's R8 **shrinking** (dead-code removal), which we keep, not renaming.

## `-renamesourcefileattribute`

`-renamesourcefileattribute SourceFile` (proguard-rules.pro) becomes a **no-op** once renaming is off. **Kept it** (with a one-line note) to minimise the diff — keeping is harmless.

## CLAUDE.md

Rewrote the "De-obfuscating release crash stack traces" → "Reading release crash stack traces" section: removed the void "defense-in-depth for a crypto/E2E app" / "keeps the AAB small" security justification, and dropped the mandatory `retrace` + per-build `mapping.txt` step for *names* (raw traces now show real names directly). Kept the Crashlytics/Play paragraph (still useful, still uploads mapping). Line numbers are unaffected — `-keepattributes SourceFile,LineNumberTable` stays (per #807).

Also updated the now-stale "code shrinking, obfuscation, and optimization" comments on both `isMinifyEnabled = true` lines in `build.gradle.kts`.

## Acceptance criteria

- [x] Measured AAB size delta (with vs without `-dontobfuscate`) reported — see table above (+42,625 bytes, +0.061%, release variant).
- [x] Delta acceptable → `-dontobfuscate` enabled; release & dev keep `isMinifyEnabled`/`isShrinkResources = true`; **release build succeeded** (BUILD SUCCESSFUL, R8 shrink/optimize ran).
- [x] A raw trace would show real class/method names + exact line numbers without retrace/`mapping.txt` — confirmed via `mapping.txt` (identity class mappings, line table kept). *(Verified from the build artifact, not from a live on-device crash.)*
- [x] CLAUDE.md updated: security justification removed; crash-reading guidance reflects no-obfuscation reality.
- [ ] **No runtime regression from removed renaming** — **NOT runtime-verified.** Removing renaming is strictly safer for reflection / kotlinx.serialization / DI / JNI (those break *under* renaming, not without it), and the build + R8 succeeded with no new warnings, but I did not install and exercise the signed release on a device to confirm those paths at runtime.

## Caveats / what I did not verify

- Measured the **release** variant (debug-keystore signing fallback), not a Play-signed production AAB; the size delta is representative regardless.
- The "no runtime regression" criterion is verified only at build/R8 level, not by running the app on a device.

Closes #831

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>