### PR TITLE
fix(chat): truncate long names in recipient chips + sender bubbles (#898)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/addgroupmembers/AddGroupMembersScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/addgroupmembers/AddGroupMembersScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -41,6 +42,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -168,11 +170,17 @@ fun AddGroupMembersUi(
                     ) {
                     items(uiState.selectedContacts) { contact ->
                         InputChip(
-                            modifier = Modifier.padding(end = 8.dp),
+                            modifier = Modifier.widthIn(max = 200.dp).padding(end = 8.dp),
                             onClick = {
                                 // onUiAction(NewConversationUiAction.ContactClicked(contact))
                             },
-                            label = { Text(text = contact.name) },
+                            label = {
+                                Text(
+                                    text = contact.name,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            },
                             selected = true,
                             leadingIcon = {
                                 ContactAvatar(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/selectmembers/SelectMembersScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/selectmembers/SelectMembersScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -41,6 +42,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -191,11 +193,17 @@ fun SelectMembersUi(
                 ) {
                 items(uiState.selectedContacts) { contact ->
                     InputChip(
-                        modifier = Modifier.padding(end = 8.dp),
+                        modifier = Modifier.widthIn(max = 200.dp).padding(end = 8.dp),
                         onClick = {
                             // onUiAction(NewConversationUiAction.ContactClicked(contact))
                         },
-                        label = { Text(text = contact.name) },
+                        label = {
+                            Text(
+                                text = contact.name,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        },
                         selected = true,
                         leadingIcon = {
                             ContactAvatar(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -572,6 +572,7 @@ fun ReceivedMessageBubble(
                             color = finalAuthorColor,
                             modifier = Modifier.padding(start = 12.dp, bottom = 2.dp),
                             maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
                         )
                     }
                     Box {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -613,6 +613,7 @@ fun MessageBubbleRaw(
                                 bottom = 4.dp,
                             ),
                             maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
                         )
                     }
                     message.messageAppData.replyPreview?.let { reply ->
@@ -710,6 +711,7 @@ fun MessageBubbleRaw(
                                         bottom = 4.dp,
                                     ),
                                     maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
                                 )
                             }
                             // Inline reply preview if this message is a reply


### PR DESCRIPTION
Closes #898

## Problem
A contact name longer than its chip/bubble **grew the container** instead of truncating with "…".

## Fix (render-layer, surrogate-safe — no pre-`take`)
- **Recipient chips** — `SelectMembersScreen` + `AddGroupMembersScreen`: cap the `InputChip` width (`widthIn(max = 200.dp)`) and add `maxLines = 1` + `TextOverflow.Ellipsis` to the label, so a long name shows `Shelly Seifert Silb…` rather than stretching the chip.
- **Group sender names** — `MessageBubble` + `MessageBubbleRaw` (both the block path and the main/`Layout` path): add `overflow = TextOverflow.Ellipsis` to the existing `maxLines = 1` so the name ellipsizes within the bubble's existing max width instead of hard-clipping/widening it.

Full name stays the accessibility label (only visual truncation).

## Acceptance
- [x] Long recipient chip name truncates with "…"; chip capped at a sensible max width.
- [x] Long group sender names truncate within the bubble; bubble doesn't grow.
- [x] Short names unchanged.
- [x] commonMain → all platforms; JVM compile green. Visual check pending below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)