### PR TITLE
fix(crash): version-scope recovery state so a fixed crash stops haunting after update

### DIFF
--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/crash/CrashReporting.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/crash/CrashReporting.kt
@@ -24,6 +24,9 @@ object CrashReporting {
     private const val LOG_TAIL_CHARS = 32_000
     private const val DEFAULT_KEEP = 5
     private const val LAUNCH_FILE = "launch_failures"
+    // Records the app version that last owned the crash state, so an update can clear
+    // stale reports — see [install].
+    private const val VERSION_FILE = "app_version"
     // iOS only: show next-launch recovery once this many consecutive launches have
     // crashed before reaching a usable state (a startup crash loop). One silent retry.
     private const val STARTUP_FAILURE_THRESHOLD = 2
@@ -39,6 +42,37 @@ object CrashReporting {
         val dir = Path(logDir, "crash")
         this.crashDir = dir
         runCatching { SystemFileSystem.createDirectories(dir) }
+        discardStaleRecoveryStateOnVersionChange(metadata.appVersion)
+    }
+
+    /**
+     * The crash report, its [PENDING_FILE] marker, and the [LAUNCH_FILE] failure counter
+     * all belong to the *binary that wrote them*. After an app update they're no longer
+     * actionable: a crash fixed by the update would otherwise be replayed on the new
+     * version's first launch (the recovery screen shows the OLD version's report — e.g. a
+     * 1.4.1731 crash surfacing on 1.4.1738), and the stale failure counter can trip the
+     * recovery gate even though the new binary never crashed.
+     *
+     * So on the first launch where [current] differs from the stored version, clear the
+     * pending marker, reset the failure counter, and drop every old `crash-*.txt`. A crash
+     * on the *new* version is written after this runs ([install] is the first startup
+     * step), so it is unaffected and surfaces normally. First install ever (no stored
+     * version) just records it without clearing.
+     */
+    private fun discardStaleRecoveryStateOnVersionChange(current: String) {
+        val dir = crashDir ?: return
+        runCatching {
+            val versionFile = Path(dir, VERSION_FILE)
+            val previous = readSmallFile(versionFile)
+            if (previous == current) return
+            if (previous != null) {
+                clearPending()
+                writeLaunchCount(0)
+                pruneOld(keep = 0)
+                runCatching { Logger.i(tag = TAG) { "App version changed ($previous -> $current); cleared stale crash recovery state" } }
+            }
+            writeSmallFile(versionFile, current)
+        }
     }
 
     /**
@@ -53,18 +87,32 @@ object CrashReporting {
         val failures = readLaunchCount()
         val report = pendingReport()
         if (failures >= STARTUP_FAILURE_THRESHOLD && report != null) return report
-        runCatching {
-            SystemFileSystem.sink(Path(dir, LAUNCH_FILE)).buffered().use { it.writeString((failures + 1).toString()) }
-        }
+        writeLaunchCount(failures + 1)
         return null
     }
 
     /** App reached a usable state — reset the consecutive-startup-failure counter. */
     fun markStartupComplete() {
+        writeLaunchCount(0)
+    }
+
+    private fun writeLaunchCount(n: Int) {
         val dir = crashDir ?: return
         runCatching {
-            SystemFileSystem.sink(Path(dir, LAUNCH_FILE)).buffered().use { it.writeString("0") }
+            SystemFileSystem.sink(Path(dir, LAUNCH_FILE)).buffered().use { it.writeString(n.toString()) }
         }
+    }
+
+    /** Read a small single-line marker file (version stamp); null if absent/empty/unreadable. */
+    private fun readSmallFile(path: Path): String? = try {
+        if (SystemFileSystem.metadataOrNull(path) == null) null
+        else SystemFileSystem.source(path).buffered().use { it.readString() }.trim().ifEmpty { null }
+    } catch (t: Throwable) {
+        null
+    }
+
+    private fun writeSmallFile(path: Path, text: String) {
+        runCatching { SystemFileSystem.sink(path).buffered().use { it.writeString(text) } }
     }
 
     private fun readLaunchCount(): Int {

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/crash/CrashReportingTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/crash/CrashReportingTest.kt
@@ -17,6 +17,12 @@ class CrashReportingTest {
     private lateinit var logDir: Path
 
     private val meta = CrashMetadata("1.0", "debug", "JVM", "test", "2026-06-10")
+    private val metaV2 = CrashMetadata("2.0", "debug", "JVM", "test", "2026-06-24")
+
+    private fun crashReports(): List<String> =
+        SystemFileSystem.list(Path(logDir, "crash"))
+            .filter { it.name.startsWith("crash-") && it.name.endsWith(".txt") }
+            .map { it.name }
 
     @BeforeTest
     fun setup() {
@@ -106,5 +112,56 @@ class CrashReportingTest {
         CrashReporting.markStartupComplete() // recovered on the retry
         // Even though a report exists, the reset counter means no recovery next launch.
         assertNull(CrashReporting.beginLaunchCheckRecovery())
+    }
+
+    @Test
+    fun appUpdate_clears_stale_recovery_state() {
+        // Build the exact "ghost" state under v1.0 (installed in setup): two startup
+        // failures + a pending report — the condition that shows the recovery screen.
+        assertNull(CrashReporting.beginLaunchCheckRecovery())
+        CrashReporting.writeReport("main", RuntimeException("startup-1"))
+        assertNull(CrashReporting.beginLaunchCheckRecovery())
+        CrashReporting.writeReport("main", RuntimeException("startup-2"))
+        assertNotNull(CrashReporting.beginLaunchCheckRecovery(), "precondition: ghost recovery armed")
+
+        // Update to v2.0 — install() runs first on the new binary and must wipe the prior
+        // version's pending marker, failure counter, and reports (a 1731 report on 1738).
+        CrashReporting.install(metaV2, logDir)
+
+        assertNull(CrashReporting.pendingReport(), "old version's pending marker must be cleared")
+        assertNull(
+            CrashReporting.beginLaunchCheckRecovery(),
+            "failure counter reset → the new version shows no ghost recovery",
+        )
+        assertTrue(crashReports().isEmpty(), "old version's reports must be pruned, found: ${crashReports()}")
+    }
+
+    @Test
+    fun same_version_relaunch_preserves_recovery_state() {
+        // A genuine startup crash loop on the SAME version must still surface — a normal
+        // relaunch re-runs install() and must not nuke a legitimate pending recovery.
+        assertNull(CrashReporting.beginLaunchCheckRecovery())
+        CrashReporting.writeReport("main", RuntimeException("startup-1"))
+        assertNull(CrashReporting.beginLaunchCheckRecovery())
+        CrashReporting.writeReport("main", RuntimeException("startup-2"))
+
+        CrashReporting.install(meta, logDir) // same version
+
+        assertNotNull(CrashReporting.pendingReport(), "same-version relaunch keeps the pending report")
+        assertNotNull(CrashReporting.beginLaunchCheckRecovery(), "same-version crash loop still shows recovery")
+    }
+
+    @Test
+    fun crash_on_new_version_after_update_still_surfaces() {
+        CrashReporting.writeReport("main", RuntimeException("old")) // pending under v1.0
+        CrashReporting.install(metaV2, logDir)                      // update clears it
+        assertNull(CrashReporting.pendingReport())
+
+        // The new binary itself crashes on startup twice — must surface normally.
+        assertNull(CrashReporting.beginLaunchCheckRecovery())
+        CrashReporting.writeReport("main", RuntimeException("new-1"))
+        assertNull(CrashReporting.beginLaunchCheckRecovery())
+        CrashReporting.writeReport("main", RuntimeException("new-2"))
+        assertNotNull(CrashReporting.beginLaunchCheckRecovery())
     }
 }

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/crash/CrashReportingTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/crash/CrashReportingTest.kt
@@ -164,4 +164,41 @@ class CrashReportingTest {
         CrashReporting.writeReport("main", RuntimeException("new-2"))
         assertNotNull(CrashReporting.beginLaunchCheckRecovery())
     }
+
+    /**
+     * The exact field incident: a report written by the OLD binary carries the OLD
+     * version stamp; after an update it must be physically gone and unrecoverable, so the
+     * new app can never surface it (a 1.4.1731 report appearing on 1.4.1738).
+     */
+    @Test
+    fun old_version_report_cannot_be_surfaced_after_update() {
+        // Written under v1.0 (installed in setup). The report embeds the running version.
+        val oldReport = CrashReporting.writeReport(
+            "Kotlin/Native", RuntimeException("no such column: fileState"),
+        )
+        assertNotNull(oldReport)
+        val oldText = SystemFileSystem.source(oldReport).buffered().use { it.readString() }
+        assertTrue("1.0" in oldText, "old report must carry the old version stamp")
+
+        // Arm the recovery gate as in the field (a startup crash loop on the old version).
+        CrashReporting.beginLaunchCheckRecovery()
+        CrashReporting.beginLaunchCheckRecovery()
+        assertNotNull(
+            CrashReporting.beginLaunchCheckRecovery(),
+            "precondition: the old version would have shown this report",
+        )
+
+        // User updates to v2.0.
+        CrashReporting.install(metaV2, logDir)
+
+        assertNull(CrashReporting.pendingReport(), "no pending report points at the old binary's crash")
+        assertNull(
+            SystemFileSystem.metadataOrNull(oldReport),
+            "the old-version report file itself must be deleted, so it can never be shown",
+        )
+        assertTrue(
+            crashReports().none { it == oldReport.name },
+            "old report must not remain on disk: ${crashReports()}",
+        )
+    }
 }


### PR DESCRIPTION
## The puzzle this fixes

A tester on **1.4.1738** (confirmed via the App Store) produced a crash report stamped **1.4.1731 (built 2026-06-19)** — the old `no such column: fileState` startup crash, fixed weeks ago. That "doesn't compute" at first glance, but it does: the version in a report is written by the **running binary** (`MainViewController.kt` reads `CFBundleShortVersionString`), so a 1731-stamped report was physically produced by a 1731 binary. What 1738 was *showing* was a leftover report from before the update.

## Root cause

The crash report, its `PENDING` marker, and the `launch_failures` counter all belong to the binary that wrote them, but **nothing cleared them on an app update**. So on the first launch after updating past a startup crash:

- `beginLaunchCheckRecovery()` sees the leftover `failures ≥ 2` **and** the leftover `PENDING` → shows the recovery screen with the **old version's** report.
- The new (fixed) binary never crashed — it's replaying pre-update state.

## Fix

`CrashReporting.install()` (the first startup step on every platform) now records the app version. When it differs from the stored one, it clears `PENDING`, resets the failure counter, and prunes old `crash-*.txt`. Because `install()` runs before anything can crash on the new binary, a genuine new-version crash is written afterward and surfaces normally; a same-version relaunch leaves a legitimate crash-loop recovery intact; first install ever just records the version.

Minor cleanup: one `writeLaunchCount` helper shared by `markStartupComplete`/`beginLaunchCheckRecovery`, plus small-file read/write helpers.

## Tests (homebase-common jvmTest)
- `appUpdate_clears_stale_recovery_state` — the ghost (pending + counter + reports) is gone after a version bump.
- `same_version_relaunch_preserves_recovery_state` — a real crash loop still surfaces.
- `crash_on_new_version_after_update_still_surfaces` — a fresh crash on the new binary surfaces normally.

Verified: `homebase-common:jvmTest` green; compiles on JVM + wasmJs. Cross-platform (commonMain), so it covers iOS/Android/desktop.

Independent of #855 (different file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)