### PR TITLE
Cache bucket 2/3 (PR A): durable outbox staging dir + missing-payload permanent classification

### DIFF
--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/file/AndroidFileOperationsProvider.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/file/AndroidFileOperationsProvider.kt
@@ -132,10 +132,14 @@ class AndroidFileOperationsProvider(
         bytes: ByteArray, prefix: String, suffix: String
     ): String = writeBytesIn(CacheAudit.UPLOAD_TEMP_DIR_NAME, bytes, prefix, suffix)
 
-    // Encrypted, ready-to-transmit payloads → outbox-temp/ (KEEP-protected; #844 PR4).
-    override suspend fun writeBytesToOutboxTempFile(
-        bytes: ByteArray, prefix: String, suffix: String
-    ): String = writeBytesIn(CacheAudit.OUTBOX_TEMP_DIR_NAME, bytes, prefix, suffix)
+    // Encrypted, ready-to-transmit payloads live in the durable staging dir (#842) — under
+    // noBackupFilesDir, NOT cacheDir: cacheDir is OS-reclaimable under storage pressure, which
+    // deleted staged payloads out from under long-lived outbox rows (the ENOENT retry loop).
+    // noBackupFilesDir (not filesDir) because the outbox DB is excluded from backup rules — a
+    // future backup enablement must not restore staged files whose rows didn't ride along.
+    // The interface default routes writeBytesToOutboxTempFile through this dir.
+    override fun getOutboxStagingDirectory(): String =
+        File(context.noBackupFilesDir, OUTBOX_STAGING_DIR_NAME).apply { mkdirs() }.absolutePath
 
     private suspend fun writeBytesIn(
         dirName: String, bytes: ByteArray, prefix: String, suffix: String

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/upload/DriveUploadProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/upload/DriveUploadProvider.kt
@@ -97,11 +97,53 @@ class DriveUploadProvider(
 
     // ==================== HIGH-LEVEL UPLOAD METHODS ====================
 
+    /**
+     * DRAIN-TIME payload integrity pre-flight (HealAudit + #842). Payload bytes are
+     * staged to a file at ENQUEUE time but read lazily at outbox-drain time, which
+     * can be days later — if the staged file is gone by then, openFileInput() would
+     * either stream 0 bytes (silently shipping an EMPTY payload that clobbers a good
+     * one on AppendOrOverwrite) or throw mid-request as a platform-specific IO error
+     * that gets misclassified as a transient "Network failure" and retried 20×.
+     *
+     * So: probe every payload path BEFORE any network call. A plain filesystem path
+     * that is missing/empty throws [StagedPayloadMissingException] — deterministic,
+     * classified PERMANENT, row drops on attempt 1 with an honest OutboxItemDropped.
+     *
+     * URI-shaped sources (Android `content://`, iOS `ph://` / raw PHAsset ids) are
+     * NOT escalated: they aren't staged artifacts we own, and getFileSize can't
+     * reliably size them (the SAF SIZE column is optional; Photos assets report 0) —
+     * a false PERMANENT drop is worse than a retry tail. They keep the WARN-only
+     * audit log.
+     */
+    private fun preflightStagedPayloads(payloads: List<PayloadFile>?, context: String) {
+        payloads?.forEach { p ->
+            val path = p.filePath
+            val size = runCatching { fileOperationsProvider.getFileSize(path) }.getOrDefault(-1L)
+            if (size > 0L) {
+                Logger.d(tag = "HealAudit") {
+                    "$TAG.$context: payload key=${p.key} size=$size at drain (preEncrypted=${p.isPreEncrypted})"
+                }
+                return@forEach
+            }
+            val isUriSource =
+                path.startsWith("content:") || path.startsWith("ph://") || path.contains("/L0/")
+            Logger.w(tag = "HealAudit") {
+                "$TAG.$context: payload key=${p.key} size=$size at drain " +
+                    "(path=$path preEncrypted=${p.isPreEncrypted}) — " +
+                    if (isUriSource) "URI source, keeping WARN-only (not escalating)"
+                    else "staged file missing, failing PERMANENT"
+            }
+            if (!isUriSource) throw StagedPayloadMissingException(path, p.key)
+        }
+    }
+
     suspend fun uploadFile(
         request: UploadFileRequest,
         onProgress: UploadProgress? = null,
         onVersionConflict: (suspend () -> CreateFileResult?)? = null
     ): CreateFileResult? {
+
+        preflightStagedPayloads(request.payloads, "uploadFile uniqueId=${request.metadata.appData.uniqueId}")
 
         val creds = requireCreds()
 
@@ -168,6 +210,8 @@ class DriveUploadProvider(
         onVersionConflict: (suspend () -> UpdateFileResult?)? = null
     ): UpdateFileResult? {
 
+        preflightStagedPayloads(request.payloads, "updateFileByFileId fileId=${request.fileId}")
+
         val creds = requireCreds()
         val sharedSecret = creds.secret.unsafeBytes
 
@@ -221,33 +265,7 @@ class DriveUploadProvider(
         val creds = requireCreds()
         val sharedSecret = creds.secret.unsafeBytes
 
-        // DRAIN-TIME payload integrity check (HealAudit). Payload bytes (e.g. the
-        // reused `convo_img` group image on a group heal) are staged to a temp
-        // file at ENQUEUE time but read lazily HERE, at outbox-drain time. On
-        // Android that staging dir is cacheDir, which the OS can reclaim while the
-        // row waits in the outbox: getFileSize() returns 0 for a missing file and
-        // openFileInput() then streams 0 bytes, so an AppendOrOverwrite can
-        // silently replace a good payload with an EMPTY one — the file header (and
-        // its previewThumbnail) survive while the full payload becomes unreadable
-        // (warning triangle over the tiny thumb). The upload still reports
-        // "success", so without this log the corruption is invisible. Logged WARN
-        // when a payload is missing/zero so a heal repro shows exactly which
-        // payload shipped empty.
-        request.payloads?.forEach { p ->
-            val size = runCatching { fileOperationsProvider.getFileSize(p.filePath) }.getOrDefault(-1L)
-            if (size <= 0L) {
-                Logger.w(tag = "HealAudit") {
-                    "$TAG.updateFileByUniqueId: payload key=${p.key} size=$size at drain " +
-                        "(uniqueId=${request.uniqueId} path=${p.filePath} preEncrypted=${p.isPreEncrypted}) — " +
-                        "AppendOrOverwrite may ship an EMPTY payload and clobber the existing one"
-                }
-            } else {
-                Logger.d(tag = "HealAudit") {
-                    "$TAG.updateFileByUniqueId: payload key=${p.key} size=$size at drain " +
-                        "(uniqueId=${request.uniqueId} preEncrypted=${p.isPreEncrypted})"
-                }
-            }
-        }
+        preflightStagedPayloads(request.payloads, "updateFileByUniqueId uniqueId=${request.uniqueId}")
 
         // Build encrypted descriptor
         val sharedSecretEncryptedDescriptor =

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/upload/StagedPayloadMissingException.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/upload/StagedPayloadMissingException.kt
@@ -1,0 +1,23 @@
+package id.homebase.api.client.drives.upload
+
+/**
+ * A payload staged for the outbox (a plain filesystem path, normally inside the
+ * durable outbox staging dir) is missing or empty at DRAIN time.
+ *
+ * Thrown by [DriveUploadProvider]'s pre-flight BEFORE any network call, which is
+ * what makes it deterministic and platform-independent: a missing file that
+ * instead surfaces during multipart body streaming arrives as a different type
+ * per platform (JVM/Android `FileNotFoundException` wrapped into a transient
+ * `NetworkException` by `OdinApiProviderBase.networkCall`, okio's eager throw on
+ * web, `IllegalStateException` on iOS) and burns ~48h of retries as a phantom
+ * "Network failure".
+ *
+ * Classified PERMANENT by `OutboxFailureClassifier`: the source bytes are gone
+ * and no retry brings them back, so the row is dropped on attempt 1 and the
+ * user sees the failure (chat offers Retry, which re-stages from the source).
+ * Never re-staged here — the original plaintext may itself be gone.
+ */
+class StagedPayloadMissingException(
+    val path: String,
+    val payloadKey: String,
+) : Exception("Staged payload missing at drain: key=$payloadKey path=$path")

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheSweeper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheSweeper.kt
@@ -130,12 +130,14 @@ internal fun decide(entry: CacheAudit.Entry, mode: SweepMode): SweepAction = whe
     // Wins over every other rule — including the full "logout" sweep.
     entry.androidSystem -> SweepAction.KEEP
     entry.name == ORPHAN_COIL_DIR_NAME -> SweepAction.ORPHAN_COIL_DELETE
-    // Encrypted outbox payload temps. KEEP on the startup / "Clear caches" sweep — each is
-    // referenced by an outbox row (long-lived when offline) and deleting it mid-flight breaks
-    // the send; the outbox reaps them along its own lifecycle (on send success, and on drop
-    // after ~48h). Only the full logout sweep wipes them. The RAW upload-temp dir gets NO such
-    // rule: it's disposable pre-encryption scratch that self-heals via the normal untracked
-    // sweep below (loss = fail-soft re-pick).
+    // LEGACY-ONLY (#842): new encrypted outbox payloads stage in the durable app-data dir
+    // (FileOperationsProvider.getOutboxStagingDirectory(), outside cacheDir — this sweeper
+    // never sees it). This rule only protects <cacheDir>/outbox-temp files referenced by
+    // outbox rows enqueued BEFORE the app update, so they still drain instead of ENOENT-ing;
+    // the dual-dir idle reap (OutboxSync.reapIdleOutboxTemps) empties leftovers. Retire the
+    // rule once pre-#842 rows can no longer exist (a release or two). The RAW upload-temp dir
+    // gets NO such rule: it's disposable pre-encryption scratch that self-heals via the normal
+    // untracked sweep below (loss = fail-soft re-pick).
     entry.name == CacheAudit.OUTBOX_TEMP_DIR_NAME -> if (mode == SweepMode.ALL) SweepAction.DELETE else SweepAction.KEEP
     !entry.known -> SweepAction.DELETE
     mode == SweepMode.ALL -> SweepAction.DELETE

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/FileOperationsProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/FileOperationsProvider.kt
@@ -3,6 +3,7 @@ package id.homebase.api.file
 import io.ktor.client.request.forms.InputProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 
 interface FileOperationsProvider {
     fun openFileInput(path: String): InputProvider
@@ -63,19 +64,55 @@ interface FileOperationsProvider {
     ): String
 
     /**
-     * Write an ENCRYPTED, ready-to-transmit payload temp into `<cacheDir>/outbox-temp/` (see
-     * [CacheAudit.OUTBOX_TEMP_DIR_NAME]). Durable: each file is referenced by an outbox row until
-     * the send completes (long-lived when offline), so the CacheSweeper KEEPs this dir on the
-     * startup / "Clear caches" sweep and only wipes it on logout; the outbox reaps individual
-     * files along its own lifecycle. Used ONLY by the encryption step (PayloadBundleEncryption
-     * Service.encryptFile). Default delegates to [writeBytesToTempFile] for any provider that
-     * hasn't overridden it (behaviour-preserving).
+     * Absolute path of the DURABLE outbox staging directory (#842). Unlike
+     * [getCacheDirectory] this location is never reclaimed by the OS under storage
+     * pressure and sits outside the CacheSweeper's reach — every file here is
+     * referenced by an outbox row until the send completes (long-lived when
+     * offline) and is reaped ONLY along the outbox lifecycle (send success /
+     * permanent drop / logout / idle orphan reap). See [OUTBOX_STAGING_DIR_NAME].
+     *
+     * Platform actuals: JVM app-data dir, Android `noBackupFilesDir`, iOS
+     * Application Support (backup-excluded). The default — used by web — stays at
+     * `<cacheDir>/outbox-temp`: the wasm FS is a RAM-only FakeFileSystem and the
+     * sql.js DB is in-memory, so outbox rows don't survive a refresh either; true
+     * web durability is deferred until web gets persistent storage.
+     */
+    fun getOutboxStagingDirectory(): String =
+        getCacheDirectory().trimEnd('/') + "/" + CacheAudit.OUTBOX_TEMP_DIR_NAME
+
+    /**
+     * Reserve a unique writable path inside [getOutboxStagingDirectory] (creating
+     * the dir) WITHOUT writing bytes — the seam for stream writers
+     * ([writeStream] of an encrypting Flow), which must produce their output
+     * directly in staging instead of writing cache scratch and copying.
+     */
+    suspend fun createOutboxStagingPath(prefix: String, suffix: String): String =
+        createStagingPathIn(getOutboxStagingDirectory(), prefix, suffix)
+
+    /**
+     * Move an encrypted, ready-to-transmit file OR directory (e.g. an
+     * `hls_<uuid>/` tree) into [getOutboxStagingDirectory] and return its new
+     * absolute path. Rename-first with a recursive copy+delete fallback for
+     * cross-filesystem moves — see [promoteIntoStaging].
+     */
+    suspend fun promoteToOutboxStaging(path: String): String =
+        promoteIntoStaging(path, getOutboxStagingDirectory())
+
+    /**
+     * Write an ENCRYPTED, ready-to-transmit payload into the durable outbox
+     * staging dir ([getOutboxStagingDirectory]) and return its absolute path.
+     * Each staged file is referenced by an outbox row and reaped only along the
+     * outbox lifecycle — never by the CacheSweeper or OS cache reclaim.
      */
     suspend fun writeBytesToOutboxTempFile(
         bytes: ByteArray,
         prefix: String,
         suffix: String
-    ): String = writeBytesToTempFile(bytes, prefix, suffix)
+    ): String {
+        val path = createOutboxStagingPath(prefix, suffix)
+        writeStream(path, flowOf(bytes))
+        return path
+    }
 
     /**
      * Write [bytes] to a sequestered subdirectory `<cacheDir>/share_outbound/`

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/OkioFileOperationsProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/OkioFileOperationsProvider.kt
@@ -50,14 +50,18 @@ open class OkioFileOperationsProvider(
         return writeBytesIn(CacheAudit.UPLOAD_TEMP_DIR_NAME, bytes, prefix, suffix)
     }
 
-    // Encrypted, ready-to-transmit payloads → outbox-temp/ (KEEP-protected; #844 PR4).
-    override suspend fun writeBytesToOutboxTempFile(
-        bytes: ByteArray,
-        prefix: String,
-        suffix: String
-    ): String = writeBytesIn(CacheAudit.OUTBOX_TEMP_DIR_NAME, bytes, prefix, suffix)
+    // Staging location keeps the interface default (<cacheDir>/outbox-temp — on web the whole
+    // FS is a RAM FakeFileSystem, so true durability is deferred; see the interface KDoc), but
+    // the path/promote operations must run over the INJECTED fileSystem, not the global
+    // systemFileSystem the interface defaults use — otherwise web/test writes would land on the
+    // wrong filesystem.
+    override suspend fun createOutboxStagingPath(prefix: String, suffix: String): String =
+        createStagingPathIn(getOutboxStagingDirectory(), prefix, suffix, fileSystem)
 
-    // upload-temp is swept every startup (disposable); outbox-temp is KEEP-protected until sent.
+    override suspend fun promoteToOutboxStaging(path: String): String =
+        promoteIntoStaging(path, getOutboxStagingDirectory(), fileSystem)
+
+    // upload-temp is swept every startup (disposable).
     private fun writeBytesIn(dirName: String, bytes: ByteArray, prefix: String, suffix: String): String {
         val dir = cacheDir.toPath() / dirName
         fileSystem.createDirectories(dir)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/OutboxStaging.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/OutboxStaging.kt
@@ -1,0 +1,114 @@
+package id.homebase.api.file
+
+import co.touchlab.kermit.Logger
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+import kotlin.random.Random
+
+/**
+ * Shared logic for the DURABLE outbox staging directory (#842) — the one place
+ * encrypted, ready-to-transmit upload payloads live while their outbox row is
+ * pending. Unlike the cache directory, the staging dir is never reclaimed by
+ * the OS under storage pressure and is invisible to [CacheSweeper] (it sits
+ * outside `getCacheDirectory()`), so a payload survives restarts, "Clear
+ * caches", and storage-pressure events until its row drains.
+ *
+ * Lifecycle (the ONLY ways a staged file dies):
+ *  - send success — `DriveUploadProvider.cleanupPayloadTempFiles`;
+ *  - permanent drop — `OutboxSync.cleanupPayloadsForDroppedRow`;
+ *  - logout — [wipeOutboxStaging] (paired with the outbox table wipe);
+ *  - idle orphan reap — `OutboxSync.reapIdleOutboxTemps` (outbox empty + >24h).
+ *
+ * All functions take an injectable [FileSystem] (pattern: [safeDeleteRecursively],
+ * `HlsScratchCleanup`) so they run unchanged over a test `FakeFileSystem`.
+ */
+const val OUTBOX_STAGING_DIR_NAME: String = "outbox-staging"
+
+/**
+ * Reserve a unique, not-yet-written path `<stagingDir>/<prefix><token><suffix>`,
+ * creating [stagingDir] if needed. Writes NOTHING — this is the seam for stream
+ * writers (`writeStream` of an encrypting Flow), which must target the staging
+ * dir directly instead of writing to cache scratch and copying.
+ */
+fun createStagingPathIn(
+    stagingDir: String,
+    prefix: String,
+    suffix: String,
+    fileSystem: FileSystem = systemFileSystem,
+): String {
+    val dir = stagingDir.toPath()
+    fileSystem.createDirectories(dir)
+    while (true) {
+        val candidate = dir / "$prefix${randomToken()}$suffix"
+        if (!fileSystem.exists(candidate)) return candidate.toString()
+    }
+}
+
+/**
+ * Move [sourcePath] (a regular file OR a directory, e.g. an `hls_<uuid>/` tree)
+ * into [stagingDir] and return its new absolute path. Rename-first; when source
+ * and staging live on different filesystems (e.g. tmpfs XDG cache vs home on
+ * Linux) the rename fails and we fall back to a recursive copy + delete — the
+ * fallback is required, not an edge case.
+ *
+ * The source's base name is kept (callers already use collision-free names:
+ * `hls_<uuid>`, `video-encrypted-<uuid>.bin`); an existing target of the same
+ * name gets a random token prepended instead of being clobbered.
+ */
+fun promoteIntoStaging(
+    sourcePath: String,
+    stagingDir: String,
+    fileSystem: FileSystem = systemFileSystem,
+): String {
+    val source = sourcePath.toPath()
+    val dir = stagingDir.toPath()
+    fileSystem.createDirectories(dir)
+    var target = dir / source.name
+    if (fileSystem.exists(target)) target = dir / "${randomToken()}-${source.name}"
+    try {
+        fileSystem.atomicMove(source, target)
+    } catch (e: Exception) {
+        // Cross-filesystem (or platform quirk) — copy the tree, then remove the
+        // source. Copy failures propagate: a payload that never reached staging
+        // must fail the send now, not ENOENT later.
+        Logger.i(tag = TAG) { "atomicMove failed (${e.message}), copying $source -> $target" }
+        copyRecursively(fileSystem, source, target)
+        runCatching { fileSystem.deleteRecursively(source) }.onFailure {
+            Logger.w(tag = TAG, throwable = it) { "failed to remove source after copy: $source" }
+        }
+    }
+    return target.toString()
+}
+
+/**
+ * Delete everything inside [stagingDir] (logout). Each child goes through
+ * [safeDeleteRecursively]'s guards; the dir itself stays. Best-effort — a
+ * per-child failure is logged there and doesn't stop the wipe.
+ */
+fun wipeOutboxStaging(
+    stagingDir: String,
+    fileSystem: FileSystem = systemFileSystem,
+) {
+    val dir = stagingDir.toPath()
+    val children = runCatching { fileSystem.list(dir) }.getOrElse { return }
+    for (child in children) {
+        safeDeleteRecursively(stagingDir, child.name, fileSystem)
+    }
+}
+
+private fun copyRecursively(fileSystem: FileSystem, source: Path, target: Path) {
+    val meta = fileSystem.metadata(source)
+    if (meta.isDirectory) {
+        fileSystem.createDirectories(target)
+        for (child in fileSystem.list(source)) {
+            copyRecursively(fileSystem, child, target / child.name)
+        }
+    } else {
+        fileSystem.copy(source, target)
+    }
+}
+
+private fun randomToken(): String = Random.nextLong().toULong().toString(16)
+
+private const val TAG = "OutboxStaging"

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxFailureClassifier.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxFailureClassifier.kt
@@ -3,6 +3,7 @@ package id.homebase.api.sync.database
 import id.homebase.api.client.ClientException
 import id.homebase.api.client.NotFoundException
 import id.homebase.api.client.OdinClientErrorCode
+import id.homebase.api.client.drives.upload.StagedPayloadMissingException
 
 /**
  * The single classification point for outbox upload failures: returns a
@@ -20,6 +21,13 @@ import id.homebase.api.client.OdinClientErrorCode
  */
 internal fun classifyPermanentFailure(e: Throwable): String? {
     if (e is NotFoundException) return "404 NotFound"
+    // A staged payload file is gone at drain time (#842). The source bytes no
+    // longer exist locally, so no retry can succeed — drop on attempt 1 instead
+    // of burning ~48h as a phantom "Network failure" (the pre-#842 symptom when
+    // the sweeper/OS reclaimed an enc temp out from under a pending row). Thrown
+    // by DriveUploadProvider's pre-flight BEFORE the network call, so it can't
+    // be wrapped into a transient NetworkException.
+    if (e is StagedPayloadMissingException) return "staged payload missing: ${e.message}"
     if (e is ClientException) {
         when (e.errorCode) {
             OdinClientErrorCode.FileNotFound,

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/file/OutboxStagingTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/file/OutboxStagingTest.kt
@@ -1,0 +1,142 @@
+package id.homebase.api.file
+
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * The durable outbox staging area (#842): path reservation, promote (file and
+ * directory, incl. the cross-filesystem copy fallback), logout wipe, and the
+ * write path landing under the staging dir. Runs over a [FakeFileSystem] on all
+ * targets — same pattern as [OkioFileOperationsProviderTest].
+ */
+class OutboxStagingTest {
+
+    private val stagingDir = "/data/app/outbox-staging"
+
+    @Test
+    fun createStagingPathIn_createsDirAndReturnsUniqueWritablePaths() {
+        val fs = FakeFileSystem()
+
+        val a = createStagingPathIn(stagingDir, "enc", ".encrypted", fs)
+        val b = createStagingPathIn(stagingDir, "enc", ".encrypted", fs)
+
+        assertTrue(fs.exists(stagingDir.toPath()), "staging dir must be created")
+        assertNotEquals(a, b, "reserved paths must be unique")
+        assertTrue(a.startsWith(stagingDir) && a.endsWith(".encrypted"), "path shape: $a")
+        assertFalse(fs.exists(a.toPath()), "reservation must NOT write the file — stream writers own that")
+
+        fs.write(a.toPath()) { writeUtf8("ciphertext") }
+        assertTrue(fs.exists(a.toPath()))
+    }
+
+    @Test
+    fun promoteIntoStaging_movesARegularFile() {
+        val fs = FakeFileSystem()
+        val src = "/cache/video-encrypted-abc.bin".toPath()
+        fs.createDirectories(src.parent!!)
+        fs.write(src) { writeUtf8("payload") }
+
+        val promoted = promoteIntoStaging(src.toString(), stagingDir, fs)
+
+        assertFalse(fs.exists(src), "source must be gone after promote")
+        assertEquals("$stagingDir/video-encrypted-abc.bin", promoted, "base name kept")
+        assertEquals("payload", fs.read(promoted.toPath()) { readUtf8() })
+    }
+
+    @Test
+    fun promoteIntoStaging_movesADirectoryTree() {
+        val fs = FakeFileSystem()
+        val hls = "/cache/hls_1234".toPath()
+        fs.createDirectories(hls)
+        fs.write(hls / "index.ts") { writeUtf8("segments") }
+        fs.write(hls / "index.m3u8") { writeUtf8("playlist") }
+
+        val promoted = promoteIntoStaging(hls.toString(), stagingDir, fs)
+
+        assertFalse(fs.exists(hls), "source dir must be gone after promote")
+        assertEquals("$stagingDir/hls_1234", promoted)
+        assertEquals("segments", fs.read(promoted.toPath() / "index.ts") { readUtf8() })
+        assertEquals("playlist", fs.read(promoted.toPath() / "index.m3u8") { readUtf8() })
+    }
+
+    @Test
+    fun promoteIntoStaging_doesNotClobberAnExistingTarget() {
+        val fs = FakeFileSystem()
+        fs.createDirectories(stagingDir.toPath())
+        fs.write("$stagingDir/enc1.bin".toPath()) { writeUtf8("already staged") }
+        val src = "/cache/enc1.bin".toPath()
+        fs.createDirectories(src.parent!!)
+        fs.write(src) { writeUtf8("newcomer") }
+
+        val promoted = promoteIntoStaging(src.toString(), stagingDir, fs)
+
+        assertNotEquals("$stagingDir/enc1.bin", promoted, "same-name target must not be clobbered")
+        assertEquals("already staged", fs.read("$stagingDir/enc1.bin".toPath()) { readUtf8() })
+        assertEquals("newcomer", fs.read(promoted.toPath()) { readUtf8() })
+    }
+
+    @Test
+    fun wipeOutboxStaging_removesAllChildrenButKeepsDir() {
+        val fs = FakeFileSystem()
+        fs.createDirectories(stagingDir.toPath())
+        fs.write("$stagingDir/enc1.encrypted".toPath()) { writeUtf8("a") }
+        fs.createDirectories("$stagingDir/hls_99".toPath())
+        fs.write("$stagingDir/hls_99/index.ts".toPath()) { writeUtf8("b") }
+
+        wipeOutboxStaging(stagingDir, fs)
+
+        assertEquals(emptyList(), fs.list(stagingDir.toPath()), "staging must be empty after wipe")
+    }
+
+    @Test
+    fun wipeOutboxStaging_onMissingDirIsANoOp() {
+        wipeOutboxStaging("/data/app/never-created", FakeFileSystem())
+    }
+
+    @Test
+    fun writeBytesToOutboxTempFile_landsUnderTheStagingDir() = runTest {
+        val fs = FakeFileSystem()
+        val ops = OkioFileOperationsProvider(fs, "/tmp/homebase")
+        val bytes = byteArrayOf(1, 2, 3, 4)
+
+        val path = ops.writeBytesToOutboxTempFile(bytes, "enc", ".encrypted")
+
+        assertTrue(
+            path.startsWith(ops.getOutboxStagingDirectory()),
+            "staged write must land in the staging dir: $path",
+        )
+        assertContentEquals(bytes, ops.readFileBytes(path), "staged bytes must round-trip")
+    }
+
+    /**
+     * THE #842 durability property: the staging dir sits outside cacheDir, so
+     * neither the startup sweep ([CacheSweeper.sweepUntracked]) nor the logout
+     * sweep ([CacheSweeper.sweepAll]) — both scoped to the cacheDir audit — can
+     * reach a staged payload. Only the explicit logout [wipeOutboxStaging]
+     * (asserted above) and the outbox's own lifecycle delete it.
+     */
+    @Test
+    fun stagedFileSurvivesBothCacheSweeps() {
+        val fs = FakeFileSystem()
+        val cacheDir = "/tmp/homebase"
+        fs.createDirectories(cacheDir.toPath())
+        // Untracked cache junk that the sweep SHOULD eat — proves the sweep ran.
+        fs.write("$cacheDir/hbvid_junk.bin".toPath()) { writeUtf8("junk") }
+        val staged = createStagingPathIn(stagingDir, "enc", ".encrypted", fs)
+        fs.write(staged.toPath()) { writeUtf8("pending payload") }
+
+        CacheSweeper.sweepUntracked(CacheAudit.audit(cacheDir, fs), fs)
+        assertFalse(fs.exists("$cacheDir/hbvid_junk.bin".toPath()), "sweep must actually run")
+        assertTrue(fs.exists(staged.toPath()), "staged payload must survive sweepUntracked")
+
+        CacheSweeper.sweepAll(CacheAudit.audit(cacheDir, fs), fs)
+        assertTrue(fs.exists(staged.toPath()), "staged payload must survive sweepAll (logout cache sweep)")
+    }
+}

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxFailureClassifierTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxFailureClassifierTest.kt
@@ -4,6 +4,7 @@ import id.homebase.api.client.ClientException
 import id.homebase.api.client.NotFoundException
 import id.homebase.api.client.OdinClientErrorCode
 import id.homebase.api.client.ProblemDetails
+import id.homebase.api.client.drives.upload.StagedPayloadMissingException
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -37,6 +38,32 @@ class OutboxFailureClassifierTest {
     @Test
     fun notFoundExceptionIsPermanent() {
         assertNotNull(classifyPermanentFailure(NotFoundException()))
+    }
+
+    /**
+     * A staged payload missing at drain time (#842): the source bytes no longer
+     * exist locally, so no retry can succeed. Pre-#842 this surfaced as a
+     * platform IO error wrapped into a transient "Network failure" and burned
+     * 20 retries over ~48h with the message permanently stuck.
+     */
+    @Test
+    fun stagedPayloadMissingIsPermanent() {
+        assertNotNull(
+            classifyPermanentFailure(
+                StagedPayloadMissingException(path = "/data/outbox-staging/enc123.encrypted", payloadKey = "chat_img")
+            )
+        )
+    }
+
+    /**
+     * Guard: ONLY the typed pre-flight exception classifies — a generic
+     * IO-flavored exception (e.g. a real network hiccup whose message happens
+     * to mention a file) must stay retryable, or transient failures would be
+     * dropped permanently.
+     */
+    @Test
+    fun genericIoFlavoredExceptionIsRetryable() {
+        assertNull(classifyPermanentFailure(Exception("open failed: ENOENT (No such file or directory)")))
     }
 
     // ---- permanent: structured error codes ----

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSyncTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSyncTest.kt
@@ -36,6 +36,7 @@ import id.homebase.api.client.NotFoundException
 import id.homebase.api.client.OdinClientErrorCode
 import id.homebase.api.client.ProblemDetails
 import id.homebase.api.client.drives.files.DriveOutboxUploader
+import id.homebase.api.client.drives.upload.StagedPayloadMissingException
 
 class TestUploader : OutboxUploader {
     var shouldFail = false
@@ -674,6 +675,55 @@ class OutboxSyncTest {
         assertEquals(0L, db.outbox.count(), "row must be dropped on first attempt")
         assertEquals(uniqueId, dropped.uniqueId)
         assertEquals(driveId, dropped.driveId)
+        assertEquals(1, dropped.attempts, "drop must happen on attempt 1, not after MAX_RETRIES")
+        sync.clearCheckout(timeoutMs = 5_000)  // drain before db.close(); see file kdoc
+    }
+
+    /**
+     * #842: a staged payload file missing at drain time (DriveUploadProvider's
+     * pre-flight throws [StagedPayloadMissingException]) is permanent — the
+     * source bytes are gone, no retry can bring them back. Pre-#842 this
+     * surfaced as a platform IO error wrapped into a transient "Network
+     * failure" and burned 20 retries (~48h) with the message stuck.
+     */
+    @Test
+    fun testPermanentFailure_StagedPayloadMissingDroppedOnFirstAttempt() = runOutboxTest { db ->
+        val eventBus = EventBus()
+        val uploader = TestUploader()
+        uploader.failureException = StagedPayloadMissingException(
+            path = "/data/outbox-staging/enc123.encrypted",
+            payloadKey = "chat_img",
+        )
+
+        val sync = OutboxSync(
+            databaseManager = db, uploader = uploader, eventBus = eventBus, scope = backgroundScope
+        )
+        sync.setOnline(true)
+
+        val droppedDeferred = async {
+            eventBus.events.filterIsInstance<BackendEvent.OutboxEvent.OutboxItemDropped>().first()
+        }
+        testScheduler.runCurrent()
+
+        val driveId = Uuid.random()
+        val uniqueId = Uuid.random()
+        db.outbox.insert(
+            driveId = driveId,
+            uniqueId = uniqueId,
+            dependencyUniqueId = null,
+            priority = 0,
+            uploadType = 0,
+            json = byteArrayOf(),
+            filePaths = null,
+        )
+
+        try { sync.send() } catch (_: Exception) {}
+        advanceUntilIdle()
+
+        val dropped = droppedDeferred.await()
+
+        assertEquals(0L, db.outbox.count(), "row must be dropped on first attempt")
+        assertEquals(uniqueId, dropped.uniqueId)
         assertEquals(1, dropped.attempts, "drop must happen on attempt 1, not after MAX_RETRIES")
         sync.clearCheckout(timeoutMs = 5_000)  // drain before db.close(); see file kdoc
     }

--- a/homebase-api/src/jvmMain/kotlin/id/homebase/api/file/JvmFileOperationsProvider.kt
+++ b/homebase-api/src/jvmMain/kotlin/id/homebase/api/file/JvmFileOperationsProvider.kt
@@ -77,16 +77,16 @@ class JvmFileOperationsProvider : FileOperationsProvider {
     ): String =
         writeBytesIn(CacheAudit.UPLOAD_TEMP_DIR_NAME, bytes, prefix, suffix)
 
-    // Encrypted, ready-to-transmit payloads → outbox-temp/ (KEEP-protected; #844 PR4).
-    override suspend fun writeBytesToOutboxTempFile(
-        bytes: ByteArray,
-        prefix: String,
-        suffix: String
-    ): String = writeBytesIn(CacheAudit.OUTBOX_TEMP_DIR_NAME, bytes, prefix, suffix)
+    // Encrypted, ready-to-transmit payloads live in the durable app-data staging dir (#842),
+    // NOT the OS-reclaimable cache dir — see getOutboxStagingDirectory(). The interface
+    // default routes writeBytesToOutboxTempFile through it.
+    override fun getOutboxStagingDirectory(): String =
+        File(JvmFileSystemUtil.getAppDataDirectory(), OUTBOX_STAGING_DIR_NAME)
+            .apply { mkdirs() }
+            .absolutePath
 
-    // Both temp dirs live under the app cache dir (not java.io.tmpdir), so the Storage screen
-    // counts them and the CacheSweeper governs them (#844 PR4). upload-temp is swept every
-    // startup (disposable); outbox-temp is KEEP-protected until the send completes.
+    // upload-temp lives under the app cache dir (not java.io.tmpdir), so the Storage screen
+    // counts it and the CacheSweeper reaps it on every startup (disposable; #844 PR4).
     private suspend fun writeBytesIn(
         dirName: String,
         bytes: ByteArray,

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/IOSFileOperationsProvider.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/IOSFileOperationsProvider.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.io.Buffer
+import platform.Foundation.NSApplicationSupportDirectory
 import platform.Foundation.NSCachesDirectory
 import platform.Foundation.NSData
 import platform.Foundation.NSFileHandle
@@ -16,6 +17,7 @@ import platform.Foundation.NSFileManager
 import platform.Foundation.NSNumber
 import platform.Foundation.NSTemporaryDirectory
 import platform.Foundation.NSURL
+import platform.Foundation.NSURLIsExcludedFromBackupKey
 import platform.Foundation.NSUUID
 import platform.Foundation.NSUserDomainMask
 import platform.Foundation.closeFile
@@ -131,16 +133,37 @@ class IOSFileOperationsProvider : FileOperationsProvider {
         suffix: String
     ): String = writeBytesIn(CacheAudit.UPLOAD_TEMP_DIR_NAME, bytes, prefix, suffix)
 
-    // Encrypted, ready-to-transmit payloads → outbox-temp/ (KEEP-protected; #844 PR4).
-    override suspend fun writeBytesToOutboxTempFile(
-        bytes: ByteArray,
-        prefix: String,
-        suffix: String
-    ): String = writeBytesIn(CacheAudit.OUTBOX_TEMP_DIR_NAME, bytes, prefix, suffix)
+    // Encrypted, ready-to-transmit payloads live in the durable staging dir (#842) — under
+    // Application Support, NOT Caches: iOS purges Caches under storage pressure, which deleted
+    // staged payloads out from under long-lived outbox rows (the ENOENT retry loop). The dir is
+    // excluded from iCloud backup on every creation (the attribute doesn't survive recreation):
+    // staged payloads are regeneratable and their outbox DB rows don't ride a restore.
+    // The interface default routes writeBytesToOutboxTempFile through this dir.
+    @OptIn(ExperimentalForeignApi::class)
+    override fun getOutboxStagingDirectory(): String {
+        val fm = NSFileManager.defaultManager
+        val supportUrl = fm.URLForDirectory(
+            directory = NSApplicationSupportDirectory,
+            inDomain = NSUserDomainMask,
+            appropriateForURL = null,
+            create = true,
+            error = null
+        )
+        val base = supportUrl?.path ?: return super.getOutboxStagingDirectory()
+        val dir = "${base.trimEnd('/')}/$OUTBOX_STAGING_DIR_NAME"
+        if (!fm.fileExistsAtPath(dir)) {
+            fm.createDirectoryAtPath(dir, true, null, null)
+        }
+        NSURL.fileURLWithPath(dir, isDirectory = true).setResourceValue(
+            value = NSNumber(bool = true),
+            forKey = NSURLIsExcludedFromBackupKey,
+            error = null
+        )
+        return dir
+    }
 
-    // Both temp dirs live under the Caches dir (not NSTemporaryDirectory()), so the Storage
-    // screen counts them and the CacheSweeper governs them (#844 PR4). upload-temp is swept every
-    // startup (disposable); outbox-temp is KEEP-protected until the send completes.
+    // upload-temp lives under the Caches dir (not NSTemporaryDirectory()), so the Storage
+    // screen counts it and the CacheSweeper reaps it on every startup (disposable; #844 PR4).
     @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
     private fun writeBytesIn(dirName: String, bytes: ByteArray, prefix: String, suffix: String): String {
         val cacheDir = getCacheDirectory().trimEnd('/')

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -9,6 +9,7 @@ import id.homebase.api.file.CacheAudit
 import id.homebase.api.file.CacheSweeper
 import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.file.systemFileSystem
+import id.homebase.api.file.wipeOutboxStaging
 import id.homebase.api.client.upgrade.IdentityUpgradeProvider
 import id.homebase.core.config.dataUpgradeReturnUrl
 
@@ -431,6 +432,17 @@ val appModule = module {
                         "logout cache sweep failed"
                     }
                 }
+                // The durable outbox staging dir (#842) sits OUTSIDE cacheDir, so the
+                // sweep above can't reach it — wipe it explicitly. Pairs with the
+                // outbox-table wipe (driveSyncManager.clearStorage()): rows and staged
+                // payloads leave together.
+                runCatching {
+                    wipeOutboxStaging(fileOps.getOutboxStagingDirectory())
+                }.onFailure {
+                    Logger.w(tag = "YouAuthFlowManager", throwable = it) {
+                        "logout outbox-staging wipe failed"
+                    }
+                }
                 runCatching { imageLoader.memoryCache?.clear() }
                     .onFailure {
                         Logger.w(tag = "YouAuthFlowManager", throwable = it) {
@@ -475,9 +487,15 @@ val appModule = module {
                 // never cancelled here; logout clears it in-stream via SessionEnded.
                 get<LiveLocationReceiveStore>().reset()
 
-                // Self-heal crash-orphaned encrypted payload temps in outbox-temp/ (#844). The
-                // dir is KEEP-protected from the CacheSweeper (a pending send's payload must
-                // survive), so this idle+age-gated reap is its safety net. Fire-and-forget.
+                // Self-heal crash-orphaned encrypted payload temps. Two dirs (#842):
+                // the durable staging dir (outside cacheDir, invisible to the
+                // CacheSweeper — this reap is its only safety net) and the legacy
+                // <cacheDir>/outbox-temp (KEEP-protected; still referenced by outbox
+                // rows enqueued before the app update — drains itself, then only this
+                // reap empties leftovers). Fire-and-forget.
+                get<OutboxSync>().scheduleIdleOutboxTempReap(
+                    get<FileOperationsProvider>().getOutboxStagingDirectory()
+                )
                 get<OutboxSync>().scheduleIdleOutboxTempReap(
                     get<FileOperationsProvider>().getCacheDirectory().trimEnd('/') +
                         "/" + CacheAudit.OUTBOX_TEMP_DIR_NAME


### PR DESCRIPTION
Part 1 of 3 for #842 (stacked series: this → `outbox-staging-video` → `outbox-staging-stream-encrypt`).

## What

Encrypted outbox payloads move out of the OS-reclaimable `cacheDir` into a durable app-data staging dir, and a staged payload missing at drain time now drops the row on attempt 1 with an honest `OutboxItemDropped` instead of burning 20 retries as a phantom "Network failure" (the ENOENT loop in #842).

- **New `FileOperationsProvider` API**: `getOutboxStagingDirectory()` / `createOutboxStagingPath()` / `promoteToOutboxStaging()`, shared okio logic in `OutboxStaging.kt` (injectable `FileSystem`). Locations: JVM app-data dir, Android `noBackupFilesDir`, iOS Application Support (backup-excluded on every creation). Web keeps the cacheDir default — the wasm FS is RAM-only and the sql.js DB is in-memory, so outbox rows don't survive a refresh either; documented as deferred.
- **`writeBytesToOutboxTempFile`** default retargets every caller into the staging dir; the four per-platform `outbox-temp` overrides are deleted.
- **Lifecycle**: logout wipes the staging dir explicitly (the cacheDir sweep can't reach it); the idle orphan reap covers BOTH the new dir and legacy `<cacheDir>/outbox-temp`. The legacy KEEP rule in `CacheSweeper.decide` stays until pre-#842 rows can no longer exist (one release or so), so in-flight rows enqueued before the update still drain.
- **`StagedPayloadMissingException`**: `DriveUploadProvider` pre-flights every payload path on all three payload-carrying methods BEFORE the network call (deterministic + platform-independent — a lazy read failure arrives as a different exception type per platform and gets wrapped as transient `NetworkException`). URI-shaped sources (`content:`, `ph://`) stay WARN-only. `OutboxFailureClassifier` maps the typed exception to permanent.

## Tests

- `OutboxStagingTest`: path reservation, promote (file + dir, no-clobber), wipe, and the #842 durability property — a staged file survives both `sweepUntracked` and `sweepAll`.
- Classifier: typed exception → permanent; generic IO-flavored message → still retryable (guard).
- `OutboxSyncTest`: `StagedPayloadMissingException` drops the row on attempt 1 with `OutboxItemDropped`.

Verified locally: `jvmTest` (all modules), `testDebugUnitTest`, `:homebase-api:wasmJsTest`, Android/wasm compiles. iOS compiles only in CI (Linux dev host).

Closes nothing on its own — #842 closes with the full series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWmvC3HQ7E1rHaD2ZXFkpC