### PR TITLE
fix(location): force-capture GPS on app-open & push via one battery-aware primitive (#878)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/LocationPointWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/LocationPointWrapper.kt
@@ -135,6 +135,12 @@ class LocationPointWrapper(
             delegate.countUnmarkedSince(fromInclusiveMs).executeAsOne()
         }
 
+    /** Un-uploaded rows older than [beforeMs] — the "stale backlog" the upload deferral must not hold. */
+    suspend fun countUnmarkedOlderThan(beforeMs: Long): Long =
+        databaseManager.readValue("locationPoint.countUnmarkedOlderThan") {
+            delegate.countUnmarkedOlderThan(beforeMs).executeAsOne()
+        }
+
     suspend fun selectLatest(): BufferedLocationPoint? {
         val row = databaseManager.readValue("locationPoint.selectLatest") {
             delegate.selectLatest().executeAsOneOrNull()

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/LocationPoint.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/LocationPoint.sq
@@ -97,6 +97,13 @@ countUnmarkedSince:
 SELECT COUNT(*) FROM LocationPoint
 WHERE t >= ? AND flushedFileUid IS NULL;
 
+-- Un-uploaded rows older than ? (epoch ms). Drives the "upload anyway, even in
+-- battery saver, if there's a >24h un-uploaded backlog" safety override so the
+-- user's history can't sit on-device indefinitely while saver is on.
+countUnmarkedOlderThan:
+SELECT COUNT(*) FROM LocationPoint
+WHERE t < ? AND flushedFileUid IS NULL;
+
 selectLatest:
 SELECT t, lat, lon, acc, alt, altAcc, spd, hdg, src, fg, steps, bat
 FROM LocationPoint

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/livelocation/LiveLocationShareServiceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/livelocation/LiveLocationShareServiceTest.kt
@@ -27,6 +27,7 @@ class LiveLocationShareServiceTest {
     private class NoSensors : DeviceSensors {
         override suspend fun batteryPercent(): Int? = null
         override suspend fun stepsSince(prevPointTimeMs: Long?, lastCumulative: Long?) = StepSample(null, null)
+        override fun isPowerSaveMode(): Boolean = false
     }
 
     private class Harness {

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.android.kt
@@ -6,6 +6,7 @@ import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import android.os.BatteryManager
+import android.os.PowerManager
 import co.touchlab.kermit.Logger
 import id.homebase.api.ActivityProvider
 import kotlinx.coroutines.withTimeoutOrNull
@@ -22,6 +23,11 @@ private object AndroidDeviceSensors : DeviceSensors {
         val bm = context.getSystemService(Context.BATTERY_SERVICE) as? BatteryManager ?: return null
         val pct = bm.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY)
         return pct.takeIf { it in 0..100 }
+    }
+
+    override fun isPowerSaveMode(): Boolean {
+        val pm = context.getSystemService(Context.POWER_SERVICE) as? PowerManager ?: return false
+        return pm.isPowerSaveMode
     }
 
     override suspend fun stepsSince(prevPointTimeMs: Long?, lastCumulative: Long?): StepSample {

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.android.kt
@@ -27,7 +27,7 @@ actual fun createOneShotLocationProvider(): OneShotLocationProvider = AndroidOne
 private object AndroidOneShotLocationProvider : OneShotLocationProvider {
 
     @SuppressLint("MissingPermission")
-    override suspend fun getCurrentFix(timeoutMs: Long): GpsFixResult {
+    override suspend fun getCurrentFix(timeoutMs: Long, maxAgeMs: Long): GpsFixResult {
         if (!isLocationPermissionGranted()) return GpsFixResult.PermissionDenied
         val context = ActivityProvider.requireApplicationContext()
         val lm = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
@@ -41,15 +41,21 @@ private object AndroidOneShotLocationProvider : OneShotLocationProvider {
             return GpsFixResult.Unavailable
         }
 
-        // 1. Freshest cached fix across enabled providers.
+        // 1. Freshest cached fix across enabled providers — but only trust it if it's recent enough.
+        // Without this age bound a force-on-stale capture would keep echoing an arbitrarily old OS
+        // last-known fix and never power the radio for a fresh one (#878 / #886 review).
         var bestCached: Location? = null
         for (provider in enabledProviders) {
             val cached = lm.getLastKnownLocation(provider)
             if (cached != null && (bestCached == null || cached.time > bestCached.time)) bestCached = cached
         }
-        if (bestCached != null) {
-            Logger.d(tag = TAG) { "cached fix from ${bestCached.provider}" }
+        val cachedAgeMs = bestCached?.let { System.currentTimeMillis() - it.time }
+        if (bestCached != null && cachedAgeMs != null && cachedAgeMs <= maxAgeMs) {
+            Logger.d(tag = TAG) { "cached fix from ${bestCached.provider} (age=${cachedAgeMs}ms <= ${maxAgeMs}ms)" }
             return GpsFixResult.Success(bestCached.toRaw())
+        }
+        Logger.d(tag = TAG) {
+            "cached fix too old (age=${cachedAgeMs}ms > ${maxAgeMs}ms) — acquiring live"
         }
 
         // 2. No cached fix — one-shot live update from the best provider, capped by timeoutMs.

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.android.kt
@@ -19,58 +19,38 @@ private const val TAG = "OneShotLocation.android"
 actual fun createOneShotLocationProvider(): OneShotLocationProvider = AndroidOneShotLocationProvider
 
 /**
- * Stock Android [LocationManager] one-shot (mirrors the former chat `LocationLauncher.android`):
- * try the cached fix from each enabled provider (cheap, no battery drain), else register a one-shot
- * [LocationListener] with a hard timeout. FusedLocationProviderClient returned null for both
+ * Stock Android [LocationManager] one-shot primitives (mirrors the former chat
+ * `LocationLauncher.android`). FusedLocationProviderClient returned null for both
  * lastLocation/getCurrentLocation on real devices + emulators, so LocationManager is used directly.
+ * The cache-vs-radio policy lives in [OneShotLocationProvider.getCurrentFix] (common); this file is
+ * just the platform I/O.
  */
 private object AndroidOneShotLocationProvider : OneShotLocationProvider {
 
     @SuppressLint("MissingPermission")
-    override suspend fun getCurrentFix(timeoutMs: Long, maxAgeMs: Long, cacheOnly: Boolean): GpsFixResult {
-        if (!isLocationPermissionGranted()) return GpsFixResult.PermissionDenied
-        val context = ActivityProvider.requireApplicationContext()
-        val lm = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
-
-        val enabledProviders = buildList {
-            if (lm.isProviderEnabled(LocationManager.GPS_PROVIDER)) add(LocationManager.GPS_PROVIDER)
-            if (lm.isProviderEnabled(LocationManager.NETWORK_PROVIDER)) add(LocationManager.NETWORK_PROVIDER)
-        }
-        if (enabledProviders.isEmpty()) {
-            Logger.w(tag = TAG) { "no providers enabled (location off / airplane mode?)" }
-            return GpsFixResult.Unavailable
-        }
-
-        // 1. Freshest cached fix across enabled providers — but only trust it if it's recent enough.
-        // Without this age bound a force-on-stale capture would keep echoing an arbitrarily old OS
-        // last-known fix and never power the radio for a fresh one (#878 / #886 review).
+    override suspend fun lastKnownFix(): RawLocationPoint? {
+        if (!isLocationPermissionGranted()) return null
+        val lm = locationManager()
+        // Freshest cached fix across enabled providers.
         var bestCached: Location? = null
-        for (provider in enabledProviders) {
+        for (provider in enabledProviders(lm)) {
             val cached = lm.getLastKnownLocation(provider)
             if (cached != null && (bestCached == null || cached.time > bestCached.time)) bestCached = cached
         }
-        val cachedAgeMs = bestCached?.let { System.currentTimeMillis() - it.time }
-        // Battery saver: serve whatever the OS already has and never power the radio.
-        if (cacheOnly) {
-            return if (bestCached != null) {
-                Logger.d(tag = TAG) { "cacheOnly: OS last-known from ${bestCached.provider} (age=${cachedAgeMs}ms)" }
-                GpsFixResult.Success(bestCached.toRaw())
-            } else {
-                Logger.d(tag = TAG) { "cacheOnly: no cached fix — skipping radio (power save)" }
-                GpsFixResult.Unavailable
-            }
-        }
-        if (bestCached != null && cachedAgeMs != null && cachedAgeMs <= maxAgeMs) {
-            Logger.d(tag = TAG) { "cached fix from ${bestCached.provider} (age=${cachedAgeMs}ms <= ${maxAgeMs}ms)" }
-            return GpsFixResult.Success(bestCached.toRaw())
-        }
-        Logger.d(tag = TAG) {
-            "cached fix too old (age=${cachedAgeMs}ms > ${maxAgeMs}ms) — acquiring live"
-        }
+        return bestCached?.toRaw()
+    }
 
-        // 2. No cached fix — one-shot live update from the best provider, capped by timeoutMs.
-        val activeProvider = enabledProviders.first()
-        Logger.d(tag = TAG) { "no cached fix; one-shot from $activeProvider (cap ${timeoutMs}ms)" }
+    @SuppressLint("MissingPermission")
+    override suspend fun acquireFreshFix(timeoutMs: Long): GpsFixResult {
+        if (!isLocationPermissionGranted()) return GpsFixResult.PermissionDenied
+        val lm = locationManager()
+        val providers = enabledProviders(lm)
+        if (providers.isEmpty()) {
+            Logger.w(tag = TAG) { "no providers enabled (location off / airplane mode?)" }
+            return GpsFixResult.Unavailable
+        }
+        val activeProvider = providers.first()
+        Logger.d(tag = TAG) { "one-shot from $activeProvider (cap ${timeoutMs}ms)" }
         val fix = withTimeoutOrNull(timeoutMs) {
             suspendCancellableCoroutine { cont ->
                 val listener = object : LocationListener {
@@ -89,6 +69,15 @@ private object AndroidOneShotLocationProvider : OneShotLocationProvider {
             }
         }
         return if (fix != null) GpsFixResult.Success(fix.toRaw()) else GpsFixResult.Timeout
+    }
+
+    private fun locationManager(): LocationManager =
+        ActivityProvider.requireApplicationContext()
+            .getSystemService(Context.LOCATION_SERVICE) as LocationManager
+
+    private fun enabledProviders(lm: LocationManager): List<String> = buildList {
+        if (lm.isProviderEnabled(LocationManager.GPS_PROVIDER)) add(LocationManager.GPS_PROVIDER)
+        if (lm.isProviderEnabled(LocationManager.NETWORK_PROVIDER)) add(LocationManager.NETWORK_PROVIDER)
     }
 
     private fun Location.toRaw(): RawLocationPoint = RawLocationPoint(

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.android.kt
@@ -27,7 +27,7 @@ actual fun createOneShotLocationProvider(): OneShotLocationProvider = AndroidOne
 private object AndroidOneShotLocationProvider : OneShotLocationProvider {
 
     @SuppressLint("MissingPermission")
-    override suspend fun getCurrentFix(timeoutMs: Long, maxAgeMs: Long): GpsFixResult {
+    override suspend fun getCurrentFix(timeoutMs: Long, maxAgeMs: Long, cacheOnly: Boolean): GpsFixResult {
         if (!isLocationPermissionGranted()) return GpsFixResult.PermissionDenied
         val context = ActivityProvider.requireApplicationContext()
         val lm = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
@@ -50,6 +50,16 @@ private object AndroidOneShotLocationProvider : OneShotLocationProvider {
             if (cached != null && (bestCached == null || cached.time > bestCached.time)) bestCached = cached
         }
         val cachedAgeMs = bestCached?.let { System.currentTimeMillis() - it.time }
+        // Battery saver: serve whatever the OS already has and never power the radio.
+        if (cacheOnly) {
+            return if (bestCached != null) {
+                Logger.d(tag = TAG) { "cacheOnly: OS last-known from ${bestCached.provider} (age=${cachedAgeMs}ms)" }
+                GpsFixResult.Success(bestCached.toRaw())
+            } else {
+                Logger.d(tag = TAG) { "cacheOnly: no cached fix — skipping radio (power save)" }
+                GpsFixResult.Unavailable
+            }
+        }
         if (bestCached != null && cachedAgeMs != null && cachedAgeMs <= maxAgeMs) {
             Logger.d(tag = TAG) { "cached fix from ${bestCached.provider} (age=${cachedAgeMs}ms <= ${maxAgeMs}ms)" }
             return GpsFixResult.Success(bestCached.toRaw())

--- a/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.apple.kt
+++ b/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.apple.kt
@@ -25,8 +25,11 @@ private object AppleDeviceSensors : DeviceSensors {
         return (level * 100f).toInt().coerceIn(0, 100)
     }
 
+    // Kotlin/Native names this boolean ObjC property after its `is`-prefixed getter, as a property:
+    // `isLowPowerModeEnabled` (no parens). The declared name `lowPowerModeEnabled` and the function
+    // form `isLowPowerModeEnabled()` both fail to resolve.
     override fun isPowerSaveMode(): Boolean =
-        NSProcessInfo.processInfo.isLowPowerModeEnabled()
+        NSProcessInfo.processInfo.isLowPowerModeEnabled
 
     override suspend fun stepsSince(prevPointTimeMs: Long?, lastCumulative: Long?): StepSample {
         // iOS answers historical intervals directly — no cumulative needed.

--- a/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.apple.kt
+++ b/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.apple.kt
@@ -4,6 +4,7 @@ import platform.CoreMotion.CMPedometer
 import platform.Foundation.NSDate
 import platform.Foundation.NSProcessInfo
 import platform.Foundation.dateWithTimeIntervalSince1970
+import platform.Foundation.isLowPowerModeEnabled
 import platform.UIKit.UIDevice
 import kotlin.coroutines.resume
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -25,11 +26,11 @@ private object AppleDeviceSensors : DeviceSensors {
         return (level * 100f).toInt().coerceIn(0, 100)
     }
 
-    // Kotlin/Native names this boolean ObjC property after its `is`-prefixed getter, as a property:
-    // `isLowPowerModeEnabled` (no parens). The declared name `lowPowerModeEnabled` and the function
-    // form `isLowPowerModeEnabled()` both fail to resolve.
+    // Kotlin/Native exposes this NSProcessInfo category member as an extension function that needs its
+    // own import (`platform.Foundation.isLowPowerModeEnabled`) — without that import neither the call
+    // nor the bare property resolves.
     override fun isPowerSaveMode(): Boolean =
-        NSProcessInfo.processInfo.isLowPowerModeEnabled
+        NSProcessInfo.processInfo.isLowPowerModeEnabled()
 
     override suspend fun stepsSince(prevPointTimeMs: Long?, lastCumulative: Long?): StepSample {
         // iOS answers historical intervals directly — no cumulative needed.

--- a/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.apple.kt
+++ b/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.apple.kt
@@ -2,6 +2,7 @@ package id.homebase.core.location.tracking
 
 import platform.CoreMotion.CMPedometer
 import platform.Foundation.NSDate
+import platform.Foundation.NSProcessInfo
 import platform.Foundation.dateWithTimeIntervalSince1970
 import platform.UIKit.UIDevice
 import kotlin.coroutines.resume
@@ -23,6 +24,9 @@ private object AppleDeviceSensors : DeviceSensors {
         if (level < 0f) return null
         return (level * 100f).toInt().coerceIn(0, 100)
     }
+
+    override fun isPowerSaveMode(): Boolean =
+        NSProcessInfo.processInfo.lowPowerModeEnabled
 
     override suspend fun stepsSince(prevPointTimeMs: Long?, lastCumulative: Long?): StepSample {
         // iOS answers historical intervals directly — no cumulative needed.

--- a/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.apple.kt
+++ b/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.apple.kt
@@ -26,7 +26,7 @@ private object AppleDeviceSensors : DeviceSensors {
     }
 
     override fun isPowerSaveMode(): Boolean =
-        NSProcessInfo.processInfo.lowPowerModeEnabled
+        NSProcessInfo.processInfo.isLowPowerModeEnabled()
 
     override suspend fun stepsSince(prevPointTimeMs: Long?, lastCumulative: Long?): StepSample {
         // iOS answers historical intervals directly — no cumulative needed.

--- a/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.apple.kt
+++ b/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.apple.kt
@@ -30,8 +30,16 @@ private object AppleOneShotLocationProvider : OneShotLocationProvider {
 
     // maxAgeMs is unused on iOS: requestLocation() always delivers a fresh fix, so there is no stale
     // OS cache to age-bound (the Android bug #886 found does not apply here).
-    override suspend fun getCurrentFix(timeoutMs: Long, maxAgeMs: Long): GpsFixResult {
+    override suspend fun getCurrentFix(timeoutMs: Long, maxAgeMs: Long, cacheOnly: Boolean): GpsFixResult {
         if (!isLocationPermissionGranted()) return GpsFixResult.PermissionDenied
+        // Battery saver: serve the manager's cached location and never power the radio.
+        if (cacheOnly) {
+            return withContext(Dispatchers.Main) {
+                val cached = CLLocationManager().location
+                if (cached != null) GpsFixResult.Success(cached.toRawPoint(fg = true))
+                else GpsFixResult.Unavailable
+            }
+        }
         return withContext(Dispatchers.Main) {
             withTimeoutOrNull(timeoutMs) {
                 suspendCancellableCoroutine<GpsFixResult> { cont ->

--- a/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.apple.kt
+++ b/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.apple.kt
@@ -21,25 +21,24 @@ private const val TAG = "OneShotLocation.ios"
 actual fun createOneShotLocationProvider(): OneShotLocationProvider = AppleOneShotLocationProvider
 
 /**
- * CLLocationManager one-shot via `requestLocation()` (mirrors the former chat `LocationLauncher.native`,
- * but suspend and feeding a [RawLocationPoint]). Runs on the main run loop so delegate callbacks fire;
- * does not request permission (returns [GpsFixResult.PermissionDenied] when not authorized).
+ * CLLocationManager one-shot primitives (mirrors the former chat `LocationLauncher.native`, but
+ * suspend and feeding a [RawLocationPoint]). The fresh fix runs `requestLocation()` on the main run
+ * loop so delegate callbacks fire. The cache-vs-radio policy lives in
+ * [OneShotLocationProvider.getCurrentFix] (common); this file is just the platform I/O. Does not
+ * request permission (returns null / [GpsFixResult.PermissionDenied] when not authorized).
  */
 @OptIn(ExperimentalForeignApi::class)
 private object AppleOneShotLocationProvider : OneShotLocationProvider {
 
-    // maxAgeMs is unused on iOS: requestLocation() always delivers a fresh fix, so there is no stale
-    // OS cache to age-bound (the Android bug #886 found does not apply here).
-    override suspend fun getCurrentFix(timeoutMs: Long, maxAgeMs: Long, cacheOnly: Boolean): GpsFixResult {
-        if (!isLocationPermissionGranted()) return GpsFixResult.PermissionDenied
-        // Battery saver: serve the manager's cached location and never power the radio.
-        if (cacheOnly) {
-            return withContext(Dispatchers.Main) {
-                val cached = CLLocationManager().location
-                if (cached != null) GpsFixResult.Success(cached.toRawPoint(fg = true))
-                else GpsFixResult.Unavailable
-            }
+    override suspend fun lastKnownFix(): RawLocationPoint? {
+        if (!isLocationPermissionGranted()) return null
+        return withContext(Dispatchers.Main) {
+            CLLocationManager().location?.toRawPoint(fg = true)
         }
+    }
+
+    override suspend fun acquireFreshFix(timeoutMs: Long): GpsFixResult {
+        if (!isLocationPermissionGranted()) return GpsFixResult.PermissionDenied
         return withContext(Dispatchers.Main) {
             withTimeoutOrNull(timeoutMs) {
                 suspendCancellableCoroutine<GpsFixResult> { cont ->

--- a/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.apple.kt
+++ b/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.apple.kt
@@ -28,7 +28,9 @@ actual fun createOneShotLocationProvider(): OneShotLocationProvider = AppleOneSh
 @OptIn(ExperimentalForeignApi::class)
 private object AppleOneShotLocationProvider : OneShotLocationProvider {
 
-    override suspend fun getCurrentFix(timeoutMs: Long): GpsFixResult {
+    // maxAgeMs is unused on iOS: requestLocation() always delivers a fresh fix, so there is no stale
+    // OS cache to age-bound (the Android bug #886 found does not apply here).
+    override suspend fun getCurrentFix(timeoutMs: Long, maxAgeMs: Long): GpsFixResult {
         if (!isLocationPermissionGranted()) return GpsFixResult.PermissionDenied
         return withContext(Dispatchers.Main) {
             withTimeoutOrNull(timeoutMs) {

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LocationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LocationService.kt
@@ -10,8 +10,37 @@ import id.homebase.core.location.tracking.OneShotLocationProvider
 import id.homebase.core.location.tracking.RawLocationPoint
 import co.touchlab.kermit.Logger
 import id.homebase.core.permissions.isLocationPermissionGranted
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.time.Clock
+
+/**
+ * Why an on-demand GPS request needs [requestLatestGps] (and a reason). The continuous tracker only
+ * arms *interval* updates on foreground; a brief app-open closes before the first interval fires, so
+ * a backgrounded moving session (e.g. sailing) records almost nothing (#878 root cause A). The fix is
+ * to force a one-shot fix on app-open / push-receipt when the last point is stale. To keep that from
+ * draining the battery when triggers cluster, every on-demand path funnels through ONE idempotent,
+ * battery-aware primitive instead of calling the one-shot provider directly.
+ */
+enum class GpsRequestReason(
+    /** Serve the last-known fix without touching hardware if it's at most this old. */
+    val staleAfterMs: Long,
+    /** How long the one-shot acquisition may wait for a fix. */
+    val timeoutMs: Long,
+) {
+    /** App brought to the foreground — afford a longer wait + high accuracy, want a recent point. */
+    AppForeground(staleAfterMs = 60_000L, timeoutMs = 15_000L),
+
+    /** Foreground on-demand (the live map, `rememberCurrentGps`) — tight freshness. */
+    LiveMap(staleAfterMs = 30_000L, timeoutMs = 15_000L),
+
+    /** Background FCM wake — short execution window: short timeout, fall back fast to last-known. */
+    PushReceived(staleAfterMs = 120_000L, timeoutMs = 5_000L),
+}
 
 /**
  * The single public entry point for "this device's location", callable from anywhere in the app. It
@@ -22,6 +51,13 @@ import kotlin.time.Clock
  *
  * It deliberately does NOT contain the routing policy — it exposes it. The persist-vs-relay decision
  * stays in [LocationFixRouter] (#835).
+ *
+ * **[requestLatestGps] is the one on-demand capture path.** Every on-demand trigger — app-open, push
+ * receipt, live map — calls it, so the battery + timing policy lives in one place (#878):
+ *  - **single-flight:** concurrent/duplicate calls coalesce onto the in-flight acquisition,
+ *  - **battery-aware:** a min interval between real acquisitions + reuse of a recent last-known,
+ *  - **timing-aware:** foreground reasons wait longer at high accuracy; background reasons use a short
+ *    timeout and fall back fast to last-known.
  */
 class LocationService(
     private val coordinator: LocationTrackingCoordinator,
@@ -29,6 +65,7 @@ class LocationService(
     private val pointStore: LocationPointStore,
     private val preferences: LocationPreferences,
     private val oneShot: OneShotLocationProvider,
+    private val scope: CoroutineScope,
     private val permissionGranted: () -> Boolean = ::isLocationPermissionGranted,
     private val nowMs: () -> Long = { Clock.System.now().toEpochMilliseconds() },
 ) {
@@ -40,38 +77,89 @@ class LocationService(
     /** Whether the user allows persisting location history. */
     val allowLocationHistory: StateFlow<Boolean> get() = preferences.allowLocationHistory
 
+    // Single-flight + battery guard state, all touched only under [acquireMutex].
+    private val acquireMutex = Mutex()
+    private var inFlight: Deferred<GpsFixResult>? = null
+    private var lastAcquireStartMs = 0L
+
     /**
-     * Get the current position. Returns the cached [lastKnown] if it's fresher than [maxAgeMs];
-     * otherwise does a one-shot fetch (capped by [timeoutMs]). Does NOT request permission — returns
-     * [GpsFixResult.PermissionDenied] when not granted (the caller prompts first if needed).
+     * Get the current position, idempotently and battery-aware. Returns the cached [lastKnown] if it's
+     * fresher than [GpsRequestReason.staleAfterMs]; otherwise does a one-shot fetch (capped by
+     * [GpsRequestReason.timeoutMs]). Does NOT request permission — returns [GpsFixResult.PermissionDenied]
+     * when not granted (the caller prompts first if needed).
+     *
+     * Guarantees (so clustered triggers don't each acquire):
+     *  - **single-flight:** if an acquisition is already in flight, this awaits and returns *its* result
+     *    rather than starting a parallel GPS lock,
+     *  - **battery min-interval:** if a real acquisition started within [MIN_ACQUISITION_INTERVAL_MS],
+     *    skip acquiring and reuse the last-known fix (so an app-open plus several pushes in a minute
+     *    coalesce to at most one acquisition).
      *
      * On a fresh fetch the fix is fed back through [LocationFixRouter] so it isn't wasted: it updates
-     * the last-known dot and is persisted (if history is on) and/or relayed (if a share is live) —
-     * exactly like a fix from the continuous tracker.
+     * the last-known dot and is persisted (if history is on) and/or relayed (if a share is live).
+     * Because every [GpsRequestReason.staleAfterMs] is larger than the store's 20 s stationary-noise
+     * window, a forced fix is never dropped by that filter — no special-casing needed.
      */
-    suspend fun getCurrentGps(
-        maxAgeMs: Long = DEFAULT_MAX_AGE_MS,
-        timeoutMs: Long = OneShotLocationProvider.DEFAULT_TIMEOUT_MS,
-    ): GpsFixResult {
+    suspend fun requestLatestGps(reason: GpsRequestReason): GpsFixResult {
         lastKnown.value?.let {
             val age = nowMs() - it.t
-            if (age <= maxAgeMs) {
-                logger.d { "getCurrentGps: served cached fix (age=${age}ms)" }
+            if (age <= reason.staleAfterMs) {
+                logger.d { "requestLatestGps($reason): served last-known (age=${age}ms)" }
                 return GpsFixResult.Success(it)
             }
         }
         if (!permissionGranted()) {
-            logger.i { "getCurrentGps: location permission not granted" }
+            logger.i { "requestLatestGps($reason): location permission not granted" }
             return GpsFixResult.PermissionDenied
         }
-        val result = oneShot.getCurrentFix(timeoutMs)
+
+        val deferred = acquireMutex.withLock {
+            // Coalesce onto an acquisition already running.
+            inFlight?.let { if (it.isActive) return@withLock it }
+            // Battery guard: too soon since the last real acquisition — reuse last-known instead.
+            val sinceLast = nowMs() - lastAcquireStartMs
+            if (lastAcquireStartMs != 0L && sinceLast < MIN_ACQUISITION_INTERVAL_MS) {
+                val fallback = lastKnown.value?.let { GpsFixResult.Success(it) } ?: GpsFixResult.Timeout
+                logger.i {
+                    "requestLatestGps($reason): battery guard (since=${sinceLast}ms < " +
+                        "${MIN_ACQUISITION_INTERVAL_MS}ms) → reuse last-known ($fallback)"
+                }
+                return fallback
+            }
+            lastAcquireStartMs = nowMs()
+            scope.async { acquireAndRoute(reason) }.also { inFlight = it }
+        }
+        return try {
+            deferred.await()
+        } finally {
+            acquireMutex.withLock { if (inFlight === deferred) inFlight = null }
+        }
+    }
+
+    /** Run the one-shot acquisition and route a successful fix through the pipeline. */
+    private suspend fun acquireAndRoute(reason: GpsRequestReason): GpsFixResult {
+        val result = oneShot.getCurrentFix(reason.timeoutMs)
         if (result is GpsFixResult.Success) {
             router.submit(listOf(result.point)) // route so the fetched fix isn't wasted
-            logger.i { "getCurrentGps: fetched & routed (src=${result.point.src})" }
+            logger.i { "requestLatestGps($reason): fetched & routed (src=${result.point.src})" }
         } else {
-            logger.i { "getCurrentGps: fetch did not yield a fix ($result)" }
+            logger.i { "requestLatestGps($reason): fetch did not yield a fix ($result)" }
         }
         return result
+    }
+
+    /**
+     * Force a capture only when a persistent consumer (history or a live share) actually wants GPS —
+     * the gate for the automatic triggers (app-open, push) so we never spin up the radio when nobody
+     * is recording. The live map calls [requestLatestGps] directly (it holds a transient demand).
+     * Returns null when nothing wants a capture.
+     */
+    suspend fun forceCaptureIfTracking(reason: GpsRequestReason): GpsFixResult? {
+        if (!coordinator.isCaptureWanted()) {
+            logger.d { "forceCaptureIfTracking($reason): skipped — no persistent consumer wants GPS" }
+            return null
+        }
+        return requestLatestGps(reason)
     }
 
     /**
@@ -92,6 +180,10 @@ class LocationService(
         coordinator.setAllowLocationHistory(enabled)
 
     companion object {
-        const val DEFAULT_MAX_AGE_MS = 15_000L
+        /**
+         * Minimum spacing between real GPS acquisitions across all on-demand triggers. Clustered
+         * triggers within this window reuse the last-known fix instead of locking the radio again.
+         */
+        const val MIN_ACQUISITION_INTERVAL_MS = 60_000L
     }
 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LocationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LocationService.kt
@@ -68,6 +68,8 @@ class LocationService(
     private val scope: CoroutineScope,
     private val permissionGranted: () -> Boolean = ::isLocationPermissionGranted,
     private val nowMs: () -> Long = { Clock.System.now().toEpochMilliseconds() },
+    /** OS battery saver on → acquire cache-only (no radio). Wired in DI to DeviceSensors. */
+    private val powerSaveMode: () -> Boolean = { false },
 ) {
     private val logger = Logger.withTag("LocationService")
 
@@ -147,7 +149,14 @@ class LocationService(
         // Bound the OS last-known cache by the same staleness tolerance: if the cache is fresher than
         // staleAfterMs we reuse it (no radio), otherwise the provider powers the radio for a fresh fix.
         // Without this, a stale OS cache would satisfy the "force" and the radio would never run (#886).
-        val result = oneShot.getCurrentFix(timeoutMs = reason.timeoutMs, maxAgeMs = reason.staleAfterMs)
+        // Under OS battery saver we go cache-only — serve the OS last-known and never power the radio.
+        val cacheOnly = powerSaveMode()
+        if (cacheOnly) logger.d { "requestLatestGps($reason): battery saver on — cache-only (no radio)" }
+        val result = oneShot.getCurrentFix(
+            timeoutMs = reason.timeoutMs,
+            maxAgeMs = reason.staleAfterMs,
+            cacheOnly = cacheOnly,
+        )
         if (result is GpsFixResult.Success) {
             router.submit(listOf(result.point)) // route so the fetched fix isn't wasted
             logger.i { "requestLatestGps($reason): fetched & routed (src=${result.point.src})" }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LocationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LocationService.kt
@@ -88,6 +88,12 @@ class LocationService(
      * [GpsRequestReason.timeoutMs]). Does NOT request permission — returns [GpsFixResult.PermissionDenied]
      * when not granted (the caller prompts first if needed).
      *
+     * **Ungated — for interactive/transient consumers only (e.g. the live map, which holds its own
+     * transient demand and legitimately wants a fix even with history off and no share).** This will
+     * power the radio regardless of whether any persistent consumer is recording. **Automatic
+     * triggers (app-open, push, future activity transitions) must call [forceCaptureIfTracking]
+     * instead**, so the "only when something is recording" gate stays in one place.
+     *
      * Guarantees (so clustered triggers don't each acquire):
      *  - **single-flight:** if an acquisition is already in flight, this awaits and returns *its* result
      *    rather than starting a parallel GPS lock,
@@ -138,7 +144,10 @@ class LocationService(
 
     /** Run the one-shot acquisition and route a successful fix through the pipeline. */
     private suspend fun acquireAndRoute(reason: GpsRequestReason): GpsFixResult {
-        val result = oneShot.getCurrentFix(reason.timeoutMs)
+        // Bound the OS last-known cache by the same staleness tolerance: if the cache is fresher than
+        // staleAfterMs we reuse it (no radio), otherwise the provider powers the radio for a fresh fix.
+        // Without this, a stale OS cache would satisfy the "force" and the radio would never run (#886).
+        val result = oneShot.getCurrentFix(timeoutMs = reason.timeoutMs, maxAgeMs = reason.staleAfterMs)
         if (result is GpsFixResult.Success) {
             router.submit(listOf(result.point)) // route so the fetched fix isn't wasted
             logger.i { "requestLatestGps($reason): fetched & routed (src=${result.point.src})" }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LocationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LocationService.kt
@@ -158,6 +158,7 @@ class LocationService(
             timeoutMs = reason.timeoutMs,
             maxAgeMs = reason.staleAfterMs,
             cacheOnly = cacheOnly,
+            nowMs = nowMs,
         )
         if (result is GpsFixResult.Success) {
             router.submit(listOf(result.point)) // route so the fetched fix isn't wasted

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LocationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LocationService.kt
@@ -52,8 +52,10 @@ enum class GpsRequestReason(
  * It deliberately does NOT contain the routing policy — it exposes it. The persist-vs-relay decision
  * stays in [LocationFixRouter] (#835).
  *
- * **[requestLatestGps] is the one on-demand capture path.** Every on-demand trigger — app-open, push
- * receipt, live map — calls it, so the battery + timing policy lives in one place (#878):
+ * **[requestLatestGps] is the one on-demand capture path** — so the battery + timing policy lives in
+ * one place (#878). Automatic triggers (app-open, push, future activity transitions) MUST go through
+ * the gated [forceCaptureIfTracking] (which delegates here); only interactive/transient consumers
+ * (the live map) call [requestLatestGps] directly. Either way every fix flows through here:
  *  - **single-flight:** concurrent/duplicate calls coalesce onto the in-flight acquisition,
  *  - **battery-aware:** a min interval between real acquisitions + reuse of a recent last-known,
  *  - **timing-aware:** foreground reasons wait longer at high accuracy; background reasons use a short

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/RememberCurrentGps.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/RememberCurrentGps.kt
@@ -19,7 +19,7 @@ fun interface CurrentGpsLauncher {
 /**
  * The UI-side one-shot GPS entry point (replaces the former chat `rememberCurrentLocationLauncher`).
  * On [CurrentGpsLauncher.launch] it ensures location permission via the platform
- * [createPermissionsManager], then calls [LocationService.getCurrentGps] — which routes the fix
+ * [createPermissionsManager], then calls [LocationService.requestLatestGps] — which routes the fix
  * through the pipeline (last-known + history/relay) so it isn't wasted. The result is delivered to
  * [onResult]. The whole one-shot platform fetch lives in `OneShotLocationProvider`; this only adds
  * the permission prompt + coroutine plumbing.
@@ -33,7 +33,7 @@ fun rememberCurrentGps(onResult: (GpsFixResult) -> Unit): CurrentGpsLauncher {
     val permissionsManager = createPermissionsManager { type, status, _ ->
         if (type != PermissionType.LOCATION) return@createPermissionsManager
         if (status == PermissionStatus.GRANTED) {
-            scope.launch { onResultState.value(service.getCurrentGps()) }
+            scope.launch { onResultState.value(service.requestLatestGps(GpsRequestReason.LiveMap)) }
         } else {
             onResultState.value(GpsFixResult.PermissionDenied)
         }
@@ -43,7 +43,7 @@ fun rememberCurrentGps(onResult: (GpsFixResult) -> Unit): CurrentGpsLauncher {
         CurrentGpsLauncher {
             scope.launch {
                 if (permissionsManager.isPermissionGranted(PermissionType.LOCATION)) {
-                    onResultState.value(service.getCurrentGps())
+                    onResultState.value(service.requestLatestGps(GpsRequestReason.LiveMap))
                 } else {
                     permissionsManager.askPermission(PermissionType.LOCATION)
                 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.kt
@@ -23,6 +23,13 @@ interface DeviceSensors {
      * to subtract; iOS ignores it and queries the interval directly).
      */
     suspend fun stepsSince(prevPointTimeMs: Long?, lastCumulative: Long?): StepSample
+
+    /**
+     * Whether the OS battery saver / low-power mode is on. Cheap, synchronous, permission-less.
+     * Drives the location power policy (#878 follow-up): on-demand fixes go cache-only (no radio)
+     * and background uploads defer while saver is on. False where the OS has no such concept.
+     */
+    fun isPowerSaveMode(): Boolean
 }
 
 expect fun createDeviceSensors(): DeviceSensors

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTrackingCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTrackingCoordinator.kt
@@ -33,8 +33,19 @@ import kotlinx.coroutines.launch
  *   headless cold starts).
  * - App foreground transitions switch the capture profile and run a periodic foreground flush
  *   ticker; backgrounding stops the ticker (background flushes piggyback on batch deliveries).
- * - [onFlushDue] / [liveShareActive] are injected by DI (the uploader and the share service live in
- *   higher modules this one cannot reference). They must be cheap.
+ *   Entering the foreground also fires [onForegroundEntry] — a one-shot "force a fix if stale" so a
+ *   brief app-open records a point instead of waiting on the 30 s interval (#878 root cause A).
+ * - [onFlushDue] / [liveShareActive] / [onForegroundEntry] are injected by DI (the uploader, the
+ *   share service and LocationService live in higher modules / form a cycle this one cannot
+ *   reference directly). They must be cheap.
+ *
+ * **Product expectation (#878).** Without a persistent foreground-service notification (intentionally
+ * out of scope — it draws heavy Play/App Store review scrutiny), Android throttles background
+ * location to a few fixes/hour regardless of speed. So a long backgrounded moving session (sailing,
+ * screen off) is inherently sparse by design. What we *can* do without a notification: a fresh point
+ * on every app-open and push-receipt (via [onForegroundEntry] / the push path → LocationService's
+ * force-on-stale primitive) plus a good track while the app is open — all rate-limited by that
+ * primitive's battery guard.
  */
 class LocationTrackingCoordinator(
     private val preferences: LocationPreferences,
@@ -52,6 +63,14 @@ class LocationTrackingCoordinator(
      * process kill, via [onProcessStart]. Default false (no hold).
      */
     var liveShareActive: () -> Boolean = { false }
+
+    /**
+     * Wired in AppModule to LocationService.requestLatestGps(AppForeground). Fired once each time the
+     * app enters the foreground while a persistent consumer wants GPS ([isCaptureWanted]), so a brief
+     * app-open forces an immediate fix instead of waiting on the capture interval (#878). Must be
+     * cheap and self-throttling — LocationService's primitive owns the staleness + battery guard.
+     */
+    var onForegroundEntry: suspend () -> Unit = {}
 
     /** Transient GPS demands (live map open, one-shot fix, …). See [acquireTransientDemand]. */
     private val demand = GpsDemand()
@@ -71,6 +90,16 @@ class LocationTrackingCoordinator(
 
     /** GPS can only physically run with hardware present AND location permission granted. */
     private fun canRunGps(): Boolean = tracker.isAvailable && isLocationPermissionGranted()
+
+    /**
+     * Whether a *persistent* consumer (location history or an active live share) wants GPS and it can
+     * physically run. This is the gate for the automatic force-on-stale captures (app-open, push): we
+     * only spin up the radio on demand when something is actually recording/relaying. It deliberately
+     * excludes pure transient demands (the live map already acquires its own fix), and is narrower
+     * than [wantsGps], which also arms for transient holds.
+     */
+    fun isCaptureWanted(): Boolean =
+        (preferences.allowLocationHistory.value || liveShareActive()) && canRunGps()
 
     /** The acquisition profile for the current foreground state + consumers (#846). */
     private fun currentProfile(): TrackingProfile =
@@ -145,8 +174,15 @@ class LocationTrackingCoordinator(
         // A foreground/background transition changes both the desired profile (live/history × FG/BG)
         // and the flush ticker; re-applying the hold handles start/stop/profile/ticker + logging.
         observeAppForeground { foreground ->
+            val enteredForeground = foreground && !isForeground
             isForeground = foreground
             applyGpsHold()
+            // Force a fresh fix on app-open when a persistent consumer is recording — a brief open
+            // would otherwise close before the capture interval fires and record nothing (#878). The
+            // primitive self-throttles (staleness + battery guard), so re-firing here is cheap.
+            if (enteredForeground && isCaptureWanted()) {
+                scope.launch { onForegroundEntry() }
+            }
         }
     }
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTrackingCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTrackingCoordinator.kt
@@ -76,7 +76,16 @@ class LocationTrackingCoordinator(
     private val demand = GpsDemand()
 
     private var processStarted = false
-    private var isForeground = false
+
+    /**
+     * Whether the app is currently foregrounded, as last reported by [observeAppForeground]. Public
+     * so the uploader can decide whether to defer background uploads in battery saver (#878 follow-up:
+     * defer only while backgrounded; a foregrounded user always uploads). False until the first
+     * foreground observation (a headless cold start is correctly treated as background).
+     */
+    var isForeground = false
+        private set
+
     private var tickerJob: Job? = null
 
     // Tracks armed-state + the last-applied profile, so [applyGpsHold] logs only on transitions

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTrackingCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTrackingCoordinator.kt
@@ -65,10 +65,11 @@ class LocationTrackingCoordinator(
     var liveShareActive: () -> Boolean = { false }
 
     /**
-     * Wired in AppModule to LocationService.requestLatestGps(AppForeground). Fired once each time the
-     * app enters the foreground while a persistent consumer wants GPS ([isCaptureWanted]), so a brief
-     * app-open forces an immediate fix instead of waiting on the capture interval (#878). Must be
-     * cheap and self-throttling — LocationService's primitive owns the staleness + battery guard.
+     * Wired in AppModule to LocationService.forceCaptureIfTracking(AppForeground) — the gated entry
+     * for automatic triggers, NOT requestLatestGps directly. Fired once each time the app enters the
+     * foreground while a persistent consumer wants GPS ([isCaptureWanted]), so a brief app-open forces
+     * an immediate fix instead of waiting on the capture interval (#878). Must be cheap and
+     * self-throttling — LocationService's primitive owns the staleness + battery guard.
      */
     var onForegroundEntry: suspend () -> Unit = {}
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.kt
@@ -1,5 +1,8 @@
 package id.homebase.core.location.tracking
 
+import id.homebase.core.permissions.isLocationPermissionGranted
+import kotlin.time.Clock
+
 /** Result of a one-shot current-location request. */
 sealed interface GpsFixResult {
     data class Success(val point: RawLocationPoint) : GpsFixResult
@@ -17,28 +20,46 @@ sealed interface GpsFixResult {
 /**
  * A single current-GPS fix, on demand — the consolidated one-shot path (replaces the former
  * Composable `rememberCurrentLocationLauncher` in homebase-chat). Platform-wrapped via
- * [createOneShotLocationProvider]; desktop/web return [GpsFixResult.Unavailable].
+ * [createOneShotLocationProvider]; desktop/web have neither primitive and so always yield
+ * [GpsFixResult.Unavailable].
+ *
+ * Platforms implement only the two **dumb I/O primitives** ([lastKnownFix], [acquireFreshFix]); the
+ * **cache-vs-radio policy** lives once in [getCurrentFix] here in common so it can't drift between
+ * Android and iOS (#886 review):
+ *  - `cacheOnly` (OS battery saver) → serve the OS last-known at any age, never power the radio,
+ *  - else serve the OS last-known when it's within `maxAgeMs`, otherwise acquire a fresh fix.
  *
  * It does **not** request permission (it's callable off the UI) — returns [GpsFixResult.PermissionDenied]
  * when not granted. Callers that need to prompt should request permission first (see `rememberCurrentGps`).
- * The returned fix is fed back through [LocationFixRouter] by `LocationService.getCurrentGps` so it's
+ * The returned fix is fed back through [LocationFixRouter] by `LocationService.requestLatestGps` so it's
  * not wasted — it updates the last-known dot and is persisted/relayed per the usual routing.
  */
 interface OneShotLocationProvider {
+    /** The OS last-known fix (carrying its capture time in [RawLocationPoint.t]), or null if none. No radio. */
+    suspend fun lastKnownFix(): RawLocationPoint?
+
+    /** Power the GPS radio for a fresh fix, capped by [timeoutMs]. */
+    suspend fun acquireFreshFix(timeoutMs: Long): GpsFixResult
+
     /**
-     * Return a current fix. A platform may serve a recent OS last-known fix without powering the GPS
-     * radio, but ONLY if it is no older than [maxAgeMs]; an older cache must fall through to a live
-     * acquisition (capped by [timeoutMs]). The age bound is what makes a force-on-stale capture
-     * actually spend battery on a fresh fix instead of echoing a stale cached one (#878 / #886 review).
-     *
-     * When [cacheOnly] is true (OS battery saver on), return the OS last-known fix at ANY age and
-     * NEVER power the radio — return [GpsFixResult.Unavailable] when there is no cached fix at all.
+     * The cache-vs-radio orchestration, shared across platforms (do not override). See the class doc
+     * for the policy. [nowMs] is injected so the age check is testable.
      */
     suspend fun getCurrentFix(
         timeoutMs: Long = DEFAULT_TIMEOUT_MS,
         maxAgeMs: Long = DEFAULT_MAX_AGE_MS,
         cacheOnly: Boolean = false,
-    ): GpsFixResult
+        nowMs: () -> Long = { Clock.System.now().toEpochMilliseconds() },
+    ): GpsFixResult {
+        if (!isLocationPermissionGranted()) return GpsFixResult.PermissionDenied
+        val cached = lastKnownFix()
+        // Battery saver: serve whatever the OS already has and never power the radio.
+        if (cacheOnly) return cached?.let { GpsFixResult.Success(it) } ?: GpsFixResult.Unavailable
+        // A cache fresher than the staleness tolerance avoids the radio; an older one falls through
+        // so a force-on-stale capture actually acquires a fresh fix instead of echoing stale cache.
+        if (cached != null && nowMs() - cached.t <= maxAgeMs) return GpsFixResult.Success(cached)
+        return acquireFreshFix(timeoutMs)
+    }
 
     companion object {
         const val DEFAULT_TIMEOUT_MS = 15_000L

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.kt
@@ -25,10 +25,22 @@ sealed interface GpsFixResult {
  * not wasted — it updates the last-known dot and is persisted/relayed per the usual routing.
  */
 interface OneShotLocationProvider {
-    suspend fun getCurrentFix(timeoutMs: Long = DEFAULT_TIMEOUT_MS): GpsFixResult
+    /**
+     * Return a current fix. A platform may serve a recent OS last-known fix without powering the GPS
+     * radio, but ONLY if it is no older than [maxAgeMs]; an older cache must fall through to a live
+     * acquisition (capped by [timeoutMs]). The age bound is what makes a force-on-stale capture
+     * actually spend battery on a fresh fix instead of echoing a stale cached one (#878 / #886 review).
+     */
+    suspend fun getCurrentFix(
+        timeoutMs: Long = DEFAULT_TIMEOUT_MS,
+        maxAgeMs: Long = DEFAULT_MAX_AGE_MS,
+    ): GpsFixResult
 
     companion object {
         const val DEFAULT_TIMEOUT_MS = 15_000L
+
+        /** Default max age for accepting an OS last-known fix before forcing a live acquisition. */
+        const val DEFAULT_MAX_AGE_MS = 15_000L
     }
 }
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.kt
@@ -30,10 +30,14 @@ interface OneShotLocationProvider {
      * radio, but ONLY if it is no older than [maxAgeMs]; an older cache must fall through to a live
      * acquisition (capped by [timeoutMs]). The age bound is what makes a force-on-stale capture
      * actually spend battery on a fresh fix instead of echoing a stale cached one (#878 / #886 review).
+     *
+     * When [cacheOnly] is true (OS battery saver on), return the OS last-known fix at ANY age and
+     * NEVER power the radio — return [GpsFixResult.Unavailable] when there is no cached fix at all.
      */
     suspend fun getCurrentFix(
         timeoutMs: Long = DEFAULT_TIMEOUT_MS,
         maxAgeMs: Long = DEFAULT_MAX_AGE_MS,
+        cacheOnly: Boolean = false,
     ): GpsFixResult
 
     companion object {

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationEntry.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationEntry.kt
@@ -2,6 +2,8 @@ package id.homebase.core.notifications
 
 import co.touchlab.kermit.Logger
 import id.homebase.core.auth.AuthConnectionCoordinator
+import id.homebase.core.location.GpsRequestReason
+import id.homebase.core.location.LocationService
 import id.homebase.core.sync.BackgroundSyncOrchestrator
 import id.homebase.core.sync.SyncOutcome
 import kotlinx.coroutines.CoroutineScope
@@ -37,6 +39,7 @@ class NotificationEntry(
     private val notificationService: NotificationService,
     private val orchestrator: BackgroundSyncOrchestrator,
     private val authConnectionCoordinator: AuthConnectionCoordinator,
+    private val locationService: LocationService,
 ) {
 
     /**
@@ -54,7 +57,15 @@ class NotificationEntry(
             "onPushArrived title=$title body=$body data.size=${data.size}"
         }
         notificationService.onFcmMessageReceived(title, body, data)
-        return orchestrator.syncIfAuthenticated()
+        val outcome = orchestrator.syncIfAuthenticated()
+        // A push briefly wakes the process — an opportunistic free moment to record a fresh point if
+        // tracking is on and the last one is stale (#878). Best-effort within the short FCM window
+        // (the primitive uses a short background timeout + last-known fallback); never fail the push
+        // sync over it. Won't help the no-signal case (no cell → no push), but adds samples whenever
+        // the user is reachable.
+        runCatching { locationService.forceCaptureIfTracking(GpsRequestReason.PushReceived) }
+            .onFailure { Logger.w(tag = "NotificationEntry", throwable = it) { "push force-capture failed" } }
+        return outcome
     }
 
     /**

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.jvm.kt
@@ -7,4 +7,6 @@ private object NoDeviceSensors : DeviceSensors {
     override suspend fun batteryPercent(): Int? = null
     override suspend fun stepsSince(prevPointTimeMs: Long?, lastCumulative: Long?): StepSample =
         StepSample(null, null)
+
+    override fun isPowerSaveMode(): Boolean = false
 }

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.jvm.kt
@@ -4,5 +4,5 @@ actual fun createOneShotLocationProvider(): OneShotLocationProvider = Unavailabl
 
 /** Desktop has no GPS. */
 private object UnavailableOneShotLocationProvider : OneShotLocationProvider {
-    override suspend fun getCurrentFix(timeoutMs: Long): GpsFixResult = GpsFixResult.Unavailable
+    override suspend fun getCurrentFix(timeoutMs: Long, maxAgeMs: Long): GpsFixResult = GpsFixResult.Unavailable
 }

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.jvm.kt
@@ -4,5 +4,6 @@ actual fun createOneShotLocationProvider(): OneShotLocationProvider = Unavailabl
 
 /** Desktop has no GPS. */
 private object UnavailableOneShotLocationProvider : OneShotLocationProvider {
-    override suspend fun getCurrentFix(timeoutMs: Long, maxAgeMs: Long): GpsFixResult = GpsFixResult.Unavailable
+    override suspend fun getCurrentFix(timeoutMs: Long, maxAgeMs: Long, cacheOnly: Boolean): GpsFixResult =
+        GpsFixResult.Unavailable
 }

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.jvm.kt
@@ -4,6 +4,6 @@ actual fun createOneShotLocationProvider(): OneShotLocationProvider = Unavailabl
 
 /** Desktop has no GPS. */
 private object UnavailableOneShotLocationProvider : OneShotLocationProvider {
-    override suspend fun getCurrentFix(timeoutMs: Long, maxAgeMs: Long, cacheOnly: Boolean): GpsFixResult =
-        GpsFixResult.Unavailable
+    override suspend fun lastKnownFix(): RawLocationPoint? = null
+    override suspend fun acquireFreshFix(timeoutMs: Long): GpsFixResult = GpsFixResult.Unavailable
 }

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/LocationServiceTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/LocationServiceTest.kt
@@ -41,6 +41,7 @@ class LocationServiceTest {
     private class NoSensors : DeviceSensors {
         override suspend fun batteryPercent(): Int? = null
         override suspend fun stepsSince(prevPointTimeMs: Long?, lastCumulative: Long?) = StepSample(null, null)
+        override fun isPowerSaveMode(): Boolean = false
     }
 
     private open class FakeTracker(override val isAvailable: Boolean) : LocationTracker {
@@ -62,11 +63,13 @@ class LocationServiceTest {
         var calls = 0
         val timeouts = mutableListOf<Long>()
         val maxAges = mutableListOf<Long>()
+        val cacheOnlyCalls = mutableListOf<Boolean>()
 
-        override suspend fun getCurrentFix(timeoutMs: Long, maxAgeMs: Long): GpsFixResult {
+        override suspend fun getCurrentFix(timeoutMs: Long, maxAgeMs: Long, cacheOnly: Boolean): GpsFixResult {
             calls++
             timeouts += timeoutMs
             maxAges += maxAgeMs
+            cacheOnlyCalls += cacheOnly
             gate?.await() // lets a test hold two callers inside one acquisition (single-flight)
             return result
         }
@@ -78,6 +81,7 @@ class LocationServiceTest {
         tracker: LocationTracker = UnavailableTracker,
         clock: TestClock = TestClock(now),
         allowHistory: Boolean = false,
+        powerSave: Boolean = false,
         body: suspend TestScope.(LocationService, LocationPointStore, TestClock) -> Unit,
     ) = runTest {
         val dispatcher = StandardTestDispatcher(testScheduler)
@@ -106,6 +110,7 @@ class LocationServiceTest {
                 scope = this,
                 permissionGranted = { permission },
                 nowMs = { clock.ms },
+                powerSaveMode = { powerSave },
             )
             this.body(service, store, clock)
         } finally {
@@ -258,6 +263,26 @@ class LocationServiceTest {
         runServiceTest(permission = true, oneShot = oneShot) { service, _, _ ->
             service.requestLatestGps(GpsRequestReason.PushReceived)
             assertEquals(GpsRequestReason.PushReceived.staleAfterMs, oneShot.maxAges.single())
+        }
+    }
+
+    @Test
+    fun batterySaverAcquiresCacheOnly() {
+        // Power save on → acquisition is cache-only (no radio).
+        val oneShot = FakeOneShot(GpsFixResult.Success(point(t = 990_000)))
+        runServiceTest(permission = true, oneShot = oneShot, powerSave = true) { service, _, _ ->
+            service.requestLatestGps(GpsRequestReason.AppForeground)
+            assertEquals(1, oneShot.calls)
+            assertEquals(true, oneShot.cacheOnlyCalls.single())
+        }
+    }
+
+    @Test
+    fun nonSaverAllowsRadio() {
+        val oneShot = FakeOneShot(GpsFixResult.Timeout)
+        runServiceTest(permission = true, oneShot = oneShot, powerSave = false) { service, _, _ ->
+            service.requestLatestGps(GpsRequestReason.AppForeground)
+            assertEquals(false, oneShot.cacheOnlyCalls.single())
         }
     }
 

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/LocationServiceTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/LocationServiceTest.kt
@@ -61,10 +61,12 @@ class LocationServiceTest {
     ) : OneShotLocationProvider {
         var calls = 0
         val timeouts = mutableListOf<Long>()
+        val maxAges = mutableListOf<Long>()
 
-        override suspend fun getCurrentFix(timeoutMs: Long): GpsFixResult {
+        override suspend fun getCurrentFix(timeoutMs: Long, maxAgeMs: Long): GpsFixResult {
             calls++
             timeouts += timeoutMs
+            maxAges += maxAgeMs
             gate?.await() // lets a test hold two callers inside one acquisition (single-flight)
             return result
         }
@@ -245,6 +247,17 @@ class LocationServiceTest {
         runServiceTest(permission = true, oneShot = oneShot) { service, _, _ ->
             service.requestLatestGps(GpsRequestReason.PushReceived)
             assertEquals(5_000L, oneShot.timeouts.single())
+        }
+    }
+
+    @Test
+    fun passesReasonStalenessAsCacheMaxAge() {
+        // The provider is told to accept an OS last-known cache only within the reason's staleness
+        // tolerance, otherwise power the radio (#886 fix 1).
+        val oneShot = FakeOneShot(GpsFixResult.Timeout)
+        runServiceTest(permission = true, oneShot = oneShot) { service, _, _ ->
+            service.requestLatestGps(GpsRequestReason.PushReceived)
+            assertEquals(GpsRequestReason.PushReceived.staleAfterMs, oneShot.maxAges.single())
         }
     }
 

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/LocationServiceTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/LocationServiceTest.kt
@@ -12,18 +12,28 @@ import id.homebase.core.location.tracking.OneShotLocationProvider
 import id.homebase.core.location.tracking.RawLocationPoint
 import id.homebase.core.location.tracking.StepSample
 import id.homebase.core.location.tracking.TrackingProfile
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 
-/** Pins [LocationService.getCurrentGps]: fresh-cache short-circuit, permission gate, and that a
- *  fetched fix is routed back through the pipeline (so it's not wasted). */
+/**
+ * Pins [LocationService.requestLatestGps] / [LocationService.forceCaptureIfTracking]: the
+ * fresh-last-known short-circuit, permission gate, single-flight coalescing, the battery
+ * min-interval guard, per-reason timing, the consumer gate, and that a fetched fix is routed back
+ * through the pipeline (so it's not wasted, and survives the stationary-noise filter).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
 class LocationServiceTest {
 
-    private val now = 100_000L
+    private val now = 1_000_000L
 
     private fun point(t: Long, lon: Double = 13.0) =
         RawLocationPoint(t = t, lat = 52.0, lon = lon, acc = 10.0, src = "gps", fg = true)
@@ -33,17 +43,29 @@ class LocationServiceTest {
         override suspend fun stepsSince(prevPointTimeMs: Long?, lastCumulative: Long?) = StepSample(null, null)
     }
 
-    private object UnavailableTracker : LocationTracker {
-        override val isAvailable = false
+    private open class FakeTracker(override val isAvailable: Boolean) : LocationTracker {
         override fun start(profile: TrackingProfile) {}
         override fun setProfile(profile: TrackingProfile) {}
         override fun stop() {}
     }
 
-    private class FakeOneShot(val result: GpsFixResult) : OneShotLocationProvider {
+    private object UnavailableTracker : FakeTracker(isAvailable = false)
+    private object AvailableTracker : FakeTracker(isAvailable = true)
+
+    /** Mutable clock so tests can advance time across the min-interval guard window. */
+    private class TestClock(var ms: Long)
+
+    private class FakeOneShot(
+        var result: GpsFixResult,
+        private val gate: CompletableDeferred<Unit>? = null,
+    ) : OneShotLocationProvider {
         var calls = 0
+        val timeouts = mutableListOf<Long>()
+
         override suspend fun getCurrentFix(timeoutMs: Long): GpsFixResult {
             calls++
+            timeouts += timeoutMs
+            gate?.await() // lets a test hold two callers inside one acquisition (single-flight)
             return result
         }
     }
@@ -51,7 +73,10 @@ class LocationServiceTest {
     private fun runServiceTest(
         permission: Boolean,
         oneShot: FakeOneShot,
-        body: suspend (LocationService, LocationPointStore) -> Unit,
+        tracker: LocationTracker = UnavailableTracker,
+        clock: TestClock = TestClock(now),
+        allowHistory: Boolean = false,
+        body: suspend TestScope.(LocationService, LocationPointStore, TestClock) -> Unit,
     ) = runTest {
         val dispatcher = StandardTestDispatcher(testScheduler)
         val db = DatabaseManager(
@@ -61,6 +86,7 @@ class LocationServiceTest {
         )
         try {
             val preferences = LocationPreferences(db)
+            if (allowHistory) preferences.setAllowLocationHistory(true)
             val store = LocationPointStore(db, NoSensors())
             val router = LocationFixRouter(
                 store = store,
@@ -68,28 +94,29 @@ class LocationServiceTest {
                 persistAsHistory = { store.persistHistory(it) },
                 relayLatest = { },
             )
-            val coordinator = LocationTrackingCoordinator(preferences, UnavailableTracker, this)
+            val coordinator = LocationTrackingCoordinator(preferences, tracker, this)
             val service = LocationService(
                 coordinator = coordinator,
                 router = router,
                 pointStore = store,
                 preferences = preferences,
                 oneShot = oneShot,
+                scope = this,
                 permissionGranted = { permission },
-                nowMs = { now },
+                nowMs = { clock.ms },
             )
-            body(service, store)
+            this.body(service, store, clock)
         } finally {
             db.close()
         }
     }
 
     @Test
-    fun returnsCachedFixWhenFresh() {
+    fun returnsLastKnownWhenFresh() {
         val oneShot = FakeOneShot(GpsFixResult.Unavailable)
-        runServiceTest(permission = false, oneShot = oneShot) { service, store ->
-            store.publishLastKnown(point(t = now)) // age 0 < maxAge
-            val result = service.getCurrentGps()
+        runServiceTest(permission = false, oneShot = oneShot) { service, store, _ ->
+            store.publishLastKnown(point(t = now)) // age 0 < staleAfterMs
+            val result = service.requestLatestGps(GpsRequestReason.AppForeground)
             assertIs<GpsFixResult.Success>(result)
             assertEquals(now, result.point.t)
             assertEquals(0, oneShot.calls) // short-circuited before any fetch
@@ -97,10 +124,22 @@ class LocationServiceTest {
     }
 
     @Test
+    fun acquiresWhenLastKnownStale() {
+        val oneShot = FakeOneShot(GpsFixResult.Success(point(t = 999_000, lon = 9.0)))
+        runServiceTest(permission = true, oneShot = oneShot) { service, store, _ ->
+            // staleAfterMs(AppForeground)=60s; seed a point 90s old so it must re-acquire.
+            store.publishLastKnown(point(t = now - 90_000))
+            val result = service.requestLatestGps(GpsRequestReason.AppForeground)
+            assertIs<GpsFixResult.Success>(result)
+            assertEquals(1, oneShot.calls)
+        }
+    }
+
+    @Test
     fun returnsPermissionDeniedWhenNotGrantedAndNoFreshCache() {
         val oneShot = FakeOneShot(GpsFixResult.Success(point(t = 50_000)))
-        runServiceTest(permission = false, oneShot = oneShot) { service, _ ->
-            val result = service.getCurrentGps()
+        runServiceTest(permission = false, oneShot = oneShot) { service, _, _ ->
+            val result = service.requestLatestGps(GpsRequestReason.AppForeground)
             assertIs<GpsFixResult.PermissionDenied>(result)
             assertEquals(0, oneShot.calls)
         }
@@ -108,13 +147,13 @@ class LocationServiceTest {
 
     @Test
     fun routesFetchedFixThroughPipeline() {
-        val oneShot = FakeOneShot(GpsFixResult.Success(point(t = 50_000, lon = 9.0)))
-        runServiceTest(permission = true, oneShot = oneShot) { service, store ->
-            val result = service.getCurrentGps()
+        val oneShot = FakeOneShot(GpsFixResult.Success(point(t = 990_000, lon = 9.0)))
+        runServiceTest(permission = true, oneShot = oneShot) { service, store, _ ->
+            val result = service.requestLatestGps(GpsRequestReason.AppForeground)
             assertIs<GpsFixResult.Success>(result)
             assertEquals(1, oneShot.calls)
             // Routed: the fetched fix became the last-known position (router.submit → publishLastKnown).
-            assertEquals(50_000, store.lastPoint.value?.t)
+            assertEquals(990_000, store.lastPoint.value?.t)
             assertEquals(9.0, store.lastPoint.value?.lon)
         }
     }
@@ -122,11 +161,118 @@ class LocationServiceTest {
     @Test
     fun timeoutPassesThroughWithoutRouting() {
         val oneShot = FakeOneShot(GpsFixResult.Timeout)
-        runServiceTest(permission = true, oneShot = oneShot) { service, store ->
-            val result = service.getCurrentGps()
+        runServiceTest(permission = true, oneShot = oneShot) { service, store, _ ->
+            val result = service.requestLatestGps(GpsRequestReason.AppForeground)
             assertIs<GpsFixResult.Timeout>(result)
             assertEquals(1, oneShot.calls)
             assertNull(store.lastPoint.value) // nothing routed
+        }
+    }
+
+    @Test
+    fun concurrentRequestsCoalesceToOneAcquisition() {
+        val gate = CompletableDeferred<Unit>()
+        val oneShot = FakeOneShot(GpsFixResult.Success(point(t = 990_000)), gate = gate)
+        runServiceTest(permission = true, oneShot = oneShot) { service, _, _ ->
+            // Both callers see a stale (absent) last-known and race into requestLatestGps.
+            val a = async { service.requestLatestGps(GpsRequestReason.AppForeground) }
+            val b = async { service.requestLatestGps(GpsRequestReason.AppForeground) }
+            advanceUntilIdle() // both reach await(); the single acquisition is parked on the gate
+            gate.complete(Unit)
+            advanceUntilIdle()
+
+            assertEquals(1, oneShot.calls) // single-flight: only one real acquisition
+            val ra = a.await()
+            val rb = b.await()
+            assertIs<GpsFixResult.Success>(ra)
+            assertIs<GpsFixResult.Success>(rb)
+            assertEquals(990_000, ra.point.t)
+            assertEquals(990_000, rb.point.t)
+        }
+    }
+
+    @Test
+    fun batteryGuardReusesLastKnownWithinMinInterval() {
+        // First acquisition fails (Timeout) so it leaves a recent lastAcquireStartMs but does NOT
+        // refresh last-known; the seeded stale point stays the best we have.
+        val oneShot = FakeOneShot(GpsFixResult.Timeout)
+        val clock = TestClock(now)
+        runServiceTest(permission = true, oneShot = oneShot, clock = clock) { service, store, c ->
+            val stale = point(t = now - 200_000, lon = 7.0) // older than every staleAfterMs
+            store.publishLastKnown(stale)
+
+            val first = service.requestLatestGps(GpsRequestReason.AppForeground)
+            assertIs<GpsFixResult.Timeout>(first)
+            assertEquals(1, oneShot.calls)
+
+            // 30s later — still within MIN_ACQUISITION_INTERVAL_MS (60s) — must NOT re-acquire.
+            c.ms = now + 30_000
+            val second = service.requestLatestGps(GpsRequestReason.AppForeground)
+            assertEquals(1, oneShot.calls) // battery guard skipped the second acquisition
+            assertIs<GpsFixResult.Success>(second)
+            assertEquals(stale.t, second.point.t) // reused last-known within tolerance
+        }
+    }
+
+    @Test
+    fun acquiresAgainAfterMinIntervalElapses() {
+        val oneShot = FakeOneShot(GpsFixResult.Timeout)
+        val clock = TestClock(now)
+        runServiceTest(permission = true, oneShot = oneShot, clock = clock) { service, store, c ->
+            store.publishLastKnown(point(t = now - 200_000))
+            service.requestLatestGps(GpsRequestReason.AppForeground)
+            assertEquals(1, oneShot.calls)
+
+            // Past the 60s min-interval — a fresh acquisition is allowed.
+            c.ms = now + LocationService.MIN_ACQUISITION_INTERVAL_MS + 1
+            service.requestLatestGps(GpsRequestReason.AppForeground)
+            assertEquals(2, oneShot.calls)
+        }
+    }
+
+    @Test
+    fun foregroundReasonUsesLongTimeout() {
+        val oneShot = FakeOneShot(GpsFixResult.Timeout)
+        runServiceTest(permission = true, oneShot = oneShot) { service, _, _ ->
+            service.requestLatestGps(GpsRequestReason.AppForeground)
+            assertEquals(15_000L, oneShot.timeouts.single())
+        }
+    }
+
+    @Test
+    fun pushReasonUsesShortTimeout() {
+        val oneShot = FakeOneShot(GpsFixResult.Timeout)
+        runServiceTest(permission = true, oneShot = oneShot) { service, _, _ ->
+            service.requestLatestGps(GpsRequestReason.PushReceived)
+            assertEquals(5_000L, oneShot.timeouts.single())
+        }
+    }
+
+    @Test
+    fun forceCaptureSkippedWhenNothingTracking() {
+        val oneShot = FakeOneShot(GpsFixResult.Success(point(t = 990_000)))
+        // UnavailableTracker + no history → isCaptureWanted() is false.
+        runServiceTest(permission = true, oneShot = oneShot, tracker = UnavailableTracker) { service, _, _ ->
+            val result = service.forceCaptureIfTracking(GpsRequestReason.PushReceived)
+            assertNull(result)
+            assertEquals(0, oneShot.calls)
+        }
+    }
+
+    @Test
+    fun forceCaptureProceedsWhenHistoryOn() {
+        val oneShot = FakeOneShot(GpsFixResult.Success(point(t = 990_000, lon = 5.0)))
+        // AvailableTracker + history on + (jvm) permission granted → isCaptureWanted() is true.
+        runServiceTest(
+            permission = true,
+            oneShot = oneShot,
+            tracker = AvailableTracker,
+            allowHistory = true,
+        ) { service, store, _ ->
+            val result = service.forceCaptureIfTracking(GpsRequestReason.PushReceived)
+            assertIs<GpsFixResult.Success>(result)
+            assertEquals(1, oneShot.calls)
+            assertEquals(990_000, store.lastPoint.value?.t) // routed + persisted (history on)
         }
     }
 }

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/LocationServiceTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/LocationServiceTest.kt
@@ -27,8 +27,11 @@ import kotlin.test.assertNull
 /**
  * Pins [LocationService.requestLatestGps] / [LocationService.forceCaptureIfTracking]: the
  * fresh-last-known short-circuit, permission gate, single-flight coalescing, the battery
- * min-interval guard, per-reason timing, the consumer gate, and that a fetched fix is routed back
- * through the pipeline (so it's not wasted, and survives the stationary-noise filter).
+ * min-interval guard, per-reason timing, the consumer gate, and routing back through the pipeline.
+ *
+ * The one-shot fake supplies the two platform primitives ([OneShotLocationProvider.lastKnownFix] /
+ * [OneShotLocationProvider.acquireFreshFix]); the cache-vs-radio orchestration is the real common
+ * [OneShotLocationProvider.getCurrentFix], so these tests also exercise the cache/age/cacheOnly path.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class LocationServiceTest {
@@ -56,22 +59,29 @@ class LocationServiceTest {
     /** Mutable clock so tests can advance time across the min-interval guard window. */
     private class TestClock(var ms: Long)
 
+    /**
+     * Supplies the two platform primitives. [cached] is the OS last-known; [fresh] is what a radio
+     * acquisition yields. Counters let tests assert whether the radio was actually used.
+     */
     private class FakeOneShot(
-        var result: GpsFixResult,
+        var fresh: GpsFixResult = GpsFixResult.Timeout,
+        var cached: RawLocationPoint? = null,
         private val gate: CompletableDeferred<Unit>? = null,
     ) : OneShotLocationProvider {
-        var calls = 0
-        val timeouts = mutableListOf<Long>()
-        val maxAges = mutableListOf<Long>()
-        val cacheOnlyCalls = mutableListOf<Boolean>()
+        var freshCalls = 0
+        var lastKnownCalls = 0
+        val freshTimeouts = mutableListOf<Long>()
 
-        override suspend fun getCurrentFix(timeoutMs: Long, maxAgeMs: Long, cacheOnly: Boolean): GpsFixResult {
-            calls++
-            timeouts += timeoutMs
-            maxAges += maxAgeMs
-            cacheOnlyCalls += cacheOnly
+        override suspend fun lastKnownFix(): RawLocationPoint? {
+            lastKnownCalls++
+            return cached
+        }
+
+        override suspend fun acquireFreshFix(timeoutMs: Long): GpsFixResult {
+            freshCalls++
+            freshTimeouts += timeoutMs
             gate?.await() // lets a test hold two callers inside one acquisition (single-flight)
-            return result
+            return fresh
         }
     }
 
@@ -120,45 +130,47 @@ class LocationServiceTest {
 
     @Test
     fun returnsLastKnownWhenFresh() {
-        val oneShot = FakeOneShot(GpsFixResult.Unavailable)
+        val oneShot = FakeOneShot()
         runServiceTest(permission = false, oneShot = oneShot) { service, store, _ ->
             store.publishLastKnown(point(t = now)) // age 0 < staleAfterMs
             val result = service.requestLatestGps(GpsRequestReason.AppForeground)
             assertIs<GpsFixResult.Success>(result)
             assertEquals(now, result.point.t)
-            assertEquals(0, oneShot.calls) // short-circuited before any fetch
+            assertEquals(0, oneShot.freshCalls) // short-circuited before any provider call
+            assertEquals(0, oneShot.lastKnownCalls)
         }
     }
 
     @Test
     fun acquiresWhenLastKnownStale() {
-        val oneShot = FakeOneShot(GpsFixResult.Success(point(t = 999_000, lon = 9.0)))
+        val oneShot = FakeOneShot(fresh = GpsFixResult.Success(point(t = 999_000, lon = 9.0)))
         runServiceTest(permission = true, oneShot = oneShot) { service, store, _ ->
             // staleAfterMs(AppForeground)=60s; seed a point 90s old so it must re-acquire.
             store.publishLastKnown(point(t = now - 90_000))
             val result = service.requestLatestGps(GpsRequestReason.AppForeground)
             assertIs<GpsFixResult.Success>(result)
-            assertEquals(1, oneShot.calls)
+            assertEquals(1, oneShot.freshCalls)
         }
     }
 
     @Test
     fun returnsPermissionDeniedWhenNotGrantedAndNoFreshCache() {
-        val oneShot = FakeOneShot(GpsFixResult.Success(point(t = 50_000)))
+        val oneShot = FakeOneShot(fresh = GpsFixResult.Success(point(t = 50_000)))
         runServiceTest(permission = false, oneShot = oneShot) { service, _, _ ->
             val result = service.requestLatestGps(GpsRequestReason.AppForeground)
             assertIs<GpsFixResult.PermissionDenied>(result)
-            assertEquals(0, oneShot.calls)
+            assertEquals(0, oneShot.freshCalls)
+            assertEquals(0, oneShot.lastKnownCalls)
         }
     }
 
     @Test
     fun routesFetchedFixThroughPipeline() {
-        val oneShot = FakeOneShot(GpsFixResult.Success(point(t = 990_000, lon = 9.0)))
+        val oneShot = FakeOneShot(fresh = GpsFixResult.Success(point(t = 990_000, lon = 9.0)))
         runServiceTest(permission = true, oneShot = oneShot) { service, store, _ ->
             val result = service.requestLatestGps(GpsRequestReason.AppForeground)
             assertIs<GpsFixResult.Success>(result)
-            assertEquals(1, oneShot.calls)
+            assertEquals(1, oneShot.freshCalls)
             // Routed: the fetched fix became the last-known position (router.submit → publishLastKnown).
             assertEquals(990_000, store.lastPoint.value?.t)
             assertEquals(9.0, store.lastPoint.value?.lon)
@@ -167,11 +179,11 @@ class LocationServiceTest {
 
     @Test
     fun timeoutPassesThroughWithoutRouting() {
-        val oneShot = FakeOneShot(GpsFixResult.Timeout)
+        val oneShot = FakeOneShot(fresh = GpsFixResult.Timeout)
         runServiceTest(permission = true, oneShot = oneShot) { service, store, _ ->
             val result = service.requestLatestGps(GpsRequestReason.AppForeground)
             assertIs<GpsFixResult.Timeout>(result)
-            assertEquals(1, oneShot.calls)
+            assertEquals(1, oneShot.freshCalls)
             assertNull(store.lastPoint.value) // nothing routed
         }
     }
@@ -179,7 +191,7 @@ class LocationServiceTest {
     @Test
     fun concurrentRequestsCoalesceToOneAcquisition() {
         val gate = CompletableDeferred<Unit>()
-        val oneShot = FakeOneShot(GpsFixResult.Success(point(t = 990_000)), gate = gate)
+        val oneShot = FakeOneShot(fresh = GpsFixResult.Success(point(t = 990_000)), gate = gate)
         runServiceTest(permission = true, oneShot = oneShot) { service, _, _ ->
             // Both callers see a stale (absent) last-known and race into requestLatestGps.
             val a = async { service.requestLatestGps(GpsRequestReason.AppForeground) }
@@ -188,7 +200,7 @@ class LocationServiceTest {
             gate.complete(Unit)
             advanceUntilIdle()
 
-            assertEquals(1, oneShot.calls) // single-flight: only one real acquisition
+            assertEquals(1, oneShot.freshCalls) // single-flight: only one real acquisition
             val ra = a.await()
             val rb = b.await()
             assertIs<GpsFixResult.Success>(ra)
@@ -202,7 +214,7 @@ class LocationServiceTest {
     fun batteryGuardReusesLastKnownWithinMinInterval() {
         // First acquisition fails (Timeout) so it leaves a recent lastAcquireStartMs but does NOT
         // refresh last-known; the seeded stale point stays the best we have.
-        val oneShot = FakeOneShot(GpsFixResult.Timeout)
+        val oneShot = FakeOneShot(fresh = GpsFixResult.Timeout)
         val clock = TestClock(now)
         runServiceTest(permission = true, oneShot = oneShot, clock = clock) { service, store, c ->
             val stale = point(t = now - 200_000, lon = 7.0) // older than every staleAfterMs
@@ -210,12 +222,12 @@ class LocationServiceTest {
 
             val first = service.requestLatestGps(GpsRequestReason.AppForeground)
             assertIs<GpsFixResult.Timeout>(first)
-            assertEquals(1, oneShot.calls)
+            assertEquals(1, oneShot.freshCalls)
 
             // 30s later — still within MIN_ACQUISITION_INTERVAL_MS (60s) — must NOT re-acquire.
             c.ms = now + 30_000
             val second = service.requestLatestGps(GpsRequestReason.AppForeground)
-            assertEquals(1, oneShot.calls) // battery guard skipped the second acquisition
+            assertEquals(1, oneShot.freshCalls) // battery guard skipped the second acquisition
             assertIs<GpsFixResult.Success>(second)
             assertEquals(stale.t, second.point.t) // reused last-known within tolerance
         }
@@ -223,83 +235,117 @@ class LocationServiceTest {
 
     @Test
     fun acquiresAgainAfterMinIntervalElapses() {
-        val oneShot = FakeOneShot(GpsFixResult.Timeout)
+        val oneShot = FakeOneShot(fresh = GpsFixResult.Timeout)
         val clock = TestClock(now)
         runServiceTest(permission = true, oneShot = oneShot, clock = clock) { service, store, c ->
             store.publishLastKnown(point(t = now - 200_000))
             service.requestLatestGps(GpsRequestReason.AppForeground)
-            assertEquals(1, oneShot.calls)
+            assertEquals(1, oneShot.freshCalls)
 
             // Past the 60s min-interval — a fresh acquisition is allowed.
             c.ms = now + LocationService.MIN_ACQUISITION_INTERVAL_MS + 1
             service.requestLatestGps(GpsRequestReason.AppForeground)
-            assertEquals(2, oneShot.calls)
+            assertEquals(2, oneShot.freshCalls)
         }
     }
 
     @Test
     fun foregroundReasonUsesLongTimeout() {
-        val oneShot = FakeOneShot(GpsFixResult.Timeout)
+        val oneShot = FakeOneShot(fresh = GpsFixResult.Timeout)
         runServiceTest(permission = true, oneShot = oneShot) { service, _, _ ->
             service.requestLatestGps(GpsRequestReason.AppForeground)
-            assertEquals(15_000L, oneShot.timeouts.single())
+            assertEquals(15_000L, oneShot.freshTimeouts.single())
         }
     }
 
     @Test
     fun pushReasonUsesShortTimeout() {
-        val oneShot = FakeOneShot(GpsFixResult.Timeout)
+        val oneShot = FakeOneShot(fresh = GpsFixResult.Timeout)
         runServiceTest(permission = true, oneShot = oneShot) { service, _, _ ->
             service.requestLatestGps(GpsRequestReason.PushReceived)
-            assertEquals(5_000L, oneShot.timeouts.single())
+            assertEquals(5_000L, oneShot.freshTimeouts.single())
         }
     }
 
     @Test
-    fun passesReasonStalenessAsCacheMaxAge() {
-        // The provider is told to accept an OS last-known cache only within the reason's staleness
-        // tolerance, otherwise power the radio (#886 fix 1).
-        val oneShot = FakeOneShot(GpsFixResult.Timeout)
+    fun servesOsCacheWithinMaxAge() {
+        // App store empty so LocationService proceeds; an OS last-known fresher than the reason's
+        // staleness tolerance is served without powering the radio (#886 fix 1).
+        val oneShot = FakeOneShot(
+            fresh = GpsFixResult.Success(point(t = 1, lon = 1.0)),
+            cached = point(t = now - 10_000, lon = 7.0), // 10s old, within AppForeground's 60s
+        )
         runServiceTest(permission = true, oneShot = oneShot) { service, _, _ ->
-            service.requestLatestGps(GpsRequestReason.PushReceived)
-            assertEquals(GpsRequestReason.PushReceived.staleAfterMs, oneShot.maxAges.single())
+            val result = service.requestLatestGps(GpsRequestReason.AppForeground)
+            assertIs<GpsFixResult.Success>(result)
+            assertEquals(now - 10_000, result.point.t) // the cached one, not the fresh one
+            assertEquals(0, oneShot.freshCalls) // no radio
         }
     }
 
     @Test
-    fun batterySaverAcquiresCacheOnly() {
-        // Power save on → acquisition is cache-only (no radio).
-        val oneShot = FakeOneShot(GpsFixResult.Success(point(t = 990_000)))
+    fun acquiresWhenOsCacheTooOld() {
+        val oneShot = FakeOneShot(
+            fresh = GpsFixResult.Success(point(t = 990_000, lon = 9.0)),
+            cached = point(t = now - 90_000), // 90s old > AppForeground's 60s
+        )
+        runServiceTest(permission = true, oneShot = oneShot) { service, _, _ ->
+            val result = service.requestLatestGps(GpsRequestReason.AppForeground)
+            assertIs<GpsFixResult.Success>(result)
+            assertEquals(990_000, result.point.t) // the freshly acquired one
+            assertEquals(1, oneShot.freshCalls)
+        }
+    }
+
+    @Test
+    fun batterySaverServesCacheOnly() {
+        // Power save on → cache-only: serve the OS last-known at ANY age, never power the radio.
+        val oneShot = FakeOneShot(
+            fresh = GpsFixResult.Success(point(t = 990_000)),
+            cached = point(t = now - 200_000, lon = 7.0), // very old
+        )
         runServiceTest(permission = true, oneShot = oneShot, powerSave = true) { service, _, _ ->
-            service.requestLatestGps(GpsRequestReason.AppForeground)
-            assertEquals(1, oneShot.calls)
-            assertEquals(true, oneShot.cacheOnlyCalls.single())
+            val result = service.requestLatestGps(GpsRequestReason.AppForeground)
+            assertIs<GpsFixResult.Success>(result)
+            assertEquals(now - 200_000, result.point.t) // old cache still served
+            assertEquals(0, oneShot.freshCalls) // never the radio
+        }
+    }
+
+    @Test
+    fun batterySaverWithoutCacheIsUnavailable() {
+        val oneShot = FakeOneShot(fresh = GpsFixResult.Success(point(t = 990_000)), cached = null)
+        runServiceTest(permission = true, oneShot = oneShot, powerSave = true) { service, _, _ ->
+            val result = service.requestLatestGps(GpsRequestReason.AppForeground)
+            assertIs<GpsFixResult.Unavailable>(result)
+            assertEquals(0, oneShot.freshCalls)
         }
     }
 
     @Test
     fun nonSaverAllowsRadio() {
-        val oneShot = FakeOneShot(GpsFixResult.Timeout)
+        val oneShot = FakeOneShot(fresh = GpsFixResult.Timeout, cached = null)
         runServiceTest(permission = true, oneShot = oneShot, powerSave = false) { service, _, _ ->
             service.requestLatestGps(GpsRequestReason.AppForeground)
-            assertEquals(false, oneShot.cacheOnlyCalls.single())
+            assertEquals(1, oneShot.freshCalls)
         }
     }
 
     @Test
     fun forceCaptureSkippedWhenNothingTracking() {
-        val oneShot = FakeOneShot(GpsFixResult.Success(point(t = 990_000)))
+        val oneShot = FakeOneShot(fresh = GpsFixResult.Success(point(t = 990_000)))
         // UnavailableTracker + no history → isCaptureWanted() is false.
         runServiceTest(permission = true, oneShot = oneShot, tracker = UnavailableTracker) { service, _, _ ->
             val result = service.forceCaptureIfTracking(GpsRequestReason.PushReceived)
             assertNull(result)
-            assertEquals(0, oneShot.calls)
+            assertEquals(0, oneShot.freshCalls)
+            assertEquals(0, oneShot.lastKnownCalls)
         }
     }
 
     @Test
     fun forceCaptureProceedsWhenHistoryOn() {
-        val oneShot = FakeOneShot(GpsFixResult.Success(point(t = 990_000, lon = 5.0)))
+        val oneShot = FakeOneShot(fresh = GpsFixResult.Success(point(t = 990_000, lon = 5.0)))
         // AvailableTracker + history on + (jvm) permission granted → isCaptureWanted() is true.
         runServiceTest(
             permission = true,
@@ -309,7 +355,7 @@ class LocationServiceTest {
         ) { service, store, _ ->
             val result = service.forceCaptureIfTracking(GpsRequestReason.PushReceived)
             assertIs<GpsFixResult.Success>(result)
-            assertEquals(1, oneShot.calls)
+            assertEquals(1, oneShot.freshCalls)
             assertEquals(990_000, store.lastPoint.value?.t) // routed + persisted (history on)
         }
     }

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/tracking/LocationFixRouterTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/tracking/LocationFixRouterTest.kt
@@ -23,6 +23,7 @@ class LocationFixRouterTest {
         override suspend fun batteryPercent(): Int? = null
         override suspend fun stepsSince(prevPointTimeMs: Long?, lastCumulative: Long?) =
             StepSample(null, null)
+        override fun isPowerSaveMode(): Boolean = false
     }
 
     private class Captured {

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/tracking/LocationPointStoreTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/tracking/LocationPointStoreTest.kt
@@ -18,6 +18,7 @@ private class FakeSensors(
     override suspend fun batteryPercent(): Int? = battery
     override suspend fun stepsSince(prevPointTimeMs: Long?, lastCumulative: Long?): StepSample =
         StepSample(delta, cumulative)
+    override fun isPowerSaveMode(): Boolean = false
 }
 
 /**

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/location/tracking/DeviceSensors.web.kt
@@ -7,4 +7,6 @@ private object NoDeviceSensors : DeviceSensors {
     override suspend fun batteryPercent(): Int? = null
     override suspend fun stepsSince(prevPointTimeMs: Long?, lastCumulative: Long?): StepSample =
         StepSample(null, null)
+
+    override fun isPowerSaveMode(): Boolean = false
 }

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.web.kt
@@ -4,6 +4,6 @@ actual fun createOneShotLocationProvider(): OneShotLocationProvider = Unavailabl
 
 /** Web one-shot GPS is not yet implemented (browser Geolocation API). */
 private object UnavailableOneShotLocationProvider : OneShotLocationProvider {
-    override suspend fun getCurrentFix(timeoutMs: Long, maxAgeMs: Long, cacheOnly: Boolean): GpsFixResult =
-        GpsFixResult.Unavailable
+    override suspend fun lastKnownFix(): RawLocationPoint? = null
+    override suspend fun acquireFreshFix(timeoutMs: Long): GpsFixResult = GpsFixResult.Unavailable
 }

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.web.kt
@@ -4,5 +4,6 @@ actual fun createOneShotLocationProvider(): OneShotLocationProvider = Unavailabl
 
 /** Web one-shot GPS is not yet implemented (browser Geolocation API). */
 private object UnavailableOneShotLocationProvider : OneShotLocationProvider {
-    override suspend fun getCurrentFix(timeoutMs: Long, maxAgeMs: Long): GpsFixResult = GpsFixResult.Unavailable
+    override suspend fun getCurrentFix(timeoutMs: Long, maxAgeMs: Long, cacheOnly: Boolean): GpsFixResult =
+        GpsFixResult.Unavailable
 }

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.web.kt
@@ -4,5 +4,5 @@ actual fun createOneShotLocationProvider(): OneShotLocationProvider = Unavailabl
 
 /** Web one-shot GPS is not yet implemented (browser Geolocation API). */
 private object UnavailableOneShotLocationProvider : OneShotLocationProvider {
-    override suspend fun getCurrentFix(timeoutMs: Long): GpsFixResult = GpsFixResult.Unavailable
+    override suspend fun getCurrentFix(timeoutMs: Long, maxAgeMs: Long): GpsFixResult = GpsFixResult.Unavailable
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -149,6 +149,7 @@ import org.koin.dsl.module
 import id.homebase.core.config.getLocationPermissionExtensionConfig
 import id.homebase.core.config.getVaultPermissionExtensionConfig
 import id.homebase.core.location.EmergencyCircleNotifier
+import id.homebase.core.location.GpsRequestReason
 import id.homebase.core.location.LocationPreferences
 import id.homebase.core.location.tracking.LocationDeviceId
 import id.homebase.core.location.tracking.DeviceSensors
@@ -295,6 +296,9 @@ val appModule = module {
             // Lets the coordinator keep GPS armed for an active live-location share (incl. across a
             // cold start / iOS relaunch) without referencing homebase-chat.
             liveShareActive = { get<LiveLocationShareService>().hasLiveShare() }
+            // Force a fresh fix on app-open when stale (#878). The coordinator already gated on
+            // isCaptureWanted() before firing; the primitive owns the staleness + battery guard.
+            onForegroundEntry = { get<LocationService>().requestLatestGps(GpsRequestReason.AppForeground) }
         }
     }
     // The single public entry point for "this device's location" — composes coordinator (acquire) +
@@ -308,6 +312,7 @@ val appModule = module {
             pointStore = get(),
             preferences = get(),
             oneShot = createOneShotLocationProvider(),
+            scope = get(),
         )
     }
     // endregion

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -296,9 +296,11 @@ val appModule = module {
             // Lets the coordinator keep GPS armed for an active live-location share (incl. across a
             // cold start / iOS relaunch) without referencing homebase-chat.
             liveShareActive = { get<LiveLocationShareService>().hasLiveShare() }
-            // Force a fresh fix on app-open when stale (#878). The coordinator already gated on
-            // isCaptureWanted() before firing; the primitive owns the staleness + battery guard.
-            onForegroundEntry = { get<LocationService>().requestLatestGps(GpsRequestReason.AppForeground) }
+            // Force a fresh fix on app-open when stale (#878). Goes through the gated
+            // forceCaptureIfTracking() — the single entry for automatic triggers — so the
+            // "only when a persistent consumer wants GPS" decision lives in one place (the
+            // coordinator's own isCaptureWanted() pre-check just avoids launching when not wanted).
+            onForegroundEntry = { get<LocationService>().forceCaptureIfTracking(GpsRequestReason.AppForeground) }
         }
     }
     // The single public entry point for "this device's location" — composes coordinator (acquire) +

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -282,6 +282,10 @@ val appModule = module {
             deviceId = get(),
             optionalDriveActivation = get(),
             scope = get(),
+            // Battery saver: defer background uploads (but a foregrounded user, or a >24h
+            // un-uploaded backlog, still uploads). #878 follow-up.
+            powerSaveMode = { get<DeviceSensors>().isPowerSaveMode() },
+            isAppForeground = { get<LocationTrackingCoordinator>().isForeground },
         )
     }
     single {
@@ -315,6 +319,8 @@ val appModule = module {
             preferences = get(),
             oneShot = createOneShotLocationProvider(),
             scope = get(),
+            // Battery saver: on-demand fixes go cache-only (no radio). #878 follow-up.
+            powerSaveMode = { get<DeviceSensors>().isPowerSaveMode() },
         )
     }
     // endregion

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationTrackUploaderService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationTrackUploaderService.kt
@@ -83,6 +83,10 @@ class LocationTrackUploaderService(
     private val scope: CoroutineScope,
     /** Injectable for tests; production reads the wall clock. */
     private val nowMs: () -> Long = { Clock.System.now().toEpochMilliseconds() },
+    /** OS battery saver on? Wired in DI to DeviceSensors. Defaults false (always upload). */
+    private val powerSaveMode: () -> Boolean = { false },
+    /** App in the foreground? Wired in DI to the coordinator. Defaults true (always upload). */
+    private val isAppForeground: () -> Boolean = { true },
 ) {
     private val logger = Logger.withTag(TAG)
     private val driveId = locationLabeledDrive.drive.alias
@@ -124,6 +128,22 @@ class LocationTrackUploaderService(
     suspend fun flushIfDue() {
         val now = nowMs()
         if (now - lastFlushAttemptMs < MIN_FLUSH_INTERVAL_MS) return
+        val powerSave = powerSaveMode()
+        val foreground = isAppForeground()
+        // Battery saver + backgrounded → defer uploads to save power; local capture still persists
+        // and drains on the next foreground / saver-off flush (#878 follow-up). Override: never let
+        // un-uploaded history sit longer than STALE_BACKLOG_MS — upload at the next chance regardless
+        // of saver, so the user's track can't be stranded on-device (and can't reach the 7-day sweep
+        // un-uploaded). The backlog query runs only in the would-defer case.
+        val hasStaleBacklog = if (powerSave && !foreground) {
+            runCatching { buffer.countUnmarkedOlderThan(now - STALE_BACKLOG_MS) }.getOrDefault(0L) > 0L
+        } else {
+            false
+        }
+        if (shouldDeferBackgroundFlush(powerSave, foreground, hasStaleBacklog)) {
+            logger.d { "Flush deferred: battery saver on + backgrounded, no >${STALE_BACKLOG_MS}ms un-uploaded backlog" }
+            return
+        }
         flush()
     }
 
@@ -475,8 +495,22 @@ class LocationTrackUploaderService(
         const val MIN_FLUSH_INTERVAL_MS = 60_000L
         const val RETENTION_MS = 7L * 24 * HOUR_MS
         const val DAY_MS = 24 * HOUR_MS
+
+        /** Un-uploaded backlog older than this forces an upload even in battery saver (24h). */
+        const val STALE_BACKLOG_MS = 24L * HOUR_MS
     }
 }
+
+/**
+ * Whether a flush should be deferred for battery saver. Deferred only while saver is on AND the app
+ * is backgrounded AND there's no un-uploaded backlog past the stale threshold — a foregrounded user
+ * always uploads, and a >24h backlog always uploads (the safety override). Pure for unit testing.
+ */
+internal fun shouldDeferBackgroundFlush(
+    powerSaveMode: Boolean,
+    appForeground: Boolean,
+    hasStaleUnuploaded: Boolean,
+): Boolean = powerSaveMode && !appForeground && !hasStaleUnuploaded
 
 /** What an outbox event means for the location point buffer. */
 internal enum class BufferAction {

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/LocationFlushDeferralTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/LocationFlushDeferralTest.kt
@@ -1,0 +1,65 @@
+package id.homebase.core.ui.screens.location
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Locks the battery-saver upload-deferral policy (#878 follow-up): defer a flush ONLY while saver is
+ * on AND the app is backgrounded AND there's no un-uploaded backlog past the 24h safety threshold.
+ * A foregrounded user always uploads; a >24h backlog always uploads.
+ */
+class LocationFlushDeferralTest {
+
+    @Test
+    fun defersOnlyWhenSaverOnAndBackgroundedAndNoStaleBacklog() {
+        assertTrue(
+            shouldDeferBackgroundFlush(
+                powerSaveMode = true,
+                appForeground = false,
+                hasStaleUnuploaded = false,
+            )
+        )
+    }
+
+    @Test
+    fun foregroundAlwaysUploads() {
+        assertFalse(
+            shouldDeferBackgroundFlush(
+                powerSaveMode = true,
+                appForeground = true,
+                hasStaleUnuploaded = false,
+            )
+        )
+    }
+
+    @Test
+    fun staleBacklogOverridesSaver() {
+        // >24h of un-uploaded points: upload even though saver is on and we're backgrounded.
+        assertFalse(
+            shouldDeferBackgroundFlush(
+                powerSaveMode = true,
+                appForeground = false,
+                hasStaleUnuploaded = true,
+            )
+        )
+    }
+
+    @Test
+    fun noSaverNeverDefers() {
+        for (foreground in listOf(true, false)) {
+            for (stale in listOf(true, false)) {
+                assertEquals(
+                    false,
+                    shouldDeferBackgroundFlush(
+                        powerSaveMode = false,
+                        appForeground = foreground,
+                        hasStaleUnuploaded = stale,
+                    ),
+                    "no-saver must never defer (foreground=$foreground stale=$stale)",
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What & why
Fixes **#878**. On Android, opening the app only *started* interval location updates — nothing requested an immediate fix — so a brief app-open closed before the 30 s `HISTORY_FG_INTERVAL_MS` fired and recorded **nothing**. A ~30 min backgrounded sailing session produced a single point despite several app opens (root cause **A**). Background OS throttling (root cause **B**) stays out of scope: we deliberately run **no foreground-service notification**, so long backgrounded sessions remain sparse *by design*.

## Approach
Every on-demand capture trigger funnels through **one** idempotent, battery-aware primitive, so the battery + timing policy lives in a single place:

**`LocationService.requestLatestGps(reason)`**
- **Staleness short-circuit** — reuse the app's last-known if within `reason.staleAfterMs` (no hardware).
- **Permission gate** — returns `PermissionDenied`, never prompts.
- **Single-flight** — concurrent/duplicate calls coalesce onto the in-flight acquisition.
- **Battery min-interval** — a real acquisition within 60 s is skipped, reusing last-known (an app-open + several pushes in a minute → **≤1** acquisition).
- **Timing-aware** — foreground waits longer at high accuracy; push uses a short timeout + fast last-known fallback.
- Successful fixes route through `LocationFixRouter` as before.

**Triggers wired into it**
- **App-open (primary, root cause A):** coordinator `onForegroundEntry` hook fires on entering the foreground, through the gated `forceCaptureIfTracking`.
- **Push receipt:** `NotificationEntry.onPushArrived` opportunistically force-captures (covers Android FCM via `DriveSyncWorker` + iOS inline); never fails the push sync.
- **Live map:** `RememberCurrentGps` migrated onto the primitive.

`forceCaptureIfTracking(reason)` is the **single gated entry for automatic triggers** — it only acquires when a persistent consumer (history or a live share) wants GPS. `requestLatestGps` is reserved for interactive/transient consumers (the live map).

## Review fixes (included in this PR)
A self-review surfaced two issues, both fixed here:

1. **Age-bound the OS last-known cache.** The Android one-shot returned `getLastKnownLocation` at *any* age, so a force-on-stale capture could echo an arbitrarily old cached fix and never power the radio — defeating the fix exactly in the backgrounded-moving case. `getCurrentFix` now takes a `maxAgeMs` (the reason's `staleAfterMs`); a cache older than that falls through to a live acquisition. So "use OS last-known vs spend battery on the radio" is now an explicit, per-reason decision.
2. **Single gated path.** The app-open trigger now routes through `forceCaptureIfTracking` (not `requestLatestGps` directly), so the "only when something is recording" gate lives in one place. Docs state the contract: automatic triggers use `forceCaptureIfTracking`; only the live map calls `requestLatestGps` directly.

## Battery-saver awareness
The app previously ignored the OS battery saver entirely. Added `DeviceSensors.isPowerSaveMode()` (Android `PowerManager`, iOS `NSProcessInfo.lowPowerModeEnabled`; desktop/web false) and two policies:

- **Rule 1 — cache-only acquisition under saver.** `getCurrentFix` gains a `cacheOnly` flag; when saver is on, every on-demand path serves the OS last-known and **never powers the radio**.
- **Rule 2 — defer background uploads under saver, only while backgrounded.** `flushIfDue()` defers when `saver && !foreground`; a foregrounded user always uploads (opening the app drains via the foreground flush ticker). Local capture still persists; only the drive upload is deferred. The decision is a pure `shouldDeferBackgroundFlush()`.
- **24h safety override.** A new `countUnmarkedOlderThan()` query forces an upload at the next opportunity once any un-uploaded point is older than 24 h — so history can't be stranded on-device, and deferred points can't reach the 7-day retention sweep un-uploaded.

## Out of scope
- **Activity Recognition** (activity-class adaptive cadence + ActivityTransition fixes) — needs `ACTIVITY_RECOGNITION`, stripped from Play store builds until the Health Apps declaration; spun out as **#885**.
- **Continuous foreground-overlay downgrade under saver** — Rule 1 applies to the on-demand path; the continuous high-accuracy tracker is unchanged.

## Tests
`LocationServiceTest` pins single-flight, the battery guard (skip + reuse, then re-acquire), staleness, per-reason timing, the consumer gate, permission, routing, the cache `maxAge` pass-through, and cache-only-under-saver. `LocationFlushDeferralTest` pins the defer/upload matrix (defer only when saver + backgrounded + no >24h backlog). All `homebase-api` / `-common` / `-core` / `-chat` jvmTests pass; `homebase-common` + `homebase-core` compile on JVM and Android.

## Manual verification (Android)
1. Enable history, grant permission. Move ~100 m, background 90 s, open briefly, close — repeat 3×. Expect a fresh point per open (not waiting on the 30 s interval).
2. `adb shell run-as id.homebase.feed.dev cat files/logs/homebase.log | grep -E "requestLatestGps|forceCapture|Routed|cacheOnly|deferred"` — one acquisition per open; clustered triggers reuse last-known; saver defers/cache-only as expected.

Closes #878.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
