### PR TITLE
Cache bucket 3/3 (PR 1): 50 MB render/export boundary + download facade + streaming reroutes

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/OdinApiProviderBase.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/OdinApiProviderBase.kt
@@ -16,7 +16,11 @@ import io.ktor.client.request.patch
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsChannel
 import io.ktor.client.statement.readRawBytes
+import io.ktor.http.contentLength
+import io.ktor.utils.io.cancel
+import io.ktor.utils.io.readAvailable
 import io.ktor.http.ContentType
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
@@ -154,13 +158,35 @@ abstract class OdinApiProviderBase(
         }
     }
 
+    /**
+     * Fetch a binary body fully into RAM. When [maxBytes] is set (#845), the read
+     * is size-guarded: an over-limit `Content-Length` is refused BEFORE the body
+     * is read, and a length-less (chunked) response is aborted the moment the
+     * running count passes the limit — worst-case RAM is limit + one chunk, never
+     * unbounded. The throw is [PayloadTooLargeException] (not an IOException), so
+     * [networkCall] passes it through untyped-wrapped and the outbox classifier /
+     * callers can treat it as non-retryable.
+     */
     protected suspend fun requestBytes(
+        maxBytes: Long? = null,
         block: suspend () -> HttpResponse
     ): ByteApiResponse {
 
         val (response, bytes) = networkCall {
             val r = block()
-            r to r.readRawBytes()
+            if (maxBytes != null) {
+                val contentLength = r.contentLength()
+                if (contentLength != null && contentLength > maxBytes) {
+                    // Best-effort body discard — some engines throw their own
+                    // length-mismatch error from cancel; never let that mask the
+                    // typed refusal.
+                    runCatching { r.bodyAsChannel().cancel(null) }
+                    throw PayloadTooLargeException(sizeBytes = contentLength, limitBytes = maxBytes)
+                }
+                r to readBodyCapped(r, maxBytes)
+            } else {
+                r to r.readRawBytes()
+            }
         }
 
         val contentType =
@@ -174,6 +200,35 @@ abstract class OdinApiProviderBase(
             bytes = bytes,
             contentType = contentType
         )
+    }
+
+    /**
+     * Read the response body while counting — the chunked-transfer fallback for
+     * the [requestBytes] size guard, for responses without a Content-Length.
+     */
+    private suspend fun readBodyCapped(response: HttpResponse, maxBytes: Long): ByteArray {
+        val channel = response.bodyAsChannel()
+        val chunks = ArrayList<ByteArray>()
+        var total = 0L
+        val buf = ByteArray(64 * 1024)
+        while (true) {
+            val read = channel.readAvailable(buf, 0, buf.size)
+            if (read == -1) break
+            if (read == 0) continue
+            total += read
+            if (total > maxBytes) {
+                channel.cancel(null)
+                throw PayloadTooLargeException(sizeBytes = -1, limitBytes = maxBytes)
+            }
+            chunks.add(buf.copyOf(read))
+        }
+        val out = ByteArray(total.toInt())
+        var off = 0
+        for (c in chunks) {
+            c.copyInto(out, off)
+            off += c.size
+        }
+        return out
     }
 
     // ------------------------------------------------------------

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/PayloadSizePolicy.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/PayloadSizePolicy.kt
@@ -1,0 +1,38 @@
+package id.homebase.api.client
+
+/**
+ * The RENDER/EXPORT boundary for downloaded payloads (#845).
+ *
+ * Guiding rule: the LRU payload cache only holds what the app can render
+ * in-app — a payload the app can't render has no second read, so caching it
+ * buys nothing and (worse) a single oversized commit makes Coil's LRU trim
+ * evict every other entry and then the new entry itself.
+ *
+ * - Byte-array payload reads at or below [RENDER_LIMIT_BYTES] are "render"
+ *   reads: allowed in RAM and admitted to the LRU disk caches.
+ * - Anything larger is "export": it must be streamed to a file
+ *   (`DriveFileProvider.streamPayloadDecryptedToPath` /
+ *   `PayloadDownloadService.exportToTemp`) and never enters a cache.
+ *
+ * One number, three enforcement points — the network byte reader
+ * (`OdinApiProviderBase.requestBytes`), the cache admission fence
+ * (`DriveFileProviderCached.writeToDiskCache`), and the send-side seeder cap
+ * (`PayloadCacheSeeder`) — all delegate here so they can't drift.
+ */
+object PayloadSizePolicy {
+    const val RENDER_LIMIT_BYTES: Long = 50L * 1024 * 1024
+}
+
+/**
+ * A byte-array payload read was refused because the body exceeds
+ * [PayloadSizePolicy.RENDER_LIMIT_BYTES]. Not retryable — the payload will
+ * never shrink; callers must switch to the streaming/export API
+ * (`streamPayloadDecryptedToPath` / `PayloadDownloadService.exportToTemp`).
+ *
+ * [sizeBytes] is the server-reported Content-Length, or -1 when the response
+ * had no length header and the limit was hit while reading.
+ */
+class PayloadTooLargeException(
+    val sizeBytes: Long,
+    val limitBytes: Long,
+) : Exception("payload ${if (sizeBytes >= 0) "$sizeBytes bytes" else "of unknown size"} exceeds render limit $limitBytes — use the streaming export API")

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
@@ -6,6 +6,7 @@ import id.homebase.api.client.ByteApiResponse
 import id.homebase.api.client.cache.CacheStats
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.NotFoundException
+import id.homebase.api.client.PayloadSizePolicy
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.drives.files.BytesResponse
 import id.homebase.api.client.drives.files.DriveFileHelpers
@@ -76,7 +77,7 @@ import okio.use
 class DriveFileProviderCached(
         httpClient: HttpClient,
         credentialsManager: CredentialsManager,
-        fileOperationsProvider: FileOperationsProvider
+        private val fileOperationsProvider: FileOperationsProvider
 ) {
     private val delegate: DriveFileHttpProvider =
             DriveFileHttpProvider(httpClient, credentialsManager)
@@ -261,11 +262,13 @@ class DriveFileProviderCached(
             key: String,
             keyHeader: KeyHeader,
             outputPath: String,
-            fileOps: FileOperationsProvider
+            fileOps: FileOperationsProvider = fileOperationsProvider,
+            onProgress: ((Float) -> Unit)? = null,
     ): Boolean {
         val cacheKey = buildPayloadCacheKey(driveId, fileId, key, null, null)
         val snapshot = payloadDiskCache.openSnapshot(cacheKey.toDiskKey())
-                ?: return delegate.streamPayloadDecryptedToPath(driveId, fileId, key, keyHeader, outputPath, fileOps)
+                ?: return delegate.streamPayloadDecryptedToPath(
+                        driveId, fileId, key, keyHeader, outputPath, fileOps, onProgress)
 
         return snapshot.use { snap ->
             val encryptedFlow = channelFlow<ByteArray> {
@@ -288,6 +291,8 @@ class DriveFileProviderCached(
 
             val decryptedFlow = AesCbc.streamDecryptWithCbc(encryptedFlow, keyHeader.aesKey, keyHeader.iv)
             fileOps.writeStream(outputPath, decryptedFlow)
+            // Cache hit is local-disk speed — progress jumps straight to done.
+            onProgress?.invoke(1f)
             true
         }
     }
@@ -444,6 +449,17 @@ class DriveFileProviderCached(
             logTag: String,
             value: ByteApiResponse
     ) {
+        // Admission fence (#845): an entry above the render limit has no second
+        // read in-app, and committing it would make Coil's trimToSize evict every
+        // other entry and then the new entry itself — pure churn. The network
+        // guard in requestBytes keeps full reads under the limit already; this is
+        // defense-in-depth for locally-seeded bytes and any future caller.
+        if (value.bytes.size > PayloadSizePolicy.RENDER_LIMIT_BYTES) {
+            Logger.w(tag = logTag) {
+                "cache-admit REFUSED size=${value.bytes.size} (> ${PayloadSizePolicy.RENDER_LIMIT_BYTES}) key=$cacheKey"
+            }
+            return
+        }
         val editor = cache.openEditor(cacheKey.toDiskKey()) ?: return
         try {
             writeBytesResponse(editor.data.toString(), value)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveFileHttpProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveFileHttpProvider.kt
@@ -4,6 +4,7 @@ import co.touchlab.kermit.Logger
 import id.homebase.api.client.ByteApiResponse
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.OdinApiProviderBase
+import id.homebase.api.client.PayloadSizePolicy
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.common.OdinId
 import id.homebase.api.crypto.AesCbc
@@ -25,6 +26,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.contentLength
 import io.ktor.utils.io.readAvailable
 
 private fun ByteReadChannel.asFlow(chunkSize: Int = 64 * 1024): Flow<ByteArray> = flow {
@@ -53,7 +55,8 @@ public class DriveFileHttpProvider(
         key: String,
         keyHeader: KeyHeader,
         outputPath: String,
-        fileOps: FileOperationsProvider
+        fileOps: FileOperationsProvider,
+        onProgress: ((Float) -> Unit)? = null,
     ): Boolean {
 
         ValidationUtil.requireValidUuid(driveId, "driveId")
@@ -86,8 +89,22 @@ public class DriveFileHttpProvider(
             )
         }
 
+        // Progress from a bytes-read counter over Content-Length (when present) —
+        // needed by the rerouted MP4 render path (#845), which showed real download
+        // progress back when it buffered the whole payload.
+        val totalBytes = response.contentLength()
+        var readSoFar = 0L
         val encryptedFlow =
-            response.bodyAsChannel().asFlow()
+            response.bodyAsChannel().asFlow().let { upstream ->
+                if (onProgress == null || totalBytes == null || totalBytes <= 0L) upstream
+                else flow {
+                    upstream.collect { chunk ->
+                        readSoFar += chunk.size
+                        onProgress((readSoFar.toFloat() / totalBytes.toFloat()).coerceAtMost(1f))
+                        emit(chunk)
+                    }
+                }
+            }
 
         val decryptedFlow =
             AesCbc.streamDecryptWithCbc(
@@ -97,13 +114,19 @@ public class DriveFileHttpProvider(
             )
 
         fileOps.writeStream(outputPath, decryptedFlow)
+        onProgress?.invoke(1f)
 
         return true
     }
 
     // This ought to be private / protected and only used by driveCache but probably rewire it all
-    // TODO: Shouldn't it (always) be streaming?! If it's a 500MB file we dont want it in memory
-    // TODO: Should we discern between HLS needing chunks and payloads not needing chunks? Two different calls?
+    /**
+     * Full (non-range) reads are size-guarded at [PayloadSizePolicy.RENDER_LIMIT_BYTES]
+     * (#845): a payload the app can't render has no business in RAM or the LRU —
+     * export flows must use [streamPayloadDecryptedToPath]. Range reads
+     * (`options.chunkStart != null`) are exempt by shape: they're the HLS playback
+     * path and are bounded by their requested chunkLength.
+     */
     suspend fun getPayloadBytesRawNetwork(
         driveId: Uuid,
         fileId: Uuid,
@@ -139,7 +162,9 @@ public class DriveFileHttpProvider(
 
         val url = apiUrl(creds.domain, path)
 
-        val response = requestBytes {
+        val response = requestBytes(
+            maxBytes = if (options.chunkStart == null) PayloadSizePolicy.RENDER_LIMIT_BYTES else null
+        ) {
             httpClient.get(url) {
                 bearerAuth(creds.accessToken)
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveFileProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveFileProvider.kt
@@ -331,8 +331,21 @@ public class DriveFileProvider(
         key: String,
         keyHeader: KeyHeader,
         outputPath: String,
-        fileOps: FileOperationsProvider
-    ): Boolean = driveCache.streamPayloadDecryptedToPath(driveId, fileId, key, keyHeader, outputPath, fileOps)
+        fileOps: FileOperationsProvider,
+        onProgress: ((Float) -> Unit)? = null,
+    ): Boolean = driveCache.streamPayloadDecryptedToPath(
+        driveId, fileId, key, keyHeader, outputPath, fileOps, onProgress)
+
+    /** [VideoPrefetchDriveAccess] variant — the cached layer supplies its own file ops. */
+    override suspend fun streamPayloadDecryptedToPath(
+        driveId: Uuid,
+        fileId: Uuid,
+        key: String,
+        keyHeader: KeyHeader,
+        outputPath: String,
+        onProgress: ((Float) -> Unit)?,
+    ): Boolean = driveCache.streamPayloadDecryptedToPath(
+        driveId, fileId, key, keyHeader, outputPath, onProgress = onProgress)
 
     suspend fun getThumbBytesDecrypted(
         driveId: Uuid,

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/PayloadDownloadService.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/PayloadDownloadService.kt
@@ -1,0 +1,116 @@
+package id.homebase.api.client.drives.files
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.NotFoundException
+import id.homebase.api.client.PayloadSizePolicy
+import id.homebase.api.client.PayloadTooLargeException
+import id.homebase.api.file.FileOperationsProvider
+import kotlin.uuid.Uuid
+
+/**
+ * Where an exported (streamed, decrypted) payload lands. Every destination is an
+ * EXISTING swept location — exports add no new cleanup surface:
+ *
+ * - [ShareOutbound] — `<cacheDir>/share_outbound/` (cleartext handed to another
+ *   app; reaped as a unit on cold start + foreground).
+ * - [UploadTemp] — `<cacheDir>/upload-temp/` (disposable scratch; swept every
+ *   startup / "Clear caches").
+ * - [CacheRoot] — a prefixed file at the cacheDir root (`hbvid_res_*`,
+ *   `hlsdl_*`-style; untracked → swept every startup).
+ */
+sealed interface ExportDestination {
+    data class ShareOutbound(val suffix: String) : ExportDestination
+    data class UploadTemp(val prefix: String, val suffix: String) : ExportDestination
+    data class CacheRoot(val prefix: String, val suffix: String) : ExportDestination
+}
+
+/**
+ * The single entry point for reading downloaded payloads (#845) — the
+ * download-side counterpart of `UploadService`. Callers declare INTENT instead
+ * of picking a read primitive, which is what keeps the render/export boundary
+ * from eroding one call site at a time (the share-to-app OOM existed in three
+ * independent copies precisely because each caller hand-rolled
+ * "get bytes → write file"):
+ *
+ * - [renderBytes] — RENDER intent: the payload will be decoded/rendered in-app.
+ *   Byte-array read, LRU-cached, guarded at [PayloadSizePolicy.RENDER_LIMIT_BYTES]
+ *   (a [PayloadTooLargeException] propagates to the caller's fallback).
+ * - [exportToTemp] — EXPORT intent: the payload is passing through to a file
+ *   destination (save, share, external player). Streamed decrypt (~64 KB working
+ *   set) at ANY size; never touches the LRU caches.
+ *
+ * Downloads are re-fetchable, therefore disposable: every destination is swept
+ * scratch, never a durable location.
+ */
+class PayloadDownloadService(
+    private val driveFileProvider: DriveFileProvider,
+    private val fileOperationsProvider: FileOperationsProvider,
+) {
+
+    /**
+     * Fetch a payload the app will render, decrypted, as bytes. Cache-admitted and
+     * size-guarded; returns null on 404. Throws [PayloadTooLargeException] above
+     * the render limit — callers with a file destination belong on [exportToTemp].
+     */
+    suspend fun renderBytes(
+        driveId: Uuid,
+        fileId: Uuid,
+        key: String,
+        keyHeader: KeyHeader,
+    ): ByteArray? {
+        val response = try {
+            driveFileProvider.getPayloadBytesDecrypted(
+                driveId = driveId,
+                fileId = fileId,
+                key = key,
+                keyHeader = keyHeader,
+                chunkStart = null,
+                chunkLength = null,
+                onDownloadProgress = null,
+            )
+        } catch (e: NotFoundException) {
+            return null
+        } ?: return null
+        return response.bytes
+    }
+
+    /**
+     * Stream-decrypt a payload into a reserved path at [destination] and return
+     * the absolute path, or null when the payload 404s. Bounded memory for any
+     * payload size; bypasses the LRU caches entirely.
+     */
+    suspend fun exportToTemp(
+        driveId: Uuid,
+        fileId: Uuid,
+        key: String,
+        keyHeader: KeyHeader,
+        destination: ExportDestination,
+        onProgress: ((Float) -> Unit)? = null,
+    ): String? {
+        val path = when (destination) {
+            is ExportDestination.ShareOutbound ->
+                fileOperationsProvider.createShareOutboundPath(destination.suffix)
+            is ExportDestination.UploadTemp ->
+                fileOperationsProvider.createUploadTempPath(destination.prefix, destination.suffix)
+            is ExportDestination.CacheRoot ->
+                fileOperationsProvider.getCacheDirectory().trimEnd('/') +
+                    "/" + destination.prefix + randomToken() + destination.suffix
+        }
+        val ok = driveFileProvider.streamPayloadDecryptedToPath(
+            driveId = driveId,
+            fileId = fileId,
+            key = key,
+            keyHeader = keyHeader,
+            outputPath = path,
+            fileOps = fileOperationsProvider,
+            onProgress = onProgress,
+        )
+        if (!ok) {
+            runCatching { fileOperationsProvider.deleteTempFile(path) }
+            return null
+        }
+        return path
+    }
+
+    private fun randomToken(): String = kotlin.random.Random.nextLong().toULong().toString(16)
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/temporal/TemporalDriveReadProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/temporal/TemporalDriveReadProvider.kt
@@ -2,6 +2,7 @@ package id.homebase.api.client.peer.temporal
 
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.OdinApiProviderBase
+import id.homebase.api.client.PayloadSizePolicy
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.drives.HomebaseFile
 import id.homebase.api.client.drives.QueryBatchRequest
@@ -161,7 +162,11 @@ class TemporalDriveReadProvider(
         val url = apiUrl(creds.domain, path)
         Logger.i(tag = TAG) { "temporalGetPayload: GET peer=${peer.domainName} drive=$driveId file=$fileId key=$payloadKey" }
 
-        val response = requestBytes {
+        // Full reads are size-guarded (#845) — location payloads are tiny, so this is
+        // pure defense; range reads stay uncapped (bounded by their chunkLength).
+        val response = requestBytes(
+            maxBytes = if (chunkStart == null) PayloadSizePolicy.RENDER_LIMIT_BYTES else null
+        ) {
             httpClient.get(url) { bearerAuth(creds.accessToken) }
         }
         if (response.status == 404) {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
@@ -17,6 +17,7 @@ import id.homebase.api.client.drives.cache.DriveFileProviderCached
 import id.homebase.api.client.drives.files.DriveFileHttpProvider
 import id.homebase.api.client.drives.files.DriveFileOperationsProvider
 import id.homebase.api.client.drives.files.DriveFileProvider
+import id.homebase.api.client.drives.files.PayloadDownloadService
 import id.homebase.api.client.drives.files.DriveOutboxUploader
 import id.homebase.api.client.drives.files.reactions.DriveFileGroupReactionProvider
 import id.homebase.api.client.drives.query.DriveQueryProvider
@@ -91,6 +92,7 @@ val apiModule = module {
     factoryOf(::DriveUploadProvider)
 
     factoryOf(::DriveFileProvider)
+    factoryOf(::PayloadDownloadService)
     factory<VideoPrefetchDriveAccess> { get<DriveFileProvider>() }
     factoryOf(::DriveFileOperationsProvider)
     factoryOf(::DriveFileGroupReactionProvider)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheAudit.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheAudit.kt
@@ -208,6 +208,8 @@ object CacheAudit {
         name == "data" -> "Android system: WebView data — sacred"
         name == "Crash Reports" -> "Android system: crash reporter — sacred"
         name == "hbvid_preload" -> "legacy video preload dir"
+        name.startsWith("hbvid_res_") -> "streamed MP4 playback temp (deleted on player dispose; swept as backstop)"
+        name.startsWith("hbvid_") -> "decrypted video playback scratch"
         name == "coil3_disk_cache" -> "orphan Coil disk cache"
         name == UPLOAD_TEMP_DIR_NAME -> "raw pre-encryption upload temps (disposable — swept every startup)"
         name == OUTBOX_TEMP_DIR_NAME -> "encrypted outbox payload temps (kept until sent/dropped to protect pending sends)"
@@ -233,5 +235,7 @@ object CacheAudit {
     private const val TAG = "CacheAudit"
 
     /** Untracked entries at or above this size are logged at WARN. */
-    private const val LOUD_THRESHOLD_BYTES = 50L * 1024L * 1024L
+    // Delegates to the render/export boundary (#845): "large enough to be loud
+    // about" and "too large to render/cache" are deliberately the same number.
+    private val LOUD_THRESHOLD_BYTES = id.homebase.api.client.PayloadSizePolicy.RENDER_LIMIT_BYTES
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/FileOperationsProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/FileOperationsProvider.kt
@@ -130,6 +130,36 @@ interface FileOperationsProvider {
         suffix: String,
     ): String
 
+    /**
+     * Reserve a unique writable path inside `<cacheDir>/share_outbound/` (creating
+     * the dir) WITHOUT writing bytes — the streaming seam for the "share to other
+     * app" flows (#845), which decrypt a payload directly to this path via
+     * `streamPayloadDecryptedToPath` instead of buffering it in RAM
+     * ([writeBytesToShareOutboundFile]). Same `share_<random><suffix>` shape and
+     * sequestration/sweep lifecycle: `share_outbound/` is reaped as a unit on cold
+     * start and app foreground.
+     */
+    suspend fun createShareOutboundPath(suffix: String): String =
+        createStagingPathIn(
+            getCacheDirectory().trimEnd('/') + "/" + SHARE_OUTBOUND_DIR_NAME,
+            "share_",
+            suffix,
+        )
+
+    /**
+     * Reserve a unique writable path inside `<cacheDir>/upload-temp/` (creating the
+     * dir) WITHOUT writing bytes — the streaming seam for export flows that need a
+     * DISPOSABLE decrypted temp (#845; e.g. vault open/share). Same dir
+     * [writeBytesToTempFile] targets, so the lifecycle is unchanged: swept on every
+     * startup / "Clear caches".
+     */
+    suspend fun createUploadTempPath(prefix: String, suffix: String): String =
+        createStagingPathIn(
+            getCacheDirectory().trimEnd('/') + "/" + CacheAudit.UPLOAD_TEMP_DIR_NAME,
+            prefix,
+            suffix,
+        )
+
     suspend fun writeStream(
         path: String,
         data: Flow<ByteArray>

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/OkioFileOperationsProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/OkioFileOperationsProvider.kt
@@ -87,6 +87,12 @@ open class OkioFileOperationsProvider(
     override suspend fun promoteToOutboxStaging(path: String): String =
         promoteIntoStaging(path, getOutboxStagingDirectory(), fileSystem)
 
+    override suspend fun createShareOutboundPath(suffix: String): String =
+        createStagingPathIn("$cacheDir/$SHARE_OUTBOUND_DIR_NAME", "share_", suffix, fileSystem)
+
+    override suspend fun createUploadTempPath(prefix: String, suffix: String): String =
+        createStagingPathIn("$cacheDir/${CacheAudit.UPLOAD_TEMP_DIR_NAME}", prefix, suffix, fileSystem)
+
     // upload-temp is swept every startup (disposable).
     private fun writeBytesIn(dirName: String, bytes: ByteArray, prefix: String, suffix: String): String {
         val dir = cacheDir.toPath() / dirName

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoContentResolver.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoContentResolver.kt
@@ -1,12 +1,31 @@
 package id.homebase.api.video
 
 import co.touchlab.kermit.Logger
+import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.serialization.OdinSystemSerializer
+import kotlin.random.Random
 import kotlin.time.measureTimedValue
 
 sealed interface VideoContent {
     data class Hls(val metadata: VideoMetadata, val originalPlaylist: String) : VideoContent
-    data class Mp4(val metadata: VideoMetadata, val bytes: ByteArray) : VideoContent
+
+    /**
+     * Decrypted MP4 streamed to a disposable cacheDir temp (`hbvid_res_*` —
+     * untracked, swept every startup; #845). Bounded RAM for any video size —
+     * the previous bytes-carrying variant buffered the whole payload (~2×) in
+     * memory, and a large foreign non-segmented MP4 could OOM the app. The
+     * playing surface owns deleting [filePath] on dispose (the sweep is the
+     * backstop).
+     */
+    data class Mp4File(val metadata: VideoMetadata, val filePath: String) : VideoContent
+
+    /**
+     * Web only (`preferBytes = true`): decrypted MP4 bytes for a Base64 object
+     * URL — the wasm FS is RAM-backed, so a file temp buys nothing there. The
+     * render-limit guard bounds it: an oversized MP4 throws
+     * `PayloadTooLargeException` before the body is buffered.
+     */
+    data class Mp4Bytes(val metadata: VideoMetadata, val bytes: ByteArray) : VideoContent
 }
 
 /** Resolves the full [VideoMetadata], fetching the descriptor payload if the stub is incomplete.
@@ -41,6 +60,8 @@ suspend fun resolveVideoMetadata(
 suspend fun resolveVideoContent(
     data: VideoPlayerData,
     driveFileProvider: VideoPrefetchDriveAccess,
+    fileOps: FileOperationsProvider? = null,
+    preferBytes: Boolean = false,
     onDownloadProgress: ((Float) -> Unit)? = null,
 ): VideoContent {
     val metadata = resolveVideoMetadata(data, driveFileProvider)
@@ -60,7 +81,10 @@ suspend fun resolveVideoContent(
             "metadata: hls path chosen — playlistChars=${hlsPlaylist.length}"
         }
         VideoContent.Hls(metadata, hlsPlaylist)
-    } else {
+    } else if (preferBytes || fileOps == null) {
+        // Web path (RAM-backed FS): bytes for a Base64 object URL, bounded by the
+        // render-limit guard — PayloadTooLargeException propagates to the surface's
+        // unplayable-message handling instead of OOM-ing the tab.
         val (bytes, payloadElapsed) = measureTimedValue {
             driveFileProvider.getPayloadBytesDecrypted(
                 driveId = data.driveId,
@@ -71,6 +95,28 @@ suspend fun resolveVideoContent(
             )?.bytes ?: error("Failed to download video")
         }
         Logger.d(tag = "VideoIO") { "resolveVideoContent total payload: ${bytes.size} bytes in $payloadElapsed" }
-        VideoContent.Mp4(metadata, bytes)
+        VideoContent.Mp4Bytes(metadata, bytes)
+    } else {
+        // Stream-decrypt to a disposable cacheDir temp (#845): bounded RAM at any
+        // size, LRU untouched, and the surfaces play from a file path — which they
+        // already did, except they used to buffer the whole payload in RAM first
+        // just to write it themselves.
+        val outputPath = fileOps.getCacheDirectory().trimEnd('/') +
+            "/hbvid_res_${Random.nextLong().toULong().toString(16)}.mp4"
+        val (ok, payloadElapsed) = measureTimedValue {
+            driveFileProvider.streamPayloadDecryptedToPath(
+                driveId = data.driveId,
+                fileId = data.fileId,
+                key = data.payloadKey,
+                keyHeader = data.keyHeader,
+                outputPath = outputPath,
+                onProgress = onDownloadProgress,
+            )
+        }
+        if (!ok) error("Failed to download video")
+        Logger.d(tag = "VideoIO") {
+            "resolveVideoContent streamed to $outputPath (${fileOps.getFileSize(outputPath)} bytes) in $payloadElapsed"
+        }
+        VideoContent.Mp4File(metadata, outputPath)
     }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPrefetchDriveAccess.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPrefetchDriveAccess.kt
@@ -33,4 +33,18 @@ interface VideoPrefetchDriveAccess {
         chunkLength: Long? = null,
         onDownloadProgress: ((Float) -> Unit)? = null,
     ): BytesResponse?
+
+    /**
+     * Stream-decrypt a full payload to [outputPath] with bounded memory (#845) —
+     * the export-shaped read [resolveVideoContent] uses for non-segmented MP4s so
+     * a large video is never buffered whole in RAM. Returns false on 404.
+     */
+    suspend fun streamPayloadDecryptedToPath(
+        driveId: Uuid,
+        fileId: Uuid,
+        key: String,
+        keyHeader: KeyHeader,
+        outputPath: String,
+        onProgress: ((Float) -> Unit)? = null,
+    ): Boolean
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPreloader.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPreloader.kt
@@ -1,6 +1,8 @@
 package id.homebase.api.video
 
 import co.touchlab.kermit.Logger
+import id.homebase.api.client.PayloadSizePolicy
+import id.homebase.api.client.PayloadTooLargeException
 import id.homebase.api.file.FileOperationsProvider
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -69,13 +71,30 @@ class VideoPreloader(
                 if (metadata?.isSegmented == true) {
                     preloadFirstHlsSegment(data, metadata, emit)
                 } else if (metadata != null) {
-                    driveFileProvider.prefetchPayload(
-                        driveId = data.driveId,
-                        fileId = data.fileId,
-                        key = data.payloadKey,
-                        onDownloadProgress = emit,
-                    )
-                    Logger.d(tag = "VideoIO") { "preload complete (mp4, encrypted cache): ${data.fileId}/${data.payloadKey}" }
+                    // Render-limit gate (#845): a full-MP4 prefetch is a whole-payload
+                    // fetch into the LRU. Only ≤5 MB sent MP4s matter here (bigger sends
+                    // are HLS); an export-sized or unknown-size mp4 (foreign client)
+                    // would be refused by the network guard anyway — skip it quietly so
+                    // preload can't churn the cache or burn a doomed request.
+                    val size = metadata.fileSize
+                    if (size <= 0L || size > PayloadSizePolicy.RENDER_LIMIT_BYTES) {
+                        Logger.d(tag = "VideoIO") {
+                            "preload skipped — export-sized/unknown mp4 (${size}B): ${data.fileId}/${data.payloadKey}"
+                        }
+                    } else {
+                        try {
+                            driveFileProvider.prefetchPayload(
+                                driveId = data.driveId,
+                                fileId = data.fileId,
+                                key = data.payloadKey,
+                                onDownloadProgress = emit,
+                            )
+                            Logger.d(tag = "VideoIO") { "preload complete (mp4, encrypted cache): ${data.fileId}/${data.payloadKey}" }
+                        } catch (e: PayloadTooLargeException) {
+                            // Belt-and-braces: metadata.fileSize lied about the real size.
+                            Logger.d(tag = "VideoIO") { "preload skipped — guard refused mp4: ${e.message}" }
+                        }
+                    }
                 }
             } catch (e: kotlinx.coroutines.CancellationException) {
                 throw e

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/file/OkioFileOperationsProviderTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/file/OkioFileOperationsProviderTest.kt
@@ -125,6 +125,35 @@ class OkioFileOperationsProviderTest {
         }
     }
 
+    /**
+     * #845: the streaming seams for export flows — reserve a unique path in an
+     * EXISTING swept dir without writing bytes.
+     */
+    @Test
+    fun createShareOutboundPathReservesUniquePathsUnderShareOutbound() = runTest {
+        val ops = provider()
+
+        val a = ops.createShareOutboundPath(".zip")
+        val b = ops.createShareOutboundPath(".zip")
+
+        assertTrue(a.contains(SHARE_OUTBOUND_DIR_NAME), "must live in the sequestered share dir: $a")
+        assertTrue(a.endsWith(".zip") && a != b, "paths must be unique, suffixed reservations")
+        assertEquals(0L, ops.getFileSize(a), "reservation must not write bytes")
+        ops.writeStream(a, flowOf(byteArrayOf(1, 2)))
+        assertContentEquals(byteArrayOf(1, 2), ops.readFileBytes(a))
+    }
+
+    @Test
+    fun createUploadTempPathReservesUnderUploadTemp() = runTest {
+        val ops = provider()
+
+        val path = ops.createUploadTempPath("share_", ".pdf")
+
+        assertTrue(path.contains(CacheAudit.UPLOAD_TEMP_DIR_NAME), "must live in upload-temp/: $path")
+        assertTrue(path.substringAfterLast('/').startsWith("share_") && path.endsWith(".pdf"))
+        assertEquals(0L, ops.getFileSize(path), "reservation must not write bytes")
+    }
+
     @Test
     fun getFileSizeOfMissingFileIsZero() {
         assertEquals(0L, provider().getFileSize("/tmp/homebase/does-not-exist.bin"))

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/video/FakeVideoPrefetchDriveAccess.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/video/FakeVideoPrefetchDriveAccess.kt
@@ -34,6 +34,13 @@ class FakeVideoPrefetchDriveAccess(
             val chunkStart: Long?,
             val chunkLength: Long?,
         ) : Call
+
+        data class StreamPayloadDecryptedToPath(
+            val driveId: Uuid,
+            val fileId: Uuid,
+            val key: String,
+            val outputPath: String,
+        ) : Call
     }
 
     private val _calls = mutableListOf<Call>()
@@ -74,5 +81,18 @@ class FakeVideoPrefetchDriveAccess(
         _calls.add(Call.GetPayloadBytesDecrypted(driveId, fileId, key, chunkStart, chunkLength))
         val json = getPayloadResponses[key] ?: return null
         return BytesResponse(bytes = json.encodeToByteArray(), contentType = "application/json")
+    }
+
+    override suspend fun streamPayloadDecryptedToPath(
+        driveId: Uuid,
+        fileId: Uuid,
+        key: String,
+        keyHeader: KeyHeader,
+        outputPath: String,
+        onProgress: ((Float) -> Unit)?,
+    ): Boolean {
+        _calls.add(Call.StreamPayloadDecryptedToPath(driveId, fileId, key, outputPath))
+        onProgress?.invoke(1f)
+        return getPayloadResponses.containsKey(key)
     }
 }

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/video/VideoContentResolverTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/video/VideoContentResolverTest.kt
@@ -1,0 +1,102 @@
+package id.homebase.api.video
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.serialization.OdinSystemSerializer
+import io.ktor.client.request.forms.InputProvider
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * The #845 S4 regression: a non-segmented MP4 must be STREAMED to a disposable
+ * `hbvid_res_*` temp — never pulled whole into RAM — except on web
+ * (`preferBytes = true`), where the guarded byte path is deliberate.
+ */
+class VideoContentResolverTest {
+
+    private val driveId = Uuid.fromLongs(0x1L, 0x2L)
+    private val fileId = Uuid.fromLongs(0x3L, 0x4L)
+    private val payloadKey = "vid_payload"
+
+    private val fileOps = object : FileOperationsProvider {
+        override fun getCacheDirectory() = "/cache"
+        override fun openFileInput(path: String): InputProvider = error("not used")
+        override suspend fun readFileBytes(path: String): ByteArray = error("not used")
+        override fun deleteTempFile(path: String) = false
+        override fun getFileSize(path: String) = 0L
+        override suspend fun writeBytesToTempFile(bytes: ByteArray, prefix: String, suffix: String): String = error("not used")
+        override suspend fun writeBytesToShareOutboundFile(bytes: ByteArray, suffix: String): String = error("not used")
+        override suspend fun writeStream(path: String, data: Flow<ByteArray>) = error("not used")
+    }
+
+    private fun playerData(stub: VideoMetadata) = VideoPlayerData(
+        fileId = fileId,
+        driveId = driveId,
+        payloadKey = payloadKey,
+        keyHeader = KeyHeader.empty(),
+        descriptorContent = OdinSystemSerializer.serialize(stub),
+    )
+
+    private val mp4Stub = VideoMetadata(
+        mimeType = "video/mp4",
+        isDescriptorContentComplete = true,
+        isSegmented = false,
+        fileSize = 300L * 1024 * 1024, // foreign large non-segmented mp4 — the S4 shape
+    )
+
+    @Test
+    fun nonSegmentedMp4_streamsToHbvidTemp_neverBuffersBytes() = runTest {
+        val fake = FakeVideoPrefetchDriveAccess(getPayloadResponses = mapOf(payloadKey to "unused"))
+
+        val content = resolveVideoContent(playerData(mp4Stub), fake, fileOps = fileOps)
+
+        val mp4 = assertIs<VideoContent.Mp4File>(content)
+        assertTrue(
+            mp4.filePath.startsWith("/cache/hbvid_res_") && mp4.filePath.endsWith(".mp4"),
+            "must stream into the swept hbvid_res_* pattern: ${mp4.filePath}",
+        )
+        assertEquals(
+            1,
+            fake.calls.filterIsInstance<FakeVideoPrefetchDriveAccess.Call.StreamPayloadDecryptedToPath>().size,
+        )
+        assertTrue(
+            fake.calls.filterIsInstance<FakeVideoPrefetchDriveAccess.Call.GetPayloadBytesDecrypted>().isEmpty(),
+            "the payload must never be byte-buffered on the file path (calls=${fake.calls})",
+        )
+    }
+
+    @Test
+    fun nonSegmentedMp4_preferBytes_returnsGuardedByteVariant() = runTest {
+        val fake = FakeVideoPrefetchDriveAccess(getPayloadResponses = mapOf(payloadKey to "tiny-mp4-bytes"))
+
+        val content = resolveVideoContent(playerData(mp4Stub), fake, fileOps = fileOps, preferBytes = true)
+
+        val mp4 = assertIs<VideoContent.Mp4Bytes>(content)
+        assertContentEquals("tiny-mp4-bytes".encodeToByteArray(), mp4.bytes)
+        assertTrue(
+            fake.calls.filterIsInstance<FakeVideoPrefetchDriveAccess.Call.StreamPayloadDecryptedToPath>().isEmpty(),
+        )
+    }
+
+    @Test
+    fun segmentedWithPlaylist_staysOnHlsBranch() = runTest {
+        val hlsStub = VideoMetadata(
+            mimeType = "application/vnd.apple.mpegurl",
+            isDescriptorContentComplete = true,
+            isSegmented = true,
+            hlsPlaylist = "#EXTM3U\n#EXT-X-BYTERANGE:1024@0\n",
+        )
+        val fake = FakeVideoPrefetchDriveAccess()
+
+        val content = resolveVideoContent(playerData(hlsStub), fake, fileOps = fileOps)
+
+        assertIs<VideoContent.Hls>(content)
+        assertTrue(fake.calls.isEmpty(), "HLS resolution must not fetch any payload bytes")
+    }
+}

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/video/VideoPreloaderTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/video/VideoPreloaderTest.kt
@@ -104,6 +104,10 @@ class VideoPreloaderTest {
             isDescriptorContentComplete = true,
             isSegmented = false,
             key = metadataKey,
+            // Real sent MP4s always carry their size (≤ 5 MB — bigger sends are
+            // HLS). The render-limit gate (#845) skips prefetch when the size is
+            // unknown or export-sized, so this must be realistic.
+            fileSize = 3L * 1024 * 1024,
         )
         val fake = FakeVideoPrefetchDriveAccess()
 
@@ -115,6 +119,43 @@ class VideoPreloaderTest {
         assertEquals(1, prefetchPayloadCalls.size)
         assertEquals(payloadKey, prefetchPayloadCalls.single().key)
         assertTrue(prefetchChunkCalls.isEmpty())
+    }
+
+    // -- #845: the render-limit gate — an export-sized or unknown-size MP4 must
+    //    NOT be prefetched (the network guard would refuse it anyway, and the
+    //    fetch would churn the LRU), but progress still settles at 1f (#788).
+    @Test
+    fun oversizedMp4_skipsPrefetch_progressStillSettles() = runTest {
+        val stub = VideoMetadata(
+            mimeType = "video/mp4",
+            isDescriptorContentComplete = true,
+            isSegmented = false,
+            key = metadataKey,
+            fileSize = id.homebase.api.client.PayloadSizePolicy.RENDER_LIMIT_BYTES + 1,
+        )
+        val fake = FakeVideoPrefetchDriveAccess()
+        var lastProgress = -1f
+
+        newPreloader(fake).preload(playerData(stub)) { lastProgress = it }
+
+        assertTrue(fake.calls.filterIsInstance<FakeVideoPrefetchDriveAccess.Call.PrefetchPayload>().isEmpty())
+        assertEquals(1f, lastProgress)
+    }
+
+    @Test
+    fun unknownSizeMp4_skipsPrefetch() = runTest {
+        val stub = VideoMetadata(
+            mimeType = "video/mp4",
+            isDescriptorContentComplete = true,
+            isSegmented = false,
+            key = metadataKey,
+            // fileSize defaults to 0 (unknown) — a foreign client's descriptor might omit it.
+        )
+        val fake = FakeVideoPrefetchDriveAccess()
+
+        newPreloader(fake).preload(playerData(stub))
+
+        assertTrue(fake.calls.filterIsInstance<FakeVideoPrefetchDriveAccess.Call.PrefetchPayload>().isEmpty())
     }
 
     // -- Case 4: HLS playlist has no explicit `<len>@<offset>` byterange on segment 0; skip the

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
@@ -17,8 +17,15 @@ import id.homebase.api.file.FileOperationsProvider
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import id.homebase.api.client.PayloadSizePolicy
+import id.homebase.api.client.PayloadTooLargeException
+import id.homebase.api.client.drives.files.PayloadOperationOptions
 import io.ktor.client.request.forms.InputProvider
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -48,11 +55,19 @@ class DriveFileProviderCachedTest {
     private var requestCount = 0
     private var nextException: Exception? = null
     private var nextStatus = HttpStatusCode.OK
+    private var nextBody: ByteArray = ByteArray(0)
+    private var nextHeaders: Headers = headersOf()
+    // When set, the body is served as a raw channel (NO Content-Length header) —
+    // exercises the chunked-transfer fallback of the requestBytes size guard.
+    private var nextChannelBody: ByteArray? = null
 
     private val mockEngine = MockEngine { _ ->
         requestCount++
         nextException?.let { e -> throw e }
-        respond("", nextStatus)
+        nextChannelBody?.let { body ->
+            return@MockEngine respond(ByteReadChannel(body), nextStatus, nextHeaders)
+        }
+        respond(nextBody, nextStatus, nextHeaders)
     }
 
     private val httpClient = HttpClient(mockEngine)
@@ -96,6 +111,9 @@ class DriveFileProviderCachedTest {
         requestCount = 0
         nextException = null
         nextStatus = HttpStatusCode.OK
+        nextBody = ByteArray(0)
+        nextHeaders = headersOf()
+        nextChannelBody = null
 
         logCollector.entries.clear()
         Logger.setLogWriters(listOf(logCollector))
@@ -339,6 +357,73 @@ class DriveFileProviderCachedTest {
      * never-sent (failed) message's media retrievable for retry. The mock
      * engine throws on any request to prove the network is never touched.
      */
+    // ==================== #845: render/export size guard ====================
+
+    @Test
+    fun `full read over the render limit is refused via Content-Length before the body is read`() = runTest {
+        // MockEngine validates the header against the body, so the oversized body is
+        // real — the assertion that matters is the guard tripping on the HEADER
+        // (sizeBytes == the advertised length, not -1 from the counting fallback).
+        nextBody = ByteArray((PayloadSizePolicy.RENDER_LIMIT_BYTES + 1).toInt())
+        nextHeaders = headersOf(HttpHeaders.ContentLength, (PayloadSizePolicy.RENDER_LIMIT_BYTES + 1).toString())
+
+        val e = assertFailsWith<PayloadTooLargeException> {
+            provider.getPayloadBytesRaw(driveId, fileId, key)
+        }
+        assertEquals(PayloadSizePolicy.RENDER_LIMIT_BYTES + 1, e.sizeBytes)
+        assertEquals(PayloadSizePolicy.RENDER_LIMIT_BYTES, e.limitBytes)
+        assertEquals(1, requestCount)
+
+        // Not cached, not 404-poisoned: a fixed server (normal size) is fetched again.
+        nextHeaders = headersOf()
+        nextBody = ByteArray(8) { 1 }
+        val second = provider.getPayloadBytesRaw(driveId, fileId, key)
+        assertEquals(2, requestCount, "a refused read must not poison the notFound cache")
+        assertContentEquals(nextBody, second.bytes)
+    }
+
+    @Test
+    fun `chunked response without Content-Length is aborted once the running count passes the limit`() = runTest {
+        // Channel body → MockEngine sends no Content-Length → the guard's counting
+        // fallback must catch it mid-read.
+        nextChannelBody = ByteArray((PayloadSizePolicy.RENDER_LIMIT_BYTES + 1024).toInt())
+
+        val e = assertFailsWith<PayloadTooLargeException> {
+            provider.getPayloadBytesRaw(driveId, fileId, key)
+        }
+        assertEquals(-1, e.sizeBytes, "no Content-Length → size unknown at refusal time")
+    }
+
+    @Test
+    fun `range reads are exempt from the size guard even when the payload total is huge`() = runTest {
+        // A range response legitimately advertises a large total via headers on some
+        // servers; the guard must not applied to chunk-shaped requests at all.
+        nextHeaders = headersOf(HttpHeaders.ContentLength, "4096")
+        nextBody = ByteArray(4096) { 7 }
+
+        val result = provider.getPayloadBytesRaw(
+            driveId, fileId, key,
+            options = PayloadOperationOptions(chunkStart = 0L, chunkLength = 4096L),
+        )
+        assertEquals(200, result.status)
+        assertEquals(4096, result.bytes.size)
+    }
+
+    @Test
+    fun `oversized seed is refused by the cache-admission fence and nothing is written`() = runTest {
+        nextException = IOException("network must not be reached")
+        val oversized = ByteArray((PayloadSizePolicy.RENDER_LIMIT_BYTES + 1).toInt())
+
+        provider.cachePayloadBytesEncrypted(driveId, fileId, key, oversized, "application/zip")
+
+        assertTrue(
+            logCollector.entries.any { it.message.contains("cache-admit REFUSED") },
+            "the refusal must be observable in the log",
+        )
+        // The entry must not be served from cache — the read goes to the (throwing) network.
+        assertFailsWith<Exception> { provider.getPayloadBytesRaw(driveId, fileId, key) }
+    }
+
     @Test
     fun `seeded payload bytes are served from cache without touching the network`() = runTest {
         nextException = IOException("network must not be reached for a seeded payload")

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/files/PayloadDownloadServiceTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/files/PayloadDownloadServiceTest.kt
@@ -1,0 +1,196 @@
+package id.homebase.api.client.drives.files
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.PayloadSizePolicy
+import id.homebase.api.client.PayloadTooLargeException
+import id.homebase.api.client.auth.ApiCredentials
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.cache.DriveFileProviderCached
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.SecureByteArray
+import id.homebase.api.file.FileOperationsProvider
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.forms.InputProvider
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import java.io.File
+import java.nio.file.Files
+import kotlin.random.Random
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * The download facade (#845): RENDER intent is guarded byte-array reads;
+ * EXPORT intent streams to a reserved path in an existing swept dir at any
+ * size, bypassing the LRU. Runs the REAL provider stack (facade →
+ * DriveFileProvider → DriveFileProviderCached → ktor MockEngine) so the
+ * export path exercises genuine streamed decryption end to end.
+ */
+class PayloadDownloadServiceTest {
+
+    private var nextStatus = HttpStatusCode.OK
+    private var nextBody: ByteArray = ByteArray(0)
+    private var nextHeaders: Headers = headersOf()
+
+    private val mockEngine = MockEngine { _ ->
+        respond(nextBody, nextStatus, nextHeaders)
+    }
+    private val httpClient = HttpClient(mockEngine)
+    private val credentialsManager = CredentialsManager()
+    private var tempDir: String = ""
+
+    private lateinit var service: PayloadDownloadService
+
+    private val driveId = Uuid.parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    private val fileId = Uuid.parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    private val key = "attachment"
+
+    // Real-file-backed fake: reserve-path defaults come from the interface
+    // (real FS under tempDir), writeStream lands on disk — the export contract.
+    private val fileOps = object : FileOperationsProvider {
+        override fun getCacheDirectory() = tempDir
+        override fun openFileInput(path: String): InputProvider = error("not used")
+        override suspend fun readFileBytes(path: String): ByteArray = File(path).readBytes()
+        override fun deleteTempFile(path: String): Boolean = File(path).delete()
+        override fun getFileSize(path: String): Long = File(path).length()
+        override suspend fun writeBytesToTempFile(bytes: ByteArray, prefix: String, suffix: String): String = error("not used")
+        override suspend fun writeBytesToShareOutboundFile(bytes: ByteArray, suffix: String): String = error("not used")
+        override suspend fun writeStream(path: String, data: Flow<ByteArray>) {
+            File(path).parentFile?.mkdirs()
+            File(path).outputStream().buffered().use { out -> data.collect { out.write(it) } }
+        }
+    }
+
+    @BeforeTest
+    fun setup() = runBlocking {
+        tempDir = Files.createTempDirectory("hb-download-test").toString()
+        credentialsManager.setActiveCredentials(
+            ApiCredentials.create(
+                domain = OdinId("frodobaggins.me"),
+                clientAccessToken = "test-token",
+                sharedSecret = SecureByteArray(ByteArray(32) { 0x01 }),
+            )
+        )
+        val driveCache = DriveFileProviderCached(httpClient, credentialsManager, fileOps)
+        service = PayloadDownloadService(DriveFileProvider(httpClient, credentialsManager, driveCache), fileOps)
+
+        nextStatus = HttpStatusCode.OK
+        nextBody = ByteArray(0)
+        nextHeaders = headersOf()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        httpClient.close()
+        runCatching {
+            Files.walk(java.nio.file.Path.of(tempDir)).sorted(Comparator.reverseOrder())
+                .forEach { Files.deleteIfExists(it) }
+        }
+    }
+
+    private suspend fun encryptedFixture(size: Int): Pair<KeyHeader, ByteArray> {
+        val keyHeader = KeyHeader.newRandom16()
+        val plaintext = ByteArray(size).also { Random.nextBytes(it) }
+        nextBody = keyHeader.encryptDataAes(plaintext)
+        return keyHeader to plaintext
+    }
+
+    @Test
+    fun `exportToTemp streams a decrypted copy into share_outbound`() = runTest {
+        val (keyHeader, plaintext) = encryptedFixture(200_000)
+
+        val path = service.exportToTemp(
+            driveId, fileId, key, keyHeader,
+            destination = ExportDestination.ShareOutbound(".zip"),
+        )
+
+        assertNotNull(path)
+        assertTrue(path.contains("share_outbound"), "must land in the sequestered share dir: $path")
+        assertTrue(path.endsWith(".zip"))
+        assertContentEquals(plaintext, File(path).readBytes(), "streamed decrypt must be byte-exact")
+    }
+
+    @Test
+    fun `exportToTemp routes UploadTemp and CacheRoot destinations to their dirs`() = runTest {
+        val (keyHeader, plaintext) = encryptedFixture(4_096)
+
+        val uploadTemp = service.exportToTemp(
+            driveId, fileId, key, keyHeader, ExportDestination.UploadTemp("share_", ".pdf"))
+        assertNotNull(uploadTemp)
+        assertTrue(uploadTemp.contains("upload-temp"), "UploadTemp must land in upload-temp/: $uploadTemp")
+        assertContentEquals(plaintext, File(uploadTemp).readBytes())
+
+        val cacheRoot = service.exportToTemp(
+            driveId, fileId, key, keyHeader, ExportDestination.CacheRoot("hbvid_res_", ".mp4"))
+        assertNotNull(cacheRoot)
+        assertEquals(tempDir, File(cacheRoot).parent, "CacheRoot must land at the cacheDir root")
+        assertTrue(File(cacheRoot).name.startsWith("hbvid_res_"))
+    }
+
+    @Test
+    fun `exportToTemp on 404 returns null and leaves no reserved file behind`() = runTest {
+        nextStatus = HttpStatusCode.NotFound
+
+        val path = service.exportToTemp(
+            driveId, fileId, key, KeyHeader.newRandom16(),
+            ExportDestination.ShareOutbound(".bin"),
+        )
+
+        assertNull(path)
+        val shareDir = File(tempDir, "share_outbound")
+        assertTrue(
+            shareDir.listFiles().isNullOrEmpty(),
+            "a failed export must not leave a reserved file: ${shareDir.listFiles()?.toList()}",
+        )
+    }
+
+    @Test
+    fun `exportToTemp forwards progress and settles at 1f`() = runTest {
+        val (keyHeader, _) = encryptedFixture(300_000)
+        // Content-Length drives the progress fraction on the network path.
+        nextHeaders = headersOf(HttpHeaders.ContentLength, nextBody.size.toString())
+        val seen = mutableListOf<Float>()
+
+        service.exportToTemp(
+            driveId, fileId, key, keyHeader,
+            ExportDestination.CacheRoot("export_", ".bin"),
+            onProgress = { seen.add(it) },
+        )
+
+        assertTrue(seen.isNotEmpty(), "progress must be reported")
+        assertEquals(1f, seen.last(), "progress must settle at done")
+        assertTrue(seen.zipWithNext().all { (a, b) -> b >= a }, "progress must be monotonic: $seen")
+    }
+
+    @Test
+    fun `renderBytes refuses an export-sized payload with the typed error`() = runTest {
+        // Real oversized body — MockEngine validates the Content-Length header.
+        nextBody = ByteArray((PayloadSizePolicy.RENDER_LIMIT_BYTES + 1).toInt())
+        nextHeaders = headersOf(HttpHeaders.ContentLength, (PayloadSizePolicy.RENDER_LIMIT_BYTES + 1).toString())
+
+        assertFailsWith<PayloadTooLargeException> {
+            service.renderBytes(driveId, fileId, key, KeyHeader.newRandom16())
+        }
+    }
+
+    @Test
+    fun `renderBytes returns null on 404`() = runTest {
+        nextStatus = HttpStatusCode.NotFound
+        assertNull(service.renderBytes(driveId, fileId, key, KeyHeader.newRandom16()))
+    }
+}

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/files/PayloadDownloadServiceTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/files/PayloadDownloadServiceTest.kt
@@ -177,6 +177,41 @@ class PayloadDownloadServiceTest {
         assertTrue(seen.zipWithNext().all { (a, b) -> b >= a }, "progress must be monotonic: $seen")
     }
 
+    /**
+     * The small-MP4 pre-cache contract (#845 must not regress it): the preloader
+     * warms the encrypted payload under the FULL cache key; playback's streamed
+     * export must be served from that warm entry with ZERO network — the same
+     * key `streamPayloadDecryptedToPath`'s snapshot lookup reads.
+     */
+    @Test
+    fun `exportToTemp is served from a prefetch-warmed cache entry without touching the network`() = runTest {
+        val keyHeader = KeyHeader.newRandom16()
+        val plaintext = ByteArray(100_000).also { Random.nextBytes(it) }
+        nextBody = keyHeader.encryptDataAes(plaintext)
+
+        // Warm the cache the way VideoPreloader.prefetchPayload does — a full
+        // read through the same provider stack, cached under the :full:full key.
+        val driveCacheWarmup = service.renderBytes(driveId, fileId, key, keyHeader)
+        assertNotNull(driveCacheWarmup)
+        val requestsAfterWarmup = mockEngine.requestHistory.size
+
+        // Kill the network: a cache miss would now fail loudly.
+        nextStatus = HttpStatusCode.InternalServerError
+        nextBody = ByteArray(0)
+
+        val path = service.exportToTemp(
+            driveId, fileId, key, keyHeader,
+            ExportDestination.CacheRoot("hbvid_res_", ".mp4"),
+        )
+
+        assertNotNull(path, "playback export must be served from the warm cache")
+        assertContentEquals(plaintext, File(path).readBytes(), "warm-cache streamed decrypt must be byte-exact")
+        assertEquals(
+            requestsAfterWarmup, mockEngine.requestHistory.size,
+            "a prefetch-warmed payload must play with zero network requests",
+        )
+    }
+
     @Test
     fun `renderBytes refuses an export-sized payload with the typed error`() = runTest {
         // Real oversized body — MockEngine validates the Content-Length header.

--- a/homebase-chat/src/androidMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.android.kt
+++ b/homebase-chat/src/androidMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.android.kt
@@ -99,12 +99,16 @@ actual fun VideoPlayerSurface(
     // gate the same optimizations behind it for a phased dark-launch.
     val context = LocalContext.current
     val driveFileProvider = koinInject<DriveFileProvider>()
+    val fileOperationsProvider = koinInject<id.homebase.api.file.FileOperationsProvider>()
     val videoPreloader = koinInject<VideoPreloader>()
     val playerPool = koinInject<ExoPlayerPool>()
     val scope = rememberCoroutineScope()
     var state by remember(data) { mutableStateOf<VpsState>(VpsState.Loading) }
     var firstFramePainted by remember(data) { mutableStateOf(false) }
     var tempDir by remember(data) { mutableStateOf<File?>(null) }
+    // Streamed-to-file MP4 temp (hbvid_res_*, #845) — the surface owns deleting
+    // it on dispose; the startup sweep is the backstop.
+    var tempFile by remember(data) { mutableStateOf<File?>(null) }
     var exoPlayer by remember(data) { mutableStateOf<ExoPlayer?>(null) }
     // The PlayerView is owned by AndroidView's factory; we keep a reference so
     // we can detach the player from it on dispose before returning the player
@@ -182,6 +186,7 @@ actual fun VideoPlayerSurface(
             tempDir?.let { dir ->
                 dir.parent?.let { parent -> safeDeleteRecursively(parent, dir.name) }
             }
+            tempFile?.delete()
         }
     }
 
@@ -258,7 +263,7 @@ actual fun VideoPlayerSurface(
 
         withContext(Dispatchers.IO) {
             try {
-                when (val content = resolveVideoContent(VideoPlayerData(data.fileId, data.driveId, data.payloadKey, data.keyHeader, data.payload.descriptorContent), driveFileProvider, onDownloadProgress = { onProgress(it * 0.5f) })) {
+                when (val content = resolveVideoContent(VideoPlayerData(data.fileId, data.driveId, data.payloadKey, data.keyHeader, data.payload.descriptorContent), driveFileProvider, fileOps = fileOperationsProvider, onDownloadProgress = { onProgress(it * 0.5f) })) {
                     is VideoContent.Hls -> {
                         // Subscribe to the preloader's live bytes progress BEFORE kicking off the
                         // preload, so StateFlow's initial value and every subsequent emit lands.
@@ -330,23 +335,13 @@ actual fun VideoPlayerSurface(
                             state = VpsState.Active
                         }
                     }
-                    is VideoContent.Mp4 -> {
+                    is VideoContent.Mp4Bytes -> error("Mp4Bytes is the web-only variant — resolveVideoContent was given fileOps")
+                    is VideoContent.Mp4File -> {
                         onProgress(0.5f)
-                        val file = run {
-                            val preloadedPath = videoPreloader.awaitPreloadedFile(data.fileId, data.payloadKey)
-                            if (preloadedPath != null) {
-                                Logger.d(tag = "VideoIO") { "mp4 using preloaded file" }
-                                File(preloadedPath)
-                            } else {
-                                val dir = File(context.cacheDir, "hbvid_${UUID.randomUUID()}").also { it.mkdirs() }
-                                tempDir = dir
-                                val (f, writeElapsed) = measureTimedValue {
-                                    File(dir, "video.mp4").also { it.writeBytes(content.bytes) }
-                                }
-                                Logger.d(tag = "VideoIO") { "mp4 temp-file write: ${content.bytes.size} bytes in $writeElapsed" }
-                                f
-                            }
-                        }
+                        // Already streamed to a disposable hbvid_res_* temp by the
+                        // resolver (#845) — no whole-payload RAM buffer, no second
+                        // temp-file write. Deleted on dispose (see tempFile).
+                        val file = File(content.filePath).also { tempFile = it }
                         withContext(Dispatchers.Main) {
                             player.setMediaItem(MediaItem.fromUri(Uri.fromFile(file)))
                             onProgress(0.8f)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MediaDownloadHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MediaDownloadHandler.kt
@@ -65,22 +65,22 @@ internal class MediaDownloadHandler(
                         "encrypted payload requires key header"
                     )
                 )
-                val bytes = chatMessageActionService.getPayloadBytes(
+                val extension = payload.contentType?.let { extensionForMimeType(it) }
+                    ?: payload.contentType?.substringAfter("/")
+                    ?: "bin"
+                // Cleartext copy of an end-to-end-encrypted Homebase payload —
+                // STREAM-decrypted straight into the share_outbound subdir (#845:
+                // bounded RAM for any payload size, LRU untouched; the old
+                // getPayloadBytes path buffered ~2× the payload in RAM). The
+                // subdir keeps the sweep story: reaped as a single unit on
+                // cold start + foreground, bounding its on-disk lifetime.
+                val tempPath = chatMessageActionService.streamPayloadToShareOutbound(
                     message.fileId,
                     action.payloadKey,
-                    KeyHeader(payloadIv, message.keyHeader.aesKey)
+                    KeyHeader(payloadIv, message.keyHeader.aesKey),
+                    ".$extension",
                 )
-                if (bytes != null) {
-                    val extension = payload.contentType?.let { extensionForMimeType(it) }
-                        ?: payload.contentType?.substringAfter("/")
-                        ?: "bin"
-                    // Cleartext copy of an end-to-end-encrypted Homebase
-                    // payload — sequestered into the share_outbound subdir so
-                    // the cold-start + foreground sweepers can reap it as a
-                    // single unit, bounding its on-disk lifetime.
-                    val tempPath = fileOperationsProvider.writeBytesToShareOutboundFile(
-                        bytes, ".$extension"
-                    )
+                if (tempPath != null) {
                     sendEvent(ShareFile(tempPath))
                 } else {
                     sendEvent(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
@@ -4,6 +4,8 @@ import co.touchlab.kermit.Logger
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.drives.files.DriveFileProvider
+import id.homebase.api.client.drives.files.ExportDestination
+import id.homebase.api.client.drives.files.PayloadDownloadService
 import id.homebase.api.client.drives.files.DeleteLocalFilesByFileIdRequest
 import id.homebase.api.client.drives.files.SendReadReceiptByFileIdsOutboxRequest
 import id.homebase.api.client.drives.files.reactions.DriveFileGroupReactionProvider
@@ -40,6 +42,7 @@ class ChatMessageActionService(
     private val reactionProvider: DriveFileGroupReactionProvider,
     private val credentialsManager: CredentialsManager,
     private val fileProvider: DriveFileProvider,
+    private val payloadDownloadService: PayloadDownloadService,
     private val dbm: DatabaseManager,
     private val outboxSync: OutboxSync,
     private val optimisticWriter: OptimisticWriter,
@@ -407,4 +410,21 @@ class ChatMessageActionService(
         )
         return response?.bytes
     }
+
+    /**
+     * Stream-decrypt a chat payload into a fresh `share_outbound/` file and return
+     * its path, or null when the payload 404s. Bounded RAM (~64 KB chunks) for ANY
+     * payload size — the EXPORT-side counterpart of [getPayloadBytes], which is a
+     * RENDER read capped at PayloadSizePolicy.RENDER_LIMIT_BYTES (#845). Sharing a
+     * 1 GB attachment used to buffer ~2× its size in RAM through getPayloadBytes.
+     */
+    suspend fun streamPayloadToShareOutbound(
+        fileId: Uuid, payloadKey: String, keyHeader: KeyHeader, suffix: String
+    ): String? = payloadDownloadService.exportToTemp(
+        driveId = chatTargetDrive.alias,
+        fileId = fileId,
+        key = payloadKey,
+        keyHeader = keyHeader,
+        destination = ExportDestination.ShareOutbound(suffix),
+    )
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ChatMediaFullScreenHost.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ChatMediaFullScreenHost.kt
@@ -84,11 +84,13 @@ fun ChatMediaFullScreenHost(
                     scope.launch {
                         try {
                             val iv = item.payload.iv?.let { Base64.decode(it) } ?: return@launch
-                            val bytes = actionService.getPayloadBytes(
-                                item.fileId, item.payload.key, KeyHeader(iv, item.keyHeader.aesKey)
+                            // Stream-decrypt straight into share_outbound (#845) —
+                            // bounded RAM for any payload size; the old byte path
+                            // buffered the whole payload (~2×) in memory.
+                            val path = actionService.streamPayloadToShareOutbound(
+                                item.fileId, item.payload.key, KeyHeader(iv, item.keyHeader.aesKey), ".$ext"
                             )
-                            if (bytes != null) {
-                                val path = fileOps.writeBytesToShareOutboundFile(bytes, ".$ext")
+                            if (path != null) {
                                 fileSystemHandler.shareFile(
                                     file = Path(path),
                                     onError = { e ->

--- a/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.jvm.kt
+++ b/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.jvm.kt
@@ -106,10 +106,14 @@ actual fun VideoPlayerSurface(
     // built-in transport UI of its own (host renders controls). Param is
     // accepted for API parity with the mobile actuals.
     val driveFileProvider = koinInject<DriveFileProvider>()
+    val fileOperationsProvider = koinInject<id.homebase.api.file.FileOperationsProvider>()
     val videoPreloader = koinInject<VideoPreloader>()
     val scope = rememberCoroutineScope()
     var state by remember(data) { mutableStateOf<VpsState>(VpsState.Loading) }
     var tempDir by remember(data) { mutableStateOf<File?>(null) }
+    // Streamed-to-file MP4 temp (hbvid_res_*, #845) — deleted on dispose; the
+    // startup sweep is the backstop.
+    var tempFile by remember(data) { mutableStateOf<File?>(null) }
     var httpServer by remember(data) { mutableStateOf<HttpServer?>(null) }
 
     DisposableEffect(data) {
@@ -118,6 +122,7 @@ actual fun VideoPlayerSurface(
             tempDir?.let { dir ->
                 dir.parent?.let { parent -> safeDeleteRecursively(parent, dir.name) }
             }
+            tempFile?.delete()
         }
     }
 
@@ -129,7 +134,7 @@ actual fun VideoPlayerSurface(
                     .also { it.mkdirs() }
                 tempDir = dir
 
-                when (val content = resolveVideoContent(VideoPlayerData(data.fileId, data.driveId, data.payloadKey, data.keyHeader, data.payload.descriptorContent), driveFileProvider, onDownloadProgress = { onProgress(it * 0.5f) })) {
+                when (val content = resolveVideoContent(VideoPlayerData(data.fileId, data.driveId, data.payloadKey, data.keyHeader, data.payload.descriptorContent), driveFileProvider, fileOps = fileOperationsProvider, onDownloadProgress = { onProgress(it * 0.5f) })) {
                     is VideoContent.Hls -> {
                         // Subscribe to the preloader's live bytes progress BEFORE kicking off the
                         // preload, so StateFlow's initial value and every subsequent emit lands.
@@ -208,21 +213,14 @@ actual fun VideoPlayerSurface(
                         progressJob.cancel()
                         state = VpsState.Playing("http://localhost:${server.address.port}/index.m3u8")
                     }
-                    is VideoContent.Mp4 -> {
-                        onProgress(0.5f)
-                        val preloadedPath = videoPreloader.awaitPreloadedFile(data.fileId, data.payloadKey)
-                        val mp4Path = if (preloadedPath != null) {
-                            Logger.d(tag = "VideoIO") { "mp4 using preloaded file" }
-                            preloadedPath
-                        } else {
-                            val (mp4File, writeElapsed) = measureTimedValue {
-                                File(dir, "video.mp4").also { it.writeBytes(content.bytes) }
-                            }
-                            Logger.d(tag = "VideoIO") { "mp4 temp-file write: ${content.bytes.size} bytes in $writeElapsed" }
-                            mp4File.absolutePath
-                        }
+                    is VideoContent.Mp4Bytes -> error("Mp4Bytes is the web-only variant — resolveVideoContent was given fileOps")
+                    is VideoContent.Mp4File -> {
+                        // Already streamed to a disposable hbvid_res_* temp by the
+                        // resolver (#845) — no whole-payload RAM buffer, no second
+                        // temp-file write. Deleted on dispose (see tempFile).
                         onProgress(0.8f)
-                        state = VpsState.Playing(mp4Path)
+                        tempFile = File(content.filePath)
+                        state = VpsState.Playing(content.filePath)
                     }
                 }
             } catch (e: Exception) {

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
@@ -11,6 +11,7 @@ import id.homebase.api.client.drives.files.DriveFileOperationsProvider
 import id.homebase.api.client.drives.files.DriveOutboxUploader
 import id.homebase.api.client.drives.files.reactions.DriveFileGroupReactionProvider
 import id.homebase.api.client.drives.files.DriveFileProvider
+import id.homebase.api.client.drives.files.PayloadDownloadService
 import id.homebase.api.client.drives.cache.DriveFileProviderCached
 import id.homebase.api.client.drives.query.QueryBatchCursor
 import id.homebase.api.client.drives.upload.DriveUploadProvider
@@ -245,6 +246,7 @@ class ChatMessageActionServiceTestFixture(
             reactionProvider = reactionProvider,
             credentialsManager = credentialsManager,
             fileProvider = fileProvider,
+            payloadDownloadService = PayloadDownloadService(fileProvider, NoopFileOperationsProvider()),
             dbm = dbm,
             outboxSync = outboxSync,
             optimisticWriter = optimisticWriter,

--- a/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.native.kt
+++ b/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.native.kt
@@ -131,11 +131,15 @@ actual fun VideoPlayerSurface(
     paused: Boolean,
 ) {
     val driveFileProvider = koinInject<DriveFileProvider>()
+    val fileOperationsProvider = koinInject<id.homebase.api.file.FileOperationsProvider>()
     val videoPreloader = koinInject<VideoPreloader>()
     val playerPool = koinInject<AVPlayerPool>()
     val scope = rememberCoroutineScope()
     var state by remember(data) { mutableStateOf<VpsState>(VpsState.Loading) }
     var tempDir by remember(data) { mutableStateOf<NSURL?>(null) }
+    // Streamed-to-file MP4 temp (hbvid_res_*, #845) — deleted on dispose; the
+    // startup sweep is the backstop.
+    var tempFilePath by remember(data) { mutableStateOf<String?>(null) }
     val notificationObservers = remember(data) { mutableListOf<NSObjectProtocol>() }
 
     DisposableEffect(data) {
@@ -163,6 +167,7 @@ actual fun VideoPlayerSurface(
             }
             notificationObservers.clear()
             tempDir?.let { NSFileManager.defaultManager.removeItemAtURL(it, null) }
+            tempFilePath?.let { NSFileManager.defaultManager.removeItemAtPath(it, null) }
         }
     }
 
@@ -230,7 +235,7 @@ actual fun VideoPlayerSurface(
         onProgress(0f)
         withContext(Dispatchers.Main) {
             try {
-                when (val content = resolveVideoContent(VideoPlayerData(data.fileId, data.driveId, data.payloadKey, data.keyHeader, data.payload.descriptorContent), driveFileProvider, onDownloadProgress = { onProgress(it * 0.5f) })) {
+                when (val content = resolveVideoContent(VideoPlayerData(data.fileId, data.driveId, data.payloadKey, data.keyHeader, data.payload.descriptorContent), driveFileProvider, fileOps = fileOperationsProvider, onDownloadProgress = { onProgress(it * 0.5f) })) {
                     is VideoContent.Hls -> {
                         // Subscribe to the preloader's live bytes progress BEFORE kicking off the
                         // preload, so StateFlow's initial value and every subsequent emit lands.
@@ -304,24 +309,14 @@ actual fun VideoPlayerSurface(
                         state = VpsState.Playing(player = player, timeObserver = timeObserver, sessionId = sessionId)
                         onProgress(1f)
                     }
-                    is VideoContent.Mp4 -> {
+                    is VideoContent.Mp4Bytes -> error("Mp4Bytes is the web-only variant — resolveVideoContent was given fileOps")
+                    is VideoContent.Mp4File -> {
                         onProgress(0.5f)
-                        val preloadedPath = videoPreloader.awaitPreloadedFile(data.fileId, data.payloadKey)
-                        val mp4Url = if (preloadedPath != null) {
-                            Logger.d(tag = "VideoIO") { "mp4 using preloaded file" }
-                            NSURL.fileURLWithPath(preloadedPath)
-                        } else {
-                            val dir = NSURL.fileURLWithPath(NSTemporaryDirectory())
-                                .URLByAppendingPathComponent("hbvid_${NSUUID().UUIDString()}")!!
-                            NSFileManager.defaultManager.createDirectoryAtURL(dir, true, null, null)
-                            tempDir = dir
-                            val url = dir.URLByAppendingPathComponent("video.mp4")!!
-                            val (_, writeElapsed) = measureTimedValue {
-                                content.bytes.toNSData().writeToURL(url, atomically = true)
-                            }
-                            Logger.d(tag = "VideoIO") { "mp4 temp-file write: ${content.bytes.size} bytes in $writeElapsed" }
-                            url
-                        }
+                        // Already streamed to a disposable hbvid_res_* temp by the
+                        // resolver (#845) — no whole-payload RAM buffer, no second
+                        // temp-file write. Deleted on dispose (see tempFilePath).
+                        tempFilePath = content.filePath
+                        val mp4Url = NSURL.fileURLWithPath(content.filePath)
                         onProgress(0.8f)
                         val player = if (useInlineOptimizations) {
                             val item = AVPlayerItem(uRL = mp4Url)

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.web.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.web.kt
@@ -85,10 +85,16 @@ actual fun VideoPlayerSurface(
                     data.payload.descriptorContent,
                 ),
                 driveFileProvider,
+                // Web builds a Base64 object URL, so it needs bytes (the wasm FS
+                // is RAM-backed anyway). The render-limit guard bounds it: an
+                // oversized MP4 throws PayloadTooLargeException into the catch
+                // below → unplayable message instead of OOM-ing the tab (#845).
+                preferBytes = true,
                 onDownloadProgress = { onProgress(it * 0.9f) },
             )
             when (content) {
-                is VideoContent.Mp4 -> {
+                is VideoContent.Mp4File -> error("Mp4File is the file-backed variant — web passes preferBytes")
+                is VideoContent.Mp4Bytes -> {
                     val mime = content.metadata.mimeType.ifBlank { "video/mp4" }
                     val url = bytesToObjectUrl(Base64.encode(content.bytes), mime)
                     objectUrl = url

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
@@ -2,6 +2,7 @@ package id.homebase.core.image
 
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.NotFoundException
+import id.homebase.api.client.PayloadTooLargeException
 import id.homebase.api.client.RetryConfig
 import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.client.withRetry
@@ -218,6 +219,16 @@ class HomebaseImageLoader(
                 )
             } catch (e: CancellationException) {
                 throw e
+            } catch (e: PayloadTooLargeException) {
+                // Above the render limit (#845): the full-res upgrade is refused
+                // deterministically — retrying can't shrink the payload. Returning
+                // null keeps the already-rendered thumbnail on screen instead of
+                // OOM-ing on a huge image.
+                Logger.w(tag = TAG) {
+                    "full payload too large to render (${e.sizeBytes} > ${e.limitBytes}) — " +
+                        "keeping thumbnail for ${data.fileId}/${data.payloadKey}"
+                }
+                return@withRetry null
             } catch (e: Exception) {
                 throw RuntimeException(
                     buildImageLoadFailureMessage(

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultUploaderService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultUploaderService.kt
@@ -5,6 +5,8 @@ package id.homebase.core.ui.screens.vault
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.drives.files.DriveFileProvider
+import id.homebase.api.client.drives.files.ExportDestination
+import id.homebase.api.client.drives.files.PayloadDownloadService
 import id.homebase.api.client.drives.files.PayloadFile
 import id.homebase.api.client.drives.files.ThumbnailFile
 import id.homebase.api.client.drives.upload.EmbeddedThumb
@@ -46,6 +48,7 @@ class VaultUploaderService(
     private val uploadService: UploadService,
     private val fileOperationsProvider: FileOperationsProvider,
     private val driveFileProvider: DriveFileProvider,
+    private val payloadDownloadService: PayloadDownloadService,
     private val localAttachmentStore: LocalAttachmentContextStore,
     private val vaultService: VaultService,
 ) {
@@ -401,18 +404,20 @@ class VaultUploaderService(
                 file.keyHeader
             }
 
-            val bytes = driveFileProvider.getPayloadBytesDecrypted(
-                driveId = file.driveId,
-                fileId = file.fileId,
-                key = payloadKey,
-                keyHeader = keyHeader,
-            )?.bytes ?: return null
-
             val ct = payloadDescriptor?.contentType ?: file.contentType
             val extension = ct.substringAfter("/", "bin").let {
                 if (it == "jpeg") "jpg" else it
             }
-            fileOperationsProvider.writeBytesToTempFile(bytes, "share_", ".$extension")
+            // Stream-decrypt into a disposable upload-temp file (#845) — bounded RAM
+            // for any payload size; the old byte path buffered the whole payload
+            // (~2×) in memory. Same dir + sweep lifecycle as writeBytesToTempFile.
+            payloadDownloadService.exportToTemp(
+                driveId = file.driveId,
+                fileId = file.fileId,
+                key = payloadKey,
+                keyHeader = keyHeader,
+                destination = ExportDestination.UploadTemp("share_", ".$extension"),
+            )
         } catch (e: Exception) {
             Logger.e(e, TAG) { "Failed to download payload $payloadKey from ${file.fileId}" }
             null

--- a/homebase-upload/src/commonMain/kotlin/id/homebase/upload/PayloadCacheSeeder.kt
+++ b/homebase-upload/src/commonMain/kotlin/id/homebase/upload/PayloadCacheSeeder.kt
@@ -83,9 +83,9 @@ open class PayloadCacheSeeder(
          * Payload seeding is a convenience (avoids a server re-download for the
          * sender); thumbnails are the critical seed and are small. Above this size
          * the 200 MB LRU payload cache can't usefully retain the entry anyway, and
-         * `readFileBytes` would spike RAM by the full payload size. Aligned with
-         * `CacheAudit.LOUD_THRESHOLD_BYTES` (the existing "large cache entry" signal).
+         * `readFileBytes` would spike RAM by the full payload size. Delegates to
+         * the render/export boundary (#845) so the numbers can't drift.
          */
-        const val MAX_SEED_PAYLOAD_BYTES: Long = 50L * 1024 * 1024
+        val MAX_SEED_PAYLOAD_BYTES: Long = id.homebase.api.client.PayloadSizePolicy.RENDER_LIMIT_BYTES
     }
 }


### PR DESCRIPTION
Part 1 of 2 for #845 (PR 2 will add the dedicated HLS chunk cache).

## Principle

Downloads are re-fetchable ⇒ disposable. **The LRU only holds what the app can render in-app (≤ 50 MB)** — anything larger has no second read, so it streams to a file and never enters a cache. No dynamic cache expansion; no new temp-dir kinds (all export destinations are existing swept dirs).

## Scenarios fixed

- **Share a 1 GB attachment to another app** (chat share, fullscreen viewer, vault — three hand-rolled copies): was full body in RAM + full decrypt ≈ **2 GB peak → OOM**, plus the 1 GB LRU commit made Coil's `trimToSize` evict *every* cached payload and then the new entry itself. Now: streamed decrypt into `share_outbound/`/`upload-temp/`, ~64 KB working set, LRU untouched.
- **Foreign large non-segmented MP4** (300 MB, `isSegmented=false`): was ~2× RAM + LRU churn + a third full copy written to a temp the player reads anyway. Now: `VideoContent.Mp4File` — the resolver streams decrypt-to-file into `hbvid_res_*` (swept pattern), all platforms play from the path, deleted on player dispose. Web keeps a guarded `Mp4Bytes` variant (RAM FS): oversized → the existing unplayable message instead of OOM-ing the tab.
- **Oversized image**: full-res upgrade refused deterministically → thumbnail stays (never OOM), WARN logged, no retries.
- **1 GB zip save**: already streamed — now structurally protected: no byte-array path can pull it into RAM/LRU.

## What

- `PayloadSizePolicy.RENDER_LIMIT_BYTES` (50 MB) + `PayloadTooLargeException`; the #947 seeder cap and `CacheAudit.LOUD_THRESHOLD_BYTES` delegate to it.
- Central guard in `requestBytes(maxBytes)`: over-limit `Content-Length` refused **before** the body is read; counting fallback for length-less responses. Full payload reads capped (deletes the standing "500MB file in memory" TODO); range reads (HLS playback) exempt by shape.
- Cache-admission fence in `writeToDiskCache` (>50 MB refused + WARN) — the oversized-commit churn becomes structurally impossible.
- **`PayloadDownloadService`** — download-side counterpart of `UploadService` (facade, not module): `renderBytes` (guarded, cached) / `exportToTemp(ExportDestination)` (streamed, any size, LRU-bypassed). All reroutes go through it; a Konsist guard banning direct byte-reads outside it is a named follow-up.
- `streamPayloadDecryptedToPath` gains `onProgress` so the rerouted MP4 path keeps real download progress.
- `VideoPreloader` skips export-sized/unknown-size MP4 prefetches (progress still settles — #788 invariant).

## Tests

Guard: header refusal (typed, carries size+limit, no cache write, no 404-poisoning), counting fallback, range exemption, seed fence. Facade: byte-exact streamed decrypt per destination, 404 → null with no leftover reservation, monotonic progress, guarded renderBytes. Resolver: S4 regression (streams, never byte-buffers; web bytes variant). Preloader gates. Path reservations + sweep compatibility.

Verified locally: `jvmTest` + `testDebugUnitTest` (all modules), `:homebase-api:wasmJsTest`, android/wasm compiles for all five modules. iOS compile rides the `Build iOS` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWmvC3HQ7E1rHaD2ZXFkpC