### PR TITLE
feat(contacts): match your own identity in search as "Name (you)" (#895)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/createconversation/CreateConversationScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/createconversation/CreateConversationScreen.kt
@@ -69,6 +69,7 @@ import id.homebase.resources.chat_search_result_empty
 import id.homebase.resources.connections_refresh
 import id.homebase.resources.cd_not_selected
 import id.homebase.resources.cd_selected
+import id.homebase.resources.contactbook_self_you
 import id.homebase.resources.contacts
 import id.homebase.resources.menu_back
 import kotlinx.coroutines.launch
@@ -247,15 +248,28 @@ fun CreateConversationUi(
                         }
 
                         is CreateConversationListItem.NoteToSelf -> {
+                            val self = item.self
                             item {
-                                ListItemAction(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(vertical = 4.dp),
-                                    imageVector = Icons.AutoMirrored.Filled.StickyNote2,
-                                    text = stringResource(MR.string.chat_note_to_self),
-                                    onClick = { onUiAction(CreateConversationUiAction.CreateSelfConversation) }
-                                )
+                                if (self != null) {
+                                    // Self surfaced by a name search: render as a contact row with
+                                    // the user's own avatar + "Name (you)"; tap still opens note-to-self.
+                                    ContactItem(
+                                        name = stringResource(MR.string.contactbook_self_you, self.name),
+                                        subTitle = stringResource(MR.string.chat_note_to_self),
+                                        odinId = self.odinId,
+                                        avatarInitials = self.initials,
+                                        onContactClick = { onUiAction(CreateConversationUiAction.CreateSelfConversation) },
+                                    )
+                                } else {
+                                    ListItemAction(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(vertical = 4.dp),
+                                        imageVector = Icons.AutoMirrored.Filled.StickyNote2,
+                                        text = stringResource(MR.string.chat_note_to_self),
+                                        onClick = { onUiAction(CreateConversationUiAction.CreateSelfConversation) }
+                                    )
+                                }
                             }
                         }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/createconversation/CreateConversationUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/createconversation/CreateConversationUiState.kt
@@ -1,6 +1,7 @@
 package id.homebase.chat.createconversation
 
 import androidx.compose.runtime.Immutable
+import id.homebase.api.common.OdinId
 import id.homebase.chat.data.ContactUiModel
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
@@ -16,7 +17,16 @@ data class CreateConversationUiState(
 sealed interface CreateConversationListItem {
     data class Contacts(val contactGroups: List<ContactGroup>) : CreateConversationListItem
     data object NewGroup : CreateConversationListItem
-    data object NoteToSelf : CreateConversationListItem
+
+    /**
+     * [self] is non-null only when surfaced by a self-name search → render as a contact row with the
+     * user's own avatar + "Name (you)". Null = the idle "Note to Self" action (sticky-note icon).
+     */
+    data class NoteToSelf(val self: SelfRef? = null) : CreateConversationListItem
+
+    /** The signed-in user, as needed to render their search-result row (avatar + name). */
+    @Immutable
+    data class SelfRef(val odinId: OdinId, val name: String, val initials: String)
     data object NewContact : CreateConversationListItem
 }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/createconversation/CreateConversationViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/createconversation/CreateConversationViewModel.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import id.homebase.api.client.auth.OwnerSession
+import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.api.client.drives.SystemDriveConstants
 import id.homebase.api.sync.DriveSyncManager
 import id.homebase.chat.data.ContactUiModel
@@ -26,6 +28,7 @@ class CreateConversationViewModel(
     private val conversationWriterService: ConversationService,
     private val connectionService: ConnectionService,
     private val driveSyncManager: DriveSyncManager,
+    private val ownerSessionRepository: OwnerSessionRepository,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(
@@ -37,10 +40,13 @@ class CreateConversationViewModel(
     init {
         viewModelScope.launch {
             contactService.start()
-            contactService.contacts
-                .combine(snapshotFlow { searchTextState.text.toString() }) { contacts, query ->
-                    filterAndGroup(contacts, query)
-                }
+            combine(
+                contactService.contacts,
+                snapshotFlow { searchTextState.text.toString() },
+                ownerSessionRepository.user,
+            ) { contacts, query, self ->
+                filterAndGroup(contacts, query, self)
+            }
                 .catch {
                     sendEvent(
                         CreateConversationUiEvent.ShowErrorMessage(
@@ -121,7 +127,8 @@ class CreateConversationViewModel(
 
     private fun filterAndGroup(
         contacts: List<ContactUiModel>,
-        query: String
+        query: String,
+        self: OwnerSession?,
     ): List<CreateConversationListItem> {
         val result = mutableListOf<CreateConversationListItem>()
 
@@ -130,6 +137,10 @@ class CreateConversationViewModel(
             result.add(CreateConversationListItem.NoteToSelf)
             result.add(CreateConversationListItem.NewContact)
             result.add(CreateConversationListItem.NewGroup)
+        } else if (self.matchesQuery(query)) {
+            // Searching your own name/handle would otherwise be a dead end (self isn't a
+            // contact) — surface Note to Self so the search resolves to something.
+            result.add(CreateConversationListItem.NoteToSelf)
         }
 
         val contacts = if (query.isEmpty()) {
@@ -156,4 +167,11 @@ class CreateConversationViewModel(
         result.add(CreateConversationListItem.Contacts(groups))
         return result
     }
+}
+
+/** True when [query] hits the signed-in user's own display name or handle (case-insensitive). */
+private fun OwnerSession?.matchesQuery(query: String): Boolean {
+    if (this == null || query.isBlank()) return false
+    return displayName?.contains(query, ignoreCase = true) == true ||
+        odinId.toString().contains(query, ignoreCase = true)
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/createconversation/CreateConversationViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/createconversation/CreateConversationViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import id.homebase.api.client.auth.OwnerSession
 import id.homebase.api.client.auth.OwnerSessionRepository
+import id.homebase.api.client.auth.initials
 import id.homebase.api.client.drives.SystemDriveConstants
 import id.homebase.api.sync.DriveSyncManager
 import id.homebase.chat.data.ContactUiModel
@@ -125,53 +126,68 @@ class CreateConversationViewModel(
         _uiState.update { it.copy(uiEvent = event) }
     }
 
-    private fun filterAndGroup(
-        contacts: List<ContactUiModel>,
-        query: String,
-        self: OwnerSession?,
-    ): List<CreateConversationListItem> {
-        val result = mutableListOf<CreateConversationListItem>()
+}
 
-        // Only display new group and note to self options if not showing search results
-        if (query.isEmpty()) {
-            result.add(CreateConversationListItem.NoteToSelf)
-            result.add(CreateConversationListItem.NewContact)
-            result.add(CreateConversationListItem.NewGroup)
-        } else if (self.matchesQuery(query)) {
-            // Searching your own name/handle would otherwise be a dead end (self isn't a
-            // contact) — surface Note to Self so the search resolves to something.
-            result.add(CreateConversationListItem.NoteToSelf)
-        }
+/**
+ * Builds the new-conversation list for [query]: the standing actions when idle, or — when the query
+ * matches the signed-in user — a self "Name (you)" row backed by [CreateConversationListItem.SelfRef],
+ * followed by the matching contacts. Self is excluded from the contact rows (Note to Self is the
+ * canonical self path). Pure function of its inputs so the self-search seam is unit-testable.
+ */
+internal fun filterAndGroup(
+    contacts: List<ContactUiModel>,
+    query: String,
+    self: OwnerSession?,
+): List<CreateConversationListItem> {
+    val result = mutableListOf<CreateConversationListItem>()
 
-        val contacts = if (query.isEmpty()) {
-            contacts
-        } else {
-            contacts.filter {
-                it.name.contains(
-                    query,
-                    ignoreCase = true
-                ) || it.odinId.toString().contains(
-                    query,
-                    ignoreCase = true
+    // Only display new group and note to self options if not showing search results
+    if (query.isEmpty()) {
+        result.add(CreateConversationListItem.NoteToSelf())
+        result.add(CreateConversationListItem.NewContact)
+        result.add(CreateConversationListItem.NewGroup)
+    } else if (self != null && self.matchesQuery(query)) {
+        // Searching your own name/handle would otherwise be a dead end (self isn't a
+        // contact) — surface Note to Self as a contact row (your avatar + "Name (you)")
+        // so the result reads as you, not a generic note.
+        result.add(
+            CreateConversationListItem.NoteToSelf(
+                CreateConversationListItem.SelfRef(
+                    odinId = self.odinId,
+                    name = self.displayLabel(),
+                    initials = self.initials(),
                 )
-            }
-        }.distinctBy { it.odinId }
-        val groups = contacts.groupBy {
-            it.name.firstOrNull()?.uppercase() ?: "#"
-        }.map { (initial, contacts) ->
-            ContactGroup(
-                initial = initial,
-                contacts = contacts
             )
-        }.sortedBy { it.initial }
-        result.add(CreateConversationListItem.Contacts(groups))
-        return result
+        )
     }
+
+    val filtered = if (query.isEmpty()) {
+        contacts
+    } else {
+        contacts.filter {
+            it.name.contains(query, ignoreCase = true) ||
+                it.odinId.toString().contains(query, ignoreCase = true)
+        }
+    }
+        .distinctBy { it.odinId }
+        // Never list the signed-in user as a normal contact — self routes to Note to Self above.
+        .filter { it.odinId != self?.odinId }
+    val groups = filtered.groupBy {
+        it.name.firstOrNull()?.uppercase() ?: "#"
+    }.map { (initial, groupContacts) ->
+        ContactGroup(initial = initial, contacts = groupContacts)
+    }.sortedBy { it.initial }
+    result.add(CreateConversationListItem.Contacts(groups))
+    return result
 }
 
 /** True when [query] hits the signed-in user's own display name or handle (case-insensitive). */
-private fun OwnerSession?.matchesQuery(query: String): Boolean {
+internal fun OwnerSession?.matchesQuery(query: String): Boolean {
     if (this == null || query.isBlank()) return false
     return displayName?.contains(query, ignoreCase = true) == true ||
         odinId.toString().contains(query, ignoreCase = true)
 }
+
+/** Display label for the signed-in user: their name, or their handle when the name isn't loaded. */
+internal fun OwnerSession.displayLabel(): String =
+    displayName?.ifBlank { null } ?: odinId.domainName

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/createconversation/SelfSearchMatchTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/createconversation/SelfSearchMatchTest.kt
@@ -1,0 +1,136 @@
+@file:OptIn(ExperimentalUuidApi::class)
+
+package id.homebase.chat.createconversation
+
+import id.homebase.api.client.auth.OwnerSession
+import id.homebase.api.common.OdinId
+import id.homebase.chat.data.ContactUiModel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * The self-search seam behind "searching your own name surfaces Note to Self as a 'Name (you)' row
+ * with your avatar" (#895). Covers the matcher/label helpers and [filterAndGroup]'s list shaping:
+ * self row only on a match, your own identity excluded from the normal contact rows.
+ */
+class SelfSearchMatchTest {
+
+    private fun session(displayName: String?, handle: String = "samwise.gamgee.demo.rocks") =
+        OwnerSession(
+            odinId = OdinId(handle),
+            displayName = displayName,
+            firstName = null,
+            surName = null,
+            profileImageFileId = null,
+            profileImageFileKey = null,
+            profileImagePreviewThumbnail = null,
+            profileImageLastModified = null,
+            status = null,
+        )
+
+    private fun contact(name: String, handle: String) =
+        ContactUiModel(id = Uuid.random(), odinId = OdinId(handle), name = name, avatarInitials = "")
+
+    // ---- matchesQuery / displayLabel ----
+
+    @Test
+    fun matches_displayName_caseInsensitive() {
+        assertTrue(session("Samwise Gamgee").matchesQuery("sam"))
+        assertTrue(session("Samwise Gamgee").matchesQuery("GAMGEE"))
+    }
+
+    @Test
+    fun matches_handle_evenWhenNameDoesnt() {
+        // A different display name, but the query hits the odinId handle.
+        assertTrue(session("Frodo Baggins").matchesQuery("gamgee.demo"))
+    }
+
+    @Test
+    fun noMatch_whenQueryHitsNeither() {
+        assertFalse(session("Frodo Baggins").matchesQuery("mordor"))
+    }
+
+    @Test
+    fun nullSession_neverMatches() {
+        assertFalse((null as OwnerSession?).matchesQuery("sam"))
+    }
+
+    @Test
+    fun blankQuery_neverMatches() {
+        assertFalse(session("Samwise Gamgee").matchesQuery("   "))
+    }
+
+    @Test
+    fun displayLabel_prefersName() {
+        assertEquals("Samwise Gamgee", session("Samwise Gamgee").displayLabel())
+    }
+
+    @Test
+    fun displayLabel_fallsBackToHandle_whenNameNullOrBlank() {
+        val expected = OdinId("samwise.gamgee.demo.rocks").domainName
+        assertEquals(expected, session(displayName = null).displayLabel())
+        assertEquals(expected, session(displayName = "   ").displayLabel())
+    }
+
+    // ---- filterAndGroup (the feature seam) ----
+
+    @Test
+    fun filterAndGroup_idle_showsStandingActions_andNoSelfRow() {
+        val items = filterAndGroup(
+            contacts = listOf(contact("Frodo Baggins", "frodo.baggins.demo.rocks")),
+            query = "",
+            self = session("Samwise Gamgee"),
+        )
+        val note = items.filterIsInstance<CreateConversationListItem.NoteToSelf>().single()
+        assertNull(note.self) // idle Note to Self carries no self ref → plain "Note to Self"
+        assertTrue(items.any { it is CreateConversationListItem.NewGroup })
+        assertTrue(items.any { it is CreateConversationListItem.NewContact })
+    }
+
+    @Test
+    fun filterAndGroup_selfMatch_emitsSelfRowWithAvatarData() {
+        val self = session("Samwise Gamgee")
+        val items = filterAndGroup(contacts = emptyList(), query = "sam", self = self)
+
+        val ref = assertNotNull(
+            items.filterIsInstance<CreateConversationListItem.NoteToSelf>().single().self
+        )
+        assertEquals(self.odinId, ref.odinId)
+        assertEquals("Samwise Gamgee", ref.name)
+        assertEquals("SG", ref.initials) // OwnerSession.initials() from the display name
+    }
+
+    @Test
+    fun filterAndGroup_excludesSelfFromContactRows_keepsDifferentSameName() {
+        val self = session("Samwise Gamgee", handle = "samwise.gamgee.demo.rocks")
+        val items = filterAndGroup(
+            contacts = listOf(
+                contact("Samwise Gamgee", "samwise.gamgee.demo.rocks"), // self, as a stored contact
+                contact("Samwise Gamgee", "samwisegamgee.me"),          // a DIFFERENT Samwise
+            ),
+            query = "sam",
+            self = self,
+        )
+        val rows = items.filterIsInstance<CreateConversationListItem.Contacts>()
+            .single().contactGroups.flatMap { it.contacts }.map { it.odinId.toString() }
+
+        assertTrue("samwisegamgee.me" in rows)             // the other person stays
+        assertFalse("samwise.gamgee.demo.rocks" in rows)   // your own identity is filtered out
+    }
+
+    @Test
+    fun filterAndGroup_noSelfMatch_emitsNoSelfRow() {
+        val items = filterAndGroup(
+            contacts = emptyList(),
+            query = "mordor",
+            self = session("Samwise Gamgee"),
+        )
+        assertTrue(items.filterIsInstance<CreateConversationListItem.NoteToSelf>().isEmpty())
+    }
+}

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1385,6 +1385,7 @@
     <!-- Contact Book (contact manager add-on) -->
     <string name="contactbook_label">Contacts</string>
     <string name="contactbook_home_subtitle">Manage your address book</string>
+    <string name="contactbook_self_you">%1$s (you)</string>
     <string name="contactbook_onboarding_title">Your contacts, in one place</string>
     <string name="contactbook_onboarding_body_1">Keep your contacts on your private Homebase cloud and reach the people you chat with. Import from your phone, or add contacts by hand.</string>
     <string name="contactbook_onboarding_body_2">Your contacts are encrypted on your personal Homebase server and sync across your devices.</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookViewModel.kt
@@ -239,7 +239,17 @@ class ContactBookViewModel(
         // entry; the rest get a synthetic display-only entry, the same projection Introduced /
         // Confirmed use.
         val unsavedConnectionDomains = connectedDomains - contactsByOdin.keys
-        val all = (overriddenContacts + unsavedConnectionDomains.map { syntheticContact(it) })
+        val selfEntry = header.ownerSession?.let { selfContact(it) }
+        val all = buildList {
+            addAll(overriddenContacts)
+            addAll(unsavedConnectionDomains.map { syntheticContact(it) })
+            // The contact store never holds the signed-in user, so a self-search finds nothing.
+            // Surface "Name (you)" when the user searches for their own name/handle — only on an
+            // active query, and only if self isn't already a saved contact (no duplicate).
+            if (selfEntry != null && ui.query.isNotBlank() &&
+                none { it.odinId?.lowercase() == selfEntry.odinId?.lowercase() }
+            ) add(selfEntry)
+        }
             .filter { it.matches(ui.query) }
             .sortedBy { it.sortKey }
 
@@ -304,6 +314,21 @@ class ContactBookViewModel(
         val byOdin = contacts.filter { !it.odinId.isNullOrBlank() }
             .associateBy { it.odinId!!.lowercase() }
         return domains.map { domain -> byOdin[domain] ?: syntheticContact(domain) }
+    }
+
+    /** A display-only "(you)" entry for the signed-in user, matched by their own name/handle. */
+    private fun selfContact(session: OwnerSession): ContactBookEntry {
+        val domain = session.odinId.domainName
+        val uid = Md5.toGuidId(domain.lowercase())
+        return ContactBookEntry(
+            uniqueId = uid,
+            fileId = uid,
+            versionTag = null,
+            odinId = domain,
+            displayName = session.displayName?.ifBlank { null } ?: domain,
+            source = ContactBookSource.CONNECTION,
+            isSelf = true,
+        )
     }
 
     /** A display-only entry for a connection/member that isn't in the contact book. */

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/ContactBookRow.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/ContactBookRow.kt
@@ -23,6 +23,7 @@ import id.homebase.core.ui.screens.contactbook.model.ContactBookEntry
 import id.homebase.resources.MR
 import id.homebase.resources.connections_introduced_by
 import id.homebase.resources.contactbook_connected
+import id.homebase.resources.contactbook_self_you
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -45,8 +46,13 @@ fun ContactBookRow(
         ContactBookAvatar(entry = entry)
         Spacer(modifier = Modifier.width(12.dp))
         Column(modifier = Modifier.weight(1f)) {
+            val name = if (entry.isSelf) {
+                stringResource(MR.string.contactbook_self_you, entry.displayName)
+            } else {
+                entry.displayName
+            }
             Text(
-                text = entry.displayName,
+                text = name,
                 style = MaterialTheme.typography.bodyLarge,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/model/ContactBookEntry.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/model/ContactBookEntry.kt
@@ -68,6 +68,8 @@ data class ContactBookEntry(
     val source: String? = null,
     /** Pending (optimistic, not yet confirmed by the drive). */
     val isPending: Boolean = false,
+    /** Synthetic entry representing the signed-in user; rendered with a "(you)" suffix. */
+    val isSelf: Boolean = false,
     // Image-display fields (carried so a stored avatar can render without a
     // second drive read). Null when the contact has no uploaded photo.
     val driveId: Uuid? = null,


### PR DESCRIPTION
Closes #895

## Problem
Searching your **own name** in contact search returned no match — your identity isn't in the contact store.

## Fix
Inject a synthetic **self** entry where it makes sense; the member-picker exclusion falls out for free (no `includeSelf` flag needed, see note).

- **Contact book** (`ContactBookViewModel`): build a self `ContactBookEntry` from `OwnerSessionRepository.user` (own `displayName` + `https://<odinId>/pub/image` avatar, falling back to the identity **domain** when the name isn't loaded). Injected into the results only on an **active query** that matches your name/handle, and only if self isn't already a saved contact (dedup by odinId). Rendered as **"Name (you)"** via a new `contactbook_self_you` (`%1$s (you)`) string + an `isSelf` flag on the entry.
- **New chat** (`CreateConversationViewModel`): a self-search now surfaces **Note to Self** (the existing item) instead of a dead end — matching the user's own display name / handle.
- **Group member pickers** (`SelectMembers` / `AddGroupMembers`): unchanged → self stays **excluded** (can't add yourself to a group).

### Note on the suggested `includeSelf` boolean
The shared `filterAndGroup` extension is used **only** by the two member pickers, both of which want self *excluded*. Adding `includeSelf` there would be a parameter that's never passed `true` (dead flexibility). The two screens that actually need self — contact book and new-chat — have their own filters, so self-injection lives there, with the per-screen tap behaviour the comment called out (contact book → profile, new-chat → Note to Self). Member-picker exclusion is the default with zero added code.

## Acceptance
- [x] Searching your own name/handle in the contact book returns a "Name (you)" entry with your avatar.
- [x] Searching yourself in new-chat surfaces Note to Self.
- [x] Self stays excluded from group member pickers.
- [x] Real own display name/avatar with domain fallback; no duplicate when self is a saved contact.
- [x] commonMain → all platforms; JVM compile green. Visual check pending below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)