### PR TITLE
feat(location): finish #879 locate freshness — 2h orange, no-data label, live refresh, unreachable state

### DIFF
--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1320,6 +1320,8 @@
     <string name="location_locate_age_hours">%1$dh</string>
     <string name="location_locate_age_days">%1$dd</string>
     <string name="location_locatable_broken_cd">No longer connected</string>
+    <string name="location_locate_no_data">no data</string>
+    <string name="location_locatable_unreachable_cd">Can't reach their server</string>
     <string name="location_emergency_access_section">Who can locate you</string>
     <string name="location_emergency_access_manage">Add emergency contacts</string>
     <string name="location_emergency_access_missing">No Emergency Location Access circle yet. Tap + to set one up in your owner console.</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
@@ -648,8 +648,8 @@ private fun IncomingShareRowItem(row: IncomingShareRow) {
 }
 
 /**
- * Trailing content for a "who I can locate" row: a spinner while the row's first temporal-access
- * preflight is in flight, a broken-link icon when access is gone, a disconnected icon when the
+ * Trailing content for a "who I can locate" row: a spinner while an expand-triggered temporal-
+ * access preflight is in flight, a broken-link icon when access is gone, a disconnected icon when the
  * peer's server couldn't be reached (inconclusive — not broken), or the compact age of the peer's
  * newest data (warning-orange past [LOCATE_AGE_WARN_MS]). Access with no data yet shows an explicit
  * "no data" label (the GPS-not-reporting case, #875). A null/absent status (section not yet

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.LinkOff
@@ -43,6 +44,7 @@ import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -59,6 +61,7 @@ import id.homebase.core.avatars.PublicAvatar
 import id.homebase.core.ui.screens.location.devices.LocationDeviceInfo
 import id.homebase.core.ui.screens.location.history.LocationTraceCanvas
 import id.homebase.core.ui.screens.location.livelocation.AGE_LABEL_AFTER_MS
+import id.homebase.core.ui.theme.HomebaseTheme
 import id.homebase.core.util.formatTimestamp
 import id.homebase.core.util.formatUntilTime
 import id.homebase.resources.MR
@@ -88,8 +91,10 @@ import id.homebase.resources.location_emergency_access_section
 import id.homebase.resources.location_locatable_broken_cd
 import id.homebase.resources.location_locatable_none
 import id.homebase.resources.location_locatable_section
+import id.homebase.resources.location_locatable_unreachable_cd
 import id.homebase.resources.location_locate_age_days
 import id.homebase.resources.location_locate_age_hours
+import id.homebase.resources.location_locate_no_data
 import id.homebase.resources.location_status_pending
 import id.homebase.resources.location_status_points_today
 import id.homebase.resources.stop_sharing
@@ -115,7 +120,7 @@ fun LocationDashboardContent(
     onOpenDevice: (Uuid) -> Unit,
     onOpenSetup: () -> Unit,
     onManageEmergencyAccess: () -> Unit,
-    onVerifyLocatable: () -> Unit,
+    onLocatableExpandedChange: (Boolean) -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -315,7 +320,7 @@ fun LocationDashboardContent(
                 loaded = uiState.whoICanLocateLoaded,
                 members = uiState.whoICanLocate,
                 emptyText = stringResource(MR.string.location_locatable_none),
-                onExpand = onVerifyLocatable,
+                onExpandedChange = onLocatableExpandedChange,
                 rowTrailing = { member ->
                     LocateStatusTrailing(uiState.whoICanLocateStatus[member.odinId.domainName])
                 },
@@ -451,13 +456,15 @@ private fun PeopleListBody(
     loaded: Boolean,
     members: List<ContactUiModel>,
     emptyText: String,
-    onExpand: (() -> Unit)? = null,
+    onExpandedChange: ((Boolean) -> Unit)? = null,
     rowTrailing: (@Composable (ContactUiModel) -> Unit)? = null,
 ) {
     var expanded by remember { mutableStateOf(false) }
-    // Fire the (optional) per-entry preflight each time the section opens; resolved rows are skipped
-    // downstream, so re-expanding is cheap.
-    LaunchedEffect(expanded) { if (expanded) onExpand?.invoke() }
+    // Report every open/close so the (optional) per-entry preflight loop starts on each expand and
+    // stops on collapse; per-row results younger than the TTL are skipped downstream, so a quick
+    // re-expand is cheap. Leaving composition (navigating away) counts as a close.
+    LaunchedEffect(expanded) { onExpandedChange?.invoke(expanded) }
+    DisposableEffect(Unit) { onDispose { onExpandedChange?.invoke(false) } }
     when {
         !loaded -> Box(
             modifier = Modifier.fillMaxWidth().padding(24.dp),
@@ -641,10 +648,12 @@ private fun IncomingShareRowItem(row: IncomingShareRow) {
 }
 
 /**
- * Trailing content for a "who I can locate" row: a spinner while the temporal-access preflight is in
- * flight, a broken-link icon when access is gone, or the compact age of the peer's newest data
- * (warning-colored past a day). A null/absent status (not yet requested, or an inconclusive failure)
- * renders nothing.
+ * Trailing content for a "who I can locate" row: a spinner while the row's first temporal-access
+ * preflight is in flight, a broken-link icon when access is gone, a disconnected icon when the
+ * peer's server couldn't be reached (inconclusive — not broken), or the compact age of the peer's
+ * newest data (warning-orange past [LOCATE_AGE_WARN_MS]). Access with no data yet shows an explicit
+ * "no data" label (the GPS-not-reporting case, #875). A null/absent status (section not yet
+ * expanded) renders nothing.
  */
 @Composable
 private fun LocateStatusTrailing(status: LocateVerifyStatus?) {
@@ -661,28 +670,41 @@ private fun LocateStatusTrailing(status: LocateVerifyStatus?) {
                 tint = MaterialTheme.colorScheme.error,
             )
 
-        is LocateVerifyStatus.Active -> status.newestModifiedMs?.let { ms ->
-            val ageMs = Clock.System.now().toEpochMilliseconds() - ms
-            val warn = ageMs > 24L * 60 * 60_000
-            Text(
-                text = formatLocateAge(ageMs),
-                style = MaterialTheme.typography.labelMedium,
-                color = if (warn) MaterialTheme.colorScheme.error
-                        else MaterialTheme.colorScheme.onSurfaceVariant,
+        is LocateVerifyStatus.Unreachable ->
+            Icon(
+                imageVector = Icons.Default.CloudOff,
+                contentDescription = stringResource(MR.string.location_locatable_unreachable_cd),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-        } // Active(null) = access but no data yet → render nothing
+
+        is LocateVerifyStatus.Active -> {
+            val ms = status.newestModifiedMs
+            if (ms == null) {
+                // Access but no data yet — their GPS isn't reporting; warn rather than stay blank.
+                Text(
+                    text = stringResource(MR.string.location_locate_no_data),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = HomebaseTheme.extendedColors.warning,
+                )
+            } else {
+                val ageMs = Clock.System.now().toEpochMilliseconds() - ms
+                Text(
+                    text = formatLocateAge(ageMs),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = if (locateAgeWarn(ageMs)) HomebaseTheme.extendedColors.warning
+                            else MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
     }
 }
 
 /** Compact "age since newest data" label: minutes, then hours (through 96 h), then days. */
 @Composable
-private fun formatLocateAge(ageMs: Long): String = when {
-    ageMs < 60 * 60_000L ->
-        stringResource(MR.string.live_location_age_minutes, (ageMs / 60_000L).toInt().coerceAtLeast(0))
-    ageMs <= 96 * 60 * 60_000L ->
-        stringResource(MR.string.location_locate_age_hours, (ageMs / 3_600_000L).toInt())
-    else ->
-        stringResource(MR.string.location_locate_age_days, (ageMs / 86_400_000L).toInt())
+private fun formatLocateAge(ageMs: Long): String = when (val bucket = locateAgeBucket(ageMs)) {
+    is LocateAgeBucket.Minutes -> stringResource(MR.string.live_location_age_minutes, bucket.minutes)
+    is LocateAgeBucket.Hours -> stringResource(MR.string.location_locate_age_hours, bucket.hours)
+    is LocateAgeBucket.Days -> stringResource(MR.string.location_locate_age_days, bucket.days)
 }
 
 @Composable

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
@@ -243,7 +243,7 @@ fun LocationScreen(
                 onManageEmergencyAccess = {
                     uiState.emergencyManageUrl?.let { uriHandler.openUrl(it) }
                 },
-                onVerifyLocatable = { execute(LocationUiAction.VerifyLocatable) },
+                onLocatableExpandedChange = { execute(LocationUiAction.SetLocatableExpanded(it)) },
             )
         } else {
             LocationContent(

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
@@ -65,13 +65,15 @@ data class LocationUiState(
 }
 
 /**
- * Result of the per-entry temporal-access preflight for a "who I can locate" row. The row shows a
- * spinner until this resolves, then either a broken-link icon or the age of the peer's newest data.
- * Resolved results carry [Resolved.verifiedAtMs] so a re-expand within [LOCATE_VERIFY_TTL_MS]
- * reuses them, while an older result is re-verified (#950).
+ * Result of the per-entry temporal-access preflight for a "who I can locate" row. A row with no
+ * prior result shows a spinner until its first verify resolves; thereafter re-verifies are silent
+ * (the old value stays visible until the new result lands). Resolved results carry
+ * [Resolved.verifiedAtMs] so a re-expand within [LOCATE_VERIFY_TTL_MS] reuses them, while an older
+ * result is re-verified (#950) — including [Unreachable], which retries on the next pass instead
+ * of blanking the row.
  */
 sealed interface LocateVerifyStatus {
-    /** Preflight in flight → spinner. */
+    /** First-ever preflight in flight (no prior result) → spinner. */
     data object Loading : LocateVerifyStatus
 
     /** A completed verify; [verifiedAtMs] is when the result landed (epoch ms), for the TTL. */
@@ -84,21 +86,49 @@ sealed interface LocateVerifyStatus {
 
     /** We hold access; [newestModifiedMs] is the peer's newest-file time, or null when no data yet. */
     data class Active(val newestModifiedMs: Long?, override val verifiedAtMs: Long) : Resolved
+
+    /**
+     * The verify threw (network/parse failure) — the peer's server is unreachable and access is
+     * unknown → disconnected icon. Inconclusive, so it must never look like [Broken]; being
+     * [Resolved] it is retried after the TTL like any other result.
+     */
+    data class Unreachable(override val verifiedAtMs: Long) : Resolved
 }
 
 /** Freshness window for a resolved locate-verify result: re-expands inside it reuse the cache. */
 const val LOCATE_VERIFY_TTL_MS = 60_000L
 
+/** Age past which a locate row's freshness label renders in the warning (orange) color (#879). */
+const val LOCATE_AGE_WARN_MS = 2 * 60 * 60_000L
+
 /**
- * Whether an expansion of "Who you can locate" should (re-)issue the temporal verify for a row in
- * this state: never while one is in flight, not while a resolved result is younger than
- * [LOCATE_VERIFY_TTL_MS], otherwise yes (never verified, dropped as inconclusive, or gone stale).
+ * Whether a verify pass over "Who you can locate" should (re-)issue the temporal verify for a row
+ * in this state: never while one is in flight, not while a resolved result is younger than
+ * [LOCATE_VERIFY_TTL_MS], otherwise yes (never verified, or gone stale — including a stale
+ * [LocateVerifyStatus.Unreachable], so a network blip retries instead of sticking).
  */
 fun LocateVerifyStatus?.needsReverify(nowMs: Long): Boolean = when (this) {
     LocateVerifyStatus.Loading -> false
     is LocateVerifyStatus.Resolved -> nowMs - verifiedAtMs >= LOCATE_VERIFY_TTL_MS
     null -> true
 }
+
+/** Compact age-label bucket for a locate row: the unit to render and its (non-negative) value. */
+sealed interface LocateAgeBucket {
+    data class Minutes(val minutes: Int) : LocateAgeBucket
+    data class Hours(val hours: Int) : LocateAgeBucket
+    data class Days(val days: Int) : LocateAgeBucket
+}
+
+/** Buckets an age into the compact label unit: minutes under 1 h, hours through 96 h, then days. */
+fun locateAgeBucket(ageMs: Long): LocateAgeBucket = when {
+    ageMs < 60 * 60_000L -> LocateAgeBucket.Minutes((ageMs / 60_000L).toInt().coerceAtLeast(0))
+    ageMs <= 96 * 60 * 60_000L -> LocateAgeBucket.Hours((ageMs / 3_600_000L).toInt())
+    else -> LocateAgeBucket.Days((ageMs / 86_400_000L).toInt())
+}
+
+/** Whether a locate freshness label should render in the warning color: strictly older than 2 h. */
+fun locateAgeWarn(ageMs: Long): Boolean = ageMs > LOCATE_AGE_WARN_MS
 
 /** One row in the "Sharing with" list: a person and the latest time my share to them lasts. */
 data class OutgoingShareRow(
@@ -153,8 +183,10 @@ sealed interface LocationUiAction {
     data class StopSharingWith(val odinId: String) : LocationUiAction
     /** Stop every outgoing live share (Dashboard "stop sharing with everyone"). */
     data object StopSharingWithEveryone : LocationUiAction
-    /** Preflight each "who I can locate" entry's link freshness (fired when the section expands). */
-    data object VerifyLocatable : LocationUiAction
+    /** "Who you can locate" section expanded/collapsed. Expanded starts the periodic per-entry
+     *  link-freshness verify loop (immediate first pass, then every [LOCATE_VERIFY_TTL_MS]);
+     *  collapsed cancels it. */
+    data class SetLocatableExpanded(val expanded: Boolean) : LocationUiAction
     data object RequestWhileInUseClicked : LocationUiAction
     data object RequestAlwaysClicked : LocationUiAction
     data object OpenSystemSettingsClicked : LocationUiAction

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
@@ -65,15 +65,16 @@ data class LocationUiState(
 }
 
 /**
- * Result of the per-entry temporal-access preflight for a "who I can locate" row. A row with no
- * prior result shows a spinner until its first verify resolves; thereafter re-verifies are silent
- * (the old value stays visible until the new result lands). Resolved results carry
+ * Result of the per-entry temporal-access preflight for a "who I can locate" row. Expand-triggered
+ * verifies show a spinner (visible feedback that the check is running); the periodic follow-up
+ * passes while the section stays open are silent (the old value stays visible until the new result
+ * lands, so the list doesn't flash spinners every minute). Resolved results carry
  * [Resolved.verifiedAtMs] so a re-expand within [LOCATE_VERIFY_TTL_MS] reuses them, while an older
  * result is re-verified (#950) — including [Unreachable], which retries on the next pass instead
  * of blanking the row.
  */
 sealed interface LocateVerifyStatus {
-    /** First-ever preflight in flight (no prior result) → spinner. */
+    /** Preflight in flight with the spinner requested (expand-triggered, or no prior result). */
     data object Loading : LocateVerifyStatus
 
     /** A completed verify; [verifiedAtMs] is when the result landed (epoch ms), for the TTL. */

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
@@ -27,6 +27,9 @@ import id.homebase.core.ui.screens.location.history.shiftDay
 import id.homebase.core.ui.screens.location.livelocation.LIVE_STALE_MS
 import id.homebase.core.ui.screens.location.livelocation.LiveLocationReceiveStore
 import id.homebase.core.util.initials
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -290,43 +293,86 @@ class LocationViewModel(
         }
     }
 
+    /** Runs the periodic locatable-verify loop while the section is expanded; null when collapsed. */
+    private var locatableVerifyJob: Job? = null
+
     /**
-     * Preflight each "who I can locate" entry: does the peer still grant us temporal read access to
-     * their location drive, and how fresh is their newest data? Fired when the section is expanded.
-     * Each member is verified in its own coroutine so the spinners resolve independently. Members
-     * with a call in flight, or a result younger than [LOCATE_VERIFY_TTL_MS], are skipped — so a
-     * quick re-expand is cheap, but a later one re-verifies with a visible spinner and a fresh age
-     * instead of showing the first-expand value forever (#950). A network/parse failure is
-     * inconclusive — we drop the key (row shows nothing) so a re-expand retries, rather than
-     * falsely showing "broken"; this mirrors [EmergencyContactReconciler]'s leave-untouched rule.
+     * Expanded: start the link-freshness loop — an immediate [verifyLocatablePass], then one every
+     * [LOCATE_VERIFY_TTL_MS] so ages and states stay current while the section is open. Every
+     * expand (re-)starts the loop; the per-row TTL inside the pass is what makes a quick re-expand
+     * cheap. Collapsed: cancel the loop (and any in-flight verifies with it) and sweep Loading
+     * placeholders — a cancelled first verify must not leave a stuck Loading that blocks the next
+     * expand forever (needsReverify(Loading) == false).
      */
-    fun verifyLocatableAccess() {
-        val now = Clock.System.now().toEpochMilliseconds()
-        _uiState.value.whoICanLocate.forEach { member ->
-            val key = member.odinId.domainName
-            if (!_uiState.value.whoICanLocateStatus[key].needsReverify(now)) return@forEach
-            _uiState.update {
-                it.copy(whoICanLocateStatus = it.whoICanLocateStatus + (key to LocateVerifyStatus.Loading))
+    private fun setLocatableExpanded(expanded: Boolean) {
+        if (expanded) {
+            if (locatableVerifyJob?.isActive == true) return
+            locatableVerifyJob = viewModelScope.launch {
+                while (true) {
+                    verifyLocatablePass()
+                    delay(LOCATE_VERIFY_TTL_MS)
+                }
             }
-            viewModelScope.launch {
-                val status = runCatching {
-                    temporalDriveReadProvider.verifyTemporalAccess(member.odinId, locationDrive)
-                }.getOrNull()
-                val verifiedAt = Clock.System.now().toEpochMilliseconds()
-                _uiState.update {
-                    val next = when {
-                        // Inconclusive (threw) → drop so the next expand retries.
-                        status == null -> it.whoICanLocateStatus - key
-                        // Gate on hasAccess alone (windowSeconds is not a reliable discriminator, #875).
-                        !status.hasAccess ->
-                            it.whoICanLocateStatus + (key to LocateVerifyStatus.Broken(verifiedAt))
-                        // newestFileModified == 0 (ZeroTime) means no files yet → Active(null) = "no data".
-                        else -> it.whoICanLocateStatus + (key to LocateVerifyStatus.Active(
-                            newestModifiedMs = status.newestFileModified.milliseconds.takeIf { ms -> ms > 0 },
-                            verifiedAtMs = verifiedAt,
-                        ))
+        } else {
+            locatableVerifyJob?.cancel()
+            locatableVerifyJob = null
+            _uiState.update { s ->
+                s.copy(
+                    whoICanLocateStatus =
+                        s.whoICanLocateStatus.filterValues { it != LocateVerifyStatus.Loading },
+                )
+            }
+        }
+    }
+
+    /**
+     * One preflight pass over the "who I can locate" entries: does the peer still grant us temporal
+     * read access to their location drive, and how fresh is their newest data? Members are verified
+     * in parallel child coroutines and the pass returns once all resolve, so loop iterations never
+     * overlap a still-running verify. Members with a verify in flight or a result younger than
+     * [LOCATE_VERIFY_TTL_MS] are skipped (#950). The Loading spinner shows only for a row's
+     * first-ever verify — a re-verify keeps the old value visible until the new result lands (no
+     * spinner flash on the periodic passes). A network/parse failure is inconclusive →
+     * [LocateVerifyStatus.Unreachable] (disconnected icon, retried after the TTL), never [Broken];
+     * this mirrors [EmergencyContactReconciler]'s leave-untouched rule.
+     */
+    private suspend fun verifyLocatablePass() {
+        val now = Clock.System.now().toEpochMilliseconds()
+        coroutineScope {
+            _uiState.value.whoICanLocate.forEach { member ->
+                val key = member.odinId.domainName
+                val current = _uiState.value.whoICanLocateStatus[key]
+                if (!current.needsReverify(now)) return@forEach
+                if (current == null) {
+                    _uiState.update {
+                        it.copy(whoICanLocateStatus = it.whoICanLocateStatus + (key to LocateVerifyStatus.Loading))
                     }
-                    it.copy(whoICanLocateStatus = next)
+                }
+                launch {
+                    val status = try {
+                        temporalDriveReadProvider.verifyTemporalAccess(member.odinId, locationDrive)
+                    } catch (e: CancellationException) {
+                        throw e // never record a cancelled verify as Unreachable
+                    } catch (_: Exception) {
+                        null
+                    }
+                    val verifiedAt = Clock.System.now().toEpochMilliseconds()
+                    _uiState.update {
+                        val next = when {
+                            // Inconclusive (threw) → Unreachable; the TTL retries it next pass.
+                            status == null ->
+                                it.whoICanLocateStatus + (key to LocateVerifyStatus.Unreachable(verifiedAt))
+                            // Gate on hasAccess alone (windowSeconds is not a reliable discriminator, #875).
+                            !status.hasAccess ->
+                                it.whoICanLocateStatus + (key to LocateVerifyStatus.Broken(verifiedAt))
+                            // newestFileModified == 0 (ZeroTime) means no files yet → Active(null) = "no data".
+                            else -> it.whoICanLocateStatus + (key to LocateVerifyStatus.Active(
+                                newestModifiedMs = status.newestFileModified.milliseconds.takeIf { ms -> ms > 0 },
+                                verifiedAtMs = verifiedAt,
+                            ))
+                        }
+                        it.copy(whoICanLocateStatus = next)
+                    }
                 }
             }
         }
@@ -389,7 +435,7 @@ class LocationViewModel(
                 viewModelScope.launch { liveShareService.stopAll() }
             }
 
-            LocationUiAction.VerifyLocatable -> verifyLocatableAccess()
+            is LocationUiAction.SetLocatableExpanded -> setLocatableExpanded(action.expanded)
 
             // Permission requests are dispatched at the screen level (the
             // PermissionsManager is composition-scoped); the VM only receives

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
@@ -300,7 +300,9 @@ class LocationViewModel(
      * Expanded: start the link-freshness loop — an immediate [verifyLocatablePass], then one every
      * [LOCATE_VERIFY_TTL_MS] so ages and states stay current while the section is open. Every
      * expand (re-)starts the loop; the per-row TTL inside the pass is what makes a quick re-expand
-     * cheap. Collapsed: cancel the loop (and any in-flight verifies with it) and sweep Loading
+     * cheap. The expand-triggered pass shows spinners (visible feedback that a verify is running);
+     * the periodic follow-ups are silent so the open list doesn't flash a spinner every minute.
+     * Collapsed: cancel the loop (and any in-flight verifies with it) and sweep Loading
      * placeholders — a cancelled first verify must not leave a stuck Loading that blocks the next
      * expand forever (needsReverify(Loading) == false).
      */
@@ -308,8 +310,10 @@ class LocationViewModel(
         if (expanded) {
             if (locatableVerifyJob?.isActive == true) return
             locatableVerifyJob = viewModelScope.launch {
+                var expandTriggered = true
                 while (true) {
-                    verifyLocatablePass()
+                    verifyLocatablePass(showSpinner = expandTriggered)
+                    expandTriggered = false
                     delay(LOCATE_VERIFY_TTL_MS)
                 }
             }
@@ -330,20 +334,21 @@ class LocationViewModel(
      * read access to their location drive, and how fresh is their newest data? Members are verified
      * in parallel child coroutines and the pass returns once all resolve, so loop iterations never
      * overlap a still-running verify. Members with a verify in flight or a result younger than
-     * [LOCATE_VERIFY_TTL_MS] are skipped (#950). The Loading spinner shows only for a row's
-     * first-ever verify — a re-verify keeps the old value visible until the new result lands (no
-     * spinner flash on the periodic passes). A network/parse failure is inconclusive →
-     * [LocateVerifyStatus.Unreachable] (disconnected icon, retried after the TTL), never [Broken];
-     * this mirrors [EmergencyContactReconciler]'s leave-untouched rule.
+     * [LOCATE_VERIFY_TTL_MS] are skipped (#950). [showSpinner] (the expand-triggered pass) marks
+     * each verifying row Loading so the user sees the verify happen; the periodic follow-up passes
+     * pass false and keep the old value visible until the new result lands, so an open list never
+     * flashes spinners every minute. A row with no prior result always spins. A network/parse
+     * failure is inconclusive → [LocateVerifyStatus.Unreachable] (disconnected icon, retried after
+     * the TTL), never [Broken]; this mirrors [EmergencyContactReconciler]'s leave-untouched rule.
      */
-    private suspend fun verifyLocatablePass() {
+    private suspend fun verifyLocatablePass(showSpinner: Boolean) {
         val now = Clock.System.now().toEpochMilliseconds()
         coroutineScope {
             _uiState.value.whoICanLocate.forEach { member ->
                 val key = member.odinId.domainName
                 val current = _uiState.value.whoICanLocateStatus[key]
                 if (!current.needsReverify(now)) return@forEach
-                if (current == null) {
+                if (showSpinner || current == null) {
                     _uiState.update {
                         it.copy(whoICanLocateStatus = it.whoICanLocateStatus + (key to LocateVerifyStatus.Loading))
                     }

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/LocateAgeLabelTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/LocateAgeLabelTest.kt
@@ -1,0 +1,69 @@
+package id.homebase.core.ui.screens.location
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+private const val MINUTE_MS = 60_000L
+private const val HOUR_MS = 60 * MINUTE_MS
+private const val DAY_MS = 24 * HOUR_MS
+
+/**
+ * Pins the "who I can locate" freshness-label rules (#879): the compact age bucketing
+ * ([locateAgeBucket] — minutes under 1 h, hours through 96 h, then days) and the warning-color
+ * threshold ([locateAgeWarn] — strictly older than 2 h renders orange).
+ */
+class LocateAgeLabelTest {
+
+    // ---- bucketing ----
+
+    @Test
+    fun underAnHourIsMinutes() {
+        assertEquals(LocateAgeBucket.Minutes(0), locateAgeBucket(0))
+        assertEquals(LocateAgeBucket.Minutes(25), locateAgeBucket(25 * MINUTE_MS))
+        assertEquals(LocateAgeBucket.Minutes(59), locateAgeBucket(60 * MINUTE_MS - 1))
+    }
+
+    @Test
+    fun negativeAgeClampsToZeroMinutes() {
+        // A peer clock slightly ahead of ours must not render "-1m".
+        assertEquals(LocateAgeBucket.Minutes(0), locateAgeBucket(-5 * MINUTE_MS))
+    }
+
+    @Test
+    fun anHourThrough96HoursIsHours() {
+        assertEquals(LocateAgeBucket.Hours(1), locateAgeBucket(HOUR_MS))
+        assertEquals(LocateAgeBucket.Hours(2), locateAgeBucket(2 * HOUR_MS))
+        assertEquals(LocateAgeBucket.Hours(96), locateAgeBucket(96 * HOUR_MS))
+    }
+
+    @Test
+    fun past96HoursIsDays() {
+        assertEquals(LocateAgeBucket.Days(4), locateAgeBucket(96 * HOUR_MS + 1))
+        assertEquals(LocateAgeBucket.Days(10), locateAgeBucket(10 * DAY_MS))
+    }
+
+    // ---- warning threshold (orange > 2 h) ----
+
+    @Test
+    fun exactlyTwoHoursIsNotYetWarned() {
+        assertFalse(locateAgeWarn(LOCATE_AGE_WARN_MS))
+    }
+
+    @Test
+    fun justPastTwoHoursWarns() {
+        assertTrue(locateAgeWarn(LOCATE_AGE_WARN_MS + 1))
+    }
+
+    @Test
+    fun freshAndFarStaleSanity() {
+        assertFalse(locateAgeWarn(25 * MINUTE_MS))
+        assertTrue(locateAgeWarn(3 * DAY_MS))
+    }
+
+    @Test
+    fun warnThresholdIsTwoHours() {
+        assertEquals(2 * HOUR_MS, LOCATE_AGE_WARN_MS)
+    }
+}

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/LocateVerifyFreshnessTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/LocateVerifyFreshnessTest.kt
@@ -56,4 +56,17 @@ class LocateVerifyFreshnessTest {
         val justUnder = now - LOCATE_VERIFY_TTL_MS + 1
         assertFalse(LocateVerifyStatus.Active(newestModifiedMs = 123L, verifiedAtMs = justUnder).needsReverify(now))
     }
+
+    // Unreachable (verify threw, #879) is Resolved: a network blip is retried after the TTL like
+    // any other result, instead of the old drop-the-key-and-blank behavior.
+
+    @Test
+    fun freshUnreachableIsNotRetriedYet() {
+        assertFalse(LocateVerifyStatus.Unreachable(verifiedAtMs = now - 1_000).needsReverify(now))
+    }
+
+    @Test
+    fun staleUnreachableRetries() {
+        assertTrue(LocateVerifyStatus.Unreachable(verifiedAtMs = now - LOCATE_VERIFY_TTL_MS).needsReverify(now))
+    }
 }


### PR DESCRIPTION
Closes #879.

## Audit — what was already done vs. what this PR adds

The issue suspected partial completion. Audit against main confirmed **already shipped** by #942/#946 (link-freshness label), #962 (re-verify on expand, 60s TTL), #928 (hasAccess gate):
- Background per-contact verify on section expand, non-blocking, per-row spinner, results fill in independently.
- Compact age of `newestFileModified` per row — "25m" / "2h" (through 96h) / "1d".
- Coalescing via `needsReverify` + 60s TTL; denied (`hasAccess=false`) → `Broken` → LinkOff in error red.

**This PR adds the remainder:**

- **Orange > 2h** — single `LOCATE_AGE_WARN_MS = 2h` constant; label renders in `HomebaseTheme.extendedColors.warning` (the existing orange role, same as `deliveryFailureTint()`). Replaces the inline 24h/`colorScheme.error` rule.
- **"No data" state** — access granted but `newestFileModified == 0` (the #875 GPS-not-reporting case) now shows an orange "no data" label instead of a blank slot.
- **Live refresh + collapse cancel** — every expand starts an immediate verify pass, then one per 60s TTL while the section stays open, so ages/states stay current. Expand-triggered passes show the row spinners (visible feedback that a verify is running); only the periodic 60s follow-up passes are silent (no spinner flash every minute on an open list). Collapse — or navigating away — cancels the loop and in-flight verifies; `Loading` placeholders are swept and `CancellationException` is rethrown past the catch so a cancelled verify can't wedge `needsReverify` or record a bogus result.
- **Unreachable state** — a verify that throws resolves to the new `LocateVerifyStatus.Unreachable` (CloudOff icon, cd "Can't reach their server", neutral tint — visually distinct from `Broken`'s red LinkOff) instead of dropping the key and blanking the row. Being `Resolved`, the TTL retries it on a later pass.
- **Expand always re-fires** (review nit from planning): expand → collapse → expand always runs a pass; the per-row 60s TTL is what makes a quick re-expand a cheap no-op.

On the "never seen the spinner" observation: most likely the verify returns faster than the ~300ms `AnimatedVisibility` expand animation reveals the rows, so `Loading` is already replaced before it's visible. Note a re-expand within the 60s TTL skips the verify entirely (cached age, no spinner — nothing is running).

## Tests
- `LocateAgeLabelTest` (new) pins `locateAgeBucket` (59m→minutes, 60m/96h→hours, 96h+1→days, negative→0m) and `locateAgeWarn` (exactly 2h → normal, 2h+1ms → orange).
- `LocateVerifyFreshnessTest` extended: fresh `Unreachable` is reused, stale `Unreachable` retries.

## Verification
- `./gradlew homebase-core:jvmTest --rerun-tasks` green (includes Konsist `ArchitectureTest`; both new strings go through `stringResource`).
- `./gradlew :homebase-core:compileAndroidMain :homebase-core:compileKotlinWasmJs` green (iOS via CI).
- Grep gate: the verify path writes only `whoICanLocateStatus` — never `iCanLocate` (display-only, per #961).
- Manual on-device pass (expand/collapse cadence, spinner on slow network, CloudOff in airplane mode, orange with >2h-old peer data) still to be done by a tester with a second identity — not runnable in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEYwcuAYV5nvoxMkdkGVis
