### PR TITLE
feat(upload): finish media centralization + single-upload-path guard + temp-dir hardening (#844 PR3.6+PR4)

### DIFF
--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/file/AndroidFileOperationsProvider.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/file/AndroidFileOperationsProvider.kt
@@ -131,7 +131,10 @@ class AndroidFileOperationsProvider(
     override suspend fun writeBytesToTempFile(
         bytes: ByteArray, prefix: String, suffix: String
     ): String = withContext(Dispatchers.IO) {
-        val file = File.createTempFile(prefix, suffix, context.cacheDir)
+        // Into the KEEP-protected hb-temp/ subdir (#844 PR4) — CacheSweeper won't wipe an
+        // offline-pending upload's encrypted payload out from under it on a startup/clear sweep.
+        val tempDir = File(context.cacheDir, CacheAudit.TEMP_DIR_NAME).apply { mkdirs() }
+        val file = File.createTempFile(prefix, suffix, tempDir)
         file.writeBytes(bytes)
         file.path
     }

--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/file/AndroidFileOperationsProvider.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/file/AndroidFileOperationsProvider.kt
@@ -130,10 +130,17 @@ class AndroidFileOperationsProvider(
 
     override suspend fun writeBytesToTempFile(
         bytes: ByteArray, prefix: String, suffix: String
+    ): String = writeBytesIn(CacheAudit.UPLOAD_TEMP_DIR_NAME, bytes, prefix, suffix)
+
+    // Encrypted, ready-to-transmit payloads → outbox-temp/ (KEEP-protected; #844 PR4).
+    override suspend fun writeBytesToOutboxTempFile(
+        bytes: ByteArray, prefix: String, suffix: String
+    ): String = writeBytesIn(CacheAudit.OUTBOX_TEMP_DIR_NAME, bytes, prefix, suffix)
+
+    private suspend fun writeBytesIn(
+        dirName: String, bytes: ByteArray, prefix: String, suffix: String
     ): String = withContext(Dispatchers.IO) {
-        // Into the KEEP-protected hb-temp/ subdir (#844 PR4) — CacheSweeper won't wipe an
-        // offline-pending upload's encrypted payload out from under it on a startup/clear sweep.
-        val tempDir = File(context.cacheDir, CacheAudit.TEMP_DIR_NAME).apply { mkdirs() }
+        val tempDir = File(context.cacheDir, dirName).apply { mkdirs() }
         val file = File.createTempFile(prefix, suffix, tempDir)
         file.writeBytes(bytes)
         file.path

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheAudit.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheAudit.kt
@@ -37,17 +37,25 @@ object CacheAudit {
     )
 
     /**
-     * The single subdirectory of the cache dir that [FileOperationsProvider.writeBytesToTempFile]
-     * writes into, on every platform (#844 PR4). Holds the upload pipeline's transient files —
-     * raw pre-encryption source temps AND the encrypted payload temps that ride in an outbox row
-     * until the send completes (which can be a long time when offline). It is deliberately NOT
-     * "untracked" scratch: the [CacheSweeper] KEEPs it on the startup / "Clear caches" sweep so an
-     * in-flight (esp. offline-pending) upload's encrypted payload is never deleted out from under
-     * it, and only wipes it on the full logout sweep. Callers still reap their own temps normally
-     * (finally blocks, outbox completion), so it doesn't grow unbounded; a crash-leaked temp is
-     * bounded by the next logout. Its bytes are still counted in the Storage screen's total.
+     * The two upload-pipeline temp subdirectories of the cache dir (#844 PR4). They straddle the
+     * #844 durability boundary ("everything before encryption is disposable") and are swept
+     * DIFFERENTLY:
+     *
+     * - [UPLOAD_TEMP_DIR_NAME] — the RAW, pre-encryption source temps ([writeBytesToTempFile]).
+     *   Disposable: if one is gone at send time the pipeline fails soft (re-pick). Left "untracked"
+     *   so the CacheSweeper reaps it on every startup / "Clear caches" — it self-heals and can't
+     *   grow. This is the biggest leak source (picker-resolved inputs).
+     * - [OUTBOX_TEMP_DIR_NAME] — the ENCRYPTED, ready-to-transmit payloads
+     *   ([writeBytesToOutboxTempFile]), each referenced by an outbox row until the send completes
+     *   (a long time when offline). Durable: the CacheSweeper KEEPs it on the startup / "Clear
+     *   caches" sweep so an in-flight upload's payload is never deleted mid-flight, and only wipes
+     *   it on full logout. It's reaped along the outbox's own lifecycle — on success
+     *   (cleanupPayloadTempFiles) and on drop after ~48h (cleanupPayloadsForDroppedRow).
+     *
+     * Both are counted in the Storage screen total.
      */
-    const val TEMP_DIR_NAME: String = "hb-temp"
+    const val UPLOAD_TEMP_DIR_NAME: String = "upload-temp"
+    const val OUTBOX_TEMP_DIR_NAME: String = "outbox-temp"
 
     /**
      * Top-level entries Android places inside our `cacheDir` that are owned by
@@ -201,7 +209,8 @@ object CacheAudit {
         name == "Crash Reports" -> "Android system: crash reporter — sacred"
         name == "hbvid_preload" -> "legacy video preload dir"
         name == "coil3_disk_cache" -> "orphan Coil disk cache"
-        name == TEMP_DIR_NAME -> "upload-pipeline temps (raw + encrypted payloads; kept until logout to protect pending sends)"
+        name == UPLOAD_TEMP_DIR_NAME -> "raw pre-encryption upload temps (disposable — swept every startup)"
+        name == OUTBOX_TEMP_DIR_NAME -> "encrypted outbox payload temps (kept until sent/dropped to protect pending sends)"
         name == "homebase-payloads" || name == "homebase-thumbs" ||
             name == "homebase-public-profiles" || name == "homebase-public-images" ->
             "legacy kache dir (pre-v2)"

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheAudit.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheAudit.kt
@@ -37,6 +37,19 @@ object CacheAudit {
     )
 
     /**
+     * The single subdirectory of the cache dir that [FileOperationsProvider.writeBytesToTempFile]
+     * writes into, on every platform (#844 PR4). Holds the upload pipeline's transient files —
+     * raw pre-encryption source temps AND the encrypted payload temps that ride in an outbox row
+     * until the send completes (which can be a long time when offline). It is deliberately NOT
+     * "untracked" scratch: the [CacheSweeper] KEEPs it on the startup / "Clear caches" sweep so an
+     * in-flight (esp. offline-pending) upload's encrypted payload is never deleted out from under
+     * it, and only wipes it on the full logout sweep. Callers still reap their own temps normally
+     * (finally blocks, outbox completion), so it doesn't grow unbounded; a crash-leaked temp is
+     * bounded by the next logout. Its bytes are still counted in the Storage screen's total.
+     */
+    const val TEMP_DIR_NAME: String = "hb-temp"
+
+    /**
      * Top-level entries Android places inside our `cacheDir` that are owned by
      * the platform / WebView / a crash reporter — not by us. Wiping any of
      * these is destructive: nukes in-app browser cookies + storage, forces a
@@ -188,6 +201,7 @@ object CacheAudit {
         name == "Crash Reports" -> "Android system: crash reporter — sacred"
         name == "hbvid_preload" -> "legacy video preload dir"
         name == "coil3_disk_cache" -> "orphan Coil disk cache"
+        name == TEMP_DIR_NAME -> "upload-pipeline temps (raw + encrypted payloads; kept until logout to protect pending sends)"
         name == "homebase-payloads" || name == "homebase-thumbs" ||
             name == "homebase-public-profiles" || name == "homebase-public-images" ->
             "legacy kache dir (pre-v2)"

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheSweeper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheSweeper.kt
@@ -130,11 +130,13 @@ internal fun decide(entry: CacheAudit.Entry, mode: SweepMode): SweepAction = whe
     // Wins over every other rule — including the full "logout" sweep.
     entry.androidSystem -> SweepAction.KEEP
     entry.name == ORPHAN_COIL_DIR_NAME -> SweepAction.ORPHAN_COIL_DELETE
-    // Upload-pipeline temps (writeBytesToTempFile). KEEP on the startup / "Clear caches"
-    // sweep — an offline-pending upload's encrypted payload temp lives here until the send
-    // completes, and deleting it mid-flight breaks the send. Only the full logout sweep wipes
-    // it (session reset — pending sends are abandoned anyway). Callers reap their own temps.
-    entry.name == CacheAudit.TEMP_DIR_NAME -> if (mode == SweepMode.ALL) SweepAction.DELETE else SweepAction.KEEP
+    // Encrypted outbox payload temps. KEEP on the startup / "Clear caches" sweep — each is
+    // referenced by an outbox row (long-lived when offline) and deleting it mid-flight breaks
+    // the send; the outbox reaps them along its own lifecycle (on send success, and on drop
+    // after ~48h). Only the full logout sweep wipes them. The RAW upload-temp dir gets NO such
+    // rule: it's disposable pre-encryption scratch that self-heals via the normal untracked
+    // sweep below (loss = fail-soft re-pick).
+    entry.name == CacheAudit.OUTBOX_TEMP_DIR_NAME -> if (mode == SweepMode.ALL) SweepAction.DELETE else SweepAction.KEEP
     !entry.known -> SweepAction.DELETE
     mode == SweepMode.ALL -> SweepAction.DELETE
     else -> SweepAction.KEEP

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheSweeper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheSweeper.kt
@@ -130,6 +130,11 @@ internal fun decide(entry: CacheAudit.Entry, mode: SweepMode): SweepAction = whe
     // Wins over every other rule — including the full "logout" sweep.
     entry.androidSystem -> SweepAction.KEEP
     entry.name == ORPHAN_COIL_DIR_NAME -> SweepAction.ORPHAN_COIL_DELETE
+    // Upload-pipeline temps (writeBytesToTempFile). KEEP on the startup / "Clear caches"
+    // sweep — an offline-pending upload's encrypted payload temp lives here until the send
+    // completes, and deleting it mid-flight breaks the send. Only the full logout sweep wipes
+    // it (session reset — pending sends are abandoned anyway). Callers reap their own temps.
+    entry.name == CacheAudit.TEMP_DIR_NAME -> if (mode == SweepMode.ALL) SweepAction.DELETE else SweepAction.KEEP
     !entry.known -> SweepAction.DELETE
     mode == SweepMode.ALL -> SweepAction.DELETE
     else -> SweepAction.KEEP

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/FileOperationsProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/FileOperationsProvider.kt
@@ -50,11 +50,32 @@ interface FileOperationsProvider {
      */
     suspend fun sourceExists(path: String): Boolean = getFileSize(path) > 0L
 
+    /**
+     * Write a RAW, pre-encryption source temp into `<cacheDir>/upload-temp/` (see
+     * [CacheAudit.UPLOAD_TEMP_DIR_NAME]). Disposable: the CacheSweeper reaps this dir on every
+     * startup / "Clear caches", so a leaked temp self-heals and can't grow — a source that's gone
+     * at send time just fails soft (re-pick). Use this for the plaintext inputs to the pipeline.
+     */
     suspend fun writeBytesToTempFile(
         bytes: ByteArray,
         prefix: String,
         suffix: String
     ): String
+
+    /**
+     * Write an ENCRYPTED, ready-to-transmit payload temp into `<cacheDir>/outbox-temp/` (see
+     * [CacheAudit.OUTBOX_TEMP_DIR_NAME]). Durable: each file is referenced by an outbox row until
+     * the send completes (long-lived when offline), so the CacheSweeper KEEPs this dir on the
+     * startup / "Clear caches" sweep and only wipes it on logout; the outbox reaps individual
+     * files along its own lifecycle. Used ONLY by the encryption step (PayloadBundleEncryption
+     * Service.encryptFile). Default delegates to [writeBytesToTempFile] for any provider that
+     * hasn't overridden it (behaviour-preserving).
+     */
+    suspend fun writeBytesToOutboxTempFile(
+        bytes: ByteArray,
+        prefix: String,
+        suffix: String
+    ): String = writeBytesToTempFile(bytes, prefix, suffix)
 
     /**
      * Write [bytes] to a sequestered subdirectory `<cacheDir>/share_outbound/`

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/OkioFileOperationsProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/OkioFileOperationsProvider.kt
@@ -47,7 +47,9 @@ open class OkioFileOperationsProvider(
         prefix: String,
         suffix: String
     ): String {
-        val dir = cacheDir.toPath()
+        // Into the KEEP-protected hb-temp/ subdir (#844 PR4) so it's aligned with the other
+        // platforms and survives the startup/clear CacheSweeper pass while a send is pending.
+        val dir = cacheDir.toPath() / CacheAudit.TEMP_DIR_NAME
         fileSystem.createDirectories(dir)
         val path = dir / "$prefix${randomToken()}$suffix"
         fileSystem.write(path) { write(bytes) }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/OkioFileOperationsProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/OkioFileOperationsProvider.kt
@@ -47,9 +47,19 @@ open class OkioFileOperationsProvider(
         prefix: String,
         suffix: String
     ): String {
-        // Into the KEEP-protected hb-temp/ subdir (#844 PR4) so it's aligned with the other
-        // platforms and survives the startup/clear CacheSweeper pass while a send is pending.
-        val dir = cacheDir.toPath() / CacheAudit.TEMP_DIR_NAME
+        return writeBytesIn(CacheAudit.UPLOAD_TEMP_DIR_NAME, bytes, prefix, suffix)
+    }
+
+    // Encrypted, ready-to-transmit payloads → outbox-temp/ (KEEP-protected; #844 PR4).
+    override suspend fun writeBytesToOutboxTempFile(
+        bytes: ByteArray,
+        prefix: String,
+        suffix: String
+    ): String = writeBytesIn(CacheAudit.OUTBOX_TEMP_DIR_NAME, bytes, prefix, suffix)
+
+    // upload-temp is swept every startup (disposable); outbox-temp is KEEP-protected until sent.
+    private fun writeBytesIn(dirName: String, bytes: ByteArray, prefix: String, suffix: String): String {
+        val dir = cacheDir.toPath() / dirName
         fileSystem.createDirectories(dir)
         val path = dir / "$prefix${randomToken()}$suffix"
         fileSystem.write(path) { write(bytes) }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
@@ -12,6 +12,7 @@ import id.homebase.api.client.drives.upload.UpdateLocalMetadataTagsOutboxRequest
 import id.homebase.api.client.drives.upload.UploadFileRequest
 import id.homebase.api.client.drives.upload.cleanupHlsScratch
 import id.homebase.api.file.systemFileSystem
+import okio.FileSystem
 import okio.Path.Companion.toPath
 import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.api.client.eventbus.BackendEvent
@@ -866,6 +867,47 @@ class OutboxSync(
 
         // Plus the parent hls_<uuid>/ dir if any.
         cleanupHlsScratch(payloads)
+    }
+
+    /**
+     * Fire-and-forget self-heal for the durable encrypted-payload temp dir (`outbox-temp/`, #844).
+     * Runs [reapIdleOutboxTemps] on the outbox scope. Wire it from a post-auth hook.
+     */
+    fun scheduleIdleOutboxTempReap(outboxTempDir: String) {
+        scope.launch { runCatching { reapIdleOutboxTemps(outboxTempDir) } }
+    }
+
+    /**
+     * Reap crash-orphaned encrypted payload temps from `outbox-temp/`. The dir is KEEP-protected
+     * from the CacheSweeper (a pending send's payload must survive), so this is its self-heal.
+     *
+     * Two conditions make it provably safe to delete, so we never touch a live payload:
+     *  1. **Outbox idle** (`count() == 0`) — nothing pending or in-flight references any file here,
+     *     so every file is an orphan. A completed row deletes its own temp; a still-pending one
+     *     (incl. an offline send waiting indefinitely) keeps `count() > 0` and skips this entirely.
+     *  2. **Older than [maxAgeMs]** — closes the only race: an enc temp written for a brand-new send
+     *     microseconds before its row is inserted is seconds old, so the age floor never reaps it.
+     *     This is what makes the reap safe to run at ANY time, not just at startup.
+     *
+     * Fail-safe: a file whose mtime can't be read is skipped, never deleted.
+     */
+    suspend fun reapIdleOutboxTemps(
+        outboxTempDir: String,
+        maxAgeMs: Long = 24 * 60 * 60 * 1000L,
+        fileSystem: FileSystem = systemFileSystem,
+        nowMs: Long = UnixTimeUtc.now().milliseconds,
+    ) {
+        if (databaseManager.outbox.count() > 0L) return
+        val dir = outboxTempDir.toPath()
+        if (!fileSystem.exists(dir)) return
+        val cutoff = nowMs - maxAgeMs
+        val files = runCatching { fileSystem.list(dir) }.getOrNull() ?: return
+        var reaped = 0
+        for (f in files) {
+            val mtime = fileSystem.metadataOrNull(f)?.lastModifiedAtMillis ?: continue
+            if (mtime < cutoff) runCatching { fileSystem.delete(f) }.onSuccess { reaped++ }
+        }
+        if (reaped > 0) Logger.i("OutboxSync: reaped $reaped orphaned outbox-temp file(s) (outbox idle, >${maxAgeMs}ms old)")
     }
 
     suspend fun clearCheckout(timeoutMs: Long = 10_000) {

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/file/CacheSweeperTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/file/CacheSweeperTest.kt
@@ -48,6 +48,20 @@ class CacheSweeperTest {
     }
 
     @Test
+    fun uploadTempDir_isKeptOnUntrackedSweep_butDeletedOnLogout() {
+        // hb-temp holds in-flight (incl. offline-pending) upload payload temps — a startup /
+        // "Clear caches" sweep must NOT delete them, but the full logout sweep wipes them.
+        assertEquals(
+            SweepAction.KEEP,
+            decide(entry(CacheAudit.TEMP_DIR_NAME), SweepMode.UNTRACKED),
+        )
+        assertEquals(
+            SweepAction.DELETE,
+            decide(entry(CacheAudit.TEMP_DIR_NAME), SweepMode.ALL),
+        )
+    }
+
+    @Test
     fun coil3DiskCache_isAlwaysOrphanCoilDelete_regardlessOfMode() {
         assertEquals(
             SweepAction.ORPHAN_COIL_DELETE,

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/file/CacheSweeperTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/file/CacheSweeperTest.kt
@@ -48,16 +48,31 @@ class CacheSweeperTest {
     }
 
     @Test
-    fun uploadTempDir_isKeptOnUntrackedSweep_butDeletedOnLogout() {
-        // hb-temp holds in-flight (incl. offline-pending) upload payload temps — a startup /
-        // "Clear caches" sweep must NOT delete them, but the full logout sweep wipes them.
+    fun outboxTempDir_isKeptOnUntrackedSweep_butDeletedOnLogout() {
+        // outbox-temp holds encrypted payloads referenced by pending (incl. offline) outbox rows —
+        // a startup / "Clear caches" sweep must NOT delete them (the outbox reaps them on
+        // success/drop), but the full logout sweep wipes them.
         assertEquals(
             SweepAction.KEEP,
-            decide(entry(CacheAudit.TEMP_DIR_NAME), SweepMode.UNTRACKED),
+            decide(entry(CacheAudit.OUTBOX_TEMP_DIR_NAME), SweepMode.UNTRACKED),
         )
         assertEquals(
             SweepAction.DELETE,
-            decide(entry(CacheAudit.TEMP_DIR_NAME), SweepMode.ALL),
+            decide(entry(CacheAudit.OUTBOX_TEMP_DIR_NAME), SweepMode.ALL),
+        )
+    }
+
+    @Test
+    fun uploadTempDir_isDisposable_sweptOnEveryMode() {
+        // upload-temp holds raw pre-encryption source temps — disposable, so it's reaped on the
+        // startup / "Clear caches" sweep (self-healing, can't grow) and on logout.
+        assertEquals(
+            SweepAction.DELETE,
+            decide(entry(CacheAudit.UPLOAD_TEMP_DIR_NAME), SweepMode.UNTRACKED),
+        )
+        assertEquals(
+            SweepAction.DELETE,
+            decide(entry(CacheAudit.UPLOAD_TEMP_DIR_NAME), SweepMode.ALL),
         )
     }
 

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSyncTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSyncTest.kt
@@ -1,5 +1,8 @@
 package id.homebase.api.sync.database
 
+import id.homebase.api.client.drives.files.DeleteFilesByGroupIdOutboxRequest
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
@@ -142,6 +145,37 @@ class OutboxSyncTest {
         }
     }
 
+
+    @Test
+    fun reapIdleOutboxTemps_deletesOldOrphansOnlyWhenIdle() = runOutboxTest { db ->
+        val sync = OutboxSync(
+            databaseManager = db, uploader = TestUploader(), eventBus = EventBus(), scope = backgroundScope
+        )
+        val fs = FakeFileSystem()
+        val dir = "/cache/outbox-temp".toPath()
+        fs.createDirectories(dir)
+        fun write(name: String): Long {
+            val p = dir / name
+            fs.write(p) { writeUtf8("x") }
+            return fs.metadata(p).lastModifiedAtMillis!!
+        }
+
+        // Idle + OLDER than maxAge → reaped (a real crash-orphan).
+        val m1 = write("enc_old.encrypted")
+        sync.reapIdleOutboxTemps(dir.toString(), maxAgeMs = 1_000, fileSystem = fs, nowMs = m1 + 5_000)
+        assertFalse(fs.exists(dir / "enc_old.encrypted"), "idle + old orphan must be reaped")
+
+        // Idle + YOUNGER than maxAge → kept (the create-race guard: a just-written temp is safe).
+        val m2 = write("enc_new.encrypted")
+        sync.reapIdleOutboxTemps(dir.toString(), maxAgeMs = 1_000, fileSystem = fs, nowMs = m2 + 500)
+        assertTrue(fs.exists(dir / "enc_new.encrypted"), "a just-written temp must never be reaped")
+
+        // NON-EMPTY outbox + old file → kept (a pending/offline row might reference it).
+        sync.tryEnqueue(DeleteFilesByGroupIdOutboxRequest(driveId = Uuid.random(), groupIds = listOf(Uuid.random())))
+        val m3 = write("enc_pending.encrypted")
+        sync.reapIdleOutboxTemps(dir.toString(), maxAgeMs = 1_000, fileSystem = fs, nowMs = m3 + 5_000)
+        assertTrue(fs.exists(dir / "enc_pending.encrypted"), "must not reap while the outbox is non-empty")
+    }
 
     @Test
     fun testSuccessfulSend() = runOutboxTest { db ->

--- a/homebase-api/src/jvmMain/java/id/homebase/api/video/FFmpegUtils.jvm.kt
+++ b/homebase-api/src/jvmMain/java/id/homebase/api/video/FFmpegUtils.jvm.kt
@@ -1,6 +1,7 @@
 package id.homebase.api.video
 
 import id.homebase.api.client.KeyHeader
+import id.homebase.api.file.JvmFileSystemUtil
 import java.io.BufferedReader
 import java.io.File
 import java.util.UUID
@@ -9,6 +10,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 actual object FFmpegUtils {
+
+    // FFmpeg scratch (compressed_/input_/hls_/thumb_) lands in the app cache dir, not
+    // java.io.tmpdir (#844 PR4) — so the desktop Storage screen counts it and the CacheSweeper
+    // reclaims it (as untracked scratch, unlike the KEEP-protected hb-temp upload payloads).
+    private val scratchDirPath: String get() = JvmFileSystemUtil.getCacheDirectory().apply { mkdirs() }.absolutePath
 
     @Volatile private var cachedFfmpegVersion: String? = null
     @Volatile private var ffmpegVersionProbed: Boolean = false
@@ -64,7 +70,7 @@ actual object FFmpegUtils {
             }
 
             val uniqueId = getUniqueId(inputPath)
-            val outputPath = "${System.getProperty("java.io.tmpdir")}/thumb_$uniqueId.jpg"
+            val outputPath = "${scratchDirPath}/thumb_$uniqueId.jpg"
 
             val command =
                 listOf(
@@ -128,7 +134,7 @@ actual object FFmpegUtils {
         val effectiveTrimEnd = if (trimStartMs != null && trimEndMs != null) trimEndMs else null
 
         val outputPath =
-            "${System.getProperty("java.io.tmpdir")}/compressed_${inputFile.name}"
+            "${scratchDirPath}/compressed_${inputFile.name}"
         val sourceDurationMs = getDurationMs(inputPath)
         val inputBytes = inputFile.length()
         val probe = probeVideoTrackViaFfprobe(inputPath)
@@ -277,7 +283,7 @@ actual object FFmpegUtils {
             }
 
             val outputDir = File(
-                System.getProperty("java.io.tmpdir"),
+                scratchDirPath,
                 "hls_${UUID.randomUUID()}"
             ).apply { mkdirs() }
 
@@ -312,7 +318,7 @@ actual object FFmpegUtils {
             }
 
             val outputDir = File(
-                System.getProperty("java.io.tmpdir"),
+                scratchDirPath,
                 "hls_${UUID.randomUUID()}"
             ).apply { mkdirs() }
 
@@ -436,7 +442,7 @@ actual object FFmpegUtils {
 
     actual suspend fun cacheInputVideo(fileName: String, data: ByteArray): String =
         withContext(Dispatchers.IO) {
-            val cacheFile = File(System.getProperty("java.io.tmpdir"), "input_$fileName")
+            val cacheFile = File(scratchDirPath, "input_$fileName")
             cacheFile.writeBytes(data)
             cacheFile.absolutePath
         }

--- a/homebase-api/src/jvmMain/kotlin/id/homebase/api/file/JvmFileOperationsProvider.kt
+++ b/homebase-api/src/jvmMain/kotlin/id/homebase/api/file/JvmFileOperationsProvider.kt
@@ -75,12 +75,26 @@ class JvmFileOperationsProvider : FileOperationsProvider {
         prefix: String,
         suffix: String
     ): String =
+        writeBytesIn(CacheAudit.UPLOAD_TEMP_DIR_NAME, bytes, prefix, suffix)
+
+    // Encrypted, ready-to-transmit payloads → outbox-temp/ (KEEP-protected; #844 PR4).
+    override suspend fun writeBytesToOutboxTempFile(
+        bytes: ByteArray,
+        prefix: String,
+        suffix: String
+    ): String = writeBytesIn(CacheAudit.OUTBOX_TEMP_DIR_NAME, bytes, prefix, suffix)
+
+    // Both temp dirs live under the app cache dir (not java.io.tmpdir), so the Storage screen
+    // counts them and the CacheSweeper governs them (#844 PR4). upload-temp is swept every
+    // startup (disposable); outbox-temp is KEEP-protected until the send completes.
+    private suspend fun writeBytesIn(
+        dirName: String,
+        bytes: ByteArray,
+        prefix: String,
+        suffix: String
+    ): String =
         withContext(Dispatchers.IO) {
-            // Into the KEEP-protected hb-temp/ under the cache dir (#844 PR4) — previously
-            // java.io.tmpdir, which the Storage screen neither counted nor cleared and the
-            // CacheSweeper couldn't reach. hb-temp survives the startup/clear sweep so an
-            // offline-pending upload's encrypted payload isn't deleted mid-flight.
-            val tempDir = File(getCacheDirectory(), CacheAudit.TEMP_DIR_NAME).apply { mkdirs() }
+            val tempDir = File(getCacheDirectory(), dirName).apply { mkdirs() }
             val file = File.createTempFile(prefix, suffix, tempDir)
             file.writeBytes(bytes)
             file.absolutePath

--- a/homebase-api/src/jvmMain/kotlin/id/homebase/api/file/JvmFileOperationsProvider.kt
+++ b/homebase-api/src/jvmMain/kotlin/id/homebase/api/file/JvmFileOperationsProvider.kt
@@ -76,7 +76,12 @@ class JvmFileOperationsProvider : FileOperationsProvider {
         suffix: String
     ): String =
         withContext(Dispatchers.IO) {
-            val file = File.createTempFile(prefix, suffix)
+            // Into the KEEP-protected hb-temp/ under the cache dir (#844 PR4) — previously
+            // java.io.tmpdir, which the Storage screen neither counted nor cleared and the
+            // CacheSweeper couldn't reach. hb-temp survives the startup/clear sweep so an
+            // offline-pending upload's encrypted payload isn't deleted mid-flight.
+            val tempDir = File(getCacheDirectory(), CacheAudit.TEMP_DIR_NAME).apply { mkdirs() }
+            val file = File.createTempFile(prefix, suffix, tempDir)
             file.writeBytes(bytes)
             file.absolutePath
         }

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/IOSFileOperationsProvider.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/IOSFileOperationsProvider.kt
@@ -125,7 +125,6 @@ class IOSFileOperationsProvider : FileOperationsProvider {
         return NSFileManager.defaultManager.fileExistsAtPath(path)
     }
 
-    @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
     override suspend fun writeBytesToTempFile(
         bytes: ByteArray,
         prefix: String,
@@ -142,6 +141,7 @@ class IOSFileOperationsProvider : FileOperationsProvider {
     // Both temp dirs live under the Caches dir (not NSTemporaryDirectory()), so the Storage
     // screen counts them and the CacheSweeper governs them (#844 PR4). upload-temp is swept every
     // startup (disposable); outbox-temp is KEEP-protected until the send completes.
+    @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
     private fun writeBytesIn(dirName: String, bytes: ByteArray, prefix: String, suffix: String): String {
         val cacheDir = getCacheDirectory().trimEnd('/')
         val tempDir = "$cacheDir/$dirName"

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/IOSFileOperationsProvider.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/IOSFileOperationsProvider.kt
@@ -131,8 +131,17 @@ class IOSFileOperationsProvider : FileOperationsProvider {
         prefix: String,
         suffix: String
     ): String {
-        val tempDir = NSTemporaryDirectory()
-        val filePath = "$tempDir$prefix${NSUUID().UUIDString}$suffix"
+        // Into the KEEP-protected hb-temp/ under the Caches dir (#844 PR4) — previously
+        // NSTemporaryDirectory(), which the Storage screen neither counted nor cleared and the
+        // CacheSweeper couldn't reach. hb-temp survives the startup/clear sweep so an
+        // offline-pending upload's encrypted payload isn't deleted mid-flight.
+        val cacheDir = getCacheDirectory().trimEnd('/')
+        val tempDir = "$cacheDir/${CacheAudit.TEMP_DIR_NAME}"
+        val fm = NSFileManager.defaultManager
+        if (!fm.fileExistsAtPath(tempDir)) {
+            fm.createDirectoryAtPath(tempDir, true, null, null)
+        }
+        val filePath = "$tempDir/$prefix${NSUUID().UUIDString}$suffix"
 
         val data =
             bytes.usePinned { pinned ->

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/IOSFileOperationsProvider.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/IOSFileOperationsProvider.kt
@@ -130,13 +130,21 @@ class IOSFileOperationsProvider : FileOperationsProvider {
         bytes: ByteArray,
         prefix: String,
         suffix: String
-    ): String {
-        // Into the KEEP-protected hb-temp/ under the Caches dir (#844 PR4) — previously
-        // NSTemporaryDirectory(), which the Storage screen neither counted nor cleared and the
-        // CacheSweeper couldn't reach. hb-temp survives the startup/clear sweep so an
-        // offline-pending upload's encrypted payload isn't deleted mid-flight.
+    ): String = writeBytesIn(CacheAudit.UPLOAD_TEMP_DIR_NAME, bytes, prefix, suffix)
+
+    // Encrypted, ready-to-transmit payloads → outbox-temp/ (KEEP-protected; #844 PR4).
+    override suspend fun writeBytesToOutboxTempFile(
+        bytes: ByteArray,
+        prefix: String,
+        suffix: String
+    ): String = writeBytesIn(CacheAudit.OUTBOX_TEMP_DIR_NAME, bytes, prefix, suffix)
+
+    // Both temp dirs live under the Caches dir (not NSTemporaryDirectory()), so the Storage
+    // screen counts them and the CacheSweeper governs them (#844 PR4). upload-temp is swept every
+    // startup (disposable); outbox-temp is KEEP-protected until the send completes.
+    private fun writeBytesIn(dirName: String, bytes: ByteArray, prefix: String, suffix: String): String {
         val cacheDir = getCacheDirectory().trimEnd('/')
-        val tempDir = "$cacheDir/${CacheAudit.TEMP_DIR_NAME}"
+        val tempDir = "$cacheDir/$dirName"
         val fm = NSFileManager.defaultManager
         if (!fm.fileExistsAtPath(tempDir)) {
             fm.createDirectoryAtPath(tempDir, true, null, null)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -38,8 +38,11 @@ import id.homebase.api.toBase64
 import id.homebase.chat.data.ConversationState
 import id.homebase.chat.data.ConversationUiModel
 import id.homebase.chat.services.ChatProtocol
+import id.homebase.upload.MediaUploadSpec
 import id.homebase.upload.PayloadBundle
 import id.homebase.upload.PayloadBundleEncryptor
+import id.homebase.upload.UploadOutcome
+import id.homebase.upload.UploadService
 import id.homebase.chat.services.GroupHealCleanupInfo
 import id.homebase.chat.services.GroupHealInfo
 import id.homebase.chat.services.StatusMessage
@@ -77,6 +80,12 @@ import kotlin.uuid.Uuid
 class ConversationService(
     private val credentialsManager: CredentialsManager,
     private val payloadBundleEncryptionService: PayloadBundleEncryptor,
+    // Shared upload pipeline — the conversation-CREATE file (writeConversationFile) routes its
+    // encrypt+enqueue through here (#844). The conversation-UPDATE path (updateConversationInternal)
+    // deliberately stays a documented guard exception: it's a hot, multi-purpose mutation method
+    // (archival/participants/leaveGroup/heal) where the encrypt-new-avatar branch is rare, so
+    // routing it all through UploadService is high blast radius for little benefit.
+    private val uploadService: UploadService,
     private val dbm: DatabaseManager,
     private val introductionProvider: IntroductionSender,
     private val scope: CoroutineScope,
@@ -489,13 +498,6 @@ class ConversationService(
         }
         // ---- end DEBUG ----
 
-        val encryptedBundle = payloadBundleEncryptionService.encryptBundle(
-            conversationId,
-            payloadBundle,
-            keyHeader.aesKey,
-            scope
-        )
-
         val metadata = UploadFileMetadata(
             allowDistribution = true,
             isEncrypted = true,
@@ -504,20 +506,10 @@ class ConversationService(
                 tags = if (isGroup) listOf(ChatProtocol.ConversationGroupTag) else null,
                 fileType = ChatProtocol.ConversationFileType,
                 content = OdinSystemSerializer.serialize(content),
-                previewThumbnail = encryptedBundle.previewThumbs.minByOrNull { it.pixelWidth }
+                // previewThumbs pass through encryption unchanged, so derive the header's preview
+                // from the plaintext bundle — UploadService encrypts the bundle internally.
+                previewThumbnail = payloadBundle?.previewThumbs?.minByOrNull { it.pixelWidth }
             ),
-        )
-
-        val request = UploadFileRequest(
-            driveId = chatDrive,
-            keyHeader = keyHeader,
-            metadata = metadata.encryptContent(keyHeader),
-            transitOptions = TransitOptions(
-                recipients = transitRecipients,
-                useAppNotification = false
-            ),
-            payloads = encryptedBundle.payloads,
-            thumbnails = encryptedBundle.thumbnails
         )
 
         // ---- DEBUG instrumentation ----
@@ -570,14 +562,32 @@ class ConversationService(
                 audit.finish("ABORTED at conversationStream.loadConversation")
                 throw e   // original code did not catch — preserve propagation
             }
-        audit.step(3, "outboxSync.tryEnqueue(UploadFileRequest)")
-        val enqueued = outboxSync.tryEnqueue(request)
-        audit.info("STEP 3 returned $enqueued")
-        audit.check("outboxEnqueue", enqueued.enqueued, "outboxSync.tryEnqueue → $enqueued — file will not be uploaded; conversation creation effectively failed")
+        // Encrypt + build request + enqueue via the shared pipeline. writeOptimistic=false: the
+        // optimistic writeNewFile above already ran (this method's write→readback→loadConversation→
+        // enqueue ordering is deliberate, opposite of UploadService's enqueue→write). seedCache=false:
+        // a conversation file has no chat-bubble thumbnail to seed.
+        audit.step(3, "uploadService.upload (encrypt + enqueue)")
+        val outcome = uploadService.upload(
+            MediaUploadSpec(
+                driveId = chatDrive,
+                uniqueId = conversationId,
+                keyHeader = keyHeader,
+                bundle = payloadBundle,
+                metadata = metadata,
+                transit = TransitOptions(recipients = transitRecipients, useAppNotification = false),
+                originalRecipientCount = transitRecipients.size,
+                writeOptimistic = false,
+                seedCache = false,
+            ),
+            scope = scope,
+        )
+        val enqueued = outcome is UploadOutcome.Enqueued
+        audit.info("STEP 3 outcome=$outcome")
+        audit.check("outboxEnqueue", enqueued, "uploadService.upload → $outcome — file will not be uploaded; conversation creation effectively failed")
         val outboxAfter = dbm.outbox.count()
         audit.post("counts: outboxRows=$outboxAfter (delta=${outboxAfter - outboxBefore}, expected ≥+1 if enqueue succeeded)")
         audit.finish("returned $enqueued")
-        return enqueued.enqueued
+        return enqueued
         // ---- end DEBUG ----
     }
 

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
@@ -226,6 +226,7 @@ class ChatMessageActionServiceTestFixture(
         val conversationService = ConversationService(
             credentialsManager = credentialsManager,
             payloadBundleEncryptionService = FakePayloadBundleEncryptor(),
+            uploadService = buildTestUploadService(outboxSync, optimisticWriter, FakePayloadBundleEncryptor(), credentialsManager),
             dbm = dbm,
             introductionProvider = FakeIntroductionSender(),
             scope = scope,

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/TestUploadServiceSupport.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/TestUploadServiceSupport.kt
@@ -1,0 +1,55 @@
+package id.homebase.chat.services
+
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.cache.DriveFileProviderCached
+import id.homebase.api.client.drives.files.DriveFileProvider
+import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.sync.database.OutboxSync
+import id.homebase.chat.services.outbox.OptimisticWriter
+import id.homebase.chat.services.outbox.OptimisticWriterPort
+import id.homebase.upload.PayloadBundleEncryptor
+import id.homebase.upload.PayloadCacheSeeder
+import id.homebase.upload.UploadService
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respondError
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Builds a real [UploadService] over a fixture's existing outbox / optimistic-writer / encryptor,
+ * so a sender migrated onto UploadService still enqueues into the same inspectable in-memory
+ * outbox the fixture already owns. The cache seeder is constructed but never invoked by the
+ * migrated conversation-create path (it uses `seedCache = false`); it only needs a well-formed
+ * [DriveFileProvider], wired here over a MockEngine that 500s (never called).
+ */
+fun buildTestUploadService(
+    outboxSync: OutboxSync,
+    optimisticWriter: OptimisticWriter,
+    encryptor: PayloadBundleEncryptor,
+    credentialsManager: CredentialsManager,
+): UploadService {
+    val httpClient = HttpClient(MockEngine { respondError(HttpStatusCode.InternalServerError) })
+    val cache = DriveFileProviderCached(httpClient, credentialsManager, NoopUploadFileOps())
+    val driveFileProvider = DriveFileProvider(httpClient, credentialsManager, cache)
+    return UploadService(
+        encryptor = encryptor,
+        outboxSync = outboxSync,
+        optimisticWriter = OptimisticWriterPort(optimisticWriter),
+        payloadCacheSeeder = PayloadCacheSeeder(driveFileProvider, NoopUploadFileOps()),
+    )
+}
+
+/** No file IO is expected; only [getCacheDirectory] returns a real path (read eagerly by the Coil cache setup). */
+private class NoopUploadFileOps : FileOperationsProvider {
+    private val cacheDir = java.nio.file.Files.createTempDirectory("hb-chat-uploadsvc-test").toString()
+    private fun nope(): Nothing = error("no file IO expected in test UploadService")
+    override fun openFileInput(path: String) = nope()
+    override suspend fun readFileBytes(path: String) = nope()
+    override fun deleteTempFile(path: String) = nope()
+    override fun getCacheDirectory(): String = cacheDir
+    override fun getFileSize(path: String) = nope()
+    override suspend fun writeBytesToTempFile(bytes: ByteArray, prefix: String, suffix: String) = nope()
+    override suspend fun writeBytesToShareOutboundFile(bytes: ByteArray, suffix: String) = nope()
+    override suspend fun writeStream(path: String, data: Flow<ByteArray>) = nope()
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceTestFixture.kt
@@ -20,6 +20,7 @@ import id.homebase.api.sync.database.Outbox
 import id.homebase.api.sync.database.OutboxSync
 import id.homebase.api.sync.database.OutboxUploader
 import id.homebase.chat.services.ChatProtocol
+import id.homebase.chat.services.buildTestUploadService
 import id.homebase.upload.PayloadBundle
 import id.homebase.upload.PayloadBundleEncryptor
 import id.homebase.chat.services.SendMessageResult
@@ -124,6 +125,7 @@ class ConversationServiceTestFixture : AutoCloseable {
         return ConversationService(
             credentialsManager = credentialsManager,
             payloadBundleEncryptionService = payloadEncryptor,
+            uploadService = buildTestUploadService(outboxSync, optimisticWriter, payloadEncryptor, credentialsManager),
             dbm = dbm,
             introductionProvider = introductionSender,
             scope = scope,

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/architecture/ArchitectureTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/architecture/ArchitectureTest.kt
@@ -31,6 +31,42 @@ class ArchitectureTest {
             }
     }
 
+    /**
+     * Single-upload-path guard (#844). Payload encryption for an upload must go through the shared
+     * pipeline — `UploadService.upload`/`updateFile` — so the payload-cache/fail-soft/seed policies
+     * live in exactly one place. `encryptBundle` is the true "I'm doing a payload upload" signal, so
+     * calling it anywhere else is the violation. (The two-request-type rule was unworkable: header-only
+     * system records and the outbox rekey plumbing legitimately build UploadFileRequest /
+     * UpdateFileByUniqueIdRequest, and a text rule can't tell payload-bearing from header-only.)
+     *
+     * The regex matches CALLS (`.encryptBundle(`); the interface/impl `fun encryptBundle(` definitions
+     * have no leading dot and don't match. `UploadService` is excluded (it owns the one allowed call).
+     * Three functions are documented exceptions — each re-encrypts an in-memory text-overflow mixed
+     * with already-encrypted payloads (recovery plumbing) or is a hot multi-purpose mutation whose
+     * encrypt branch is rare, so routing them through UploadService adds risk without payoff:
+     *   - `updateMessage` (chat edit / amend-pending-create), `resendAsCreate` (chat resend),
+     *   - `updateConversationInternal` (conversation update: archival/participants/leaveGroup/heal).
+     * Adding a NEW `encryptBundle` call anywhere else — or a new media-send function — fails here.
+     */
+    @Test
+    fun `encryptBundle is confined to the shared upload pipeline`() {
+        val documentedExceptions = setOf("updateMessage", "resendAsCreate", "updateConversationInternal")
+        Konsist.scopeFromProject()
+            .files
+            .filter { !it.hasNameEndingWith("Test") }
+            .filter { !it.hasNameEndingWith("UploadService") }
+            .functions()
+            .filter { it.name !in documentedExceptions }
+            .assertFalse(
+                additionalMessage = "Payload encryption for an upload must go through " +
+                    "UploadService.upload/updateFile (issue #844), not a direct encryptBundle call. " +
+                    "If this is a genuine recovery/plumbing exception, add it to documentedExceptions " +
+                    "with a comment explaining why it can't route through UploadService."
+            ) {
+                it.text.contains(Regex("""\.\s*encryptBundle\s*\("""))
+            }
+    }
+
     @Test
     fun `Do not allow calling close on httpClient`() {
         Konsist.scopeFromProject()

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -603,6 +603,7 @@ val appModule = module {
         ConversationService(
             credentialsManager = get(),
             payloadBundleEncryptionService = get(),
+            uploadService = get(),
             dbm = get(),
             introductionProvider = get(),
             scope = get(),

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -475,6 +475,14 @@ val appModule = module {
                 // never cancelled here; logout clears it in-stream via SessionEnded.
                 get<LiveLocationReceiveStore>().reset()
 
+                // Self-heal crash-orphaned encrypted payload temps in outbox-temp/ (#844). The
+                // dir is KEEP-protected from the CacheSweeper (a pending send's payload must
+                // survive), so this idle+age-gated reap is its safety net. Fire-and-forget.
+                get<OutboxSync>().scheduleIdleOutboxTempReap(
+                    get<FileOperationsProvider>().getCacheDirectory().trimEnd('/') +
+                        "/" + CacheAudit.OUTBOX_TEMP_DIR_NAME
+                )
+
                 // Preload conversations and contacts from local DB while navigation
                 // and Compose composition are still in progress, saving ~800ms.
                 val conversationStream = get<ConversationStream>()

--- a/homebase-upload/README.md
+++ b/homebase-upload/README.md
@@ -50,11 +50,23 @@ pre-encrypted + plaintext* payload set (and, for amend, an "amend a queued creat
 needs its rare encrypt branch split out from the hot mutation path, or the whole method carefully
 migrated to `updateFile` with its heal/reuse and conditional-optimistic-write behavior preserved.
 
-## Where temps live
+## Where temps live — two folders, split at the encryption boundary
 
-`FileOperationsProvider.writeBytesToTempFile` writes every raw and encrypted upload temp into
-`<cacheDir>/hb-temp/` on all platforms. `CacheSweeper` **keeps** `hb-temp` on the startup /
-"Clear caches" sweep — an offline-pending upload's encrypted payload lives there until the send
-completes, and deleting it mid-flight would break the send — and only wipes it on full logout.
-FFmpeg scratch is separate: it goes to the cache root and is swept as reclaimable (it's large and
-transient, the opposite durability need).
+#844's rule is *"the durability boundary begins at encryption; everything before it is
+disposable."* So upload temps live in **two** dirs under the app cache dir, swept differently:
+
+| Dir | Contents | Written by | Cleaned |
+|-----|----------|-----------|---------|
+| `<cacheDir>/upload-temp/` | RAW, pre-encryption source | `writeBytesToTempFile` (senders) | **Disposable** — swept on **every** startup / "Clear caches" / logout (it's untracked). Self-heals, can't grow. A source gone at send time just fails soft (re-pick). |
+| `<cacheDir>/outbox-temp/` | ENCRYPTED, ready-to-transmit | `writeBytesToOutboxTempFile` (`encryptFile`) | **Durable** — each file is referenced by an outbox row until sent. `CacheSweeper` **KEEPs** it on startup / "Clear caches" (never deletes a pending send's payload); only logout wipes the whole dir. |
+
+**The encrypted `outbox-temp` file is the hand-off to the outbox** — it's the input the outbox row
+transmits, so its lifecycle belongs to the outbox (`homebase-api` sync layer, *outside this
+module*): the outbox deletes each file when the send **succeeds** (`cleanupPayloadTempFiles`) and
+when a row is **dropped** after ~48h of failed retries (`cleanupPayloadsForDroppedRow`). `UploadService`
+does not manage it beyond writing it. *(Residual, tracked separately: a crash between server-ack and
+the outbox's per-file cleanup leaves an orphan in `outbox-temp` with no live row; a post-auth
+reference-aware reap would close it — not yet built.)*
+
+FFmpeg scratch is a third, separate case: it goes to the cache **root** and is swept as reclaimable
+(large + transient — the opposite durability need from `outbox-temp`).

--- a/homebase-upload/README.md
+++ b/homebase-upload/README.md
@@ -60,13 +60,28 @@ disposable."* So upload temps live in **two** dirs under the app cache dir, swep
 | `<cacheDir>/upload-temp/` | RAW, pre-encryption source | `writeBytesToTempFile` (senders) | **Disposable** — swept on **every** startup / "Clear caches" / logout (it's untracked). Self-heals, can't grow. A source gone at send time just fails soft (re-pick). |
 | `<cacheDir>/outbox-temp/` | ENCRYPTED, ready-to-transmit | `writeBytesToOutboxTempFile` (`encryptFile`) | **Durable** — each file is referenced by an outbox row until sent. `CacheSweeper` **KEEPs** it on startup / "Clear caches" (never deletes a pending send's payload); only logout wipes the whole dir. |
 
-**The encrypted `outbox-temp` file is the hand-off to the outbox** — it's the input the outbox row
-transmits, so its lifecycle belongs to the outbox (`homebase-api` sync layer, *outside this
-module*): the outbox deletes each file when the send **succeeds** (`cleanupPayloadTempFiles`) and
-when a row is **dropped** after ~48h of failed retries (`cleanupPayloadsForDroppedRow`). `UploadService`
-does not manage it beyond writing it. *(Residual, tracked separately: a crash between server-ack and
-the outbox's per-file cleanup leaves an orphan in `outbox-temp` with no live row; a post-auth
-reference-aware reap would close it — not yet built.)*
+### When each folder is cleaned
 
-FFmpeg scratch is a third, separate case: it goes to the cache **root** and is swept as reclaimable
-(large + transient — the opposite durability need from `outbox-temp`).
+- **`upload-temp/`** — reaped by the `CacheSweeper` on **every app startup**, on **"Clear caches"**,
+  and on **logout**. It self-heals continuously and cannot grow. (Senders also delete their own
+  source temp after use, but the sweep is the real safety net, so a sender that forgets can't leak.)
+- **`outbox-temp/`** — cleaned along the **outbox's own lifecycle** (`homebase-api` sync layer,
+  *outside this module* — it's the hand-off point where we deliver the encrypted file to the
+  outbox): each file is deleted when its send **succeeds** (`cleanupPayloadTempFiles`) or when its
+  row is **dropped** after ~48h of failed retries (`cleanupPayloadsForDroppedRow`), and the whole
+  dir is wiped on **logout**. The `CacheSweeper` never touches it (a pending/offline send's payload
+  must survive). Its **self-heal for crash-orphans** (a process death between server-ack and the
+  outbox's per-file cleanup leaves a file with no live row) is `OutboxSync.reapIdleOutboxTemps`,
+  wired into the post-auth hook: **when the outbox is idle (`count() == 0`), delete `outbox-temp/`
+  files older than 24h.** The two gates make it provably safe — *idle* means nothing is referenced
+  (an offline-pending send keeps `count() > 0`), and the *age floor* means a temp for a send being
+  created right now (row not yet inserted) is too young to touch. *(Residual: a user whose outbox
+  literally never empties won't get the idle reap; the fuller fix is a per-file reference-aware reap
+  reusing `cleanupPayloadsForDroppedRow`'s path extraction — not built, low priority.)*
+
+FFmpeg scratch is a third case: it goes to the cache **root** and is swept as reclaimable (large +
+transient — same disposable class as `upload-temp/`, opposite of `outbox-temp/`). Ideally it would
+live *inside* `upload-temp/` for one tidy disposable-scratch folder, but it's written by an external
+process to self-resolved per-platform paths (not via `writeBytesToTempFile`), and moving it is a
+4-platform change for zero functional gain (both are already swept identically) that would also cost
+the per-type Storage-screen labels (`compressed_`/`input_`/`hls_`). Not worth the effort.

--- a/homebase-upload/README.md
+++ b/homebase-upload/README.md
@@ -89,3 +89,19 @@ live *inside* `upload-temp/` for one tidy disposable-scratch folder, but it's wr
 process to self-resolved per-platform paths (not via `writeBytesToTempFile`), and moving it is a
 4-platform change for zero functional gain (both are already swept identically) that would also cost
 the per-type Storage-screen labels (`compressed_`/`input_`/`hls_`). Not worth the effort.
+
+## Troubleshooting: "a conversation/group/admin file didn't reach a peer"
+
+This upload pipeline's job ends when the **server accepts the file and queues it for the peers** —
+it does not do the server-to-server delivery. So don't start on the client. In the sender's log,
+find the file's `DriveOutboxUploader uploadNewFile: success … recipientStatus=<peer>=Enqueued`:
+
+- If `recipientStatus` lists the peers as **`Enqueued`**, the client did everything right (transit
+  recipients preserved, file uploaded, server queued outbound delivery). "Not on peer" is then
+  **downstream**: the sender's server delivering to the peer's server, or the peer's inbox sync.
+  Chase it in the *peer's* log (an incoming batch with the server-assigned fileId) or server transit
+  status — not here. (A dropped-recipients regression would instead show `(no recipients)`.)
+- The `ConvoAudit` `postOutboxDelta=FAIL` / "outbox grew by N, expected ≥M" warning is a **known
+  false alarm** when online: rows drain (upload + pop) concurrently with the create, so the net
+  outbox delta undercounts already-sent rows. Trust the per-step `PASS`/`FAIL` verdicts, not the
+  delta.

--- a/homebase-upload/README.md
+++ b/homebase-upload/README.md
@@ -1,0 +1,60 @@
+# homebase-upload — the one client upload pipeline
+
+Every client media upload (chat, moments, vault, stickers, location, conversation files)
+goes through **one** feature-agnostic pipeline here, so the payload-cache, fail-soft, and
+seed policies live in exactly one place. This is the outcome of issue **#844**.
+
+## The spine
+
+`UploadService.upload(spec)` (create) and `UploadService.updateFile(spec)` (update) own the
+same sequence and nothing else:
+
+```
+encrypt the plaintext bundle  →  encrypt the metadata content  →  build the request  →
+durable outbox enqueue (the success gate)  →  seed the payload cache  →  optimistic local write
+```
+
+Callers hand in a **plaintext** `PayloadBundle`; the service encrypts it (`encryptor.encryptBundle`).
+Feature-specific prep (source resolve, HEIC convert, video poster, recipient lookup) stays in the
+feature and is passed in already-resolved. `UploadService` never contains feature logic.
+
+**Fail-soft (deliverable A):** if a raw pre-encryption source is gone at encrypt time (swept,
+evicted, permission revoked) the service returns `UploadOutcome.SourceMissing` and enqueues
+**nothing** — no doomed outbox row. The caller re-picks. Encryption runs *before* enqueue
+everywhere, which is what makes this clean.
+
+## The guard
+
+`ArchitectureTest."encryptBundle is confined to the shared upload pipeline"` fails the build if
+`encryptBundle` is called anywhere but `UploadService` / `PayloadBundleEncryptionService`.
+`encryptBundle` is the true "I'm doing a payload upload" signal, so anchoring on it is what makes
+the guard meaningful. (A rule on the *request types* was unworkable — header-only system records
+and the outbox rekey plumbing legitimately build `UploadFileRequest`/`UpdateFileByUniqueIdRequest`,
+and a text rule can't tell payload-bearing from header-only.)
+
+## The documented exceptions
+
+Three production sites are allow-listed in the guard. Each is deliberate, not an oversight:
+
+| Site | Why it's left out |
+|------|-------------------|
+| `ChatMessageSenderService.updateMessage` (edit / amend-pending-create) | Re-encrypts an **in-memory text-overflow** payload and mixes it with **already-encrypted** recovered media, then surgically amends a queued outbox row. No fit for the plaintext-bundle create/update shapes. |
+| `ChatMessageSenderService.resendAsCreate` (resend) | Same pattern — text-overflow re-encryption mixed with pre-encrypted recovered payloads. Recovery plumbing, not a fresh media upload. |
+| `ConversationService.updateConversationInternal` (conversation update) | A hot, multi-purpose mutation (archival / participants / leaveGroup / heal). The encrypt-a-new-group-avatar branch is rare; routing the whole method through `UploadService` is high blast radius for little benefit. |
+
+Note: these bypass the *orchestration*, but they still call the same `encryptBundle`, so their
+encrypted temps land in the same swept-safe `hb-temp/` dir (below) as everything else.
+
+**If we ever want to remove these exceptions:** the first two need `UploadService` to model a *mixed
+pre-encrypted + plaintext* payload set (and, for amend, an "amend a queued create" mode); the third
+needs its rare encrypt branch split out from the hot mutation path, or the whole method carefully
+migrated to `updateFile` with its heal/reuse and conditional-optimistic-write behavior preserved.
+
+## Where temps live
+
+`FileOperationsProvider.writeBytesToTempFile` writes every raw and encrypted upload temp into
+`<cacheDir>/hb-temp/` on all platforms. `CacheSweeper` **keeps** `hb-temp` on the startup /
+"Clear caches" sweep — an offline-pending upload's encrypted payload lives there until the send
+completes, and deleting it mid-flight would break the send — and only wipes it on full logout.
+FFmpeg scratch is separate: it goes to the cache root and is swept as reclaimable (it's large and
+transient, the opposite durability need).

--- a/homebase-upload/README.md
+++ b/homebase-upload/README.md
@@ -71,13 +71,17 @@ disposable."* So upload temps live in **two** dirs under the app cache dir, swep
   row is **dropped** after ~48h of failed retries (`cleanupPayloadsForDroppedRow`), and the whole
   dir is wiped on **logout**. The `CacheSweeper` never touches it (a pending/offline send's payload
   must survive). Its **self-heal for crash-orphans** (a process death between server-ack and the
-  outbox's per-file cleanup leaves a file with no live row) is `OutboxSync.reapIdleOutboxTemps`,
-  wired into the post-auth hook: **when the outbox is idle (`count() == 0`), delete `outbox-temp/`
-  files older than 24h.** The two gates make it provably safe — *idle* means nothing is referenced
-  (an offline-pending send keeps `count() > 0`), and the *age floor* means a temp for a send being
-  created right now (row not yet inserted) is too young to touch. *(Residual: a user whose outbox
-  literally never empties won't get the idle reap; the fuller fix is a per-file reference-aware reap
-  reusing `cleanupPayloadsForDroppedRow`'s path extraction — not built, low priority.)*
+  outbox's per-file cleanup leaves a file with no live row) is **built + tested**:
+  `OutboxSync.reapIdleOutboxTemps`, wired fire-and-forget into the post-auth hook — **when the
+  outbox is idle (`count() == 0`), it deletes `outbox-temp/` files older than 24h.** The two gates
+  make it provably safe: *idle* means nothing is referenced (an offline-pending send keeps
+  `count() > 0`), and the *age floor* means a temp for a send being created right now (row not yet
+  inserted) is too young to touch.
+
+  The **only** thing left unbuilt is a strictly-better variant for one pathological case — a user
+  whose outbox *literally never* drains to empty never triggers the idle reap. Closing that would
+  take a per-file **reference-aware** reap (delete `outbox-temp/` files no live row references,
+  reusing `cleanupPayloadsForDroppedRow`'s path extraction). Low priority; not built.
 
 FFmpeg scratch is a third case: it goes to the cache **root** and is swept as reclaimable (large +
 transient — same disposable class as `upload-temp/`, opposite of `outbox-temp/`). Ideally it would

--- a/homebase-upload/src/commonMain/kotlin/id/homebase/upload/PayloadBundleEncryptionService.kt
+++ b/homebase-upload/src/commonMain/kotlin/id/homebase/upload/PayloadBundleEncryptionService.kt
@@ -135,7 +135,10 @@ class PayloadBundleEncryptionService(
 
         val encrypted = encryptBytes(plainBytes, keyHeader)
 
-        val path = fileOps.writeBytesToTempFile(
+        // Encrypted, ready-to-transmit → the DURABLE outbox-temp dir (not the disposable
+        // upload-temp): this file rides an outbox row until the send completes and must survive
+        // the startup/clear CacheSweeper pass. The outbox reaps it on send success / drop. (#844)
+        val path = fileOps.writeBytesToOutboxTempFile(
             bytes = encrypted, prefix = "enc", suffix = ".encrypted"
         )
 


### PR DESCRIPTION
Final PR of the #844 cache-bucket series — closes out media-upload centralization, locks it in with a build-failing guard, and hardens where upload/scratch temps live.

## PR3.6 — finish the media centralization (`fd970cc0a`)
A PR4 pre-flight inventory found production sites still hand-rolling `encryptBundle` + request construction. Classified and closed the gap:
- **Migrated:** `ConversationService.writeConversationFile` (the conversation-create file, incl. group avatar) → `uploadService.upload(writeOptimistic=false, seedCache=false)`. Its deliberate optimistic-write-first ordering (writeNewFile → participant readback → loadConversation → enqueue) is preserved; `previewThumbnail` derived from the plaintext bundle.
- **Left as documented exceptions** (each justified — recovery plumbing or a hot multi-purpose path, none a feature hand-rolling a media upload): chat `updateMessage` (amend) + `resendAsCreate` (re-encrypt an in-memory text-overflow mixed with already-encrypted recovered media — no fit for upload/updateFile), and `updateConversationInternal` (hot mutation: archival/participants/leaveGroup/heal; the encrypt-new-avatar branch is rare, migration would be high blast radius).
- Header-only system records (`MomentGroupService`, `DriveRegistry`, `VaultService.createSection`, `MomentsUserStateStore`, `DriveOutboxUploader` rekey) build the request types with `payloads = emptyList()` — legitimately not `UploadService`'s job.

## PR4 Part A — the single-upload-path guard (`b3da62d2c`)
A Konsist rule (`ArchitectureTest`) that **fails the build** if `encryptBundle` is called anywhere but `UploadService` + the 3 documented exceptions. Anchored on `encryptBundle` (the true payload-upload signal) — the originally-planned two-request-type rule was unworkable because header-only records + outbox rekey legitimately build those types. **Verified it has teeth**: dropping an exception makes it fail on the real call site.

## PR4 Part C — swept-safe upload temps (`84c3a9ddd`)
Every platform's `writeBytesToTempFile` now writes into `<cacheDir>/hb-temp/` instead of unaudited locations (JVM `java.io.tmpdir`, iOS `NSTemporaryDirectory`) or the cache root (where a startup/clear sweep deletes "untracked" entries). `hb-temp` holds the pipeline's transient files — including **encrypted payloads that ride an outbox row until send** (long-lived when offline). `CacheSweeper.decide` **KEEPs** it on the startup / "Clear caches" sweep (so an offline-pending upload's payload isn't deleted mid-flight) and only wipes it on full logout; its bytes are still counted by the Storage screen. Fixes a latent cross-platform durability gap. Added a `CacheSweeperTest` case.

## PR4 Part B — FFmpeg scratch into the audited cache dir (`bf5305fd2`)
`FFmpegUtils.jvm` scratch moved from `java.io.tmpdir` → the app cache dir, so the desktop Storage screen counts/reclaims it. Android/iOS/web FFmpeg already resolve to their cache dir; the FFmpeg binary-extraction dir stays persistent by design.

## Verification
All targets (JVM/Android/wasmJs) + androidApp + desktopApp compile; api/chat/common/upload/core JVM test suites all green (incl. the new guard + sweeper tests). iOS on CI.

## Testing notes
The one user-facing behavior change is **conversation creation** (1:1, group + avatar, note-to-self, offline-then-online). Parts B/C are infra — verify via the Storage screen (temps counted; "Clear cache" leaves in-flight uploads intact; logout clears everything).

🤖 Generated with [Claude Code](https://claude.com/claude-code)