### PR TITLE
Refine contact detail layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,6 +323,29 @@ visibility, optional biometric gate), follow the recipe in
 routing, `AppNavHost` wiring, `AuthConnectionCoordinator` drive subscription, DI, and the
 expect/actual biometric layer.
 
+## Phone numbers & email addresses in the UI
+
+Any UI that captures a phone number or email — primary slot, additional/extra slots, add
+flows, anywhere — must enforce the canonical format. Don't drop a raw `OutlinedTextField`
+in for these.
+
+- **Phone numbers** are stored as **E.164** (`+14155550123`). Capture them with
+  `PhoneNumberField` (`…/contactbook/components/PhoneNumberField.kt`) — a country-code
+  selector + national-number field that emits a normalized E.164 string (or `""` when
+  blank). The user never types the `+` or country code. Never persist a hand-typed national
+  string. The control is stateful (it seeds its country/national once and then owns them),
+  so render lists of them under a **stable `key(id)`**, not the list index — index-keying
+  shuffles a row's seeded state when a sibling above it is removed. See the keyed
+  `DraftPhone` rows in `ContactEditSheet.kt`.
+- **Email addresses** must be validated before they can be saved.
+- Use `ContactFieldValidation` (`…/contactbook/ContactFieldValidation.kt`) as the single
+  source of truth: `isValidPhone` (E.164), `isValidEmail`, `normalizePhone`. Validators
+  treat blank as valid (fields are optional); the empty-vs-required decision is the caller's.
+- **Legacy data may not be E.164.** Show it (seed it into `PhoneNumberField`, render it in
+  the email field) and flag it with the field's `isError` + `errorText`, but **block Save
+  until it's corrected** — gate the Save button on every phone/email being valid, primary
+  *and* additional. Error strings: `contactbook_error_phone`, `contactbook_error_email`.
+
 ## Adding a New Typed Message Kind
 
 When adding a new chat message kind (poll, doodle, sticker — anything whose descriptor

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1445,6 +1445,9 @@
     <string name="contactbook_detail_tab_details">Details</string>
     <string name="contactbook_detail_tab_about">About</string>
     <string name="contactbook_detail_tab_activity">Activity</string>
+    <string name="contactbook_detail_name">Name</string>
+    <string name="contactbook_detail_about_empty">There's nothing here yet. A bio, experience, and social links will show up once this person shares them.</string>
+    <string name="contactbook_detail_activity_empty">No shared activity yet. Media and other things you share in your conversation will appear here.</string>
     <string name="contactbook_detail_manage">Manage contact</string>
     <string name="contactbook_detail_social">Social</string>
     <string name="contactbook_detail_location">Location</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1533,6 +1533,9 @@
     <string name="add_contact_send_request">Send connection request</string>
     <string name="add_contact_send_request_help">Not connected yet. Send a request so you can message each other.</string>
     <string name="add_contact_already_connected">You're already connected</string>
+    <string name="add_contact_save_as_new">Save as new contact</string>
+    <string name="add_contact_already_saved">Already in your contacts</string>
+    <string name="add_contact_blocked">You've blocked this person</string>
 
     <string name="storage_diagnostics_header">Diagnostics (dev)</string>
     <string name="storage_diagnostics_force_native_crash">Force native crash (test)</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
@@ -128,7 +128,10 @@ sealed class Route {
 
     @Serializable
     @SerialName("contactbook-add")
-    data object AddContact : Route()
+    // identityOnly: launched from a chat flow, where a contact is only useful if it has a
+    // Homebase ID (you can't message someone without one) — so the manual-entry affordances
+    // are hidden and the screen stays a Homebase ID lookup.
+    data class AddContact(val identityOnly: Boolean = false) : Route()
 
     @Serializable
     @SerialName("feed")

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -356,7 +356,7 @@ fun AppNavHost(
                 is ContactBookUiEvent.OpenDetail ->
                     navController.navigate(Route.ContactBookDetail(event.uniqueId, event.odinId))
                 ContactBookUiEvent.OpenAddContact ->
-                    navController.navigate(Route.AddContact)
+                    navController.navigate(Route.AddContact())
                 ContactBookUiEvent.CloseOnboarding ->
                     navController.popBackStack(Route.ChatList, inclusive = false)
                 else -> { /* Error handled by ContactBookScreen */ }
@@ -804,11 +804,13 @@ fun AppNavHost(
                             }
                         }
 
-                        composable<Route.AddContact> {
+                        composable<Route.AddContact> { backStackEntry ->
                             if (isAuthenticated) {
+                                val route = backStackEntry.toRoute<Route.AddContact>()
                                 AddContactScreen(
                                     viewModel = koinViewModel(),
                                     connectRequestViewModel = koinViewModel(),
+                                    identityOnly = route.identityOnly,
                                     onBack = { navController.popBackStack() },
                                     onOpenConversation = { conversationId ->
                                         navController.selectConversationOnChatList(conversationId)
@@ -956,7 +958,9 @@ fun AppNavHost(
                                         navController.navigate(Route.CreateConversationSelectMembers)
                                     },
                                     onAddContact = {
-                                        navController.navigate(Route.AddContact)
+                                        // From a chat flow: a contact is only useful with a
+                                        // Homebase ID, so hide manual entry.
+                                        navController.navigate(Route.AddContact(identityOnly = true))
                                     })
                             }
                         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -144,7 +144,6 @@ import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import id.homebase.core.util.getUriHandler
 import kotlinx.io.files.Path
-import id.homebase.core.widget.ConnectionRequestHeaderBanner
 import id.homebase.core.widget.InAppNotificationBanner
 import id.homebase.core.widget.UpdateAvailableBanner
 import id.homebase.imageeditor.ui.CropScreen
@@ -606,15 +605,6 @@ fun AppNavHost(
                                 onUpdateClick = { viewModel.triggerUpdate() }
                             )
                         }
-                        if (uiState.incomingRequests.isNotEmpty()) {
-                            ConnectionRequestHeaderBanner(
-                                requestCount = uiState.incomingRequests.size,
-                                // Pending requests now live in the Contact Book's Requests pill
-                                // (accept/reject in-app), so land there instead of the owner console.
-                                onBannerClick = openContactBook,
-                            )
-                        }
-
                         val pendingUpgrade = uiState.pendingUpgrade
                         if (pendingUpgrade is PendingUpgradeState.ShowSnackbar) {
                             LaunchedEffect(pendingUpgrade) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppViewModel.kt
@@ -8,8 +8,6 @@ import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.common.OdinId
-import id.homebase.chat.data.IncomingConnectionRequestUiModel
-import id.homebase.chat.services.requests.ConnectionRequestService
 import id.homebase.core.auth.AuthConnectionCoordinator
 import id.homebase.core.notifications.BadgeManager
 import id.homebase.core.notifications.NotificationNavigationEvent
@@ -39,10 +37,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlin.coroutines.cancellation.CancellationException
 
 class AppViewModel(
-    private val connectionRequestService: ConnectionRequestService,
     private val credentialsManager: CredentialsManager,
     private val notificationService: NotificationService,
     private val shareContentProcessor: ShareContentProcessor,
@@ -62,7 +58,6 @@ class AppViewModel(
     val navigationEvents: Flow<NotificationNavigationEvent> = _navigationEvents.receiveAsFlow()
 
     private var credentialsJob: Job? = null
-    private var listenForConnectionRequestsJob: Job? = null
     private var upgradeCheckJob: Job? = null
 
     init {
@@ -108,10 +103,7 @@ class AppViewModel(
             credentialsManager.credentialsFlow.collect { credentials ->
                 if (credentials != null) {
                     _uiState.update { it.copy(currentOdinId = credentials.domain) }
-                    listenForConnectionRequests()
                     checkPendingUpgrade()
-                } else {
-                    listenForConnectionRequestsJob?.cancel()
                 }
             }
         }
@@ -235,30 +227,11 @@ class AppViewModel(
         _navigationEvents.trySend(NotificationNavigationEvent.OpenMomentCompose)
     }
 
-    private fun listenForConnectionRequests() {
-        listenForConnectionRequestsJob?.cancel()
-        listenForConnectionRequestsJob = viewModelScope.launch {
-            try {
-                connectionRequestService.start()
-                connectionRequestService.incomingRequests.collect { incomingRequests ->
-                    _uiState.update { it.copy(incomingRequests = incomingRequests) }
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Logger.e(
-                    throwable = e,
-                    tag = "AppViewModel"
-                ) { "Failed to collect incoming requests: ${e.message}" }
-            }
-        }
-    }
 }
 
 @Immutable
 data class AppUiState(
     val currentOdinId: OdinId? = null,
-    val incomingRequests: List<IncomingConnectionRequestUiModel> = listOf(),
     val inAppNotification: RichNotificationData? = null,
     val updateAvailable: Boolean = false,
     val updateAvailableVersion: String = "",

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookContent.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import id.homebase.core.ui.screens.contactbook.components.ContactBookEmptyState
 import id.homebase.core.ui.screens.contactbook.components.ContactBookRow
+import id.homebase.core.widget.ConnectionRequestHeaderBanner
 import id.homebase.resources.MR
 import id.homebase.resources.contactbook_confirmed_empty
 import id.homebase.resources.contactbook_filter_all
@@ -47,6 +48,16 @@ fun ContactBookContent(
 ) {
     Column(modifier = modifier.fillMaxSize()) {
         FilterRow(uiState.filter, uiState.requests.size, onAction)
+
+        // Incoming connection requests surface here (not as a global app banner). Tapping it
+        // jumps straight to the Requests pill. Hidden once that pill is active to avoid
+        // redundancy.
+        if (uiState.filter != ContactFilter.REQUESTS && uiState.incomingRequestCount > 0) {
+            ConnectionRequestHeaderBanner(
+                requestCount = uiState.incomingRequestCount,
+                onBannerClick = { onAction(ContactBookUiAction.FilterChanged(ContactFilter.REQUESTS)) },
+            )
+        }
 
         if (uiState.filter == ContactFilter.REQUESTS) {
             RequestsList(uiState, onAction)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookUiState.kt
@@ -101,6 +101,11 @@ data class ContactBookUiState(
     val confirmed: List<ContactBookEntry> = emptyList(),
     /** Requests filter: pending connection requests (incoming + outgoing), newest first. */
     val requests: List<PendingRequestEntry> = emptyList(),
+    /**
+     * Count of incoming connection requests, unfiltered by search — drives the in-list banner
+     * that jumps to the Requests pill.
+     */
+    val incomingRequestCount: Int = 0,
     /** Lowercased contact-domain → introducer display name, for the "Introduced by" row line. */
     val introducedByDomain: Map<String, String> = emptyMap(),
     /** Circles tab. */

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookViewModel.kt
@@ -291,6 +291,7 @@ class ContactBookViewModel(
             introduced = introduced,
             confirmed = confirmed,
             requests = requests,
+            incomingRequestCount = incomingRequests.size,
             introducedByDomain = introducedByDomain,
             circles = circlesData.circles.filter { it.matchesQuery(ui.query) },
             circlesLoading = circlesData.loading,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactScreen.kt
@@ -21,7 +21,9 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.AddAPhoto
+import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.ErrorOutline
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.PersonAddAlt1
@@ -52,6 +54,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
+import id.homebase.api.client.identity.PublicIdentity
 import id.homebase.api.client.identity.displayNameOrDomain
 import id.homebase.api.client.identity.initials
 import id.homebase.api.common.OdinId
@@ -64,9 +67,10 @@ import id.homebase.core.connections.RecipientResolution
 import id.homebase.core.ui.screens.contactbook.components.PhoneNumberField
 import id.homebase.resources.MR
 import id.homebase.resources.add_contact_already_connected
+import id.homebase.resources.add_contact_already_saved
+import id.homebase.resources.add_contact_blocked
 import id.homebase.resources.add_contact_byid_link
 import id.homebase.resources.add_contact_details_optional
-import id.homebase.resources.add_contact_identity_found
 import id.homebase.resources.add_contact_invalid
 import id.homebase.resources.add_contact_lead_help
 import id.homebase.resources.add_contact_manual_link
@@ -75,9 +79,19 @@ import id.homebase.resources.add_contact_odinid_hint
 import id.homebase.resources.add_contact_odinid_label
 import id.homebase.resources.add_contact_photo_from_profile
 import id.homebase.resources.add_contact_resolving
+import id.homebase.resources.add_contact_save_as_new
 import id.homebase.resources.add_contact_send_request
 import id.homebase.resources.add_contact_send_request_help
 import id.homebase.resources.add_contact_title
+import id.homebase.resources.contactbook_action_request_accepted
+import id.homebase.resources.contactbook_action_request_cancelled
+import id.homebase.resources.contactbook_action_request_rejected
+import id.homebase.resources.contactbook_detail_accept
+import id.homebase.resources.contactbook_detail_cancel_request
+import id.homebase.resources.contactbook_detail_request_incoming
+import id.homebase.resources.contactbook_detail_request_outgoing
+import id.homebase.resources.contactbook_detail_reject
+import id.homebase.resources.auto_connect_failed_generic
 import id.homebase.resources.contactbook_edit_change_photo
 import id.homebase.resources.contactbook_edit_city
 import id.homebase.resources.contactbook_edit_country
@@ -111,6 +125,10 @@ fun AddContactScreen(
     val errSave = stringResource(MR.string.contactbook_error_save)
     val errForbidden = stringResource(MR.string.contactbook_error_forbidden)
     val errPhoto = stringResource(MR.string.contactbook_error_photo)
+    val msgAccepted = stringResource(MR.string.contactbook_action_request_accepted)
+    val msgRejected = stringResource(MR.string.contactbook_action_request_rejected)
+    val msgCancelled = stringResource(MR.string.contactbook_action_request_cancelled)
+    val msgActionFailed = stringResource(MR.string.auto_connect_failed_generic)
 
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
@@ -119,6 +137,12 @@ fun AddContactScreen(
                 AddContactEvent.Forbidden -> snackbarHostState.showSnackbar(errForbidden)
                 AddContactEvent.Error -> snackbarHostState.showSnackbar(errSave)
                 AddContactEvent.PhotoFailed -> snackbarHostState.showSnackbar(errPhoto)
+                // Request actions keep the user on the screen — the card reflects the new
+                // relationship reactively, and we just confirm with a snackbar.
+                AddContactEvent.RequestAccepted -> snackbarHostState.showSnackbar(msgAccepted)
+                AddContactEvent.RequestRejected -> snackbarHostState.showSnackbar(msgRejected)
+                AddContactEvent.RequestCancelled -> snackbarHostState.showSnackbar(msgCancelled)
+                AddContactEvent.RequestActionFailed -> snackbarHostState.showSnackbar(msgActionFailed)
             }
         }
     }
@@ -194,15 +218,6 @@ fun AddContactScreen(
 
                 AddContactMode.MANUAL -> ManualSection(uiState, viewModel::onAction)
             }
-
-            Spacer(modifier = Modifier.height(24.dp))
-            Button(
-                onClick = { viewModel.onAction(AddContactAction.SaveClicked) },
-                enabled = uiState.canSave,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Text(stringResource(MR.string.contactbook_edit_save))
-            }
         }
 
         ConnectRequestBottomSheet(
@@ -269,28 +284,217 @@ private fun ByIdentitySection(
 
     ResolutionIndicator(resolution)
 
-    // A resolved identity is someone you can actually connect with — offer to send a request
-    // (reuses the same autoConnect pipeline as the rest of the app) right alongside saving them
-    // to the contact book. If you're already connected, say so instead of offering to connect.
-    if (resolution is RecipientResolution.Resolved) {
-        if (uiState.alreadyConnected) {
-            AlreadyConnectedNote()
-        } else {
-            ConnectRequestOffer(onClick = { onSendConnectionRequest(resolution.identity.odinId) })
+    when (resolution) {
+        // A resolved identity is presented read-only: the profile data we pulled, plus exactly
+        // the connection action that currently applies (send / accept / reject / cancel /
+        // already connected) and a one-tap "Save as new contact". We deliberately do NOT show
+        // editable fields for data that came from their Homebase profile.
+        is RecipientResolution.Resolved -> {
+            ResolvedIdentityCard(resolution.identity)
+            RelationActions(
+                relation = uiState.relation,
+                odinId = resolution.identity.odinId,
+                actionInProgress = uiState.actionInProgress,
+                onSendConnectionRequest = onSendConnectionRequest,
+                onAction = onAction,
+            )
+            SaveAsNewRow(uiState, onAction)
         }
-    }
 
-    // Once the user has committed to an identity (resolved or "add anyway"), let them refine
-    // the name and add optional details before saving.
-    if (resolution is RecipientResolution.Resolved || resolution is RecipientResolution.NotFound) {
-        NameFields(uiState, onAction)
-        Spacer(modifier = Modifier.height(8.dp))
-        OptionalDetails(uiState, onAction)
+        // Couldn't resolve the ID, but the user can still add them by hand ("add anyway").
+        RecipientResolution.NotFound -> {
+            NameFields(uiState, onAction)
+            Spacer(modifier = Modifier.height(8.dp))
+            OptionalDetails(uiState, onAction)
+            SaveButton(
+                enabled = uiState.canSave,
+                onClick = { onAction(AddContactAction.SaveClicked) },
+            )
+        }
+
+        else -> {}
     }
 
     Spacer(modifier = Modifier.height(8.dp))
     TextButton(onClick = { onAction(AddContactAction.SwitchToManual) }) {
         Text(stringResource(MR.string.add_contact_manual_link))
+    }
+}
+
+/** Read-only display of the data pulled from a resolved Homebase profile. */
+@Composable
+private fun ResolvedIdentityCard(identity: PublicIdentity) {
+    Spacer(modifier = Modifier.height(4.dp))
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = identity.displayNameOrDomain(),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = identity.odinId.domainName,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        identity.status?.takeIf { it.isNotBlank() }?.let { status ->
+            Text(
+                text = status,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+        }
+    }
+}
+
+/** The single connection action applicable to the resolved identity's current relationship. */
+@Composable
+private fun RelationActions(
+    relation: IdentityRelation,
+    odinId: OdinId,
+    actionInProgress: Boolean,
+    onSendConnectionRequest: (OdinId) -> Unit,
+    onAction: (AddContactAction) -> Unit,
+) {
+    when (relation) {
+        IdentityRelation.NONE ->
+            ConnectRequestOffer(onClick = { onSendConnectionRequest(odinId) })
+
+        IdentityRelation.INCOMING_PENDING -> {
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = stringResource(MR.string.contactbook_detail_request_incoming),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Button(
+                    onClick = { onAction(AddContactAction.AcceptRequestClicked) },
+                    enabled = !actionInProgress,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Icon(Icons.Outlined.Check, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(modifier = Modifier.size(8.dp))
+                    Text(stringResource(MR.string.contactbook_detail_accept))
+                }
+                OutlinedButton(
+                    onClick = { onAction(AddContactAction.RejectRequestClicked) },
+                    enabled = !actionInProgress,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text(stringResource(MR.string.contactbook_detail_reject))
+                }
+            }
+        }
+
+        IdentityRelation.OUTGOING_PENDING -> {
+            Spacer(modifier = Modifier.height(12.dp))
+            IndicatorRow(
+                content = {
+                    Icon(
+                        Icons.Outlined.CheckCircle,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(18.dp),
+                    )
+                },
+                text = stringResource(MR.string.contactbook_detail_request_outgoing),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            OutlinedButton(
+                onClick = { onAction(AddContactAction.CancelRequestClicked) },
+                enabled = !actionInProgress,
+                modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+            ) {
+                Icon(Icons.Outlined.Close, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(modifier = Modifier.size(8.dp))
+                Text(stringResource(MR.string.contactbook_detail_cancel_request))
+            }
+        }
+
+        IdentityRelation.CONNECTED -> AlreadyConnectedNote()
+
+        IdentityRelation.BLOCKED -> {
+            Spacer(modifier = Modifier.height(12.dp))
+            IndicatorRow(
+                content = {
+                    Icon(
+                        Icons.Outlined.ErrorOutline,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(18.dp),
+                    )
+                },
+                text = stringResource(MR.string.add_contact_blocked),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+/** "Save as new contact" affordance, or a note if they're already in the book. */
+@Composable
+private fun SaveAsNewRow(
+    uiState: AddContactUiState,
+    onAction: (AddContactAction) -> Unit,
+) {
+    if (uiState.alreadySaved) {
+        Spacer(modifier = Modifier.height(12.dp))
+        IndicatorRow(
+            content = {
+                Icon(
+                    Icons.Outlined.CheckCircle,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(18.dp),
+                )
+            },
+            text = stringResource(MR.string.add_contact_already_saved),
+            tint = MaterialTheme.colorScheme.primary,
+        )
+        return
+    }
+    // Keep one primary (filled) button on screen: when the relationship already has a filled CTA
+    // (Send request / Accept), Save is the secondary outlined action; otherwise it's primary.
+    val saveSecondary = uiState.relation == IdentityRelation.NONE ||
+        uiState.relation == IdentityRelation.INCOMING_PENDING
+    Spacer(modifier = Modifier.height(8.dp))
+    if (saveSecondary) {
+        OutlinedButton(
+            onClick = { onAction(AddContactAction.SaveClicked) },
+            enabled = uiState.canSave,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(stringResource(MR.string.add_contact_save_as_new))
+        }
+    } else {
+        Button(
+            onClick = { onAction(AddContactAction.SaveClicked) },
+            enabled = uiState.canSave,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(stringResource(MR.string.add_contact_save_as_new))
+        }
+    }
+}
+
+/** Full-width primary Save used by manual entry and the "add anyway" (NotFound) path. */
+@Composable
+private fun SaveButton(enabled: Boolean, onClick: () -> Unit) {
+    Spacer(modifier = Modifier.height(24.dp))
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(stringResource(MR.string.contactbook_edit_save))
     }
 }
 
@@ -320,7 +524,7 @@ private fun ConnectRequestOffer(onClick: () -> Unit) {
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
     )
-    OutlinedButton(onClick = onClick, modifier = Modifier.fillMaxWidth()) {
+    Button(onClick = onClick, modifier = Modifier.fillMaxWidth()) {
         Icon(Icons.Outlined.PersonAddAlt1, contentDescription = null)
         Spacer(modifier = Modifier.size(8.dp))
         Text(stringResource(MR.string.add_contact_send_request))
@@ -335,21 +539,8 @@ private fun ResolutionIndicator(resolution: RecipientResolution) {
             text = stringResource(MR.string.add_contact_resolving),
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        is RecipientResolution.Resolved -> IndicatorRow(
-            content = {
-                Icon(
-                    Icons.Outlined.CheckCircle,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(18.dp),
-                )
-            },
-            text = stringResource(
-                MR.string.add_contact_identity_found,
-                resolution.identity.displayNameOrDomain(),
-            ),
-            tint = MaterialTheme.colorScheme.primary,
-        )
+        // A resolved identity is rendered by ResolvedIdentityCard, not as a one-line indicator.
+        is RecipientResolution.Resolved -> {}
         RecipientResolution.NotFound -> IndicatorRow(
             content = {
                 Icon(
@@ -389,6 +580,10 @@ private fun ManualSection(
 ) {
     NameFields(uiState, onAction)
     OptionalDetails(uiState, onAction)
+    SaveButton(
+        enabled = uiState.canSave,
+        onClick = { onAction(AddContactAction.SaveClicked) },
+    )
     Spacer(modifier = Modifier.height(8.dp))
     TextButton(onClick = { onAction(AddContactAction.SwitchToByIdentity) }) {
         Text(stringResource(MR.string.add_contact_byid_link))

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.Message
 import androidx.compose.material.icons.outlined.AddAPhoto
 import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material.icons.outlined.CheckCircle
@@ -88,6 +89,7 @@ import id.homebase.resources.contactbook_action_request_cancelled
 import id.homebase.resources.contactbook_action_request_rejected
 import id.homebase.resources.contactbook_detail_accept
 import id.homebase.resources.contactbook_detail_cancel_request
+import id.homebase.resources.contactbook_detail_message
 import id.homebase.resources.contactbook_detail_request_incoming
 import id.homebase.resources.contactbook_detail_request_outgoing
 import id.homebase.resources.contactbook_detail_reject
@@ -118,6 +120,10 @@ fun AddContactScreen(
     connectRequestViewModel: ConnectRequestViewModel,
     onBack: () -> Unit,
     onOpenConversation: (Uuid) -> Unit,
+    // Launched from a chat flow: a contact is only useful with a Homebase ID (you can't message
+    // someone without one), so manual entry and "save as new contact" are hidden — a resolved
+    // identity is actionable only as connect/accept/cancel, or Message once connected.
+    identityOnly: Boolean = false,
 ) {
     val uiState by viewModel.state.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -143,6 +149,7 @@ fun AddContactScreen(
                 AddContactEvent.RequestRejected -> snackbarHostState.showSnackbar(msgRejected)
                 AddContactEvent.RequestCancelled -> snackbarHostState.showSnackbar(msgCancelled)
                 AddContactEvent.RequestActionFailed -> snackbarHostState.showSnackbar(msgActionFailed)
+                is AddContactEvent.OpenConversation -> onOpenConversation(event.conversationId)
             }
         }
     }
@@ -209,6 +216,7 @@ fun AddContactScreen(
                 AddContactMode.BY_IDENTITY -> ByIdentitySection(
                     uiState = uiState,
                     onAction = viewModel::onAction,
+                    identityOnly = identityOnly,
                     onSendConnectionRequest = { odinId ->
                         connectRequestViewModel.onAction(
                             ConnectRequestAction.OpenDialogWithRecipient(odinId),
@@ -265,6 +273,7 @@ private fun AddContactAvatar(uiState: AddContactUiState, photoBytes: ByteArray?)
 private fun ByIdentitySection(
     uiState: AddContactUiState,
     onAction: (AddContactAction) -> Unit,
+    identityOnly: Boolean,
     onSendConnectionRequest: (OdinId) -> Unit,
 ) {
     val resolution = uiState.resolution
@@ -295,29 +304,39 @@ private fun ByIdentitySection(
                 relation = uiState.relation,
                 odinId = resolution.identity.odinId,
                 actionInProgress = uiState.actionInProgress,
+                identityOnly = identityOnly,
                 onSendConnectionRequest = onSendConnectionRequest,
                 onAction = onAction,
             )
-            SaveAsNewRow(uiState, onAction)
+            // In identity-only (chat) mode a contact can't be "saved as new" — the only useful
+            // outcomes are connect or message-once-connected, both handled by RelationActions.
+            if (!identityOnly) SaveAsNewRow(uiState, onAction)
         }
 
-        // Couldn't resolve the ID, but the user can still add them by hand ("add anyway").
+        // Couldn't resolve the ID. Outside chat the user can still add them by hand ("add anyway");
+        // in identity-only mode there's nothing to do without a Homebase ID, so we stop here.
         RecipientResolution.NotFound -> {
-            NameFields(uiState, onAction)
-            Spacer(modifier = Modifier.height(8.dp))
-            OptionalDetails(uiState, onAction)
-            SaveButton(
-                enabled = uiState.canSave,
-                onClick = { onAction(AddContactAction.SaveClicked) },
-            )
+            if (!identityOnly) {
+                NameFields(uiState, onAction)
+                Spacer(modifier = Modifier.height(8.dp))
+                OptionalDetails(uiState, onAction)
+                SaveButton(
+                    enabled = uiState.canSave,
+                    onClick = { onAction(AddContactAction.SaveClicked) },
+                )
+            }
         }
 
         else -> {}
     }
 
-    Spacer(modifier = Modifier.height(8.dp))
-    TextButton(onClick = { onAction(AddContactAction.SwitchToManual) }) {
-        Text(stringResource(MR.string.add_contact_manual_link))
+    // The "Add manually" escape hatch is only offered when a manual contact is useful — never
+    // from a chat flow, where a contact without a Homebase ID can't be messaged.
+    if (!identityOnly) {
+        Spacer(modifier = Modifier.height(8.dp))
+        TextButton(onClick = { onAction(AddContactAction.SwitchToManual) }) {
+            Text(stringResource(MR.string.add_contact_manual_link))
+        }
     }
 }
 
@@ -356,6 +375,7 @@ private fun RelationActions(
     relation: IdentityRelation,
     odinId: OdinId,
     actionInProgress: Boolean,
+    identityOnly: Boolean,
     onSendConnectionRequest: (OdinId) -> Unit,
     onAction: (AddContactAction) -> Unit,
 ) {
@@ -419,7 +439,17 @@ private fun RelationActions(
             }
         }
 
-        IdentityRelation.CONNECTED -> AlreadyConnectedNote()
+        // Already connected: in a chat flow, offer to jump straight into the conversation;
+        // otherwise just note the connection (the contact-book add has nothing to message from).
+        IdentityRelation.CONNECTED ->
+            if (identityOnly) {
+                MessageConnectedButton(
+                    enabled = !actionInProgress,
+                    onClick = { onAction(AddContactAction.MessageClicked) },
+                )
+            } else {
+                AlreadyConnectedNote()
+            }
 
         IdentityRelation.BLOCKED -> {
             Spacer(modifier = Modifier.height(12.dp))
@@ -495,6 +525,21 @@ private fun SaveButton(enabled: Boolean, onClick: () -> Unit) {
         modifier = Modifier.fillMaxWidth(),
     ) {
         Text(stringResource(MR.string.contactbook_edit_save))
+    }
+}
+
+/** Primary "Message" CTA shown for an already-connected identity in the chat (identity-only) flow. */
+@Composable
+private fun MessageConnectedButton(enabled: Boolean, onClick: () -> Unit) {
+    Spacer(modifier = Modifier.height(8.dp))
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Icon(Icons.AutoMirrored.Outlined.Message, contentDescription = null, modifier = Modifier.size(18.dp))
+        Spacer(modifier = Modifier.size(8.dp))
+        Text(stringResource(MR.string.contactbook_detail_message))
     }
 }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactUiState.kt
@@ -1,9 +1,13 @@
+@file:OptIn(ExperimentalUuidApi::class)
+
 package id.homebase.core.ui.screens.contactbook.add
 
 import androidx.compose.runtime.Immutable
 import id.homebase.core.connections.RecipientResolution
 import id.homebase.core.ui.screens.contactbook.ContactDraft
 import io.github.vinceglb.filekit.PlatformFile
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 /** Whether the Add Contact flow leads with a Homebase ID lookup or a plain manual form. */
 enum class AddContactMode { BY_IDENTITY, MANUAL }
@@ -52,6 +56,8 @@ sealed interface AddContactAction {
     data object SwitchToManual : AddContactAction
     data object SwitchToByIdentity : AddContactAction
     data object SaveClicked : AddContactAction
+    /** Open (or reuse) the 1:1 conversation with the resolved, already-connected identity. */
+    data object MessageClicked : AddContactAction
     /** Accept the incoming request from the resolved identity. */
     data object AcceptRequestClicked : AddContactAction
     /** Reject the incoming request from the resolved identity. */
@@ -78,5 +84,7 @@ sealed interface AddContactEvent {
     data object RequestCancelled : AddContactEvent
     /** An accept/reject/cancel action failed. */
     data object RequestActionFailed : AddContactEvent
+    /** Open the 1:1 conversation with an already-connected identity. */
+    data class OpenConversation(val conversationId: Uuid) : AddContactEvent
     data object Back : AddContactEvent
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactUiState.kt
@@ -8,16 +8,38 @@ import io.github.vinceglb.filekit.PlatformFile
 /** Whether the Add Contact flow leads with a Homebase ID lookup or a plain manual form. */
 enum class AddContactMode { BY_IDENTITY, MANUAL }
 
+/**
+ * The signed-in user's relationship to a resolved identity — drives which connection action the
+ * Add Contact card offers. Derived live from the connection map plus the pending incoming/outgoing
+ * request lists.
+ */
+enum class IdentityRelation {
+    /** Not connected and no pending request either way — offer to send one. */
+    NONE,
+    /** We've sent them a request that's still pending — offer to cancel it. */
+    OUTGOING_PENDING,
+    /** They've sent us a request — offer to accept or reject. */
+    INCOMING_PENDING,
+    /** Already connected. */
+    CONNECTED,
+    /** We've blocked them. */
+    BLOCKED,
+}
+
 @Immutable
 data class AddContactUiState(
     val mode: AddContactMode = AddContactMode.BY_IDENTITY,
     /** Live lookup status for the entered Homebase ID (BY_IDENTITY mode). */
     val resolution: RecipientResolution = RecipientResolution.Idle,
-    /** True when the resolved identity is already a connection — suppresses the request offer. */
-    val alreadyConnected: Boolean = false,
+    /** Relationship to the resolved identity — selects the applicable connection action. */
+    val relation: IdentityRelation = IdentityRelation.NONE,
+    /** True when the resolved identity is already saved in the contact book. */
+    val alreadySaved: Boolean = false,
     val draft: ContactDraft = ContactDraft(),
     val photo: PlatformFile? = null,
     val isSaving: Boolean = false,
+    /** An accept/reject/cancel request action is in flight — disables the action buttons. */
+    val actionInProgress: Boolean = false,
 ) {
     val canSave: Boolean get() = draft.isSavable && !isSaving
 }
@@ -30,6 +52,12 @@ sealed interface AddContactAction {
     data object SwitchToManual : AddContactAction
     data object SwitchToByIdentity : AddContactAction
     data object SaveClicked : AddContactAction
+    /** Accept the incoming request from the resolved identity. */
+    data object AcceptRequestClicked : AddContactAction
+    /** Reject the incoming request from the resolved identity. */
+    data object RejectRequestClicked : AddContactAction
+    /** Cancel the outgoing request to the resolved identity. */
+    data object CancelRequestClicked : AddContactAction
     data object BackClicked : AddContactAction
 }
 
@@ -42,5 +70,13 @@ sealed interface AddContactEvent {
     data object Forbidden : AddContactEvent
     /** Any other save failure. */
     data object Error : AddContactEvent
+    /** An incoming request was accepted — stay on screen, show a confirmation. */
+    data object RequestAccepted : AddContactEvent
+    /** An incoming request was rejected. */
+    data object RequestRejected : AddContactEvent
+    /** An outgoing request was cancelled. */
+    data object RequestCancelled : AddContactEvent
+    /** An accept/reject/cancel action failed. */
+    data object RequestActionFailed : AddContactEvent
     data object Back : AddContactEvent
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactViewModel.kt
@@ -11,6 +11,7 @@ import id.homebase.api.client.identity.PublicIdentityRepository
 import id.homebase.api.client.identity.displayNameOrDomain
 import id.homebase.api.common.OdinId
 import id.homebase.chat.services.convo.contact.ConnectionService
+import id.homebase.chat.services.requests.ConnectionRequestService
 import id.homebase.core.connections.RecipientResolution
 import id.homebase.core.ui.screens.contactbook.ContactDraft
 import id.homebase.core.ui.screens.contactbook.ContactSaveResult
@@ -44,32 +45,57 @@ class AddContactViewModel(
     private val repo: ContactRepository,
     private val publicIdentityRepository: PublicIdentityRepository,
     private val connectionService: ConnectionService,
+    private val connectionRequestService: ConnectionRequestService,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(AddContactUiState())
 
     /**
-     * Public state, with [AddContactUiState.alreadyConnected] folded in live from the connection
-     * list so the "Send connection request" offer never tells you to connect with someone you're
-     * already connected to.
+     * Public state, with [AddContactUiState.relation] and [AddContactUiState.alreadySaved] folded
+     * in live from the connection map, the pending incoming/outgoing request lists, and the saved
+     * contacts. This is what lets the resolved-identity card offer exactly the applicable action
+     * (send / accept / reject / cancel / nothing) and avoid offering to save a contact twice.
      */
     val state: StateFlow<AddContactUiState> =
-        combine(_state, connectionService.connections) { s, conn ->
-            val resolved = (s.resolution as? RecipientResolution.Resolved)
+        combine(
+            _state,
+            connectionService.connections,
+            connectionRequestService.incomingRequests,
+            connectionRequestService.outgoingRequests,
+            repo.contacts,
+        ) { s, conn, incoming, outgoing, contacts ->
+            val domain = (s.resolution as? RecipientResolution.Resolved)
                 ?.identity?.odinId?.domainName?.lowercase()
-            val connectedDomains = conn.map
-                .filterValues { it.status == ConnectionStatus.Connected }
-                .keys.map { it.domainName.lowercase() }.toSet()
-            s.copy(alreadyConnected = resolved != null && resolved in connectedDomains)
+            val status = domain?.let { d ->
+                conn.map.entries
+                    .firstOrNull { it.key.domainName.lowercase() == d }
+                    ?.value?.status
+            }
+            val relation = when {
+                domain == null -> IdentityRelation.NONE
+                status == ConnectionStatus.Connected -> IdentityRelation.CONNECTED
+                status == ConnectionStatus.Blocked -> IdentityRelation.BLOCKED
+                incoming.any { it.senderOdinId.domainName.lowercase() == domain } ->
+                    IdentityRelation.INCOMING_PENDING
+                outgoing.any { it.recipientOdinId.domainName.lowercase() == domain } ->
+                    IdentityRelation.OUTGOING_PENDING
+                else -> IdentityRelation.NONE
+            }
+            val alreadySaved = domain != null &&
+                contacts.any { it.content.odinId?.lowercase() == domain }
+            s.copy(relation = relation, alreadySaved = alreadySaved)
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AddContactUiState())
 
     private val _events = MutableSharedFlow<AddContactEvent>(extraBufferCapacity = 8)
     val events: SharedFlow<AddContactEvent> = _events.asSharedFlow()
 
     init {
-        // Idempotent — already started by app bootstrap; ensures the connection map is hydrated
-        // so `alreadyConnected` is accurate even if Add Contact is reached very early.
+        // All idempotent — already started by app bootstrap; we re-trigger so the connection map,
+        // the pending-request lists, and the contact list are hydrated even if Add Contact is the
+        // first screen reached, keeping `relation` / `alreadySaved` accurate from the start.
         connectionService.start()
+        viewModelScope.launch { connectionRequestService.start() }
+        viewModelScope.launch { repo.ensureLoaded() }
     }
 
     private var resolveJob: Job? = null
@@ -98,7 +124,44 @@ class AddContactViewModel(
             AddContactAction.SwitchToByIdentity ->
                 _state.update { it.copy(mode = AddContactMode.BY_IDENTITY) }
             AddContactAction.SaveClicked -> save()
+            AddContactAction.AcceptRequestClicked -> handleRequestAction(
+                AddContactEvent.RequestAccepted,
+            ) { connectionRequestService.acceptIncomingRequest(it) }
+            AddContactAction.RejectRequestClicked -> handleRequestAction(
+                AddContactEvent.RequestRejected,
+            ) { connectionRequestService.rejectIncomingRequest(it) }
+            AddContactAction.CancelRequestClicked -> handleRequestAction(
+                AddContactEvent.RequestCancelled,
+            ) { connectionRequestService.cancelOutgoingRequest(it) }
             AddContactAction.BackClicked -> _events.tryEmit(AddContactEvent.Back)
+        }
+    }
+
+    /**
+     * Runs an accept/reject/cancel against the resolved identity. The relation/alreadySaved
+     * state updates reactively once the service refreshes its lists, so we only manage the
+     * in-flight flag and surface a success/failure event for the snackbar.
+     */
+    private fun handleRequestAction(
+        success: AddContactEvent,
+        action: suspend (OdinId) -> Unit,
+    ) {
+        val odinId = (_state.value.resolution as? RecipientResolution.Resolved)?.identity?.odinId
+            ?: return
+        if (_state.value.actionInProgress) return
+        _state.update { it.copy(actionInProgress = true) }
+        viewModelScope.launch {
+            try {
+                runCatching { action(odinId) }
+                    .onSuccess { _events.tryEmit(success) }
+                    .onFailure {
+                        if (it is CancellationException) throw it
+                        Logger.w(it) { "Request action failed for $odinId" }
+                        _events.tryEmit(AddContactEvent.RequestActionFailed)
+                    }
+            } finally {
+                _state.update { it.copy(actionInProgress = false) }
+            }
         }
     }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactViewModel.kt
@@ -10,6 +10,7 @@ import id.homebase.api.client.contacts.ContactRepository
 import id.homebase.api.client.identity.PublicIdentityRepository
 import id.homebase.api.client.identity.displayNameOrDomain
 import id.homebase.api.common.OdinId
+import id.homebase.chat.services.convo.ConversationService
 import id.homebase.chat.services.convo.contact.ConnectionService
 import id.homebase.chat.services.requests.ConnectionRequestService
 import id.homebase.core.connections.RecipientResolution
@@ -46,6 +47,7 @@ class AddContactViewModel(
     private val publicIdentityRepository: PublicIdentityRepository,
     private val connectionService: ConnectionService,
     private val connectionRequestService: ConnectionRequestService,
+    private val conversationService: ConversationService,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(AddContactUiState())
@@ -124,6 +126,7 @@ class AddContactViewModel(
             AddContactAction.SwitchToByIdentity ->
                 _state.update { it.copy(mode = AddContactMode.BY_IDENTITY) }
             AddContactAction.SaveClicked -> save()
+            AddContactAction.MessageClicked -> openConversation()
             AddContactAction.AcceptRequestClicked -> handleRequestAction(
                 AddContactEvent.RequestAccepted,
             ) { connectionRequestService.acceptIncomingRequest(it) }
@@ -220,6 +223,28 @@ class AddContactViewModel(
                     },
                 )
             }
+        }
+    }
+
+    /**
+     * Opens (or reuses) the 1:1 conversation with the resolved, already-connected identity, then
+     * navigates into it. Used by the identity-only (chat) entry where a connected contact is
+     * actionable as "Message" rather than "Save as new contact".
+     */
+    private fun openConversation() {
+        val odinId = (_state.value.resolution as? RecipientResolution.Resolved)?.identity?.odinId
+            ?: return
+        viewModelScope.launch {
+            val id = try {
+                conversationService.createConversation(listOf(odinId), "", null).conversationId
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Logger.w(e) { "Failed to open conversation with $odinId" }
+                _events.tryEmit(AddContactEvent.Error)
+                return@launch
+            }
+            _events.tryEmit(AddContactEvent.OpenConversation(id))
         }
     }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/ContactEditSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/ContactEditSheet.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import id.homebase.core.image.HomebaseImage
 import id.homebase.core.ui.screens.contactbook.ContactDraft
+import id.homebase.core.ui.screens.contactbook.ContactFieldValidation
 import id.homebase.core.ui.screens.contactbook.model.ContactBookEntry
 import id.homebase.core.ui.screens.contactbook.syncedDraft
 import id.homebase.core.ui.screens.contactbook.toDraft
@@ -74,6 +75,7 @@ import id.homebase.resources.contactbook_edit_title_edit
 import id.homebase.resources.contactbook_edit_title_new
 import id.homebase.resources.contactbook_error_email
 import id.homebase.resources.contactbook_error_odinid
+import id.homebase.resources.contactbook_error_phone
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher
@@ -89,7 +91,12 @@ fun ContactEditSheet(
 ) {
     var draft by remember { mutableStateOf(editing?.toDraft() ?: ContactDraft()) }
     // Extra phones/emails beyond the single canonical slot — app-local additions (see overlay).
-    var addPhones by remember { mutableStateOf(editing?.additionalPhones.orEmpty()) }
+    // Phones carry a stable id so the stateful PhoneNumberField rows keep their seeded country/
+    // national state when a row above them is removed (index-keying would shuffle that state).
+    var addPhones by remember {
+        mutableStateOf(editing?.additionalPhones.orEmpty().mapIndexed { i, v -> DraftPhone(i, v) })
+    }
+    var nextPhoneId by remember { mutableStateOf(editing?.additionalPhones.orEmpty().size) }
     var addEmails by remember { mutableStateOf(editing?.additionalEmails.orEmpty()) }
     // Identity contact (has odinId): fields are synced from the profile and edits become private
     // overrides. `synced` is the pre-override baseline used for the per-field affordance.
@@ -173,11 +180,14 @@ fun ContactEditSheet(
             var phoneSeed by remember { mutableStateOf(0) }
             val phoneOverridden =
                 isIdentity && synced?.phone.orEmpty().trim() != draft.phone.trim()
+            val phoneErrorText = stringResource(MR.string.contactbook_error_phone)
             key(phoneSeed) {
                 PhoneNumberField(
                     e164Value = draft.phone,
                     onValueChange = { draft = draft.copy(phone = it) },
                     label = stringResource(MR.string.contactbook_edit_phone),
+                    isError = draft.phone.isNotBlank() && !draft.phoneValid,
+                    errorText = phoneErrorText,
                     supportingText = if (isIdentity) {
                         syncedSupportingText(draft.phone, synced?.phone)
                     } else null,
@@ -193,20 +203,27 @@ fun ContactEditSheet(
                 )
             }
             val removeDesc = stringResource(MR.string.contactbook_edit_remove)
-            addPhones.forEachIndexed { i, value ->
-                Field(
-                    value = value,
-                    label = stringResource(MR.string.contactbook_edit_phone),
-                    keyboardType = KeyboardType.Phone,
-                    trailingIcon = {
-                        IconButton(onClick = { addPhones = addPhones.removeAt(i) }) {
-                            Icon(Icons.Outlined.Close, contentDescription = removeDesc)
-                        }
-                    },
-                ) { addPhones = addPhones.replaceAt(i, it) }
+            // Additional phones use the same E.164 control + validation as the primary number.
+            addPhones.forEachIndexed { i, entry ->
+                key(entry.id) {
+                    PhoneNumberField(
+                        e164Value = entry.value,
+                        onValueChange = { addPhones = addPhones.replaceAt(i, entry.copy(value = it)) },
+                        label = stringResource(MR.string.contactbook_edit_phone),
+                        isError = entry.value.isNotBlank() &&
+                            !ContactFieldValidation.isValidPhone(entry.value),
+                        errorText = phoneErrorText,
+                        trailingIcon = {
+                            IconButton(onClick = { addPhones = addPhones.filterNot { it.id == entry.id } }) {
+                                Icon(Icons.Outlined.Close, contentDescription = removeDesc)
+                            }
+                        },
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                    )
+                }
             }
             AddMoreButton(stringResource(MR.string.contactbook_edit_add_phone)) {
-                addPhones = addPhones + ""
+                addPhones = addPhones + DraftPhone(nextPhoneId++, "")
             }
             SyncedField(
                 value = draft.email,
@@ -217,10 +234,13 @@ fun ContactEditSheet(
                 keyboardType = KeyboardType.Email,
                 onReset = { draft = draft.copy(email = synced?.email.orEmpty()) },
             ) { draft = draft.copy(email = it) }
+            val emailErrorText = stringResource(MR.string.contactbook_error_email)
             addEmails.forEachIndexed { i, value ->
                 Field(
                     value = value,
                     label = stringResource(MR.string.contactbook_edit_email),
+                    isError = !ContactFieldValidation.isValidEmail(value),
+                    errorText = emailErrorText,
                     keyboardType = KeyboardType.Email,
                     trailingIcon = {
                         IconButton(onClick = { addEmails = addEmails.removeAt(i) }) {
@@ -259,12 +279,18 @@ fun ContactEditSheet(
                 TextButton(onClick = onDismiss) {
                     Text(stringResource(MR.string.contactbook_edit_cancel))
                 }
-                // Savable if the primary draft is valid OR there's at least one additional
-                // phone/email — so adding only an extra contact method still enables Save.
-                val hasAdditions = addPhones.any { it.isNotBlank() } || addEmails.any { it.isNotBlank() }
+                // Save requires at least one meaningful field AND every phone/email — primary and
+                // additional — to be well-formed (E.164 / valid email). Legacy bad data stays
+                // visible but blocks Save until corrected.
+                val hasContent = draft.givenName.isNotBlank() || draft.surname.isNotBlank() ||
+                    draft.phone.isNotBlank() || draft.email.isNotBlank() || draft.odinId.isNotBlank() ||
+                    addPhones.any { it.value.isNotBlank() } || addEmails.any { it.isNotBlank() }
+                val primaryValid = draft.phoneValid && draft.emailValid && draft.odinIdValid
+                val additionsValid = addPhones.all { ContactFieldValidation.isValidPhone(it.value) } &&
+                    addEmails.all { ContactFieldValidation.isValidEmail(it) }
                 Button(
-                    onClick = { onSave(draft, addPhones, addEmails, photo) },
-                    enabled = draft.isSavable || hasAdditions,
+                    onClick = { onSave(draft, addPhones.map { it.value }, addEmails, photo) },
+                    enabled = hasContent && primaryValid && additionsValid,
                 ) {
                     Text(stringResource(MR.string.contactbook_edit_save))
                 }
@@ -389,6 +415,13 @@ private fun syncedSupportingText(value: String, synced: String?): String? {
         else -> null
     }
 }
+
+/** An additional phone row with a stable id, so the stateful [PhoneNumberField] keeps its seeded
+ *  country/national state across insertions and removals of sibling rows. */
+private data class DraftPhone(val id: Int, val value: String)
+
+private fun List<DraftPhone>.replaceAt(index: Int, value: DraftPhone): List<DraftPhone> =
+    toMutableList().also { it[index] = value }
 
 private fun List<String>.replaceAt(index: Int, value: String): List<String> =
     toMutableList().also { it[index] = value }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/Countries.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/Countries.kt
@@ -31,6 +31,37 @@ fun splitE164(value: String): Pair<Country?, String> {
     return country to national.filter { it.isDigit() }
 }
 
+/**
+ * Formats a stored E.164 number for **display** ("+1 (415) 555-0123") using the dial-code table.
+ * NANP numbers get the familiar `(area) prefix-line` shape; everything else is grouped generically
+ * (`+CC` then national digits in readable chunks). Display-only — the stored value stays E.164.
+ *
+ * Returns the input unchanged when it can't be parsed (not E.164, or an unknown dial code), so
+ * legacy/unrecognized data is still shown rather than mangled.
+ */
+fun formatPhoneForDisplay(e164: String): String {
+    val v = e164.trim()
+    val (country, national) = splitE164(v)
+    if (!v.startsWith("+") || country == null || national.isEmpty()) return v
+    // North American Numbering Plan: +1 (NXX) NXX-XXXX.
+    if (country.dialCode == "1" && national.length == 10) {
+        return "+1 (${national.substring(0, 3)}) ${national.substring(3, 6)}-${national.substring(6)}"
+    }
+    return "+${country.dialCode} ${groupNationalDigits(national)}"
+}
+
+/** Groups national digits into readable chunks of three, merging a lone trailing digit into the
+ *  previous group so we never leave a one-digit orphan (e.g. "12345678" → "123 456 78"). */
+private fun groupNationalDigits(digits: String): String {
+    if (digits.length <= 4) return digits
+    val groups = digits.chunked(3).toMutableList()
+    if (groups.size >= 2 && groups.last().length == 1) {
+        val orphan = groups.removeAt(groups.lastIndex)
+        groups[groups.lastIndex] = groups.last() + orphan
+    }
+    return groups.joinToString(" ")
+}
+
 private fun c(iso: String, name: String, dial: String) = Country(iso, name, dial)
 
 /** ISO 3166-1 territories with ITU calling codes. Sorted by name in the picker. */

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/PhoneNumberField.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/PhoneNumberField.kt
@@ -35,6 +35,10 @@ import org.jetbrains.compose.resources.stringResource
  * number field. Emits a normalized **E.164** string (e.g. `+14155550123`) via
  * [onValueChange], or `""` when the number is blank — so the user never types `+` or
  * the country code. Defaults the country from the device region.
+ *
+ * Set [isError] (with [errorText]) to flag a value that isn't valid E.164 — e.g. legacy
+ * data imported before this control existed. The bad value stays visible (seeded into the
+ * national field) so the user can see and re-enter it; editing it emits a proper E.164 string.
  */
 @Composable
 fun PhoneNumberField(
@@ -42,6 +46,8 @@ fun PhoneNumberField(
     onValueChange: (String) -> Unit,
     label: String,
     modifier: Modifier = Modifier,
+    isError: Boolean = false,
+    errorText: String? = null,
     supportingText: String? = null,
     trailingIcon: (@Composable () -> Unit)? = null,
 ) {
@@ -78,7 +84,12 @@ fun PhoneNumberField(
             }
         },
         trailingIcon = trailingIcon,
-        supportingText = supportingText?.let { { Text(it) } },
+        isError = isError,
+        supportingText = when {
+            isError && errorText != null -> { { Text(errorText) } }
+            supportingText != null -> { { Text(supportingText) } }
+            else -> null
+        },
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
         modifier = modifier,
     )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailScreen.kt
@@ -231,8 +231,8 @@ fun ContactDetailScreen(
                     // nothing, so the contact's layout stays consistent.
                     val tabs = listOf(
                         ContactDetailTab.DETAILS,
-                        ContactDetailTab.ABOUT,
                         ContactDetailTab.ACTIVITY,
+                        ContactDetailTab.ABOUT,
                     )
                     var selectedTab by rememberSaveable(entry.uniqueId) {
                         mutableStateOf(ContactDetailTab.DETAILS)
@@ -301,9 +301,19 @@ fun ContactDetailScreen(
 
                                 ContactDetailTab.ABOUT -> {
                                     if (uiState.hasAboutContent) {
-                                        BioSection(entry.shortBio)
-                                        ExperienceSection(uiState.experience, uiState.experienceImage)
-                                        SocialSection(entry.socialHandles)
+                                        // Bio, then social handles, then experience. All text here
+                                        // is selectable/copyable (one selection scope for the whole
+                                        // tab — it reads like a profile page).
+                                        SelectionContainer {
+                                            Column {
+                                                BioSection(entry.shortBio)
+                                                SocialSection(entry.socialHandles)
+                                                ExperienceSection(
+                                                    uiState.experience,
+                                                    uiState.experienceImage,
+                                                )
+                                            }
+                                        }
                                     } else {
                                         TabEmptyMessage(
                                             stringResource(MR.string.contactbook_detail_about_empty),

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailScreen.kt
@@ -3,6 +3,7 @@
 package id.homebase.core.ui.screens.contactbook.detail
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -183,28 +184,34 @@ fun ContactDetailScreen(
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = {},
-                navigationIcon = {
-                    IconButton(onClick = { viewModel.onAction(ContactDetailAction.BackClicked) }) {
-                        Icon(
-                            Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(MR.string.menu_back),
-                        )
-                    }
-                },
-                actions = {
-                    IconButton(onClick = { viewModel.onAction(ContactDetailAction.EditClicked) }) {
-                        Icon(
-                            Icons.Outlined.Edit,
-                            contentDescription = stringResource(MR.string.contactbook_detail_edit),
-                        )
-                    }
-                    if (uiState.entry != null) {
-                        ManagementMenu(uiState = uiState, onAction = viewModel::onAction)
-                    }
-                },
-            )
+            // While the full-screen media viewer is open it draws its own top bar
+            // (contact name + date + back/menu). Suppress this screen's app bar so
+            // the two don't stack — the viewer's opaque surface already covers the
+            // content beneath it. Mirrors ConversationMediaScreen.
+            if (uiState.fullScreenMedia == null) {
+                TopAppBar(
+                    title = {},
+                    navigationIcon = {
+                        IconButton(onClick = { viewModel.onAction(ContactDetailAction.BackClicked) }) {
+                            Icon(
+                                Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = stringResource(MR.string.menu_back),
+                            )
+                        }
+                    },
+                    actions = {
+                        IconButton(onClick = { viewModel.onAction(ContactDetailAction.EditClicked) }) {
+                            Icon(
+                                Icons.Outlined.Edit,
+                                contentDescription = stringResource(MR.string.contactbook_detail_edit),
+                            )
+                        }
+                        if (uiState.entry != null) {
+                            ManagementMenu(uiState = uiState, onAction = viewModel::onAction)
+                        }
+                    },
+                )
+            }
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { padding ->
@@ -476,17 +483,22 @@ private fun DetailHeader(
     ) {
         ContactBookAvatar(entry = entry, size = 88.dp)
         Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = entry.displayName,
-            style = MaterialTheme.typography.headlineSmall,
-            textAlign = TextAlign.Center,
-        )
-        entry.odinId?.let {
+        // Name and Homebase ID are selectable so they can be copied (the ID especially).
+        SelectionContainer {
             Text(
-                text = it,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                text = entry.displayName,
+                style = MaterialTheme.typography.headlineSmall,
+                textAlign = TextAlign.Center,
             )
+        }
+        entry.odinId?.let {
+            SelectionContainer {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
 
         // Free-text status/tagline the contact set, under the odinId.

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailScreen.kt
@@ -86,6 +86,8 @@ import id.homebase.resources.contactbook_detail_emergency_badge
 import id.homebase.resources.contactbook_detail_location_data_as_of
 import id.homebase.resources.contactbook_action_unblocked
 import id.homebase.resources.contactbook_connected
+import id.homebase.resources.contactbook_detail_about_empty
+import id.homebase.resources.contactbook_detail_activity_empty
 import id.homebase.resources.contactbook_detail_block
 import id.homebase.resources.contactbook_detail_block_message
 import id.homebase.resources.contactbook_detail_block_title
@@ -218,12 +220,13 @@ fun ContactDetailScreen(
 
                 else -> {
                     var detailsExpanded by rememberSaveable(entry.uniqueId) { mutableStateOf(false) }
-                    // Only show tabs that have content; a plain contact stays a single list.
-                    val tabs = buildList {
-                        add(ContactDetailTab.DETAILS)
-                        if (uiState.hasAboutContent) add(ContactDetailTab.ABOUT)
-                        if (uiState.hasActivityContent) add(ContactDetailTab.ACTIVITY)
-                    }
+                    // Always show all three tabs; each renders a friendly empty state when it has
+                    // nothing, so the contact's layout stays consistent.
+                    val tabs = listOf(
+                        ContactDetailTab.DETAILS,
+                        ContactDetailTab.ABOUT,
+                        ContactDetailTab.ACTIVITY,
+                    )
                     var selectedTab by rememberSaveable(entry.uniqueId) {
                         mutableStateOf(ContactDetailTab.DETAILS)
                     }
@@ -290,21 +293,33 @@ fun ContactDetailScreen(
                                 }
 
                                 ContactDetailTab.ABOUT -> {
-                                    BioSection(entry.shortBio)
-                                    ExperienceSection(uiState.experience, uiState.experienceImage)
-                                    SocialSection(entry.socialHandles)
+                                    if (uiState.hasAboutContent) {
+                                        BioSection(entry.shortBio)
+                                        ExperienceSection(uiState.experience, uiState.experienceImage)
+                                        SocialSection(entry.socialHandles)
+                                    } else {
+                                        TabEmptyMessage(
+                                            stringResource(MR.string.contactbook_detail_about_empty),
+                                        )
+                                    }
                                 }
 
                                 ContactDetailTab.ACTIVITY -> {
-                                    RecentMediaSection(
-                                        overview = uiState.overview,
-                                        onMediaClick = {
-                                            viewModel.onAction(ContactDetailAction.OpenMedia(it))
-                                        },
-                                        onSeeAll = {
-                                            viewModel.onAction(ContactDetailAction.SeeAllMediaClicked)
-                                        },
-                                    )
+                                    if (uiState.hasActivityContent) {
+                                        RecentMediaSection(
+                                            overview = uiState.overview,
+                                            onMediaClick = {
+                                                viewModel.onAction(ContactDetailAction.OpenMedia(it))
+                                            },
+                                            onSeeAll = {
+                                                viewModel.onAction(ContactDetailAction.SeeAllMediaClicked)
+                                            },
+                                        )
+                                    } else {
+                                        TabEmptyMessage(
+                                            stringResource(MR.string.contactbook_detail_activity_empty),
+                                        )
+                                    }
                                 }
                             }
                             Spacer(modifier = Modifier.height(24.dp))

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailSections.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailSections.kt
@@ -65,6 +65,7 @@ import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.ConversationAvatar
 import id.homebase.core.config.chatTargetDrive
 import id.homebase.core.image.ImageSize
+import id.homebase.core.ui.screens.contactbook.components.formatPhoneForDisplay
 import id.homebase.api.client.contacts.ContactExperience
 import id.homebase.api.client.contacts.ContactSocialNetwork
 import id.homebase.core.ui.screens.contactbook.model.ContactBookEntry
@@ -314,11 +315,13 @@ fun ContactFieldsSection(
     }
     val fields = buildList {
         fullName?.let { add(DetailFieldRow(Icons.Outlined.Person, lblName, it, syncedName)) }
-        entry.phone?.takeIf { it.isNotBlank() }
-            ?.let { add(DetailFieldRow(Icons.Outlined.Call, lblPhone, it, o?.phone)) }
+        // Phones are stored E.164; format them country-aware for display ("+1 (415) 555-0123").
+        entry.phone?.takeIf { it.isNotBlank() }?.let {
+            add(DetailFieldRow(Icons.Outlined.Call, lblPhone, formatPhoneForDisplay(it), o?.phone?.let(::formatPhoneForDisplay)))
+        }
         // App-local additional phones (no synced counterpart) render as plain extra rows.
         entry.additionalPhones.filter { it.isNotBlank() }
-            .forEach { add(DetailFieldRow(Icons.Outlined.Call, lblPhone, it, null)) }
+            .forEach { add(DetailFieldRow(Icons.Outlined.Call, lblPhone, formatPhoneForDisplay(it), null)) }
         entry.email?.takeIf { it.isNotBlank() }
             ?.let { add(DetailFieldRow(Icons.Outlined.Email, lblEmail, it, o?.email)) }
         entry.additionalEmails.filter { it.isNotBlank() }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailSections.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailSections.kt
@@ -4,6 +4,7 @@ package id.homebase.core.ui.screens.contactbook.detail
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -48,6 +49,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
@@ -76,14 +78,12 @@ import id.homebase.resources.contactbook_detail_circles_empty
 import id.homebase.resources.contactbook_detail_contact_details
 import id.homebase.resources.contactbook_detail_experience
 import id.homebase.resources.contactbook_detail_location
+import id.homebase.resources.contactbook_detail_name
 import id.homebase.resources.contactbook_detail_override_none
 import id.homebase.resources.contactbook_detail_override_synced
 import id.homebase.resources.contactbook_edit_birthday
 import id.homebase.resources.contactbook_edit_email
-import id.homebase.resources.contactbook_edit_given_name
-import id.homebase.resources.contactbook_edit_odinid
 import id.homebase.resources.contactbook_edit_phone
-import id.homebase.resources.contactbook_edit_surname
 import id.homebase.resources.contactbook_detail_groups_connect
 import id.homebase.resources.contactbook_detail_groups_empty
 import id.homebase.resources.contactbook_detail_less
@@ -232,6 +232,25 @@ private fun CircleChip(name: String) {
     }
 }
 
+/**
+ * Friendly, centered empty state for a whole tab that currently has nothing to show. Tabs are
+ * always present, so this explains why one is blank rather than leaving an empty pane.
+ */
+@Composable
+fun TabEmptyMessage(text: String) {
+    Box(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 32.dp, vertical = 48.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
 /** Muted single-line hint used by sections for their empty / not-connected states. */
 @Composable
 private fun SectionHint(text: String) {
@@ -260,17 +279,16 @@ fun ContactFieldsSection(
     )
 
     // Labels resolved here (stringResource can't be called inside the buildList builder).
-    val lblFirst = stringResource(MR.string.contactbook_edit_given_name)
-    val lblLast = stringResource(MR.string.contactbook_edit_surname)
-    val lblId = stringResource(MR.string.contactbook_edit_odinid)
+    val lblName = stringResource(MR.string.contactbook_detail_name)
     val lblPhone = stringResource(MR.string.contactbook_edit_phone)
     val lblEmail = stringResource(MR.string.contactbook_edit_email)
     val lblLocation = stringResource(MR.string.contactbook_detail_location)
     val lblBirthday = stringResource(MR.string.contactbook_edit_birthday)
 
     // Each field carries its synced original ([DetailFieldRow.synced]) when the user has overridden
-    // it, so a small peek icon can reveal "their profile says …". Name parts come first so an
-    // identity contact shows its real details, not just the Homebase ID; the rest tuck behind "More".
+    // it, so a small peek icon can reveal "their profile says …". The full name comes first so an
+    // identity contact shows its real details; the rest tuck behind "More". The Homebase ID isn't
+    // repeated here — it's already shown under the name in the header.
     val o = entry.syncedOverlay
     val syncedLocation = o?.let { ov ->
         if (ov.city != null || ov.country != null) {
@@ -279,13 +297,23 @@ fun ContactFieldsSection(
             null
         }
     }
+    // First and last name on one line.
+    val fullName = listOfNotNull(
+        entry.givenName?.ifBlank { null },
+        entry.surname?.ifBlank { null },
+    ).joinToString(" ").ifBlank { null }
+    // Synced "their profile says …" original, only when given/surname was overridden; the
+    // non-overridden part falls back to the entry's own value so the peek shows the whole name.
+    val syncedName = if (o?.givenName != null || o?.surname != null) {
+        listOfNotNull(
+            (o?.givenName ?: entry.givenName)?.ifBlank { null },
+            (o?.surname ?: entry.surname)?.ifBlank { null },
+        ).joinToString(" ").ifBlank { null }
+    } else {
+        null
+    }
     val fields = buildList {
-        entry.givenName?.takeIf { it.isNotBlank() }
-            ?.let { add(DetailFieldRow(Icons.Outlined.Person, lblFirst, it, o?.givenName)) }
-        entry.surname?.takeIf { it.isNotBlank() }
-            ?.let { add(DetailFieldRow(Icons.Outlined.Person, lblLast, it, o?.surname)) }
-        entry.odinId?.takeIf { it.isNotBlank() }
-            ?.let { add(DetailFieldRow(Icons.Outlined.AlternateEmail, lblId, it, null)) }
+        fullName?.let { add(DetailFieldRow(Icons.Outlined.Person, lblName, it, syncedName)) }
         entry.phone?.takeIf { it.isNotBlank() }
             ?.let { add(DetailFieldRow(Icons.Outlined.Call, lblPhone, it, o?.phone)) }
         // App-local additional phones (no synced counterpart) render as plain extra rows.

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailSections.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailSections.kt
@@ -3,6 +3,7 @@
 package id.homebase.core.ui.screens.contactbook.detail
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -528,7 +529,9 @@ private fun DetailField(icon: ImageVector, label: String, value: String?, synced
     ListItem(
         leadingContent = { Icon(icon, contentDescription = null) },
         overlineContent = { Text(label) },
-        headlineContent = { Text(value) },
+        // Wrap the value so it can be long-pressed/drag-selected and copied (phone, email,
+        // address, …). Per-row scope keeps selection inside one value at a time.
+        headlineContent = { SelectionContainer { Text(value) } },
         trailingContent = synced?.let { { SyncedValuePeek(it) } },
     )
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/model/ContactBookEntry.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/model/ContactBookEntry.kt
@@ -15,6 +15,7 @@ import id.homebase.api.client.contacts.ContactSocialNetwork
 import id.homebase.api.client.contacts.resolveDisplayName
 import id.homebase.api.client.contacts.socialHandles
 import id.homebase.core.contactbook.iCanLocate
+import id.homebase.core.ui.screens.contactbook.components.formatPhoneForDisplay
 import id.homebase.api.client.drives.files.PayloadDescriptor
 import id.homebase.api.client.drives.upload.EmbeddedThumb
 import id.homebase.core.image.HomebaseImageData
@@ -105,8 +106,9 @@ data class ContactBookEntry(
             return if (c in 'A'..'Z') c.toString() else "#"
         }
 
-    /** Secondary line under the name in list rows. */
-    val subtitle: String? get() = odinId ?: phone ?: email
+    /** Secondary line under the name in list rows. A phone falls through to a country-aware
+     *  display format; non-E.164 legacy values are shown as stored. */
+    val subtitle: String? get() = odinId ?: phone?.let { formatPhoneForDisplay(it) } ?: email
 
     /**
      * The full postal address formatted for display on a single line: street lines, then

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/model/ContactBookEntry.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/model/ContactBookEntry.kt
@@ -109,8 +109,8 @@ data class ContactBookEntry(
     val subtitle: String? get() = odinId ?: phone ?: email
 
     /**
-     * The full postal address formatted for display, one component per line:
-     * street lines, then "postcode city", then country. Null when nothing is set.
+     * The full postal address formatted for display on a single line: street lines, then
+     * "postcode city", then country, joined with commas. Null when nothing is set.
      */
     val location: String?
         get() = listOfNotNull(
@@ -119,7 +119,7 @@ data class ContactBookEntry(
             listOfNotNull(postcode?.ifBlank { null }, city?.ifBlank { null })
                 .joinToString(" ").ifBlank { null },
             country?.ifBlank { null },
-        ).joinToString("\n").ifBlank { null }
+        ).joinToString(", ").ifBlank { null }
 
     fun matches(query: String): Boolean {
         if (query.isBlank()) return true

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/contactbook/components/PhoneDisplayFormatTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/contactbook/components/PhoneDisplayFormatTest.kt
@@ -1,0 +1,29 @@
+package id.homebase.core.ui.screens.contactbook.components
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PhoneDisplayFormatTest {
+
+    @Test
+    fun `formats NANP numbers as area-prefix-line`() {
+        assertEquals("+1 (415) 555-0123", formatPhoneForDisplay("+14155550123"))
+    }
+
+    @Test
+    fun `groups non-NANP national digits in readable chunks`() {
+        // UK national 7911123456 (10 digits): 791 112 345 + orphan 6 merged -> 3456.
+        assertEquals("+44 791 112 3456", formatPhoneForDisplay("+447911123456"))
+        // Germany national 30123456 (8 digits): 301 234 56.
+        assertEquals("+49 301 234 56", formatPhoneForDisplay("+4930123456"))
+    }
+
+    @Test
+    fun `returns the input unchanged when it is not parseable E164`() {
+        // Legacy/non-E.164 data must still be shown, not mangled.
+        assertEquals("555-1234", formatPhoneForDisplay("555-1234"))
+        assertEquals("", formatPhoneForDisplay(""))
+        // Plus-prefixed but unknown dial code: left as-is.
+        assertEquals("+9990000", formatPhoneForDisplay("+9990000"))
+    }
+}


### PR DESCRIPTION
## Summary

Cleans up the contact detail screen layout per design feedback:

- **Name on one line** — combine first + last name into a single **Name** row instead of two separate rows. The synced "their profile says…" peek is preserved (falls back to the entry's own value for the non-overridden part so it shows the whole name).
- **Drop the redundant Homebase ID field** — the odinId is already shown directly under the name in the header, so it's no longer repeated in the details list.
- **Address on one line** — `ContactBookEntry.location` now joins its components with `, ` instead of newlines (e.g. `123 Main St, 90210 Springfield, USA`). Only consumed by the detail screen.
- **Tabs always show** — Details / About / Activity are always present (no longer gated on having content), each with a friendly centered empty-state message explaining why it's blank.

New strings: `contactbook_detail_name`, `contactbook_detail_about_empty`, `contactbook_detail_activity_empty`.

> Note: this branch also carries in-progress ContactBook changes from a parallel session (`AppNavHost`, `AppViewModel`, `ContactBookContent`/`UiState`/`ViewModel`) that were in the working tree.

## Test plan

- `./gradlew :homebase-core:compileKotlinJvm` passes.
- Manually verify a contact with: full name + address + odinId; a plain (non-Homebase) contact; and a contact with empty About/Activity tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)