### PR TITLE
fix(android): contain note-to-self bootstrap crash + show recovery screen for fast crashes

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -166,6 +166,11 @@ dependencies {
     implementation(libs.androidx.lifecycle.process)
     implementation(libs.firebase.messaging)
     implementation(libs.firebase.crashlytics)
+    // Native (NDK) crash capture: installs Google's async-signal-safe signal handler so
+    // native crashes (e.g. a SQLCipher SIGSEGV/SIGABRT) — which the JVM uncaught handler
+    // in GlobalCrashHandler can never see — are recorded and reflected by
+    // didCrashOnPreviousExecution(). Prebuilt artifact; no NDK/CMake build on our side.
+    implementation(libs.firebase.crashlytics.ndk)
 
     debugImplementation(libs.androidx.ui.tooling)
 

--- a/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
@@ -31,6 +31,7 @@ import id.homebase.core.notifications.RichNotificationDisplayer
 import id.homebase.core.logging.StartupLogger
 import id.homebase.core.notifications.decideNotificationIntent
 import id.homebase.core.notifications.isReplayedFromHistory
+import id.homebase.feed.crash.NativeCrashRecovery
 import id.homebase.feed.share.ShareShortcutPublisher
 import id.homebase.core.settings.ThemeState
 import id.homebase.core.settings.UserPreferences
@@ -52,6 +53,15 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+
+        // If the previous run died in a *native* crash (an NDK signal — e.g. a SQLCipher
+        // SIGSEGV — that the JVM GlobalCrashHandler can never see), surface the recovery
+        // screen now instead of starting normally. Returns false on a clean previous run.
+        if (NativeCrashRecovery.checkAndMaybeLaunch(this)) {
+            finish()
+            return
+        }
+
         // The gap from MainApplication's "onCreate end" to here is process-idle /
         // background→foreground (a background-woken process sits here until the user
         // opens it). The gap from here to "App() first composition" is the real

--- a/androidApp/src/main/kotlin/id/homebase/feed/crash/GlobalCrashHandler.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/crash/GlobalCrashHandler.kt
@@ -66,6 +66,11 @@ object GlobalCrashHandler {
                     return@setDefaultUncaughtExceptionHandler
                 }
 
+                // Mark this run's death as a JVM crash we handled, so the next launch's
+                // NativeCrashRecovery doesn't misclassify it as native. A native signal
+                // crash never reaches this handler, so it never sets this marker.
+                NativeCrashRecovery.markJvmCrashHandled(app)
+
                 CrashLogger.logCrash(thread.name, throwable)
                 val reportPath = CrashReporting.writeReport(thread.name, throwable)
                 // Record as a non-fatal: the captured default handler is Crashlytics',

--- a/androidApp/src/main/kotlin/id/homebase/feed/crash/GlobalCrashHandler.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/crash/GlobalCrashHandler.kt
@@ -1,7 +1,6 @@
 package id.homebase.feed.crash
 
 import android.app.Application
-import android.content.Context
 import android.content.Intent
 import android.content.pm.ApplicationInfo
 import android.os.Build
@@ -24,9 +23,10 @@ import kotlin.system.exitProcess
  */
 object GlobalCrashHandler {
     private const val TAG = "GlobalCrashHandler"
-    private const val CRASH_LOOP_PREFS = "crash_loop_guard"
-    private const val KEY_LAST_CRASH_MS = "last_crash_ms"
-    private const val CRASH_LOOP_WINDOW_MS = 10_000L
+
+    // CrashActivity runs in this dedicated process (see AndroidManifest android:process).
+    // A crash *inside* it is the only real "loop" we must not relaunch the screen for.
+    private const val CRASH_PROCESS_SUFFIX = ":crash"
 
     fun install(app: Application) {
         CrashReporting.install(
@@ -72,7 +72,7 @@ object GlobalCrashHandler {
                 // and chaining to it would re-raise the OS dialog we're replacing.
                 runCatching { Firebase.crashlytics.recordException(throwable) }
 
-                if (!isCrashLooping(app) && reportPath != null) {
+                if (shouldLaunchRecoveryScreen(currentProcessName(), reportPath?.toString())) {
                     launchCrashActivity(app, reportPath.toString())
                 }
             } catch (t: Throwable) {
@@ -85,14 +85,40 @@ object GlobalCrashHandler {
         }
     }
 
-    /** True if another crash happened < 10s ago (likely CrashActivity itself crashed). */
-    private fun isCrashLooping(app: Application): Boolean {
-        val prefs = app.getSharedPreferences(CRASH_LOOP_PREFS, Context.MODE_PRIVATE)
-        val now = System.currentTimeMillis()
-        val last = prefs.getLong(KEY_LAST_CRASH_MS, 0L)
-        prefs.edit().putLong(KEY_LAST_CRASH_MS, now).apply()
-        return now - last < CRASH_LOOP_WINDOW_MS
+    /**
+     * Whether to launch the [CrashActivity] recovery screen for this crash. Pure so it
+     * is unit-testable.
+     *
+     * We show the screen for **every main-process crash** — including a fast,
+     * deterministic, repeatable one. The previous heuristic suppressed any crash that
+     * happened < 10s after the last one, which silently swallowed exactly the worst
+     * case: a reproducible launch crash (e.g. the note-to-self bootstrap firing before
+     * credentials are ready) that crashes a few seconds into every relaunch. The user
+     * saw a bare death with no recovery screen and no Share button.
+     *
+     * The only crash we must NOT relaunch the screen for is one happening *inside* the
+     * `:crash` process itself — that means [CrashActivity] crashed, and relaunching it
+     * would loop. A null [processName] can't prove we're that process, so we default to
+     * showing (better a possible extra screen than a silent death). No [reportPath] →
+     * nothing to show.
+     */
+    internal fun shouldLaunchRecoveryScreen(processName: String?, reportPath: String?): Boolean {
+        if (reportPath == null) return false
+        return processName?.endsWith(CRASH_PROCESS_SUFFIX) != true
     }
+
+    /**
+     * Name of the current process. [Application.getProcessName] is API 28+; below that we
+     * read `/proc/self/cmdline` (the process name, NUL-padded). Returns null if unknown.
+     */
+    private fun currentProcessName(): String? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            runCatching { Application.getProcessName() }.getOrNull()
+        } else {
+            runCatching {
+                java.io.File("/proc/self/cmdline").readText().substringBefore('\u0000').trim()
+            }.getOrNull()
+        }
 
     private fun launchCrashActivity(app: Application, reportPath: String) {
         val intent = Intent(app, CrashActivity::class.java).apply {

--- a/androidApp/src/main/kotlin/id/homebase/feed/crash/NativeCrashRecovery.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/crash/NativeCrashRecovery.kt
@@ -1,0 +1,88 @@
+package id.homebase.feed.crash
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import co.touchlab.kermit.Logger
+import com.google.firebase.Firebase
+import com.google.firebase.crashlytics.crashlytics
+
+/**
+ * Surfaces **native** crashes — NDK signals (SIGSEGV/SIGABRT/SIGBUS/SIGILL/SIGFPE) from
+ * e.g. SQLCipher — that the JVM uncaught-exception handler in [GlobalCrashHandler] cannot
+ * see. Such a crash kills the process via a signal, not a Java `Throwable`, so the JVM
+ * handler never runs: no written report, no in-process recovery screen, and (before the
+ * firebase-crashlytics-ndk dependency) not even a Crashlytics report.
+ *
+ * The NDK component installs Google's async-signal-safe handler, so a native crash is
+ * recorded and reflected by [com.google.firebase.crashlytics.FirebaseCrashlytics.didCrashOnPreviousExecution].
+ * We can't show a screen *during* a native crash (the signal kills us), so we detect it on
+ * the **next** launch and show [CrashActivity] then.
+ *
+ * Telling a *native* crash apart from a *JVM* crash we already surfaced in-process:
+ * [GlobalCrashHandler] writes [KEY_JVM_SURFACED] = true (synchronously, via commit()) for
+ * every real JVM crash it handles. Native crashes never reach it, so they never set it.
+ * Hence on the next launch:
+ *
+ *   previous run crashed (didCrashOnPreviousExecution) AND we did NOT handle it ourselves
+ *   (no JVM marker)  ⇒  it was native — show recovery now.
+ */
+object NativeCrashRecovery {
+    private const val TAG = "NativeCrashRecovery"
+    internal const val PREFS = "crash_native_recovery"
+    internal const val KEY_JVM_SURFACED = "jvm_crash_surfaced"
+
+    /**
+     * Pure policy (unit-tested). Show the next-launch native recovery screen only when the
+     * previous run crashed and [GlobalCrashHandler] did *not* already surface it — i.e. it
+     * was a native signal, not a JVM exception we showed in-process.
+     */
+    internal fun shouldShowNativeCrashRecovery(
+        didCrashOnPreviousExecution: Boolean,
+        jvmCrashSurfacedLastRun: Boolean,
+    ): Boolean = didCrashOnPreviousExecution && !jvmCrashSurfacedLastRun
+
+    /**
+     * Record that [GlobalCrashHandler] handled a JVM crash this run. Uses commit() (not
+     * apply()) because the process is about to be killed — an async apply() write may not
+     * reach disk first.
+     */
+    fun markJvmCrashHandled(context: Context) {
+        runCatching {
+            context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+                .edit().putBoolean(KEY_JVM_SURFACED, true).commit()
+        }
+    }
+
+    /**
+     * At launch: if the previous run died in a native crash we couldn't surface in-process,
+     * launch [CrashActivity] and return true (caller should finish() and skip normal
+     * startup). Always clears the per-run JVM marker so it reflects only the current run.
+     */
+    fun checkAndMaybeLaunch(activity: Activity): Boolean {
+        val prefs = activity.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        val jvmSurfacedLastRun = prefs.getBoolean(KEY_JVM_SURFACED, false)
+        // Reset for the current run (the value above reflects the previous run).
+        runCatching { prefs.edit().putBoolean(KEY_JVM_SURFACED, false).commit() }
+
+        val didCrash = runCatching {
+            Firebase.crashlytics.didCrashOnPreviousExecution()
+        }.getOrDefault(false)
+
+        if (!shouldShowNativeCrashRecovery(didCrash, jvmSurfacedLastRun)) return false
+
+        Logger.w(tag = TAG) {
+            "Previous run ended in a native crash not surfaced in-process; showing recovery."
+        }
+        return runCatching {
+            activity.startActivity(
+                Intent(activity, CrashActivity::class.java).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                    // No EXTRA_REPORT_PATH: the native trace lives in Crashlytics, not our
+                    // file log, so CrashActivity shows the table-flip + "report unavailable".
+                }
+            )
+            true
+        }.getOrDefault(false)
+    }
+}

--- a/androidApp/src/test/kotlin/id/homebase/feed/crash/GlobalCrashHandlerScreenGuardTest.kt
+++ b/androidApp/src/test/kotlin/id/homebase/feed/crash/GlobalCrashHandlerScreenGuardTest.kt
@@ -1,0 +1,51 @@
+package id.homebase.feed.crash
+
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+/**
+ * Guards [GlobalCrashHandler.shouldLaunchRecoveryScreen] — the decision that used to be
+ * a 10-second time window and silently swallowed the recovery screen for fast,
+ * repeatable launch crashes (the user saw a bare death, no table-flip screen, no Share).
+ */
+class GlobalCrashHandlerScreenGuardTest {
+
+    private val mainProcess = "id.homebase.feed.dev"
+    private val crashProcess = "id.homebase.feed.dev:crash"
+    private val report = "/data/.../crash/crash-123.txt"
+
+    @Test
+    fun mainProcessCrash_withReport_showsScreen() {
+        assertTrue(GlobalCrashHandler.shouldLaunchRecoveryScreen(mainProcess, report))
+    }
+
+    @Test
+    fun repeatedFastMainProcessCrash_stillShowsScreen() {
+        // The regression: a deterministic launch crash crashes a few seconds into every
+        // relaunch. Each one is a main-process crash, so each must surface the screen —
+        // the old time guard suppressed every one after the first.
+        repeat(5) {
+            assertTrue(
+                GlobalCrashHandler.shouldLaunchRecoveryScreen(mainProcess, report),
+                "every main-process crash must show the recovery screen",
+            )
+        }
+    }
+
+    @Test
+    fun crashProcessCrash_isSuppressed_toBreakTheLoop() {
+        // CrashActivity itself crashed — relaunching it would loop forever.
+        assertFalse(GlobalCrashHandler.shouldLaunchRecoveryScreen(crashProcess, report))
+    }
+
+    @Test
+    fun unknownProcess_defaultsToShowing() {
+        assertTrue(GlobalCrashHandler.shouldLaunchRecoveryScreen(null, report))
+    }
+
+    @Test
+    fun noReport_showsNothing() {
+        assertFalse(GlobalCrashHandler.shouldLaunchRecoveryScreen(mainProcess, null))
+    }
+}

--- a/androidApp/src/test/kotlin/id/homebase/feed/crash/NativeCrashRecoveryTest.kt
+++ b/androidApp/src/test/kotlin/id/homebase/feed/crash/NativeCrashRecoveryTest.kt
@@ -1,0 +1,41 @@
+package id.homebase.feed.crash
+
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+/**
+ * Guards [NativeCrashRecovery.shouldShowNativeCrashRecovery] — the policy that decides, on
+ * the next launch, whether the previous run died in a native (NDK signal) crash that the
+ * JVM [GlobalCrashHandler] could not surface in-process, and therefore needs the recovery
+ * screen shown now.
+ *
+ * The signal-catch itself (firebase-crashlytics-ndk) can only be exercised by forcing a
+ * native crash on a device; this pins the classification logic, which is the part that
+ * decides whether the screen appears.
+ */
+class NativeCrashRecoveryTest {
+
+    @Test
+    fun nativeCrash_previousRunCrashed_notSurfacedByJvm_showsRecovery() {
+        // didCrashOnPreviousExecution=true, and GlobalCrashHandler did NOT mark it → native.
+        assertTrue(NativeCrashRecovery.shouldShowNativeCrashRecovery(true, false))
+    }
+
+    @Test
+    fun jvmCrash_alreadySurfacedInProcess_doesNotReshow() {
+        // We showed CrashActivity in-process at JVM-crash time; don't double-show next launch.
+        assertFalse(NativeCrashRecovery.shouldShowNativeCrashRecovery(true, true))
+    }
+
+    @Test
+    fun cleanPreviousRun_showsNothing() {
+        assertFalse(NativeCrashRecovery.shouldShowNativeCrashRecovery(false, false))
+    }
+
+    @Test
+    fun cleanPreviousRun_evenWithStaleJvmMarker_showsNothing() {
+        // No crash last run ⇒ never show, regardless of a leftover marker.
+        assertFalse(NativeCrashRecovery.shouldShowNativeCrashRecovery(false, true))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -218,6 +218,7 @@ accompanist-systemuicontroller = { module = "com.google.accompanist:accompanist-
 kmpnotifier = { module = "io.github.mirzemehdi:kmpnotifier", version.ref = "kmpnotifier" }
 firebase-messaging = { module = "com.google.firebase:firebase-messaging", version.ref = "firebase-messaging" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics", version.ref = "firebase-crashlytics" }
+firebase-crashlytics-ndk = { module = "com.google.firebase:firebase-crashlytics-ndk", version.ref = "firebase-crashlytics" }
 composenativetray = { module = "io.github.kdroidfilter:composenativetray", version.ref = "composenativetray" }
 composenativewebview = { module = "io.github.kdroidfilter:composewebview", version.ref = "composenativewebview" }
 conveyor-control = { module = "dev.hydraulic.conveyor:conveyor-control", version.ref = "conveyorControl" }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -523,8 +523,29 @@ class ConversationListViewModel(
         }
 
         viewModelScope.launch {
+            // The note-to-self bootstrap needs *credentials*, not just a renderable
+            // list. `dataReady` can fire from cached conversations + a synthesized
+            // session (see the leading-edge debounce note above) before
+            // CredentialsManager has its active credentials — and the first thing
+            // ensureNoteToSelfExists() does is requireActiveDomain(), which throws
+            // "No active credentials set" in that window. An empty/just-wiped DB (e.g.
+            // a legacy install landing on a fresh odin-2.db, or the stale-schema
+            // self-heal) makes the cached list resolve faster, widening that window.
+            //
+            // This launch runs on the bare viewModelScope (no CoroutineExceptionHandler),
+            // so an uncaught throw here reaches the global crash handler and kills the
+            // app right as the overview appears. Gate on credentials so we don't run too
+            // early, and contain any residual failure — this is a best-effort bootstrap
+            // that is retried on every launch, never worth crashing over.
             conversationStream.conversations.first { it.dataReady }
-            conversationService.ensureNoteToSelfExists()
+            credentialsManager.credentialsFlow.first { it != null }
+            try {
+                conversationService.ensureNoteToSelfExists()
+            } catch (e: Throwable) {
+                Logger.w(tag = TAG, throwable = e) {
+                    "ensureNoteToSelfExists failed; will retry on next launch"
+                }
+            }
         }
 
         // Listen for search query changes

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/NoteToSelfBootstrapCrashTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/NoteToSelfBootstrapCrashTest.kt
@@ -1,0 +1,163 @@
+package id.homebase.chat.services.convo
+
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Reproduces the Android launch crash where the conversation overview renders
+ * (only the cached "note to self" row + a spinner) and then the process dies —
+ * with no table-flip recovery screen.
+ *
+ * ## The mechanism
+ *
+ * `ConversationListViewModel`'s init launches, on the bare `viewModelScope`
+ * (SupervisorJob + Dispatchers.Main, **no** CoroutineExceptionHandler), and with
+ * **no** local try/catch:
+ *
+ * ```
+ * viewModelScope.launch {
+ *     conversationStream.conversations.first { it.dataReady }
+ *     conversationService.ensureNoteToSelfExists()
+ * }
+ * ```
+ *
+ * `dataReady` does **not** imply "credentials are ready". Per the debounce comment
+ * a few lines above that launch, the first ready list is produced "within a few ms
+ * of vmInit" from **cached conversations + a credentials-synthesized session** — so
+ * `first { it.dataReady }` can unblock *before* `CredentialsManager.activeCredentials`
+ * has been populated by the real auth/connect lifecycle. A freshly-wiped or
+ * just-created DB (e.g. after the stale-schema self-heal) makes the cached list
+ * resolve even faster, widening that window.
+ *
+ * `ensureNoteToSelfExists()`'s very first statement is
+ * `credentialsManager.requireActiveDomain()`, which throws
+ * `IllegalStateException("No active credentials set")` when credentials aren't set
+ * yet. The method's `catch (e: Throwable)` only logs/audits and then **rethrows**,
+ * so the exception leaves the suspend fun. Because the launch site has no try/catch
+ * and `viewModelScope` carries no CoroutineExceptionHandler, the exception reaches
+ * `Thread.setDefaultUncaughtExceptionHandler` → `GlobalCrashHandler` →
+ * `Process.killProcess`. The app crashes exactly when the symptom describes: just
+ * after the cached note-to-self row is on screen.
+ *
+ * These two tests pin both halves: the deterministic throw, and the fact that the
+ * production launch pattern does not contain it.
+ */
+class NoteToSelfBootstrapCrashTest {
+
+    /**
+     * Root cause, deterministic: when the conversation list becomes `dataReady`
+     * from cached data before credentials settle, `ensureNoteToSelfExists()` throws
+     * `IllegalStateException` out of the suspend fun (it rethrows after auditing).
+     */
+    @Test
+    fun ensureNoteToSelfExists_beforeCredentialsReady_throws() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+
+            // Model the race: the cached/synthesized list fired `dataReady` and the
+            // bootstrap ran, but the real active credentials are not set yet.
+            fixture.credentialsManager.removeActiveCredentials()
+
+            val ex = assertFailsWith<IllegalStateException> {
+                service.ensureNoteToSelfExists()
+            }
+            assertTrue(
+                ex.message?.contains("No active credentials") == true,
+                "expected the requireActiveDomain() guard to be the thrower, was: ${ex.message}",
+            )
+        }
+    }
+
+    /**
+     * Propagation, modelling the production call site: launching the bootstrap on a
+     * `SupervisorJob`-only scope (the shape of `viewModelScope`) with no try/catch
+     * lets the exception escape the launch block uncaught.
+     *
+     * Here a CoroutineExceptionHandler stands in for "the uncaught path" so the test
+     * can observe delivery without killing the test JVM. On the real `viewModelScope`
+     * there is *no* such handler, so the same escaping exception lands on
+     * `Thread.setDefaultUncaughtExceptionHandler` → `GlobalCrashHandler` and the
+     * process is killed. The fix (wrap the launch body in try/catch, or give the
+     * bootstrap a contained handler) would stop the exception here and this handler
+     * would never fire.
+     */
+    @Test
+    fun ensureNoteToSelfExists_launchedLikeTheViewModel_escapesUncaught() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            fixture.credentialsManager.removeActiveCredentials()
+
+            var escaped: Throwable? = null
+            val handlerStandingInForCrashHandler = CoroutineExceptionHandler { _, e ->
+                escaped = e
+            }
+            // SupervisorJob + no try/catch in the body, exactly like viewModelScope. The
+            // only difference is the observable handler we attach to catch the escape;
+            // viewModelScope has none, so on-device the escape goes to the JVM default
+            // uncaught handler instead. Unconfined runs the body inline so the throw
+            // (requireActiveDomain, before any real suspension) propagates synchronously.
+            val viewModelLikeScope =
+                CoroutineScope(SupervisorJob() + Dispatchers.Unconfined + handlerStandingInForCrashHandler)
+
+            // The exact unguarded pattern from ConversationListViewModel.init.
+            val job = viewModelLikeScope.launch {
+                service.ensureNoteToSelfExists()
+            }
+            job.join()
+
+            assertNotNull(
+                escaped,
+                "the bootstrap exception was contained — expected it to escape the launch uncaught",
+            )
+            assertTrue(
+                escaped is IllegalStateException,
+                "the bootstrap exception escaped the launch uncaught (this is the crash); was: $escaped",
+            )
+        }
+    }
+
+    /**
+     * The fix, modelling the patched call site in `ConversationListViewModel`: the
+     * same unguarded scope, but the bootstrap body is wrapped in try/catch (and, in
+     * production, additionally gated on `credentialsFlow.first { it != null }`). The
+     * exception is contained and logged instead of escaping — the handler standing in
+     * for the crash path never fires, so the app survives.
+     */
+    @Test
+    fun ensureNoteToSelfExists_containedLikeTheFix_doesNotEscape() = runTest {
+        ConversationServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            fixture.credentialsManager.removeActiveCredentials()
+
+            var escaped: Throwable? = null
+            val viewModelLikeScope = CoroutineScope(
+                SupervisorJob() + Dispatchers.Unconfined +
+                    CoroutineExceptionHandler { _, e -> escaped = e },
+            )
+
+            val job = viewModelLikeScope.launch {
+                // The fix: contain the best-effort bootstrap (retried next launch).
+                try {
+                    service.ensureNoteToSelfExists()
+                } catch (_: Throwable) {
+                    // swallowed-and-logged in production (Logger.w)
+                }
+            }
+            job.join()
+
+            assertNull(
+                escaped,
+                "the contained bootstrap must not reach the uncaught path; was: $escaped",
+            )
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes an Android launch crash (overview renders → cached **note to self** + spinner → process dies, **no recovery screen, nothing in Crashlytics**) and closes the observability gaps behind it.

## 1. The crash — `ConversationListViewModel`
The note-to-self bootstrap was gated only on `dataReady` and launched on the bare `viewModelScope` (no `CoroutineExceptionHandler`) with no try/catch. `dataReady` fires from cached conversations + a synthesized session **before** credentials settle, so `ensureNoteToSelfExists()` → `requireActiveDomain()` throws `IllegalStateException("No active credentials set")`, rethrows, escapes uncaught, and the global handler kills the app. An empty/just-created DB (legacy install on a fresh `odin-2.db`, or the stale-schema self-heal) widens the window.

**Fix:** wait for `credentialsFlow.first { it != null }`, then contain + log any residual failure (best-effort bootstrap, retried each launch).

## 2. The missing recovery screen — `GlobalCrashHandler`
`isCrashLooping` suppressed `CrashActivity` for *any* crash <10s after the previous one — which a deterministic fast launch crash trips on every relaunch. Replaced the time heuristic with a precise process-identity check: **every main-process crash shows the screen**; only a crash inside the `:crash` process is suppressed.

## 3. Native (NDK) crash capture + next-launch recovery
A native crash (SIGSEGV/SIGABRT from e.g. SQLCipher) kills the process via a signal, so the JVM handler never runs and — with no `firebase-crashlytics-ndk` present — Crashlytics never saw it either. Added `firebase-crashlytics-ndk` (Google's async-signal-safe handler; prebuilt, no NDK/CMake on our side). Since we can't show a screen *during* a native crash, `NativeCrashRecovery` detects it on the **next** launch via `didCrashOnPreviousExecution()` and shows `CrashActivity`, distinguishing native from already-surfaced JVM crashes by a per-run marker `GlobalCrashHandler` writes (via `commit()`).

## Tests (CI-runnable, JVM)
- `NoteToSelfBootstrapCrashTest` — the throw, the unguarded launch escaping uncaught, the fixed pattern containing it.
- `GlobalCrashHandlerScreenGuardTest` — repeated fast main-process crash still shows the screen; `:crash`-process crash suppressed.
- `NativeCrashRecoveryTest` — native-vs-JVM classification truth table.

The native **signal-catch** itself is device-only (no NDK/emulator on the dev host, no connected-android-test job in CI) — verify by forcing a native crash on a device and confirming the next-launch screen + the Crashlytics dashboard entry.

Verified locally: `homebase-chat:jvmTest` green, `androidApp:testDebugUnitTest` green, `androidApp:compileDebugKotlin` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)