### PR TITLE
fix(vault): share-prepare feedback + re-tap guard (#850)

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultScreen.kt
@@ -364,6 +364,7 @@ fun VaultScreen(
                                     VaultUiAction.MoveEntryToSection(overlay.file, targetSectionId),
                                 )
                             },
+                            preparingShareKeys = uiState.preparingShareKeys,
                             sharedTransitionScope = this@SharedTransitionLayout,
                             animatedVisibilityScope = this@AnimatedContent,
                         )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultUiState.kt
@@ -13,6 +13,12 @@ data class VaultUiState(
     val isSyncing: Boolean = false,
     val sections: List<VaultSection> = emptyList(),
     val fullScreenOverlay: VaultOverlay? = null,
+    /**
+     * Payload keys currently downloading/decrypting for a share or save. Drives the
+     * gallery's per-page spinner and re-entrancy guard so the share button isn't a dead,
+     * tappable-forever control while the payload preps (#850).
+     */
+    val preparingShareKeys: Set<String> = emptySet(),
 )
 
 sealed interface VaultOverlay {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
@@ -65,6 +65,7 @@ class VaultViewModel(
     private val _overlayState = MutableStateFlow<VaultOverlay?>(null)
     private val _syncingState = MutableStateFlow(false)
     private val _checkingPermissions = MutableStateFlow(false)
+    private val _preparingShareKeys = MutableStateFlow<Set<String>>(emptySet())
 
     val uiState: StateFlow<VaultUiState> = combine(
         combine(vaultStream.sections, vaultStream.entriesBySection, vaultStream.isLoaded) { s, e, l ->
@@ -73,8 +74,9 @@ class VaultViewModel(
         _overlayState,
         _syncingState,
         _checkingPermissions,
-    ) { (sections, entriesBySection, isLoaded), overlay, syncing, checkingPermissions ->
-        buildUiState(sections, entriesBySection, isLoaded, overlay, syncing, checkingPermissions)
+        _preparingShareKeys,
+    ) { (sections, entriesBySection, isLoaded), overlay, syncing, checkingPermissions, preparing ->
+        buildUiState(sections, entriesBySection, isLoaded, overlay, syncing, checkingPermissions, preparing)
     }.stateIn(
         viewModelScope,
         SharingStarted.WhileSubscribed(5_000),
@@ -93,6 +95,7 @@ class VaultViewModel(
             overlay = _overlayState.value,
             syncing = _syncingState.value,
             checkingPermissions = _checkingPermissions.value,
+            preparingShareKeys = _preparingShareKeys.value,
         ),
     )
 
@@ -107,6 +110,7 @@ class VaultViewModel(
         overlay: VaultOverlay?,
         syncing: Boolean,
         checkingPermissions: Boolean,
+        preparingShareKeys: Set<String>,
     ): VaultUiState {
         val sectionModels = sections.mapIndexed { index, section ->
             section.copy(
@@ -125,6 +129,7 @@ class VaultViewModel(
             isSyncing = syncing,
             isCheckingPermissions = checkingPermissions,
             fullScreenOverlay = refreshedOverlay ?: overlay,
+            preparingShareKeys = preparingShareKeys,
         )
     }
 
@@ -678,29 +683,44 @@ class VaultViewModel(
     }
 
     private fun handleSharePage(action: VaultUiAction.SharePage) {
+        // Re-entrancy guard: a tap while this page is already downloading is a no-op, so
+        // repeated taps don't queue duplicate downloads / multiple share sheets (#850).
+        // onAction runs on the UI thread, so this check-then-add is effectively atomic.
+        if (action.payloadKey in _preparingShareKeys.value) return
+        _preparingShareKeys.update { it + action.payloadKey }
         viewModelScope.launch {
-            val tempPath = vaultUploaderService.downloadPayload(action.file, action.payloadKey)
-            if (tempPath != null) {
-                val descriptor = action.file.payloadDescriptors.find { it.key == action.payloadKey }
-                val contentType = descriptor?.contentType ?: action.file.contentType
-                _events.tryEmit(
-                    VaultUiEvent.ShareFileReady(tempPath, action.file.fileName, contentType),
-                )
-            } else {
-                _events.tryEmit(VaultUiEvent.Error(VaultError.DownloadPageFailed))
+            try {
+                val tempPath = vaultUploaderService.downloadPayload(action.file, action.payloadKey)
+                if (tempPath != null) {
+                    val descriptor = action.file.payloadDescriptors.find { it.key == action.payloadKey }
+                    val contentType = descriptor?.contentType ?: action.file.contentType
+                    _events.tryEmit(
+                        VaultUiEvent.ShareFileReady(tempPath, action.file.fileName, contentType),
+                    )
+                } else {
+                    _events.tryEmit(VaultUiEvent.Error(VaultError.DownloadPageFailed))
+                }
+            } finally {
+                _preparingShareKeys.update { it - action.payloadKey }
             }
         }
     }
 
     private fun handleSavePage(action: VaultUiAction.SavePage) {
+        if (action.payloadKey in _preparingShareKeys.value) return
+        _preparingShareKeys.update { it + action.payloadKey }
         viewModelScope.launch {
-            val tempPath = vaultUploaderService.downloadPayload(action.file, action.payloadKey)
-            if (tempPath != null) {
-                _events.tryEmit(
-                    VaultUiEvent.SaveFileReady(tempPath, action.file.fileName),
-                )
-            } else {
-                _events.tryEmit(VaultUiEvent.Error(VaultError.DownloadPageFailed))
+            try {
+                val tempPath = vaultUploaderService.downloadPayload(action.file, action.payloadKey)
+                if (tempPath != null) {
+                    _events.tryEmit(
+                        VaultUiEvent.SaveFileReady(tempPath, action.file.fileName),
+                    )
+                } else {
+                    _events.tryEmit(VaultUiEvent.Error(VaultError.DownloadPageFailed))
+                }
+            } finally {
+                _preparingShareKeys.update { it - action.payloadKey }
             }
         }
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultGalleryScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultGalleryScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BottomSheetScaffold
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -95,6 +96,8 @@ fun VaultGalleryScreen(
     onDeleteEntry: () -> Unit,
     sections: List<VaultSection>,
     onMoveToSection: (Uuid) -> Unit,
+    /** Payload keys whose share/save download is in flight — drives the spinner + disabled state. */
+    preparingShareKeys: Set<String> = emptySet(),
     sharedTransitionScope: SharedTransitionScope? = null,
     animatedVisibilityScope: AnimatedVisibilityScope? = null,
 ) {
@@ -281,13 +284,27 @@ fun VaultGalleryScreen(
                         },
                         actions = {
                             if (currentDescriptor != null) {
-                                IconButton(onClick = { onSharePage(currentDescriptor.key) }) {
-                                    Icon(
-                                        imageVector = Icons.Default.Share,
-                                        contentDescription = stringResource(MR.string.vault_gallery_share_page),
-                                    )
+                                val isPreparing = currentDescriptor.key in preparingShareKeys
+                                IconButton(
+                                    onClick = { onSharePage(currentDescriptor.key) },
+                                    enabled = !isPreparing,
+                                ) {
+                                    if (isPreparing) {
+                                        CircularProgressIndicator(
+                                            modifier = Modifier.size(20.dp),
+                                            strokeWidth = 2.dp,
+                                        )
+                                    } else {
+                                        Icon(
+                                            imageVector = Icons.Default.Share,
+                                            contentDescription = stringResource(MR.string.vault_gallery_share_page),
+                                        )
+                                    }
                                 }
-                                IconButton(onClick = { onSavePage(currentDescriptor.key) }) {
+                                IconButton(
+                                    onClick = { onSavePage(currentDescriptor.key) },
+                                    enabled = !isPreparing,
+                                ) {
                                     Icon(
                                         imageVector = Icons.Outlined.Download,
                                         contentDescription = stringResource(MR.string.vault_gallery_save_page),


### PR DESCRIPTION
## Summary
Sharing/saving a Vault page downloads + decrypts the payload first (a network fetch on cache miss, ~5s). There was **no loading feedback** and **no re-entrancy guard**, so the share button looked dead — users tapped it repeatedly, queuing duplicate downloads and possibly multiple share sheets.

## Changes
- Add `preparingShareKeys: Set<String>` to `VaultUiState`, wired as a 5th source into the VM's `combine` (immutable-copy `update {}` pattern).
- `handleSharePage` / `handleSavePage`: ignore a tap whose key is already preparing (re-entrancy guard), add the key before download, clear it in `finally` (success **and** error).
- Gallery: show a `CircularProgressIndicator` in place of the share icon and disable the share/save buttons while that page's payload is preparing. Guard is **per-key** so sharing image A doesn't block image B.

## Verification
- `homebase-core` JVM **compiles** clean.
- Behaviour is an on-device UX change (spinner + dedupe); verify on device. The VM isn't unit-constructable without a large fake harness (11 deps + active init collectors), so no VM unit test was added.

Closes #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)