### PR TITLE
fix(connections): fail gracefully when accepting an already-withdrawn request

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/requests/ConnectionRequestService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/requests/ConnectionRequestService.kt
@@ -1,6 +1,8 @@
 package id.homebase.chat.services.requests
 
 import co.touchlab.kermit.Logger
+import id.homebase.api.client.ClientException
+import id.homebase.api.client.OdinClientErrorCode
 import id.homebase.api.client.connections.AutoConnectOutcome
 import id.homebase.api.client.connections.ConnectionRequestResult
 import id.homebase.api.client.connections.ConnectionRequestHeader
@@ -261,9 +263,23 @@ class ConnectionRequestService(
      * UI flips "Invited" → (removed) and the conversation's 1:1 status flips to Connected
      * immediately. The server also emits a websocket event for both sides, but we don't want
      * the UI to wait on round-trip latency.
+     *
+     * If the sender already withdrew the request (cancel-outgoing's best-effort remote
+     * withdrawal beat us here — see [ConnectionRequestProvider.cancelOutgoingRequest]), the
+     * accept call fails with [OdinClientErrorCode.IncomingRequestNotFound]. That's authoritative:
+     * drop our stale copy too so it doesn't linger in the UI, then rethrow so the caller can show
+     * a specific "this request was withdrawn" message instead of a generic failure.
      */
     suspend fun acceptIncomingRequest(senderId: OdinId) {
-        connectionRequestProvider.acceptIncomingRequest(senderId)
+        try {
+            connectionRequestProvider.acceptIncomingRequest(senderId)
+        } catch (e: ClientException) {
+            if (e.errorCode == OdinClientErrorCode.IncomingRequestNotFound) {
+                removeFromIncoming(senderId)
+                refresh()
+            }
+            throw e
+        }
         contactRepository.sync(senderId)
         removeFromIncoming(senderId)
         refresh()

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1525,6 +1525,7 @@
     <string name="contactbook_action_request_accepted">Connection request accepted.</string>
     <string name="contactbook_action_request_rejected">Connection request declined.</string>
     <string name="contactbook_action_request_cancelled">Connection request canceled.</string>
+    <string name="contactbook_action_request_withdrawn">This request was withdrawn by the sender.</string>
 
     <string name="add_contact_title">Add contact</string>
     <string name="add_contact_odinid_label">Homebase ID</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactScreen.kt
@@ -90,6 +90,7 @@ import id.homebase.resources.add_contact_send_request_help
 import id.homebase.resources.add_contact_title
 import id.homebase.resources.contactbook_action_request_accepted
 import id.homebase.resources.contactbook_action_request_cancelled
+import id.homebase.resources.contactbook_action_request_withdrawn
 import id.homebase.resources.contactbook_action_request_rejected
 import id.homebase.resources.contactbook_detail_accept
 import id.homebase.resources.contactbook_detail_cancel_request
@@ -139,6 +140,7 @@ fun AddContactScreen(
     val msgRejected = stringResource(MR.string.contactbook_action_request_rejected)
     val msgCancelled = stringResource(MR.string.contactbook_action_request_cancelled)
     val msgActionFailed = stringResource(MR.string.auto_connect_failed_generic)
+    val msgWithdrawn = stringResource(MR.string.contactbook_action_request_withdrawn)
 
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
@@ -153,6 +155,7 @@ fun AddContactScreen(
                 AddContactEvent.RequestRejected -> snackbarHostState.showSnackbar(msgRejected)
                 AddContactEvent.RequestCancelled -> snackbarHostState.showSnackbar(msgCancelled)
                 AddContactEvent.RequestActionFailed -> snackbarHostState.showSnackbar(msgActionFailed)
+                AddContactEvent.RequestWithdrawn -> snackbarHostState.showSnackbar(msgWithdrawn)
                 is AddContactEvent.OpenConversation -> onOpenConversation(event.conversationId)
             }
         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactUiState.kt
@@ -84,6 +84,8 @@ sealed interface AddContactEvent {
     data object RequestCancelled : AddContactEvent
     /** An accept/reject/cancel action failed. */
     data object RequestActionFailed : AddContactEvent
+    /** Accept failed because the sender already withdrew the request (server-confirmed gone). */
+    data object RequestWithdrawn : AddContactEvent
     /** Open the 1:1 conversation with an already-connected identity. */
     data class OpenConversation(val conversationId: Uuid) : AddContactEvent
     data object Back : AddContactEvent

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactViewModel.kt
@@ -5,6 +5,8 @@ package id.homebase.core.ui.screens.contactbook.add
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
+import id.homebase.api.client.ClientException
+import id.homebase.api.client.OdinClientErrorCode
 import id.homebase.api.client.connections.ConnectionStatus
 import id.homebase.api.client.contacts.ContactRepository
 import id.homebase.api.client.identity.PublicIdentityRepository
@@ -160,7 +162,15 @@ class AddContactViewModel(
                     .onFailure {
                         if (it is CancellationException) throw it
                         Logger.w(it) { "Request action failed for $odinId" }
-                        _events.tryEmit(AddContactEvent.RequestActionFailed)
+                        // Accept raced a since-completed cancel-outgoing on the sender's side;
+                        // ConnectionRequestService.acceptIncomingRequest already dropped the
+                        // stale local copy before rethrowing — just show the specific message.
+                        val withdrawn = it is ClientException &&
+                            it.errorCode == OdinClientErrorCode.IncomingRequestNotFound
+                        _events.tryEmit(
+                            if (withdrawn) AddContactEvent.RequestWithdrawn
+                            else AddContactEvent.RequestActionFailed
+                        )
                     }
             } finally {
                 _state.update { it.copy(actionInProgress = false) }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailScreen.kt
@@ -81,6 +81,7 @@ import id.homebase.resources.contactbook_action_blocked
 import id.homebase.resources.contactbook_action_request_accepted
 import id.homebase.resources.contactbook_action_request_cancelled
 import id.homebase.resources.contactbook_action_request_rejected
+import id.homebase.resources.contactbook_action_request_withdrawn
 import id.homebase.resources.contactbook_action_sync_started
 import id.homebase.resources.contactbook_action_disconnected
 import id.homebase.resources.contactbook_detail_emergency_badge
@@ -154,6 +155,7 @@ fun ContactDetailScreen(
     val msgRequestAccepted = stringResource(MR.string.contactbook_action_request_accepted)
     val msgRequestRejected = stringResource(MR.string.contactbook_action_request_rejected)
     val msgRequestCancelled = stringResource(MR.string.contactbook_action_request_cancelled)
+    val msgRequestWithdrawn = stringResource(MR.string.contactbook_action_request_withdrawn)
 
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
@@ -178,6 +180,7 @@ fun ContactDetailScreen(
                 ContactDetailEvent.RequestAccepted -> snackbarHostState.showSnackbar(msgRequestAccepted)
                 ContactDetailEvent.RequestRejected -> snackbarHostState.showSnackbar(msgRequestRejected)
                 ContactDetailEvent.RequestCancelled -> snackbarHostState.showSnackbar(msgRequestCancelled)
+                ContactDetailEvent.RequestWithdrawn -> snackbarHostState.showSnackbar(msgRequestWithdrawn)
             }
         }
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailUiState.kt
@@ -135,4 +135,6 @@ sealed interface ContactDetailEvent {
     data object RequestAccepted : ContactDetailEvent
     data object RequestRejected : ContactDetailEvent
     data object RequestCancelled : ContactDetailEvent
+    /** Accept failed because the sender already withdrew the request (server-confirmed gone). */
+    data object RequestWithdrawn : ContactDetailEvent
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailViewModel.kt
@@ -7,7 +7,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import co.touchlab.kermit.Logger
+import id.homebase.api.client.ClientException
 import id.homebase.api.client.ForbiddenException
+import id.homebase.api.client.OdinClientErrorCode
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.api.client.connections.ConnectionNetworkProvider
@@ -436,12 +438,20 @@ class ContactDetailViewModel(
     /**
      * The server returns 200 for no-ops and never echoes the new state, so we only refresh
      * after a successful call. A 403 means this app wasn't granted manage-connections
-     * permission — surface that distinctly from a generic/transient failure.
+     * permission — surface that distinctly from a generic/transient failure. A withdrawn
+     * request (accept raced a since-completed cancel-outgoing on the sender's side) is also
+     * distinguished — [ConnectionRequestService.acceptIncomingRequest] already dropped the
+     * stale local copy before rethrowing, so we just need the specific message here.
      */
     private fun emitConnectionError(error: Throwable) {
         _events.tryEmit(
-            if (error is ForbiddenException) ContactDetailEvent.ConnectionForbidden
-            else ContactDetailEvent.Error
+            when {
+                error is ForbiddenException -> ContactDetailEvent.ConnectionForbidden
+                error is ClientException &&
+                    error.errorCode == OdinClientErrorCode.IncomingRequestNotFound ->
+                    ContactDetailEvent.RequestWithdrawn
+                else -> ContactDetailEvent.Error
+            }
         )
     }
 


### PR DESCRIPTION
Closes #920

## Summary
Second half of #920 (first half: #933, cancel-outgoing now asks the server to notify the recipient). Withdrawal delivery is best-effort/eventual, not synchronous, so a recipient can still race a tap on Accept against a since-completed cancel on the sender's side. The server surfaces that as `ClientException` with `errorCode = IncomingRequestNotFound` — no server change needed, this code was already defined and returned.

- `ConnectionRequestService.acceptIncomingRequest()` now catches that specific error, drops the stale entry from `_incomingRequests`, refreshes, and rethrows so callers can show a specific message.
- `ContactDetailViewModel` and `AddContactViewModel` (the only two call sites of `acceptIncomingRequest`) distinguish it into a new `RequestWithdrawn` event — a clear "This request was withdrawn by the sender." snackbar instead of the generic failure message.
- `ContactBookViewModel`'s Requests tab has no separate accept path (it navigates into `ContactDetailScreen`), so both call sites are covered.

## Test plan
- [x] `:homebase-chat:compileKotlinJvm` / `:homebase-core:compileKotlinJvm` — build clean
- [ ] Manual (two identities): A sends B a request, A cancels (via #933's notifyRemote), B's server hasn't yet processed the withdrawal, B taps Accept → confirm B sees "This request was withdrawn" and the request disappears from B's list, not a generic error