### PR TITLE
feat(location): per-entry link freshness in "Who I can locate"

### DIFF
--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1318,6 +1318,9 @@
     <string name="location_devices_section">Find my device</string>
     <string name="location_locatable_section">Who you can locate</string>
     <string name="location_locatable_none">You can't locate anyone yet. People appear here when they add you to their emergency circle.</string>
+    <string name="location_locate_age_hours">%1$dh</string>
+    <string name="location_locate_age_days">%1$dd</string>
+    <string name="location_locatable_broken_cd">No longer connected</string>
     <string name="location_emergency_access_section">Who can locate you</string>
     <string name="location_emergency_access_manage">Add emergency contacts</string>
     <string name="location_emergency_access_missing">No Emergency Location Access circle yet. Tap + to set one up in your owner console.</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -832,6 +832,7 @@ val appModule = module {
             connectionService = get(),
             contactService = get(),
             emergencyContactReconciler = get(),
+            temporalDriveReadProvider = get(),
             credentialsManager = get(),
             tracker = get(),
             receiveStore = get(),

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.LinkOff
 import androidx.compose.material.icons.outlined.Computer
 import androidx.compose.material.icons.outlined.Language
 import androidx.compose.material.icons.outlined.LocationOn
@@ -42,6 +43,7 @@ import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -81,11 +83,15 @@ import id.homebase.resources.location_emergency_access_manage
 import id.homebase.resources.location_emergency_access_more
 import id.homebase.resources.location_emergency_access_none
 import id.homebase.resources.location_emergency_access_section
+import id.homebase.resources.location_locatable_broken_cd
 import id.homebase.resources.location_locatable_none
 import id.homebase.resources.location_locatable_section
+import id.homebase.resources.location_locate_age_days
+import id.homebase.resources.location_locate_age_hours
 import id.homebase.resources.location_status_pending
 import id.homebase.resources.location_status_points_today
 import id.homebase.resources.stop_sharing
+import kotlin.time.Clock
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
 import org.jetbrains.compose.resources.stringResource
@@ -107,6 +113,7 @@ fun LocationDashboardContent(
     onOpenDevice: (Uuid) -> Unit,
     onOpenSetup: () -> Unit,
     onManageEmergencyAccess: () -> Unit,
+    onVerifyLocatable: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -306,6 +313,10 @@ fun LocationDashboardContent(
                 loaded = uiState.whoICanLocateLoaded,
                 members = uiState.whoICanLocate,
                 emptyText = stringResource(MR.string.location_locatable_none),
+                onExpand = onVerifyLocatable,
+                rowTrailing = { member ->
+                    LocateStatusTrailing(uiState.whoICanLocateStatus[member.odinId.domainName])
+                },
             )
         }
 
@@ -438,8 +449,13 @@ private fun PeopleListBody(
     loaded: Boolean,
     members: List<ContactUiModel>,
     emptyText: String,
+    onExpand: (() -> Unit)? = null,
+    rowTrailing: (@Composable (ContactUiModel) -> Unit)? = null,
 ) {
     var expanded by remember { mutableStateOf(false) }
+    // Fire the (optional) per-entry preflight each time the section opens; resolved rows are skipped
+    // downstream, so re-expanding is cheap.
+    LaunchedEffect(expanded) { if (expanded) onExpand?.invoke() }
     when {
         !loaded -> Box(
             modifier = Modifier.fillMaxWidth().padding(24.dp),
@@ -490,7 +506,9 @@ private fun PeopleListBody(
                                 Text(
                                     text = member.name,
                                     style = MaterialTheme.typography.bodyLarge,
+                                    modifier = Modifier.weight(1f),
                                 )
+                                rowTrailing?.invoke(member)
                             }
                         }
                     }
@@ -618,6 +636,51 @@ private fun IncomingShareRowItem(row: IncomingShareRow) {
             )
         }
     }
+}
+
+/**
+ * Trailing content for a "who I can locate" row: a spinner while the temporal-access preflight is in
+ * flight, a broken-link icon when access is gone, or the compact age of the peer's newest data
+ * (warning-colored past a day). A null/absent status (not yet requested, or an inconclusive failure)
+ * renders nothing.
+ */
+@Composable
+private fun LocateStatusTrailing(status: LocateVerifyStatus?) {
+    when (status) {
+        null -> Unit
+
+        LocateVerifyStatus.Loading ->
+            CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+
+        LocateVerifyStatus.Broken ->
+            Icon(
+                imageVector = Icons.Default.LinkOff,
+                contentDescription = stringResource(MR.string.location_locatable_broken_cd),
+                tint = MaterialTheme.colorScheme.error,
+            )
+
+        is LocateVerifyStatus.Active -> status.newestModifiedMs?.let { ms ->
+            val ageMs = Clock.System.now().toEpochMilliseconds() - ms
+            val warn = ageMs > 24L * 60 * 60_000
+            Text(
+                text = formatLocateAge(ageMs),
+                style = MaterialTheme.typography.labelMedium,
+                color = if (warn) MaterialTheme.colorScheme.error
+                        else MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        } // Active(null) = access but no data yet → render nothing
+    }
+}
+
+/** Compact "age since newest data" label: minutes, then hours, then days. */
+@Composable
+private fun formatLocateAge(ageMs: Long): String = when {
+    ageMs < 60 * 60_000L ->
+        stringResource(MR.string.live_location_age_minutes, (ageMs / 60_000L).toInt().coerceAtLeast(0))
+    ageMs < 24 * 60 * 60_000L ->
+        stringResource(MR.string.location_locate_age_hours, (ageMs / 3_600_000L).toInt())
+    else ->
+        stringResource(MR.string.location_locate_age_days, (ageMs / 86_400_000L).toInt())
 }
 
 @Composable

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
@@ -243,6 +243,7 @@ fun LocationScreen(
                 onManageEmergencyAccess = {
                     uiState.emergencyManageUrl?.let { uriHandler.openUrl(it) }
                 },
+                onVerifyLocatable = { execute(LocationUiAction.VerifyLocatable) },
             )
         } else {
             LocationContent(

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
@@ -46,6 +46,9 @@ data class LocationUiState(
     val whoICanLocate: List<ContactUiModel> = emptyList(),
     /** False until the locatable-contacts list has loaded at least once (drives the spinner). */
     val whoICanLocateLoaded: Boolean = false,
+    /** Per-entry temporal-verify status for the "who I can locate" list, keyed by odinId.domainName.
+     *  Absent key = not yet requested (renders nothing until the section is expanded). */
+    val whoICanLocateStatus: Map<String, LocateVerifyStatus> = emptyMap(),
     /** Owner-console deep link to manage the Emergency Location Access circle (the actual location
      *  drive grant); null until the identity is known. */
     val emergencyManageUrl: String? = null,
@@ -59,6 +62,21 @@ data class LocationUiState(
 ) {
     /** Only OSM tiles are implemented today; the canvas takes a boolean. */
     val showMapTiles: Boolean get() = mapProvider == LocationMapProvider.OpenStreetMap
+}
+
+/**
+ * Result of the per-entry temporal-access preflight for a "who I can locate" row. The row shows a
+ * spinner until this resolves, then either a broken-link icon or the age of the peer's newest data.
+ */
+sealed interface LocateVerifyStatus {
+    /** Preflight in flight → spinner. */
+    data object Loading : LocateVerifyStatus
+
+    /** Verify succeeded but the peer no longer grants us access → broken-link icon. */
+    data object Broken : LocateVerifyStatus
+
+    /** We hold access; [newestModifiedMs] is the peer's newest-file time, or null when no data yet. */
+    data class Active(val newestModifiedMs: Long?) : LocateVerifyStatus
 }
 
 /** One row in the "Sharing with" list: a person and the latest time my share to them lasts. */
@@ -116,6 +134,8 @@ sealed interface LocationUiAction {
     data class StopSharingWith(val odinId: String) : LocationUiAction
     /** Stop every outgoing live share (Dashboard "stop sharing with everyone"). */
     data object StopSharingWithEveryone : LocationUiAction
+    /** Preflight each "who I can locate" entry's link freshness (fired when the section expands). */
+    data object VerifyLocatable : LocationUiAction
     data object RequestWhileInUseClicked : LocationUiAction
     data object RequestAlwaysClicked : LocationUiAction
     data object OpenSystemSettingsClicked : LocationUiAction

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
@@ -3,6 +3,7 @@ package id.homebase.core.ui.screens.location
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.peer.temporal.TemporalDriveReadProvider
 import id.homebase.api.common.OdinId
 import id.homebase.api.client.contacts.ContactRepository
 import id.homebase.chat.conversationlist.ExtendPermissionUiState
@@ -56,6 +57,7 @@ class LocationViewModel(
     private val connectionService: ConnectionService,
     private val contactService: ContactService,
     private val emergencyContactReconciler: EmergencyContactReconciler,
+    private val temporalDriveReadProvider: TemporalDriveReadProvider,
     private val credentialsManager: CredentialsManager,
     private val receiveStore: LiveLocationReceiveStore,
     private val liveShareService: LiveLocationShareService,
@@ -96,6 +98,9 @@ class LocationViewModel(
 
     // Synchronous one-shot guard for the auto-activate collector below — see MomentsViewModel.
     private var activationKicked = false
+
+    // The location drive we preflight per "who I can locate" entry (same alias the reconciler uses).
+    private val locationDrive = locationLabeledDrive.drive.alias
 
     init {
         // "Who can locate you" = the members of our emergency-location-access circle. We host this
@@ -293,6 +298,47 @@ class LocationViewModel(
         }
     }
 
+    /**
+     * Preflight each "who I can locate" entry: does the peer still grant us temporal read access to
+     * their location drive, and how fresh is their newest data? Fired when the section is expanded.
+     * Each member is verified in its own coroutine so the spinners resolve independently. Members
+     * already resolved (or in flight) are skipped, so a re-expand is cheap. A network/parse failure
+     * is inconclusive — we drop the key (row shows nothing) so a re-expand retries, rather than
+     * falsely showing "broken"; this mirrors [EmergencyContactReconciler]'s leave-untouched rule.
+     */
+    fun verifyLocatableAccess() {
+        _uiState.value.whoICanLocate.forEach { member ->
+            val key = member.odinId.domainName
+            when (_uiState.value.whoICanLocateStatus[key]) {
+                LocateVerifyStatus.Loading,
+                LocateVerifyStatus.Broken,
+                is LocateVerifyStatus.Active -> return@forEach // resolved or in flight
+                null -> Unit // (re)issue
+            }
+            _uiState.update {
+                it.copy(whoICanLocateStatus = it.whoICanLocateStatus + (key to LocateVerifyStatus.Loading))
+            }
+            viewModelScope.launch {
+                val status = runCatching {
+                    temporalDriveReadProvider.verifyTemporalAccess(member.odinId, locationDrive)
+                }.getOrNull()
+                _uiState.update {
+                    val next = when {
+                        // Inconclusive (threw) → drop so the next expand retries.
+                        status == null -> it.whoICanLocateStatus - key
+                        // Gate on hasAccess alone (windowSeconds is not a reliable discriminator, #875).
+                        !status.hasAccess -> it.whoICanLocateStatus + (key to LocateVerifyStatus.Broken)
+                        // newestFileModified == 0 (ZeroTime) means no files yet → Active(null) = "no data".
+                        else -> it.whoICanLocateStatus + (key to LocateVerifyStatus.Active(
+                            status.newestFileModified.milliseconds.takeIf { ms -> ms > 0 }
+                        ))
+                    }
+                    it.copy(whoICanLocateStatus = next)
+                }
+            }
+        }
+    }
+
     fun onAction(action: LocationUiAction) {
         when (action) {
             LocationUiAction.SetupClicked -> viewModelScope.launch {
@@ -349,6 +395,8 @@ class LocationViewModel(
             LocationUiAction.StopSharingWithEveryone -> {
                 viewModelScope.launch { liveShareService.stopAll() }
             }
+
+            LocationUiAction.VerifyLocatable -> verifyLocatableAccess()
 
             // Permission requests are dispatched at the screen level (the
             // PermissionsManager is composition-scoped); the VM only receives


### PR DESCRIPTION
## What

On the Location dashboard, expanding the **"Who I can locate"** section now shows, on the right of each row:

- a **small spinner** while the check is in flight,
- a **`LinkOff` icon** (error-tinted) when the peer no longer grants us access,
- otherwise the **compact age** of their newest location data (`23m` / `5h` / `2d`), **warning-colored past a day**.

Previously each expanded row showed only avatar + name, with no signal of whether the link was still alive or how stale the data was.

## How

On expand, each entry fires the existing side-effect-free preflight `TemporalDriveReadProvider.verifyTemporalAccess(peer, locationDrive)` (reads no data, fires no notification on the peer) in its own coroutine, so spinners resolve independently. Results are cached per-entry in `LocationUiState.whoICanLocateStatus` (keyed by `odinId.domainName`).

The status mapping mirrors the already-in-production pattern in `ContactDetailViewModel.verifyLocateAccess` / `EmergencyContactReconciler`:

- gate on `hasAccess` alone (`windowSeconds` is not a reliable discriminator — #875),
- treat `newestFileModified == 0` (ZeroTime) as "access but no data yet" → render nothing,
- on an inconclusive (thrown) result, **drop the key** so a re-expand retries, rather than falsely showing "broken".

The shared `PeopleListBody` gains optional `onExpand` + `rowTrailing` slots; the sibling **"Who can locate you"** section passes neither and is visually unchanged.

## Files

- `LocationUiState.kt` — `LocateVerifyStatus` sealed interface, `whoICanLocateStatus` map, `VerifyLocatable` action
- `LocationViewModel.kt` — inject `TemporalDriveReadProvider`, `verifyLocatableAccess()`
- `LocationDashboardContent.kt` — `PeopleListBody` slots, `LocateStatusTrailing`, `formatLocateAge`
- `LocationScreen.kt`, `di/AppModule.kt`, `strings.xml` — wiring + 3 new strings

## Verification

- ✅ `:homebase-core:compileKotlinJvm` and `:homebase-core:compileAndroidMain` pass clean.
- ⚠️ Not driven end-to-end: no device was attached, and the new UI only exercises with contacts flagged `iCanLocate` on an activated location drive. Live behavior (spinner → age / broken-icon) is unverified against a running app — recommend a quick `androidApp:installDebug` smoke test with a connected identity that grants emergency location access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)