### PR TITLE
fix(chat): Note-to-Self avatar uses full-res /pub/image, not 20px embedded preview (#956)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationEnricher.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationEnricher.kt
@@ -111,4 +111,30 @@ internal fun ConversationUiModel.withOwnerProfileAvatar(
 ): ConversationUiModel {
     if (avatarModel.type != ConversationAvatarModel.Type.Owner) return this
     return copy(avatarModel = avatarModel.copy(initials = ownerSession.initials()))
+
+    // TODO(#956, option 2): once we fetch the owner's real profile image data
+    // (real profileImageFileId/profileImageFileKey with an upgrade path), attach
+    // it here so the preview is only a placeholder that upgrades to full-res —
+    // instead of relying solely on /pub/image. The synthetic preview-only shape
+    // that produced the 20px blur is kept below for reference; it must NOT ship as-is.
+    // Restore imports KeyHeader, EmbeddedThumb, HomebaseImageData, kotlin.uuid.Uuid when reviving.
+    //
+    // val ownerImageData = HomebaseImageData(
+    //     driveId = Uuid.NIL,
+    //     fileId = Uuid.NIL,
+    //     payloadKey = "",
+    //     isEncrypted = false,
+    //     previewThumbnail = EmbeddedThumb(
+    //         pixelWidth = 0,
+    //         pixelHeight = 0,
+    //         contentType = "image/webp",
+    //         content = ownerSession.profileImagePreviewThumbnail.orEmpty(),
+    //     ),
+    //     lastModified = ownerSession.profileImageLastModified,
+    //     keyHeader = KeyHeader.newRandom16(),
+    // )
+    // return copy(avatarModel = avatarModel.copy(
+    //     initials = ownerSession.initials(),
+    //     imageData = ownerImageData,
+    // ))
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationEnricher.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationEnricher.kt
@@ -1,18 +1,14 @@
 package id.homebase.chat.services.convo
 
 import co.touchlab.kermit.Logger
-import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.auth.OwnerSession
 import id.homebase.api.client.auth.initials
 import id.homebase.api.client.connections.ConnectionStatus
-import id.homebase.api.client.drives.upload.EmbeddedThumb
 import id.homebase.api.client.connections.RedactedIdentityConnectionRegistration
 import id.homebase.api.common.OdinId
 import id.homebase.chat.data.*
 import id.homebase.chat.services.convo.contact.ContactConnectionState
 import id.homebase.core.avatars.ConversationAvatarModel
-import id.homebase.core.image.HomebaseImageData
-import kotlin.uuid.Uuid
 
 class ConversationEnricher {
 
@@ -99,51 +95,20 @@ class ConversationEnricher {
 }
 
 /**
- * Patches the note-to-self conversation's [ConversationAvatarModel] so the
- * Owner avatar renders the user's own profile photo.
+ * Patches the note-to-self conversation's [ConversationAvatarModel] with the
+ * owner's initials.
  *
- * [ConversationMapper.buildConversationAvatarModel] builds the self avatar with
- * `imageData = null`, which makes [id.homebase.core.avatars.OwnerAvatar] fall
- * through to [id.homebase.core.avatars.PublicAvatar] — and the owner's own
- * `https://{odinId}/pub/image` is empty, so the avatar shows blank. The owner's
- * profile-image bytes never live on the chat drive, but [OwnerSession] already
- * carries the base64 [OwnerSession.profileImagePreviewThumbnail] that renders
- * without any decryption keys. We attach it as the avatar's
- * [HomebaseImageData.previewThumbnail] so the photo shows immediately.
- *
- * The synthetic image data is deliberately preview-only: [HomebaseImageData.fileId]
- * is [Uuid.NIL] so [OwnerAvatar] paints the embedded preview directly instead of
- * attempting a server fetch on the chat drive (which has no such file). When the
- * owner has no profile photo (preview is null), the avatar is left untouched so
- * the existing [PublicAvatar] fallback still applies.
+ * imageData is deliberately left null so [id.homebase.core.avatars.OwnerAvatar]
+ * falls through to [id.homebase.core.avatars.PublicAvatar] →
+ * `https://{odinId}/pub/image`, the full-res source the chat header already
+ * renders successfully. Attaching the tiny base64
+ * [OwnerSession.profileImagePreviewThumbnail] here instead blew a 20px preview up
+ * into the avatar circle — blurry (#956). Initials remain the fallback until the
+ * photo loads (or when the owner has none).
  */
 internal fun ConversationUiModel.withOwnerProfileAvatar(
     ownerSession: OwnerSession,
 ): ConversationUiModel {
     if (avatarModel.type != ConversationAvatarModel.Type.Owner) return this
-
-    // Owner's /pub/image is empty: without initials a missing/late photo shows blank.
-    val withInitials = copy(avatarModel = avatarModel.copy(initials = ownerSession.initials()))
-
-    val previewContent = ownerSession.profileImagePreviewThumbnail?.takeIf { it.isNotBlank() }
-        ?: return withInitials
-
-    val ownerImageData = HomebaseImageData(
-        driveId = Uuid.NIL,
-        fileId = Uuid.NIL,
-        payloadKey = "",
-        isEncrypted = false,
-        previewThumbnail = EmbeddedThumb(
-            pixelWidth = 0,
-            pixelHeight = 0,
-            contentType = "image/webp",
-            content = previewContent,
-        ),
-        lastModified = ownerSession.profileImageLastModified,
-        keyHeader = KeyHeader.newRandom16(),
-    )
-
-    return withInitials.copy(
-        avatarModel = withInitials.avatarModel.copy(imageData = ownerImageData)
-    )
+    return copy(avatarModel = avatarModel.copy(initials = ownerSession.initials()))
 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationEnricherTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationEnricherTest.kt
@@ -100,4 +100,22 @@ class ConversationEnricherTest {
         assertEquals("O", result.conversation.avatarModel.initials)
         assertEquals(null, result.conversation.avatarModel.imageData)
     }
+
+    @Test
+    fun enrich_withSelf_ownerAvatar_hasNoSyntheticImageData_evenWithPreview() {
+        // Regression for #956: even when the owner has a profile preview, the
+        // self avatar must NOT carry a synthetic 20px imageData. Leaving it null
+        // routes OwnerAvatar -> PublicAvatar -> /pub/image (full-res), matching
+        // the sharp header avatar instead of a blurry blown-up preview.
+        val enricher = ConversationEnricher()
+
+        val result = enricher.enrich(
+            convo = selfOwnerConvo(),
+            contactMap = emptyMap(),
+            ownerSession = session.copy(profileImagePreviewThumbnail = "d2hhdGV2ZXI="),
+        )
+
+        assertEquals(null, result.conversation.avatarModel.imageData)
+        assertEquals("O", result.conversation.avatarModel.initials)
+    }
 }


### PR DESCRIPTION
Closes #956.

## Problem
The **Note-to-Self** conversation avatar rendered blurry while the top **header** avatar (same user) was sharp. They came from two different sources:

- **Header (sharp):** `profileImageData = null` → `OwnerAvatar` → `PublicAvatar` → `https://{odinId}/pub/image` (full-res).
- **Note-to-Self row (blurry):** `ConversationEnricher.withOwnerProfileAvatar` attached a synthetic `HomebaseImageData` with `fileId = Uuid.NIL` and only a **20px `previewThumbnail`**, which `OwnerAvatar` paints directly with **no upgrade path** — a 20px image blown up into the avatar circle.

The enricher's old comment assumed the owner's `/pub/image` was empty; the header proves it isn't. (Related avatar centralization from #957 is already merged; this is consistent with it.)

## Fix (option 1 — fewest moving parts)
Stop attaching the synthetic low-res `imageData` for the self-conversation; leave it `null` so the row falls through to the **same full-res `/pub/image`** source the header already uses successfully. Keep the initials fallback.

Net: `-45 / +10` in `ConversationEnricher.kt` (also removed 4 now-unused imports; corrected the KDoc).

## Regression safety
- Self-labeling/initials preserved (existing #793 test still green).
- Group/other-conversation avatars untouched — the function early-returns on `type != Owner`.
- Survives cache clear: re-fetches full-res via Coil like the header does.

## Test
Added `enrich_withSelf_ownerAvatar_hasNoSyntheticImageData_evenWithPreview` — asserts `imageData == null` even when a preview thumbnail is present.

## Verification
- `:homebase-chat:compileKotlinJvm` + `:homebase-chat:compileAndroidMain` — BUILD SUCCESSFUL
- `:homebase-chat:jvmTest --tests '*ConversationEnricher*'` — 3/3 green
- [ ] **Device verification pending** (Android + iOS: self avatar sharp, survives cache clear) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Note:** the option-2 path (attach the owner's *real* profile image data with an upgrade path) is intentionally kept as a **commented reference block** with a `TODO(#956, option 2)` in `withOwnerProfileAvatar` — to revive when owner image-data fetching is wired up, rather than re-deriving the `HomebaseImageData` shape later. It must not ship uncommented as-is (that's the 20px-blur shape).