### PR TITLE
fix(moments): single-tap-to-open + landscape letterbox under pinch-zoom (#873, #874)

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsScreen.kt
@@ -1188,14 +1188,20 @@ private fun MomentPostCard(
                         downloadingFiles = emptySet(),
                         sharedTransitionScope = null,
                         animatedVisibilityScope = null,
-                        // Inner per-cell click handlers stay disabled in the feed
-                        // so the card-level multi-tap detector receives all taps
-                        // — that's what makes double/triple-tap-to-react work on
-                        // the media area itself (Instagram-style). For the
-                        // carousel path the embedded video tile handles its
-                        // own play tap; double-tap-heart bubbles up via the
-                        // onDoubleTap callback below.
-                        onMediaClick = null,
+                        // Photos render through the inline pinch-zoom wrapper,
+                        // whose gesture detector consumes taps over the image —
+                        // so the card-level multi-tap detector never sees them
+                        // (#874). Route a single tap (open) through the per-cell
+                        // handler so the zoom wrapper's onTap opens the moment,
+                        // exactly like the card detector's single-tap does;
+                        // pinch + double-tap-zoom still work, and on the image
+                        // they replace double/triple-tap-react (taps elsewhere on
+                        // the card still react). Video tiles keep their own play
+                        // tap and double-tap-heart via the onDoubleTap callback.
+                        onMediaClick = { tapped ->
+                            if (commentsSheetOnTap) onOpenComments(tapped.key)
+                            else onCardClick(tapped.key)
+                        },
                         isUploading = uploadStatus != null,
                         isMuted = isMuted,
                         onToggleMute = onToggleMute,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaGallery.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaGallery.kt
@@ -137,11 +137,14 @@ private fun SingleImageLayout(
 ) {
     // Compute aspect from the payload's thumbnail metadata so the cell sizes
     // before the (possibly remote, encrypted) full image is decoded. Falls
-    // back to 1:1 when no thumbnail data is present. Capped at
-    // [MaxFeedMediaAspect] so a wide landscape doesn't render as a thin strip
-    // — the cell stays a comfortable height and ContentScale.Crop
-    // (preserveAspectRatio = false, below) fills it, trimming the far edges.
-    val aspect = (aspectRatioFor(payload) ?: 1f).coerceAtMost(MaxFeedMediaAspect)
+    // back to 1:1 when no thumbnail data is present. The photo is drawn
+    // ContentScale.Fit by the inline zoom wrapper (enableZoom below), so the
+    // cell must match the photo's real aspect or Fit leaves blank bars — the
+    // landscape letterbox of #873 (and the mirror-image side-crop of #818 back
+    // when this was Crop into a fixed-tall cell). Size to the natural aspect;
+    // clamp only extreme panoramas to [MaxFeedPhotoAspect] so a very wide shot
+    // doesn't collapse into a thin strip. Tall portraits keep their height.
+    val aspect = (aspectRatioFor(payload) ?: 1f).coerceAtMost(MaxFeedPhotoAspect)
 
     MomentMediaItem(
         payload = payload,
@@ -189,14 +192,26 @@ private fun SingleImageLayout(
  * available — caller decides the fallback.
  */
 /**
- * Upper bound on a feed cell's width/height ratio. 0.8 == a 4:5 portrait
- * frame: any photo at least as wide as 4:5 (landscape, square, and mildly
- * portrait shots) is sized to this tall frame and center-cropped
- * (ContentScale.Crop) so it reads as a substantial card instead of a short
- * horizontal strip. Taller portraits (ratio < 0.8) keep their natural height.
- * Detail/full-screen views are unaffected — they size media independently.
+ * Crop cap for the single-**video** feed tile (width/height). 0.8 == a 4:5
+ * portrait frame: a video at least as wide as 4:5 is sized to this tall frame
+ * and center-cropped (ContentScale.Crop) so it reads as a substantial card
+ * instead of a short horizontal strip; tap-to-play then shows the whole frame.
+ * Taller portrait videos (ratio < 0.8) keep their natural height. Photos use
+ * [MaxFeedPhotoAspect] instead (they're drawn Fit, so the cell tracks the real
+ * aspect). Detail/full-screen views size media independently.
  */
 internal const val MaxFeedMediaAspect = 0.8f
+
+/**
+ * Upper bound on a single-**photo** feed cell's width/height ratio.
+ * 1.91 ≈ 1.91:1 (Instagram's widest landscape). The photo is drawn
+ * ContentScale.Fit by the inline zoom wrapper, so the cell is sized to the
+ * photo's real aspect and Fit fills it exactly — no letterbox (#873), no
+ * side-crop (#818). Only panoramas wider than this clamp letterbox slightly
+ * (by design, so they don't render as a sliver); tall portraits are never
+ * clamped and keep their natural height.
+ */
+internal const val MaxFeedPhotoAspect = 1.91f
 
 internal fun aspectRatioFor(payload: PayloadDescriptor): Float? {
     val thumb = payload.previewThumbnail ?: payload.thumbnails?.lastOrNull()


### PR DESCRIPTION
Fixes #873 and #874 — both are regressions from the inline pinch-zoom integration (PR #827 / #819) in the **Moments timeline**, in the same code area, so they're fixed together (per the issues' own suggestion).

## #874 — single tap no longer opened a photo
`ZoomableSubSamplingImage`'s gesture detector consumes taps over the image. In the feed the gallery was passed `onMediaClick = null` (so the card-level multi-tap detector would receive taps), but the zoom wrapper swallows them before they reach the card — so a single tap did nothing.

**Fix:** route the open action through the gallery's per-cell `onMediaClick` (`MomentsScreen.kt`). The zoom wrapper's `onTap` now opens the moment — for **single and multi-image** moments — doing exactly what the card detector's single-tap did (`onOpenComments` in compact, `onCardClick` in wide). Pinch + double-tap-zoom are unaffected; on the photo they replace the old double/triple-tap-react (taps elsewhere on the card still react). Video tiles keep their own play tap and double-tap-heart.

## #873 — landscape photos showed a blank letterbox gap
The zoom wrapper draws the photo `ContentScale.Fit`, but `SingleImageLayout` still capped the single-photo cell to a tall `0.8` (4:5) frame — so a wide image was *fit* into a too-tall cell, leaving blank bars (the mirror image of #818's old side-crop).

**Fix:** size the single-photo cell to the photo's **real aspect** (new `MaxFeedPhotoAspect = 1.91f`, clamping only extreme panoramas so they don't become slivers). `Fit` now fills the cell exactly — **no letterbox (#873) and no side-crop (#818)**. Tall portraits keep their natural height. The single-**video** crop cap (`MaxFeedMediaAspect = 0.8f`) is unchanged; multi-image carousels (fixed `CarouselAspectRatio`) are unaffected.

## Scope
2 files, commonMain → all platforms:
- `moments/MomentsScreen.kt` — feed `onMediaClick` wiring (#874)
- `moments/widget/MomentMediaGallery.kt` — single-photo cell aspect + `MaxFeedPhotoAspect` (#873)

## Verification
- ✅ `:homebase-core:compileKotlinJvm` (BUILD SUCCESSFUL).
- ⏳ **Needs device verification** (Moments needs real photo data — can't reproduce easily on desktop):
  - [ ] Single tap on a single-image moment **opens** it; pinch + double-tap-zoom still work.
  - [ ] Single tap on a **multi-image** carousel page opens it.
  - [ ] A **landscape** photo renders with **no blank gap** and **not** side-cropped.
  - [ ] Portrait photos and the single-video tile unchanged.
  - [ ] iOS + Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)