### PR TITLE
fix(chat): stop endless spinner for outbox-queued media; % spinner only while uploading (#948)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
@@ -173,13 +173,22 @@ fun MediaMessage(
             }
         }
 
-        if (uploadStatus != null && !isLinkPreview) {
+        if (uploadStatus != null && uploadStatus.showsMediaOverlay() && !isLinkPreview) {
             UploadProgressOverlay(
                 status = uploadStatus,
                 modifier = Modifier.matchParentSize(),
             )
         }
     }
+}
+
+// Only draw the dark scrim + big spinner while real work is in flight (video transcode,
+// active upload) or on the brief completion tick. Preparing/Sending are shown by the
+// bottom-right outbox indicator alone — an offline-queued item durably enqueues as
+// Sending and never progresses, so gating it here stops the endless spinner (#948).
+internal fun UploadStatus.showsMediaOverlay(): Boolean = when (this) {
+    UploadStatus.Preparing, UploadStatus.Sending -> false
+    is UploadStatus.Processing, is UploadStatus.Uploading, UploadStatus.Completed -> true
 }
 
 @Composable

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/UploadOverlayVisibilityTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/UploadOverlayVisibilityTest.kt
@@ -1,0 +1,24 @@
+package id.homebase.chat.widget
+
+import id.homebase.chat.conversationlist.UploadStatus
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class UploadOverlayVisibilityTest {
+
+    @Test
+    fun stagedAndQueuedStatesHideOverlay() {
+        // Offline-queued media stays on Sending forever; neither it nor Preparing may
+        // draw the scrim + spinner (#948) — the outbox corner icon covers them.
+        assertFalse(UploadStatus.Preparing.showsMediaOverlay())
+        assertFalse(UploadStatus.Sending.showsMediaOverlay())
+    }
+
+    @Test
+    fun inFlightAndCompletedStatesShowOverlay() {
+        assertTrue(UploadStatus.Processing(progress = 0.5f).showsMediaOverlay())
+        assertTrue(UploadStatus.Uploading(progress = 0.5f).showsMediaOverlay())
+        assertTrue(UploadStatus.Completed.showsMediaOverlay())
+    }
+}


### PR DESCRIPTION
Closes #948.

## Problem
Sending a picture/video in **airplane mode** showed a large centered spinner + dark scrim over the media that **never stopped** — the item durably queues in the outbox but can't upload offline, so no `ItemProgress`/`ItemStarted`/`ItemCompleted` ever arrives and `UploadStatus` is stuck on `Sending` forever, keeping the always-on overlay up.

## Fix (minimal)
Gate the media overlay so the scrim + big spinner render **only for actively-in-flight states**, not for the staged/queued ones:

```kotlin
if (uploadStatus != null && uploadStatus.showsMediaOverlay() && !isLinkPreview) { … }

internal fun UploadStatus.showsMediaOverlay(): Boolean = when (this) {
    UploadStatus.Preparing, UploadStatus.Sending -> false           // corner outbox icon only
    is UploadStatus.Processing, is UploadStatus.Uploading, UploadStatus.Completed -> true
}
```

- **Queued/offline (`Sending`)** → no scrim/spinner; the existing lower-right outbox `Alarm` icon (`isPendingSend`, `MessageBubble.DeliveryStatus`) already indicates "waiting in the outbox" and is unchanged.
- **Uploading** → the existing `%` ring shows (was previously buried behind the always-on scrim); unchanged plumbing.
- **Processing** (local video transcode, real progress) and the brief **Completed** checkmark still show.
- Local thumbnail stays visible and the play button stays suppressed while queued — driven by the untouched `isUploading = uploadStatus != null` flag.

Optional `ItemStarted` handling was **not** added (marginal polish, extra collector churn; the corner icon covers the sub-second checkout→first-progress window).

## Test
`UploadOverlayVisibilityTest` (commonTest) asserts the predicate hides `Preparing`/`Sending` and shows `Processing`/`Uploading`/`Completed`.

## Verification
- `:homebase-chat:compileKotlinJvm` + `:homebase-chat:compileAndroidMain` — BUILD SUCCESSFUL
- `:homebase-chat:jvmTest --tests '*UploadOverlayVisibility*'` — green
- [ ] **Device verification pending** (Android + iOS, online + airplane mode, image + video) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**✅ Device-verified** (Redmi Note 5 Pro, Android 11, debug build `id.homebase.feed.debug`): in airplane mode a queued image renders the local thumbnail with only the bottom-right "Sending" outbox indicator — no perpetual scrim/spinner. (Online → %-progress → completion half not re-checked this pass.)