### PR TITLE
fix(desktop): bundle ISRG Root X2 so Let's Encrypt validates on the JBR

### DIFF
--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/client/PlatformHttpClient.android.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/client/PlatformHttpClient.android.kt
@@ -1,0 +1,14 @@
+package id.homebase.api.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.okhttp.OkHttp
+
+/**
+ * Android uses the OkHttp engine, which validates TLS against the OS trust store.
+ * Android keeps its CA set current via Play system updates, so no extra roots are
+ * needed here — we just name the engine and apply the shared config.
+ */
+internal actual fun createPlatformHttpClient(
+    block: HttpClientConfig<*>.() -> Unit,
+): HttpClient = HttpClient(OkHttp) { block() }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/HttpClientProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/HttpClientProvider.kt
@@ -28,7 +28,7 @@ internal val HttpBreadcrumbPlugin = createClientPlugin("HttpBreadcrumb") {
 
 object HttpClientProvider {
     fun create(): HttpClient {
-        return HttpClient {
+        return createPlatformHttpClient {
             install(HttpBreadcrumbPlugin)
 
             install(ContentNegotiation) {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/PlatformHttpClient.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/PlatformHttpClient.kt
@@ -1,0 +1,19 @@
+package id.homebase.api.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+
+/**
+ * Builds an [HttpClient] on the platform's native engine, applying the shared
+ * [block] configuration. Centralising engine selection here (rather than relying
+ * on Ktor's classpath auto-resolution at each `HttpClient { }` call site) gives
+ * each platform a single place to attach engine-specific tweaks.
+ *
+ * The JVM/Desktop actual uses this to install a TLS trust manager that augments
+ * the runtime's default trust store with CA roots the bundled JRE may not carry
+ * (see `PlatformHttpClient.jvm.kt`). Android/iOS/Web defer entirely to the OS
+ * trust store, so their actuals just name the engine and apply [block] verbatim.
+ */
+internal expect fun createPlatformHttpClient(
+    block: HttpClientConfig<*>.() -> Unit = {},
+): HttpClient

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerWebSocketClient.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerWebSocketClient.kt
@@ -3,6 +3,7 @@ package id.homebase.api.client.peer
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.SharedSecretEncryptedPayload
 import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.createPlatformHttpClient
 import id.homebase.api.client.drives.TargetDrive
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
@@ -24,7 +25,6 @@ import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.DriveWebSocketUpsertWorker
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.toBase64
-import io.ktor.client.HttpClient
 import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
 import io.ktor.client.plugins.websocket.WebSockets
 import io.ktor.client.plugins.websocket.webSocket
@@ -82,7 +82,7 @@ class PeerWebSocketClient(
     private val maxReconnectDelayMs = 30_000L
     private var closed = false
 
-    private val client = HttpClient { install(WebSockets) }
+    private val client = createPlatformHttpClient { install(WebSockets) }
 
     // Per-drive upsert workers, keyed by drive alias. Lazily created on the first file event.
     private val wsUpsertWorkers = mutableMapOf<Uuid, DriveWebSocketUpsertWorker>()

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
@@ -5,6 +5,7 @@ import id.homebase.api.PlatformType
 import id.homebase.api.getPlatform
 import id.homebase.api.client.SharedSecretEncryptedPayload
 import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.createPlatformHttpClient
 import id.homebase.api.client.drives.TargetDrive
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
@@ -17,7 +18,6 @@ import id.homebase.api.sync.DriveWebSocketUpsertWorker
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.MainIndexMetaHelpers
 import id.homebase.api.toBase64
-import io.ktor.client.HttpClient
 import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
 import io.ktor.client.plugins.websocket.WebSockets
 import io.ktor.client.plugins.websocket.webSocket
@@ -71,7 +71,7 @@ class OdinWebSocketClient(
     private val MAX_RECONNECT_DELAY_BACKGROUND_MS = 30_000L
     private var closed = false
 
-    private val client = HttpClient {
+    private val client = createPlatformHttpClient {
         // TODO: enable per-message deflate compression via WebSocketDeflateExtension once
         //  server support is confirmed (RFC 7692 / permessage-deflate).
         //  install(WebSockets) { extensions { install(WebSocketDeflateExtension) } }

--- a/homebase-api/src/jvmMain/kotlin/id/homebase/api/client/PlatformHttpClient.jvm.kt
+++ b/homebase-api/src/jvmMain/kotlin/id/homebase/api/client/PlatformHttpClient.jvm.kt
@@ -36,13 +36,16 @@ internal actual fun createPlatformHttpClient(
     }
 }
 
-private object HomebaseTrustManager {
+internal object HomebaseTrustManager {
     /**
      * An [X509TrustManager] trusting the JRE default anchors plus [ExtraTrustRoots],
      * or `null` if it could not be built (in which case CIO keeps its default and we
      * log — we never want a trust-store hiccup to silently disable TLS validation).
      */
     val augmented: X509TrustManager? by lazy { runCatching { build() }.getOrElse { it.log(); null } }
+
+    /** The JRE's default trust anchors, exposed so tests can assert we ADD to (never replace) them. */
+    internal fun jreDefaults(): X509TrustManager = defaultTrustManager()
 
     private fun build(): X509TrustManager {
         val ks = KeyStore.getInstance(KeyStore.getDefaultType()).apply { load(null, null) }
@@ -88,7 +91,7 @@ private object HomebaseTrustManager {
  * root rotation reintroduces the symptom, append its PEM rather than reaching for
  * a broader (and riskier) "trust the OS keychain" scheme.
  */
-private object ExtraTrustRoots {
+internal object ExtraTrustRoots {
     // ISRG Root X2 (Let's Encrypt ECDSA root, valid 2020-09-04 .. 2040-09-17).
     // SHA-256: 69:72:9B:8E:15:A8:6E:FC:17:7A:57:AF:B7:17:1D:FC:64:AD:D2:8C:2F:CA:8C:F1:50:7E:34:45:3C:CB:14:70
     private const val ISRG_ROOT_X2 = """-----BEGIN CERTIFICATE-----

--- a/homebase-api/src/jvmMain/kotlin/id/homebase/api/client/PlatformHttpClient.jvm.kt
+++ b/homebase-api/src/jvmMain/kotlin/id/homebase/api/client/PlatformHttpClient.jvm.kt
@@ -1,0 +1,110 @@
+package id.homebase.api.client
+
+import co.touchlab.kermit.Logger
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.cio.CIO
+import java.security.KeyStore
+import java.security.cert.CertificateFactory
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
+
+/**
+ * Desktop/JVM HTTP client. Ktor's JVM target resolves to the CIO engine, whose
+ * pure-Kotlin TLS stack (`io.ktor.network.tls`) validates server certificates
+ * against a JDK [X509TrustManager] built from the running JRE's `cacerts`.
+ *
+ * That store is whatever the launch runtime ships — for `desktopApp:run` and the
+ * packaged app that's the JetBrains Runtime, whose `cacerts` historically lags the
+ * public CA set. Concretely, JBR 17.0.9 carries ISRG Root X1 but **not** ISRG Root
+ * X2; when a Let's Encrypt server cert renews onto an X2-anchored chain, CIO can no
+ * longer build a trust path and every HTTPS call dies with
+ * `SunCertPathBuilderException: unable to find valid certification path`.
+ *
+ * We fix it by giving CIO a trust manager seeded from the JRE defaults **plus** the
+ * extra roots in [ExtraTrustRoots] (currently ISRG Root X2). Android/iOS/Web use
+ * their OS trust stores and don't need this.
+ */
+internal actual fun createPlatformHttpClient(
+    block: HttpClientConfig<*>.() -> Unit,
+): HttpClient = HttpClient(CIO) {
+    block()
+    engine {
+        https {
+            HomebaseTrustManager.augmented?.let { trustManager = it }
+        }
+    }
+}
+
+private object HomebaseTrustManager {
+    /**
+     * An [X509TrustManager] trusting the JRE default anchors plus [ExtraTrustRoots],
+     * or `null` if it could not be built (in which case CIO keeps its default and we
+     * log — we never want a trust-store hiccup to silently disable TLS validation).
+     */
+    val augmented: X509TrustManager? by lazy { runCatching { build() }.getOrElse { it.log(); null } }
+
+    private fun build(): X509TrustManager {
+        val ks = KeyStore.getInstance(KeyStore.getDefaultType()).apply { load(null, null) }
+
+        // Seed with the JRE's default trust anchors so we ADD to, never replace, them.
+        val defaults = defaultTrustManager()
+        defaults.acceptedIssuers.forEachIndexed { i, cert -> ks.setCertificateEntry("default-$i", cert) }
+
+        // Add the bundled roots the JRE may be missing.
+        val cf = CertificateFactory.getInstance("X.509")
+        ExtraTrustRoots.pems.forEachIndexed { i, pem ->
+            val cert = pem.byteInputStream().use { cf.generateCertificate(it) }
+            ks.setCertificateEntry("homebase-extra-$i", cert)
+        }
+
+        val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        tmf.init(ks)
+        val tm = tmf.trustManagers.filterIsInstance<X509TrustManager>().first()
+        Logger.i(tag = "TLS") {
+            "CIO trust manager augmented: ${defaults.acceptedIssuers.size} default + " +
+                "${ExtraTrustRoots.pems.size} bundled root(s) = ${tm.acceptedIssuers.size} anchors"
+        }
+        return tm
+    }
+
+    private fun defaultTrustManager(): X509TrustManager {
+        val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        tmf.init(null as KeyStore?)
+        return tmf.trustManagers.filterIsInstance<X509TrustManager>().first()
+    }
+
+    private fun Throwable.log() =
+        Logger.w(tag = "TLS", throwable = this) { "Failed to build augmented trust manager; using CIO default" }
+}
+
+/**
+ * CA roots bundled with the app because the launch JRE's `cacerts` may not carry
+ * them. Add a root here (PEM) when an in-use identity's chain anchors at a CA the
+ * JetBrains Runtime is missing.
+ *
+ * Targeted-but-extensible: bundling specific roots fixes today's failure
+ * deterministically without trusting anything extra. If a future Let's Encrypt
+ * root rotation reintroduces the symptom, append its PEM rather than reaching for
+ * a broader (and riskier) "trust the OS keychain" scheme.
+ */
+private object ExtraTrustRoots {
+    // ISRG Root X2 (Let's Encrypt ECDSA root, valid 2020-09-04 .. 2040-09-17).
+    // SHA-256: 69:72:9B:8E:15:A8:6E:FC:17:7A:57:AF:B7:17:1D:FC:64:AD:D2:8C:2F:CA:8C:F1:50:7E:34:45:3C:CB:14:70
+    private const val ISRG_ROOT_X2 = """-----BEGIN CERTIFICATE-----
+MIICGzCCAaGgAwIBAgIQQdKd0XLq7qeAwSxs6S+HUjAKBggqhkjOPQQDAzBPMQsw
+CQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJuZXQgU2VjdXJpdHkgUmVzZWFyY2gg
+R3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBYMjAeFw0yMDA5MDQwMDAwMDBaFw00
+MDA5MTcxNjAwMDBaME8xCzAJBgNVBAYTAlVTMSkwJwYDVQQKEyBJbnRlcm5ldCBT
+ZWN1cml0eSBSZXNlYXJjaCBHcm91cDEVMBMGA1UEAxMMSVNSRyBSb290IFgyMHYw
+EAYHKoZIzj0CAQYFK4EEACIDYgAEzZvVn4CDCuwJSvMWSj5cz3es3mcFDR0HttwW
++1qLFNvicWDEukWVEYmO6gbf9yoWHKS5xcUy4APgHoIYOIvXRdgKam7mAHf7AlF9
+ItgKbppbd9/w+kHsOdx1ymgHDB/qo0IwQDAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0T
+AQH/BAUwAwEB/zAdBgNVHQ4EFgQUfEKWrt5LSDv6kviejM9ti6lyN5UwCgYIKoZI
+zj0EAwMDaAAwZQIwe3lORlCEwkSHRhtFcP9Ymd70/aTSVaYgLXTWNLxBo1BfASdW
+tL4ndQavEi51mI38AjEAi/V3bNTIZargCyzuFJ0nN6T5U6VR5CmD1/iQMVtCnwr1
+/q4AaOeMSQ+2b1tbFfLn
+-----END CERTIFICATE-----"""
+
+    val pems: List<String> = listOf(ISRG_ROOT_X2)
+}

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/BundledTrustRootsTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/BundledTrustRootsTest.kt
@@ -1,0 +1,77 @@
+package id.homebase.api.client
+
+import java.security.MessageDigest
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Security guard for the desktop bundled-roots fix (no device/network needed) — the JVM
+ * counterpart to Android's `NetworkSecurityConfigTest`.
+ *
+ * The whole fix rests on [ExtraTrustRoots] being the *genuine* ISRG Root X2. If a corrupted,
+ * wrong, swapped, or expired cert ever slips into the bundle, these assertions fail loudly
+ * instead of the app quietly trusting (or failing to trust) the wrong anchor:
+ *  - subject/issuer CN is "ISRG Root X2",
+ *  - it is self-signed (a root, not an intermediate),
+ *  - it is currently valid,
+ *  - and its SHA-256 fingerprint matches the pinned, published value.
+ *
+ * It also asserts [HomebaseTrustManager] only ADDS to the JRE defaults — it never replaces
+ * them — which is the JVM analog of Android keeping `system` and never adding `user`.
+ */
+class BundledTrustRootsTest {
+
+    // ISRG Root X2, published at https://letsencrypt.org/certs/ (valid 2020-09-04 .. 2040-09-17).
+    private val isrgRootX2Sha256 =
+        "69:72:9B:8E:15:A8:6E:FC:17:7A:57:AF:B7:17:1D:FC:" +
+            "64:AD:D2:8C:2F:CA:8C:F1:50:7E:34:45:3C:CB:14:70"
+
+    private fun parse(pem: String): X509Certificate =
+        pem.byteInputStream().use {
+            CertificateFactory.getInstance("X.509").generateCertificate(it) as X509Certificate
+        }
+
+    private fun sha256(cert: X509Certificate): String =
+        MessageDigest.getInstance("SHA-256").digest(cert.encoded)
+            .joinToString(":") { "%02X".format(it) }
+
+    @Test
+    fun bundledRoots_areExactlyTheGenuineIsrgRootX2() {
+        assertEquals(1, ExtraTrustRoots.pems.size, "expected exactly one bundled root (ISRG Root X2)")
+        val cert = parse(ExtraTrustRoots.pems.single())
+
+        assertTrue(
+            cert.subjectX500Principal.name.contains("CN=ISRG Root X2"),
+            "subject was ${cert.subjectX500Principal.name}",
+        )
+        // Self-signed root: issuer == subject, and it verifies under its own key.
+        assertEquals(cert.subjectX500Principal, cert.issuerX500Principal, "root must be self-issued")
+        cert.verify(cert.publicKey) // throws if the self-signature doesn't check out
+        cert.checkValidity()        // throws if expired / not yet valid
+
+        assertEquals(isrgRootX2Sha256, sha256(cert), "bundled ISRG Root X2 fingerprint changed")
+    }
+
+    @Test
+    fun augmentedTrustManager_addsToJreDefaults_neverReplacesThem() {
+        val augmented = HomebaseTrustManager.augmented
+        assertNotNull(augmented, "augmented trust manager should build on a normal JRE")
+
+        val defaultCount = HomebaseTrustManager.jreDefaults().acceptedIssuers.size
+        val augmentedIssuers = augmented.acceptedIssuers.toList()
+
+        assertTrue(
+            augmentedIssuers.size >= defaultCount,
+            "augmented anchors (${augmentedIssuers.size}) must not drop any of the $defaultCount JRE defaults",
+        )
+        val bundled = parse(ExtraTrustRoots.pems.single())
+        assertTrue(
+            augmentedIssuers.any { it.subjectX500Principal == bundled.subjectX500Principal },
+            "augmented trust manager must include the bundled ISRG Root X2",
+        )
+    }
+}

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/client/PlatformHttpClient.native.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/client/PlatformHttpClient.native.kt
@@ -1,0 +1,14 @@
+package id.homebase.api.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.darwin.Darwin
+
+/**
+ * iOS/macOS native uses the Darwin engine, which validates TLS against the system
+ * trust store (kept current by the OS). No extra roots needed — name the engine
+ * and apply the shared config.
+ */
+internal actual fun createPlatformHttpClient(
+    block: HttpClientConfig<*>.() -> Unit,
+): HttpClient = HttpClient(Darwin) { block() }

--- a/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/client/PlatformHttpClient.wasmJs.kt
+++ b/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/client/PlatformHttpClient.wasmJs.kt
@@ -1,0 +1,14 @@
+package id.homebase.api.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.js.Js
+
+/**
+ * Web uses the JS engine, which delegates to the browser's fetch/WebSocket stack
+ * and therefore the browser's own trust store. No extra roots needed — name the
+ * engine and apply the shared config.
+ */
+internal actual fun createPlatformHttpClient(
+    block: HttpClientConfig<*>.() -> Unit,
+): HttpClient = HttpClient(Js) { block() }


### PR DESCRIPTION
Desktop port of the Android ISRG-roots fix (#872).

## Problem
On Desktop the Ktor **CIO** engine validates server certs against the launch JRE's `cacerts`. The **JetBrains Runtime lags the public CA set** — JBR 17 carries ISRG Root X1 but **not X2**. When a Homebase identity's Let's Encrypt ECDSA cert renews onto an X2-anchored chain, CIO can no longer build a trust path and every HTTPS call dies with:

```
SunCertPathBuilderException: unable to find valid certification path
```

(Chrome, with its own root store, still works — same signature as the Android failure that #872 fixed.)

## Fix
Route every Ktor client through a single `createPlatformHttpClient` expect/actual seam:

- **JVM actual** gives CIO an `X509TrustManager` seeded from the JRE defaults **plus** the bundled **ISRG Root X2**, so the chain validates regardless of JBR trust-store lag. If the augmented manager can't be built, it logs and falls back to CIO's default — a trust-store hiccup never silently disables TLS validation.
- **Android / iOS / web actuals** just name their engine (OkHttp / Darwin / JS) and apply the shared config; their OS/browser trust stores stay current on their own.

**Consistency is the point:** the seam is wired into all three production client sites — the REST client (`HttpClientProvider`) and **both** websockets (`OdinWebSocketClient`, `PeerWebSocketClient`) — so the desktop websockets don't keep failing the X2 handshake after the REST client is fixed.

## Programmatic equivalent of Android's config
| | Android (#872) | Desktop (this PR) |
|---|---|---|
| Mechanism | `network-security-config.xml` (declarative) | `X509TrustManager` built in code |
| Trust set | `system` + bundled ISRG X1/X2 | JRE `cacerts` defaults + bundled ISRG X2 |
| Safety | keeps `system`, never adds `user` | adds to JRE defaults, never replaces |

## Security
Only **adds** one well-known public root to the JRE defaults; never replaces them and adds nothing user-installed, so validation isn't weakened.
ISRG Root X2 SHA-256 `69:72:9B:8E:15:A8:6E:FC:...:CB:14:70` (self-signed, valid to 2040).

## Testing
- Compiles JVM + Android + wasmJs + iosSimulatorArm64.
- ⚠️ Runtime trust behaviour can't be unit-tested on the host — needs `desktopApp:run` against an X2-anchored identity to confirm end to end (watch for the `CIO trust manager augmented: N default + 1 bundled root(s)` log line).

### Follow-up (not in this PR)
A JVM test guard pinning the bundled PEM's SHA-256 / self-signature / validity, mirroring Android's `NetworkSecurityConfigTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)