### PR TITLE
fix(location): never clear incoming iCanLocate from verify-based reconcile (#961)

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/contactbook/EmergencyContactReconciler.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/contactbook/EmergencyContactReconciler.kt
@@ -13,24 +13,27 @@ import kotlinx.coroutines.launch
 import kotlin.uuid.ExperimentalUuidApi
 
 /**
- * Reconciles the cached `iCanLocate` flag against the authoritative grant — the background backstop
- * for the best-effort status-message path ([EmergencyContactReceiveService]). The live status
- * message only fires on the WS-push path, so a designation/revocation that arrives during cold sync
- * (offline → login catch-up) or in a dropped event never updates the flag. Here we re-derive the
- * truth by preflighting the peer's location drive with
- * [TemporalDriveReadProvider.verifyTemporalAccess] (reads no data, fires no notification on the peer).
+ * Recovers a missed "they added me" designation — the set-only background backstop for the
+ * best-effort status-message path ([EmergencyContactReceiveService]). The live status message
+ * only fires on the WS-push path, so a designation that arrives during cold sync (offline →
+ * login catch-up) or in a dropped event never sets the flag. Here we re-derive it by
+ * preflighting the peer's location drive with
+ * [TemporalDriveReadProvider.verifyTemporalAccess] (reads no data, fires no notification on the
+ * peer).
  *
- * Two entry points by cost:
- * - [reconcileAll] — full two-way pass over identity contacts: SET the flag where we now have access
- *   (recovers a missed "they added me") and CLEAR it where we don't (recovers a missed "they removed
- *   me"). One preflight per identity contact; run in the background at login via [start], NOT per
- *   screen open.
- * - [reconcile] — cheap clear-only pass over already-flagged contacts. Safe to call on screen open.
+ * Deliberately SET-only (issue #961): a non-throwing `hasAccess = false` is NOT a trustworthy
+ * revocation signal — it also fires on benign/ambiguous negatives (and has been observed after
+ * the owner emptied their own *outgoing* emergency circle), so a verify-based clear silently
+ * wiped the incoming "Who you can locate" list. The only path that clears `iCanLocate` is the
+ * peer's explicit revocation message ([EmergencyContactReceiveService.onRevoked]); a stale flag
+ * surfaces non-destructively as a broken row via the per-entry freshness check instead.
  *
- * A network/parse failure is inconclusive — we leave the flag untouched rather than flip on a guess.
+ * A network/parse failure is inconclusive — we leave the flag untouched rather than flip on a
+ * guess.
  *
- * Limitation: only contacts we already hold can be reconciled (a peer who added us but isn't in our
- * contact book yet has no row to flag — the status message remains the discovery path for those).
+ * Limitation: only contacts we already hold can be reconciled (a peer who added us but isn't in
+ * our contact book yet has no row to flag — the status message remains the discovery path for
+ * those).
  */
 class EmergencyContactReconciler(
     private val contactRepository: ContactRepository,
@@ -39,56 +42,53 @@ class EmergencyContactReconciler(
 ) {
     private val locationDrive = locationLabeledDrive.drive.alias
 
-    /** Fire-and-forget the full two-way reconcile in the background (called once at login). */
+    /** Fire-and-forget the full set-only reconcile in the background (called once at login). */
     fun start() {
         scope.launch { runCatching { reconcileAll() } }
     }
 
     /**
-     * Full two-way reconcile over identity-backed contacts. Recovers both directions the live
-     * status-message path can miss. One temporal-access preflight per identity contact.
+     * Set-only pass over identity-backed contacts: recovers a designation the live status-message
+     * path missed. One temporal-access preflight per unflagged identity contact.
      */
     suspend fun reconcileAll() {
         contactRepository.ensureLoaded()
         for (contact in contactRepository.contacts.value) {
-            reconcileContact(contact, allowSet = true)
+            reconcileContact(contact)
         }
     }
 
-    /** Cheap clear-only pass: verify each can-locate contact still grants us access, clear if not. */
-    suspend fun reconcile() {
-        contactRepository.ensureLoaded()
-        for (contact in contactRepository.contacts.value.filter { it.iCanLocate() }) {
-            reconcileContact(contact, allowSet = false)
-        }
-    }
-
-    /**
-     * Aligns one contact's [iCanLocate] flag with the authoritative preflight. When [allowSet] is
-     * false this is clear-only and skips contacts that aren't flagged (so it never preflights — and
-     * never pays for — a contact there's nothing to clear on).
-     */
-    private suspend fun reconcileContact(contact: Contact, allowSet: Boolean) {
+    private suspend fun reconcileContact(contact: Contact) {
         val odinId = contact.content.odinId?.takeIf { it.isNotBlank() }?.let { OdinId(it) } ?: return
         val versionTag = contact.versionTag ?: return
-        val flagged = contact.iCanLocate()
-        // Clear-only mode has nothing to do for an unflagged contact — skip the preflight entirely.
-        if (!flagged && !allowSet) return
+        // Set-only: an already-flagged contact has nothing to recover — skip the preflight entirely.
+        if (contact.iCanLocate()) return
 
         val status = runCatching { temporalRead.verifyTemporalAccess(odinId, locationDrive) }
-            .getOrNull() ?: return
-        // Emergency designation == currently holding temporal read access to the peer's location
-        // drive. windowSeconds is NOT a reliable ACL-type discriminator — a real emergency-circle
-        // grant has been observed reporting windowSeconds=null in practice (see issue #875) — so
-        // gate on hasAccess alone.
-        when {
-            status.hasAccess && !flagged && allowSet ->
-                runCatching { contactRepository.setICanLocate(contact.uniqueId, versionTag) }
-                    .onFailure { Logger.w(it) { "reconcile: setICanLocate failed for ${odinId.domainName}" } }
-
-            !status.hasAccess && flagged ->
-                runCatching { contactRepository.clearICanLocate(contact.uniqueId, versionTag) }
-                    .onFailure { Logger.w(it) { "reconcile: clearICanLocate failed for ${odinId.domainName}" } }
+            .getOrNull()
+        if (reconcileAction(status?.hasAccess, flagged = false) == ReconcileAction.Set) {
+            runCatching { contactRepository.setICanLocate(contact.uniqueId, versionTag) }
+                .onFailure { Logger.w(it) { "reconcile: setICanLocate failed for ${odinId.domainName}" } }
         }
     }
 }
+
+/** What a verify-based reconcile pass may do to a contact's [iCanLocate] flag. */
+enum class ReconcileAction { Set, None }
+
+/**
+ * Decides what a verify-based pass does with one contact, given the preflight outcome.
+ * [hasAccess] is null when the preflight threw (network/parse failure) — inconclusive, never act.
+ *
+ * There is deliberately NO Clear (issue #961): a non-throwing `hasAccess = false` is not a
+ * trustworthy revocation, so verify-based passes must never wipe the flag. The only clear path
+ * is the peer's explicit revocation ([EmergencyContactReceiveService.onRevoked] via
+ * [revocationAction]).
+ *
+ * Emergency designation == currently holding temporal read access to the peer's location drive.
+ * windowSeconds is NOT a reliable ACL-type discriminator — a real emergency-circle grant has
+ * been observed reporting windowSeconds=null in practice (see issue #875) — so gate on
+ * hasAccess alone.
+ */
+fun reconcileAction(hasAccess: Boolean?, flagged: Boolean): ReconcileAction =
+    if (hasAccess == true && !flagged) ReconcileAction.Set else ReconcileAction.None

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -549,9 +549,10 @@ val appModule = module {
                     emergencyContactReceive.onRevoked(sender, file)
                 }
                 // Background backstop: the live status-message handlers above only fire on the
-                // WS-push path, so a designation/revocation that arrived during cold sync (or a
-                // dropped event) is never applied. Reconcile both directions against the
-                // authoritative temporal-access grant in the background — no screen required.
+                // WS-push path, so a designation that arrived during cold sync (or a dropped
+                // event) is never applied. Recover missed SETs against the temporal-access
+                // preflight in the background — no screen required. Set-only: the reconciler
+                // never clears; revocation is applied solely by onRevoked above (issue #961).
                 get<EmergencyContactReconciler>().start()
                 // endregion
 
@@ -849,7 +850,6 @@ val appModule = module {
             contactRepository = get(),
             connectionService = get(),
             contactService = get(),
-            emergencyContactReconciler = get(),
             temporalDriveReadProvider = get(),
             credentialsManager = get(),
             tracker = get(),

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailViewModel.kt
@@ -30,7 +30,8 @@ import id.homebase.core.config.AUTO_CONNECTIONS_CIRCLE_ID
 import id.homebase.core.config.CONFIRMED_CONNECTIONS_CIRCLE_ID
 import id.homebase.core.config.locationLabeledDrive
 import id.homebase.core.contactbook.ContactOverrideStore
-import id.homebase.core.contactbook.clearICanLocate
+import id.homebase.core.contactbook.ReconcileAction
+import id.homebase.core.contactbook.reconcileAction
 import id.homebase.core.contactbook.setICanLocate
 import id.homebase.core.ui.navigation.Route
 import id.homebase.core.ui.screens.contactbook.RequestDirection
@@ -337,18 +338,17 @@ class ContactDetailViewModel(
             // drive has no files yet — render "no data", not the epoch.
             val newest = status.newestFileModified.takeIf { it.milliseconds > 0 }
             _uiState.update { it.copy(locateNewestDataAt = newest) }
-            if (entry != null && versionTag != null && !entry.iCanLocate) {
+            if (entry != null && versionTag != null &&
+                reconcileAction(status.hasAccess, entry.iCanLocate) == ReconcileAction.Set
+            ) {
                 runCatching { contactRepository.setICanLocate(entry.uniqueId, versionTag) }
                     .onFailure { Logger.w(it, TAG) { "setICanLocate failed for ${peer.domainName}" } }
             }
         } else {
+            // Never clear the flag here (issue #961): hasAccess=false is not a trustworthy
+            // revocation — only the peer's explicit revocation message clears iCanLocate
+            // (EmergencyContactReceiveService.onRevoked). See reconcileAction.
             _uiState.update { it.copy(locateNewestDataAt = null) }
-            // A successful verify without a temporal grant is authoritative: clear a stale flag,
-            // mirroring EmergencyContactReconciler. Skip the write when the flag isn't set.
-            if (entry != null && versionTag != null && entry.iCanLocate) {
-                runCatching { contactRepository.clearICanLocate(entry.uniqueId, versionTag) }
-                    .onFailure { Logger.w(it, TAG) { "clearICanLocate failed for ${peer.domainName}" } }
-            }
         }
     }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
@@ -15,7 +15,6 @@ import id.homebase.chat.services.convo.contact.ContactService
 import id.homebase.chat.services.livelocation.LiveLocationShareService
 import id.homebase.core.config.EMERGENCY_LOCATION_CIRCLE_ID
 import id.homebase.core.config.locationLabeledDrive
-import id.homebase.core.contactbook.EmergencyContactReconciler
 import id.homebase.core.contactbook.locatableContacts
 import id.homebase.core.location.LocationPreferences
 import id.homebase.core.location.tracking.LocationPointStore
@@ -56,7 +55,6 @@ class LocationViewModel(
     private val contactRepository: ContactRepository,
     private val connectionService: ConnectionService,
     private val contactService: ContactService,
-    private val emergencyContactReconciler: EmergencyContactReconciler,
     private val temporalDriveReadProvider: TemporalDriveReadProvider,
     private val credentialsManager: CredentialsManager,
     private val receiveStore: LiveLocationReceiveStore,
@@ -142,10 +140,6 @@ class LocationViewModel(
                     }
                 }
         }
-
-        // On dashboard open, reconcile the iCanLocate cache against the authoritative temporal-access
-        // grant so a lost revocation (stale flag) self-corrects. Best-effort, one-shot per open.
-        viewModelScope.launch { runCatching { emergencyContactReconciler.reconcile() } }
 
         viewModelScope.launch {
             locationPermissionViewModel.permissionsGranted

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/contactbook/EmergencyContactReconcileActionTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/contactbook/EmergencyContactReconcileActionTest.kt
@@ -1,0 +1,58 @@
+package id.homebase.core.contactbook
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins [reconcileAction] — the decision table for the verify-based reconcile passes.
+ *
+ * The core contract (issue #961): a verify-based pass must NEVER clear the incoming
+ * `iCanLocate` flag. A non-throwing `hasAccess=false` is not a trustworthy revocation signal —
+ * it also fires on benign/ambiguous negatives (and possibly when the owner empties their own
+ * outgoing emergency circle). The only clear path is the peer's explicit revocation
+ * ([EmergencyContactReceiveService.onRevoked] via [revocationAction]).
+ */
+class EmergencyContactReconcileActionTest {
+
+    @Test
+    fun `no access on a flagged contact does nothing - the 961 wipe regression pin`() {
+        assertEquals(
+            ReconcileAction.None,
+            reconcileAction(hasAccess = false, flagged = true),
+        )
+    }
+
+    @Test
+    fun `access on an unflagged contact recovers the missed designation`() {
+        assertEquals(
+            ReconcileAction.Set,
+            reconcileAction(hasAccess = true, flagged = false),
+        )
+    }
+
+    @Test
+    fun `access on an already-flagged contact does nothing`() {
+        assertEquals(
+            ReconcileAction.None,
+            reconcileAction(hasAccess = true, flagged = true),
+        )
+    }
+
+    @Test
+    fun `no access on an unflagged contact does nothing`() {
+        assertEquals(
+            ReconcileAction.None,
+            reconcileAction(hasAccess = false, flagged = false),
+        )
+    }
+
+    @Test
+    fun `a failed preflight is inconclusive and never acts`() {
+        for (flagged in listOf(true, false)) {
+            assertEquals(
+                ReconcileAction.None,
+                reconcileAction(hasAccess = null, flagged = flagged),
+            )
+        }
+    }
+}


### PR DESCRIPTION
Fixes #961.

## Problem

Emptying my own **outgoing** emergency circle also wiped the **incoming** "Who you can locate" list. Three verify-based write sites existed; two of them destructively cleared the `iCanLocate` flag on any non-throwing `hasAccess=false` from `verifyTemporalAccess` — a signal that also fires on benign/ambiguous negatives (and possibly via server-side coupling of the two directions, still to be confirmed in odin-core):

- `EmergencyContactReconciler.reconcileContact` — the clear branch was **not gated by `allowSet`**, so both the login `reconcileAll()` and the dashboard-open clear-only `reconcile()` (fired on every Location dashboard open) wiped flags.
- `ContactDetailViewModel.verifyLocateAccess` — same defect on contact-detail open.

## Fix

Per the issue's proposed fix #1: incoming `iCanLocate` is cleared **only** by the authoritative peer revocation (`EmergencyContactReceiveService.onRevoked`).

- `EmergencyContactReconciler` is now a **set-only** backstop (recovers a missed "they added me"); it skips the preflight entirely for already-flagged contacts. The clear-only `reconcile()` pass and its dashboard-open call site (plus the ViewModel dependency/DI wiring) are deleted.
- `ContactDetailViewModel.verifyLocateAccess` no longer clears; it keeps the `locateNewestDataAt` UI update.
- Both remaining set sites route through one pure decision table, `reconcileAction(hasAccess, flagged)`, with `ReconcileAction = { Set, None }` — deliberately no `Clear`.

Trade-off (per issue acceptance criteria): a revocation missed while offline leaves the row visible and marked broken by the per-entry freshness check (#950/#962) instead of silently vanishing — never destructive on a guess.

## Proof by test (red first)

The decision logic was first extracted verbatim (including the destructive `Clear`) and `EmergencyContactReconcileActionTest` was run against it: exactly the two #961 pins failed (`hasAccess=false && flagged → None` in both clear-only and full mode), the other five cases passed. Removing the `Clear` turned them green. The test pins the full truth table including "failed preflight is inconclusive — never act".

## Verification

- `./gradlew homebase-core:jvmTest --rerun-tasks` — green (includes Konsist `ArchitectureTest`).
- `./gradlew :homebase-core:compileAndroidMain :homebase-core:compileKotlinWasmJs` — green (iOS covered by CI).
- Grep gate: `clearICanLocate` callers are now exactly the `EmergencyContact.kt` helper definition and `EmergencyContactReceiveService.onRevoked`.
- Manual two-identity e2e (A↔B repro from the issue) was **not** run — no second identity available in this environment.

Cross-repo follow-up for the suspected temporal-verify direction coupling (issue candidate 1) tracked separately in odin-core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEYwcuAYV5nvoxMkdkGVis