### PR TITLE
feat(location): show link-freshness age in hours through 96h

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
@@ -672,12 +672,12 @@ private fun LocateStatusTrailing(status: LocateVerifyStatus?) {
     }
 }
 
-/** Compact "age since newest data" label: minutes, then hours, then days. */
+/** Compact "age since newest data" label: minutes, then hours (through 96 h), then days. */
 @Composable
 private fun formatLocateAge(ageMs: Long): String = when {
     ageMs < 60 * 60_000L ->
         stringResource(MR.string.live_location_age_minutes, (ageMs / 60_000L).toInt().coerceAtLeast(0))
-    ageMs < 24 * 60 * 60_000L ->
+    ageMs <= 96 * 60 * 60_000L ->
         stringResource(MR.string.location_locate_age_hours, (ageMs / 3_600_000L).toInt())
     else ->
         stringResource(MR.string.location_locate_age_days, (ageMs / 86_400_000L).toInt())


### PR DESCRIPTION
## What

Follow-up to #942. Adjusts the compact "age since newest data" label in the **"Who I can locate"** dashboard section so it stays in **hours until the data is older than 96 hours**, then switches to **days** (previously it switched at 24 h).

A 3-day-old fix now reads `72h` instead of `3d`.

## Change

`formatLocateAge` in `LocationDashboardContent.kt` — the days threshold moves from `24 * 60 * 60_000L` to `96 * 60 * 60_000L`:

- `< 60 min` → minutes (`23m`)
- `≤ 96 h` → hours (`5h`, `72h`)
- `> 96 h` → days (`5d`)

The warning-color threshold (past a day) is unchanged, so e.g. `72h` still renders warning-colored.

## Verification

- ✅ `:homebase-core:compileKotlinJvm` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)