### PR TITLE
Send path: stop buffering whole payloads in memory (iOS upload read, Okio read, seeder cap)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/OkioFileOperationsProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/OkioFileOperationsProvider.kt
@@ -4,6 +4,9 @@ import io.ktor.client.request.forms.InputProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.io.Buffer
+import kotlinx.io.RawSource
+import kotlinx.io.buffered
+import okio.BufferedSource
 import okio.FileSystem
 import okio.buffer
 import okio.use
@@ -22,10 +25,18 @@ open class OkioFileOperationsProvider(
     private val cacheDir: String,
 ) : FileOperationsProvider {
 
-    override fun openFileInput(path: String): InputProvider {
-        val bytes = fileSystem.read(path.toPath()) { readByteArray() }
-        return InputProvider(size = bytes.size.toLong()) { Buffer().apply { write(bytes) } }
-    }
+    /**
+     * Lazy, CHUNKED multipart upload source (#947). Previously this read the whole
+     * file eagerly at `openFileInput` time and replayed the captured array on every
+     * block invocation. Now each ktor block invocation reopens the file (the block
+     * is re-invoked on ktor retries and outbox re-drives) and streams 64 KB at a
+     * time. `size` stays populated from metadata — it feeds the multipart
+     * Content-Length and is pinned by OkioFileOperationsProviderTest.
+     */
+    override fun openFileInput(path: String): InputProvider =
+        InputProvider(size = fileSystem.metadataOrNull(path.toPath())?.size) {
+            OkioBackedRawSource(fileSystem.source(path.toPath()).buffer()).buffered()
+        }
 
     override suspend fun readFileBytes(path: String): ByteArray =
         fileSystem.read(path.toPath()) { readByteArray() }
@@ -112,4 +123,28 @@ open class OkioFileOperationsProvider(
     }
 
     private fun randomToken(): String = Random.nextLong().toULong().toString(16)
+}
+
+/**
+ * A [kotlinx.io.RawSource] over an okio [BufferedSource], read in [chunkSize] steps —
+ * the lazy backing for [OkioFileOperationsProvider.openFileInput] (#947). Holds at
+ * most one chunk in memory. No okio↔kotlinx-io bridge exists in the repo; this small
+ * adapter is that bridge for the read direction.
+ */
+private class OkioBackedRawSource(
+    private val source: BufferedSource,
+    private val chunkSize: Int = FileOperationsProvider.DEFAULT_HEADER_BYTES,
+) : RawSource {
+    private val buf = ByteArray(chunkSize)
+
+    override fun readAtMostTo(sink: Buffer, byteCount: Long): Long {
+        require(byteCount >= 0L) { "byteCount must be non-negative: $byteCount" }
+        if (byteCount == 0L) return 0L
+        val read = source.read(buf, 0, minOf(byteCount, chunkSize.toLong()).toInt())
+        if (read == -1) return -1L
+        sink.write(buf, startIndex = 0, endIndex = read)
+        return read.toLong()
+    }
+
+    override fun close() = source.close()
 }

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/file/OkioFileOperationsProviderTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/file/OkioFileOperationsProviderTest.kt
@@ -3,10 +3,12 @@ package id.homebase.api.file
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
+import kotlinx.io.readByteArray
 import okio.fakefilesystem.FakeFileSystem
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
 import kotlin.test.assertTrue
 
 /**
@@ -83,6 +85,44 @@ class OkioFileOperationsProviderTest {
 
         assertTrue(path.contains(SHARE_OUTBOUND_DIR_NAME), "must live under the share-outbound subdir: $path")
         assertContentEquals(byteArrayOf(7, 8, 9), ops.readFileBytes(path), "share file must round-trip")
+    }
+
+    /**
+     * #947: openFileInput must be LAZY and CHUNKED — the block reopens the file per
+     * invocation (ktor re-invokes it on retries; the outbox re-drives whole sends),
+     * and nothing is read until the block runs.
+     */
+    @Test
+    fun openFileInputStreamsLazilyAndIsReinvokable() = runTest {
+        val ops = provider()
+        // Bigger than one 64 KB chunk so the chunk loop actually iterates.
+        val bytes = ByteArray(150_000) { (it % 251).toByte() }
+        val path = ops.writeBytesToTempFile(bytes, "input_", ".bin")
+
+        val input = ops.openFileInput(path)
+        assertEquals(bytes.size.toLong(), input.size, "size must come from metadata")
+
+        // Two invocations of the SAME provider block must each yield the full bytes —
+        // the old impl replayed one eagerly-captured array; the contract is reopen-per-call.
+        repeat(2) { round ->
+            val source = input.block()
+            assertContentEquals(bytes, source.readByteArray(), "block invocation #$round must stream the full file")
+        }
+    }
+
+    @Test
+    fun openFileInputReadsNothingUntilTheBlockRuns() = runTest {
+        val ops = provider()
+        val path = ops.writeBytesToTempFile(byteArrayOf(1, 2, 3), "lazy_", ".bin")
+
+        val input = ops.openFileInput(path)
+        // Deleting AFTER openFileInput but BEFORE the block runs must make the read
+        // fail — proof no eager read happened at openFileInput time.
+        ops.deleteTempFile(path)
+
+        assertFails("a missing file must surface when the block runs, not earlier") {
+            input.block().readByteArray()
+        }
     }
 
     @Test

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/IOSFileOperationsProvider.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/file/IOSFileOperationsProvider.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.io.Buffer
+import kotlinx.io.RawSource
+import kotlinx.io.buffered
 import platform.Foundation.NSApplicationSupportDirectory
 import platform.Foundation.NSCachesDirectory
 import platform.Foundation.NSData
@@ -60,13 +62,31 @@ class IOSFileOperationsProvider : FileOperationsProvider {
         }
     }
 
+    /**
+     * Lazy, CHUNKED multipart upload source (#947). The previous implementation
+     * buffered the entire staged encrypted payload (`Buffer().write(readFileData(path))`)
+     * when the outbox drained — with single-file HLS that meant a whole video in RAM
+     * at send time, despite streamed encryption (#842). Now the ktor block opens a
+     * fresh [FileHandleRawSource] per invocation (the block is re-invoked on ktor
+     * retries and outbox re-drives, so it must be re-creatable) and streams 64 KB at
+     * a time. `size` feeds the multipart Content-Length; app-level progress totals
+     * come from `calculateUploadSize`, not from here.
+     *
+     * Photos-library sources (`ph://` / raw PHAsset ids) keep the whole-file path:
+     * PHImageManager has no byte-stream API, these are photo-sized, and videos never
+     * come through here — they're materialized to a real file via [resolveToFilePath].
+     */
     @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
-    override fun openFileInput(path: String): InputProvider = InputProvider {
+    override fun openFileInput(path: String): InputProvider {
         if (path.startsWith("ph://") || path.contains("/L0/")) {
-            val bytes = runBlocking { readPhotoLibraryAsset(path) }
-            return@InputProvider Buffer().apply { write(bytes) }
+            return InputProvider {
+                val bytes = runBlocking { readPhotoLibraryAsset(path) }
+                Buffer().apply { write(bytes) }
+            }
         }
-        Buffer().apply { write(readFileData(path)) }
+        return InputProvider(size = getFileSize(path).takeIf { it > 0 }) {
+            FileHandleRawSource(path).buffered()
+        }
     }
 
     @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
@@ -392,4 +412,48 @@ class IOSFileOperationsProvider : FileOperationsProvider {
         }
 
 
+}
+
+/**
+ * A [RawSource] over an [NSFileHandle] read in [chunkSize] steps — the lazy backing
+ * for [IOSFileOperationsProvider.openFileInput] (#947). Holds at most one chunk in
+ * memory at a time. Mirrors the chunk loop of `readFileAsFlow` (incl. the pinned
+ * `memcpy` idiom) and the security-scoped-resource guard of `readFileData`: access
+ * is acquired on construction and released in [close] alongside the file handle.
+ * A missing file throws the same `IllegalStateException("Unable to read file …")`
+ * shape as the other readers.
+ */
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+private class FileHandleRawSource(
+    path: String,
+    private val chunkSize: Int = FileOperationsProvider.DEFAULT_HEADER_BYTES,
+) : RawSource {
+    private val url = NSURL.fileURLWithPath(path)
+    private val accessed = url.startAccessingSecurityScopedResource()
+    private val handle = NSFileHandle.fileHandleForReadingAtPath(path)
+        ?: run {
+            if (accessed) url.stopAccessingSecurityScopedResource()
+            error("Unable to read file at $path")
+        }
+    private var closed = false
+
+    override fun readAtMostTo(sink: Buffer, byteCount: Long): Long {
+        require(byteCount >= 0L) { "byteCount must be non-negative: $byteCount" }
+        if (byteCount == 0L) return 0L
+        check(!closed) { "source is closed" }
+        val data = handle.readDataOfLength(minOf(byteCount, chunkSize.toLong()).toULong())
+        val len = data.length.toInt()
+        if (len == 0) return -1L
+        val bytes = ByteArray(len)
+        bytes.usePinned { pinned -> memcpy(pinned.addressOf(0), data.bytes, data.length) }
+        sink.write(bytes)
+        return len.toLong()
+    }
+
+    override fun close() {
+        if (closed) return
+        closed = true
+        handle.closeFile()
+        if (accessed) url.stopAccessingSecurityScopedResource()
+    }
 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/PayloadCacheSeederTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/PayloadCacheSeederTest.kt
@@ -24,6 +24,8 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertTrue
 import kotlin.uuid.Uuid
 
 /**
@@ -45,13 +47,21 @@ class PayloadCacheSeederTest {
 
     // Returns bytes for a known path; throws for the "missing" path to exercise best-effort.
     private val fileBytes = mutableMapOf<String, ByteArray>()
+    // Overrides what getFileSize reports for a path (defaults to the byte length) —
+    // lets the cap test claim a huge size without allocating it.
+    private val fileSizes = mutableMapOf<String, Long>()
+    // Every readFileBytes call — the cap test asserts the capped payload was never read.
+    private val readPaths = mutableListOf<String>()
     private val fileOps = object : FileOperationsProvider {
         override fun getCacheDirectory() = tempDir
-        override suspend fun readFileBytes(path: String): ByteArray =
-            fileBytes[path] ?: throw IOException("no bytes for $path")
+        override suspend fun readFileBytes(path: String): ByteArray {
+            readPaths += path
+            return fileBytes[path] ?: throw IOException("no bytes for $path")
+        }
         override fun openFileInput(path: String): InputProvider = error("not used")
         override fun deleteTempFile(path: String) = false
-        override fun getFileSize(path: String) = 0L
+        override fun getFileSize(path: String) =
+            fileSizes[path] ?: fileBytes[path]?.size?.toLong() ?: 0L
         override suspend fun writeBytesToTempFile(bytes: ByteArray, prefix: String, suffix: String): String = error("not used")
         override suspend fun writeBytesToShareOutboundFile(bytes: ByteArray, suffix: String): String = error("not used")
         override suspend fun writeStream(path: String, data: Flow<ByteArray>) = error("not used")
@@ -143,5 +153,45 @@ class PayloadCacheSeederTest {
         assertContentEquals(goodBytes, good.bytes)
         val thumb = driveCache.getThumbBytesRaw(driveId, fileId, "good", 320, 320)
         assertContentEquals(ByteArray(8) { 7 }, thumb.bytes)
+    }
+
+    /**
+     * #947: a payload above [PayloadCacheSeeder.MAX_SEED_PAYLOAD_BYTES] must not be
+     * read at all (readFileBytes buffers the whole payload in RAM — a full-video-size
+     * allocation per send) and must not land in the cache; its thumbnails are the
+     * critical seed and still land. Small payloads in the same bundle are unaffected.
+     */
+    @Test
+    fun `skips payload seeding above the size cap but still seeds thumbnails`() = runTest {
+        val bigPath = "/tmp/huge-video"
+        fileBytes[bigPath] = ByteArray(4) { 9 }              // present on disk...
+        fileSizes[bigPath] = PayloadCacheSeeder.MAX_SEED_PAYLOAD_BYTES + 1  // ...but reports as huge
+        val smallBytes = ByteArray(16) { 0x21 }
+        fileBytes["/tmp/small"] = smallBytes
+        val videoThumb = ByteArray(12) { 5 }
+
+        val bundle = PayloadBundle(
+            payloads = listOf(
+                PayloadFile(key = "video", filePath = bigPath, contentType = "video/mp2t"),
+                PayloadFile(key = "photo", filePath = "/tmp/small", contentType = "image/jpeg"),
+            ),
+            thumbnails = listOf(
+                ThumbnailFile(pixelWidth = 320, pixelHeight = 180, thumbnailBytes = videoThumb, key = "video"),
+            ),
+            previewThumbs = emptyList(),
+        )
+
+        seeder.seed(driveId, fileId, bundle)
+
+        assertTrue(bigPath !in readPaths, "capped payload must never be readFileBytes'd")
+        // Not seeded → the read escapes the cache and hits the throwing MockEngine.
+        assertFails("capped payload must not be served from the cache") {
+            driveCache.getPayloadBytesRaw(driveId, fileId, "video")
+        }
+        // The video's thumbnail and the sibling small payload are seeded as before.
+        val thumb = driveCache.getThumbBytesRaw(driveId, fileId, "video", 320, 180)
+        assertContentEquals(videoThumb, thumb.bytes)
+        val small = driveCache.getPayloadBytesRaw(driveId, fileId, "photo")
+        assertContentEquals(smallBytes, small.bytes)
     }
 }

--- a/homebase-upload/src/commonMain/kotlin/id/homebase/upload/PayloadCacheSeeder.kt
+++ b/homebase-upload/src/commonMain/kotlin/id/homebase/upload/PayloadCacheSeeder.kt
@@ -22,6 +22,13 @@ import kotlin.uuid.Uuid
  * Best-effort: each entry is independent, the cache is LRU-bounded, and a miss
  * only degrades to a re-download / unrecoverable-media retry — so a single
  * failure is logged and skipped, never propagated.
+ *
+ * Payloads above [MAX_SEED_PAYLOAD_BYTES] are NOT seeded (#947): the thumbnail
+ * seed below is the critical one (it's what the bubble renders) and is small;
+ * the payload seed is a convenience that avoids a server re-download. The
+ * consequence of a skip is the same as an LRU eviction: a failed-send Retry
+ * whose create never reached the server degrades to UnrecoverableMedia for
+ * that message.
  */
 open class PayloadCacheSeeder(
     private val driveFileProvider: DriveFileProvider,
@@ -30,6 +37,17 @@ open class PayloadCacheSeeder(
     open suspend fun seed(driveId: Uuid, fileId: Uuid, bundle: PayloadBundle) {
         for (payload in bundle.payloads) {
             try {
+                // Probe the size BEFORE readFileBytes — the read buffers the whole
+                // payload in RAM, which for a large (single-file HLS) video was a
+                // full-video-size allocation on every send (#947).
+                val size = fileOperationsProvider.getFileSize(payload.filePath)
+                if (size > MAX_SEED_PAYLOAD_BYTES) {
+                    Logger.i(tag = TAG) {
+                        "seed: skipping payload seed key=${payload.key} size=$size " +
+                            "(> $MAX_SEED_PAYLOAD_BYTES) — convenience seed only, thumbs still seeded"
+                    }
+                    continue
+                }
                 driveFileProvider.cachePayloadBytesEncrypted(
                     driveId = driveId,
                     fileId = fileId,
@@ -58,7 +76,16 @@ open class PayloadCacheSeeder(
         }
     }
 
-    private companion object {
-        const val TAG = "PayloadCacheSeeder"
+    companion object {
+        private const val TAG = "PayloadCacheSeeder"
+
+        /**
+         * Payload seeding is a convenience (avoids a server re-download for the
+         * sender); thumbnails are the critical seed and are small. Above this size
+         * the 200 MB LRU payload cache can't usefully retain the entry anyway, and
+         * `readFileBytes` would spike RAM by the full payload size. Aligned with
+         * `CacheAudit.LOUD_THRESHOLD_BYTES` (the existing "large cache entry" signal).
+         */
+        const val MAX_SEED_PAYLOAD_BYTES: Long = 50L * 1024 * 1024
     }
 }


### PR DESCRIPTION
Fixes #947 — follow-up to the #842 series (#943/#944/#945).

## What

Three send-path sites still loaded an entire payload into RAM:

1. **iOS upload read (worst)**: `openFileInput` buffered the whole staged encrypted payload at outbox-drain time — with single-file HLS that's the entire video in RAM despite streamed encryption. New `FileHandleRawSource` (`kotlinx.io.RawSource` over `NSFileHandle`, 64 KB chunks, same security-scoped-resource guard as `readFileData`) behind a lazy `InputProvider` whose block reopens the file per invocation (ktor retries / outbox re-drives re-invoke it). `ph://` images keep the whole-file path (no Photos byte-stream API; videos are materialized to real files first).
2. **Okio/web `openFileInput`**: read the whole file eagerly at `openFileInput` time and replayed the captured array on every block invocation. New `OkioBackedRawSource` (okio `BufferedSource` → `kotlinx.io.RawSource` bridge); reopen-per-call; `.size` stays populated from metadata.
3. **`PayloadCacheSeeder`**: `readFileBytes` on every payload (full-video-size allocation per send) to seed the *convenience* payload cache. Payloads > 50 MB are now skipped with a log — thumbnails, the critical seed, are unchanged and tiny. A skipped seed has the same consequence as today's LRU eviction: a never-landed create's Retry degrades to `UnrecoverableMedia`.

No wire-format change — same bytes, different read strategy. App-level upload progress is unaffected (`calculateUploadSize` owns totals).

## Tests
- Okio `InputProvider`: streams the exact bytes, block re-invokable (full bytes both times — pins the reopen contract the old impl violated), nothing read until the block runs (delete-after-open proves laziness).
- Seeder: capped payload never `readFileBytes`'d and not served from cache; its thumbnail and sibling small payloads still seed.
- iOS `RawSource`: compiles in the `Build iOS` CI job (Linux dev host can't); logic mirrors the tested JVM/Okio chunk loops.

Verified locally: `jvmTest` + `testDebugUnitTest` (all modules), `:homebase-api:wasmJsTest`, jvm/android/wasm compiles for homebase-api + homebase-upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWmvC3HQ7E1rHaD2ZXFkpC