### PR TITLE
fix(vault): don't re-prompt biometric during active in-Vault use; only re-lock on genuine background (#936)

### DIFF
--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/vault/VaultPreferences.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/vault/VaultPreferences.kt
@@ -7,7 +7,10 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
 
-class VaultPreferences(private val databaseManager: DatabaseManager) {
+class VaultPreferences(
+    private val databaseManager: DatabaseManager,
+    private val clock: Clock = Clock.System,
+) {
 
     private val keyValue get() = databaseManager.keyValue
 
@@ -40,26 +43,30 @@ class VaultPreferences(private val databaseManager: DatabaseManager) {
     }
 
     fun recordAuthSuccess() {
-        val now = Clock.System.now().toEpochMilliseconds()
+        val now = clock.now().toEpochMilliseconds()
         lastAuthTimeMs = now
         lastActionTimeMs = now
     }
 
     fun recordAppBackgrounded() {
-        lastBackgroundTimeMs = Clock.System.now().toEpochMilliseconds()
+        lastBackgroundTimeMs = clock.now().toEpochMilliseconds()
     }
 
     fun recordUserAction() {
-        lastActionTimeMs = Clock.System.now().toEpochMilliseconds()
+        lastActionTimeMs = clock.now().toEpochMilliseconds()
     }
 
     fun isAuthSessionValid(): Boolean {
         if (lastAuthTimeMs == 0L) return false
-        val now = Clock.System.now().toEpochMilliseconds()
-        if (now - lastActionTimeMs > AUTH_SESSION_DURATION_MS) return false
+        val now = clock.now().toEpochMilliseconds()
+        // (B) Genuine app-background re-lock — always applies, even mid-session.
         if (lastBackgroundTimeMs > lastAuthTimeMs &&
             now - lastBackgroundTimeMs > BACKGROUND_THRESHOLD_MS
         ) return false
+        // (A) Idle auto-lock — suppressed while the user is actively inside the Vault
+        // (any sub-screen). Uninterrupted foreground work never idle-locks; a real
+        // background still re-locks via (B) above.
+        if (!isVaultScreenActive && now - lastActionTimeMs > AUTH_SESSION_DURATION_MS) return false
         return true
     }
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/vault/VaultPreferences.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/vault/VaultPreferences.kt
@@ -29,8 +29,18 @@ class VaultPreferences(
     var isVaultScreenActive: Boolean = false
         private set
 
+    // True while a system picker/camera is presented from the Vault. Leaving to a picker
+    // stops the Activity, which must NOT count as a genuine app-background (it would re-lock
+    // on return). Set true before launching, cleared when the picker is handled.
+    var isPickerActive: Boolean = false
+        private set
+
     fun setVaultScreenActive(active: Boolean) {
         isVaultScreenActive = active
+    }
+
+    fun setPickerActive(active: Boolean) {
+        isPickerActive = active
     }
 
     fun reset() {
@@ -40,6 +50,7 @@ class VaultPreferences(
         lastBackgroundTimeMs = 0L
         lastActionTimeMs = 0L
         isVaultScreenActive = false
+        isPickerActive = false
     }
 
     fun recordAuthSuccess() {
@@ -49,7 +60,13 @@ class VaultPreferences(
     }
 
     fun recordAppBackgrounded() {
-        lastBackgroundTimeMs = clock.now().toEpochMilliseconds()
+        val now = clock.now().toEpochMilliseconds()
+        // The biometric prompt itself stops the Activity briefly right around a successful
+        // unlock on some devices (e.g. MIUI), which would otherwise record a "background"
+        // timestamped just after the auth and re-lock via (B) once you're gone >30s. Churn
+        // within a short settle window of a successful unlock is not a genuine app-background.
+        if (lastAuthTimeMs != 0L && now - lastAuthTimeMs in 0..POST_AUTH_SETTLE_MS) return
+        lastBackgroundTimeMs = now
     }
 
     fun recordUserAction() {
@@ -100,5 +117,6 @@ class VaultPreferences(
 
         private const val AUTH_SESSION_DURATION_MS = 5 * 60 * 1000L  // 5 minutes
         private const val BACKGROUND_THRESHOLD_MS = 30 * 1000L       // 30 seconds
+        private const val POST_AUTH_SETTLE_MS = 2 * 1000L            // ignore bg churn for 2s after unlock
     }
 }

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/vault/VaultPreferencesAuthSessionTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/vault/VaultPreferencesAuthSessionTest.kt
@@ -8,6 +8,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Clock
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
@@ -49,6 +50,22 @@ class VaultPreferencesAuthSessionTest {
         clock += 31.seconds
 
         assertFalse(prefs.isAuthSessionValid())
+    }
+
+    // (2b) A background recorded within the settle window right after a successful unlock is
+    // ignored (biometric-prompt lifecycle churn on some devices), so it must NOT re-lock.
+    @Test
+    fun `background right after unlock is ignored and does not re-lock`() = runTest {
+        val clock = clock()
+        val prefs = VaultPreferences(createTestDatabaseManager(), clock)
+        prefs.recordAuthSuccess()
+        prefs.setVaultScreenActive(true)
+
+        clock += 100.milliseconds // biometric prompt stops the Activity ~right after auth
+        prefs.recordAppBackgrounded()
+        clock += 5.minutes // later, well past the 30s background threshold
+
+        assertTrue(prefs.isAuthSessionValid())
     }
 
     // (3) When NOT active, the old 5-minute idle auto-lock still applies.

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/vault/VaultPreferencesAuthSessionTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/vault/VaultPreferencesAuthSessionTest.kt
@@ -1,0 +1,73 @@
+package id.homebase.core.vault
+
+import id.homebase.core.sync.createTestDatabaseManager
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
+class VaultPreferencesAuthSessionTest {
+
+    private class MutableClock(var current: Instant) : Clock {
+        override fun now(): Instant = current
+        operator fun plusAssign(delta: Duration) { current += delta }
+    }
+
+    private fun clock() = MutableClock(Instant.fromEpochMilliseconds(1_000_000_000L))
+
+    // (1) Active in-Vault use must never idle-lock, no matter how long.
+    @Test
+    fun `active vault session survives idle beyond five minutes`() = runTest {
+        val clock = clock()
+        val prefs = VaultPreferences(createTestDatabaseManager(), clock)
+        prefs.recordAuthSuccess()
+        prefs.setVaultScreenActive(true)
+
+        clock += 6.minutes // no user action recorded during this stretch (typing a note)
+
+        assertTrue(prefs.isAuthSessionValid())
+    }
+
+    // (2) A genuine background beyond the threshold still re-locks, even while active.
+    @Test
+    fun `active vault session still re-locks after a genuine background`() = runTest {
+        val clock = clock()
+        val prefs = VaultPreferences(createTestDatabaseManager(), clock)
+        prefs.recordAuthSuccess()
+        prefs.setVaultScreenActive(true)
+
+        clock += 1.minutes // use the vault for a bit, then leave
+        prefs.recordAppBackgrounded()
+        clock += 31.seconds
+
+        assertFalse(prefs.isAuthSessionValid())
+    }
+
+    // (3) When NOT active, the old 5-minute idle auto-lock still applies.
+    @Test
+    fun `inactive vault session idle-locks after five minutes`() = runTest {
+        val clock = clock()
+        val prefs = VaultPreferences(createTestDatabaseManager(), clock)
+        prefs.recordAuthSuccess()
+        // isVaultScreenActive stays false
+
+        clock += 6.minutes
+
+        assertFalse(prefs.isAuthSessionValid())
+    }
+
+    // Guard: a fresh session (never authenticated) is invalid.
+    @Test
+    fun `unauthenticated session is invalid`() = runTest {
+        val prefs = VaultPreferences(createTestDatabaseManager(), clock())
+        assertFalse(prefs.isAuthSessionValid())
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -50,6 +51,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
@@ -291,6 +293,32 @@ fun AppNavHost(
                 viewModel.onPaused()
             }
         }
+    }
+
+    // --- Vault biometric session lifecycle (spans the whole Vault flow) ---
+    // Each Vault sub-screen (grid, note editor, …) is its own nav route, so
+    // VaultBiometricGate is disposed whenever one is pushed. Owning these signals here,
+    // off the back stack, keeps them alive across every sub-screen.
+    val backStack by navController.currentBackStack.collectAsStateWithLifecycle()
+    val inVaultFlow = backStack.any { it.destination.hasRoute(Route.Vault::class) }
+    // Foreground-active flag: suppresses the 5-minute idle auto-lock while the user is
+    // anywhere in the Vault. A genuine app-background still re-locks (trigger B).
+    LaunchedEffect(inVaultFlow) {
+        vaultPreferences.setVaultScreenActive(inVaultFlow)
+    }
+    // Record a genuine background while on a gate-less Vault sub-screen (VaultBiometricGate
+    // does this for Route.Vault, guarded by its picker check). Without this, backgrounding
+    // mid note-edit would not re-lock now that idle is suppressed.
+    val onGatelessVaultScreen = inVaultFlow && currentDestination?.hasRoute(Route.Vault::class) != true
+    DisposableEffect(lifecycleOwner, onGatelessVaultScreen) {
+        if (!onGatelessVaultScreen) return@DisposableEffect onDispose { }
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_STOP && vaultPreferences.biometricsEnabled.value) {
+                vaultPreferences.recordAppBackgrounded()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     // Track active conversation + auth guard + notification permission

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -34,7 +34,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -51,7 +50,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
@@ -119,6 +117,7 @@ import id.homebase.core.ui.screens.notifications.NotificationSettingsScreen
 import id.homebase.core.ui.screens.settings.SettingsScreen
 import androidx.compose.material3.CircularProgressIndicator
 import id.homebase.core.ui.screens.vault.VaultScreen
+import id.homebase.core.ui.screens.vault.auth.VaultSessionTracker
 import id.homebase.core.ui.screens.vault.VaultUiEvent
 import id.homebase.core.ui.screens.vault.VaultViewModel
 import id.homebase.core.ui.screens.vault.note.VaultNoteEditorScreen
@@ -295,31 +294,9 @@ fun AppNavHost(
         }
     }
 
-    // --- Vault biometric session lifecycle (spans the whole Vault flow) ---
-    // Each Vault sub-screen (grid, note editor, …) is its own nav route, so
-    // VaultBiometricGate is disposed whenever one is pushed. Owning these signals here,
-    // off the back stack, keeps them alive across every sub-screen.
-    val backStack by navController.currentBackStack.collectAsStateWithLifecycle()
-    val inVaultFlow = backStack.any { it.destination.hasRoute(Route.Vault::class) }
-    // Foreground-active flag: suppresses the 5-minute idle auto-lock while the user is
-    // anywhere in the Vault. A genuine app-background still re-locks (trigger B).
-    LaunchedEffect(inVaultFlow) {
-        vaultPreferences.setVaultScreenActive(inVaultFlow)
-    }
-    // Record a genuine background while on a gate-less Vault sub-screen (VaultBiometricGate
-    // does this for Route.Vault, guarded by its picker check). Without this, backgrounding
-    // mid note-edit would not re-lock now that idle is suppressed.
-    val onGatelessVaultScreen = inVaultFlow && currentDestination?.hasRoute(Route.Vault::class) != true
-    DisposableEffect(lifecycleOwner, onGatelessVaultScreen) {
-        if (!onGatelessVaultScreen) return@DisposableEffect onDispose { }
-        val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_STOP && vaultPreferences.biometricsEnabled.value) {
-                vaultPreferences.recordAppBackgrounded()
-            }
-        }
-        lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
-    }
+    // Keeps the Vault biometric session alive across every Vault sub-screen — owned by
+    // the vault feature, not this nav host.
+    VaultSessionTracker(navController)
 
     // Track active conversation + auth guard + notification permission
     LaunchedEffect(authState, currentDestination) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultScreen.kt
@@ -225,6 +225,10 @@ fun VaultScreen(
 
     // Picker active tracking (passed to biometric gate to suppress background detection)
     var isPickerActive by remember { mutableStateOf(false) }
+    // Mirror to VaultPreferences so VaultSessionTracker (Activity lifecycle) skips the
+    // background re-lock while a picker is presented — leaving to a picker stops the Activity
+    // but isn't "leaving the app" (#936).
+    LaunchedEffect(isPickerActive) { vaultPreferences.setPickerActive(isPickerActive) }
 
     var fileForAppend by remember { mutableStateOf<VaultEntry?>(null) }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/auth/VaultBiometricGate.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/auth/VaultBiometricGate.kt
@@ -50,12 +50,10 @@ fun VaultBiometricGate(
 
     val biometricsEnabled by vaultPreferences.biometricsEnabled.collectAsStateWithLifecycle()
 
-    DisposableEffect(biometricsEnabled) {
-        vaultPreferences.setVaultScreenActive(biometricsEnabled)
-        onDispose {
-            vaultPreferences.setVaultScreenActive(false)
-        }
-    }
+    // NOTE: `isVaultScreenActive` (the foreground-active flag that suppresses the idle
+    // auto-lock and drives the iOS privacy overlay) is owned by AppNavHost, which tracks
+    // the whole Vault back stack — this gate is disposed when a sub-screen (e.g. the note
+    // editor) is pushed on top, so it can't span the flow.
 
     var isPrivacyOverlayVisible by remember { mutableStateOf(false) }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/auth/VaultBiometricGate.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/auth/VaultBiometricGate.kt
@@ -77,9 +77,13 @@ fun VaultBiometricGate(
         val observer = LifecycleEventObserver { _, event ->
             when (event) {
                 Lifecycle.Event.ON_STOP -> {
+                    // This observer is bound to the grid's NavBackStackEntry, so ON_STOP also
+                    // fires when navigating to a Vault sub-screen — NOT only on a genuine
+                    // app-background. recordAppBackgrounded() therefore lives in
+                    // VaultSessionTracker (Activity lifecycle); here we only note that the
+                    // grid was stopped so ON_RESUME re-checks the (already-correct) session.
                     if (!isPickerActive) {
                         hasBeenBackgrounded = true
-                        vaultPreferences.recordAppBackgrounded()
                     }
                     if (biometricsEnabled && needsComposePrivacyOverlay) {
                         isPrivacyOverlayVisible = true

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/auth/VaultSessionTracker.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/auth/VaultSessionTracker.kt
@@ -1,0 +1,57 @@
+package id.homebase.core.ui.screens.vault.auth
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.NavHostController
+import id.homebase.core.ui.navigation.Route
+import id.homebase.core.vault.VaultPreferences
+import org.koin.compose.koinInject
+
+/**
+ * Owns the Vault biometric-session signals for the whole Vault flow (grid, note editor, …).
+ * Each sub-screen is its own nav route, so [VaultBiometricGate] is disposed when one is pushed
+ * on top; owning these here — off the back stack, on the Activity lifecycle — keeps them
+ * correct across every sub-screen. Call once from the app nav host.
+ *
+ * - **Idle suppression:** `isVaultScreenActive` is true while anywhere in the Vault, which
+ *   suppresses the 5-minute idle auto-lock. A genuine app-background still re-locks via (B).
+ * - **Background detection:** records the app-background on the **Activity** `ON_STOP` (which
+ *   fires only when the whole app leaves — NOT when navigating between Vault screens, which
+ *   only stops a `NavBackStackEntry`). This is why background recording lives here and not in
+ *   the gate, whose observer is bound to the grid's entry and mis-fired on navigation. A
+ *   presented picker also stops the Activity but isn't "leaving", so it's skipped via
+ *   `isPickerActive`.
+ */
+@Composable
+fun VaultSessionTracker(
+    navController: NavHostController,
+    vaultPreferences: VaultPreferences = koinInject(),
+) {
+    val backStack by navController.currentBackStack.collectAsStateWithLifecycle()
+    val inVaultFlow = backStack.any { it.destination.hasRoute(Route.Vault::class) }
+    LaunchedEffect(inVaultFlow) {
+        vaultPreferences.setVaultScreenActive(inVaultFlow)
+    }
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner, inVaultFlow) {
+        if (!inVaultFlow) return@DisposableEffect onDispose { }
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_STOP &&
+                vaultPreferences.biometricsEnabled.value &&
+                !vaultPreferences.isPickerActive
+            ) {
+                vaultPreferences.recordAppBackgrounded()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+}


### PR DESCRIPTION
Closes #936.

## Problem
Editing a note in the Vault and returning re-prompts biometric. #936 framed this as a 5-minute idle timer expiring under the note editor — but **device testing revealed the re-prompt is driven by trigger (B), the background re-lock**, not idle, and there were **three** distinct causes. The unit tests (which exercise `isAuthSessionValid()` in isolation) could not catch #2 and #3 — only on-device logs did.

## Root causes & fixes
**1. Idle timer expiring under the note editor (trigger A).** The note editor is a separate nav route that never records activity, and `VaultBiometricGate` is disposed under it, so `lastActionTimeMs` froze. → **`isVaultScreenActive`** flag (owned by `VaultSessionTracker`, off the nav back stack) suppresses idle (A) while anywhere in the Vault; a genuine background still re-locks via (B).

**2. Navigation misread as a background (trigger B).** `VaultBiometricGate`'s lifecycle observer is bound to the grid's **`NavBackStackEntry`**, so navigating grid→note fired `ON_STOP` — a normal navigation event — and called `recordAppBackgrounded()`. Returning >30s later tripped (B). → **Move background detection to `VaultSessionTracker` on the *Activity* lifecycle** (fires only when the whole app leaves, never on inter-screen navigation) and **remove the gate's `recordAppBackgrounded()`**.

**3. The biometric prompt itself stops the Activity right after unlock (MIUI).** That records a "background" timestamped just after `recordAuthSuccess()`, arming (B). → **Ignore background churn within a 2s settle window after a successful unlock.**

Plus: an **`isPickerActive` guard** in `VaultPreferences` (mirrored from `VaultScreen`) so the grid's picker/camera — which also stops the Activity — isn't misread as leaving. This also fixes a **pre-existing stale-capture bug** where the gate's own picker guard captured the initial `false` and never actually worked.

## Design
Vault-session logic is owned by a new **`VaultSessionTracker`** composable (in the vault package), called once from `AppNavHost` — the app-root nav host no longer contains Vault-specific logic (addresses the coupling smell from code review).

## Tests
`VaultPreferencesAuthSessionTest` — 5/5 green: active survives idle beyond 5 min; genuine background still re-locks; background-within-settle-window ignored; inactive idle-locks; unauthenticated invalid.

## Device verification (Redmi Note 5 Pro, MIUI, debug)
On-device `VaultDiag` logs confirmed: opening a note records **no** background (navigation phantom gone); the biometric-prompt background is **ignored** (`recordAppBackgrounded IGNORED (…ms after auth)`); `isAuthSessionValid=true active=true` across the note-editor round-trip. Residual flapping seen only when the phone was physically **rotated** (Activity recreation; auto-rotate is off, so not a normal-use path).

## Security tradeoff (sign-off)
A Vault screen left **foregrounded but untouched** no longer idle-locks — only a genuine app-background beyond 30s re-locks. This matches the reporter's ask; the 30s background threshold and picker guard are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)