### PR TITLE
fix(android): don't crash on a transient/TLS network failure (+ characterization test)

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/crash/GlobalCrashHandler.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/crash/GlobalCrashHandler.kt
@@ -52,29 +52,28 @@ object GlobalCrashHandler {
         val previousHandler = Thread.getDefaultUncaughtExceptionHandler()
 
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            // Containable, non-fatal failures are handled BEFORE the terminating try/finally
+            // below, so they return WITHOUT killing the process. The coroutine machinery
+            // invokes this handler as a plain call — it does NOT unwind the Looper/thread — so
+            // returning here lets the app keep running. This is PR #737's intent; the old
+            // `finally { killProcess }` wrapped these returns and defeated it, so a dropped
+            // connection or a TLS-inspecting VPN/proxy (an SSLHandshakeException on every call,
+            // landing on a scope with no CoroutineExceptionHandler) could still silently kill an
+            // already-authenticated app. See TlsInterceptionTest.
+            if (isContainableNonFatal(throwable)) {
+                runCatching { Firebase.crashlytics.recordException(throwable) }
+                Logger.w(tag = TAG) {
+                    val kind = if (throwable.isMlKitTeardownFailure()) {
+                        "ML Kit/MediaPipe failure (background removal degrades to no cutout)"
+                    } else {
+                        "Transient network failure"
+                    }
+                    "$kind on '${thread.name}'; contained, not crashing: ${throwable.message}"
+                }
+                return@setDefaultUncaughtExceptionHandler
+            }
+
             try {
-                // Preserve PR #737: a transient network blip that leaked to the global
-                // handler must NOT crash the app or show the recovery screen.
-                if (throwable.isTransientNetworkFailure()) {
-                    runCatching { Firebase.crashlytics.recordException(throwable) }
-                    Logger.w(tag = TAG) {
-                        "Transient network failure on '${thread.name}'; not crashing: ${throwable.message}"
-                    }
-                    return@setDefaultUncaughtExceptionHandler
-                }
-
-                // Same class as the network case: ML Kit / MediaPipe background-removal runs on
-                // native threads we don't own, so a teardown/callback failure can leak here that
-                // no local try/catch could reach. Background removal is best-effort — degrade to
-                // "no cutout", record a non-fatal, and keep the app alive.
-                if (throwable.isMlKitTeardownFailure()) {
-                    runCatching { Firebase.crashlytics.recordException(throwable) }
-                    Logger.w(tag = TAG) {
-                        "ML Kit/MediaPipe failure on '${thread.name}'; not crashing (background removal degrades to no cutout): ${throwable.message}"
-                    }
-                    return@setDefaultUncaughtExceptionHandler
-                }
-
                 // Mark this run's death as a JVM crash we handled, so the next launch's
                 // NativeCrashRecovery doesn't misclassify it as native. A native signal
                 // crash never reaches this handler, so it never sets this marker.
@@ -108,6 +107,20 @@ object GlobalCrashHandler {
             }
         }
     }
+
+    /**
+     * A failure we contain (record + keep running) instead of terminating the process for:
+     *  - a transient network blip — dropped socket, DNS, timeout, **or a TLS handshake
+     *    failure**, including a TLS-inspecting VPN/proxy/AV presenting an untrusted cert; and
+     *  - an ML Kit / MediaPipe teardown (best-effort background removal on native threads).
+     *
+     * Both routinely leak from a coroutine launched on a scope without its own
+     * CoroutineExceptionHandler (e.g. a bare `viewModelScope.launch`). Killing the process for
+     * them is the very thing PR #737 set out to avoid — and what the `finally` below used to do
+     * anyway. Pure so it's unit-testable.
+     */
+    internal fun isContainableNonFatal(throwable: Throwable): Boolean =
+        throwable.isTransientNetworkFailure() || throwable.isMlKitTeardownFailure()
 
     /**
      * Whether to launch the [CrashActivity] recovery screen for this crash. Pure so it

--- a/androidApp/src/test/kotlin/id/homebase/feed/crash/GlobalCrashHandlerContainmentTest.kt
+++ b/androidApp/src/test/kotlin/id/homebase/feed/crash/GlobalCrashHandlerContainmentTest.kt
@@ -1,0 +1,48 @@
+package id.homebase.feed.crash
+
+import id.homebase.api.client.NetworkException
+import java.io.IOException
+import javax.net.ssl.SSLHandshakeException
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+/**
+ * Guards [GlobalCrashHandler.isContainableNonFatal] — the decision that keeps a transient
+ * network failure (incl. a TLS-inspecting VPN/proxy throwing SSLHandshakeException on every
+ * call) from killing an already-authenticated app, while a genuine bug still terminates.
+ *
+ * The process-kill itself can't be unit-tested (it would kill the test JVM), so this pins the
+ * pure decision that gates it. See TlsInterceptionTest for how the failure reaches the handler.
+ */
+class GlobalCrashHandlerContainmentTest {
+
+    private val trustAnchorError = SSLHandshakeException(
+        "java.security.cert.CertPathValidatorException: Trust anchor for certification path not found."
+    )
+
+    @Test
+    fun tlsHandshakeFailure_isContained() {
+        // A VPN/proxy/AV intercepting HTTPS → handshake fails → must NOT crash the app.
+        assertTrue(GlobalCrashHandler.isContainableNonFatal(trustAnchorError))
+    }
+
+    @Test
+    fun networkExceptionWrappingTls_isContained() {
+        // As surfaced by the API layer (OdinApiProviderBase wraps transport failures).
+        assertTrue(GlobalCrashHandler.isContainableNonFatal(NetworkException(trustAnchorError)))
+    }
+
+    @Test
+    fun plainNetworkIoFailure_isContained() {
+        assertTrue(GlobalCrashHandler.isContainableNonFatal(IOException("socket closed")))
+    }
+
+    @Test
+    fun genuineBug_isNotContained_soItStillCrashes() {
+        // The note-to-self bootstrap bug, a NPE, etc. must still terminate + report.
+        assertFalse(GlobalCrashHandler.isContainableNonFatal(IllegalStateException("No active credentials set")))
+        assertFalse(GlobalCrashHandler.isContainableNonFatal(NullPointerException()))
+        assertFalse(GlobalCrashHandler.isContainableNonFatal(IllegalArgumentException("bad")))
+    }
+}

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/TlsInterceptionTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/TlsInterceptionTest.kt
@@ -1,46 +1,29 @@
 package id.homebase.api.client
 
 import id.homebase.api.client.auth.CredentialsManager
-import id.homebase.api.coroutines.supervisedScope
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.request.get
-import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import javax.net.ssl.SSLHandshakeException
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
-import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 /**
- * Simulates the field situation: a TLS-intercepting network — a VPN/proxy/antivirus doing
- * "TLS inspection", or any MITM presenting a certificate from a CA the device doesn't trust
- * — makes every HTTPS call fail with the exact error a user in the wild hit:
+ * The two HTTP-layer contracts the crash-containment fix relies on
+ * ([GlobalCrashHandler.isContainableNonFatal], pinned by `GlobalCrashHandlerContainmentTest`),
+ * exercised against a TLS-intercepting network — a VPN/proxy/antivirus doing "TLS inspection"
+ * that makes every HTTPS call fail with the exact error a user in the wild hit:
  *
  *   SSLHandshakeException: java.security.cert.CertPathValidatorException:
  *   Trust anchor for certification path not found.
  *
- * What these tests pin:
- *  1. The HTTP layer maps that SSL failure to a typed [NetworkException] (catchable), with
- *     the raw SSL cause preserved — so well-behaved callers can degrade gracefully.
- *  2. It classifies as [isTransientNetworkFailure] == true, i.e. the Android global handler
- *     treats it as the "quiet" branch: no table-flip recovery screen, recorded only as a
- *     non-fatal that often loses the flush race. That's the mechanism behind the original
- *     "crashes, no screen, nothing in Crashlytics" report.
- *  3. On a *supervised* scope (the app's protected scopes) the failure is contained — a
- *     sibling survives and the scope stays alive.
- *  4. On a bare scope with no [CoroutineExceptionHandler] (the shape of `viewModelScope`),
- *     it escapes uncaught — the robustness gap that turns an intercepting VPN into a
- *     repeating, silent crash for an already-authenticated user.
+ *  1. `request()` maps that transport/TLS failure to a typed [NetworkException], preserving the
+ *     raw SSL cause — so callers (and the login "Show error details" toggle) can read it.
+ *  2. The result classifies as [isTransientNetworkFailure] == true — the signal the global
+ *     handler keys on to *contain* it instead of crashing the app.
  */
 class TlsInterceptionTest {
 
@@ -79,47 +62,10 @@ class TlsInterceptionTest {
     }
 
     @Test
-    fun tlsFailure_isClassifiedTransient_soItTakesTheSilentBranch() {
-        // Raw, and wrapped exactly as the API layer wraps it — both must be "transient" so
-        // the global handler skips the recovery screen and records only a (often-unflushed)
-        // non-fatal. This is why such a crash is silent and absent from Crashlytics.
+    fun tlsFailure_isClassifiedTransient() {
+        // Raw, and wrapped exactly as the API layer wraps it — both must be "transient" so the
+        // global handler contains it (isContainableNonFatal) instead of terminating the process.
         assertTrue(trustAnchorError.isTransientNetworkFailure())
         assertTrue(NetworkException(trustAnchorError).isTransientNetworkFailure())
-    }
-
-    @Test
-    fun tlsFailure_onSupervisedScope_isContained() = runTest {
-        val scope = supervisedScope("drive-sync", StandardTestDispatcher(testScheduler))
-
-        var siblingCompleted = false
-        scope.launch { throw NetworkException(trustAnchorError) }
-        scope.launch { siblingCompleted = true }
-        advanceUntilIdle()
-
-        assertTrue(siblingCompleted, "a sibling must survive the TLS failure")
-        assertTrue(scope.isActive, "the supervised scope must stay alive")
-    }
-
-    @Test
-    fun tlsFailure_onBareScope_escapesUncaught_theCrash() = runTest {
-        // A viewModelScope-shaped scope: SupervisorJob, no CoroutineExceptionHandler. The
-        // handler here stands in for the uncaught path (the real viewModelScope has none, so
-        // on Android the escape reaches Thread.setDefaultUncaughtExceptionHandler). Unconfined
-        // runs the body inline so the throw propagates synchronously.
-        var escaped: Throwable? = null
-        val viewModelLikeScope = CoroutineScope(
-            SupervisorJob() + Dispatchers.Unconfined +
-                CoroutineExceptionHandler { _, e -> escaped = e },
-        )
-
-        // e.g. a sync/API call launched without a local try/catch.
-        val job = viewModelLikeScope.launch { throw NetworkException(trustAnchorError) }
-        job.join()
-
-        assertNotNull(
-            escaped,
-            "the TLS failure escaped the launch uncaught — on Android this reaches the global handler",
-        )
-        assertIs<NetworkException>(escaped)
     }
 }

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/TlsInterceptionTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/TlsInterceptionTest.kt
@@ -1,0 +1,125 @@
+package id.homebase.api.client
+
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.coroutines.supervisedScope
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.request.get
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import javax.net.ssl.SSLHandshakeException
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Simulates the field situation: a TLS-intercepting network — a VPN/proxy/antivirus doing
+ * "TLS inspection", or any MITM presenting a certificate from a CA the device doesn't trust
+ * — makes every HTTPS call fail with the exact error a user in the wild hit:
+ *
+ *   SSLHandshakeException: java.security.cert.CertPathValidatorException:
+ *   Trust anchor for certification path not found.
+ *
+ * What these tests pin:
+ *  1. The HTTP layer maps that SSL failure to a typed [NetworkException] (catchable), with
+ *     the raw SSL cause preserved — so well-behaved callers can degrade gracefully.
+ *  2. It classifies as [isTransientNetworkFailure] == true, i.e. the Android global handler
+ *     treats it as the "quiet" branch: no table-flip recovery screen, recorded only as a
+ *     non-fatal that often loses the flush race. That's the mechanism behind the original
+ *     "crashes, no screen, nothing in Crashlytics" report.
+ *  3. On a *supervised* scope (the app's protected scopes) the failure is contained — a
+ *     sibling survives and the scope stays alive.
+ *  4. On a bare scope with no [CoroutineExceptionHandler] (the shape of `viewModelScope`),
+ *     it escapes uncaught — the robustness gap that turns an intercepting VPN into a
+ *     repeating, silent crash for an already-authenticated user.
+ */
+class TlsInterceptionTest {
+
+    private val trustAnchorError
+        get() = SSLHandshakeException(
+            "java.security.cert.CertPathValidatorException: " +
+                "Trust anchor for certification path not found."
+        )
+
+    /** Minimal concrete provider exposing the protected request() primitive. */
+    private class TestProvider(client: HttpClient) :
+        OdinApiProviderBase(client, CredentialsManager()) {
+        suspend fun ping(): ApiResponse = request(
+            block = { httpClient.get("https://queralt.dominion.id/api/v2/health/ping") },
+            secret = null,
+        )
+    }
+
+    /** A client whose every call dies in the TLS handshake, as a MITM/intercepting VPN does. */
+    private fun interceptingClient(): HttpClient =
+        HttpClient(MockEngine { throw trustAnchorError })
+
+    @Test
+    fun apiCall_throughTlsInterception_mapsToTypedNetworkException() = runTest {
+        val provider = TestProvider(interceptingClient())
+
+        val thrown = assertFailsWith<NetworkException> { provider.ping() }
+
+        // The raw SSL cause is preserved for the crash report / the login "details" toggle.
+        val cause = thrown.cause
+        assertIs<SSLHandshakeException>(cause)
+        assertTrue(
+            cause.message?.contains("Trust anchor") == true,
+            "the SSL cause must be carried; was: ${cause.message}",
+        )
+    }
+
+    @Test
+    fun tlsFailure_isClassifiedTransient_soItTakesTheSilentBranch() {
+        // Raw, and wrapped exactly as the API layer wraps it — both must be "transient" so
+        // the global handler skips the recovery screen and records only a (often-unflushed)
+        // non-fatal. This is why such a crash is silent and absent from Crashlytics.
+        assertTrue(trustAnchorError.isTransientNetworkFailure())
+        assertTrue(NetworkException(trustAnchorError).isTransientNetworkFailure())
+    }
+
+    @Test
+    fun tlsFailure_onSupervisedScope_isContained() = runTest {
+        val scope = supervisedScope("drive-sync", StandardTestDispatcher(testScheduler))
+
+        var siblingCompleted = false
+        scope.launch { throw NetworkException(trustAnchorError) }
+        scope.launch { siblingCompleted = true }
+        advanceUntilIdle()
+
+        assertTrue(siblingCompleted, "a sibling must survive the TLS failure")
+        assertTrue(scope.isActive, "the supervised scope must stay alive")
+    }
+
+    @Test
+    fun tlsFailure_onBareScope_escapesUncaught_theCrash() = runTest {
+        // A viewModelScope-shaped scope: SupervisorJob, no CoroutineExceptionHandler. The
+        // handler here stands in for the uncaught path (the real viewModelScope has none, so
+        // on Android the escape reaches Thread.setDefaultUncaughtExceptionHandler). Unconfined
+        // runs the body inline so the throw propagates synchronously.
+        var escaped: Throwable? = null
+        val viewModelLikeScope = CoroutineScope(
+            SupervisorJob() + Dispatchers.Unconfined +
+                CoroutineExceptionHandler { _, e -> escaped = e },
+        )
+
+        // e.g. a sync/API call launched without a local try/catch.
+        val job = viewModelLikeScope.launch { throw NetworkException(trustAnchorError) }
+        job.join()
+
+        assertNotNull(
+            escaped,
+            "the TLS failure escaped the launch uncaught — on Android this reaches the global handler",
+        )
+        assertIs<NetworkException>(escaped)
+    }
+}


### PR DESCRIPTION
A TLS-inspecting network (VPN/proxy/AV) makes every HTTPS call throw `SSLHandshakeException`. This PR proves that can silently crash an authenticated app — and fixes it.

## The bug
`GlobalCrashHandler`'s transient-network branch logged "not crashing" and `return`ed — but the surrounding `finally { Process.killProcess() }` ran on that return and **killed the process anyway**. So a transient/TLS failure that landed on a scope without a `CoroutineExceptionHandler` (e.g. a bare `viewModelScope.launch`) still killed the app — and because it took the transient branch, with **no recovery screen** and only a non-fatal that often didn't flush. That's the original "crashes, no screen, nothing in Crashlytics" signature.

## The fix
Handle the containable failures (transient network **incl. TLS handshake**, and ML Kit teardown) **before** the terminating `try/finally`, so they return without killing. The coroutine machinery invokes the uncaught handler as a plain call (it doesn't unwind the Looper/thread), so the app keeps running — the failed coroutine dies, its `SupervisorJob` scope and siblings survive. Genuine bugs (NPE, `IllegalState`, …) still report + chain to Crashlytics + terminate exactly as before. Decision extracted to `GlobalCrashHandler.isContainableNonFatal`.

## Tests
- `TlsInterceptionTest` (homebase-api) — characterizes the path: a `MockEngine` TLS failure → typed `NetworkException`; classified transient; contained on a supervised scope; escapes on a bare scope.
- `GlobalCrashHandlerContainmentTest` (androidApp) — pins the fix: `SSLHandshakeException` / `NetworkException(SSL)` / `IOException` → contained; `NPE` / `IllegalState` / `IllegalArgument` → still crash.

`homebase-api:jvmTest` + androidApp crash unit tests green; `compileDebugKotlin` green.

## Caveat
The `killProcess` itself isn't unit-testable (would kill the test JVM); end-to-end "app survives a TLS-inspecting VPN" needs the Dev build behind an interceptor (mitmproxy/AdGuard). The decision that gates it is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)