### PR TITLE
fix(connections): cancel outgoing request now asks the server to notify the recipient

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/connections/ConnectionRequestProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/connections/ConnectionRequestProvider.kt
@@ -221,6 +221,13 @@ class ConnectionRequestProvider(
     // CANCEL (DELETE outgoing)
     // ------------------------------------------------------------
 
+    /**
+     * `notifyRemote=true` (plain, unencrypted query param — not the `ss` encrypted-queryString
+     * mechanism [encryptedGet] uses) asks the server to also transit a best-effort, eventual
+     * withdrawal to the recipient's server, deleting their matching pending incoming request.
+     * Always on: idempotent, safe to send unconditionally for a normal user-initiated cancel
+     * (server-side default stays off for other unrelated callers of the same endpoint).
+     */
     suspend fun cancelOutgoingRequest(
         recipientId: OdinId
     ) {
@@ -228,7 +235,7 @@ class ConnectionRequestProvider(
         val creds = requireCreds()
 
         val endpoint =
-            "/connections/requests/outgoing/$recipientId"
+            "/connections/requests/outgoing/$recipientId?notifyRemote=true"
 
         val response = encryptedDelete(
             url = apiUrl(creds.domain, endpoint),


### PR DESCRIPTION
Part of #920 (does not fully close it — see below)

## Summary
- The server's cancel-outgoing endpoint (`DELETE /api/v2/connections/requests/outgoing/{recipientId}`) gained an opt-in `notifyRemote` query param that transits a best-effort, eventual withdrawal to the recipient's server, deleting their matching pending incoming request.
- `ConnectionRequestProvider.cancelOutgoingRequest()` now passes `notifyRemote=true` unconditionally — it's idempotent and safe for a normal user-initiated cancel (per backend guidance). No UI toggle added.
- This is a plain, unencrypted query param — not routed through the `ss` encrypted-queryString mechanism `encryptedGet` uses for other endpoints, since the server describes `notifyRemote` as an ordinary query param, not part of the encrypted payload.

## Not in scope here
Withdrawal delivery is best-effort/eventual, not synchronous, so a recipient can still tap Accept on a request that was already withdrawn but hasn't synced yet. Graceful handling of that (issue #920's second acceptance criterion — clear "withdrawn" message + auto-remove the stale entry) is blocked on the server returning a distinguishable error for "accept a request that's gone," which is being tracked separately.

## Test plan
- [x] `:homebase-api:compileKotlinJvm` — build clean
- [ ] Manual: A sends B a request, A cancels, confirm B's pending request disappears (within the server's outbox retry window) instead of lingering