### PR TITLE
Fix video progress spinner: complete on first of READY / first-frame / error

### DIFF
--- a/homebase-chat/src/androidMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.android.kt
+++ b/homebase-chat/src/androidMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.android.kt
@@ -300,14 +300,28 @@ actual fun VideoPlayerSurface(
                             player.setMediaSource(mediaSource)
                             val prepareStart = TimeSource.Monotonic.markNow()
                             val hlsFirstFrameListener = object : Player.Listener {
-                                private var stateReadyLogged = false
+                                private var progressCompleted = false
+                                // Progress completion fires on WHICHEVER of STATE_READY /
+                                // first-frame / player-error arrives first: on some
+                                // device+codec combos the first frame renders BEFORE the
+                                // READY transition, and the old remove-listener-on-first-
+                                // frame left nobody around to hear READY — the spinner
+                                // froze at its last emit (0% on a warm cache) over a
+                                // PLAYING video. An error means READY never comes at all
+                                // (e.g. 10-bit AVC High-10 → NO_EXCEEDS_CAPABILITIES),
+                                // which used to spin forever.
+                                private fun completeProgress(source: String) {
+                                    if (progressCompleted) return
+                                    progressCompleted = true
+                                    Logger.d(tag = "VideoIO") { "HLS progress complete via $source: ${prepareStart.elapsedNow()}  |  total click→ready: ${clickMark.elapsedNow()}" }
+                                    progressJob.cancel()
+                                    onProgress(1f)
+                                }
                                 override fun onPlaybackStateChanged(playbackState: Int) {
-                                    if (playbackState == Player.STATE_READY && !stateReadyLogged) {
-                                        stateReadyLogged = true
-                                        Logger.d(tag = "VideoIO") { "HLS prepare→STATE_READY: ${prepareStart.elapsedNow()}  |  total click→ready: ${clickMark.elapsedNow()}" }
-                                        progressJob.cancel()
-                                        onProgress(1f)
-                                    }
+                                    if (playbackState == Player.STATE_READY) completeProgress("STATE_READY")
+                                }
+                                override fun onPlayerError(error: PlaybackException) {
+                                    completeProgress("player-error")
                                 }
                                 // Hide the loading spinner the moment a real
                                 // pixel has been pushed to the TextureView —
@@ -318,6 +332,7 @@ actual fun VideoPlayerSurface(
                                 // between "ready to play" and "playing".
                                 override fun onRenderedFirstFrame() {
                                     Logger.d(tag = "VideoIO") { "HLS first-frame: ${clickMark.elapsedNow()}" }
+                                    completeProgress("first-frame")
                                     firstFramePainted = true
                                     onFirstFrame()
                                     player.removeListener(this)
@@ -347,16 +362,26 @@ actual fun VideoPlayerSurface(
                             onProgress(0.8f)
                             val prepareStart = TimeSource.Monotonic.markNow()
                             val mp4FirstFrameListener = object : Player.Listener {
-                                private var stateReadyLogged = false
+                                private var progressCompleted = false
+                                // Same completion race as the HLS listener above: first
+                                // frame can render BEFORE STATE_READY, and the old
+                                // remove-on-first-frame lost the READY→100% emit — the
+                                // bar froze at exactly 80% over a playing video.
+                                private fun completeProgress(source: String) {
+                                    if (progressCompleted) return
+                                    progressCompleted = true
+                                    Logger.d(tag = "VideoIO") { "mp4 progress complete via $source: ${prepareStart.elapsedNow()}  |  total click→ready: ${clickMark.elapsedNow()}" }
+                                    onProgress(1f)
+                                }
                                 override fun onPlaybackStateChanged(playbackState: Int) {
-                                    if (playbackState == Player.STATE_READY && !stateReadyLogged) {
-                                        stateReadyLogged = true
-                                        Logger.d(tag = "VideoIO") { "mp4 prepare→STATE_READY: ${prepareStart.elapsedNow()}  |  total click→ready: ${clickMark.elapsedNow()}" }
-                                        onProgress(1f)
-                                    }
+                                    if (playbackState == Player.STATE_READY) completeProgress("STATE_READY")
+                                }
+                                override fun onPlayerError(error: PlaybackException) {
+                                    completeProgress("player-error")
                                 }
                                 override fun onRenderedFirstFrame() {
                                     Logger.d(tag = "VideoIO") { "mp4 first-frame: ${clickMark.elapsedNow()}" }
+                                    completeProgress("first-frame")
                                     firstFramePainted = true
                                     onFirstFrame()
                                     player.removeListener(this)


### PR DESCRIPTION
Found while device-testing the #845 builds — but pre-existing on `main` (reproduced identically on build 1947), diagnosed from the device log:

```
13:10:52.992  mp4 first-frame: 284ms
13:10:53.099  player state → READY        ← 100ms later; listener already removed
```

## The race

The per-play `Player.Listener` removed itself in `onRenderedFirstFrame`, but progress completion (`progressJob.cancel()` + `onProgress(1f)`) lived only in the `STATE_READY` handler. On device+codec combos where the first frame renders **before** READY, nobody was left listening:

- **MP4**: bar frozen at exactly **80%** over a playing video.
- **HLS**: spinner frozen at **0%** (warm cache → no download ticks below 1f) over a playing video.
- **Decode error** (e.g. 10-bit AVC High-10 HLG → `NO_EXCEEDS_CAPABILITIES`): READY never comes → spinner forever over a dead player.

## Fix

Both listeners route `STATE_READY` / `onRenderedFirstFrame` / `onPlayerError` through one idempotent `completeProgress(source)` (which logs which signal won, for future triage). Android-only: desktop switches UI state unconditionally; iOS already guards with `AVPlayerItemStatusFailed` + 10s timeout and emits 1f unconditionally.

The **10-bit send-side encode policy** (why that video can't decode at all on this device) is a separate issue to file.

Stacked on #955; retarget after it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWmvC3HQ7E1rHaD2ZXFkpC