### PR TITLE
fix(chat): render block markdown synchronously to stop bubble reflow (#938)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MarkdownRenderer.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MarkdownRenderer.kt
@@ -42,6 +42,7 @@ import com.mikepenz.markdown.m3.markdownColor
 import com.mikepenz.markdown.m3.markdownTypography
 import com.mikepenz.markdown.model.markdownDimens
 import com.mikepenz.markdown.model.markdownPadding
+import com.mikepenz.markdown.model.rememberMarkdownState
 import id.homebase.api.util.markdownHasBlockElements
 import id.homebase.api.util.markdownToPlainPreview
 import id.homebase.api.util.withChatHardLineBreaks
@@ -252,8 +253,18 @@ fun ChatMarkdown(
         ),
     )
 
-    Markdown(
+    // Parse the markdown SYNCHRONOUSLY (immediate = true) so the block bubble measures
+    // at its final height on the first frame. The default async parse renders an empty
+    // loading placeholder for ~400ms then jumps to full height, reflowing the message
+    // list — the "bubble shifts down" bug (#938). Chat bodies are size-capped (7 KB
+    // header) and the parse is remember(content)-memoized, so the synchronous cost is
+    // small; the library's "blocks composition" warning targets large documents.
+    val markdownState = rememberMarkdownState(
         content = content.withChatHardLineBreaks(),
+        immediate = true,
+    )
+    Markdown(
+        markdownState = markdownState,
         colors = colors,
         typography = typography,
         // Default is fillMaxSize(); a chat bubble must wrap its content.


### PR DESCRIPTION
## Summary
Fixes #938 — block-markdown chat bubbles reflow ~a screenful on first render.

Block-markdown bodies (multi-paragraph, or heading / list / quote / code / table / rule) render through mikepenz `Markdown()`, which parses **asynchronously** and shows a fixed ~198px loading placeholder for ~400ms before swapping in the real content — a large, late height change that reflows the `LazyColumn` (the visible "bubble shifting down"). Inline-only bodies render synchronously and are unaffected.

This parses the block markdown **synchronously** so the bubble measures at its final height on the first frame:

```kotlin
val markdownState = rememberMarkdownState(content.withChatHardLineBreaks(), immediate = true)
Markdown(markdownState = markdownState, …)
```

`immediate = true` runs `parseBlocking()` in the initial `remember`, so the state is `Success` on the first composition — no loading placeholder.

## Verification (device — Redmi Note 5 Pro)
Instrumented `onSizeChanged` on the bubble root, cold-open of the same conversation:

```
BEFORE:  69ac  198 → 996  (jump 418ms later)     a3ba  198 → 512  (jump 421ms later)
AFTER:   69ac  996 (first frame, once)           a3ba  512 (first frame, once)
```

No placeholder frame, no reflow. Markdown (bold / link / etc.) still renders correctly; inline bubbles unchanged.

## Notes
- Chat bodies are 7 KB-capped and the parse is `remember(content)`-memoized, so the synchronous cost is small; the library's "blocks composition" warning targets large documents.
- Follow-up if the scroll-in re-parse ever becomes a cost on low-end devices: hoist/cache the parsed `MarkdownState` per message id above the `LazyColumn` so list recycling doesn't re-parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125H6rYqdTyGMeVvwPXCUuq
