### PR TITLE
EventBus: decouple notification dispatch from debounce + widen buffer

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/eventbus/EventBus.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/eventbus/EventBus.kt
@@ -9,7 +9,12 @@ import kotlin.time.TimeSource
 
 class EventBus(
     replay: Int = 1,
-    extraBufferCapacity: Int = 10
+    // Buffer headroom for bursts: the whole bus is gated by its slowest collector (a
+    // SharedFlow buffer is shared across all subscribers), so when one DB-bound subscriber
+    // falls behind, every emitter suspends until it catches up. 64 slots absorb a typical
+    // WSPush/outbox burst without parking producers. NOTE: this is headroom, not a fix —
+    // a persistently slow subscriber still backs the bus up; it only widens the runway.
+    extraBufferCapacity: Int = 64
 ) {
     private val _events =
         MutableSharedFlow<BackendEvent>(replay = replay, extraBufferCapacity = extraBufferCapacity)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/temporal/TemporalAccessStatus.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/temporal/TemporalAccessStatus.kt
@@ -27,4 +27,13 @@ data class TemporalAccessStatus(
     val targetDrive: TargetDrive? = null,
     val windowSeconds: Long? = null,
     val newestFileModified: UnixTimeUtc = UnixTimeUtc.ZeroTime,
-)
+) {
+    /**
+     * True only for a *time-clamped* grant — [hasAccess] AND a finite [windowSeconds]. This is the
+     * `ConditionalTemporalRead` signature, so it's the correct signal for "this peer designated me an
+     * emergency contact". Plain full/unconstrained read also reports `hasAccess = true` but with
+     * `windowSeconds == null`, so gating on [hasAccess] alone wrongly treats any readable location
+     * drive as an emergency designation.
+     */
+    val isTimeWindowed: Boolean get() = hasAccess && windowSeconds != null
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
@@ -123,6 +123,12 @@ class OdinWebSocketClient(
 
     private var notificationFlushJob: Job? = null
 
+    // The in-flight dispatch of a coalesced batch. Kept SEPARATE from [notificationFlushJob]
+    // (the cancellable debounce window) so that a newly-arrived notification resetting the
+    // burst window cancels only the pending delay — never a dispatch already underway. Each
+    // new batch's dispatch joins the previous one, so batches still run strictly in order.
+    private var notificationDispatchJob: Job? = null
+
     private val NOTIFICATION_BURST_MS = 200L
 
 
@@ -387,23 +393,32 @@ class OdinWebSocketClient(
             notificationBuffer += notification
         }
 
-        // cancel pending flush
+        // Reset the coalescing window only. This cancels the *delay*, not any dispatch
+        // already running — that lives in notificationDispatchJob (see below).
         notificationFlushJob?.cancel()
 
         notificationFlushJob = scope.launch {
             delay(NOTIFICATION_BURST_MS)
 
-            val batch = notificationBufferMutex.withLock {
-                val snapshot = notificationBuffer.toList()
+            // Snapshot the batch and hand off to a dispatch job under the same lock, so the
+            // snapshot-and-chain is atomic w.r.t. a concurrent flush. launch() does not
+            // suspend, so the lock is held only briefly.
+            notificationBufferMutex.withLock {
+                val batch = notificationBuffer.toList()
                 notificationBuffer.clear()
-                snapshot
-            }
+                if (batch.isEmpty()) return@launch
 
-            for (n in batch) {
-                try {
-                    dispatchNotification(n)
-                } catch (e: Exception) {
-                    Logger.e(e) { "Failed to dispatch notification type=${n.notificationType}, data=${n.data.take(200)}" }
+                val previousDispatch = notificationDispatchJob
+                notificationDispatchJob = scope.launch {
+                    // Preserve ordering: don't start this batch until the previous one finished.
+                    previousDispatch?.join()
+                    for (n in batch) {
+                        try {
+                            dispatchNotification(n)
+                        } catch (e: Exception) {
+                            Logger.e(e) { "Failed to dispatch notification type=${n.notificationType}, data=${n.data.take(200)}" }
+                        }
+                    }
                 }
             }
         }

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSyncTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSyncTest.kt
@@ -395,7 +395,7 @@ class OutboxSyncTest {
             // ConnectionRequestService / AuthConnectionCoordinator / DriveContactService
             // subscribers do when they call a suspending network fetch on partial
             // connectivity: the first event is picked up, the collect body never returns,
-            // and further emissions pile up in the 11-slot buffer.
+            // and further emissions pile up in the 65-slot buffer (replay 1 + extraBufferCapacity 64).
             val blocker = CompletableDeferred<Unit>()
             val collectorJob = backgroundScope.launch {
                 eventBus.events.collect {
@@ -406,8 +406,9 @@ class OutboxSyncTest {
 
             // Saturate the bus buffer. We launch each emit so emits that can't fit don't
             // suspend the test body itself — they stay parked inside their own launched
-            // coroutine, leaving the bus in a "next emit will suspend" state.
-            repeat(20) { i ->
+            // coroutine, leaving the bus in a "next emit will suspend" state. The count must
+            // exceed the 65-slot buffer with margin; the overflow emits simply park harmlessly.
+            repeat(128) { i ->
                 backgroundScope.launch {
                     eventBus.emit(BackendEvent.OutboxEvent.Failed("saturate-$i"))
                 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/contactbook/EmergencyContactReconciler.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/contactbook/EmergencyContactReconciler.kt
@@ -3,46 +3,88 @@
 package id.homebase.core.contactbook
 
 import co.touchlab.kermit.Logger
+import id.homebase.api.client.contacts.Contact
 import id.homebase.api.client.contacts.ContactRepository
 import id.homebase.api.client.peer.temporal.TemporalDriveReadProvider
 import id.homebase.api.common.OdinId
 import id.homebase.core.config.locationLabeledDrive
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import kotlin.uuid.ExperimentalUuidApi
 
 /**
- * Reconciles the cached `iCanLocate` flag against the authoritative grant. The flag is set/cleared by
- * best-effort status messages ([EmergencyContactReceiveService]); if a revocation is lost, the flag
- * is left wrongly `true` and we'd claim we can locate someone we can't. This corrects that: for each
- * contact we think we can locate, preflight the peer's location drive with
- * [TemporalDriveReadProvider.verifyTemporalAccess] (reads no data, fires no notification on the peer)
- * and clear the flag when the grant is gone.
+ * Reconciles the cached `iCanLocate` flag against the authoritative grant — the background backstop
+ * for the best-effort status-message path ([EmergencyContactReceiveService]). The live status
+ * message only fires on the WS-push path, so a designation/revocation that arrives during cold sync
+ * (offline → login catch-up) or in a dropped event never updates the flag. Here we re-derive the
+ * truth by preflighting the peer's location drive with
+ * [TemporalDriveReadProvider.verifyTemporalAccess] (reads no data, fires no notification on the peer).
  *
- * Scope: clears STALE flags only. A lost *designation* (grant exists but the flag never got set)
- * isn't recovered here — that would require preflighting every connected contact on each open. The
- * message + its re-delivery remain the path for the true→ direction; the read itself verifies access
- * at locate time.
+ * Two entry points by cost:
+ * - [reconcileAll] — full two-way pass over identity contacts: SET the flag where we now have access
+ *   (recovers a missed "they added me") and CLEAR it where we don't (recovers a missed "they removed
+ *   me"). One preflight per identity contact; run in the background at login via [start], NOT per
+ *   screen open.
+ * - [reconcile] — cheap clear-only pass over already-flagged contacts. Safe to call on screen open.
+ *
+ * A network/parse failure is inconclusive — we leave the flag untouched rather than flip on a guess.
+ *
+ * Limitation: only contacts we already hold can be reconciled (a peer who added us but isn't in our
+ * contact book yet has no row to flag — the status message remains the discovery path for those).
  */
 class EmergencyContactReconciler(
     private val contactRepository: ContactRepository,
     private val temporalRead: TemporalDriveReadProvider,
+    private val scope: CoroutineScope,
 ) {
     private val locationDrive = locationLabeledDrive.drive.alias
 
-    /** Verify each can-locate contact still grants us access; clear the flag where it doesn't. */
+    /** Fire-and-forget the full two-way reconcile in the background (called once at login). */
+    fun start() {
+        scope.launch { runCatching { reconcileAll() } }
+    }
+
+    /**
+     * Full two-way reconcile over identity-backed contacts. Recovers both directions the live
+     * status-message path can miss. One temporal-access preflight per identity contact.
+     */
+    suspend fun reconcileAll() {
+        contactRepository.ensureLoaded()
+        for (contact in contactRepository.contacts.value) {
+            reconcileContact(contact, allowSet = true)
+        }
+    }
+
+    /** Cheap clear-only pass: verify each can-locate contact still grants us access, clear if not. */
     suspend fun reconcile() {
         contactRepository.ensureLoaded()
-        val flagged = contactRepository.contacts.value.filter { it.iCanLocate() }
-        for (contact in flagged) {
-            val odinId = contact.content.odinId?.takeIf { it.isNotBlank() }?.let { OdinId(it) } ?: continue
-            val versionTag = contact.versionTag ?: continue
-            // A network/parse failure is inconclusive — leave the cache untouched rather than clear
-            // a flag that may still be valid.
-            val status = runCatching { temporalRead.verifyTemporalAccess(odinId, locationDrive) }
-                .getOrNull() ?: continue
-            if (!status.hasAccess) {
+        for (contact in contactRepository.contacts.value.filter { it.iCanLocate() }) {
+            reconcileContact(contact, allowSet = false)
+        }
+    }
+
+    /**
+     * Aligns one contact's [iCanLocate] flag with the authoritative preflight. When [allowSet] is
+     * false this is clear-only and skips contacts that aren't flagged (so it never preflights — and
+     * never pays for — a contact there's nothing to clear on).
+     */
+    private suspend fun reconcileContact(contact: Contact, allowSet: Boolean) {
+        val odinId = contact.content.odinId?.takeIf { it.isNotBlank() }?.let { OdinId(it) } ?: return
+        val versionTag = contact.versionTag ?: return
+        val flagged = contact.iCanLocate()
+        // Clear-only mode has nothing to do for an unflagged contact — skip the preflight entirely.
+        if (!flagged && !allowSet) return
+
+        val status = runCatching { temporalRead.verifyTemporalAccess(odinId, locationDrive) }
+            .getOrNull() ?: return
+        when {
+            status.hasAccess && !flagged && allowSet ->
+                runCatching { contactRepository.setICanLocate(contact.uniqueId, versionTag) }
+                    .onFailure { Logger.w(it) { "reconcile: setICanLocate failed for ${odinId.domainName}" } }
+
+            !status.hasAccess && flagged ->
                 runCatching { contactRepository.clearICanLocate(contact.uniqueId, versionTag) }
                     .onFailure { Logger.w(it) { "reconcile: clearICanLocate failed for ${odinId.domainName}" } }
-            }
         }
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/contactbook/EmergencyContactReconciler.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/contactbook/EmergencyContactReconciler.kt
@@ -77,12 +77,15 @@ class EmergencyContactReconciler(
 
         val status = runCatching { temporalRead.verifyTemporalAccess(odinId, locationDrive) }
             .getOrNull() ?: return
+        // Emergency designation == a time-clamped grant (ConditionalTemporalRead), NOT plain full
+        // read — which also reports hasAccess=true. Gate on isTimeWindowed so a contact whose
+        // location drive we can merely read isn't mistaken for an emergency contact.
         when {
-            status.hasAccess && !flagged && allowSet ->
+            status.isTimeWindowed && !flagged && allowSet ->
                 runCatching { contactRepository.setICanLocate(contact.uniqueId, versionTag) }
                     .onFailure { Logger.w(it) { "reconcile: setICanLocate failed for ${odinId.domainName}" } }
 
-            !status.hasAccess && flagged ->
+            !status.isTimeWindowed && flagged ->
                 runCatching { contactRepository.clearICanLocate(contact.uniqueId, versionTag) }
                     .onFailure { Logger.w(it) { "reconcile: clearICanLocate failed for ${odinId.domainName}" } }
         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -496,6 +496,11 @@ val appModule = module {
                 conversationStream.onEmergencyContactRevoked = { sender, file ->
                     emergencyContactReceive.onRevoked(sender, file)
                 }
+                // Background backstop: the live status-message handlers above only fire on the
+                // WS-push path, so a designation/revocation that arrived during cold sync (or a
+                // dropped event) is never applied. Reconcile both directions against the
+                // authoritative temporal-access grant in the background — no screen required.
+                get<EmergencyContactReconciler>().start()
                 // endregion
 
                 // region Auto-unarchive: incoming message for archived conversation

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailViewModel.kt
@@ -240,7 +240,9 @@ class ContactDetailViewModel(
         val entry = _uiState.value.entry
         val versionTag = entry?.versionTag
 
-        if (status.hasAccess) {
+        // "Emergency contact" means a time-clamped (ConditionalTemporalRead) grant specifically —
+        // NOT plain full read, which also reports hasAccess=true (see TemporalAccessStatus).
+        if (status.isTimeWindowed) {
             // newestFileModified is only a real timestamp when we have access; 0 (ZeroTime) means the
             // drive has no files yet — render "no data", not the epoch.
             val newest = status.newestFileModified.takeIf { it.milliseconds > 0 }
@@ -251,8 +253,8 @@ class ContactDetailViewModel(
             }
         } else {
             _uiState.update { it.copy(locateNewestDataAt = null) }
-            // A successful verify with hasAccess=false is authoritative: clear a stale flag, mirroring
-            // EmergencyContactReconciler. Skip the write when the flag isn't set (nothing to clear).
+            // A successful verify without a temporal grant is authoritative: clear a stale flag,
+            // mirroring EmergencyContactReconciler. Skip the write when the flag isn't set.
             if (entry != null && versionTag != null && entry.iCanLocate) {
                 runCatching { contactRepository.clearICanLocate(entry.uniqueId, versionTag) }
                     .onFailure { Logger.w(it, TAG) { "clearICanLocate failed for ${peer.domainName}" } }


### PR DESCRIPTION
Dropped WebSocket notifications (e.g. connectionChanged/CircleGranted "Failed to dispatch ... JobCancellationException") were caused by two interacting issues under load:

1. The notification flush job did both the 200ms coalescing delay AND the dispatch loop, so a newly-arrived notification calling notificationFlushJob.cancel() to reset the burst window also aborted a dispatch already in flight. Move dispatch into a separate notificationDispatchJob; the debounce cancel now resets only the delay. Batches stay strictly ordered via previousDispatch.join().

2. The EventBus SharedFlow had only 11 buffer slots shared across all subscribers, so one slow (DB-bound) collector parked every emitter under backpressure, widening the cancel window above. Bump extraBufferCapacity 10 -> 64 for burst headroom (runway, not a cure for a persistently slow subscriber).

Restore testTryEnqueueDoesNotBlockOnSaturatedEventBus's premise: saturate with 128 emits (> the new 65-slot buffer) instead of 20.