### PR TITLE
#846: per-consumer GPS acquisition profile + cadence docs

### DIFF
--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/LocationTracker.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/LocationTracker.android.kt
@@ -26,11 +26,14 @@ actual fun createLocationTracker(sink: LocationPointSink): LocationTracker =
  *   [LocationUpdatesReceiver] even when the app process is dead (the receiver
  *   wake restarts it). This is the only path that works in the background
  *   without a foreground service, at whatever cadence the OS allows.
- * - **Foreground overlay** (only in [TrackingMode.Foreground]): a high-accuracy
- *   callback at 15s/10m feeding [sink] directly for precise capture while the
- *   user has the app open. Removed on backgrounding; the PendingIntent stays
- *   registered throughout so there is no gap, and the store's time/displacement
- *   dedup absorbs the overlap.
+ * - **Foreground overlay** (only for a foreground profile): a callback feeding
+ *   [sink] directly for precise capture while the user has the app open. Its
+ *   accuracy/cadence depends on the profile (#846): `LiveForeground` runs
+ *   high-accuracy 15s/10m (a live share or the live map wants fresh fixes);
+ *   `HistoryForeground` runs balanced 30s/25m (history-only doesn't need the
+ *   battery cost of second-by-second precision). Removed on backgrounding; the
+ *   PendingIntent stays registered throughout so there is no gap, and the
+ *   store's time/displacement dedup absorbs the overlap.
  *
  * NOTE: this codebase previously saw fused *one-shot* reads (lastLocation /
  * getCurrentLocation) return null (see chat's LocationLauncher.android.kt);
@@ -49,14 +52,17 @@ private class AndroidLocationTracker(
 
     private var started = false
     private var foregroundCallback: LocationCallback? = null
+    // Which foreground profile the overlay is currently registered with (null = no overlay), so a
+    // change between LiveForeground and HistoryForeground re-registers with the new params.
+    private var foregroundProfile: TrackingProfile? = null
 
     private val context: Context get() = ActivityProvider.requireApplicationContext()
     private val fusedClient get() = LocationServices.getFusedLocationProviderClient(context)
 
     @SuppressLint("MissingPermission")
-    override fun start(mode: TrackingMode) {
+    override fun start(profile: TrackingProfile) {
         if (started) {
-            setMode(mode)
+            setProfile(profile)
             return
         }
         runCatching {
@@ -75,51 +81,64 @@ private class AndroidLocationTracker(
             logger.e(it) { "Failed to start location updates" }
             return
         }
-        setMode(mode)
+        setProfile(profile)
     }
 
     @SuppressLint("MissingPermission")
-    override fun setMode(mode: TrackingMode) {
+    override fun setProfile(profile: TrackingProfile) {
         if (!started) return
-        when (mode) {
-            TrackingMode.Foreground -> {
-                if (foregroundCallback != null) return
-                val callback = object : LocationCallback() {
-                    override fun onLocationResult(result: com.google.android.gms.location.LocationResult) {
-                        val points = result.locations.map { it.toRawPoint(fg = true) }
-                        if (points.isEmpty()) return
-                        scope.launch { sink.submit(points) }
-                    }
-                }
-                runCatching {
-                    val request = LocationRequest.Builder(
-                        Priority.PRIORITY_HIGH_ACCURACY,
-                        FOREGROUND_INTERVAL_MS,
-                    )
-                        .setMinUpdateDistanceMeters(FOREGROUND_MIN_DISPLACEMENT_M)
-                        .build()
-                    fusedClient.requestLocationUpdates(request, callback, Looper.getMainLooper())
-                    foregroundCallback = callback
-                    logger.i { "Foreground precise overlay on" }
-                }.onFailure { logger.e(it) { "Failed to start foreground overlay" } }
-            }
-
-            TrackingMode.Background -> {
-                foregroundCallback?.let {
-                    fusedClient.removeLocationUpdates(it)
-                    foregroundCallback = null
-                    logger.i { "Foreground precise overlay off" }
-                }
+        val overlay = foregroundOverlayParams(profile)
+        if (overlay == null) {
+            // Background profile — drop the precise overlay; the PendingIntent keeps running.
+            removeForegroundOverlay()
+            return
+        }
+        if (foregroundProfile == profile) return // overlay already running with the right params
+        // Foreground profile changed (e.g. History→Live when a share starts) — re-register.
+        removeForegroundOverlay()
+        val callback = object : LocationCallback() {
+            override fun onLocationResult(result: com.google.android.gms.location.LocationResult) {
+                val points = result.locations.map { it.toRawPoint(fg = true) }
+                if (points.isEmpty()) return
+                scope.launch { sink.submit(points) }
             }
         }
+        runCatching {
+            val request = LocationRequest.Builder(overlay.priority, overlay.intervalMs)
+                .setMinUpdateDistanceMeters(overlay.minDisplacementM)
+                .build()
+            fusedClient.requestLocationUpdates(request, callback, Looper.getMainLooper())
+            foregroundCallback = callback
+            foregroundProfile = profile
+            logger.i { "Foreground overlay on (profile=$profile)" }
+        }.onFailure { logger.e(it) { "Failed to start foreground overlay" } }
     }
 
     override fun stop() {
-        foregroundCallback?.let { fusedClient.removeLocationUpdates(it) }
-        foregroundCallback = null
+        removeForegroundOverlay()
         fusedClient.removeLocationUpdates(backgroundPendingIntent())
         started = false
         logger.i { "Stopped all location updates" }
+    }
+
+    private fun removeForegroundOverlay() {
+        foregroundCallback?.let {
+            fusedClient.removeLocationUpdates(it)
+            foregroundCallback = null
+            foregroundProfile = null
+            logger.i { "Foreground overlay off" }
+        }
+    }
+
+    private data class OverlayParams(val priority: Int, val intervalMs: Long, val minDisplacementM: Float)
+
+    /** Foreground overlay params per profile; null for background profiles (no precise overlay). */
+    private fun foregroundOverlayParams(profile: TrackingProfile): OverlayParams? = when (profile) {
+        TrackingProfile.LiveForeground ->
+            OverlayParams(Priority.PRIORITY_HIGH_ACCURACY, LIVE_FG_INTERVAL_MS, LIVE_FG_MIN_DISPLACEMENT_M)
+        TrackingProfile.HistoryForeground ->
+            OverlayParams(Priority.PRIORITY_BALANCED_POWER_ACCURACY, HISTORY_FG_INTERVAL_MS, HISTORY_FG_MIN_DISPLACEMENT_M)
+        TrackingProfile.LiveBackground, TrackingProfile.HistoryBackground -> null
     }
 
     private fun backgroundPendingIntent(): PendingIntent {
@@ -142,8 +161,14 @@ private class AndroidLocationTracker(
         const val BACKGROUND_MAX_DELAY_MS = 600_000L
         const val BACKGROUND_MIN_DISPLACEMENT_M = 25f
 
-        const val FOREGROUND_INTERVAL_MS = 15_000L
-        const val FOREGROUND_MIN_DISPLACEMENT_M = 10f
+        // Live foreground (share or live-map view): high accuracy, frequent — fresh fixes matter.
+        const val LIVE_FG_INTERVAL_MS = 15_000L
+        const val LIVE_FG_MIN_DISPLACEMENT_M = 10f
+
+        // History-only foreground: balanced power, larger displacement. No live consumer needs
+        // second-by-second precision, so trade freshness for battery (#846). Tune on-device.
+        const val HISTORY_FG_INTERVAL_MS = 30_000L
+        const val HISTORY_FG_MIN_DISPLACEMENT_M = 25f
     }
 }
 

--- a/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/LocationTracker.apple.kt
+++ b/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/LocationTracker.apple.kt
@@ -11,6 +11,7 @@ import platform.CoreLocation.CLLocationManager
 import platform.CoreLocation.CLLocationManagerDelegateProtocol
 import platform.CoreLocation.kCLLocationAccuracyBest
 import platform.CoreLocation.kCLLocationAccuracyHundredMeters
+import platform.CoreLocation.kCLLocationAccuracyNearestTenMeters
 import platform.Foundation.NSError
 import platform.Foundation.timeIntervalSince1970
 import platform.darwin.NSObject
@@ -42,13 +43,13 @@ private class AppleLocationTracker(
     override val isAvailable: Boolean = true
 
     private var started = false
-    private var mode = TrackingMode.Background
+    private var profile = TrackingProfile.HistoryBackground
 
     private val delegate = object : NSObject(), CLLocationManagerDelegateProtocol {
         override fun locationManager(manager: CLLocationManager, didUpdateLocations: List<*>) {
             val points = didUpdateLocations
                 .filterIsInstance<CLLocation>()
-                .map { it.toRawPoint(fg = mode == TrackingMode.Foreground) }
+                .map { it.toRawPoint(fg = isForegroundProfile(profile)) }
             if (points.isEmpty()) return
             scope.launch { sink.submit(points) }
         }
@@ -67,22 +68,22 @@ private class AppleLocationTracker(
         }
     }
 
-    override fun start(mode: TrackingMode) {
-        this.mode = mode
-        applyProfile(mode)
+    override fun start(profile: TrackingProfile) {
+        this.profile = profile
+        applyProfile(profile)
         if (started) return
         manager.startMonitoringSignificantLocationChanges()
         manager.startUpdatingLocation()
         started = true
-        logger.i { "Started (mode=$mode)" }
+        logger.i { "Started (profile=$profile)" }
     }
 
-    override fun setMode(mode: TrackingMode) {
-        if (this.mode == mode) return
-        this.mode = mode
+    override fun setProfile(profile: TrackingProfile) {
+        if (this.profile == profile) return
+        this.profile = profile
         if (!started) return
-        applyProfile(mode)
-        logger.i { "Profile -> $mode" }
+        applyProfile(profile)
+        logger.i { "Profile -> $profile" }
     }
 
     override fun stop() {
@@ -92,19 +93,28 @@ private class AppleLocationTracker(
         logger.i { "Stopped" }
     }
 
-    private fun applyProfile(mode: TrackingMode) {
-        when (mode) {
-            TrackingMode.Foreground -> {
+    private fun applyProfile(profile: TrackingProfile) {
+        when (profile) {
+            // Live (share / live-map view): best accuracy, tight filter — fresh fixes matter.
+            TrackingProfile.LiveForeground -> {
                 manager.desiredAccuracy = kCLLocationAccuracyBest
                 manager.distanceFilter = 10.0
             }
-
-            TrackingMode.Background -> {
+            // History-only foreground: balanced — no live consumer needs best accuracy (#846).
+            TrackingProfile.HistoryForeground -> {
+                manager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters
+                manager.distanceFilter = 25.0
+            }
+            // Background (live or history): low power, OS-throttled — unchanged.
+            TrackingProfile.LiveBackground, TrackingProfile.HistoryBackground -> {
                 manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
                 manager.distanceFilter = 50.0
             }
         }
     }
+
+    private fun isForegroundProfile(profile: TrackingProfile): Boolean =
+        profile == TrackingProfile.LiveForeground || profile == TrackingProfile.HistoryForeground
 }
 
 @OptIn(ExperimentalForeignApi::class)

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/GpsDemand.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/GpsDemand.kt
@@ -34,6 +34,22 @@ class GpsDemand {
     fun wants(allowHistory: Boolean, liveShare: Boolean): Boolean =
         allowHistory || liveShare || tokens.value.isNotEmpty()
 
+    /**
+     * Pick the acquisition profile for the current consumers (#846). A **live** consumer — an active
+     * share OR a transient hold (the live-map view) — wants frequent, high-accuracy fixes and takes
+     * priority; otherwise (history only) use the battery-friendly profile. Crossed with the app's
+     * foreground state. Caller must only act on this when [wants] is true.
+     */
+    fun resolveProfile(isForeground: Boolean, allowHistory: Boolean, liveShare: Boolean): TrackingProfile {
+        val wantsLive = liveShare || hasTransient()
+        return when {
+            wantsLive && isForeground -> TrackingProfile.LiveForeground
+            wantsLive -> TrackingProfile.LiveBackground
+            isForeground -> TrackingProfile.HistoryForeground
+            else -> TrackingProfile.HistoryBackground
+        }
+    }
+
     /** Whether any transient hold is currently held. */
     fun hasTransient(): Boolean = tokens.value.isNotEmpty()
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationPointStore.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationPointStore.kt
@@ -62,8 +62,16 @@ class LocationPointStore(
         return accepted
     }
 
-    /** A fix closer than [MIN_DISPLACEMENT_M] in space AND [MIN_INTERVAL_MS] in time to the previous
-     *  accepted fix is stationary noise — drop it before it costs DB and upload bytes. */
+    /**
+     * A fix closer than [MIN_DISPLACEMENT_M] in space AND [MIN_INTERVAL_MS] in time to the previous
+     * accepted fix is stationary noise — drop it before it costs DB and upload bytes.
+     *
+     * Deliberately defensive over the OS-level displacement filter (#846 Q3): it is the **single**
+     * gate every capture path funnels through — the Android foreground overlay (10 m), the iOS
+     * distance filter (which drifts and re-fires near the threshold), the background PendingIntent
+     * (25 m), **and** one-shot `getCurrentGps` fixes (no OS displacement filter at all). Enforcing the
+     * 8 m∧20 s rule here guarantees consistent thinning regardless of which source produced the fix.
+     */
     private fun isStationaryNoise(prev: RawLocationPoint, p: RawLocationPoint): Boolean =
         p.t - prev.t < MIN_INTERVAL_MS &&
             haversineMeters(prev.lat, prev.lon, p.lat, p.lon) < MIN_DISPLACEMENT_M

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTracker.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTracker.kt
@@ -1,13 +1,28 @@
 package id.homebase.core.location.tracking
 
 /**
- * Capture profile for the platform tracker.
+ * Acquisition profile for the platform tracker — chosen by [LocationTrackingCoordinator] from BOTH
+ * the app's foreground state AND *why* GPS is running (resolved by [GpsDemand.resolveProfile]). A
+ * **live** consumer (an active share or the live-map view) wants frequent, fresh, high-accuracy
+ * fixes; **history**-only wants battery-friendly, displacement-based sampling.
  *
- * - [Foreground] — the app is visible: high accuracy, tight interval/displacement.
- * - [Background] — the app is backgrounded: low power, batched/OS-throttled
- *   delivery. No foreground service on Android; the OS decides the cadence.
+ * Today only the two FOREGROUND profiles differ in their parameters; both background profiles map to
+ * the same OS-throttled low-power cadence — the background / cold-wake path is intentionally left
+ * untouched (changing it is higher risk, lower value, and OS-capped anyway).
  */
-enum class TrackingMode { Foreground, Background }
+enum class TrackingProfile {
+    /** App foreground + a live consumer: high accuracy, tight interval/displacement. */
+    LiveForeground,
+
+    /** App background + a live consumer: low power, batched/OS-throttled. */
+    LiveBackground,
+
+    /** App foreground, history only: balanced power, larger displacement (battery-friendly). */
+    HistoryForeground,
+
+    /** App background, history only (and the default at cold start): low power, batched. */
+    HistoryBackground,
+}
 
 /**
  * One captured GPS fix, platform-agnostic. Optional fields are null when the
@@ -55,7 +70,7 @@ interface LocationPointSink {
  *
  * Battery contract (see plan): Android uses FusedLocationProvider — a
  * balanced-power batched PendingIntent registration that survives the app
- * process, plus a high-accuracy callback overlay only while [TrackingMode.Foreground];
+ * process, plus a high-accuracy callback overlay only while a foreground profile is active;
  * no foreground service. iOS uses CLLocationManager with auto-pause and
  * significant-location-change as the relaunch vector.
  */
@@ -64,13 +79,13 @@ interface LocationTracker {
     val isAvailable: Boolean
 
     /**
-     * Idempotent. Registers OS location updates with the profile for [mode].
+     * Idempotent. Registers OS location updates for [profile].
      * On platforms with [isAvailable] = false this is a no-op.
      */
-    fun start(mode: TrackingMode)
+    fun start(profile: TrackingProfile)
 
-    /** Switch capture profile on app foreground/background transitions while running. */
-    fun setMode(mode: TrackingMode)
+    /** Switch the acquisition profile while running (foreground/background or live/history change). */
+    fun setProfile(profile: TrackingProfile)
 
     /** Unregister all OS location updates. */
     fun stop()

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTrackingCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTrackingCoordinator.kt
@@ -60,9 +60,10 @@ class LocationTrackingCoordinator(
     private var isForeground = false
     private var tickerJob: Job? = null
 
-    // Tracks whether we've armed the tracker, so [applyGpsHold] logs only on transitions (not on
-    // every idempotent re-evaluation).
+    // Tracks armed-state + the last-applied profile, so [applyGpsHold] logs only on transitions
+    // (armed/stopped or a profile change), not on every idempotent re-evaluation.
     private var gpsRunning = false
+    private var lastProfile: TrackingProfile? = null
 
     /** GPS should run when history is allowed, a live share needs it, OR a transient hold is held. */
     private fun wantsGps(): Boolean =
@@ -70,6 +71,10 @@ class LocationTrackingCoordinator(
 
     /** GPS can only physically run with hardware present AND location permission granted. */
     private fun canRunGps(): Boolean = tracker.isAvailable && isLocationPermissionGranted()
+
+    /** The acquisition profile for the current foreground state + consumers (#846). */
+    private fun currentProfile(): TrackingProfile =
+        demand.resolveProfile(isForeground, preferences.allowLocationHistory.value, liveShareActive())
 
     /**
      * Start or stop the tracker to match [wantsGps] (gated by [canRunGps]). The single start/stop
@@ -79,21 +84,24 @@ class LocationTrackingCoordinator(
         if (!tracker.isAvailable) return
         val wants = wantsGps()
         if (wants && canRunGps()) {
-            tracker.start(if (isForeground) TrackingMode.Foreground else TrackingMode.Background)
-            if (isForeground) startTicker()
-            if (!gpsRunning) {
-                gpsRunning = true
+            val profile = currentProfile()
+            tracker.start(profile)
+            if (isForeground) startTicker() else stopTicker()
+            if (!gpsRunning || profile != lastProfile) {
                 logger.i {
-                    "GPS armed (mode=${if (isForeground) "FG" else "BG"} " +
+                    "GPS armed (profile=$profile " +
                         "allowHistory=${preferences.allowLocationHistory.value} " +
                         "liveShare=${liveShareActive()} transient=${demand.hasTransient()})"
                 }
             }
+            gpsRunning = true
+            lastProfile = profile
         } else {
             tracker.stop()
             stopTicker()
             if (gpsRunning) {
                 gpsRunning = false
+                lastProfile = null
                 logger.i { "GPS stopped (nothing wants it, or not permitted)" }
             }
             // Key diagnostic for "I'm on the live map but my dot never appears": something wants GPS
@@ -134,12 +142,11 @@ class LocationTrackingCoordinator(
                 "liveShare=${liveShareActive()} transient=${demand.hasTransient()} permitted=${isLocationPermissionGranted()})"
         }
 
+        // A foreground/background transition changes both the desired profile (live/history × FG/BG)
+        // and the flush ticker; re-applying the hold handles start/stop/profile/ticker + logging.
         observeAppForeground { foreground ->
             isForeground = foreground
-            if (wantsGps() && canRunGps()) {
-                tracker.setMode(if (foreground) TrackingMode.Foreground else TrackingMode.Background)
-            }
-            if (foreground) startTicker() else stopTicker()
+            applyGpsHold()
         }
     }
 
@@ -177,6 +184,14 @@ class LocationTrackingCoordinator(
         }
     }
 
+    /**
+     * Foreground flush ticker (#846 Q2). Its job is to **drain the history buffer to hour files even
+     * when no new fixes are arriving** — e.g. a stationary user whose fixes are all dropped by the
+     * store's stationary-noise filter would otherwise never trigger a flush (those are fired from the
+     * router's persist path). It is intentionally slower (120 s) than the uploader's own 60 s flush
+     * rate-gate: the gate bounds how often a flush *can* run; this ticker only guarantees one happens
+     * periodically while foregrounded. Background flushes piggyback on batch deliveries instead.
+     */
     private fun startTicker() {
         if (tickerJob?.isActive == true) return
         tickerJob = scope.launch {

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/location/tracking/GpsDemandTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/location/tracking/GpsDemandTest.kt
@@ -62,4 +62,50 @@ class GpsDemandTest {
         demand.acquire(DemandReason.LiveMapOpen)
         assertEquals(listOf(DemandReason.LiveMapOpen), demand.activeReasons().toList())
     }
+
+    // ── resolveProfile (#846): live (share OR transient hold) beats history; crossed with FG/BG ──
+
+    @Test
+    fun profileLiveForegroundWhenSharingInForeground() {
+        assertEquals(
+            TrackingProfile.LiveForeground,
+            GpsDemand().resolveProfile(isForeground = true, allowHistory = false, liveShare = true),
+        )
+    }
+
+    @Test
+    fun profileLiveBackgroundWhenSharingInBackground() {
+        assertEquals(
+            TrackingProfile.LiveBackground,
+            GpsDemand().resolveProfile(isForeground = false, allowHistory = true, liveShare = true),
+        )
+    }
+
+    @Test
+    fun profileHistoryForegroundWhenOnlyHistoryInForeground() {
+        assertEquals(
+            TrackingProfile.HistoryForeground,
+            GpsDemand().resolveProfile(isForeground = true, allowHistory = true, liveShare = false),
+        )
+    }
+
+    @Test
+    fun profileHistoryBackgroundWhenOnlyHistoryInBackground() {
+        assertEquals(
+            TrackingProfile.HistoryBackground,
+            GpsDemand().resolveProfile(isForeground = false, allowHistory = true, liveShare = false),
+        )
+    }
+
+    @Test
+    fun transientHoldCountsAsLiveForProfile() {
+        // The live-map view holds GPS via a transient demand with history off and no share — it still
+        // wants the high-accuracy Live profile, not the battery-saving History one.
+        val demand = GpsDemand()
+        demand.acquire(DemandReason.LiveMapOpen)
+        assertEquals(
+            TrackingProfile.LiveForeground,
+            demand.resolveProfile(isForeground = true, allowHistory = false, liveShare = false),
+        )
+    }
 }

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/location/tracking/LocationTracker.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/location/tracking/LocationTracker.jvm.kt
@@ -6,7 +6,7 @@ actual fun createLocationTracker(sink: LocationPointSink): LocationTracker =
 /** Desktop has no GPS — the Location screen shows the unavailable state. */
 private object UnavailableLocationTracker : LocationTracker {
     override val isAvailable: Boolean = false
-    override fun start(mode: TrackingMode) {}
-    override fun setMode(mode: TrackingMode) {}
+    override fun start(profile: TrackingProfile) {}
+    override fun setProfile(profile: TrackingProfile) {}
     override fun stop() {}
 }

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/LocationServiceTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/LocationServiceTest.kt
@@ -11,7 +11,7 @@ import id.homebase.core.location.tracking.LocationTrackingCoordinator
 import id.homebase.core.location.tracking.OneShotLocationProvider
 import id.homebase.core.location.tracking.RawLocationPoint
 import id.homebase.core.location.tracking.StepSample
-import id.homebase.core.location.tracking.TrackingMode
+import id.homebase.core.location.tracking.TrackingProfile
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -35,8 +35,8 @@ class LocationServiceTest {
 
     private object UnavailableTracker : LocationTracker {
         override val isAvailable = false
-        override fun start(mode: TrackingMode) {}
-        override fun setMode(mode: TrackingMode) {}
+        override fun start(profile: TrackingProfile) {}
+        override fun setProfile(profile: TrackingProfile) {}
         override fun stop() {}
     }
 

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/location/tracking/LocationTracker.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/location/tracking/LocationTracker.web.kt
@@ -9,7 +9,7 @@ actual fun createLocationTracker(sink: LocationPointSink): LocationTracker =
  */
 private object UnavailableLocationTracker : LocationTracker {
     override val isAvailable: Boolean = false
-    override fun start(mode: TrackingMode) {}
-    override fun setMode(mode: TrackingMode) {}
+    override fun start(profile: TrackingProfile) {}
+    override fun setProfile(profile: TrackingProfile) {}
     override fun stop() {}
 }


### PR DESCRIPTION
Closes #846.

## What & why

Today the foreground tracker uses one profile (high-accuracy 15s/10m) **regardless of why GPS is on**, so **history-only** capture pays a live-grade battery cost it doesn't need. This picks the foreground profile by *which consumer* needs GPS, building on the `GpsDemand` model from #847.

## B2 — per-consumer profile (behavior change)
- `GpsDemand.resolveProfile(isForeground, allowHistory, liveShare)` → `TrackingProfile` = {Live,History} × {Foreground,Background}. A **live** consumer (active share **or** the live-map transient hold) takes priority; otherwise history-only.
- `LocationTracker` interface: `TrackingMode` → `TrackingProfile`; `setMode` → `setProfile`. Coordinator resolves the profile and re-applies on foreground / demand / share changes, logging transitions (`GPS armed (profile=…)`).
- **Android** foreground overlay per profile: `LiveForeground` HIGH_ACCURACY 15s/10m (unchanged), `HistoryForeground` BALANCED 30s/25m (new, lighter). Background PendingIntent unchanged.
- **iOS**: `LiveForeground` best/10m (unchanged), `HistoryForeground` nearestTenMeters/25m; background hundredMeters/50m unchanged.
- Differentiates the **foreground profile only** — the OS-throttled background / cold-wake path is left untouched (lower risk, OS-capped anyway). The `HistoryForeground` values are starting points to **tune on-device**.

## B1 — cadence docs (no behavior change)
- Named the foreground flush ticker's purpose (Q2: drain even when no new fixes arrive; 120s vs the uploader's 60s gate).
- Justified the store stationary-noise filter over the OS filter (Q3: it's the single gate all sources — incl. one-shot, with no OS filter — funnel through).

## Tests
`resolveProfile` truth table (commonTest, pure → all targets). JVM/Android/Web compile; `homebase-common:jvmTest` + Konsist green.

## ⚠️ Requires on-device verification before merge — do NOT auto-merge
This changes real GPS accuracy/battery behavior. Validate on Android + iOS:
- history-on only, foreground → lighter profile still yields a usable trail (`homebase.log`: `GPS armed (profile=HistoryForeground …)`).
- start a live share / open the live map → high-accuracy resumes (`profile=LiveForeground`) and the recipient sees timely updates.
- toggle history/share/live-map and foreground/background → profile transitions log correctly; GPS stop/start matches `wantsGps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)