### PR TITLE
Cache bucket 2/3 (PR B): route encrypted video artifacts into durable outbox staging

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/upload/HlsScratchCleanup.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/upload/HlsScratchCleanup.kt
@@ -29,8 +29,12 @@ import okio.Path.Companion.toPath
  * removes the dir; subsequent calls fall through `safeDeleteRecursively`'s
  * "missing target → quiet false" path. A small in-call dedup avoids logging
  * the same path more than once per invocation.
+ *
+ * Public (not internal) because `PayloadBundleEncryptionService` in the
+ * homebase-upload module also calls it from its fail-soft catch — a bundle
+ * that dies mid-encryption must not leave a staged `hls_<uuid>/` dir behind.
  */
-internal fun cleanupHlsScratch(
+fun cleanupHlsScratch(
     payloads: List<PayloadFile>?,
     fileSystem: FileSystem = systemFileSystem,
 ) {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
@@ -11,6 +11,7 @@ import id.homebase.api.client.drives.upload.UpdateLocalAppdataContentOutboxReque
 import id.homebase.api.client.drives.upload.UpdateLocalMetadataTagsOutboxRequest
 import id.homebase.api.client.drives.upload.UploadFileRequest
 import id.homebase.api.client.drives.upload.cleanupHlsScratch
+import id.homebase.api.file.safeDeleteRecursively
 import id.homebase.api.file.systemFileSystem
 import okio.FileSystem
 import okio.Path.Companion.toPath
@@ -904,10 +905,22 @@ class OutboxSync(
         val files = runCatching { fileSystem.list(dir) }.getOrNull() ?: return
         var reaped = 0
         for (f in files) {
-            val mtime = fileSystem.metadataOrNull(f)?.lastModifiedAtMillis ?: continue
-            if (mtime < cutoff) runCatching { fileSystem.delete(f) }.onSuccess { reaped++ }
+            val meta = fileSystem.metadataOrNull(f) ?: continue
+            val mtime = meta.lastModifiedAtMillis ?: continue
+            if (mtime >= cutoff) continue
+            if (meta.isDirectory) {
+                // Staged HLS payloads are whole hls_<uuid>/ directories (#842) — a flat
+                // delete() fails on a non-empty dir, so they'd leak forever. Recursive-
+                // delete them (age-gated on the dir's own mtime, same idle precondition).
+                // Any OTHER directory shape is unexpected here: skip it, never guess.
+                if (f.name.startsWith("hls_") &&
+                    safeDeleteRecursively(outboxTempDir, f.name, fileSystem)
+                ) reaped++
+            } else {
+                runCatching { fileSystem.delete(f) }.onSuccess { reaped++ }
+            }
         }
-        if (reaped > 0) Logger.i("OutboxSync: reaped $reaped orphaned outbox-temp file(s) (outbox idle, >${maxAgeMs}ms old)")
+        if (reaped > 0) Logger.i("OutboxSync: reaped $reaped orphaned outbox-temp entrie(s) (outbox idle, >${maxAgeMs}ms old)")
     }
 
     suspend fun clearCheckout(timeoutMs: Long = 10_000) {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPayloadProcessor.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPayloadProcessor.kt
@@ -13,9 +13,9 @@ import id.homebase.api.file.withResolvedFile
 import id.homebase.api.image.createThumbnails
 import id.homebase.api.serialization.OdinSystemSerializer
 import io.ktor.utils.io.core.toByteArray
+import okio.Path.Companion.toPath
 import kotlin.time.Duration
 import kotlin.time.measureTimedValue
-import kotlin.uuid.Uuid
 
 
 class VideoPayloadProcessor(
@@ -238,7 +238,32 @@ class VideoPayloadProcessor(
                         "segments=${fileOperationsProvider.getFileSize(segmented.segmentsPath)}B"
                 }
 
-                Triple(segmented.playlistPath, segmented.segmentsPath, true)
+                // Promote the finished hls_<uuid>/ dir out of cacheDir scratch into the
+                // durable outbox staging dir (#842): the segment file rides an outbox row
+                // (possibly for days) and cacheDir scratch is swept on every startup.
+                // FFmpeg keeps writing into cacheDir (failure partials stay owned by
+                // FfmpegOutputCleanup / the startup sweep); this promote at the
+                // segmentation-success boundary IS the durability boundary. Key material
+                // (enc.key/keyinfo.txt) is already deleted by segmentAndEncrypt. The
+                // playlist references segments by bare filename, so moving the dir
+                // wholesale keeps it valid; cleanupHlsScratch keys off the hls_ dir-name
+                // prefix, which the promote preserves.
+                val scratchHlsDir = segmented.segmentsPath.toPath().parent
+                    ?: error("HLS segments path has no parent: ${segmented.segmentsPath}")
+                // Every FFmpegUtils actual writes into its own hls_<uuid>/ dir; promoting
+                // anything else wholesale (e.g. a shared scratch root) would drag sibling
+                // files along — fail loudly instead.
+                check(scratchHlsDir.name.startsWith("hls_")) {
+                    "expected an hls_<uuid> segment dir, got $scratchHlsDir"
+                }
+                val stagedHlsDir =
+                    fileOperationsProvider.promoteToOutboxStaging(scratchHlsDir.toString()).toPath()
+
+                Triple(
+                    (stagedHlsDir / segmented.playlistPath.toPath().name).toString(),
+                    (stagedHlsDir / segmented.segmentsPath.toPath().name).toString(),
+                    true,
+                )
             } else {
                 Triple(null, compressedPath, false)
             }
@@ -340,7 +365,10 @@ class VideoPayloadProcessor(
                     PayloadFile(
                         key = descriptorContentPayloadKey,
                         filePath =
-                            fileOperationsProvider.writeBytesToTempFile(
+                            // Encrypted, ready-to-transmit and referenced by the outbox row —
+                            // belongs in the durable staging bucket, NOT the disposable
+                            // upload-temp/ that gets swept every startup (#842).
+                            fileOperationsProvider.writeBytesToOutboxTempFile(
                                 keyHeader.encryptDataAes(metadataJson.toByteArray()),
                                 "payload",
                                 ".metadata"
@@ -377,8 +405,11 @@ class VideoPayloadProcessor(
         inputPath: String,
         keyHeader: KeyHeader
     ): String {
+        // Encrypted output goes straight into the durable outbox staging dir (#842) —
+        // writing it to cacheDir root left it untracked, so the startup sweep / OS
+        // cache reclaim deleted it out from under a pending outbox row (ENOENT retries).
         val outputPath =
-            "${fileOperationsProvider.getCacheDirectory()}/video-encrypted-${Uuid.random()}.bin"
+            fileOperationsProvider.createOutboxStagingPath("video-encrypted-", ".bin")
         fileOperationsProvider.writeStream(
             path = outputPath,
             data = AesCbc.streamEncryptWithCbc(

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSyncTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxSyncTest.kt
@@ -171,11 +171,33 @@ class OutboxSyncTest {
         sync.reapIdleOutboxTemps(dir.toString(), maxAgeMs = 1_000, fileSystem = fs, nowMs = m2 + 500)
         assertTrue(fs.exists(dir / "enc_new.encrypted"), "a just-written temp must never be reaped")
 
+        // Staged HLS payloads are whole hls_<uuid>/ DIRECTORIES (#842): idle + old → reaped
+        // recursively (a flat delete() would fail on the non-empty dir and leak it forever).
+        val hlsDir = dir / "hls_orphan"
+        fs.createDirectories(hlsDir)
+        fs.write(hlsDir / "index.ts") { writeUtf8("segments") }
+        fs.write(hlsDir / "index.m3u8") { writeUtf8("playlist") }
+        val hlsMtime = fs.metadata(hlsDir).lastModifiedAtMillis!!
+        sync.reapIdleOutboxTemps(dir.toString(), maxAgeMs = 1_000, fileSystem = fs, nowMs = hlsMtime + 5_000)
+        assertFalse(fs.exists(hlsDir), "idle + old orphan hls_ dir must be reaped recursively")
+
+        // A directory that is NOT hls_-shaped is unexpected here → never touched.
+        val strangeDir = dir / "not-ours"
+        fs.createDirectories(strangeDir)
+        fs.write(strangeDir / "file.bin") { writeUtf8("x") }
+        val strangeMtime = fs.metadata(strangeDir).lastModifiedAtMillis!!
+        sync.reapIdleOutboxTemps(dir.toString(), maxAgeMs = 1_000, fileSystem = fs, nowMs = strangeMtime + 5_000)
+        assertTrue(fs.exists(strangeDir / "file.bin"), "non-hls directories must never be reaped")
+
         // NON-EMPTY outbox + old file → kept (a pending/offline row might reference it).
         sync.tryEnqueue(DeleteFilesByGroupIdOutboxRequest(driveId = Uuid.random(), groupIds = listOf(Uuid.random())))
         val m3 = write("enc_pending.encrypted")
+        val hlsPending = dir / "hls_pending"
+        fs.createDirectories(hlsPending)
+        fs.write(hlsPending / "index.ts") { writeUtf8("segments") }
         sync.reapIdleOutboxTemps(dir.toString(), maxAgeMs = 1_000, fileSystem = fs, nowMs = m3 + 5_000)
         assertTrue(fs.exists(dir / "enc_pending.encrypted"), "must not reap while the outbox is non-empty")
+        assertTrue(fs.exists(hlsPending / "index.ts"), "must not reap hls dirs while the outbox is non-empty")
     }
 
     @Test

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/video/VideoPayloadProcessorCompressionSeamTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/video/VideoPayloadProcessorCompressionSeamTest.kt
@@ -28,11 +28,14 @@ import kotlin.test.assertTrue
 class VideoPayloadProcessorCompressionSeamTest {
 
     private val cacheDir = "/cache"
+    private val stagingDir = "/staging"
 
     /** Minimal in-memory [FileOperationsProvider] backed by a path→bytes map. */
     private inner class FakeFileOperationsProvider(
         private val store: MutableMap<String, ByteArray>,
     ) : FileOperationsProvider {
+        private var stagingCounter = 0
+
         override fun openFileInput(path: String): InputProvider =
             throw UnsupportedOperationException("not used")
 
@@ -63,6 +66,22 @@ class VideoPayloadProcessorCompressionSeamTest {
             val out = ArrayList<Byte>()
             data.collect { chunk -> chunk.forEach { out.add(it) } }
             store[path] = out.toByteArray()
+        }
+
+        // The interface defaults for the staging trio operate on the real
+        // systemFileSystem — reimplement them over the in-memory store.
+        override fun getOutboxStagingDirectory(): String = stagingDir
+
+        override suspend fun createOutboxStagingPath(prefix: String, suffix: String): String =
+            "$stagingDir/$prefix${stagingCounter++}$suffix"
+
+        override suspend fun promoteToOutboxStaging(path: String): String {
+            val target = "$stagingDir/${path.substringAfterLast('/')}"
+            val childPrefix = "$path/"
+            for (key in store.keys.filter { it == path || it.startsWith(childPrefix) }) {
+                store["$target${key.removePrefix(path)}"] = store.remove(key)!!
+            }
+            return target
         }
     }
 
@@ -165,8 +184,10 @@ class VideoPayloadProcessorCompressionSeamTest {
     fun largeCompressedVideoTakesHlsSegmentationPath() = runTest {
         val inputPath = "$cacheDir/input.mp4"
         val compressedPath = "$cacheDir/compressed.mp4"
-        val playlistPath = "$cacheDir/playlist.m3u8"
-        val segmentsPath = "$cacheDir/segments.ts"
+        // Real FFmpegUtils actuals write into an hls_<uuid>/ scratch dir; the processor
+        // promotes that whole dir into the durable staging area after segmentation (#842).
+        val playlistPath = "$cacheDir/hls_test/playlist.m3u8"
+        val segmentsPath = "$cacheDir/hls_test/segments.ts"
         val playlistText = "#EXTM3U\n#EXT-X-VERSION:3\n"
         // >= 5 MB → HLS segmentation.
         val store = mutableMapOf(
@@ -194,14 +215,60 @@ class VideoPayloadProcessorCompressionSeamTest {
         assertEquals("application/vnd.apple.mpegurl", result.videoMetadata.mimeType)
         assertEquals(playlistText, result.videoMetadata.hlsPlaylist)
         assertEquals(9_000f, result.videoMetadata.duration)
+
+        // #842: the segment payload the outbox row will reference must live in the
+        // durable staging dir (the hls_<uuid>/ dir was promoted out of cache scratch),
+        // and the scratch location must be gone.
+        val videoPayload = result.payloads.single { it.key == "vid" }
+        assertEquals("$stagingDir/hls_test/segments.ts", videoPayload.filePath)
+        assertFalse(store.containsKey(segmentsPath), "scratch segments must be moved, not copied")
+        assertFalse(store.containsKey(playlistPath), "scratch playlist must be moved, not copied")
+    }
+
+    @Test
+    fun oversizeMetadataStagesOverflowPayloadInTheDurableBucket() = runTest {
+        val inputPath = "$cacheDir/input.mp4"
+        val compressedPath = "$cacheDir/compressed.mp4"
+        val playlistPath = "$cacheDir/hls_big/playlist.m3u8"
+        val segmentsPath = "$cacheDir/hls_big/segments.ts"
+        // A playlist too large to embed in the descriptor (> MaxPayloadDescriptorBytes)
+        // forces the second, encrypted metadata payload — which rides the outbox row and
+        // must be staged in the durable bucket, NOT the disposable upload-temp (#842).
+        val playlistText = "#EXTM3U\n" + "#EXTINF:2.0,\nseg.ts\n".repeat(200)
+        val store = mutableMapOf(
+            inputPath to ByteArray(1024),
+            compressedPath to ByteArray(5 * 1024 * 1024),
+            playlistPath to playlistText.encodeToByteArray(),
+            segmentsPath to ByteArray(2048),
+        )
+        val fileOps = FakeFileOperationsProvider(store)
+        val compressor = FakeVideoCompressor(
+            compressedPath = compressedPath,
+            segmented = SegmentedVideo(playlistPath, segmentsPath),
+        )
+        val processor = VideoPayloadProcessor(fileOps, compressor, FakeVideoProbe(9_000L))
+
+        val result = processor.process(
+            payload = PayloadFile(key = "vid", filePath = inputPath),
+            keyHeader = KeyHeader.newRandom16(),
+            onProgress = null,
+            descriptorContentPayloadKey = "descriptor",
+        )
+
+        val overflow = result.payloads.single { it.key == "descriptor" }
+        assertTrue(
+            overflow.filePath.startsWith(stagingDir),
+            "overflow metadata payload must be staged durably: ${overflow.filePath}",
+        )
+        assertTrue(store.containsKey(overflow.filePath), "overflow payload bytes must be written")
     }
 
     @Test
     fun videoProgressIsDeduplicatedToWholePercentPerPhase() = runTest {
         val inputPath = "$cacheDir/input.mp4"
         val compressedPath = "$cacheDir/compressed.mp4"
-        val playlistPath = "$cacheDir/playlist.m3u8"
-        val segmentsPath = "$cacheDir/segments.ts"
+        val playlistPath = "$cacheDir/hls_test/playlist.m3u8"
+        val segmentsPath = "$cacheDir/hls_test/segments.ts"
         val playlistText = "#EXTM3U\n#EXT-X-VERSION:3\n"
         // >= 5 MB → HLS, so both compress and segmentAndEncrypt run (and fire progress ticks).
         val store = mutableMapOf(

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/video/VideoPayloadProcessorStreamEncryptTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/video/VideoPayloadProcessorStreamEncryptTest.kt
@@ -6,6 +6,7 @@ import java.io.File
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
+import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 
 /**
@@ -42,9 +43,17 @@ class VideoPayloadProcessorStreamEncryptTest {
         for (size in sizes) {
             val plaintext = ByteArray(size).also { Random.nextBytes(it) }
             val inputPath = provider.writeBytesToTempFile(plaintext, "stream_in_", ".bin")
+            var outputPath: String? = null
 
             try {
-                val outputPath = processor.encryptVideoFile(inputPath, key)
+                outputPath = processor.encryptVideoFile(inputPath, key)
+
+                // #842: the encrypted output an outbox row will reference must land in
+                // the durable staging dir, not cacheDir (which gets swept/OS-reclaimed).
+                assertTrue(
+                    outputPath.startsWith(provider.getOutboxStagingDirectory()),
+                    "encrypted video must be staged durably: $outputPath",
+                )
 
                 val bulkCipher = key.encryptDataAes(plaintext)
                 val streamCipher = File(outputPath).readBytes()
@@ -54,9 +63,9 @@ class VideoPayloadProcessorStreamEncryptTest {
                     streamCipher,
                     "Ciphertext mismatch at size=$size — streaming path is incompatible with bulk path",
                 )
-                provider.deleteTempFile(outputPath)
             } finally {
                 provider.deleteTempFile(inputPath)
+                outputPath?.let { provider.deleteTempFile(it) }
             }
         }
     }
@@ -69,14 +78,15 @@ class VideoPayloadProcessorStreamEncryptTest {
         val plaintext = ByteArray(5 * 1024 * 1024 + 123).also { Random.nextBytes(it) }
         val inputPath = provider.writeBytesToTempFile(plaintext, "rt_in_", ".bin")
 
+        var outputPath: String? = null
         try {
-            val outputPath = processor.encryptVideoFile(inputPath, key)
+            outputPath = processor.encryptVideoFile(inputPath, key)
             val cipherBytes = File(outputPath).readBytes()
             val decrypted = key.decrypt(cipherBytes)
             assertContentEquals(plaintext, decrypted)
-            provider.deleteTempFile(outputPath)
         } finally {
             provider.deleteTempFile(inputPath)
+            outputPath?.let { provider.deleteTempFile(it) }
         }
     }
 

--- a/homebase-upload/src/commonMain/kotlin/id/homebase/upload/PayloadBundleEncryptionService.kt
+++ b/homebase-upload/src/commonMain/kotlin/id/homebase/upload/PayloadBundleEncryptionService.kt
@@ -3,6 +3,7 @@ package id.homebase.upload
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.drives.files.PayloadFile
 import id.homebase.api.client.drives.files.ThumbnailFile
+import id.homebase.api.client.drives.upload.cleanupHlsScratch
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.common.SecureByteArray
@@ -116,6 +117,10 @@ class PayloadBundleEncryptionService(
             // swept-mid-bundle race). Reap the encrypted temps produced so far so the
             // failed send leaves no orphaned enc*/video temps, then rethrow to fail soft.
             newPayloads.forEach { runCatching { fileOps.deleteTempFile(it.filePath) } }
+            // The per-file delete above reaps a staged HLS index.ts but leaves its
+            // hls_<uuid>/ parent (and sibling playlist). In the durable staging dir that
+            // would linger until the idle reap instead of the next startup sweep (#842).
+            runCatching { cleanupHlsScratch(newPayloads) }
             throw e
         }
 


### PR DESCRIPTION
Part 2 of 3 for #842 — stacked on #943. Retarget to `main` after #943 merges (GitHub does this automatically on branch delete); CI runs then.

## What

The three video staging sites that still wrote sweeper-eligible cache locations move into the durable staging dir from #943:

- **Non-HLS**: `encryptVideoFile` output (`video-encrypted-*.bin`) was written to cacheDir ROOT — untracked, deleted by every startup sweep while its outbox row waited. Now reserved via `createOutboxStagingPath()`.
- **HLS**: ffmpeg keeps writing `hls_<uuid>/` into cacheDir scratch (failure partials stay owned by `FfmpegOutputCleanup`/startup sweep); the finished dir is PROMOTED wholesale into staging at the segmentation-success boundary — no `FFmpegUtils` actual touched. Receivers rewrite every non-comment playlist line to their local segment file, so the embedded playlist needs no content rewrite; `cleanupHlsScratch` keys off the `hls_` dir-name prefix, which the promote preserves.
- **HLS-overflow metadata payload**: was staged via `writeBytesToTempFile` into the DISPOSABLE `upload-temp` bucket; now `writeBytesToOutboxTempFile`.

Supporting: `reapIdleOutboxTemps` recursively reaps orphaned `hls_*` directories (a flat `delete()` fails on non-empty dirs → they'd leak forever; non-hls dirs are never touched), and `PayloadBundleEncryptionService`'s fail-soft catch also runs `cleanupHlsScratch` (widened to public for the cross-module call).

## Tests

Seam tests assert segment + overflow payloads land in staging and scratch is moved-not-copied; stream-encrypt parity test pins the staging location; reaper tests cover hls-dir reap/keep/idle-gate cases.

Verified locally: `jvmTest` (all modules), `testDebugUnitTest`, `:homebase-api:wasmJsTest`, Android/wasm compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWmvC3HQ7E1rHaD2ZXFkpC