### PR TITLE
fix(contacts): read vetted status directly from the connection, not circle membership

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/connections/ProviderTypes.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/connections/ProviderTypes.kt
@@ -92,7 +92,15 @@ data class RedactedIdentityConnectionRegistration(
     val introducerOdinId: OdinId? = null,
     val connectionRequestOrigin: ConnectionRequestOrigin,
     val hasVerificationHash: Boolean,
-    val rku: Boolean
+    val rku: Boolean,
+    /**
+     * True when this identity is connected AND a member of the Confirmed Connections system
+     * circle — server-computed (see issue #919). False covers everyone else who's connected but
+     * unconfirmed: auto-connected/introduced identities, and any plain direct connection that
+     * hasn't been explicitly confirmed. Defaulted so deserialization stays safe against any
+     * response shape that hasn't rolled this field out yet.
+     */
+    val vetted: Boolean = false
 )
 
 // ------------------------------------------------------------

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookViewModel.kt
@@ -17,7 +17,6 @@ import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.common.OdinId
 import id.homebase.api.crypto.Md5
 import id.homebase.chat.services.convo.ConversationService
-import id.homebase.chat.services.convo.contact.CircleMembershipState
 import id.homebase.chat.services.convo.contact.ConnectionService
 import id.homebase.chat.services.convo.contact.ConnectionState
 import id.homebase.chat.data.IncomingConnectionRequestUiModel
@@ -26,7 +25,6 @@ import id.homebase.chat.services.requests.ConnectionRequestService
 import id.homebase.core.auth.AuthConnectionCoordinator
 import id.homebase.core.auth.toConnectionStatus
 import id.homebase.core.avatars.AppConnectionStatus
-import id.homebase.core.config.CONFIRMED_CONNECTIONS_CIRCLE_ID
 import id.homebase.core.config.contactTargetDrive
 import id.homebase.core.contactbook.ContactBookPreferences
 import id.homebase.core.contactbook.ContactOverrideStore
@@ -144,7 +142,6 @@ class ContactBookViewModel(
         val contacts: List<ContactBookEntry>,
         val loaded: Boolean,
         val connections: ConnectionState,
-        val circles: CircleMembershipState,
         val overrides: Map<Uuid, ContactFieldOverlay>,
     )
 
@@ -176,10 +173,9 @@ class ContactBookViewModel(
             entries,
             repo.isLoaded,
             connectionService.connections,
-            connectionService.circles,
             overrideStore.overrides,
-        ) { c, l, conn, circ, overrides ->
-            ContactsBundle(c, l, conn, circ, overrides)
+        ) { c, l, conn, overrides ->
+            ContactsBundle(c, l, conn, overrides)
         },
         combine(_searchQuery, _filter, _selectedTab, _overlay) { q, f, tab, o ->
             UiBits(q, f, tab, o)
@@ -204,18 +200,17 @@ class ContactBookViewModel(
         //  - Introduced = provenance: the connection originated from an introduction. This is
         //    permanent (it stays true after confirmation), which is what "we connected via an
         //    intro" means, and it rides in the connection data so it needs no circle load.
-        //  - Confirmed = membership in the Confirmed Connections system circle (the explicit
-        //    confirm action). Until the circle list loads we fall back to "connected and not
-        //    introduced" so the pill isn't empty on a cold start.
+        //  - Confirmed = the server-computed `vetted` flag (connected AND a member of the
+        //    Confirmed Connections system circle — see issue #919). Rides with the connection
+        //    data itself, so unlike the old circle-membership derivation it needs no separate
+        //    circle-load fallback.
         val introducedDomains = connectedRegs
             .filterValues { it.connectionRequestOrigin == ConnectionRequestOrigin.Introduction }
             .keys.map { it.domainName.lowercase() }
             .toSet()
-        val confirmedDomains = if (contactsData.circles.isLoaded) {
-            connectedDomains intersect contactsData.circles.membersOf(CONFIRMED_CONNECTIONS_CIRCLE_ID)
-        } else {
-            connectedDomains - introducedDomains
-        }
+        val confirmedDomains = connectedRegs.filterValues { it.vetted }
+            .keys.map { it.domainName.lowercase() }
+            .toSet()
 
         // contact-domain (lowercase) → introducer display name, resolved to a saved
         // contact's name when we have one, else the raw introducer domain.


### PR DESCRIPTION
Part of #919 (Unvetted pill groundwork — does not close it)

## Summary
- Backend now returns a server-computed `vetted: boolean` on `RedactedIdentityConnectionRegistration` (connected AND a member of the Confirmed Connections system circle), removing the need to cross-reference `GET /connections/circles/with-members` and hardcode the Confirmed Connections circle GUID client-side.
- `ContactBookViewModel`'s `confirmedDomains` now reads `vetted` directly off each connection instead of intersecting circle membership, and the cold-start fallback (`connectedDomains - introducedDomains`) is gone entirely — `vetted` rides with the connection data itself, so there's no gap while circles are still loading.
- `connectionService.circles` was the only reason this ViewModel's main `combine` depended on circle data; with it gone, dropped that combine input and the now-unused `ContactsBundle.circles` field/import.

## Not in scope here
This is the data-layer piece only. The rest of #919 (drop Introduced/Confirmed pills, add an Unvetted pill, move requests to the top of the list) is separate follow-up work.

## Test plan
- [x] `:homebase-api:compileKotlinJvm` / `:homebase-core:compileKotlinJvm` — build clean
- [x] `homebase-api:jvmTest` / `homebase-core:jvmTest` — pass
- [ ] Manual: confirm the existing "Confirmed" pill in Contacts still shows the right people now that it's reading `vetted` instead of circle membership