### PR TITLE
fix(chat): use platform MIME type for gallery picks (#905)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -671,6 +671,7 @@ internal class MessageActionsHandler(
                         var filePath = attachment.image.file.toUploadPath(fileOperationsProvider)
                         var contentType = resolveContentType(
                             fileName = attachment.image.fileName,
+                            platformMimeType = attachment.image.file.mimeType()?.toString(),
                         )
                         if (contentType == "image/heic" || contentType == "image/heif") {
                             val heicBytes = fileOperationsProvider.readFileBytes(filePath)

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/util/ContentTypeUtilTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/util/ContentTypeUtilTest.kt
@@ -1,0 +1,39 @@
+package id.homebase.core.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ContentTypeUtilTest {
+
+    // Issue #905: a gallery pick whose filename lacks a usable extension must still
+    // resolve to its real image type when the platform MIME type is available,
+    // instead of falling through to application/octet-stream (which renders as a file).
+    @Test
+    fun platformMimeTypeWinsOverExtensionlessFilename() {
+        assertEquals(
+            "image/jpeg",
+            resolveContentType(fileName = "IMG_1234", platformMimeType = "image/jpeg"),
+        )
+    }
+
+    @Test
+    fun fallsBackToExtensionWhenPlatformMimeIsMissing() {
+        assertEquals("image/png", resolveContentType(fileName = "photo.png", platformMimeType = null))
+    }
+
+    @Test
+    fun genericOctetStreamPlatformMimeIsIgnoredInFavourOfExtension() {
+        assertEquals(
+            "image/png",
+            resolveContentType(fileName = "photo.png", platformMimeType = "application/octet-stream"),
+        )
+    }
+
+    @Test
+    fun returnsOctetStreamWhenNothingIsResolvable() {
+        assertEquals(
+            "application/octet-stream",
+            resolveContentType(fileName = "IMG_1234", platformMimeType = null),
+        )
+    }
+}


### PR DESCRIPTION
Fixes #905.

## Problem
`MessageActionsHandler.addMessageWithFiles` resolved the attachment `contentType` in the **gallery** pick branch from the filename **only**:

```kotlin
var contentType = resolveContentType(fileName = attachment.image.fileName)
```

Every other branch (`FileImage`/`toImageAttachmentInput`, `FileVideo`, `File`, `Audio`) also passes `platformMimeType = …mimeType()?.toString()`. Since `contentType` is the single determinant of image-vs-file rendering (`MediaItem.kt`: `startsWith("image/")` → image bubble; `startsWith("application/")` → generic file chip), a gallery item whose `fileName` lacks a usable image extension could resolve to `application/octet-stream` and render as a **file with no thumbnail** — even though the bytes are a valid image.

## Fix
Mirror the sibling branches — pass the FileKit-derived platform MIME type in the gallery branch:

```kotlin
var contentType = resolveContentType(
    fileName = attachment.image.fileName,
    platformMimeType = attachment.image.file.mimeType()?.toString(),
)
```

`resolveContentType` prefers a concrete platform MIME, ignores a generic `application/octet-stream`, and falls back to extension lookup when the platform MIME is null — so the existing iOS `image/heic` → JPEG conversion path is preserved (verified: FileKit returns `null` for the iOS `ph://` identifier, so the concrete `image/heic` extension detection still runs).

> Note: I deliberately did **not** use the already-populated `GalleryImage.mimeType` field — on iOS that field is a hardcoded constant `"image/*"`/`"video/*"`, which would short-circuit `resolveContentType` and skip concrete-type detection, breaking the HEIC→JPEG path.

## Tests
Adds `ContentTypeUtilTest` covering the precedence the fix relies on (concrete platform MIME beats an extensionless filename; generic octet-stream is ignored; null falls back to extension). `homebase-common:jvmTest` green; `homebase-chat:compileKotlinJvm` clean.

## Verification note
The original incident was **not deterministically reproducible** (per the issue — a logging-only rebuild "fixed" it), consistent with an extensionless gallery filename. The fix removes the fragility structurally; the pure-function test guards the guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)