### PR TITLE
feat(login): name the TLS cause — cert issuer, exact host, friendly message

### DIFF
--- a/homebase-auth/src/androidMain/kotlin/id/homebase/auth/login/CertificateProbe.android.kt
+++ b/homebase-auth/src/androidMain/kotlin/id/homebase/auth/login/CertificateProbe.android.kt
@@ -1,0 +1,61 @@
+package id.homebase.auth.login
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import java.net.InetSocketAddress
+import java.security.KeyStore
+import java.security.cert.X509Certificate
+import javax.net.ssl.SNIHostName
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSocket
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
+
+// NOTE: kept byte-for-byte identical to CertificateProbe.jvm.kt — Android and desktop both
+// use javax.net.ssl, but the KMP hierarchy gives them no shared parent source set, so the
+// implementation is duplicated. Change both together.
+internal actual suspend fun probeCertificateInfo(host: String): String? =
+    withContext(Dispatchers.IO) {
+        withTimeoutOrNull(8_000) {
+            runCatching {
+                // Platform default trust manager. We DO NOT trust-all — we still validate; we
+                // only record the presented chain in the callback (which runs before any
+                // rejection), so an untrusted intercepting cert is captured AND still rejected.
+                val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+                tmf.init(null as KeyStore?)
+                val defaultTm = tmf.trustManagers.filterIsInstance<X509TrustManager>().first()
+
+                var presented: Array<X509Certificate>? = null
+                val capturingTm = object : X509TrustManager {
+                    override fun checkClientTrusted(chain: Array<X509Certificate>?, authType: String?) {}
+                    override fun checkServerTrusted(chain: Array<X509Certificate>?, authType: String?) {
+                        presented = chain
+                        defaultTm.checkServerTrusted(chain, authType) // still validates; may throw
+                    }
+
+                    override fun getAcceptedIssuers(): Array<X509Certificate> = defaultTm.acceptedIssuers
+                }
+
+                val ctx = SSLContext.getInstance("TLS").apply { init(null, arrayOf(capturingTm), null) }
+                (ctx.socketFactory.createSocket() as SSLSocket).use { socket ->
+                    socket.sslParameters = socket.sslParameters.apply {
+                        serverNames = listOf(SNIHostName(host))
+                    }
+                    socket.connect(InetSocketAddress(host, 443), 6_000)
+                    socket.soTimeout = 6_000
+                    // Triggers checkServerTrusted (records the chain), then may throw on an
+                    // untrusted cert — exactly the case we want to report. No app data is sent.
+                    runCatching { socket.startHandshake() }
+                }
+
+                presented?.firstOrNull()?.let { leaf ->
+                    "certificate presented by $host was issued by [${leaf.issuerX500Principal.name}]" +
+                        " (subject [${leaf.subjectX500Principal.name}])"
+                }
+            }.onFailure {
+                Logger.w(tag = "CertificateProbe") { "probe failed for $host: ${it.message}" }
+            }.getOrNull()
+        }
+    }

--- a/homebase-auth/src/appleMain/kotlin/id/homebase/auth/login/CertificateProbe.apple.kt
+++ b/homebase-auth/src/appleMain/kotlin/id/homebase/auth/login/CertificateProbe.apple.kt
@@ -1,0 +1,6 @@
+package id.homebase.auth.login
+
+// iOS: capturing the presented cert on a handshake failure goes through the NSURLSession
+// server-trust delegate / Security framework — not wired yet. Return null so the TLS error
+// still shows the host + exception, just without the issuer line.
+internal actual suspend fun probeCertificateInfo(host: String): String? = null

--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/CertificateProbe.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/CertificateProbe.kt
@@ -1,0 +1,16 @@
+package id.homebase.auth.login
+
+/**
+ * Best-effort diagnostic, run only after a TLS login failure: connect to [host]:443, read the
+ * leaf certificate the server (or an interceptor) actually presents, and return a short human
+ * description of its issuer + subject — so the error can name the culprit (e.g. "issued by
+ * AdGuard Personal CA" pinpoints AdGuard intercepting HTTPS, vs "Let's Encrypt" for the real
+ * server). Returns null when unsupported (iOS/web) or on any error; never throws.
+ *
+ * Safety (see the JVM/Android actual): it does NOT weaken validation — the platform default
+ * trust manager still runs and still rejects an untrusted cert; we only *record* the presented
+ * chain in the callback (which fires before the rejection). It sends no application data — the
+ * throwaway socket is closed right after the handshake attempt. The production HTTP client's
+ * TLS is untouched.
+ */
+internal expect suspend fun probeCertificateInfo(host: String): String?

--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/IdentityPing.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/IdentityPing.kt
@@ -66,11 +66,19 @@ private fun Throwable.looksLikeTlsFailure(): Boolean {
  *
  * [httpClient] must have the `HttpTimeout` plugin installed (the production client does);
  * the timeouts mirror the previous inline values.
+ *
+ * [certProbe] is injected so tests don't open a real socket; production uses the platform
+ * [probeCertificateInfo] to read the presented cert's issuer on a TLS failure.
  */
-internal suspend fun pingIdentity(httpClient: HttpClient, identity: OdinId): IdentityPingResult {
+internal suspend fun pingIdentity(
+    httpClient: HttpClient,
+    identity: OdinId,
+    certProbe: suspend (host: String) -> String? = { probeCertificateInfo(it) },
+): IdentityPingResult {
+    val url = "https://$identity/api/v2/health/ping"
     return try {
-        Logger.i(tag = "IdentityPing") { "Pinging https://$identity/api/v2/health/ping ..." }
-        val response = httpClient.get("https://$identity/api/v2/health/ping") {
+        Logger.i(tag = "IdentityPing") { "Pinging $url ..." }
+        val response = httpClient.get(url) {
             timeout {
                 requestTimeoutMillis = 15_000
                 connectTimeoutMillis = 10_000
@@ -84,18 +92,24 @@ internal suspend fun pingIdentity(httpClient: HttpClient, identity: OdinId): Ide
             // erroring, usually transiently (a real Homebase backend mid-restart, overloaded,
             // or a 502/503/504 from a proxy in front of it). That's "try again", not a verdict
             // that the ID isn't Homebase. Only a non-5xx non-200 (404/403/…) earns NotHomebase.
-            code in 500..599 -> IdentityPingResult.Unreachable(
-                "HTTP $code (server error) from https://$identity/api/v2/health/ping"
-            )
+            code in 500..599 -> IdentityPingResult.Unreachable("HTTP $code (server error) from $url")
             else -> IdentityPingResult.NotHomebase(code)
         }
     } catch (t: Throwable) {
-        val detail = "${t::class.simpleName ?: "Error"}: ${t.message ?: "(no message)"}"
-        Logger.e(tag = "IdentityPing") { "Ping failed for $identity: $detail" }
+        // Echo the exact host we tried (rules out any field/typo mangling) + the raw cause.
+        val cause = "${t::class.simpleName ?: "Error"}: ${t.message ?: "(no message)"}"
+        Logger.e(tag = "IdentityPing") { "Ping failed for $url: $cause" }
         if (t.looksLikeTlsFailure()) {
-            IdentityPingResult.TlsError(detail)
+            // Read who actually signed the presented cert — names an interceptor (e.g. AdGuard).
+            val cert = runCatching { certProbe(identity.toString()) }.getOrNull()
+            IdentityPingResult.TlsError(
+                buildString {
+                    append("Tried ").append(url).append(" — ").append(cause)
+                    if (!cert.isNullOrBlank()) append(" — ").append(cert)
+                }
+            )
         } else {
-            IdentityPingResult.Unreachable(detail)
+            IdentityPingResult.Unreachable("Tried $url — $cause")
         }
     }
 }

--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/IdentityPing.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/IdentityPing.kt
@@ -26,6 +26,36 @@ sealed interface IdentityPingResult {
      * a Homebase ID?" case. [statusCode] is the HTTP status it answered with.
      */
     data class NotHomebase(val statusCode: Int) : IdentityPingResult
+
+    /**
+     * The TLS handshake itself failed — most often because a VPN, ad blocker, or antivirus
+     * is intercepting HTTPS and presenting a certificate the device doesn't trust ("Trust
+     * anchor for certification path not found"), or a missing/mismatched cert. Split out from
+     * [Unreachable] so the UI can name the likely cause (turn off the interceptor), which is
+     * far more actionable than a generic "check your connection". [detail] is the raw cause.
+     */
+    data class TlsError(val detail: String) : IdentityPingResult
+}
+
+/**
+ * Heuristic: does this throwable (or its cause chain) look like a TLS/certificate failure?
+ * The concrete types are platform-specific (`SSLHandshakeException`/`CertPathValidatorException`
+ * on Android/JVM, Darwin TLS errors on iOS), so we match on class name + message rather than
+ * referencing `javax.net.ssl.*` from common code.
+ */
+private val TLS_MARKERS = listOf(
+    "SSL", "TLS", "certificate", "CertPath", "cert path", "trust anchor", "handshake", "X509",
+)
+
+private fun Throwable.looksLikeTlsFailure(): Boolean {
+    val seen = HashSet<Throwable>()
+    var cur: Throwable? = this
+    while (cur != null && seen.add(cur)) {
+        val haystack = "${cur::class.simpleName ?: ""} ${cur.message ?: ""}"
+        if (TLS_MARKERS.any { haystack.contains(it, ignoreCase = true) }) return true
+        cur = cur.cause
+    }
+    return false
 }
 
 /**
@@ -62,6 +92,10 @@ internal suspend fun pingIdentity(httpClient: HttpClient, identity: OdinId): Ide
     } catch (t: Throwable) {
         val detail = "${t::class.simpleName ?: "Error"}: ${t.message ?: "(no message)"}"
         Logger.e(tag = "IdentityPing") { "Ping failed for $identity: $detail" }
-        IdentityPingResult.Unreachable(detail)
+        if (t.looksLikeTlsFailure()) {
+            IdentityPingResult.TlsError(detail)
+        } else {
+            IdentityPingResult.Unreachable(detail)
+        }
     }
 }

--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt
@@ -25,6 +25,7 @@ import id.homebase.resources.error_unknown
 import id.homebase.resources.login_error_generic
 import id.homebase.resources.login_error_invalid_id
 import id.homebase.resources.login_error_not_homebase
+import id.homebase.resources.login_error_tls
 import id.homebase.resources.login_error_unreachable
 import io.ktor.client.HttpClient
 import kotlinx.collections.immutable.toImmutableList
@@ -124,10 +125,12 @@ class LoginViewModel(
             if (ping != IdentityPingResult.Ok) {
                 Logger.w(tag = "LoginViewModel", messageString = "Identity $homebaseId ping=$ping, aborting login")
                 val errorRes = when (ping) {
+                    is IdentityPingResult.TlsError -> MR.string.login_error_tls
                     is IdentityPingResult.Unreachable -> MR.string.login_error_unreachable
                     else -> MR.string.login_error_not_homebase
                 }
                 val details = when (ping) {
+                    is IdentityPingResult.TlsError -> ping.detail
                     is IdentityPingResult.Unreachable -> ping.detail
                     is IdentityPingResult.NotHomebase ->
                         "HTTP ${ping.statusCode} from https://${homebaseId.domainName}/api/v2/health/ping"

--- a/homebase-auth/src/commonTest/kotlin/id/homebase/auth/login/IdentityPingTest.kt
+++ b/homebase-auth/src/commonTest/kotlin/id/homebase/auth/login/IdentityPingTest.kt
@@ -78,18 +78,32 @@ class IdentityPingTest {
     fun requestThrows_isUnreachable_withDetail() = runTest {
         // Offline / DNS / timeout / connection refused — a connectivity problem, NOT a verdict
         // on the ID. The old code wrongly called this "are you sure it's a Homebase ID?".
-        val result = pingIdentity(clientThrowing(), identity)
+        val result = pingIdentity(clientThrowing(), identity) { null }
         assertIs<IdentityPingResult.Unreachable>(result)
-        // The raw cause is carried for the "Show error details" toggle.
+        // The raw cause + the exact host we tried are carried for the "Show error details" toggle.
         assertTrue(result.detail.contains("simulated network failure"), "detail was: ${result.detail}")
+        assertTrue(result.detail.contains("sam.homebase.id"), "host must be echoed; was: ${result.detail}")
     }
 
     @Test
-    fun tlsHandshakeFailure_isTlsError_withRawCause() = runTest {
+    fun tlsHandshakeFailure_isTlsError_withHostAndIssuer() = runTest {
         // A VPN/ad-blocker/AV intercepting HTTPS → its own untrusted cert → handshake fails.
-        // This must be its own bucket so the UI can name the likely cause, not just "try again".
-        val result = pingIdentity(clientThrowingTls(), identity)
+        // Its own bucket, AND the injected probe names who signed the presented cert.
+        val fakeProbe: suspend (String) -> String? = { host ->
+            "certificate presented by $host was issued by [CN=AdGuard Personal CA, O=AdGuard]"
+        }
+        val result = pingIdentity(clientThrowingTls(), identity, fakeProbe)
         assertIs<IdentityPingResult.TlsError>(result)
-        assertTrue(result.detail.contains("Trust anchor"), "detail was: ${result.detail}")
+        assertTrue(result.detail.contains("Trust anchor"), "raw cause; was: ${result.detail}")
+        assertTrue(result.detail.contains("sam.homebase.id"), "host must be echoed; was: ${result.detail}")
+        assertTrue(result.detail.contains("AdGuard"), "issuer must be named; was: ${result.detail}")
+    }
+
+    @Test
+    fun tlsHandshakeFailure_probeUnavailable_stillTlsErrorWithHost() = runTest {
+        // iOS/web (or a probe error) returns null — we still get TlsError with host + cause.
+        val result = pingIdentity(clientThrowingTls(), identity) { null }
+        assertIs<IdentityPingResult.TlsError>(result)
+        assertTrue(result.detail.contains("sam.homebase.id"), "host must be echoed; was: ${result.detail}")
     }
 }

--- a/homebase-auth/src/commonTest/kotlin/id/homebase/auth/login/IdentityPingTest.kt
+++ b/homebase-auth/src/commonTest/kotlin/id/homebase/auth/login/IdentityPingTest.kt
@@ -28,6 +28,21 @@ class IdentityPingTest {
         MockEngine { throw RuntimeException("simulated network failure") }
     ) { install(HttpTimeout) }
 
+    /**
+     * Simulates a TLS-intercepting network (VPN/ad-blocker/AV). commonTest can't reference
+     * `javax.net.ssl.SSLHandshakeException`, so we throw the real-world message — the
+     * classifier matches on class name + message, and on JVM/Android the real type's name
+     * ("SSLHandshakeException") matches too.
+     */
+    private fun clientThrowingTls() = HttpClient(
+        MockEngine {
+            throw RuntimeException(
+                "javax.net.ssl.SSLHandshakeException: java.security.cert.CertPathValidatorException: " +
+                    "Trust anchor for certification path not found."
+            )
+        }
+    ) { install(HttpTimeout) }
+
     @Test
     fun http200_isOk() = runTest {
         assertEquals(
@@ -61,11 +76,20 @@ class IdentityPingTest {
 
     @Test
     fun requestThrows_isUnreachable_withDetail() = runTest {
-        // Offline / DNS / timeout / TLS / connection refused — a connectivity problem, NOT
-        // a verdict on the ID. The old code wrongly called this "are you sure it's a Homebase ID?".
+        // Offline / DNS / timeout / connection refused — a connectivity problem, NOT a verdict
+        // on the ID. The old code wrongly called this "are you sure it's a Homebase ID?".
         val result = pingIdentity(clientThrowing(), identity)
         assertIs<IdentityPingResult.Unreachable>(result)
         // The raw cause is carried for the "Show error details" toggle.
         assertTrue(result.detail.contains("simulated network failure"), "detail was: ${result.detail}")
+    }
+
+    @Test
+    fun tlsHandshakeFailure_isTlsError_withRawCause() = runTest {
+        // A VPN/ad-blocker/AV intercepting HTTPS → its own untrusted cert → handshake fails.
+        // This must be its own bucket so the UI can name the likely cause, not just "try again".
+        val result = pingIdentity(clientThrowingTls(), identity)
+        assertIs<IdentityPingResult.TlsError>(result)
+        assertTrue(result.detail.contains("Trust anchor"), "detail was: ${result.detail}")
     }
 }

--- a/homebase-auth/src/jvmMain/kotlin/id/homebase/auth/login/CertificateProbe.jvm.kt
+++ b/homebase-auth/src/jvmMain/kotlin/id/homebase/auth/login/CertificateProbe.jvm.kt
@@ -1,0 +1,61 @@
+package id.homebase.auth.login
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import java.net.InetSocketAddress
+import java.security.KeyStore
+import java.security.cert.X509Certificate
+import javax.net.ssl.SNIHostName
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSocket
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
+
+// NOTE: kept byte-for-byte identical to CertificateProbe.android.kt — Android and desktop both
+// use javax.net.ssl, but the KMP hierarchy gives them no shared parent source set, so the
+// implementation is duplicated. Change both together.
+internal actual suspend fun probeCertificateInfo(host: String): String? =
+    withContext(Dispatchers.IO) {
+        withTimeoutOrNull(8_000) {
+            runCatching {
+                // Platform default trust manager. We DO NOT trust-all — we still validate; we
+                // only record the presented chain in the callback (which runs before any
+                // rejection), so an untrusted intercepting cert is captured AND still rejected.
+                val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+                tmf.init(null as KeyStore?)
+                val defaultTm = tmf.trustManagers.filterIsInstance<X509TrustManager>().first()
+
+                var presented: Array<X509Certificate>? = null
+                val capturingTm = object : X509TrustManager {
+                    override fun checkClientTrusted(chain: Array<X509Certificate>?, authType: String?) {}
+                    override fun checkServerTrusted(chain: Array<X509Certificate>?, authType: String?) {
+                        presented = chain
+                        defaultTm.checkServerTrusted(chain, authType) // still validates; may throw
+                    }
+
+                    override fun getAcceptedIssuers(): Array<X509Certificate> = defaultTm.acceptedIssuers
+                }
+
+                val ctx = SSLContext.getInstance("TLS").apply { init(null, arrayOf(capturingTm), null) }
+                (ctx.socketFactory.createSocket() as SSLSocket).use { socket ->
+                    socket.sslParameters = socket.sslParameters.apply {
+                        serverNames = listOf(SNIHostName(host))
+                    }
+                    socket.connect(InetSocketAddress(host, 443), 6_000)
+                    socket.soTimeout = 6_000
+                    // Triggers checkServerTrusted (records the chain), then may throw on an
+                    // untrusted cert — exactly the case we want to report. No app data is sent.
+                    runCatching { socket.startHandshake() }
+                }
+
+                presented?.firstOrNull()?.let { leaf ->
+                    "certificate presented by $host was issued by [${leaf.issuerX500Principal.name}]" +
+                        " (subject [${leaf.subjectX500Principal.name}])"
+                }
+            }.onFailure {
+                Logger.w(tag = "CertificateProbe") { "probe failed for $host: ${it.message}" }
+            }.getOrNull()
+        }
+    }

--- a/homebase-auth/src/wasmJsMain/kotlin/id/homebase/auth/login/CertificateProbe.wasmJs.kt
+++ b/homebase-auth/src/wasmJsMain/kotlin/id/homebase/auth/login/CertificateProbe.wasmJs.kt
@@ -1,0 +1,4 @@
+package id.homebase.auth.login
+
+// Web: the browser owns TLS; the app can't read the presented certificate. Return null.
+internal actual suspend fun probeCertificateInfo(host: String): String? = null

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -188,6 +188,7 @@
     <string name="login_error_invalid_id">Please enter a valid Homebase ID</string>
     <string name="login_error_unreachable">Couldn't reach %1$s — check your connection and try again.</string>
     <string name="login_error_not_homebase">%1$s doesn't look like a Homebase identity.</string>
+    <string name="login_error_tls">Couldn't establish a secure connection to %1$s. A VPN, ad blocker, or antivirus may be intercepting HTTPS — try turning it off, then retry. Tap "Show error details" for the exact error.</string>
     <string name="login_error_details_show">Show error details</string>
     <string name="login_error_details_hide">Hide error details</string>
     <string name="login_error_details_copy">Copy</string>


### PR DESCRIPTION
Builds on merged #862. Makes a TLS/cert login failure self-diagnosing instead of a generic "couldn't reach you".

## 1. Friendly, cause-naming message
TLS handshake failures get their own bucket (`IdentityPingResult.TlsError`) and a message that points at the real culprit:
> Couldn't establish a secure connection to `<id>`. A VPN, ad blocker, or antivirus may be intercepting HTTPS — try turning it off, then retry. Tap "Show error details" for the exact error.

(Offline/DNS/timeout → "check your connection"; 5xx → "try again"; 404 → "not a Homebase identity".) Classified by a cross-platform name/message heuristic since the exception types are platform-specific.

## 2. Cert-issuer probe — names the interceptor
After a TLS failure, a best-effort diagnostic connects to `<host>:443`, reads the **leaf certificate actually presented**, and puts its **issuer** in the detail:
> certificate presented by `queralt.dominion.id` was issued by **[CN=AdGuard Personal CA, O=AdGuard]**

That instantly distinguishes interception (AdGuard/VPN/AV) from the real server (Let's Encrypt) — no screenshots needed.

**Safe by construction:** the platform default trust manager still runs and still **rejects** an untrusted cert — we only *record* the presented chain in the callback (which fires before the rejection); **no app data is sent** (throwaway socket, closed after the handshake attempt); the production HTTP client's TLS is **untouched**. expect/actual: real on **Android + desktop** (`javax.net.ssl`), **null on iOS/web** (cert capture there needs the Security framework / isn't possible in-browser). Injected into `pingIdentity` so tests never open a socket.

## 3. Echo the exact host
Every ping-failure detail now starts with `Tried https://<host>/api/v2/health/ping`, so the precise domain we hit is visible — ruling out any field/typo mangling of the entered ID. (Verified the field is clean: `cleanDomain()` round-trips its space-encoding back to dots and `OdinId` validates, so a broken domain fails earlier with a different error — but now it's empirically visible too.)

## Tests
`IdentityPingTest` — issuer-named, probe-unavailable, and host-echo cases across buckets; 7/7 green. Compiles JVM + wasmJs + Android; iOS/native = the null actual (CI-checked).

## Caveat
The cert *capture* itself can't be exercised on the build host — it needs the **Dev build behind an interceptor** (AdGuard/proxy) to confirm it grabs the issuer. The classification, host echo, and message are unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)