### PR TITLE
fix(chat): full-bleed gallery+caption in sent & preparing bubbles, with invariant suite (#964)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ChatBubbleTestTags.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ChatBubbleTestTags.kt
@@ -1,0 +1,17 @@
+package id.homebase.chat.widget
+
+/**
+ * Stable `testTag` strings shared by the chat-bubble composables and their layout
+ * regression suite (BubbleLayoutInvariantTest). Kept in one object so production and
+ * test never drift apart.
+ */
+object ChatBubbleTestTags {
+    /** Outer bubble Surface — its bounds are the bubble's. */
+    const val BUBBLE = "chat.bubble"
+
+    /** The media/gallery container (single image, or 2/3/4+ gallery). */
+    const val MEDIA = "chat.bubble.media"
+
+    /** The rendered caption text (inside its padded row). */
+    const val CAPTION = "chat.bubble.caption"
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaGallery.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaGallery.kt
@@ -71,6 +71,14 @@ fun MediaGallery(
     messageId: Uuid,
     downloadingFiles: Set<String>,
     isUploading: Boolean = false,
+    /**
+     * When true the gallery fills the width it is given (rather than pinning to a
+     * discrete album width) and derives its cell heights from that laid-out width.
+     * The caption bubble path (#964) sets this so a 2/3/4-up album stretches to the
+     * bubble instead of leaving a blue gap beside a wider caption. Defaults to false
+     * so the media-only / reply gallery keeps its original bounded album width.
+     */
+    fillWidth: Boolean = false,
 ) {
     if (payloads.isEmpty()) return
 
@@ -81,8 +89,12 @@ fun MediaGallery(
             maxWidth >= 360.dp -> 252.dp
             else -> Dimens.Album.totalWidth
         }
+        // Cell heights are derived from the actual laid-out width: the given width
+        // when filling, else the discrete album width.
+        val layoutWidth = if (fillWidth) maxWidth else albumWidth
+        val widthModifier = if (fillWidth) Modifier.fillMaxWidth() else Modifier.width(albumWidth)
 
-        Box(modifier = Modifier.width(albumWidth)) {
+        Box(modifier = widthModifier) {
             when (payloads.size) {
                 1 -> {
                     MediaItem(
@@ -106,7 +118,7 @@ fun MediaGallery(
 
                 2 ->
                     TwoImageLayout(
-                        albumWidth = albumWidth,
+                        albumWidth = layoutWidth,
                         payloads = payloads,
                         fileId = fileId,
                         driveId = driveId,
@@ -122,7 +134,7 @@ fun MediaGallery(
 
                 3 ->
                     ThreeImageLayout(
-                        albumWidth = albumWidth,
+                        albumWidth = layoutWidth,
                         payloads = payloads,
                         fileId = fileId,
                         driveId = driveId,
@@ -138,7 +150,7 @@ fun MediaGallery(
 
                 else ->
                     FourPlusImageLayout(
-                        albumWidth = albumWidth,
+                        albumWidth = layoutWidth,
                         payloads = payloads,
                         fileId = fileId,
                         driveId = driveId,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.drives.files.DescriptorContent
@@ -88,6 +89,9 @@ fun MediaMessage(
     messageId: Uuid,
     downloadingFiles: Set<String>,
     uploadStatus: UploadStatus? = null,
+    /** #964: forwarded to [MediaGallery] so a 2+-image album stretches to the bubble
+     *  width in the caption path instead of leaving a gap. No effect on single media. */
+    fillWidth: Boolean = false,
 ) {
     if (payloads.isEmpty()) return
 
@@ -109,7 +113,7 @@ fun MediaMessage(
         payloads.size == 1 && payloads[0].key == ChatProtocol.PAYLOAD_KEY_LINKS
     }
 
-    Box(modifier = Modifier.animateContentSize()) {
+    Box(modifier = Modifier.testTag(ChatBubbleTestTags.MEDIA).animateContentSize()) {
         when (payloads.size) {
             1 -> {
                 // Stickers drop the opaque surface fill so transparent pixels show the
@@ -169,6 +173,7 @@ fun MediaMessage(
                     messageId = messageId,
                     downloadingFiles = downloadingFiles,
                     isUploading = uploadStatus != null,
+                    fillWidth = fillWidth,
                 )
             }
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.Placeable
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLayoutResult
@@ -296,6 +297,14 @@ fun MessageBubbleRaw(
                 !it.key.startsWith(ChatProtocol.DEFAULT_PAYLOAD_DESCRIPTOR_KEY)
     }
     val hasMedia = !filteredPayloads.isNullOrEmpty()
+    // #964: a 2+-image album (MediaGallery) sitting above a caption. Only this case
+    // has the fixed-width gap + edge-to-edge margin mismatch the fix addresses — a
+    // single image already adapts to its aspect, so it is left untouched.
+    val isGallery = (filteredPayloads?.size ?: 0) >= 2
+    // #964: the album is inset horizontally to line up with the 12dp-padded caption
+    // below it (media was drawn edge-to-edge while the caption is inset). Applied only
+    // to the caption-bearing text+media paths and only to a gallery.
+    val galleryInset = if (isGallery) Modifier.padding(horizontal = 12.dp) else Modifier
     // We store the result of the text layout to know where the last line ends
     var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
 
@@ -441,6 +450,7 @@ fun MessageBubbleRaw(
 
     Surface(
         modifier = modifier
+            .testTag(ChatBubbleTestTags.BUBBLE)
             .ifTrue(!isStickerBubble) { Modifier.clip(shape) }
             .ifTrue(isMobile()) {
                 Modifier.combinedClickable(
@@ -626,28 +636,34 @@ fun MessageBubbleRaw(
                         )
                     }
                     if (hasMedia) {
-                        MediaMessage(
-                            payloads = filteredPayloads.toPersistentList(),
-                            decryptedFiles = decryptedFiles,
-                            fileId = message.fileId,
-                            driveId = chatTargetDrive.alias,
-                            previewThumbnail = message.previewThumbnail,
-                            onMediaClick = onMediaClick,
-                            keyHeader = message.keyHeader,
-                            shape = if (authorName == null && message.messageAppData.replyPreview == null) RoundedCornerShape(
-                                topStart = Dimens.Message.cornerRadius,
-                                topEnd = Dimens.Message.cornerRadius
-                            ) else RoundedCornerShape(0.dp),
-                            onMediaLongPress = { _, _ -> handleLongClick() },
-                        liveControls = liveControls,
-                        locationHeaderDescriptor = locationDescriptor,
-                            onRequestDecryptedFile = onRequestDecryptedFile,
-                            sharedTransitionScope = sharedTransitionScope,
-                            animatedVisibilityScope = animatedVisibilityScope,
-                            messageId = message.id,
-                            downloadingFiles = downloadingFiles,
-                            uploadStatus = uploadStatus,
-                        )
+                        // #964: a gallery fills the (caption-driven) bubble width and is
+                        // inset 12dp to line up with the caption; a single image is
+                        // rendered exactly as before.
+                        Box(modifier = if (isGallery) Modifier.fillMaxWidth().then(galleryInset) else Modifier) {
+                            MediaMessage(
+                                payloads = filteredPayloads.toPersistentList(),
+                                decryptedFiles = decryptedFiles,
+                                fileId = message.fileId,
+                                driveId = chatTargetDrive.alias,
+                                previewThumbnail = message.previewThumbnail,
+                                onMediaClick = onMediaClick,
+                                keyHeader = message.keyHeader,
+                                shape = if (authorName == null && message.messageAppData.replyPreview == null) RoundedCornerShape(
+                                    topStart = Dimens.Message.cornerRadius,
+                                    topEnd = Dimens.Message.cornerRadius
+                                ) else RoundedCornerShape(0.dp),
+                                onMediaLongPress = { _, _ -> handleLongClick() },
+                                liveControls = liveControls,
+                                locationHeaderDescriptor = locationDescriptor,
+                                onRequestDecryptedFile = onRequestDecryptedFile,
+                                sharedTransitionScope = sharedTransitionScope,
+                                animatedVisibilityScope = animatedVisibilityScope,
+                                messageId = message.id,
+                                downloadingFiles = downloadingFiles,
+                                uploadStatus = uploadStatus,
+                                fillWidth = isGallery,
+                            )
+                        }
                     }
                     Row(
                         modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp),
@@ -656,6 +672,7 @@ fun MessageBubbleRaw(
                         // timestamp is placed below as its own row (next).
                         ChatMarkdown(
                             content = bodyText,
+                            modifier = Modifier.testTag(ChatBubbleTestTags.CAPTION),
                             color = contentColor,
                             style = MaterialTheme.typography.bodyLarge,
                             searchQuery = effectiveSearchQuery,
@@ -725,28 +742,38 @@ fun MessageBubbleRaw(
                                 )
                             }
                             if (hasMedia) {
-                                MediaMessage(
-                                    payloads = filteredPayloads.toPersistentList(),
-                                    decryptedFiles = decryptedFiles,
-                                    fileId = message.fileId,
-                                    driveId = chatTargetDrive.alias,
-                                    previewThumbnail = message.previewThumbnail,
-                                    onMediaClick = onMediaClick,
-                                    keyHeader = message.keyHeader,
-                                    shape = if (authorName == null && message.messageAppData.replyPreview == null) RoundedCornerShape(
-                                        topStart = Dimens.Message.cornerRadius,
-                                        topEnd = Dimens.Message.cornerRadius
-                                    ) else RoundedCornerShape(0.dp),
-                                    onMediaLongPress = { _, _ -> handleLongClick() },
-                        liveControls = liveControls,
-                        locationHeaderDescriptor = locationDescriptor,
-                                    onRequestDecryptedFile = onRequestDecryptedFile,
-                                    sharedTransitionScope = sharedTransitionScope,
-                                    animatedVisibilityScope = animatedVisibilityScope,
-                                    messageId = message.id,
-                                    downloadingFiles = downloadingFiles,
-                                    uploadStatus = uploadStatus,
-                                )
+                                // #964: inset a gallery 12dp to line up with the caption
+                                // (which the custom Layout below clamps to the media width).
+                                // Stays one measurable, so the index math is unchanged. A
+                                // single image keeps its edge-to-edge, aspect-driven render.
+                                Box(modifier = galleryInset) {
+                                    MediaMessage(
+                                        payloads = filteredPayloads.toPersistentList(),
+                                        decryptedFiles = decryptedFiles,
+                                        fileId = message.fileId,
+                                        driveId = chatTargetDrive.alias,
+                                        previewThumbnail = message.previewThumbnail,
+                                        onMediaClick = onMediaClick,
+                                        keyHeader = message.keyHeader,
+                                        shape = if (authorName == null && message.messageAppData.replyPreview == null) RoundedCornerShape(
+                                            topStart = Dimens.Message.cornerRadius,
+                                            topEnd = Dimens.Message.cornerRadius
+                                        ) else RoundedCornerShape(0.dp),
+                                        onMediaLongPress = { _, _ -> handleLongClick() },
+                                        liveControls = liveControls,
+                                        locationHeaderDescriptor = locationDescriptor,
+                                        onRequestDecryptedFile = onRequestDecryptedFile,
+                                        sharedTransitionScope = sharedTransitionScope,
+                                        animatedVisibilityScope = animatedVisibilityScope,
+                                        messageId = message.id,
+                                        downloadingFiles = downloadingFiles,
+                                        uploadStatus = uploadStatus,
+                                        // The custom Layout below already clamps the caption to
+                                        // the media width, so there is no gap to fill here — only
+                                        // the 12dp inset (galleryInset) is needed for alignment.
+                                        fillWidth = false,
+                                    )
+                                }
                             }
                             Row(
                                 modifier = Modifier.padding(
@@ -782,6 +809,7 @@ fun MessageBubbleRaw(
                                     }
                                     ChatMarkdown(
                                         content = bodyText,
+                                        modifier = Modifier.testTag(ChatBubbleTestTags.CAPTION),
                                         color = contentColor,
                                         style = MaterialTheme.typography.bodyLarge,
                                         searchQuery = effectiveSearchQuery,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -297,14 +297,11 @@ fun MessageBubbleRaw(
                 !it.key.startsWith(ChatProtocol.DEFAULT_PAYLOAD_DESCRIPTOR_KEY)
     }
     val hasMedia = !filteredPayloads.isNullOrEmpty()
-    // #964: a 2+-image album (MediaGallery) sitting above a caption. Only this case
-    // has the fixed-width gap + edge-to-edge margin mismatch the fix addresses — a
-    // single image already adapts to its aspect, so it is left untouched.
+    // #964: a 2+-image album (MediaGallery) sitting above a caption renders full-bleed —
+    // the images run edge-to-edge to the bubble, and only the caption below keeps its
+    // 12dp inset (the messenger convention, matching this app's media-only bubbles). A
+    // single image already renders edge-to-edge, so it is untouched.
     val isGallery = (filteredPayloads?.size ?: 0) >= 2
-    // #964: the album is inset horizontally to line up with the 12dp-padded caption
-    // below it (media was drawn edge-to-edge while the caption is inset). Applied only
-    // to the caption-bearing text+media paths and only to a gallery.
-    val galleryInset = if (isGallery) Modifier.padding(horizontal = 12.dp) else Modifier
     // We store the result of the text layout to know where the last line ends
     var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
 
@@ -636,10 +633,10 @@ fun MessageBubbleRaw(
                         )
                     }
                     if (hasMedia) {
-                        // #964: a gallery fills the (caption-driven) bubble width and is
-                        // inset 12dp to line up with the caption; a single image is
+                        // #964: a gallery fills the full bubble width edge-to-edge; the
+                        // caption below keeps its own 12dp inset. A single image is
                         // rendered exactly as before.
-                        Box(modifier = if (isGallery) Modifier.fillMaxWidth().then(galleryInset) else Modifier) {
+                        Box(modifier = if (isGallery) Modifier.fillMaxWidth() else Modifier) {
                             MediaMessage(
                                 payloads = filteredPayloads.toPersistentList(),
                                 decryptedFiles = decryptedFiles,
@@ -742,11 +739,12 @@ fun MessageBubbleRaw(
                                 )
                             }
                             if (hasMedia) {
-                                // #964: inset a gallery 12dp to line up with the caption
-                                // (which the custom Layout below clamps to the media width).
-                                // Stays one measurable, so the index math is unchanged. A
-                                // single image keeps its edge-to-edge, aspect-driven render.
-                                Box(modifier = galleryInset) {
+                                // #964: a gallery renders full-bleed (edge-to-edge). The
+                                // custom Layout below clamps the caption to the media width,
+                                // and the caption Row's own 12dp padding insets the text —
+                                // so the images reach the bubble edges with no strip beside
+                                // them. Stays one measurable, so the index math is unchanged.
+                                Box {
                                     MediaMessage(
                                         payloads = filteredPayloads.toPersistentList(),
                                         decryptedFiles = decryptedFiles,
@@ -769,8 +767,8 @@ fun MessageBubbleRaw(
                                         downloadingFiles = downloadingFiles,
                                         uploadStatus = uploadStatus,
                                         // The custom Layout below already clamps the caption to
-                                        // the media width, so there is no gap to fill here — only
-                                        // the 12dp inset (galleryInset) is needed for alignment.
+                                        // the media width, so there is no gap to fill — the
+                                        // gallery renders full-bleed at its album width.
                                         fillWidth = false,
                                     )
                                 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/PendingMessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/PendingMessageBubble.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.api.client.KeyHeader
@@ -131,41 +132,70 @@ private fun MediaPlaceholderBubble(
         shape = bubbleShape,
         color = HomebaseTheme.extendedColors.bubbleSentSurface,
     ) {
-        Column {
-            message.replyPreview?.let { reply ->
-                InlineReplyPreview(
-                    replyPreview = reply,
-                    sentByYou = true,
-                    onClick = {},
-                    replyMessage = null,
+        // Mirror the real bubble's media+caption layout so the placeholder matches it at
+        // the same size (no pop on takeover): the gallery renders full-bleed and the
+        // caption below is clamped to the media's width. Without the clamp a caption wider
+        // than the album width stretches the bubble while the gallery stays pinned to the
+        // album width — the #964 blue gap beside the images, in the pending state.
+        Layout(
+            content = {
+                message.replyPreview?.let { reply ->
+                    InlineReplyPreview(
+                        replyPreview = reply,
+                        sentByYou = true,
+                        onClick = {},
+                        replyMessage = null,
+                        driveId = chatTargetDrive.alias,
+                    )
+                }
+                MediaMessage(
+                    payloads = syntheticPayloads,
+                    decryptedFiles = persistentMapOf(),
+                    fileId = message.id,
                     driveId = chatTargetDrive.alias,
+                    keyHeader = fakeKeyHeader,
+                    shape = if (hasText || message.replyPreview != null) {
+                        RoundedCornerShape(0.dp)
+                    } else {
+                        bubbleShape
+                    },
+                    sharedTransitionScope = null,
+                    animatedVisibilityScope = null,
+                    messageId = message.id,
+                    downloadingFiles = emptySet(),
+                    uploadStatus = uploadStatus ?: UploadStatus.Preparing,
                 )
-            }
-            MediaMessage(
-                payloads = syntheticPayloads,
-                decryptedFiles = persistentMapOf(),
-                fileId = message.id,
-                driveId = chatTargetDrive.alias,
-                keyHeader = fakeKeyHeader,
-                shape = if (hasText || message.replyPreview != null) {
-                    RoundedCornerShape(0.dp)
-                } else {
-                    bubbleShape
-                },
-                sharedTransitionScope = null,
-                animatedVisibilityScope = null,
-                messageId = message.id,
-                downloadingFiles = emptySet(),
-                uploadStatus = uploadStatus ?: UploadStatus.Preparing,
-            )
 
-            if (hasText) {
-                Text(
-                    text = message.text,
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = HomebaseTheme.extendedColors.bubbleSentOnSurface,
-                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
-                )
+                if (hasText) {
+                    Text(
+                        text = message.text,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = HomebaseTheme.extendedColors.bubbleSentOnSurface,
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                    )
+                }
+            },
+        ) { measurables, constraints ->
+            val hasReply = message.replyPreview != null
+            var i = 0
+            val replyIndex = if (hasReply) i++ else -1
+            val mediaIndex = i++
+            val captionIndex = if (hasText) i else -1
+
+            // Media drives the width (the gallery's discrete album width); reply and
+            // caption are clamped to it so neither can widen the bubble past the images.
+            val mediaPlaceable = measurables[mediaIndex].measure(constraints)
+            val width = mediaPlaceable.width
+            val clamped = constraints.copy(minWidth = width, maxWidth = width)
+            val replyPlaceable = if (replyIndex >= 0) measurables[replyIndex].measure(clamped) else null
+            val captionPlaceable = if (captionIndex >= 0) measurables[captionIndex].measure(clamped) else null
+
+            val height = (replyPlaceable?.height ?: 0) + mediaPlaceable.height + (captionPlaceable?.height ?: 0)
+            layout(width, height) {
+                var y = 0
+                replyPlaceable?.let { it.placeRelative(0, y); y += it.height }
+                mediaPlaceable.placeRelative(0, y); y += mediaPlaceable.height
+                captionPlaceable?.placeRelative(0, y)
             }
         }
     }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
@@ -1,0 +1,310 @@
+package id.homebase.chat.widget
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.dp
+import coil3.ImageLoader
+import coil3.PlatformContext
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.drives.files.PayloadDescriptor
+import id.homebase.api.client.drives.files.ThumbnailDescriptor
+import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.SecureByteArray
+import id.homebase.chat.data.MessageUiModel
+import id.homebase.chat.services.LocalAttachmentContextStore
+import id.homebase.chat.services.MessageAppData
+import id.homebase.chat.services.ReplyPreview
+import id.homebase.core.ui.theme.HomebaseTheme
+import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import org.koin.compose.KoinApplication
+import org.koin.dsl.koinConfiguration
+import org.koin.dsl.module
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * #964 — chat-bubble layout regression suite.
+ *
+ * Renders [MessageBubbleRaw] on the JVM host renderer (`runComposeUiTest`, same as
+ * [ConversationMessagePreviewTest] / [ReactionMenuTest]) across a matrix of
+ * {sent, received} × {0..4 images} × {no / short / long / block caption} × {reply}
+ * and asserts geometric invariants on the tagged bubble / media / caption bounds
+ * ([ChatBubbleTestTags]).
+ *
+ * The bug it guards: a 2+-image gallery above a caption used to be pinned to a fixed
+ * album width, leaving an empty strip beside the images when the caption was wider,
+ * and the edge-to-edge media never lined up with the 12dp-inset caption. The core
+ * invariants below (margins align + media fills the content column with no asymmetric
+ * strip) FAIL on the pre-fix code and PASS after it.
+ */
+@OptIn(ExperimentalTestApi::class, ExperimentalEncodingApi::class)
+class BubbleLayoutInvariantTest {
+
+    // Bounded conversation column so a long caption has a width to fill and the bubble
+    // stays deterministic (mirrors the real caller which hands the bubble a max width).
+    private val columnWidth = 400.dp
+    private val tol = 1.0f // dp; text layout produces sub-pixel widths
+
+    private val koin = koinConfiguration {
+        modules(module {
+            // The two Koin singletons any rendered MediaItem resolves. An empty Coil
+            // ImageLoader is enough — the images never need to decode; the invariants
+            // are about the media container's laid-out bounds, not pixel content.
+            single { ImageLoader.Builder(PlatformContext.INSTANCE).build() }
+            single { LocalAttachmentContextStore(EventBus(), CoroutineScope(SupervisorJob())) }
+        })
+    }
+
+    @Composable
+    private fun Host(content: @Composable () -> Unit) {
+        KoinApplication(configuration = koin) {
+            HomebaseTheme(darkTheme = false) {
+                CompositionLocalProvider(LocalCurrentOdinId provides "me.example.com") {
+                    Box(Modifier.width(columnWidth)) { content() }
+                }
+            }
+        }
+    }
+
+    // ---- fixtures ---------------------------------------------------------
+
+    private enum class Caption(val text: String, val hasCaption: Boolean) {
+        NONE("", false),
+        SHORT("Nice", true),
+        LONG(
+            "This is a long single paragraph caption, wide enough to exceed a fixed " +
+                "album width so any empty strip beside the images would show.",
+            true,
+        ),
+        // A markdown heading forces the block-markdown Column render path (distinct
+        // from the inline custom-Layout path) — this is where the gap lived.
+        BLOCK(
+            "## Album\n\nA block-markdown caption with a heading so the bubble takes " +
+                "the wrapContentWidth Column path instead of the timestamp-tuck Layout.",
+            true,
+        ),
+    }
+
+    private data class Case(
+        val name: String,
+        val sent: Boolean,
+        val images: Int,
+        val caption: Caption,
+        val reply: Boolean = false,
+    )
+
+    private fun imagePayload(i: Int) = PayloadDescriptor(
+        key = "chat_img$i",
+        contentType = "image/jpeg",
+        iv = Base64.encode(ByteArray(16)),
+        // Landscape 4:3 so a single image resolves to a real (non-zero) width.
+        previewThumbnail = ThumbnailDescriptor(
+            pixelWidth = 1200, pixelHeight = 900, contentType = "image/jpeg", content = "",
+        ),
+    )
+
+    private fun Case.message(): MessageUiModel {
+        val reply = if (reply) ReplyPreview(
+            replyUniqueId = Uuid.random(),
+            authorOdinId = "bob.example.com",
+            message = "the message being replied to",
+        ) else null
+        return MessageUiModel(
+            id = Uuid.random(),
+            globalTransitId = null,
+            fileId = Uuid.random(),
+            conversationId = Uuid.random(),
+            content = caption.text,
+            userDate = Instant.fromEpochMilliseconds(0),
+            modified = null,
+            created = Instant.fromEpochMilliseconds(0),
+            originalAuthor = if (sent) null else OdinId("alice.example.com"),
+            sender = if (sent) null else OdinId("alice.example.com"),
+            displayName = "Alice",
+            messageAppData = MessageAppData(replyPreview = reply),
+            reactionPreview = null,
+            previewThumbnail = null,
+            payloads = (0 until images).map { imagePayload(it) }.toPersistentList(),
+            keyHeader = KeyHeader(iv = ByteArray(16), aesKey = SecureByteArray(ByteArray(16))),
+            versionTag = Uuid.random(),
+            isPendingSend = false,
+            hasMore = false,
+        )
+    }
+
+    private fun ComposeUiTest.render(case: Case) = setContent {
+        Host {
+            MessageBubbleRaw(
+                message = case.message(),
+                decryptedFiles = persistentMapOf(),
+                sentByYou = case.sent,
+                onLongClick = {},
+                onMediaClick = {},
+                onClickMessageId = {},
+                sharedTransitionScope = null,
+                animatedVisibilityScope = null,
+                downloadingFiles = emptySet(),
+            )
+        }
+    }
+
+    private fun ComposeUiTest.boundsOf(tag: String): DpRect =
+        onNodeWithTag(tag).getUnclippedBoundsInRoot()
+
+    private fun ComposeUiTest.exists(tag: String): Boolean =
+        onNodeWithTag(tag).let { runCatching { it.getUnclippedBoundsInRoot() }.isSuccess }
+
+    private fun approx(a: Float, b: Float) = kotlin.math.abs(a - b) <= tol
+
+    // ---- tests ------------------------------------------------------------
+
+    /**
+     * THE fix. For every 2/3/4-image gallery that sits above a caption:
+     *  - the media's left edge lines up with the caption's left edge (margins align), and
+     *  - the media is symmetrically inset — no asymmetric empty strip beside the images
+     *    (the "blue gap"), and
+     *  - for a full-width caption the media's right edge lines up with the caption's.
+     * All within the bubble.
+     *
+     * On the pre-fix code the gallery is pinned to a fixed album width (edge-to-edge,
+     * L=0) while the caption is inset 12dp, so both the align and the no-gap checks fail.
+     */
+    @Test
+    fun galleryWithCaption_marginsAlign_andNoGap() = runComposeUiTest {
+        val cases = buildList {
+            for (sent in listOf(true, false))
+                for (images in listOf(2, 3, 4))
+                    for (cap in listOf(Caption.SHORT, Caption.LONG, Caption.BLOCK))
+                        add(Case("${images}img/${cap}/${if (sent) "sent" else "recv"}", sent, images, cap))
+            // reply above a captioned gallery must not disturb the alignment
+            add(Case("2img/LONG/sent+reply", true, 2, Caption.LONG, reply = true))
+            add(Case("3img/BLOCK/recv+reply", false, 3, Caption.BLOCK, reply = true))
+        }
+        val failures = mutableListOf<String>()
+        for (case in cases) {
+            render(case)
+            val bubble = boundsOf(ChatBubbleTestTags.BUBBLE)
+            val media = boundsOf(ChatBubbleTestTags.MEDIA)
+            val caption = boundsOf(ChatBubbleTestTags.CAPTION)
+
+            fun check(cond: Boolean, why: String) { if (!cond) failures += "[${case.name}] $why" }
+
+            val leftInset = media.left.value - bubble.left.value
+            val rightInset = bubble.right.value - media.right.value
+
+            // Margins align: media and caption share a left edge.
+            check(approx(media.left.value, caption.left.value),
+                "media.left=${media.left.value} != caption.left=${caption.left.value}")
+            // No asymmetric strip: media is symmetrically inset inside the bubble
+            // (pre-fix the right strip was ~the whole caption overhang).
+            check(approx(leftInset, rightInset),
+                "asymmetric insets: left=$leftInset right=$rightInset (gap beside images)")
+            // Media reaches the content-column right edge (no gap between media and it).
+            check(approx(media.right.value, bubble.right.value - leftInset),
+                "media.right=${media.right.value} does not fill content (bubble.right=${bubble.right.value}, inset=$leftInset)")
+            // Everything within the bubble.
+            check(media.left.value >= bubble.left.value - tol && media.right.value <= bubble.right.value + tol,
+                "media overflows bubble")
+            check(caption.left.value >= bubble.left.value - tol && caption.right.value <= bubble.right.value + tol,
+                "caption overflows bubble")
+
+            // A full-width caption ends exactly where the media does.
+            if (case.caption == Caption.LONG || case.caption == Caption.BLOCK) {
+                check(approx(media.right.value, caption.right.value),
+                    "media.right=${media.right.value} != caption.right=${caption.right.value}")
+            }
+        }
+        assertTrue(failures.isEmpty(), "gallery+caption invariant failures:\n" + failures.joinToString("\n"))
+    }
+
+    /**
+     * Consistent edge inset: the left inset of the gallery from the bubble edge is the
+     * SAME across every gallery+caption case (it is the caption's own inset, not a
+     * per-count value). Guards against a count-dependent album offset creeping back.
+     */
+    @Test
+    fun galleryWithCaption_consistentEdgeInset() = runComposeUiTest {
+        val insets = mutableListOf<Pair<String, Float>>()
+        for (images in listOf(2, 3, 4)) for (cap in listOf(Caption.SHORT, Caption.LONG, Caption.BLOCK)) {
+            val case = Case("${images}img/$cap", true, images, cap)
+            render(case)
+            val bubble = boundsOf(ChatBubbleTestTags.BUBBLE)
+            val media = boundsOf(ChatBubbleTestTags.MEDIA)
+            insets += case.name to (media.left.value - bubble.left.value)
+        }
+        val distinct = insets.map { kotlin.math.round(it.second) }.distinct()
+        assertTrue(distinct.size == 1, "gallery edge inset must be constant, got: $insets")
+    }
+
+    /**
+     * Regression guard: a SINGLE image + caption is UNCHANGED — the image stays
+     * edge-to-edge (spans the full bubble width, not inset like a gallery), and the
+     * bubble hugs it. The fix must not touch this path.
+     */
+    @Test
+    fun singleImageWithCaption_unchanged_edgeToEdge() = runComposeUiTest {
+        val failures = mutableListOf<String>()
+        for (sent in listOf(true, false)) for (cap in listOf(Caption.LONG, Caption.BLOCK)) {
+            val case = Case("1img/$cap/${if (sent) "sent" else "recv"}", sent, 1, cap)
+            render(case)
+            val bubble = boundsOf(ChatBubbleTestTags.BUBBLE)
+            val media = boundsOf(ChatBubbleTestTags.MEDIA)
+            if (!approx(media.left.value, bubble.left.value))
+                failures += "[${case.name}] single image should be edge-to-edge: media.left=${media.left.value} bubble.left=${bubble.left.value}"
+            if (!approx(media.right.value, bubble.right.value))
+                failures += "[${case.name}] single image should span bubble width: media.right=${media.right.value} bubble.right=${bubble.right.value}"
+        }
+        assertTrue(failures.isEmpty(), "single-image invariant failures:\n" + failures.joinToString("\n"))
+    }
+
+    /**
+     * Regression guard: media-only bubbles (no caption, any image count) are UNCHANGED —
+     * the media fills the whole bubble, no inset, no gap.
+     */
+    @Test
+    fun mediaOnly_unchanged_mediaFillsBubble() = runComposeUiTest {
+        val failures = mutableListOf<String>()
+        for (images in listOf(1, 2, 3, 4)) {
+            val case = Case("${images}img/media-only", true, images, Caption.NONE)
+            render(case)
+            val bubble = boundsOf(ChatBubbleTestTags.BUBBLE)
+            val media = boundsOf(ChatBubbleTestTags.MEDIA)
+            if (exists(ChatBubbleTestTags.CAPTION))
+                failures += "[${case.name}] media-only bubble unexpectedly has a caption"
+            if (!approx(media.left.value, bubble.left.value) || !approx(media.right.value, bubble.right.value))
+                failures += "[${case.name}] media should fill bubble: media=[${media.left.value},${media.right.value}] bubble=[${bubble.left.value},${bubble.right.value}]"
+        }
+        assertTrue(failures.isEmpty(), "media-only invariant failures:\n" + failures.joinToString("\n"))
+    }
+
+    /**
+     * A text-only bubble (no media) renders with a caption and no media node — sanity
+     * that the tags/harness behave at the 0-image corner of the matrix.
+     */
+    @Test
+    fun textOnly_hasCaption_noMedia() = runComposeUiTest {
+        for (cap in listOf(Caption.SHORT, Caption.LONG, Caption.BLOCK)) {
+            render(Case("0img/$cap", true, 0, cap))
+            assertTrue(exists(ChatBubbleTestTags.BUBBLE), "bubble missing for $cap")
+            assertTrue(exists(ChatBubbleTestTags.CAPTION), "caption missing for $cap")
+            assertTrue(!exists(ChatBubbleTestTags.MEDIA), "unexpected media for text-only $cap")
+        }
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
@@ -49,10 +49,10 @@ import kotlin.uuid.Uuid
  * ([ChatBubbleTestTags]).
  *
  * The bug it guards: a 2+-image gallery above a caption used to be pinned to a fixed
- * album width, leaving an empty strip beside the images when the caption was wider,
- * and the edge-to-edge media never lined up with the 12dp-inset caption. The core
- * invariants below (margins align + media fills the content column with no asymmetric
- * strip) FAIL on the pre-fix code and PASS after it.
+ * album width, leaving an empty strip beside the images. The fix renders the gallery
+ * full-bleed (edge-to-edge to the bubble) with only the caption inset 12dp — so the
+ * core invariant below (media reaches both bubble edges, caption inset) FAILS on the
+ * pre-fix code and PASSES after it.
  */
 @OptIn(ExperimentalTestApi::class, ExperimentalEncodingApi::class)
 class BubbleLayoutInvariantTest {
@@ -176,24 +176,26 @@ class BubbleLayoutInvariantTest {
     // ---- tests ------------------------------------------------------------
 
     /**
-     * THE fix. For every 2/3/4-image gallery that sits above a caption:
-     *  - the media's left edge lines up with the caption's left edge (margins align), and
-     *  - the media is symmetrically inset — no asymmetric empty strip beside the images
-     *    (the "blue gap"), and
-     *  - for a full-width caption the media's right edge lines up with the caption's.
-     * All within the bubble.
+     * THE fix (#964, full-bleed). For every 2/3/4-image gallery that sits above a
+     * caption the images run EDGE-TO-EDGE to the bubble — no blue strip beside them —
+     * while the caption below keeps its own 12dp inset (the messenger convention,
+     * matching this app's media-only bubbles):
+     *  - media.left == bubble.left and media.right == bubble.right (full-bleed, no gap), and
+     *  - the caption is inset from the bubble's left edge (not flush with the media), and
+     *  - the caption stays within the bubble.
      *
-     * On the pre-fix code the gallery is pinned to a fixed album width (edge-to-edge,
-     * L=0) while the caption is inset 12dp, so both the align and the no-gap checks fail.
+     * On the pre-fix code the gallery was pinned to a fixed album width and inset 12dp to
+     * line up with the caption, leaving the strip the user reported; the edge-to-edge
+     * checks below fail on that layout and pass once the media inset is removed.
      */
     @Test
-    fun galleryWithCaption_marginsAlign_andNoGap() = runComposeUiTest {
+    fun galleryWithCaption_mediaFullBleed_captionInset() = runComposeUiTest {
         val cases = buildList {
             for (sent in listOf(true, false))
                 for (images in listOf(2, 3, 4))
                     for (cap in listOf(Caption.SHORT, Caption.LONG, Caption.BLOCK))
                         add(Case("${images}img/${cap}/${if (sent) "sent" else "recv"}", sent, images, cap))
-            // reply above a captioned gallery must not disturb the alignment
+            // reply above a captioned gallery must not disturb the full-bleed media
             add(Case("2img/LONG/sent+reply", true, 2, Caption.LONG, reply = true))
             add(Case("3img/BLOCK/recv+reply", false, 3, Caption.BLOCK, reply = true))
         }
@@ -206,38 +208,26 @@ class BubbleLayoutInvariantTest {
 
             fun check(cond: Boolean, why: String) { if (!cond) failures += "[${case.name}] $why" }
 
-            val leftInset = media.left.value - bubble.left.value
-            val rightInset = bubble.right.value - media.right.value
-
-            // Margins align: media and caption share a left edge.
-            check(approx(media.left.value, caption.left.value),
-                "media.left=${media.left.value} != caption.left=${caption.left.value}")
-            // No asymmetric strip: media is symmetrically inset inside the bubble
-            // (pre-fix the right strip was ~the whole caption overhang).
-            check(approx(leftInset, rightInset),
-                "asymmetric insets: left=$leftInset right=$rightInset (gap beside images)")
-            // Media reaches the content-column right edge (no gap between media and it).
-            check(approx(media.right.value, bubble.right.value - leftInset),
-                "media.right=${media.right.value} does not fill content (bubble.right=${bubble.right.value}, inset=$leftInset)")
-            // Everything within the bubble.
-            check(media.left.value >= bubble.left.value - tol && media.right.value <= bubble.right.value + tol,
-                "media overflows bubble")
+            // Full-bleed: the gallery reaches BOTH bubble edges — this is the "no strip
+            // beside the images" the fix restores.
+            check(approx(media.left.value, bubble.left.value),
+                "media.left=${media.left.value} != bubble.left=${bubble.left.value} (left strip)")
+            check(approx(media.right.value, bubble.right.value),
+                "media.right=${media.right.value} != bubble.right=${bubble.right.value} (right strip)")
+            // The caption is inset from the bubble edge (not flush with the full-bleed media).
+            check(caption.left.value > bubble.left.value + tol,
+                "caption should be inset from bubble edge: caption.left=${caption.left.value} bubble.left=${bubble.left.value}")
+            // Caption stays within the bubble.
             check(caption.left.value >= bubble.left.value - tol && caption.right.value <= bubble.right.value + tol,
                 "caption overflows bubble")
-
-            // A full-width caption ends exactly where the media does.
-            if (case.caption == Caption.LONG || case.caption == Caption.BLOCK) {
-                check(approx(media.right.value, caption.right.value),
-                    "media.right=${media.right.value} != caption.right=${caption.right.value}")
-            }
         }
-        assertTrue(failures.isEmpty(), "gallery+caption invariant failures:\n" + failures.joinToString("\n"))
+        assertTrue(failures.isEmpty(), "gallery full-bleed invariant failures:\n" + failures.joinToString("\n"))
     }
 
     /**
-     * Consistent edge inset: the left inset of the gallery from the bubble edge is the
-     * SAME across every gallery+caption case (it is the caption's own inset, not a
-     * per-count value). Guards against a count-dependent album offset creeping back.
+     * Consistent edge inset: the gallery's left offset from the bubble edge is the SAME
+     * across every gallery+caption case — now 0 (full-bleed), and crucially not a
+     * per-image-count value. Guards against a count-dependent album offset creeping back.
      */
     @Test
     fun galleryWithCaption_consistentEdgeInset() = runComposeUiTest {


### PR DESCRIPTION
Closes #964.

## What this delivers
1. A **parameterized bubble-layout invariant test suite** (host-runnable via `runComposeUiTest`, JVM/CI — no emulator) that renders `MessageBubbleRaw` across the text×image matrix and asserts geometric invariants, and
2. the **fix**: a 2+-image gallery above a caption now renders **full-bleed** (images edge-to-edge to the bubble, caption inset) in **both** the sent bubble and the preparing/pending placeholder.

## The bug
A sent message with a **2-image gallery + caption** drew the images at a fixed ≤300dp album width, leaving a **blue gap** to their right. The first fix aligned the gallery to the caption's 12dp inset, which removed the right-gap but left a **thin blue strip on both sides** of the photos — not how any messenger renders it, and inconsistent with this app's own media-only bubbles (which are full-bleed).

## Fix — full-bleed gallery, inset caption (chat widgets only; Moments untouched)
Design decision (device-reviewed): **images run edge-to-edge to the bubble corners; only the caption keeps its 12dp inset** — the messenger convention, matching media-only bubbles here.

- **`MessageBubbleRaw.kt`** — drop the 12dp `galleryInset` on the media in both the block-markdown and custom-`Layout` caption paths. The custom `Layout` already clamps the caption to the media width, so removing the inset gives full-bleed images while the caption's own 12dp Row padding insets the text. A single image is unchanged (already edge-to-edge).
- **`PendingMessageBubble.kt`** — the preparing/pending placeholder is a *separate* composable. It stacked the gallery (pinned to album width) and the caption in a plain `Column`, so a caption wider than the album stretched the bubble while the gallery stayed narrow — the same #964 gap, in the pending path. Replaced the `Column` with a custom `Layout` that clamps the caption to the media width, mirroring the real bubble so the placeholder matches it at the same size (no pop on takeover).
- **`MediaGallery.kt` / `MediaMessage.kt`** — the `fillWidth` opt-in remains for the block path; media-only / reply galleries unchanged.

## The suite — `BubbleLayoutInvariantTest.kt` (`homebase-chat/src/jvmTest`)
Mirrors the existing host-render tests. ~40 named scenarios across `{sent,received} × {0–4 images} × {none/short/long/block caption} × {reply}`. Core invariant is now **full-bleed**: for every gallery+caption case `media.left == bubble.left` and `media.right == bubble.right` (images reach both edges, no strip), and the caption is inset from the bubble edge. Single-image + media-only + text-only asserted **unchanged**. `testTag`s via `ChatBubbleTestTags`.

- `:homebase-chat:jvmTest` → `BubbleLayoutInvariantTest` **tests=5 failures=0**.

## Verification
- `:homebase-chat:compileKotlinJvm` + Android `installDebug` — pass.
- Full-bleed **device-verified on Android** (Redmi Note 5 Pro): sent 2/3-image + caption render edge-to-edge, caption inset; measured media `0.424→0.959` == bubble `0.424→0.959`.
- [ ] Preparing-state device re-check (send 2–3 images + long caption; confirm no side strip + no size pop on takeover).
- [ ] iOS device pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)