### PR TITLE
#841: prompt to enable GPS on the live map when permission is missing

### DIFF
--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1310,6 +1310,10 @@
     <string name="location_history_you">(you)</string>
     <string name="live_location_title">Live location</string>
     <string name="live_location_empty">No one is sharing their live location right now.</string>
+    <string name="live_location_enable_gps_title">Show your location?</string>
+    <string name="live_location_enable_gps_text">Allow location access so your position appears on the map alongside the people sharing with you.</string>
+    <string name="live_location_enable_gps_confirm">Allow</string>
+    <string name="live_location_enable_gps_dismiss">Not now</string>
     <string name="live_location_marker_cd">%1$s's live location</string>
     <string name="live_location_you">You</string>
     <string name="live_location_age_minutes">%1$dm</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LocationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LocationService.kt
@@ -80,6 +80,13 @@ class LocationService(
      */
     fun acquireDemand(reason: DemandReason): DemandToken = coordinator.acquireTransientDemand(reason)
 
+    /**
+     * Re-evaluate the GPS hold — e.g. after location permission is granted while a transient demand
+     * is already held (the live map): the held demand now passes the permission gate and GPS arms,
+     * so the user's own dot appears without re-acquiring or leaving the screen.
+     */
+    fun refreshGpsHold() = coordinator.refreshGpsHold()
+
     /** Turn location-history persistence on/off (also arms/disarms GPS accordingly). */
     suspend fun setAllowLocationHistory(enabled: Boolean) =
         coordinator.setAllowLocationHistory(enabled)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationScreen.kt
@@ -13,24 +13,42 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.Map
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.api.client.location.LocationPreviewProvider
+import id.homebase.core.permissions.PermissionStatus
+import id.homebase.core.permissions.PermissionType
+import id.homebase.core.permissions.createPermissionsManager
+import id.homebase.core.permissions.isLocationPermissionGranted
 import id.homebase.resources.MR
 import id.homebase.resources.live_location_empty
+import id.homebase.resources.live_location_enable_gps_confirm
+import id.homebase.resources.live_location_enable_gps_dismiss
+import id.homebase.resources.live_location_enable_gps_text
+import id.homebase.resources.live_location_enable_gps_title
 import id.homebase.resources.live_location_title
 import id.homebase.resources.location_maps_off_cta
 import id.homebase.resources.location_maps_off_title
@@ -47,6 +65,58 @@ fun LiveLocationScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val previewProvider = koinInject<LocationPreviewProvider>()
+
+    // Your own dot needs location permission (the map's transient GPS hold arms the tracker only when
+    // permitted — history is irrelevant). On each open, if permission is missing, prompt for it; on
+    // grant, re-arm GPS so the dot appears without leaving the map or enabling history (#841).
+    var permanentlyDenied by remember { mutableStateOf(false) }
+    var showEnableGpsDialog by remember { mutableStateOf(false) }
+    val permissionsManager = createPermissionsManager { type, status, deniedForever ->
+        if (type != PermissionType.LOCATION) return@createPermissionsManager
+        if (status == PermissionStatus.GRANTED) {
+            showEnableGpsDialog = false
+            viewModel.onPermissionGranted()
+        } else {
+            permanentlyDenied = deniedForever
+        }
+    }
+
+    // Prompt on entry when un-permitted. Plain remember (not saveable) so a fresh open re-prompts.
+    LaunchedEffect(Unit) {
+        if (!isLocationPermissionGranted()) showEnableGpsDialog = true
+    }
+    // Returning from system Settings: if permission was granted there, clear the prompt and arm GPS.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME && isLocationPermissionGranted()) {
+                showEnableGpsDialog = false
+                viewModel.onPermissionGranted()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    if (showEnableGpsDialog) {
+        AlertDialog(
+            onDismissRequest = { showEnableGpsDialog = false },
+            title = { Text(stringResource(MR.string.live_location_enable_gps_title)) },
+            text = { Text(stringResource(MR.string.live_location_enable_gps_text)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    // Once permanently denied, the OS won't re-prompt — send the user to Settings.
+                    if (permanentlyDenied) permissionsManager.launchSettings()
+                    else permissionsManager.askPermission(PermissionType.LOCATION)
+                }) { Text(stringResource(MR.string.live_location_enable_gps_confirm)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showEnableGpsDialog = false }) {
+                    Text(stringResource(MR.string.live_location_enable_gps_dismiss))
+                }
+            },
+        )
+    }
 
     Scaffold(
         topBar = {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationViewModel.kt
@@ -56,6 +56,13 @@ class LiveLocationViewModel(
         super.onCleared()
     }
 
+    /**
+     * Called by the screen when location permission is granted. The map's [DemandReason.LiveMapOpen]
+     * hold is already held; this re-evaluates the GPS hold so the now-permitted tracker arms and the
+     * user's own dot appears — without enabling history or leaving the screen.
+     */
+    fun onPermissionGranted() = locationService.refreshGpsHold()
+
     // Re-emits so age labels update and stale dots drop without a new store packet.
     private val ticker = flow {
         while (true) {


### PR DESCRIPTION
Closes #841.

## What & why

After #847 the live map shows your own dot via a transient GPS hold — but only when location **permission** is granted. Open it without permission and there was no dot and no way to fix it from the map (the coordinator already logs `GPS wanted but NOT started — location permission not granted`). Now, every time the live map opens without permission, a dialog prompts to grant it.

## How

- **Permission-only trigger** (`isLocationPermissionGranted()`), not history/tracking — the held `LiveMapOpen` demand arms GPS regardless of history once permitted (this was the correction to the original issue framing).
- **Inline request** via the existing `createPermissionsManager(PermissionType.LOCATION)` so the user stays on the map and history is *not* enabled; a permanently-denied permission routes to system Settings (`launchSettings()`).
- **On grant**, `LiveLocationViewModel.onPermissionGranted()` → `LocationService.refreshGpsHold()` → `coordinator.refreshGpsHold()` re-arms GPS for the already-held demand, so the dot appears without leaving the screen.
- **Every open**: a plain `remember` flag (not saveable) re-prompts on each open; an `ON_RESUME` re-check clears the prompt and arms GPS when permission is granted via system Settings.

## Files
`LiveLocationScreen.kt` (dialog + permission manager + resume re-check), `LiveLocationViewModel.kt` (+`onPermissionGranted`), `LocationService.kt` (+`refreshGpsHold` passthrough), 4 new `live_location_enable_gps_*` strings.

## Verification
- Compiles JVM/Android/Web for homebase-core + homebase-common; Konsist `ArchitectureTest` green (dialog text via `stringResource`). iOS compiled by CI.
- **Manual (Android):** permission OFF + history OFF → open live map → dialog; Allow → grant → own dot appears without leaving the map, history still off (`homebase.log`: `GPS armed (profile=LiveForeground …)`). "Not now" → map shows others; re-open → prompts again. Grant via system Settings → resume re-check shows the dot. Permission already granted → no dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)