### PR TITLE
fix(contacts): reorder circles list, rename auto-connected circle to "Unvetted"

### DIFF
--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1406,6 +1406,7 @@
     <string name="contactbook_introduced_empty">No introduced connections yet.</string>
     <string name="contactbook_confirmed_empty">No confirmed connections yet.</string>
     <string name="contactbook_circles_empty">You don't have any circles yet.</string>
+    <string name="contactbook_circle_unvetted">Unvetted</string>
     <string name="contactbook_circle_members_empty">This circle has no members.</string>
     <string name="contactbook_circle_members_count">%1$d members</string>
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CirclesTabContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CirclesTabContent.kt
@@ -21,7 +21,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import id.homebase.api.client.connections.CircleWithMembers
+import id.homebase.core.config.AUTO_CONNECTIONS_CIRCLE_ID
 import id.homebase.resources.MR
+import id.homebase.resources.contactbook_circle_unvetted
 import id.homebase.resources.contactbook_circles_empty
 import org.jetbrains.compose.resources.stringResource
 
@@ -49,29 +51,39 @@ fun CirclesTabContent(
             )
         }
 
-        else -> LazyColumn(
-            modifier = modifier.fillMaxSize(),
-            contentPadding = PaddingValues(vertical = 8.dp),
-        ) {
-            items(circles, key = { it.circle.id }) { circle ->
-                val description = circle.circle.description
-                ListItem(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable { onAction(ContactBookUiAction.CircleClicked(circle)) },
-                    leadingContent = { Icon(Icons.Outlined.Groups, contentDescription = null) },
-                    headlineContent = { Text(circle.circle.name) },
-                    supportingContent = if (!description.isNullOrBlank()) {
-                        { Text(description) }
-                    } else null,
-                    trailingContent = {
-                        Icon(
-                            Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    },
-                )
+        else -> {
+            // Client-side display override only — the auto-connected system circle keeps its
+            // server-side name/id, we just relabel it "Unvetted" here.
+            val unvettedName = stringResource(MR.string.contactbook_circle_unvetted)
+            LazyColumn(
+                modifier = modifier.fillMaxSize(),
+                contentPadding = PaddingValues(vertical = 8.dp),
+            ) {
+                items(circles, key = { it.circle.id }) { circle ->
+                    val description = circle.circle.description
+                    val displayName = if (circle.circle.id == AUTO_CONNECTIONS_CIRCLE_ID) {
+                        unvettedName
+                    } else {
+                        circle.circle.name
+                    }
+                    ListItem(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onAction(ContactBookUiAction.CircleClicked(circle)) },
+                        leadingContent = { Icon(Icons.Outlined.Groups, contentDescription = null) },
+                        headlineContent = { Text(displayName) },
+                        supportingContent = if (!description.isNullOrBlank()) {
+                            { Text(description) }
+                        } else null,
+                        trailingContent = {
+                            Icon(
+                                Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        },
+                    )
+                }
             }
         }
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookViewModel.kt
@@ -26,6 +26,7 @@ import id.homebase.chat.services.requests.ConnectionRequestService
 import id.homebase.core.auth.AuthConnectionCoordinator
 import id.homebase.core.auth.toConnectionStatus
 import id.homebase.core.avatars.AppConnectionStatus
+import id.homebase.core.config.AUTO_CONNECTIONS_CIRCLE_ID
 import id.homebase.core.config.CONFIRMED_CONNECTIONS_CIRCLE_ID
 import id.homebase.core.config.contactTargetDrive
 import id.homebase.core.contactbook.ContactBookPreferences
@@ -451,7 +452,16 @@ class ContactBookViewModel(
                 Logger.w(e, "ContactBookViewModel") { "getCirclesWithMembers failed" }
                 emptyList()
             }
-            _circles.value = circles.sortedBy { it.circle.name.lowercase() }
+            // Pin the auto-connected ("Unvetted") system circle to the top, sink the confirmed-
+            // connected system circle to the bottom, and keep the user's own circles (including
+            // Emergency Location Access, which is a user circle, not a system one) alphabetical
+            // in between.
+            _circles.value = circles.sortedWith(
+                compareBy(
+                    { it.circle.id.circleSortRank() },
+                    { it.circle.name.lowercase() },
+                ),
+            )
             _circlesLoading.value = false
         }
     }
@@ -514,4 +524,15 @@ private fun CircleWithMembers.matchesQuery(query: String): Boolean {
     val q = query.trim().lowercase()
     return circle.name.lowercase().contains(q) ||
         circle.description?.lowercase()?.contains(q) == true
+}
+
+/**
+ * Sort bucket for the Circles tab: the auto-connected ("Unvetted") system circle first, the
+ * user's own circles (including Emergency Location Access — a user circle, not a system one)
+ * in the middle, and the confirmed-connected system circle last.
+ */
+private fun String.circleSortRank(): Int = when (this) {
+    AUTO_CONNECTIONS_CIRCLE_ID -> 0
+    CONFIRMED_CONNECTIONS_CIRCLE_ID -> 2
+    else -> 1
 }


### PR DESCRIPTION
Closes #916

## Summary
- The Circles tab rendered in plain alphabetical order, interleaving the two system circles ("Auto-connected Identities", "Confirmed Connected Identities") with the user's own circles.
- `ContactBookViewModel.loadCircles()` now sorts by a bucket (`circleSortRank()`): auto-connected first, the user's own circles (including Emergency Location Access — a user circle, not a system one) alphabetical in the middle, confirmed-connected last.
- `CirclesTabContent.kt` applies a client-side-only display-name override, rendering "Unvetted" for the auto-connected circle at the row level. Server-side name/id are untouched — this is UI-only, matching the issue's constraint.
- Identification is by the existing well-known GUID constants (`AUTO_CONNECTIONS_CIRCLE_ID`, `CONFIRMED_CONNECTIONS_CIRCLE_ID` in `AppConfig.kt`), the same pattern already used in `ContactDetailViewModel` to filter these two circles out of the detail-screen chips.

## Test plan
- [x] `:homebase-common:compileKotlinJvm` / `:homebase-core:compileKotlinJvm` — build clean
- [x] `homebase-core:jvmTest` — pass
- [ ] Manual: open Contacts → Circles tab, confirm "Unvetted" (was "Auto-connected Identities") is first, "Confirmed Connected Identities" is last, and the user's own circles (including Emergency Location Access) sit in the middle unchanged