### PR TITLE
feat(location): subject-driven Location History title; drop in-map subject line (#894)

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/DayPlaybackMap.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/DayPlaybackMap.kt
@@ -58,8 +58,7 @@ private const val DAY_MS = 24L * 60 * 60 * 1000
  * tile provider — so it can show the local History day, or any pulled day from
  * another identity (e.g. a family member during an emergency).
  *
- * [subjectName], when set, is shown as a header so the viewer is sure whose day
- * they're looking at — pass the person's name for pulled data, null for one's own.
+ * Whose day this is lives in the host screen's title (see #894), not here.
  *
  * @param dayStartMs device-local midnight of the shown day (anchors the 24h slider).
  */
@@ -69,7 +68,6 @@ fun DayPlaybackMap(
     dayStartMs: Long,
     showMapTiles: Boolean,
     modifier: Modifier = Modifier,
-    subjectName: String? = null,
     isLoading: Boolean = false,
     /** Whether personal location history is on. Drives the empty-state "turn on tracking" hint. */
     allowLocationHistory: Boolean = true,
@@ -108,17 +106,6 @@ fun DayPlaybackMap(
     }
 
     Column(modifier = modifier.fillMaxSize()) {
-        if (subjectName != null) {
-            Text(
-                text = subjectName,
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 4.dp),
-                textAlign = TextAlign.Center,
-            )
-        }
-
         // ── Trace canvas ──
         // Card clips and insets the map so it doesn't run into whatever sits
         // above it or the stats/scrubber below.
@@ -240,7 +227,7 @@ fun DayPlaybackMap(
 /**
  * Convenience overload taking one subject's flat day-point list (as the emergency
  * feature would pull for a family member) — gap-segments it into a single trace and
- * plays it back. [subjectName] is shown as the header. Points keep `steps`/`bat`.
+ * plays it back. Points keep `steps`/`bat`. Whose day it is lives in the host title.
  */
 @Composable
 fun DayPlaybackMap(
@@ -249,7 +236,6 @@ fun DayPlaybackMap(
     dayStartMs: Long,
     showMapTiles: Boolean,
     modifier: Modifier = Modifier,
-    subjectName: String? = null,
     isLoading: Boolean = false,
 ) {
     val traces = remember(points, subjectId) {
@@ -260,7 +246,6 @@ fun DayPlaybackMap(
         dayStartMs = dayStartMs,
         showMapTiles = showMapTiles,
         modifier = modifier,
-        subjectName = subjectName,
         isLoading = isLoading,
     )
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/history/LocationHistoryScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.core.util.formatMediumDate
@@ -51,10 +52,10 @@ import id.homebase.resources.location_history_next_day
 import id.homebase.resources.location_history_pick_date
 import id.homebase.resources.location_history_previous_day
 import id.homebase.resources.location_history_title
-import id.homebase.resources.location_history_you
 import id.homebase.resources.location_menu_more
 import id.homebase.resources.menu_back
 import id.homebase.resources.ok
+import id.homebase.resources.you
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
@@ -76,11 +77,31 @@ fun LocationHistoryScreen(
     var menuOpen by remember { mutableStateOf(false) }
     var showDeleteConfirm by remember { mutableStateOf(false) }
     val deviceTz = remember { TimeZone.currentSystemDefault() }
+    // Subject-driven title: "You" for one's own history, a contact's name for the
+    // (future) emergency-locate view. This is the single seam that path feeds into;
+    // no hardcoded "you" further down. See #894.
+    val subjectName = stringResource(MR.string.you)
 
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(MR.string.location_history_title)) },
+                title = {
+                    Column {
+                        Text(
+                            text = subjectName,
+                            style = MaterialTheme.typography.titleMedium,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            text = stringResource(MR.string.location_history_title),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                },
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
                         Icon(
@@ -161,14 +182,13 @@ fun LocationHistoryScreen(
             }
 
             // The map, dwell dots, stats and 24h scrubber are the reusable player.
-            // "(you)" makes it clear this is your own data — the same header the
-            // emergency feature uses for a relative's name.
+            // The subject now lives in the title (#894), so no in-map header line —
+            // the map grows into the reclaimed height.
             DayPlaybackMap(
                 traces = uiState.traces,
                 dayStartMs = uiState.dayStartMs,
                 showMapTiles = uiState.showMapTiles,
                 isLoading = uiState.isLoading,
-                subjectName = stringResource(MR.string.location_history_you),
                 allowLocationHistory = uiState.allowLocationHistory,
                 onEnableTracking = onNavigateToDashboard,
                 modifier = Modifier.weight(1f),


### PR DESCRIPTION
Closes #894

## Problem
The subject ("you") sat as a centered line **inside the map** while the title bar showed a generic "History" — wasting vertical space and burying whose history you're viewing. The subject is **not always "you"** (a contact's name in the emergency-locate view).

## Fix (narrow, per the issue's tightened scope)
- **`LocationHistoryScreen`**: two-line, **subject-driven** title — subject (**"You"**, from `MR.string.you`) over **"History"**, both `maxLines = 1` + ellipsis so a long (future contact) name truncates. Driven by a `subjectName` value, **never a hardcoded "you"** — this title is the single seam the emergency-locate view (#875/#879) will feed a contact name into.
- **`DayPlaybackMap`**: remove the standalone in-map subject line and the now-dead `subjectName` param from both overloads. The map (`weight(1f)`) grows into the reclaimed height automatically.

Everything else — day-nav (← date-chip →), stats, timestamp, 24h scrubber, Delete-this-day (#834) — is untouched.

## Acceptance
- [x] Subject appears in the title bar, not as a centered line in the map.
- [x] Title is subject-driven (no hardcoded "you"); the seam carries a contact name for the future emergency view.
- [x] In-map subject line removed; map is correspondingly taller.
- [x] Day-nav, stats, scrubber, Delete-this-day unchanged.
- [x] commonMain → all platforms; JVM compile green. Visual check pending below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)