### PR TITLE
fix(chat): stop shared/transparent images from auto-stickering (#854)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/AttachmentInput.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/AttachmentInput.kt
@@ -16,10 +16,10 @@ data class AttachmentInput(
      */
     val inputBlobUrl: String? = null,
     /**
-     * Image-only: force this attachment to be sent as a sticker (transparent cut-out
-     * render), skipping the automatic alpha probe. v1 leaves this `false` and relies on
-     * auto-detection; the future manual "Send as sticker" toggle flips this without any
-     * further change to the attachment builder.
+     * Image-only: send this attachment as a sticker (transparent cut-out render). This is
+     * the ONLY way an attachment becomes a sticker — the "Send as sticker" toggle, the
+     * sticker tool, and the background-remover set it. There is no transparency
+     * auto-detection: a shared/normal image is never stickered without this opt-in (#854).
      */
     val forceSticker: Boolean = false,
 )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilder.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilder.kt
@@ -3,7 +3,6 @@ package id.homebase.chat.services.builder
 import id.homebase.api.client.drives.files.DescriptorContent
 import id.homebase.api.client.drives.files.PayloadFile
 import id.homebase.api.file.FileOperationsProvider
-import id.homebase.api.image.ImageUtils
 import id.homebase.api.lib.image.ImageFormatDetector
 import id.homebase.chat.services.PayloadBundle
 
@@ -39,25 +38,18 @@ object MessageAttachmentBuilder {
                                 fileOperationsProvider,
                             )
 
-                        // Sticker auto-detect: a transparent cut-out image renders
-                        // without the opaque bubble backdrop. Detect on the ORIGINAL
-                        // source bytes (the generator already read them — no second
-                        // read), gated to alpha-capable formats (PNG/WebP). forceSticker
-                        // (the "Send as sticker" toggle) bypasses detection. We store a tiny
-                        // {"isSticker":true,"format":...} descriptor only when transparent;
-                        // ordinary photos keep the legacy "" so nothing changes for them.
-                        val format = ImageFormatDetector.detectFormat(thumbs.sourceBytes)
-                        val isSticker = attachment.forceSticker ||
-                            ((format == "image/png" || format == "image/webp") &&
-                                ImageUtils.hasNonOpaquePixels(thumbs.sourceBytes))
+                        // Sticker is opt-in only: the "Send as sticker" toggle, the sticker
+                        // tool, and the background-remover all set forceSticker=true. We do
+                        // NOT auto-sticker by transparency — a shared/normal image (or any
+                        // transparent PNG/WebP the user didn't choose to stickerize) must send
+                        // as a normal image (issue #854). When it IS a sticker we detect the
+                        // real format so the download is named "StickerFile.<ext>"; ordinary
+                        // photos keep the legacy "" so nothing changes for them.
                         val descriptorContent =
-                            if (isSticker) {
-                                // Carry the detected format so a downloaded sticker is named
-                                // "StickerFile.<ext>" (see PayloadDescriptor.filename()) rather
-                                // than the sender's original filename (e.g. IMG_1234.png).
+                            if (attachment.forceSticker) {
                                 DescriptorContent.descriptorContentFromImage(
                                     isSticker = true,
-                                    format = format,
+                                    format = ImageFormatDetector.detectFormat(thumbs.sourceBytes),
                                 )
                             } else {
                                 ""

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilderStickerTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilderStickerTest.kt
@@ -17,10 +17,10 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.test.runTest
 
 /**
- * Pins the sticker auto-detection in MessageAttachmentBuilder's image branch:
- * a transparent PNG produces a {"isSticker":true} descriptor, an opaque JPEG keeps
- * the legacy "" descriptor, and forceSticker overrides detection. This is the
- * send-side half of the sticker feature (the render-side reads descriptorInfo()).
+ * Pins MessageAttachmentBuilder's image branch: a sticker is produced ONLY when
+ * forceSticker is set. Transparency does NOT auto-sticker — a shared/normal transparent
+ * PNG sends as a normal image (issue #854). This is the send-side half of the sticker
+ * feature (the render-side reads descriptorInfo()).
  */
 class MessageAttachmentBuilderStickerTest {
 
@@ -99,7 +99,9 @@ class MessageAttachmentBuilderStickerTest {
         ).filename()
 
     @Test
-    fun transparentPng_setsStickerDescriptor() = runTest {
+    fun transparentPng_withoutForceSticker_isNotASticker() = runTest {
+        // #854: transparency alone must NOT auto-sticker. A shared/normal transparent PNG
+        // keeps the legacy "" descriptor and sends as a normal image.
         val path = "/tmp/cutout.png"
         val bundle = MessageAttachmentBuilder.buildSingle(
             attachment = AttachmentInput(filePath = path, contentType = "image/png"),
@@ -107,7 +109,8 @@ class MessageAttachmentBuilderStickerTest {
             payloadKey = "chat_web0",
         )
         val payload = bundle.payloads.single()
-        assertEquals(true, stickerOf(payload.descriptorContent))
+        assertEquals("", payload.descriptorContent)
+        assertEquals(false, stickerOf(payload.descriptorContent))
     }
 
     @Test
@@ -125,7 +128,7 @@ class MessageAttachmentBuilderStickerTest {
     }
 
     @Test
-    fun forceSticker_overridesDetection_onOpaqueImage() = runTest {
+    fun forceSticker_producesSticker_onOpaqueImage() = runTest {
         val path = "/tmp/opaque.png"
         val bundle = MessageAttachmentBuilder.buildSingle(
             attachment = AttachmentInput(
@@ -144,11 +147,11 @@ class MessageAttachmentBuilderStickerTest {
     }
 
     @Test
-    fun transparentPng_descriptorParsesAsStickerImageFile() = runTest {
-        // End-to-end: the descriptor written at send must round-trip to ImageFile(isSticker=true).
+    fun forceStickerPng_descriptorParsesAsStickerImageFile() = runTest {
+        // End-to-end: a forceSticker send's descriptor must round-trip to ImageFile(isSticker=true).
         val path = "/tmp/cutout2.png"
         val bundle = MessageAttachmentBuilder.buildSingle(
-            attachment = AttachmentInput(filePath = path, contentType = "image/png"),
+            attachment = AttachmentInput(filePath = path, contentType = "image/png", forceSticker = true),
             fileOperationsProvider = fakeFsServing(path, transparentPng()),
             payloadKey = "chat_web0",
         )
@@ -162,12 +165,12 @@ class MessageAttachmentBuilderStickerTest {
     }
 
     @Test
-    fun transparentPng_downloadNameIsStickerFilePng() = runTest {
-        // An auto-detected transparent PNG sticker downloads as StickerFile.png, not the
-        // sender's original camera-roll name.
+    fun forceStickerPng_downloadNameIsStickerFilePng() = runTest {
+        // A forceSticker PNG downloads as StickerFile.png, not the sender's original
+        // camera-roll name. The real detected extension is preserved.
         val path = "/tmp/IMG_1234.png"
         val bundle = MessageAttachmentBuilder.buildSingle(
-            attachment = AttachmentInput(filePath = path, contentType = "image/png"),
+            attachment = AttachmentInput(filePath = path, contentType = "image/png", forceSticker = true),
             fileOperationsProvider = fakeFsServing(path, transparentPng()),
             payloadKey = "chat_web0",
         )

--- a/iosApp/ShareExtension/SharedContentSaver.swift
+++ b/iosApp/ShareExtension/SharedContentSaver.swift
@@ -118,11 +118,14 @@ struct SharedContentSaver {
                                 mimeTypes.append(result.mimeType)
                             }
                         } else if let imageData = item as? Data {
-                            let name = "share_\(Int(Date().timeIntervalSince1970 * 1000)).jpg"
+                            // Sniff the real type from the bytes — never blanket-label as JPEG
+                            // (a shared PNG with alpha must keep image/png, etc.). #854.
+                            let ext = imageExtensionForData(imageData)
+                            let name = "share_\(Int(Date().timeIntervalSince1970 * 1000)).\(ext)"
                             let destURL = filesDir.appendingPathComponent(name)
                             try? imageData.write(to: destURL)
                             fileNames.append(name)
-                            mimeTypes.append("image/jpeg")
+                            mimeTypes.append(mimeTypeForExtension(ext))
                         }
                         group.leave()
                     }
@@ -228,5 +231,21 @@ struct SharedContentSaver {
             return utType.preferredMIMEType ?? "application/octet-stream"
         }
         return "application/octet-stream"
+    }
+
+    /// Sniff an image file extension from magic bytes. Shared image `Data` carries no
+    /// extension or reliable MIME, so we read the signature rather than assume JPEG (#854).
+    private static func imageExtensionForData(_ data: Data) -> String {
+        let b = [UInt8](data.prefix(16))
+        func match(_ sig: [UInt8], at offset: Int = 0) -> Bool {
+            guard b.count >= offset + sig.count else { return false }
+            for (i, v) in sig.enumerated() where b[offset + i] != v { return false }
+            return true
+        }
+        if match([0x89, 0x50, 0x4E, 0x47]) { return "png" }                       // PNG
+        if match([0x47, 0x49, 0x46, 0x38]) { return "gif" }                       // GIF8
+        if match([0x52, 0x49, 0x46, 0x46]) && match([0x57, 0x45, 0x42, 0x50], at: 8) { return "webp" } // RIFF…WEBP
+        if match([0x66, 0x74, 0x79, 0x70], at: 4) { return "heic" }               // ftyp (HEIF/HEIC family)
+        return "jpg"                                                              // FFD8 JPEG / default
     }
 }


### PR DESCRIPTION
## Summary
Sharing an image into Homebase (iOS share sheet), or sending any transparent PNG/WebP, silently rendered it as a frameless **sticker**. `MessageAttachmentBuilder.build()` auto-classified stickers by transparency, so an image with any alpha channel became a sticker without the user choosing it.

## Changes
- **Drop the transparency auto-heuristic.** Sticker is now opt-in only — only `forceSticker` produces a sticker. Every intentional sticker path already sets it: the "Send as sticker" toggle, the sticker tool (`StickerHandler`), and the background-remover (`AttachmentHandler`). Shared/normal images never auto-sticker.
- **iOS share extension MIME.** The raw-`Data` image branch hardcoded `image/jpeg`/`.jpg`. Now sniffs the real type from magic bytes (PNG/GIF/WebP/HEIC/JPEG) and records the correct MIME + extension.
- Updated `AttachmentInput.forceSticker` doc to reflect opt-in-only.

## Verification
- `MessageAttachmentBuilderStickerTest` flipped to the new contract and **passes**: transparency alone no longer stickers; `forceSticker` still does (incl. `StickerFile.<ext>` download naming).
- iOS share-extension MIME change is Swift-only; verify on-device.

Closes #854

🤖 Generated with [Claude Code](https://claude.com/claude-code)