### PR TITLE
feat(chat): PDF preview thumbnail + tap-to-view for PDF attachments (#909)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -311,16 +311,13 @@ sealed interface FullScreenOverlay {
         val uploadMessageId: Uuid? = null,
     ) : FullScreenOverlay
 
-    // PDF viewer (issue #909). The decrypted file is produced by the existing
-    // DecryptFile path and read back from decryptedFiles[DecryptedFileKey(fileId,
-    // payloadKey)]; this overlay just needs enough to look it up and to offer
-    // download in the viewer bar.
     @Immutable
     data class PdfViewerData(
         val messageId: Uuid,
         val fileId: Uuid,
         val payloadKey: String,
         val title: String,
+        val userDate: Instant,
     ) : FullScreenOverlay
 }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -310,6 +310,18 @@ sealed interface FullScreenOverlay {
         val localFilePath: String? = null,
         val uploadMessageId: Uuid? = null,
     ) : FullScreenOverlay
+
+    // PDF viewer (issue #909). The decrypted file is produced by the existing
+    // DecryptFile path and read back from decryptedFiles[DecryptedFileKey(fileId,
+    // payloadKey)]; this overlay just needs enough to look it up and to offer
+    // download in the viewer bar.
+    @Immutable
+    data class PdfViewerData(
+        val messageId: Uuid,
+        val fileId: Uuid,
+        val payloadKey: String,
+        val title: String,
+    ) : FullScreenOverlay
 }
 
 sealed class AttachmentPendingFile(val attachmentId: Uuid) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MediaDownloadHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MediaDownloadHandler.kt
@@ -380,8 +380,6 @@ internal class MediaDownloadHandler(
 
                     contentType.startsWith("audio/") -> {}
                     contentType == "application/pdf" -> {
-                        // Decrypt to a local cache path (reusing the DecryptFile path) so
-                        // the viewer can render it, then open the fullscreen PDF overlay.
                         val alreadyDecrypted = messagesUiState.value.decryptedFiles
                             .containsKey(DecryptedFileKey(action.message.fileId, action.payloadKey))
                         if (!alreadyDecrypted) {
@@ -398,6 +396,7 @@ internal class MediaDownloadHandler(
                                     fileId = action.message.fileId,
                                     payloadKey = action.payloadKey,
                                     title = action.message.originalAuthor?.domainName ?: "null",
+                                    userDate = action.message.userDate,
                                 )
                             )
                         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MediaDownloadHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MediaDownloadHandler.kt
@@ -379,6 +379,29 @@ internal class MediaDownloadHandler(
                     }
 
                     contentType.startsWith("audio/") -> {}
+                    contentType == "application/pdf" -> {
+                        // Decrypt to a local cache path (reusing the DecryptFile path) so
+                        // the viewer can render it, then open the fullscreen PDF overlay.
+                        val alreadyDecrypted = messagesUiState.value.decryptedFiles
+                            .containsKey(DecryptedFileKey(action.message.fileId, action.payloadKey))
+                        if (!alreadyDecrypted) {
+                            dispatch(
+                                ConversationListUiAction.DecryptFile(
+                                    action.message.id, action.payloadKey
+                                )
+                            )
+                        }
+                        messagesUiState.update {
+                            it.copy(
+                                fullScreenOverlay = FullScreenOverlay.PdfViewerData(
+                                    messageId = action.message.id,
+                                    fileId = action.message.fileId,
+                                    payloadKey = action.payloadKey,
+                                    title = action.message.originalAuthor?.domainName ?: "null",
+                                )
+                            )
+                        }
+                    }
                     contentType.startsWith("application/") || contentType.startsWith("text/") || contentType.startsWith(
                         "message/"
                     ) -> {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilder.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilder.kt
@@ -96,10 +96,6 @@ object MessageAttachmentBuilder {
                         )
                     }
                     attachment.contentType == "application/pdf" -> {
-                        // Ride a first-page preview on the message like images do, so the
-                        // receiver sees it without downloading the full PDF. If rendering
-                        // isn't available (web / unreadable PDF) thumbs is null and we send
-                        // a plain payload — the bubble then shows the icon row.
                         val thumbs =
                             MessageThumbnailGenerator.generateFromPdf(attachment.filePath, payloadKey)
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilder.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilder.kt
@@ -95,6 +95,29 @@ object MessageAttachmentBuilder {
                             previewThumbs = listOfNotNull(thumbs?.preview)
                         )
                     }
+                    attachment.contentType == "application/pdf" -> {
+                        // Ride a first-page preview on the message like images do, so the
+                        // receiver sees it without downloading the full PDF. If rendering
+                        // isn't available (web / unreadable PDF) thumbs is null and we send
+                        // a plain payload — the bubble then shows the icon row.
+                        val thumbs =
+                            MessageThumbnailGenerator.generateFromPdf(attachment.filePath, payloadKey)
+
+                        PayloadBundle(
+                            payloads =
+                                listOf(
+                                    PayloadFile(
+                                        key = payloadKey,
+                                        filePath = attachment.filePath,
+                                        contentType = attachment.contentType,
+                                        previewThumbnail = thumbs?.preview,
+                                        descriptorContent = attachment.displayName,
+                                    )
+                                ),
+                            thumbnails = thumbs?.thumbnails ?: emptyList(),
+                            previewThumbs = listOfNotNull(thumbs?.preview)
+                        )
+                    }
                     else ->
                         PayloadBundle(
                             payloads =

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/MessageThumbnailGenerator.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/MessageThumbnailGenerator.kt
@@ -9,8 +9,6 @@ import kotlinx.coroutines.withContext
 
 object MessageThumbnailGenerator {
 
-    // Render width for the first PDF page before it is fed through the normal
-    // image thumbnail ladder — large enough that the widest thumb stays crisp.
     private const val PDF_PREVIEW_RENDER_WIDTH = 1600
 
     suspend fun generate(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/MessageThumbnailGenerator.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/MessageThumbnailGenerator.kt
@@ -1,9 +1,17 @@
 package id.homebase.chat.services.builder
 
+import co.touchlab.kermit.Logger
 import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.image.createThumbnails
+import id.homebase.core.pdf.generatePdfThumbnailFromFile
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 object MessageThumbnailGenerator {
+
+    // Render width for the first PDF page before it is fed through the normal
+    // image thumbnail ladder — large enough that the widest thumb stays crisp.
+    private const val PDF_PREVIEW_RENDER_WIDTH = 1600
 
     suspend fun generate(
         filePath: String,
@@ -18,6 +26,31 @@ object MessageThumbnailGenerator {
             preview = tinyThumb,
             thumbnails = thumbnails,
             sourceBytes = bytes
+        )
+    }
+
+    /**
+     * Renders the first page of a PDF and runs it through the same image
+     * thumbnail pipeline, so the receiver sees a preview without downloading
+     * the full PDF. Returns null (caller falls back to a plain, preview-less
+     * payload → the icon row) when the renderer is unavailable (web) or the
+     * PDF can't be rendered.
+     */
+    suspend fun generateFromPdf(filePath: String, payloadKey: String): ThumbnailResult? {
+        val pageJpeg = withContext(Dispatchers.Default) {
+            try {
+                generatePdfThumbnailFromFile(filePath, PDF_PREVIEW_RENDER_WIDTH)?.thumbnailBytes
+            } catch (e: Exception) {
+                Logger.w(tag = "MessageThumbnailGenerator", throwable = e) { "PDF preview render failed" }
+                null
+            }
+        } ?: return null
+
+        val (_, tinyThumb, thumbnails) = createThumbnails(pageJpeg, payloadKey)
+        return ThumbnailResult(
+            preview = tinyThumb,
+            thumbnails = thumbnails,
+            sourceBytes = pageJpeg
         )
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ChatPdfViewer.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ChatPdfViewer.kt
@@ -1,56 +1,101 @@
 package id.homebase.chat.widget
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.Scaffold
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import id.homebase.core.pdf.PdfPageViewer
+import id.homebase.core.util.formatTimestamp
 import id.homebase.resources.MR
 import id.homebase.resources.chat_message_download_file
-import id.homebase.resources.chat_pdf_viewer_close
+import id.homebase.resources.menu_back
 import org.jetbrains.compose.resources.stringResource
+import kotlin.time.Instant
 
 /**
- * Fullscreen PDF viewer for a chat attachment (issue #909). Thin wrapper around the
- * shared [PdfPageViewer]: [filePath] is the already-decrypted local file (null while
- * the DecryptFile path is still running → spinner). Download reuses the normal
- * DownloadMedia action so the viewer also satisfies "save the PDF".
+ * Fullscreen PDF viewer for a chat attachment (issue #909). Mirrors
+ * [FullScreenMediaViewer]'s chrome so PDFs feel like the image viewer: a
+ * name + date top bar that a tap toggles, back-arrow to dismiss, and the
+ * shared [PdfPageViewer] (whose native Android/iOS renderer provides pinch
+ * zoom). [filePath] is the already-decrypted local file, produced by the
+ * DecryptFile path; null while it's still decrypting → spinner.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ChatPdfViewer(
     title: String,
+    userDate: Instant,
     filePath: String?,
     isDownloading: Boolean,
     onDownload: () -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Scaffold(
-        modifier = modifier.fillMaxSize(),
-        topBar = {
+    var showUI by remember { mutableStateOf(true) }
+
+    Box(
+        modifier = modifier.fillMaxSize().background(MaterialTheme.colorScheme.surface),
+    ) {
+        if (filePath == null) {
+            CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+        } else {
+            PdfPageViewer(
+                filePath = filePath,
+                onTap = { showUI = !showUI },
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+
+        AnimatedVisibility(
+            visible = showUI,
+            modifier = Modifier.align(Alignment.TopCenter),
+            enter = fadeIn() + slideInVertically(),
+            exit = fadeOut() + slideOutVertically(),
+        ) {
             TopAppBar(
-                title = { Text(text = title, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                title = {
+                    Column {
+                        Text(
+                            text = title,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Text(
+                            text = formatTimestamp(userDate),
+                            style = MaterialTheme.typography.labelMedium,
+                        )
+                    }
+                },
                 navigationIcon = {
                     IconButton(onClick = onDismiss) {
                         Icon(
-                            imageVector = Icons.Default.Close,
-                            contentDescription = stringResource(MR.string.chat_pdf_viewer_close),
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(MR.string.menu_back),
                         )
                     }
                 },
@@ -67,17 +112,6 @@ fun ChatPdfViewer(
                     }
                 },
             )
-        },
-    ) { innerPadding ->
-        Box(
-            modifier = Modifier.fillMaxSize().padding(innerPadding),
-            contentAlignment = Alignment.Center,
-        ) {
-            if (filePath == null) {
-                CircularProgressIndicator()
-            } else {
-                PdfPageViewer(filePath = filePath, modifier = Modifier.fillMaxSize())
-            }
         }
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ChatPdfViewer.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ChatPdfViewer.kt
@@ -1,0 +1,83 @@
+package id.homebase.chat.widget
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import id.homebase.core.pdf.PdfPageViewer
+import id.homebase.resources.MR
+import id.homebase.resources.chat_message_download_file
+import id.homebase.resources.chat_pdf_viewer_close
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Fullscreen PDF viewer for a chat attachment (issue #909). Thin wrapper around the
+ * shared [PdfPageViewer]: [filePath] is the already-decrypted local file (null while
+ * the DecryptFile path is still running → spinner). Download reuses the normal
+ * DownloadMedia action so the viewer also satisfies "save the PDF".
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChatPdfViewer(
+    title: String,
+    filePath: String?,
+    isDownloading: Boolean,
+    onDownload: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text(text = title, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                navigationIcon = {
+                    IconButton(onClick = onDismiss) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = stringResource(MR.string.chat_pdf_viewer_close),
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(onClick = onDownload, enabled = !isDownloading) {
+                        if (isDownloading) {
+                            CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
+                        } else {
+                            Icon(
+                                imageVector = Icons.Default.Download,
+                                contentDescription = stringResource(MR.string.chat_message_download_file),
+                            )
+                        }
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier.fillMaxSize().padding(innerPadding),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (filePath == null) {
+                CircularProgressIndicator()
+            } else {
+                PdfPageViewer(filePath = filePath, modifier = Modifier.fillMaxSize())
+            }
+        }
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
@@ -352,6 +352,7 @@ fun ConversationMessagesPane(
                     is FullScreenOverlay.PdfViewerData -> {
                         ChatPdfViewer(
                             title = data.title,
+                            userDate = data.userDate,
                             filePath = uiState.decryptedFiles[
                                 DecryptedFileKey(data.fileId, data.payloadKey)
                             ],

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
@@ -47,6 +47,7 @@ import id.homebase.chat.conversationlist.ConversationListUiAction.SaveScrollPosi
 import id.homebase.chat.conversationlist.ConversationListUiAction.SendFile
 import id.homebase.chat.conversationlist.ConversationListUiAction.ShareMedia
 import id.homebase.chat.conversationlist.ConversationListUiAction.UnAttachFile
+import id.homebase.chat.conversationlist.DecryptedFileKey
 import id.homebase.chat.conversationlist.FullScreenOverlay
 import id.homebase.chat.conversationlist.MessageListContentModel
 import id.homebase.chat.conversationlist.MessageListUiState
@@ -274,6 +275,7 @@ fun ConversationMessagesPane(
                     is FullScreenOverlay.ViewMessageData -> "view"
                     is FullScreenOverlay.VideoPlayerData -> "videoPlayer"
                     is FullScreenOverlay.AttachmentData -> "attachment"
+                    is FullScreenOverlay.PdfViewerData -> "pdf"
                 }
             },
             transitionSpec = {
@@ -344,6 +346,18 @@ fun ConversationMessagesPane(
                             onDismiss = { onUiAction(CloseFullScreenOverlay) },
                             onSave = { onUiAction(DownloadVideoMedia(data.fileId, data.payloadKey, data.keyHeader, data.payload)) },
                             uploadStatus = data.uploadMessageId?.let { uiState.uploadProgress[it] },
+                        )
+                    }
+
+                    is FullScreenOverlay.PdfViewerData -> {
+                        ChatPdfViewer(
+                            title = data.title,
+                            filePath = uiState.decryptedFiles[
+                                DecryptedFileKey(data.fileId, data.payloadKey)
+                            ],
+                            isDownloading = "${data.messageId}_${data.payloadKey}" in uiState.downloadingFiles,
+                            onDownload = { onUiAction(DownloadMedia(data.messageId, data.payloadKey)) },
+                            onDismiss = { onUiAction(CloseFullScreenOverlay) },
                         )
                     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/DocumentMediaItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/DocumentMediaItem.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -23,10 +24,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import id.homebase.api.client.drives.files.PayloadDescriptor
+import id.homebase.core.image.HomebaseImage
+import id.homebase.core.image.HomebaseImageData
 import id.homebase.core.ui.assets.Apk
 import id.homebase.core.ui.assets.Excel
 import id.homebase.core.ui.assets.File
@@ -40,6 +44,7 @@ import id.homebase.core.util.formatFileSize
 import id.homebase.resources.MR
 import id.homebase.resources.chat_message_download_file
 import id.homebase.resources.chat_message_file_type_icon
+import id.homebase.resources.chat_message_pdf_preview
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -48,7 +53,14 @@ fun DocumentMediaItem(
     modifier: Modifier = Modifier,
     onDownloadClick: () -> Unit,
     onLongPress: () -> Unit,
-    isDownloading: Boolean = false
+    isDownloading: Boolean = false,
+    // When set (PDFs, issue #909) a first-page preview is rendered above the file
+    // row and the row's leading icon is dropped — the card reads as a preview, not
+    // a plain chip. Null keeps the original icon-only row for every other document.
+    previewImageData: HomebaseImageData? = null,
+    // PDFs open in a viewer on tap (which offers download), so their bubble drops
+    // the redundant download button; other documents keep it as the tap target.
+    showDownloadButton: Boolean = true,
 ) {
     val contentType = payload.contentType ?: ""
     val fileName = payload.descriptorContent ?: payload.key
@@ -65,67 +77,80 @@ fun DocumentMediaItem(
         else -> HomebaseIcons.File
     }
 
-    Row(
+    Column(
         modifier = modifier.fillMaxWidth().clip(RoundedCornerShape(Dimens.Message.cornerRadius))
             .background(MaterialTheme.colorScheme.surfaceContainerHigh)
             .combinedClickable(
                 onClick = onDownloadClick,
                 onLongClick = onLongPress
             )
-            .padding(12.dp),
-        verticalAlignment = Alignment.CenterVertically
     ) {
-        // File Icon
-        Box(
-            modifier = Modifier.size(48.dp).clip(RoundedCornerShape(8.dp))
-                .background(MaterialTheme.colorScheme.primaryContainer),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                imageVector = fileIcon,
-                contentDescription = stringResource(MR.string.chat_message_file_type_icon),
-                tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                modifier = Modifier.size(24.dp)
+        if (previewImageData != null) {
+            HomebaseImage(
+                imageData = previewImageData,
+                modifier = Modifier.fillMaxWidth().height(180.dp),
+                contentScale = ContentScale.Crop,
+                contentDescription = stringResource(MR.string.chat_message_pdf_preview),
             )
         }
 
-        Spacer(modifier = Modifier.width(12.dp))
-
-        // File Details
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = fileName,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-            if (fileSize.isNotEmpty()) {
-                Text(
-                    text = fileSize,
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // File Icon
+            Box(
+                modifier = Modifier.size(48.dp).clip(RoundedCornerShape(8.dp))
+                    .background(MaterialTheme.colorScheme.primaryContainer),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = fileIcon,
+                    contentDescription = stringResource(MR.string.chat_message_file_type_icon),
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                    modifier = Modifier.size(24.dp)
                 )
             }
-        }
 
-        Spacer(modifier = Modifier.width(8.dp))
+            Spacer(modifier = Modifier.width(12.dp))
 
-        // Download Action (always visible)
-        IconButton(onClick = { onDownloadClick() }, modifier = Modifier.size(40.dp).testTag("downloadButton")) {
-            if (isDownloading) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(24.dp),
-                    color = MaterialTheme.colorScheme.primary,
-                    strokeWidth = 2.dp
+            // File Details
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = fileName,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
-            } else {
-                Icon(
-                    modifier = Modifier.testTag("downloadButtonIcon"),
-                    imageVector = Icons.Default.Download,
-                    contentDescription = stringResource(MR.string.chat_message_download_file),
-                    tint = MaterialTheme.colorScheme.primary
-                )
+                if (fileSize.isNotEmpty()) {
+                    Text(
+                        text = fileSize,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            if (showDownloadButton) {
+                Spacer(modifier = Modifier.width(8.dp))
+
+                IconButton(onClick = { onDownloadClick() }, modifier = Modifier.size(40.dp).testTag("downloadButton")) {
+                    if (isDownloading) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(24.dp),
+                            color = MaterialTheme.colorScheme.primary,
+                            strokeWidth = 2.dp
+                        )
+                    } else {
+                        Icon(
+                            modifier = Modifier.testTag("downloadButtonIcon"),
+                            imageVector = Icons.Default.Download,
+                            contentDescription = stringResource(MR.string.chat_message_download_file),
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                }
             }
         }
     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/DocumentMediaItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/DocumentMediaItem.kt
@@ -54,12 +54,7 @@ fun DocumentMediaItem(
     onDownloadClick: () -> Unit,
     onLongPress: () -> Unit,
     isDownloading: Boolean = false,
-    // When set (PDFs, issue #909) a first-page preview is rendered above the file
-    // row and the row's leading icon is dropped — the card reads as a preview, not
-    // a plain chip. Null keeps the original icon-only row for every other document.
     previewImageData: HomebaseImageData? = null,
-    // PDFs open in a viewer on tap (which offers download), so their bubble drops
-    // the redundant download button; other documents keep it as the tap target.
     showDownloadButton: Boolean = true,
 ) {
     val contentType = payload.contentType ?: ""
@@ -90,6 +85,7 @@ fun DocumentMediaItem(
                 imageData = previewImageData,
                 modifier = Modifier.fillMaxWidth().height(180.dp),
                 contentScale = ContentScale.Crop,
+                alignment = Alignment.TopCenter,
                 contentDescription = stringResource(MR.string.chat_message_pdf_preview),
             )
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
@@ -556,11 +556,6 @@ fun MediaItem(
         }
 
         contentType == "application/pdf" -> {
-            // Reuse the image thumbnail path: the sender ships a first-page preview on
-            // the message (previewThumbnail + thumbnail ladder), so the receiver sees it
-            // without downloading the full PDF. No preview (old sends / web / render
-            // failure) → the plain icon row. Tap opens the PDF viewer either way (see
-            // MediaDownloadHandler.handleMediaClicked).
             val pdfPreviewData =
                 remember(driveId, fileId, payload.key, payload.lastModified) {
                     val previewThumb = payload.previewThumbnail?.toEmbeddedThumb() ?: previewThumbnail

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
@@ -555,6 +555,41 @@ fun MediaItem(
             )
         }
 
+        contentType == "application/pdf" -> {
+            // Reuse the image thumbnail path: the sender ships a first-page preview on
+            // the message (previewThumbnail + thumbnail ladder), so the receiver sees it
+            // without downloading the full PDF. No preview (old sends / web / render
+            // failure) → the plain icon row. Tap opens the PDF viewer either way (see
+            // MediaDownloadHandler.handleMediaClicked).
+            val pdfPreviewData =
+                remember(driveId, fileId, payload.key, payload.lastModified) {
+                    val previewThumb = payload.previewThumbnail?.toEmbeddedThumb() ?: previewThumbnail
+                    val payloadIv = payload.iv?.let { Base64.decode(it) }
+                    if (previewThumb == null || payloadIv == null) return@remember null
+                    HomebaseImageData(
+                        driveId = driveId,
+                        fileId = fileId,
+                        payloadKey = payload.key,
+                        previewThumbnail = previewThumb,
+                        requestedSize = ImageSize.THUMB_MEDIUM,
+                        availableThumbSizes = thumbSizesFrom(payload.thumbnails),
+                        lastModified = payload.lastModified,
+                        isEncrypted = true,
+                        payloadContentType = contentType,
+                        keyHeader = KeyHeader(iv = payloadIv, aesKey = keyHeader.aesKey),
+                    )
+                }
+            DocumentMediaItem(
+                payload = payload,
+                modifier = baseModifier,
+                onDownloadClick = { onClick?.invoke() },
+                onLongPress = { onLongPress?.invoke(Offset.Zero) },
+                isDownloading = isDownloading,
+                previewImageData = pdfPreviewData,
+                showDownloadButton = false,
+            )
+        }
+
         contentType == "application/zip" ||
                 contentType == "application/x-rar-compressed" ||
                 contentType == "application/vnd.android.package-archive" ||

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilderPdfTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilderPdfTest.kt
@@ -18,8 +18,6 @@ import kotlin.test.assertTrue
  */
 class MessageAttachmentBuilderPdfTest {
 
-    // The PDF branch renders straight from the file path (JVM PDFBox actual) and never
-    // touches FileOperationsProvider, so every op here should be unreachable.
     private fun failingFs() = object : FileOperationsProvider {
         override fun getCacheDirectory(): String = "/tmp/test-cache"
         override fun openFileInput(path: String): InputProvider = fail("openFileInput")

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilderPdfTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilderPdfTest.kt
@@ -1,0 +1,57 @@
+package id.homebase.chat.services.builder
+
+import id.homebase.api.file.FileOperationsProvider
+import io.ktor.client.request.forms.InputProvider
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Issue #909: a PDF attachment whose file can't be rendered (missing / not a real
+ * PDF) must fall back to a plain, preview-less payload — contentType and filename
+ * preserved, no crash — so the bubble shows the icon row instead of throwing. The
+ * happy-path (a renderable PDF → embedded preview + thumbnail ladder) is verified
+ * on-device; there's no lightweight PDF fixture to render in a JVM unit test.
+ */
+class MessageAttachmentBuilderPdfTest {
+
+    // The PDF branch renders straight from the file path (JVM PDFBox actual) and never
+    // touches FileOperationsProvider, so every op here should be unreachable.
+    private fun failingFs() = object : FileOperationsProvider {
+        override fun getCacheDirectory(): String = "/tmp/test-cache"
+        override fun openFileInput(path: String): InputProvider = fail("openFileInput")
+        override suspend fun readFileBytes(path: String): ByteArray = fail("readFileBytes")
+        override fun deleteTempFile(path: String): Boolean = false
+        override fun getFileSize(path: String): Long = 0L
+        override suspend fun writeBytesToTempFile(bytes: ByteArray, prefix: String, suffix: String): String =
+            fail("writeBytesToTempFile")
+        override suspend fun writeBytesToShareOutboundFile(bytes: ByteArray, suffix: String): String =
+            fail("writeBytesToShareOutboundFile")
+        override suspend fun writeStream(path: String, data: Flow<ByteArray>) = fail<Unit>("writeStream")
+        private fun <T> fail(name: String): T =
+            throw UnsupportedOperationException("$name should not be called from the PDF path")
+    }
+
+    @Test
+    fun pdf_withUnrenderableFile_fallsBackToPreviewlessPayload() = runTest {
+        val bundle = MessageAttachmentBuilder.buildSingle(
+            attachment = AttachmentInput(
+                filePath = "/tmp/does-not-exist-909.pdf",
+                contentType = "application/pdf",
+                displayName = "report.pdf",
+            ),
+            fileOperationsProvider = failingFs(),
+            payloadKey = "chat_web0",
+        )
+
+        val payload = bundle.payloads.single()
+        assertEquals("application/pdf", payload.contentType)
+        assertEquals("report.pdf", payload.descriptorContent)
+        assertNull(payload.previewThumbnail, "an unrenderable PDF must not carry a preview thumb")
+        assertTrue(bundle.thumbnails.isEmpty())
+        assertTrue(bundle.previewThumbs.isEmpty())
+    }
+}

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfPageViewer.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfPageViewer.android.kt
@@ -80,16 +80,15 @@ actual fun PdfPageViewer(
                 existing.documentUri = uri
             }
         },
-        onReset = { frameLayout ->
-            val activity = context as? FragmentActivity
-            if (activity != null) {
-                val fm = activity.supportFragmentManager
-                val fragment = fm.findFragmentByTag(fragmentTag)
-                if (fragment != null) {
-                    fm.beginTransaction().remove(fragment).commitAllowingStateLoss()
-                }
-            }
-        },
+        onReset = { removePdfFragment(context, fragmentTag) },
+        onRelease = { removePdfFragment(context, fragmentTag) },
         modifier = modifier,
     )
+}
+
+private fun removePdfFragment(context: Context, fragmentTag: String) {
+    val activity = context as? FragmentActivity ?: return
+    val fm = activity.supportFragmentManager
+    val fragment = fm.findFragmentByTag(fragmentTag) ?: return
+    fm.beginTransaction().remove(fragment).commitAllowingStateLoss()
 }

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -922,7 +922,6 @@
     <string name="chat_message_download_file">Download file</string>
     <string name="chat_message_file_type_icon">File type icon</string>
     <string name="chat_message_pdf_preview">PDF preview</string>
-    <string name="chat_pdf_viewer_close">Close</string>
     <string name="chat_message_microphone">Microphone</string>
     <string name="chat_message_emoji">Emoji</string>
 

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -921,6 +921,8 @@
     <string name="moment_video_fit_screen">Fit to screen</string>
     <string name="chat_message_download_file">Download file</string>
     <string name="chat_message_file_type_icon">File type icon</string>
+    <string name="chat_message_pdf_preview">PDF preview</string>
+    <string name="chat_pdf_viewer_close">Close</string>
     <string name="chat_message_microphone">Microphone</string>
     <string name="chat_message_emoji">Emoji</string>
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImage.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImage.kt
@@ -70,6 +70,7 @@ fun HomebaseImage(
     modifier: Modifier = Modifier,
     contentDescription: String? = null,
     contentScale: ContentScale = ContentScale.Fit,
+    alignment: Alignment = Alignment.Center,
     placeholder: @Composable (() -> Unit)? = null,
     error: @Composable (() -> Unit)? = null,
     onClick: (() -> Unit)? = null,
@@ -187,6 +188,7 @@ fun HomebaseImage(
                         painter = loadingPainter,
                         contentDescription = contentDescription,
                         contentScale = contentScale,
+                        alignment = alignment,
                         modifier = Modifier.fillMaxSize().then(blurMod)
                     )
                 } else if (previewBitmap != null) {
@@ -194,6 +196,7 @@ fun HomebaseImage(
                         bitmap = previewBitmap,
                         contentDescription = contentDescription,
                         contentScale = contentScale,
+                        alignment = alignment,
                         modifier = Modifier.fillMaxSize().then(blurMod)
                     )
                 } else {
@@ -207,6 +210,7 @@ fun HomebaseImage(
                         bitmap = previewBitmap,
                         contentDescription = contentDescription,
                         contentScale = contentScale,
+                        alignment = alignment,
                         modifier = Modifier.fillMaxSize().then(blurMod)
                     )
                 } else {
@@ -217,7 +221,8 @@ fun HomebaseImage(
             is AsyncImagePainter.State.Success -> {
                 SubcomposeAsyncImageContent(
                     modifier = Modifier.fillMaxSize().then(blurMod),
-                    contentScale = contentScale
+                    contentScale = contentScale,
+                    alignment = alignment
                 )
             }
 
@@ -231,6 +236,7 @@ fun HomebaseImage(
                             bitmap = previewBitmap,
                             contentDescription = contentDescription,
                             contentScale = contentScale,
+                            alignment = alignment,
                             modifier = Modifier.fillMaxSize().then(blurMod)
                         )
                     } else {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
@@ -620,8 +620,7 @@ fun MomentDetailPane(
                 }
 
                 is FullScreenOverlay.PdfViewerData -> {
-                    // Not used by moments — PDF attachments are chat-only. The VM
-                    // never emits this variant.
+                    // Not used by moments — PDFs are chat-only.
                 }
             }
         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentDetailScreen.kt
@@ -567,6 +567,7 @@ fun MomentDetailPane(
                     is FullScreenOverlay.ViewMessageData -> "image"
                     is FullScreenOverlay.VideoPlayerData -> "video"
                     is FullScreenOverlay.AttachmentData -> "attachment"
+                    is FullScreenOverlay.PdfViewerData -> "pdf"
                 }
             },
             transitionSpec = {
@@ -616,6 +617,11 @@ fun MomentDetailPane(
                 is FullScreenOverlay.AttachmentData -> {
                     // Not used by moments — that overlay is the chat composer's
                     // attachment editor. The VM never emits this variant.
+                }
+
+                is FullScreenOverlay.PdfViewerData -> {
+                    // Not used by moments — PDF attachments are chat-only. The VM
+                    // never emits this variant.
                 }
             }
         }


### PR DESCRIPTION
Fixes #909.

Chat PDF attachments rendered as a plain icon row with no preview, while Vault already shows a rendered first-page thumbnail. This reuses the **existing cross-platform PDF stack** (`homebase-common/.../pdf/*`) — no new renderer.

## What changed

**Send-time preview** (`MessageAttachmentBuilder` + `MessageThumbnailGenerator`)
- New `application/pdf` branch renders the first page (`generatePdfThumbnailFromFile`) and runs the JPEG through the normal image thumbnail pipeline (`createThumbnails`). So the receiver sees the preview **without downloading the full PDF** — the embedded `previewThumbnail` rides on the message and a small thumbnail ladder is uploaded, exactly like images.
- Renderer unavailable (web returns `null`) or an unreadable/encrypted PDF → `null` → a plain preview-less payload (icon row). Wrapped in try/catch — **render failures fall back, never crash**.

**Bubble preview** (`DocumentMediaItem` + `MediaItem`)
- Rather than cloning a new `PdfMediaItem`, `DocumentMediaItem` gained an optional `previewImageData` + `showDownloadButton`. A PDF renders the first-page preview above the file row via `HomebaseImage`, which fetches the **small server thumbnail, never the full PDF** (`THUMBLESS_CONTENT_TYPES` is gif-only, so a PDF takes the thumbnail branch).
- No preview (old sends / web / render failure) → the original icon row, **unchanged for every other document type**.

**Tap-to-view** (`FullScreenOverlay.PdfViewerData` + `ChatPdfViewer`)
- Tapping a PDF decrypts it via the **existing `DecryptFile` path** into the `decryptedFiles` cache and opens a fullscreen `ChatPdfViewer` — a thin wrapper around the shared `PdfPageViewer` with a download action in the top bar. No decrypt logic duplicated from Vault's `PdfViewerPage`.

## Acceptance criteria
- [x] PDF shows a first-page preview thumbnail in the bubble (new sends).
- [x] Tapping a PDF opens a full page viewer (shared `PdfPageViewer`), with download in the bar.
- [x] Preview visible to the receiver **without** downloading the full PDF (send-time `previewThumbnail` + small thumbnail ladder).
- [x] Other document types (Word/Excel/zip/…) unchanged (icon row).
- [x] Render failures fall back to the icon row, not a crash (unit-tested).
- [x] Compiles on Android / iOS / Desktop(JVM) / Web(wasmJs).

## Deliberate simplifications (ponytail)
- **Old preview-less PDFs** (sent before this change) show the icon row, not an auto-rendered bubble thumbnail — but they're now **tappable to open the viewer** (which downloads + renders). Auto-rendering an old PDF's bubble thumbnail would mean decrypting the full file on scroll; skipped as low-value. The viewer covers it.
- **No happy-path unit test** for preview generation — there's no lightweight PDF fixture to render in a JVM unit test without hand-rolling a fragile PDF. `MessageAttachmentBuilderPdfTest` covers the fail-soft branch; the render path is device-verified.

## Tests
`homebase-chat:jvmTest` green (incl. new `MessageAttachmentBuilderPdfTest`); compiles clean on JVM/Android/wasmJs/iOS.

CI: all checks green (Build Android & Desktop, Build iOS, JVM/unit tests, Lint). On-device verification (Redmi) pending — no Android device attached at author time; the render path (real PDF → preview + viewer) is best confirmed on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Round 2 — device testing on Redmi Note 5 Pro

Device-verified the send→preview→viewer flow and fixed what turned up:

- **Bubble top-crop** — the first-page preview showed the centre of the page. Added an `alignment` param to `HomebaseImage` and pass `TopCenter`, so the preview shows the top of page 1 (verified on device).
- **Viewer reopen hang** — reopening the viewer loaded forever. Root cause: the Android `PdfPageViewer` only handled `onReset` (reuse pools), not `onRelease`, so in the `AnimatedContent` overlay the `androidx.pdf` fragment leaked and a reopen found the stale same-tag fragment on a destroyed container. Now removed on `onRelease` too — fix is in the shared viewer, so Vault benefits as well.
- **Image-style viewer** — `ChatPdfViewer` now mirrors `FullScreenMediaViewer`: name + date top bar that a tap toggles, back-arrow to dismiss, native pinch-zoom. `PdfViewerData` carries `userDate`.

Also merged latest `main` (incl. the #844 upload-service migration) into the branch — no conflicts.

Follow-up (separate PR): PDF first-page preview inside `MediaAttachmentEditor` (the composer), and an optional shared-element transition from the bubble into the viewer.
