### PR TITLE
fix(location): link to enable history on Find Device empty state

### DIFF
--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1298,6 +1298,7 @@
     <string name="location_find_last_seen">Last seen %1$s</string>
     <string name="location_find_battery">🔋 %1$s</string>
     <string name="location_find_no_location">No known location for this device</string>
+    <string name="location_find_history_off">Location history is off, so this device hasn't recorded its position yet.</string>
     <string name="location_find_freshness">Position is as of the device's last upload and this device's last sync.</string>
     <string name="location_find_refresh">Refresh</string>
     <string name="location_dashboard_perm_banner">Location permission needs attention — tap to fix</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -1333,6 +1333,9 @@ fun AppNavHost(
                                             Route.LocationFindDevice(deviceId.toString())
                                         )
                                     },
+                                    // Empty-because-history-off → link to the Location dashboard
+                                    // where the history toggle lives.
+                                    onEnableHistory = openLocation,
                                 )
                             }
                         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/devices/FindDeviceScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/devices/FindDeviceScreen.kt
@@ -1,12 +1,15 @@
 package id.homebase.core.ui.screens.location.devices
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -27,6 +30,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.api.client.location.LocationPreviewProvider
@@ -38,10 +43,12 @@ import id.homebase.resources.MR
 import id.homebase.resources.location_device_unnamed
 import id.homebase.resources.location_find_battery
 import id.homebase.resources.location_find_freshness
+import id.homebase.resources.location_find_history_off
 import id.homebase.resources.location_find_last_seen
 import id.homebase.resources.location_find_no_location
 import id.homebase.resources.location_find_refresh
 import id.homebase.resources.location_find_title
+import id.homebase.resources.location_history_enable_tracking
 import id.homebase.resources.menu_back
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
@@ -60,6 +67,7 @@ fun FindDeviceScreen(
     viewModel: FindDeviceViewModel,
     onNavigateBack: () -> Unit,
     onOpenDevice: (Uuid) -> Unit,
+    onEnableHistory: () -> Unit = {},
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val previewProvider = koinInject<LocationPreviewProvider>()
@@ -161,6 +169,33 @@ fun FindDeviceScreen(
                         when {
                             uiState.isLoading && trace == null ->
                                 CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+
+                            // This device, empty *because* history is off → link to turn it on,
+                            // instead of a dead-end "no data" + refresh that can never help. Other
+                            // devices (whose tracking we can't control), or history-on-but-no-fix-
+                            // yet, fall through to the plain "no location data" text.
+                            trace == null && uiState.device?.isThisDevice == true &&
+                                !uiState.allowLocationHistory ->
+                                Column(
+                                    modifier = Modifier.align(Alignment.Center).padding(24.dp),
+                                    horizontalAlignment = Alignment.CenterHorizontally,
+                                ) {
+                                    Text(
+                                        text = stringResource(MR.string.location_find_history_off),
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        textAlign = TextAlign.Center,
+                                    )
+                                    Spacer(modifier = Modifier.height(8.dp))
+                                    Text(
+                                        text = stringResource(MR.string.location_history_enable_tracking),
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        color = MaterialTheme.colorScheme.primary,
+                                        textDecoration = TextDecoration.Underline,
+                                        textAlign = TextAlign.Center,
+                                        modifier = Modifier.clickable { onEnableHistory() },
+                                    )
+                                }
 
                             trace == null ->
                                 Text(

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/devices/FindDeviceViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/devices/FindDeviceViewModel.kt
@@ -22,6 +22,8 @@ data class FindDeviceUiState(
     val deviceTrace: DeviceTrace? = null,
     val isLoading: Boolean = true,
     val showMapTiles: Boolean = false,
+    /** Whether this device records location history — drives the empty-state "turn it on" hint. */
+    val allowLocationHistory: Boolean = false,
 )
 
 class FindDeviceViewModel(
@@ -37,12 +39,19 @@ class FindDeviceViewModel(
             deviceId = deviceIdArg,
             showMapTiles =
                 locationPreferences.mapProvider.value == LocationMapProvider.OpenStreetMap,
+            allowLocationHistory = locationPreferences.allowLocationHistory.value,
         )
     )
     val uiState: StateFlow<FindDeviceUiState> = _uiState.asStateFlow()
 
     init {
         refresh()
+        // Reactive so the empty-state hint clears once the user enables history and returns.
+        viewModelScope.launch {
+            locationPreferences.allowLocationHistory.collect { enabled ->
+                _uiState.update { it.copy(allowLocationHistory = enabled) }
+            }
+        }
     }
 
     fun refresh() {


### PR DESCRIPTION
## What & why

On **Find Device** (`Route.LocationFindDevice`), locating a device renders its recorded **history**. With location history OFF, *this* device has never recorded a position, so the screen showed a dead-end "No known location for this device" + a refresh button that can never help.

Now, when the located device is **this device** and history is off, it shows a short explanation plus a tappable **"Turn on location tracking"** link to the Location dashboard (where the history toggle lives). Other devices — whose tracking we can't control — and the history-on-but-no-fix-yet case keep the plain "no location" text.

## How

- `FindDeviceUiState` gains `allowLocationHistory`, **reactively collected** so the hint clears as soon as the user enables history and returns.
- Reuses `LocationDeviceInfo.isThisDevice` and the existing `DayPlaybackMap` link pattern (`location_history_enable_tracking`, underlined primary, `clickable`); adds one explanatory string `location_find_history_off`.
- `AppNavHost` wires `onEnableHistory` to the existing `openLocation` lambda → `Route.Location`.

## Verification

- Compiles JVM/Android/Web for `homebase-core`; Konsist `ArchitectureTest` green (strings via `stringResource`).
- Manual (Android): history OFF → Find Device → this device → explanation + link → dashboard; enable history, return → hint clears reactively, then "no location" until the first fix uploads. A different device with no data still shows the plain text.

Follow-up to the location pipeline work in #847.

🤖 Generated with [Claude Code](https://claude.com/claude-code)