### PR TITLE
fix(location): "Who you can locate" re-verifies on expansion with a 60s cache

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
@@ -654,7 +654,7 @@ private fun LocateStatusTrailing(status: LocateVerifyStatus?) {
         LocateVerifyStatus.Loading ->
             CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
 
-        LocateVerifyStatus.Broken ->
+        is LocateVerifyStatus.Broken ->
             Icon(
                 imageVector = Icons.Default.LinkOff,
                 contentDescription = stringResource(MR.string.location_locatable_broken_cd),

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
@@ -67,16 +67,37 @@ data class LocationUiState(
 /**
  * Result of the per-entry temporal-access preflight for a "who I can locate" row. The row shows a
  * spinner until this resolves, then either a broken-link icon or the age of the peer's newest data.
+ * Resolved results carry [Resolved.verifiedAtMs] so a re-expand within [LOCATE_VERIFY_TTL_MS]
+ * reuses them, while an older result is re-verified (#950).
  */
 sealed interface LocateVerifyStatus {
     /** Preflight in flight → spinner. */
     data object Loading : LocateVerifyStatus
 
+    /** A completed verify; [verifiedAtMs] is when the result landed (epoch ms), for the TTL. */
+    sealed interface Resolved : LocateVerifyStatus {
+        val verifiedAtMs: Long
+    }
+
     /** Verify succeeded but the peer no longer grants us access → broken-link icon. */
-    data object Broken : LocateVerifyStatus
+    data class Broken(override val verifiedAtMs: Long) : Resolved
 
     /** We hold access; [newestModifiedMs] is the peer's newest-file time, or null when no data yet. */
-    data class Active(val newestModifiedMs: Long?) : LocateVerifyStatus
+    data class Active(val newestModifiedMs: Long?, override val verifiedAtMs: Long) : Resolved
+}
+
+/** Freshness window for a resolved locate-verify result: re-expands inside it reuse the cache. */
+const val LOCATE_VERIFY_TTL_MS = 60_000L
+
+/**
+ * Whether an expansion of "Who you can locate" should (re-)issue the temporal verify for a row in
+ * this state: never while one is in flight, not while a resolved result is younger than
+ * [LOCATE_VERIFY_TTL_MS], otherwise yes (never verified, dropped as inconclusive, or gone stale).
+ */
+fun LocateVerifyStatus?.needsReverify(nowMs: Long): Boolean = when (this) {
+    LocateVerifyStatus.Loading -> false
+    is LocateVerifyStatus.Resolved -> nowMs - verifiedAtMs >= LOCATE_VERIFY_TTL_MS
+    null -> true
 }
 
 /** One row in the "Sharing with" list: a person and the latest time my share to them lasts. */

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
@@ -300,19 +300,17 @@ class LocationViewModel(
      * Preflight each "who I can locate" entry: does the peer still grant us temporal read access to
      * their location drive, and how fresh is their newest data? Fired when the section is expanded.
      * Each member is verified in its own coroutine so the spinners resolve independently. Members
-     * already resolved (or in flight) are skipped, so a re-expand is cheap. A network/parse failure
-     * is inconclusive — we drop the key (row shows nothing) so a re-expand retries, rather than
+     * with a call in flight, or a result younger than [LOCATE_VERIFY_TTL_MS], are skipped — so a
+     * quick re-expand is cheap, but a later one re-verifies with a visible spinner and a fresh age
+     * instead of showing the first-expand value forever (#950). A network/parse failure is
+     * inconclusive — we drop the key (row shows nothing) so a re-expand retries, rather than
      * falsely showing "broken"; this mirrors [EmergencyContactReconciler]'s leave-untouched rule.
      */
     fun verifyLocatableAccess() {
+        val now = Clock.System.now().toEpochMilliseconds()
         _uiState.value.whoICanLocate.forEach { member ->
             val key = member.odinId.domainName
-            when (_uiState.value.whoICanLocateStatus[key]) {
-                LocateVerifyStatus.Loading,
-                LocateVerifyStatus.Broken,
-                is LocateVerifyStatus.Active -> return@forEach // resolved or in flight
-                null -> Unit // (re)issue
-            }
+            if (!_uiState.value.whoICanLocateStatus[key].needsReverify(now)) return@forEach
             _uiState.update {
                 it.copy(whoICanLocateStatus = it.whoICanLocateStatus + (key to LocateVerifyStatus.Loading))
             }
@@ -320,15 +318,18 @@ class LocationViewModel(
                 val status = runCatching {
                     temporalDriveReadProvider.verifyTemporalAccess(member.odinId, locationDrive)
                 }.getOrNull()
+                val verifiedAt = Clock.System.now().toEpochMilliseconds()
                 _uiState.update {
                     val next = when {
                         // Inconclusive (threw) → drop so the next expand retries.
                         status == null -> it.whoICanLocateStatus - key
                         // Gate on hasAccess alone (windowSeconds is not a reliable discriminator, #875).
-                        !status.hasAccess -> it.whoICanLocateStatus + (key to LocateVerifyStatus.Broken)
+                        !status.hasAccess ->
+                            it.whoICanLocateStatus + (key to LocateVerifyStatus.Broken(verifiedAt))
                         // newestFileModified == 0 (ZeroTime) means no files yet → Active(null) = "no data".
                         else -> it.whoICanLocateStatus + (key to LocateVerifyStatus.Active(
-                            status.newestFileModified.milliseconds.takeIf { ms -> ms > 0 }
+                            newestModifiedMs = status.newestFileModified.milliseconds.takeIf { ms -> ms > 0 },
+                            verifiedAtMs = verifiedAt,
                         ))
                     }
                     it.copy(whoICanLocateStatus = next)

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/LocateVerifyFreshnessTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/LocateVerifyFreshnessTest.kt
@@ -1,0 +1,59 @@
+package id.homebase.core.ui.screens.location
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the 60s freshness contract for the "who I can locate" temporal verify (#950).
+ *
+ * Regression: the expand guard skipped every already-resolved row for the ViewModel's whole
+ * lifetime, so the verify only ever ran once per contact — a re-expand showed no spinner and a
+ * frozen first-expand age. The guard now keys on [needsReverify]: in-flight still short-circuits
+ * (no double-fire), a resolved result younger than [LOCATE_VERIFY_TTL_MS] is reused (instant
+ * re-expand by design), and anything older — or never verified / dropped as inconclusive —
+ * re-issues the verify.
+ */
+class LocateVerifyFreshnessTest {
+
+    private val now = 1_000_000_000L
+
+    @Test
+    fun neverVerifiedReverifies() {
+        assertTrue((null as LocateVerifyStatus?).needsReverify(now))
+    }
+
+    @Test
+    fun inFlightNeverDoubleFires() {
+        assertFalse(LocateVerifyStatus.Loading.needsReverify(now))
+        // Even a stale-looking in-flight marker must not re-fire.
+        assertFalse(LocateVerifyStatus.Loading.needsReverify(now + 10 * LOCATE_VERIFY_TTL_MS))
+    }
+
+    @Test
+    fun freshResultsAreReused() {
+        val justVerified = now - 1_000
+        assertFalse(LocateVerifyStatus.Active(newestModifiedMs = 123L, verifiedAtMs = justVerified).needsReverify(now))
+        assertFalse(LocateVerifyStatus.Active(newestModifiedMs = null, verifiedAtMs = justVerified).needsReverify(now))
+        assertFalse(LocateVerifyStatus.Broken(verifiedAtMs = justVerified).needsReverify(now))
+    }
+
+    @Test
+    fun staleResultsReverify() {
+        val stale = now - LOCATE_VERIFY_TTL_MS - 1
+        assertTrue(LocateVerifyStatus.Active(newestModifiedMs = 123L, verifiedAtMs = stale).needsReverify(now))
+        assertTrue(LocateVerifyStatus.Broken(verifiedAtMs = stale).needsReverify(now))
+    }
+
+    @Test
+    fun exactlyTtlOldReverifies() {
+        val atTtl = now - LOCATE_VERIFY_TTL_MS
+        assertTrue(LocateVerifyStatus.Active(newestModifiedMs = 123L, verifiedAtMs = atTtl).needsReverify(now))
+    }
+
+    @Test
+    fun justUnderTtlIsReused() {
+        val justUnder = now - LOCATE_VERIFY_TTL_MS + 1
+        assertFalse(LocateVerifyStatus.Active(newestModifiedMs = 123L, verifiedAtMs = justUnder).needsReverify(now))
+    }
+}


### PR DESCRIPTION
Fixes #950.

## Problem
Expanding "Who you can locate" only ran the per-contact temporal verify **once per ViewModel lifetime**: the guard in `LocationViewModel.verifyLocatableAccess()` early-returned for any already-resolved row, so every re-expand was instant, showed no spinner, and kept displaying the age from the first-expand `newestFileModified` forever.

## Fix
- `LocateVerifyStatus.Broken`/`Active` now carry `verifiedAtMs` (via a new `Resolved` sub-interface) recording when the verify completed.
- The expand guard now uses a pure `needsReverify(nowMs)` helper with a **60s TTL** (`LOCATE_VERIFY_TTL_MS`):
  - in-flight `Loading` still short-circuits (no double-fire on rapid toggles),
  - a resolved result **younger than 60s** is reused — instant re-expand, no network call, by design,
  - anything **older than 60s** (or never verified / dropped as inconclusive) re-issues the verify: the row goes back to `Loading`, so the existing per-row spinner (`LocateStatusTrailing`) shows, and the age refreshes from the fresh `newestFileModified`.
- The inconclusive-failure contract is unchanged: a thrown verify still drops the key so the next expand retries.

Out of scope per the issue: the temporal-verify API itself, the `iCanLocate` reconcile logic (#875), and the optional live-ticker age recompute.

## Testing
- New `LocateVerifyFreshnessTest` (jvmTest) pins the TTL contract: never-verified → verify; in-flight → never re-fire; <60s → reuse; ≥60s (incl. exactly 60s) → re-verify.
- `:homebase-core:compileKotlinJvm`, `:compileAndroidMain`, `:compileKotlinWasmJs` all green (iOS not compiled — Linux host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)