### PR TITLE
Fix offline desktop crash: centrally handle CIO UnresolvedAddressException (#877)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/NetworkException.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/NetworkException.kt
@@ -35,8 +35,25 @@ fun Throwable.isTransientNetworkFailure(): Boolean {
     val seen = HashSet<Throwable>()
     var cur: Throwable? = this
     while (cur != null && seen.add(cur)) {
-        if (cur is NetworkException || cur is IOException) return true
+        if (cur is NetworkException || cur is IOException || cur.isConnectTimeNetworkType()) return true
         cur = cur.cause
     }
     return false
+}
+
+/**
+ * True when [this] is an engine connect-time failure that is NOT an [IOException] and thus
+ * bypasses the IOException-shaped catch/classify paths. Ktor CIO (Desktop/JVM) throws
+ * `java.nio.channels.UnresolvedAddressException` (an `IllegalArgumentException`, not an
+ * `IOException`) on DNS failure / no network — the Desktop variant of the OkHttp
+ * `UnknownHostException` already covered above.
+ *
+ * Matched by qualified class name because this code is in `commonMain`, which cannot
+ * reference the JVM-only type. Mirrors [isMlKitTeardownFailure]'s class-name approach. The
+ * match is narrow (the specific class name, not its `IllegalArgumentException` supertype) to
+ * avoid masking unrelated bugs.
+ */
+private fun Throwable.isConnectTimeNetworkType(): Boolean {
+    val name = this::class.qualifiedName?.lowercase() ?: return false
+    return "unresolvedaddressexception" in name
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/OdinApiProviderBase.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/OdinApiProviderBase.kt
@@ -96,6 +96,13 @@ abstract class OdinApiProviderBase(
             throw e
         } catch (e: IOException) {
             throw NetworkException(e)
+        } catch (e: Exception) {
+            // Some engines raise connect-time transport failures that are NOT IOExceptions —
+            // Ktor CIO (Desktop) throws UnresolvedAddressException (an IllegalArgumentException)
+            // on DNS/offline. Wrap those too so every engine surfaces one typed NetworkException;
+            // anything that isn't a transport failure rethrows unchanged.
+            if (e.isTransientNetworkFailure()) throw NetworkException(e)
+            throw e
         }
 
     protected suspend fun request(

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/CioOfflineConnectTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/CioOfflineConnectTest.kt
@@ -1,0 +1,59 @@
+package id.homebase.api.client
+
+import id.homebase.api.client.auth.CredentialsManager
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.request.get
+import kotlinx.coroutines.test.runTest
+import java.nio.channels.UnresolvedAddressException
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * The Desktop/CIO offline variant of [TlsInterceptionTest]. On DNS failure / no network the
+ * Ktor CIO engine (Desktop, JVM) throws `java.nio.channels.UnresolvedAddressException` — an
+ * `IllegalArgumentException`, NOT an `IOException` — so it bypasses the IOException-shaped
+ * catch that already covers OkHttp's `UnknownHostException` (Android). This pins the two
+ * contracts the crash-containment fix relies on for that shape:
+ *
+ *  1. `request()` maps the CIO connect-time failure to a typed [NetworkException], preserving
+ *     the raw cause.
+ *  2. The result classifies as [isTransientNetworkFailure] == true — the signal the platform
+ *     uncaught handlers key on to contain it instead of crashing the offline cold start.
+ */
+class CioOfflineConnectTest {
+
+    /** Minimal concrete provider exposing the protected request() primitive. */
+    private class TestProvider(client: HttpClient) :
+        OdinApiProviderBase(client, CredentialsManager()) {
+        suspend fun ping(): ApiResponse = request(
+            block = { httpClient.get("https://queralt.dominion.id/api/v2/health/ping") },
+            secret = null,
+        )
+    }
+
+    /** A client whose every call dies the way CIO does when offline (no DNS resolution). */
+    private fun offlineClient(): HttpClient =
+        HttpClient(MockEngine { throw UnresolvedAddressException() })
+
+    @Test
+    fun apiCall_whenOffline_mapsToTypedNetworkException() = runTest {
+        val provider = TestProvider(offlineClient())
+
+        val thrown = assertFailsWith<NetworkException> { provider.ping() }
+
+        // The raw CIO cause is preserved for the crash report.
+        assertIs<UnresolvedAddressException>(thrown.cause)
+    }
+
+    @Test
+    fun cioOfflineFailure_isClassifiedTransient() {
+        val raw = UnresolvedAddressException()
+        // Raw, and wrapped exactly as the API layer wraps it — both must be "transient" so the
+        // platform handlers contain it instead of terminating the process.
+        assertTrue(raw.isTransientNetworkFailure())
+        assertTrue(NetworkException(raw).isTransientNetworkFailure())
+    }
+}

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/NetworkExceptionTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/NetworkExceptionTest.kt
@@ -37,6 +37,37 @@ class NetworkExceptionTest {
     }
 
     @Test
+    fun `UnknownHostException (OkHttp-Android shape) classifies as transient`() {
+        // Regression guard for Android: OkHttp throws UnknownHostException, an IOException,
+        // on DNS failure — must stay classified after broadening for the CIO shape.
+        assertTrue(java.net.UnknownHostException("no host").isTransientNetworkFailure())
+    }
+
+    @Test
+    fun `UnresolvedAddressException (Ktor CIO-Desktop shape) classifies as transient`() {
+        // Desktop variant: Ktor CIO throws UnresolvedAddressException — an
+        // IllegalArgumentException, NOT an IOException — on DNS failure / offline. It must
+        // classify as a network error so the platform uncaught handlers swallow it, exactly
+        // like the OkHttp UnknownHostException case above.
+        assertTrue(java.nio.channels.UnresolvedAddressException().isTransientNetworkFailure())
+    }
+
+    @Test
+    fun `UnresolvedAddressException nested in a cause chain classifies as transient`() {
+        val wrapped = RuntimeException("security context fetch failed",
+            java.nio.channels.UnresolvedAddressException())
+        assertTrue(wrapped.isTransientNetworkFailure())
+    }
+
+    @Test
+    fun `a plain IllegalArgumentException stays fatal`() {
+        // The CIO match is narrow (the specific class name), NOT its IllegalArgumentException
+        // supertype — a generic IllegalArgumentException is a programming bug, not a transport
+        // failure, and must remain fatal.
+        assertFalse(IllegalArgumentException("bad arg").isTransientNetworkFailure())
+    }
+
+    @Test
     fun `NetworkException nested in a cause chain classifies as transient`() {
         val wrapped = RuntimeException("thumb load failed", NetworkException(IOException("dns")))
         assertTrue(wrapped.isTransientNetworkFailure())


### PR DESCRIPTION
## Summary
Fixes #877 — the **Desktop** app (JVM/CIO) crashed on an **offline cold start** with an uncaught `java.nio.channels.UnresolvedAddressException` on the AWT UI thread. This is the **Desktop/CIO variant** of the known offline-network-crash class; the existing central handling missed it because it is shaped for the Android/OkHttp exception type.

## Root cause
The two HTTP engines throw structurally different types on DNS failure / no network:
- **OkHttp (Android):** `java.net.UnknownHostException` — an `IOException`.
- **Ktor CIO (Desktop, `jvmMain`):** `java.nio.channels.UnresolvedAddressException` — an **`IllegalArgumentException`, NOT an `IOException`**.

So the CIO exception slipped past both central guards:
- `OdinApiProviderBase.networkCall` only wrapped `IOException` → propagated raw instead of as a typed `NetworkException`.
- `isTransientNetworkFailure()` only recognized `NetworkException`/`IOException` → the platform uncaught handlers (desktop `Main.kt`, android `GlobalCrashHandler`, iOS `IOSCrashHandler`) rethrew it → fatal.

## Fix (central, engine-agnostic)
- **`NetworkException.kt`** — add private `isConnectTimeNetworkType()` that matches `UnresolvedAddressException` by **qualified class name** (`commonMain` can't reference the JVM-only type; mirrors `MlKitFailure.isMlKitTeardownFailure()`), and consult it from `isTransientNetworkFailure()`. Match is narrow (the class name, not its `IllegalArgumentException` supertype).
- **`OdinApiProviderBase.kt`** — broaden `networkCall` with a third `catch` that wraps connect-time transport failures that aren't `IOException`s, reusing the classifier as the single source of truth. `CancellationException` still rethrows first; non-network exceptions rethrow unchanged.

This covers the single chokepoint for all REST calls (`request`/`requestBytes`), so offline calls now surface as handled `NetworkException` and classify as transient — exactly like the OkHttp `UnknownHostException` case already does.

## Not changed
`MomentsPostSenderService.resolveCommentRecipients` is left as-is — it's an architectural change (read local DB instead of a server GET to avoid losing a typed comment), not a redundant catch, so the central fix doesn't make it obsolete.

## Tests
- `NetworkExceptionTest` — pins `UnresolvedAddressException` (raw + nested) as transient; regression guards for the Android `UnknownHostException` shape and for a plain `IllegalArgumentException` staying fatal.
- New `CioOfflineConnectTest` — request-layer test (mirroring `TlsInterceptionTest`) proving a CIO `UnresolvedAddressException` from a `MockEngine` surfaces as a typed `NetworkException` with the raw cause preserved (exercises the new non-`IOException` catch).

`./gradlew :homebase-api:jvmTest` passes (new + existing `NetworkExceptionTest`/`TlsInterceptionTest`/`CoroutineExceptionHandlersTest`).

## Acceptance criteria
- [x] CIO `UnresolvedAddressException` is wrapped (request layer) **and** classified (classifier) centrally.
- [x] Unit test pins it as a network error (mirrors the `UnknownHostException` case).
- [x] No regression to Android's existing offline handling.
- [ ] Manual end-to-end: offline desktop cold start no longer crashes — needs a desktop run on an offline machine.

## Out of scope
Offline UX (retry banners) and the unrelated `github.com` update-check `UnknownHostException` (already non-fatal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
