### PR TITLE
feat(login): detect a missing root CA on a TLS failure + name it

### DIFF
--- a/homebase-auth/src/androidMain/kotlin/id/homebase/auth/login/CertificateProbe.android.kt
+++ b/homebase-auth/src/androidMain/kotlin/id/homebase/auth/login/CertificateProbe.android.kt
@@ -50,9 +50,32 @@ internal actual suspend fun probeCertificateInfo(host: String): String? =
                     runCatching { socket.startHandshake() }
                 }
 
-                presented?.firstOrNull()?.let { leaf ->
-                    "certificate presented by $host was issued by [${leaf.issuerX500Principal.name}]" +
-                        " (subject [${leaf.subjectX500Principal.name}])"
+                val chain = presented
+                if (chain.isNullOrEmpty()) {
+                    null
+                } else {
+                    val leaf = chain.first()
+                    // The roots THIS device trusts (the system store the app uses) — a local
+                    // query, no network. The chain anchors on the issuer of its top cert (or the
+                    // top cert itself, if the server sent the self-signed root). "MISSING" means
+                    // the device's trust store lacks the needed root — and we name it: e.g.
+                    // [ISRG Root X2] for a genuine Let's Encrypt cert an old/OEM Android doesn't
+                    // trust (fix is ours: broaden the chain / bundle the root), vs an
+                    // interceptor's own CA like [AdGuard Personal CA] (fix is theirs: turn it off).
+                    val trustedSubjects = defaultTm.acceptedIssuers.asSequence()
+                        .map { it.subjectX500Principal.name }
+                        .toSet()
+                    val top = chain.last()
+                    val anchorDN = top.issuerX500Principal.name
+                    val anchored = anchorDN in trustedSubjects ||
+                        top.subjectX500Principal.name in trustedSubjects
+                    buildString {
+                        append("certificate presented by ").append(host)
+                        append(" was issued by [").append(leaf.issuerX500Principal.name).append("]")
+                        append("; chain anchors to [").append(anchorDN).append("] — ")
+                        append(if (anchored) "present" else "MISSING")
+                        append(" in this device's ").append(trustedSubjects.size).append(" trusted roots")
+                    }
                 }
             }.onFailure {
                 Logger.w(tag = "CertificateProbe") { "probe failed for $host: ${it.message}" }

--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/CertificateProbe.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/CertificateProbe.kt
@@ -3,9 +3,11 @@ package id.homebase.auth.login
 /**
  * Best-effort diagnostic, run only after a TLS login failure: connect to [host]:443, read the
  * leaf certificate the server (or an interceptor) actually presents, and return a short human
- * description of its issuer + subject — so the error can name the culprit (e.g. "issued by
- * AdGuard Personal CA" pinpoints AdGuard intercepting HTTPS, vs "Let's Encrypt" for the real
- * server). Returns null when unsupported (iOS/web) or on any error; never throws.
+ * description of its issuer — AND whether the root the chain needs is in this device's trust
+ * store. So the error can both name the culprit ("issued by AdGuard Personal CA" → interception)
+ * and detect a missing root ("chain anchors to [ISRG Root X2] — MISSING" → the device lacks a
+ * legit public root, e.g. an old/OEM Android; fix is on our chain, not the user). Returns null
+ * when unsupported (iOS/web) or on any error; never throws.
  *
  * Safety (see the JVM/Android actual): it does NOT weaken validation — the platform default
  * trust manager still runs and still rejects an untrusted cert; we only *record* the presented

--- a/homebase-auth/src/jvmMain/kotlin/id/homebase/auth/login/CertificateProbe.jvm.kt
+++ b/homebase-auth/src/jvmMain/kotlin/id/homebase/auth/login/CertificateProbe.jvm.kt
@@ -50,9 +50,32 @@ internal actual suspend fun probeCertificateInfo(host: String): String? =
                     runCatching { socket.startHandshake() }
                 }
 
-                presented?.firstOrNull()?.let { leaf ->
-                    "certificate presented by $host was issued by [${leaf.issuerX500Principal.name}]" +
-                        " (subject [${leaf.subjectX500Principal.name}])"
+                val chain = presented
+                if (chain.isNullOrEmpty()) {
+                    null
+                } else {
+                    val leaf = chain.first()
+                    // The roots THIS device trusts (the system store the app uses) — a local
+                    // query, no network. The chain anchors on the issuer of its top cert (or the
+                    // top cert itself, if the server sent the self-signed root). "MISSING" means
+                    // the device's trust store lacks the needed root — and we name it: e.g.
+                    // [ISRG Root X2] for a genuine Let's Encrypt cert an old/OEM Android doesn't
+                    // trust (fix is ours: broaden the chain / bundle the root), vs an
+                    // interceptor's own CA like [AdGuard Personal CA] (fix is theirs: turn it off).
+                    val trustedSubjects = defaultTm.acceptedIssuers.asSequence()
+                        .map { it.subjectX500Principal.name }
+                        .toSet()
+                    val top = chain.last()
+                    val anchorDN = top.issuerX500Principal.name
+                    val anchored = anchorDN in trustedSubjects ||
+                        top.subjectX500Principal.name in trustedSubjects
+                    buildString {
+                        append("certificate presented by ").append(host)
+                        append(" was issued by [").append(leaf.issuerX500Principal.name).append("]")
+                        append("; chain anchors to [").append(anchorDN).append("] — ")
+                        append(if (anchored) "present" else "MISSING")
+                        append(" in this device's ").append(trustedSubjects.size).append(" trusted roots")
+                    }
                 }
             }.onFailure {
                 Logger.w(tag = "CertificateProbe") { "probe failed for $host: ${it.message}" }


### PR DESCRIPTION
Extends the cert probe (merged in #870 — runs only on a TLS login failure, shows under "Show error details") to answer the question that's been the live thread: *is the device missing the root CA, or is something intercepting?*

## What it adds
After reading the presented chain, the probe now also enumerates the roots **this device trusts** (the system store the app uses — a local, no-network query) and reports whether the root the chain anchors on is present:

> certificate presented by `queralt.dominion.id` was issued by **[CN=YE2, O=Let's Encrypt]**; chain anchors to **[CN=ISRG Root X2, …]** — **MISSING** in this device's 142 trusted roots

## Why it's decisive
It splits the two look-alike causes of `Trust anchor for certification path not found`, **by name**:
- anchors to a **known public root that's MISSING** (e.g. ISRG Root X2 on an old/OEM Android) → the device lacks a legit root → **fix is ours** (broaden the served chain / bundle the root).
- anchors to a **local/proxy CA** (e.g. AdGuard Personal CA), MISSING → **interception** → fix is theirs.
- **present** → the trust-anchor error is something else (incomplete chain, expiry, hostname).

This is exactly the manual diagnosis we did over screenshots, now in-app.

## Scope / constraints
- Runs **only** on a TLS error during login (unchanged); surfaces in the `TlsError` detail (unchanged).
- **Android + desktop** only (system-store access via `javax.net.ssl`); **iOS/web stay null**.

## Verification
Compiles JVM + wasmJs + Android; `homebase-auth:jvmTest` green. The present/MISSING verdict is trust-store-dependent at runtime — needs the **Dev build** (and ideally a device missing ISRG Root X2, or one behind AdGuard) to confirm end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)