### PR TITLE
Cache bucket 3/3 (PR 2): dedicated HLS playback-chunk cache

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
@@ -41,13 +41,18 @@ import okio.use
  * [DriveFileHttpProvider] so callers get transparent read-through caching
  * for payloads and thumbnails.
  *
- * Two underlying [coil3.disk.DiskCache] instances back the two
+ * Three underlying [coil3.disk.DiskCache] instances back the three
  * Storage-screen rows:
- * - `drive_payloads`   — media payload bytes (attachments). Directory
+ * - `drive_payloads`   — full media payload bytes (attachments), admission-
+ *   capped at PayloadSizePolicy.RENDER_LIMIT_BYTES (#845). Directory
  *   `homebase-payloads-v2`, cap 200 MB. Fetches are gated by
  *   [payloadSemaphore] (1 concurrent network request).
  * - `drive_thumbnails` — thumbnail bytes. Directory `homebase-thumbs-v2`,
  *   cap 300 MB. Fetches are gated by [thumbnailSemaphore] (30 concurrent).
+ * - `hls_chunks` — HLS playback byte-range entries (#845). Directory
+ *   `homebase-hls-chunks-v1`, cap 100 MB. Isolated so one long video can't
+ *   evict images/attachments and vice versa; routed by request shape in
+ *   [getPayloadBytesRaw].
  *
  * The payload/thumbnail split follows the same "small-hot vs large-cold"
  * stratification as PublicProfileProviderCached — thumbnails render on
@@ -123,6 +128,22 @@ class DriveFileProviderCached(
             .maxSizeBytes(300L * 1024L * 1024L) // 300MB
             .build()
 
+    // HLS playback range-chunks get their OWN cache (#845): every byte-range a
+    // player requests is an independent LRU entry, so one long video used to
+    // flood the shared payload cache and evict every image/attachment — and an
+    // image burst evicted warm chunks mid-playback. Isolation means the two
+    // populations can no longer evict each other. Routing is by request shape
+    // (chunkStart != null) inside getPayloadBytesRaw — NOT per-caller — so the
+    // seg-0 preloader, ExoPlayer's decrypted-range reads, iOS LocalVideoServer's
+    // encrypted-range reads, and desktop VLC range reads all converge here (all
+    // four cache the same encrypted range bytes; decryption is always post-read).
+    private val hlsChunkDir = "$directory/homebase-hls-chunks-v1"
+    private val hlsChunkDiskCache: DiskCache = DiskCache.Builder()
+            .directory(hlsChunkDir.toPath())
+            .fileSystem(fileSystem)
+            .maxSizeBytes(100L * 1024L * 1024L) // 100MB
+            .build()
+
     init {
         // Fire-and-forget reclaim of the pre-migration mayakapps/kache cache
         // directories. Best-effort — a missing dir is fine, and any failure
@@ -166,6 +187,12 @@ class DriveFileProviderCached(
     ): ByteApiResponse {
         val cacheKey =
                 buildPayloadCacheKey(driveId, fileId, key, options.chunkStart, options.chunkLength)
+        // The ONE routing decision (#845): range-shaped requests live in the
+        // dedicated chunk cache, full-payload reads in the payload LRU. Keeping
+        // it here (not per-caller) guarantees prefetch and playback share a
+        // cache — split caches would make every seg-0 prefetch a guaranteed
+        // playback miss AND pollute the payload LRU.
+        val cache = if (options.chunkStart != null) hlsChunkDiskCache else payloadDiskCache
 
         // 1️⃣ Check in-memory 404 cache first
         if (cacheKey in notFoundCache) {
@@ -173,7 +200,7 @@ class DriveFileProviderCached(
         }
 
         // 2️⃣ Peek in disk cache and return result if it's there
-        readCachedPayloadOrLog(cacheKey)?.let { return it }
+        readCachedPayloadOrLog(cache, cacheKey)?.let { return it }
 
         // 2️⃣ Fetch from network but lock to make sure that we don't load the same
         // resource twice over the network
@@ -185,7 +212,7 @@ class DriveFileProviderCached(
             if (cacheKey in notFoundCache) {
                 return@withLock ByteApiResponse.EMPTY_404
             }
-            readCachedPayloadOrLog(cacheKey)?.let { return@withLock it }
+            readCachedPayloadOrLog(cache, cacheKey)?.let { return@withLock it }
 
             // we allow up to 3 concurrent semaphore payloads over the network
             return payloadSemaphore.withPermit {
@@ -196,7 +223,7 @@ class DriveFileProviderCached(
                     check(result.status in 200..299) {
                         "Unexpected non-2xx status ${result.status} reached disk cache write — not caching"
                     }
-                    writeToDiskCache(payloadDiskCache, cacheKey, "PayloadIO", result)
+                    writeToDiskCache(cache, cacheKey, "PayloadIO", result)
                     result
                 } catch (e: NotFoundException) {
                     // 404 thrown by network layer — cache it so future calls skip the network
@@ -382,9 +409,9 @@ class DriveFileProviderCached(
      * Payload-cache analog of [readCachedThumbOrLog]. Defense-in-depth against
      * parse failures.
      */
-    private fun readCachedPayloadOrLog(cacheKey: String): ByteApiResponse? {
+    private fun readCachedPayloadOrLog(cache: DiskCache, cacheKey: String): ByteApiResponse? {
         return try {
-            payloadDiskCache.openSnapshot(cacheKey.toDiskKey())?.use { snap ->
+            cache.openSnapshot(cacheKey.toDiskKey())?.use { snap ->
                 readBytesResponse(snap.data.toString())
             }
         } catch (e: Exception) {
@@ -599,6 +626,10 @@ class DriveFileProviderCached(
             newFileId: Uuid,
             payloads: List<PayloadDescriptor>
     ) {
+        // Chunk-cache entries are intentionally NOT rekeyed (#845): range entries
+        // only exist for files already synced under their server fileId (the
+        // sender's own playback uses the local file, and the seeder seeds full
+        // payloads only) — there is nothing under the optimistic fileId to move.
         for (descriptor in payloads) {
             moveCacheEntry(
                     cache = payloadDiskCache,
@@ -703,6 +734,11 @@ class DriveFileProviderCached(
         } catch (e: Exception) {
             Logger.w(tag = "DriveFileProviderCached", throwable = e) { "thumb cache clear failed" }
         }
+        try {
+            hlsChunkDiskCache.clear()
+        } catch (e: Exception) {
+            Logger.w(tag = "DriveFileProviderCached", throwable = e) { "hls chunk cache clear failed" }
+        }
 
         notFoundCache = emptySet()
     }
@@ -724,6 +760,12 @@ class DriveFileProviderCached(
         } catch (e: Throwable) {
             Logger.w(tag = "DriveFileProviderCached", throwable = e) { "drive_thumbnails stats unavailable" }
             out.add(CacheStats(id = "drive_thumbnails", sizeBytes = CacheStats.UNAVAILABLE, maxBytes = 0L))
+        }
+        try {
+            out.add(CacheStats(id = "hls_chunks", sizeBytes = hlsChunkDiskCache.size, maxBytes = hlsChunkDiskCache.maxSize))
+        } catch (e: Throwable) {
+            Logger.w(tag = "DriveFileProviderCached", throwable = e) { "hls_chunks stats unavailable" }
+            out.add(CacheStats(id = "hls_chunks", sizeBytes = CacheStats.UNAVAILABLE, maxBytes = 0L))
         }
         return out
     }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheAudit.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/file/CacheAudit.kt
@@ -34,6 +34,9 @@ object CacheAudit {
         "homebase-thumbs-v2",
         "homebase-public-profiles-v2",
         "homebase-public-images-v2",
+        // Dedicated HLS playback-chunk LRU (#845) — isolated so one long video
+        // can't evict images/attachments and vice versa.
+        "homebase-hls-chunks-v1",
     )
 
     /**

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/file/CacheAuditTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/file/CacheAuditTest.kt
@@ -59,6 +59,23 @@ class CacheAuditTest {
     }
 
     @Test
+    fun audit_countsHlsChunkCacheAsKnown() {
+        // The dedicated HLS chunk cache (#845) must be a tracked dir — otherwise
+        // the startup sweep would wipe warm playback chunks on every launch.
+        val fs = FakeFileSystem()
+        fs.createDirectories(cacheDir)
+        fs.writeFile("/cache/homebase-hls-chunks-v1/chunk", 400)
+
+        val report = CacheAudit.audit(cacheDir.toString(), fs)
+
+        assertEquals(400L, report.knownBytes)
+        assertEquals(0L, report.untrackedBytes)
+        val entry = report.entries.single { it.name == "homebase-hls-chunks-v1" }
+        assertTrue(entry.known)
+        assertEquals("tracked Coil disk cache", entry.label)
+    }
+
+    @Test
     fun audit_missingCacheDir_returnsEmptyReport() {
         val fs = FakeFileSystem()
         val report = CacheAudit.audit("/nonexistent".toPath().toString(), fs)

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/file/CacheSweeperTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/file/CacheSweeperTest.kt
@@ -48,6 +48,20 @@ class CacheSweeperTest {
     }
 
     @Test
+    fun hlsChunkCacheDir_isTracked_keptOnStartupSweep_deletedOnLogout() {
+        // The dedicated HLS chunk cache (#845) is a tracked Coil LRU like the
+        // -v2 dirs: KEEP on the startup / "Clear caches" sweep, DELETE on logout.
+        assertEquals(
+            SweepAction.KEEP,
+            decide(entry("homebase-hls-chunks-v1", known = true), SweepMode.UNTRACKED),
+        )
+        assertEquals(
+            SweepAction.DELETE,
+            decide(entry("homebase-hls-chunks-v1", known = true), SweepMode.ALL),
+        )
+    }
+
+    @Test
     fun outboxTempDir_isKeptOnUntrackedSweep_butDeletedOnLogout() {
         // outbox-temp holds encrypted payloads referenced by pending (incl. offline) outbox rows —
         // a startup / "Clear caches" sweep must NOT delete them (the outbox reaps them on

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
@@ -43,6 +43,7 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.uuid.Uuid
 
@@ -336,10 +337,11 @@ class DriveFileProviderCachedTest {
 
         val stats = provider.getCacheStats()
 
-        assertEquals(2, stats.size, "both rows must be returned even if one ctor failed")
+        assertEquals(3, stats.size, "all rows must be returned even if one ctor failed")
 
         val payload = stats.single { it.id == "drive_payloads" }
         val thumb = stats.single { it.id == "drive_thumbnails" }
+        val chunks = stats.single { it.id == "hls_chunks" }
 
         assertTrue(
             payload.sizeBytes != CacheStats.UNAVAILABLE,
@@ -349,6 +351,10 @@ class DriveFileProviderCachedTest {
             CacheStats.UNAVAILABLE, thumb.sizeBytes,
             "broken thumb cache must be marked unavailable via the sentinel"
         )
+        assertTrue(
+            chunks.sizeBytes != CacheStats.UNAVAILABLE,
+            "healthy chunk cache must NOT be marked unavailable (got sizeBytes=${chunks.sizeBytes})"
+        )
     }
 
     /**
@@ -357,6 +363,116 @@ class DriveFileProviderCachedTest {
      * never-sent (failed) message's media retrievable for retry. The mock
      * engine throws on any request to prove the network is never touched.
      */
+    // ==================== #845 PR2: dedicated HLS chunk cache ====================
+
+    private fun statsSize(stats: List<CacheStats>, id: String): Long =
+        stats.single { it.id == id }.sizeBytes
+
+    @Test
+    fun `range reads land in the chunk cache and never pollute the payload LRU`() = runTest {
+        nextBody = ByteArray(4096) { 3 }
+
+        provider.getPayloadBytesRaw(
+            driveId, fileId, key,
+            options = PayloadOperationOptions(chunkStart = 0L, chunkLength = 4096L),
+        )
+
+        val stats = provider.getCacheStats()
+        assertTrue(statsSize(stats, "hls_chunks") > 0L, "chunk must land in the chunk cache: $stats")
+        assertEquals(0L, statsSize(stats, "drive_payloads"), "the payload LRU must contain NO range entries: $stats")
+
+        // Second identical range read → served from the chunk cache, no new fetch.
+        val before = requestCount
+        val again = provider.getPayloadBytesRaw(
+            driveId, fileId, key,
+            options = PayloadOperationOptions(chunkStart = 0L, chunkLength = 4096L),
+        )
+        assertEquals(before, requestCount, "warm chunk must be served without the network")
+        assertContentEquals(nextBody, again.bytes)
+    }
+
+    /**
+     * OWNER-REQUIRED (#845): the seg-0 PRELOADER and playback range reads must
+     * converge on the same chunk cache. The preloader warms via
+     * `DriveFileProvider.prefetchPayloadChunk`; iOS's LocalVideoServer reads the
+     * same range via `getPayloadBytesEncryptedChunk` — two different entry
+     * points, ONE network fetch, and zero range entries in the payload LRU.
+     * (If routing were per-caller, prefetch would write the payload LRU while
+     * playback reads the chunk cache: a guaranteed seg-0 double-download plus
+     * pollution.)
+     */
+    @Test
+    fun `prefetched seg0 is served to playback from the chunk cache with no second fetch`() = runTest {
+        nextBody = ByteArray(2048) { 9 }
+        val fileProvider = id.homebase.api.client.drives.files.DriveFileProvider(
+            httpClient, credentialsManager, provider,
+        )
+
+        // 1) Preloader shape: VideoPreloader.preloadFirstHlsSegment → prefetchPayloadChunk.
+        fileProvider.prefetchPayloadChunk(driveId, fileId, key, chunkStart = 0L, chunkLength = 2048L)
+        assertEquals(1, requestCount)
+
+        // 2) Playback shape: iOS LocalVideoServer → getPayloadBytesEncryptedChunk, same range.
+        val bytes = fileProvider.getPayloadBytesEncryptedChunk(driveId, fileId, key, chunkStart = 0L, chunkLength = 2048L)
+
+        assertEquals(1, requestCount, "playback must be served from the prefetch-warmed chunk cache")
+        assertContentEquals(nextBody, assertNotNull(bytes))
+        assertEquals(0L, statsSize(provider.getCacheStats(), "drive_payloads"),
+            "no range entry may leak into the payload LRU")
+    }
+
+    @Test
+    fun `full reads still land in the payload LRU, not the chunk cache`() = runTest {
+        nextBody = ByteArray(1024) { 5 }
+
+        provider.getPayloadBytesRaw(driveId, fileId, key)
+
+        val stats = provider.getCacheStats()
+        assertTrue(statsSize(stats, "drive_payloads") > 0L, "full read must land in the payload LRU: $stats")
+        assertEquals(0L, statsSize(stats, "hls_chunks"), "full read must not leak into the chunk cache: $stats")
+    }
+
+    @Test
+    fun `clearCaches empties the chunk cache and getCacheStats reports its 100 MB cap`() = runTest {
+        nextBody = ByteArray(512) { 1 }
+        provider.getPayloadBytesRaw(
+            driveId, fileId, key,
+            options = PayloadOperationOptions(chunkStart = 0L, chunkLength = 512L),
+        )
+        assertTrue(statsSize(provider.getCacheStats(), "hls_chunks") > 0L)
+        assertEquals(100L * 1024 * 1024, provider.getCacheStats().single { it.id == "hls_chunks" }.maxBytes)
+
+        provider.clearCaches()
+
+        assertEquals(0L, statsSize(provider.getCacheStats(), "hls_chunks"))
+        val before = requestCount
+        provider.getPayloadBytesRaw(
+            driveId, fileId, key,
+            options = PayloadOperationOptions(chunkStart = 0L, chunkLength = 512L),
+        )
+        assertEquals(before + 1, requestCount, "cleared chunk must be re-fetched")
+    }
+
+    @Test
+    fun `rekey leaves chunk entries alone`() = runTest {
+        nextBody = ByteArray(256) { 2 }
+        provider.getPayloadBytesRaw(
+            driveId, fileId, key,
+            options = PayloadOperationOptions(chunkStart = 0L, chunkLength = 256L),
+        )
+        val chunkBytesBefore = statsSize(provider.getCacheStats(), "hls_chunks")
+
+        provider.rekeyCachedFile(
+            driveId, fileId, Uuid.parse("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+            payloads = listOf(PayloadDescriptor(key = key, contentType = "video/mp2t")),
+        )
+
+        assertEquals(
+            chunkBytesBefore, statsSize(provider.getCacheStats(), "hls_chunks"),
+            "chunk entries are intentionally not rekeyed — they only exist post-sync",
+        )
+    }
+
     // ==================== #845: render/export size guard ====================
 
     @Test

--- a/homebase-chat/src/androidMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.android.kt
+++ b/homebase-chat/src/androidMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.android.kt
@@ -300,14 +300,28 @@ actual fun VideoPlayerSurface(
                             player.setMediaSource(mediaSource)
                             val prepareStart = TimeSource.Monotonic.markNow()
                             val hlsFirstFrameListener = object : Player.Listener {
-                                private var stateReadyLogged = false
+                                private var progressCompleted = false
+                                // Progress completion fires on WHICHEVER of STATE_READY /
+                                // first-frame / player-error arrives first: on some
+                                // device+codec combos the first frame renders BEFORE the
+                                // READY transition, and the old remove-listener-on-first-
+                                // frame left nobody around to hear READY — the spinner
+                                // froze at its last emit (0% on a warm cache) over a
+                                // PLAYING video. An error means READY never comes at all
+                                // (e.g. 10-bit AVC High-10 → NO_EXCEEDS_CAPABILITIES),
+                                // which used to spin forever.
+                                private fun completeProgress(source: String) {
+                                    if (progressCompleted) return
+                                    progressCompleted = true
+                                    Logger.d(tag = "VideoIO") { "HLS progress complete via $source: ${prepareStart.elapsedNow()}  |  total click→ready: ${clickMark.elapsedNow()}" }
+                                    progressJob.cancel()
+                                    onProgress(1f)
+                                }
                                 override fun onPlaybackStateChanged(playbackState: Int) {
-                                    if (playbackState == Player.STATE_READY && !stateReadyLogged) {
-                                        stateReadyLogged = true
-                                        Logger.d(tag = "VideoIO") { "HLS prepare→STATE_READY: ${prepareStart.elapsedNow()}  |  total click→ready: ${clickMark.elapsedNow()}" }
-                                        progressJob.cancel()
-                                        onProgress(1f)
-                                    }
+                                    if (playbackState == Player.STATE_READY) completeProgress("STATE_READY")
+                                }
+                                override fun onPlayerError(error: PlaybackException) {
+                                    completeProgress("player-error")
                                 }
                                 // Hide the loading spinner the moment a real
                                 // pixel has been pushed to the TextureView —
@@ -318,6 +332,7 @@ actual fun VideoPlayerSurface(
                                 // between "ready to play" and "playing".
                                 override fun onRenderedFirstFrame() {
                                     Logger.d(tag = "VideoIO") { "HLS first-frame: ${clickMark.elapsedNow()}" }
+                                    completeProgress("first-frame")
                                     firstFramePainted = true
                                     onFirstFrame()
                                     player.removeListener(this)
@@ -347,16 +362,26 @@ actual fun VideoPlayerSurface(
                             onProgress(0.8f)
                             val prepareStart = TimeSource.Monotonic.markNow()
                             val mp4FirstFrameListener = object : Player.Listener {
-                                private var stateReadyLogged = false
+                                private var progressCompleted = false
+                                // Same completion race as the HLS listener above: first
+                                // frame can render BEFORE STATE_READY, and the old
+                                // remove-on-first-frame lost the READY→100% emit — the
+                                // bar froze at exactly 80% over a playing video.
+                                private fun completeProgress(source: String) {
+                                    if (progressCompleted) return
+                                    progressCompleted = true
+                                    Logger.d(tag = "VideoIO") { "mp4 progress complete via $source: ${prepareStart.elapsedNow()}  |  total click→ready: ${clickMark.elapsedNow()}" }
+                                    onProgress(1f)
+                                }
                                 override fun onPlaybackStateChanged(playbackState: Int) {
-                                    if (playbackState == Player.STATE_READY && !stateReadyLogged) {
-                                        stateReadyLogged = true
-                                        Logger.d(tag = "VideoIO") { "mp4 prepare→STATE_READY: ${prepareStart.elapsedNow()}  |  total click→ready: ${clickMark.elapsedNow()}" }
-                                        onProgress(1f)
-                                    }
+                                    if (playbackState == Player.STATE_READY) completeProgress("STATE_READY")
+                                }
+                                override fun onPlayerError(error: PlaybackException) {
+                                    completeProgress("player-error")
                                 }
                                 override fun onRenderedFirstFrame() {
                                     Logger.d(tag = "VideoIO") { "mp4 first-frame: ${clickMark.elapsedNow()}" }
+                                    completeProgress("first-frame")
                                     firstFramePainted = true
                                     onFirstFrame()
                                     player.removeListener(this)

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -609,6 +609,7 @@
     <string name="storage_defragment_button">Defragmentér</string>
     <string name="storage_cache_payloads">Mediedata</string>
     <string name="storage_cache_thumbnails">Miniaturebilleder</string>
+    <string name="storage_cache_hls_chunks">Videostream-cache</string>
     <string name="storage_cache_profile_images">Profilbilleder</string>
     <string name="storage_cache_profiles">Offentlige profiler</string>
     <string name="storage_cache_coil_memory">Billeder i hukommelsen</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -235,6 +235,7 @@
     <string name="storage_cache_profile_images">Profile images</string>
     <string name="storage_cache_payloads">Media payloads</string>
     <string name="storage_cache_thumbnails">Thumbnails</string>
+    <string name="storage_cache_hls_chunks">Video stream cache</string>
     <string name="storage_cache_unknown">Other</string>
     <string name="storage_cache_size_format">%1$s / %2$s</string>
     <string name="storage_drive_count_format">%1$d items</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsScreen.kt
@@ -55,6 +55,7 @@ import id.homebase.resources.storage_orphan_coil_title
 import id.homebase.resources.storage_cache_coil_memory
 import id.homebase.resources.storage_cache_payloads
 import id.homebase.resources.storage_cache_profile_images
+import id.homebase.resources.storage_cache_hls_chunks
 import id.homebase.resources.storage_cache_profiles
 import id.homebase.resources.storage_cache_ram_badge
 import id.homebase.resources.storage_cache_size_format
@@ -444,6 +445,7 @@ private fun cacheColor(id: String): Color = when (id) {
     "public_images"    -> MaterialTheme.colorScheme.tertiary
     "drive_payloads"   -> MaterialTheme.colorScheme.secondary
     "drive_thumbnails" -> MaterialTheme.colorScheme.errorContainer
+    "hls_chunks"       -> MaterialTheme.colorScheme.tertiaryContainer
     else               -> MaterialTheme.colorScheme.outline
 }
 
@@ -550,6 +552,7 @@ private fun cacheLabelRes(id: String): StringResource = when (id) {
     "public_images" -> MR.string.storage_cache_profile_images
     "drive_payloads" -> MR.string.storage_cache_payloads
     "drive_thumbnails" -> MR.string.storage_cache_thumbnails
+    "hls_chunks" -> MR.string.storage_cache_hls_chunks
     StorageSettingsViewModel.COIL_MEMORY_ID -> MR.string.storage_cache_coil_memory
     else -> MR.string.storage_cache_unknown
 }


### PR DESCRIPTION
Part 2 of 2 for #845 — stacked on #954. Retarget to `main` after #954 merges; CI runs then. Closes #845 on merge.

## What

HLS playback range-reads were cached per `(chunkStart, chunkLength)` in the shared **200 MB payload LRU** — watching one long video evicted every cached image/attachment, and an image burst evicted warm video chunks mid-playback (S2 in the issue). Chunks now live in a dedicated **`homebase-hls-chunks-v1` cache (100 MB, tracked)**.

**The load-bearing design point:** routing is one request-shaped decision inside `DriveFileProviderCached.getPayloadBytesRaw` (`chunkStart != null` → chunk cache), *not* per-caller — so the **seg-0 preloader**, ExoPlayer's decrypted-range reads, iOS `LocalVideoServer`'s encrypted-range reads, and desktop VLC range reads all converge on the same cache. A per-caller split would make every prefetch a guaranteed playback miss *plus* LRU pollution. All platforms cache the same encrypted range bytes (decryption is post-read), so one cache serves everything. PR 1's 50 MB admission fence also covers open-ended AVPlayer probes (`bytes=0-`) producing file-sized "chunks".

Lifecycle rides existing machinery: `KNOWN_CACHE_DIRS` inclusion gives KEEP-on-startup-sweep / DELETE-on-logout automatically; `clearCaches`/`getCacheStats`/Storage screen gain the third row ("Video stream cache", en+da). `rekeyCachedFile` intentionally ignores chunk entries (they only exist post-sync under the server fileId — documented in code).

## Tests

- Range reads land in the chunk cache; **zero range entries in the payload LRU** (the invariant).
- **Owner-required convergence test**: prefetch seg-0 via `prefetchPayloadChunk`, then read the same range via `getPayloadBytesEncryptedChunk` (the iOS playback shape) → **one network fetch total**.
- Full reads still land in the payload LRU (no leak the other way); warm-chunk re-read = no network; clear/stats (100 MB cap, sentinel isolation)/rekey behavior; `CacheAudit` counts the dir as known; sweeper KEEP/DELETE mode tests.

Verified locally: `jvmTest` + `testDebugUnitTest` (all modules), `:homebase-api:wasmJsTest`, android/wasm compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWmvC3HQ7E1rHaD2ZXFkpC