### PR TITLE
feat(location): live-share offer on both sides + one-tap share-back (#966)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
@@ -357,6 +357,19 @@ sealed interface ConversationListUiAction {
         val messageId: Uuid,
     ) : ConversationListUiAction
 
+    /**
+     * Share your live location back from someone ELSE's location bubble. Never touches their
+     * message — sends a NEW lightweight live location message of your own (no map payload) and
+     * starts the relay. [messageId] is the received bubble, used to resolve the conversation and,
+     * when [durationMs] is null, the sender's own live end-time to mirror: a single tap on a LIVE
+     * bubble shares back for exactly the sender's remaining window so both shares end together.
+     * Non-null [durationMs] comes from the duration menu on a received static (fresh) bubble.
+     */
+    data class ShareLiveLocationBack(
+        val messageId: Uuid,
+        val durationMs: Long?,
+    ) : ConversationListUiAction
+
     /** Open the Live Location map (tap a live location bubble's map). */
     data object OpenLiveLocationMap : ConversationListUiAction
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -32,6 +32,9 @@ import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.LocalAttachmentContextStore
 import id.homebase.chat.services.content.MessageContent
 import id.homebase.chat.services.content.MessageContentParser
+import id.homebase.chat.services.livelocation.ShareBackResult
+import id.homebase.chat.services.livelocation.shareLiveLocationBack
+import id.homebase.core.location.GpsRequestReason
 import id.homebase.chat.services.convo.ConversationEnricher
 import id.homebase.chat.services.convo.ConversationService
 import id.homebase.chat.services.convo.ConversationStream
@@ -55,10 +58,12 @@ import id.homebase.core.util.ScrollPosition
 import id.homebase.core.util.applyDefaultStyling
 import id.homebase.resources.MR
 import id.homebase.resources.chat_introduce_preflight_in_progress
+import id.homebase.resources.chat_location_unavailable
 import id.homebase.resources.chat_search_result_conversations
 import id.homebase.resources.chat_search_result_messages
 import id.homebase.resources.chat_search_result_pinned
 import id.homebase.resources.conversation_jump_message_unavailable
+import id.homebase.resources.live_share_ended
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
@@ -148,6 +153,7 @@ class ConversationListViewModel(
     private val stickerPermissionViewModel: ExtendPermissionViewModel,
     private val liveLocationShareService: id.homebase.chat.services.livelocation.LiveLocationShareService,
     private val liveShareReadiness: id.homebase.chat.services.livelocation.LiveShareReadiness,
+    private val locationService: id.homebase.core.location.LocationService,
 ) : ViewModel() {
 
     companion object {
@@ -895,6 +901,40 @@ class ConversationListViewModel(
                 val recipients = conversationStream.getRecipients(msg.conversationId, emptyList(), null)
                 if (untilMs != null) liveLocationShareService.stop(recipients, untilMs)
                 updateLocationLiveShare(action.messageId, Clock.System.now().toEpochMilliseconds())
+            }
+
+            // Share back from someone ELSE's location bubble (#966). Their message is never
+            // touched (liveShareUntilMs is only ever written on the sharer's own message) —
+            // shareLiveLocationBack sends a NEW lightweight live message of our own and starts
+            // the relay; see its doc for the mirror-the-sender's-window semantics.
+            is ConversationListUiAction.ShareLiveLocationBack -> viewModelScope.launch {
+                if (!liveShareReadiness.isReady()) {
+                    _uiState.update { it.copy(uiDialog = ConversationListUiDialog.EnableLocationForShare) }
+                    return@launch
+                }
+                val msg = chatMessageStream.getMessage(action.messageId) ?: return@launch
+                val recipients = conversationStream.getRecipients(msg.conversationId, emptyList(), null)
+                val result = shareLiveLocationBack(
+                    durationMs = action.durationMs,
+                    senderLiveShareUntilMs =
+                        (msg.messageContent as? MessageContent.Location)?.descriptor?.liveShareUntilMs,
+                    nowMs = Clock.System.now().toEpochMilliseconds(),
+                    getFix = { locationService.requestLatestGps(GpsRequestReason.LiveMap) },
+                    send = { descriptor ->
+                        chatMessageSenderService.sendNewTypedMessage(
+                            messageUniqueId = Uuid.random(),
+                            conversationId = msg.conversationId,
+                            content = MessageContent.Location(descriptor),
+                            previousMessageUniqueId = null,
+                        )
+                    },
+                    startRelay = { untilMs -> liveLocationShareService.start(recipients, untilMs) },
+                )
+                when (result) {
+                    ShareBackResult.Expired -> sendEvent(ShowInfoMessage(MR.string.live_share_ended))
+                    ShareBackResult.NoFix -> sendEvent(ShowInfoMessage(MR.string.chat_location_unavailable))
+                    ShareBackResult.Sent -> Unit
+                }
             }
 
             is ConversationListUiAction.SearchBackClicked -> {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/livelocation/LiveShareBack.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/livelocation/LiveShareBack.kt
@@ -1,0 +1,57 @@
+package id.homebase.chat.services.livelocation
+
+import id.homebase.chat.services.builder.LocationPreviewDescriptor
+import id.homebase.core.location.tracking.GpsFixResult
+
+/** Outcome of a share-back attempt — the caller maps these to user feedback. */
+enum class ShareBackResult {
+    /** Own live message sent and relay started. */
+    Sent,
+
+    /** No usable window: mirroring a share that already ended (or a message with none). */
+    Expired,
+
+    /** GPS fix unavailable — nothing was sent. */
+    NoFix,
+}
+
+/**
+ * Share your live location back from someone ELSE's location bubble (#966). Their message is
+ * never touched — this sends a NEW lightweight live location message of our own (header
+ * descriptor only, no static-map payload, live already set at creation) and starts the relay.
+ *
+ * [durationMs] null = mirror [senderLiveShareUntilMs], the sender's absolute end-time synced in
+ * their header descriptor — a single tap on a LIVE bubble shares back for exactly the sender's
+ * remaining window so both shares end together. Non-null = picked from the duration menu on a
+ * received static (fresh) bubble.
+ *
+ * [send] receives the ready descriptor; [startRelay] receives the SAME absolute end-time the
+ * descriptor carries — the {recipient, endTime} pair is the roster's stop key, so the two halves
+ * must never diverge. The relay only starts after a successful send.
+ */
+suspend fun shareLiveLocationBack(
+    durationMs: Long?,
+    senderLiveShareUntilMs: Long?,
+    nowMs: Long,
+    getFix: suspend () -> GpsFixResult,
+    send: suspend (LocationPreviewDescriptor) -> Unit,
+    startRelay: suspend (untilMs: Long) -> Unit,
+): ShareBackResult {
+    val untilMs = durationMs?.let { nowMs + it } ?: senderLiveShareUntilMs
+    if (untilMs == null || untilMs <= nowMs) return ShareBackResult.Expired
+    val fix = getFix()
+    if (fix !is GpsFixResult.Success) return ShareBackResult.NoFix
+    send(
+        LocationPreviewDescriptor(
+            lat = fix.point.lat,
+            lon = fix.point.lon,
+            address = "",
+            hasImage = false,
+            imageWidth = null,
+            imageHeight = null,
+            liveShareUntilMs = untilMs,
+        )
+    )
+    startRelay(untilMs)
+    return ShareBackResult.Sent
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LiveLocationBubbleControls.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LiveLocationBubbleControls.kt
@@ -8,11 +8,15 @@ package id.homebase.chat.widget
  *
  * - [sentByYou] gates the start/stop links (you can only share/stop your own location message).
  * - [onStart]/[onStop] update this message's descriptor (set/clear the live window).
+ * - [onStartShareBack] shares YOUR live location from someone else's bubble — sends a new own
+ *   message instead of touching theirs. Null duration = mirror the sender's live end-time
+ *   (single tap on a LIVE bubble); non-null = picked from the menu on a fresh static bubble.
  * - [onOpenMap] opens the Live Location map (used by either side when the share is live).
  */
 data class LiveLocationBubbleControls(
     val sentByYou: Boolean,
     val onStart: (durationMs: Long) -> Unit,
     val onStop: () -> Unit,
+    val onStartShareBack: (durationMs: Long?) -> Unit,
     val onOpenMap: () -> Unit,
 )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LocationPreview.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LocationPreview.kt
@@ -64,7 +64,9 @@ import id.homebase.resources.live_share_2h
 import id.homebase.resources.live_share_30m
 import id.homebase.resources.live_share_24h
 import id.homebase.resources.live_share_4h
+import id.homebase.resources.live_location_title
 import id.homebase.resources.live_share_active
+import id.homebase.resources.live_share_back
 import id.homebase.resources.live_share_duration_prompt
 import id.homebase.resources.live_share_ended
 import id.homebase.resources.share_live_location
@@ -353,6 +355,27 @@ fun LocationPreviewCard(
                     contentScale = ContentScale.Crop,
                     contentDescription = descriptor.address,
                 )
+            } else if (until != null) {
+                // Lightweight live-share message (share-back): no static map payload by design —
+                // the live map is the position's source of truth. A compact header row instead of
+                // the tall empty pin box; the live-share area below carries the countdown/actions.
+                Row(
+                    modifier = Modifier.padding(start = 12.dp, top = 12.dp, end = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.LocationOn,
+                        contentDescription = stringResource(MR.string.cd_location_pin),
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(20.dp),
+                    )
+                    Spacer(modifier = Modifier.size(6.dp))
+                    Text(
+                        text = stringResource(MR.string.live_location_title),
+                        style = MaterialTheme.typography.titleSmall,
+                        color = contentColor,
+                    )
+                }
             } else {
                 Box(
                     modifier = Modifier.fillMaxWidth().height(100.dp),
@@ -455,7 +478,9 @@ private fun LiveShareActionArea(
     Box {
         when {
             isLive -> {
-                // Both sides show the live caption + time left; only the sender gets the Stop link.
+                // Both sides show the live caption + time left; the sender gets the Stop link, the
+                // receiver gets a single-tap "share your live location" — no duration menu; the
+                // share-back mirrors the sender's remaining window (#966) so both end together.
                 Column {
                     if (controls.sentByYou) {
                         Row(
@@ -477,6 +502,12 @@ private fun LiveShareActionArea(
                                 color = MaterialTheme.colorScheme.error,
                             )
                         }
+                    } else {
+                        LiveShareLinkRow(
+                            label = stringResource(MR.string.live_share_back),
+                            contentColor = contentColor,
+                            onClick = { controls.onStartShareBack(null) },
+                        )
                     }
                     Text(
                         text = stringResource(MR.string.live_share_active, formatRemaining(remainingMs)),
@@ -495,53 +526,86 @@ private fun LiveShareActionArea(
                 )
             }
 
-            controls.sentByYou && canStart -> {
-                // STATIC, my own, still-fresh message: offer to share live. Uses the bubble's content
-                // color so the link is visible on both the grey (received) and tinted (sent) bubble.
-                // Hidden once the pin is stale (canStart=false) — a live share streams the CURRENT
-                // position, which has nothing to do with an old pin.
-                var menuExpanded by remember { mutableStateOf(false) }
-                Column {
-                    Row(
-                        modifier = Modifier
-                            .clickable { menuExpanded = true }
-                            .padding(vertical = 6.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.Send,
-                            contentDescription = null,
-                            tint = contentColor,
-                            modifier = Modifier.size(18.dp),
-                        )
-                        Spacer(modifier = Modifier.size(6.dp))
-                        Text(
-                            text = stringResource(MR.string.share_live_location),
-                            style = MaterialTheme.typography.labelLarge,
-                            color = contentColor,
-                        )
-                    }
-                    DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
-                        Text(
-                            text = stringResource(MR.string.live_share_duration_prompt),
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                        )
-                        HorizontalDivider()
-                        DURATION_OPTIONS.forEach { (labelRes, durationMs) ->
-                            DropdownMenuItem(
-                                text = { Text(stringResource(labelRes)) },
-                                onClick = {
-                                    menuExpanded = false
-                                    controls.onStart(durationMs)
-                                },
-                            )
-                        }
-                    }
+            canStart -> {
+                // STATIC, still-fresh message (either side, #966): offer to share live. My own bubble
+                // upgrades this message in place; someone else's sends a new own live message. Uses
+                // the bubble's content color so the link is visible on both the grey (received) and
+                // tinted (sent) bubble. Hidden once the pin is stale (canStart=false) — a live share
+                // streams the CURRENT position, which has nothing to do with an old pin.
+                if (controls.sentByYou) {
+                    ShareLiveOfferRow(
+                        label = stringResource(MR.string.share_live_location),
+                        contentColor = contentColor,
+                        onPick = { durationMs -> controls.onStart(durationMs) },
+                    )
+                } else {
+                    ShareLiveOfferRow(
+                        label = stringResource(MR.string.live_share_back),
+                        contentColor = contentColor,
+                        onPick = { durationMs -> controls.onStartShareBack(durationMs) },
+                    )
                 }
             }
-            // Receiver + STATIC: no action area.
+            // Stale static pin: no action area (either side).
+        }
+    }
+}
+
+/** The icon + label link row used by every live-share affordance on the bubble. */
+@Composable
+private fun LiveShareLinkRow(
+    label: String,
+    contentColor: Color,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .clickable { onClick() }
+            .padding(vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.Send,
+            contentDescription = null,
+            tint = contentColor,
+            modifier = Modifier.size(18.dp),
+        )
+        Spacer(modifier = Modifier.size(6.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelLarge,
+            color = contentColor,
+        )
+    }
+}
+
+/** [LiveShareLinkRow] that opens the duration menu and reports the picked duration. */
+@Composable
+private fun ShareLiveOfferRow(
+    label: String,
+    contentColor: Color,
+    onPick: (durationMs: Long) -> Unit,
+) {
+    var menuExpanded by remember { mutableStateOf(false) }
+    Column {
+        LiveShareLinkRow(label = label, contentColor = contentColor, onClick = { menuExpanded = true })
+        DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
+            Text(
+                text = stringResource(MR.string.live_share_duration_prompt),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+            HorizontalDivider()
+            DURATION_OPTIONS.forEach { (labelRes, durationMs) ->
+                DropdownMenuItem(
+                    text = { Text(stringResource(labelRes)) },
+                    onClick = {
+                        menuExpanded = false
+                        onPick(durationMs)
+                    },
+                )
+            }
         }
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageItem.kt
@@ -67,6 +67,9 @@ fun MessageItem(
                 onUiAction(ConversationListUiAction.StartLiveLocationShare(message.id, durationMs))
             },
             onStop = { onUiAction(ConversationListUiAction.StopLiveLocationShare(message.id)) },
+            onStartShareBack = { durationMs ->
+                onUiAction(ConversationListUiAction.ShareLiveLocationBack(message.id, durationMs))
+            },
             onOpenMap = { onUiAction(ConversationListUiAction.OpenLiveLocationMap) },
         )
     }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/content/LocationDescriptorRoundTripTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/content/LocationDescriptorRoundTripTest.kt
@@ -1,0 +1,71 @@
+package id.homebase.chat.services.content
+
+import id.homebase.chat.services.ChatProtocol
+import id.homebase.chat.services.builder.LocationPreviewDescriptor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Round-trips the #966 lightweight share-back descriptor (imageless, live at creation) through
+ * MessageContentParser: what the sender serializes is exactly what the receiver parses, and
+ * `explicitNulls=false` keeps the never-set optionals out of the header JSON (7 KB budget).
+ */
+class LocationDescriptorRoundTripTest {
+
+    @Test
+    fun lightweightLiveDescriptorSurvivesSerializeParse() {
+        val descriptor = LocationPreviewDescriptor(
+            lat = 52.5,
+            lon = 13.4,
+            address = "",
+            hasImage = false,
+            imageWidth = null,
+            imageHeight = null,
+            liveShareUntilMs = 1_720_000_000_000L,
+        )
+        val json = MessageContentParser.serialize(MessageContent.Location(descriptor))
+        val parsed = MessageContentParser.parse(ChatProtocol.ChatLocationMessageDataType, json)
+        assertIs<MessageContent.Location>(parsed)
+        assertEquals(descriptor, parsed.descriptor)
+    }
+
+    @Test
+    fun unsetOptionalsAreOmittedFromTheHeaderJson() {
+        val json = MessageContentParser.serialize(
+            MessageContent.Location(
+                LocationPreviewDescriptor(
+                    lat = 1.0,
+                    lon = 2.0,
+                    address = "",
+                    hasImage = false,
+                    imageWidth = null,
+                    imageHeight = null,
+                    liveShareUntilMs = 42L,
+                )
+            )
+        )
+        assertFalse("caption" in json, "explicitNulls=false should omit unset caption: $json")
+        assertFalse("imageWidth" in json, "explicitNulls=false should omit null imageWidth: $json")
+        assertTrue("liveShareUntilMs" in json)
+    }
+
+    @Test
+    fun staticDescriptorWithCaptionRoundTrips() {
+        val descriptor = LocationPreviewDescriptor(
+            lat = -33.9,
+            lon = 151.2,
+            address = "Sydney NSW, Australia",
+            hasImage = true,
+            imageWidth = 256,
+            imageHeight = 256,
+            caption = "meet here 🍕",
+        )
+        val json = MessageContentParser.serialize(MessageContent.Location(descriptor))
+        val parsed = MessageContentParser.parse(ChatProtocol.ChatLocationMessageDataType, json)
+        assertIs<MessageContent.Location>(parsed)
+        assertEquals(descriptor, parsed.descriptor)
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/livelocation/LiveShareBackTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/livelocation/LiveShareBackTest.kt
@@ -1,0 +1,110 @@
+package id.homebase.chat.services.livelocation
+
+import id.homebase.chat.services.builder.LocationPreviewDescriptor
+import id.homebase.core.location.tracking.GpsFixResult
+import id.homebase.core.location.tracking.RawLocationPoint
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Pins the #966 share-back contract: the recipient's reciprocal share sends a NEW lightweight
+ * message (never touching the sender's), mirrors the sender's absolute end-time on a single tap,
+ * refuses to send without a GPS fix or a usable window, and hands the relay the SAME end-time the
+ * descriptor carries (the roster's stop key).
+ */
+class LiveShareBackTest {
+
+    private val fix = GpsFixResult.Success(
+        RawLocationPoint(t = 1_000L, lat = 52.5, lon = 13.4, acc = 10.0, src = "gps", fg = true)
+    )
+
+    private class Harness {
+        val sent = mutableListOf<LocationPreviewDescriptor>()
+        val relayStarts = mutableListOf<Long>()
+    }
+
+    private suspend fun run(
+        durationMs: Long?,
+        senderUntilMs: Long?,
+        nowMs: Long,
+        fixResult: GpsFixResult,
+        h: Harness,
+    ): ShareBackResult = shareLiveLocationBack(
+        durationMs = durationMs,
+        senderLiveShareUntilMs = senderUntilMs,
+        nowMs = nowMs,
+        getFix = { fixResult },
+        send = { h.sent += it },
+        startRelay = { h.relayStarts += it },
+    )
+
+    @Test
+    fun mirrorUsesSenderAbsoluteEndTimeNotNowPlusDuration() = runTest {
+        val h = Harness()
+        val senderUntil = 90_000L
+        val result = run(durationMs = null, senderUntilMs = senderUntil, nowMs = 10_000L, fixResult = fix, h = h)
+        assertEquals(ShareBackResult.Sent, result)
+        assertEquals(senderUntil, h.sent.single().liveShareUntilMs)
+        assertEquals(listOf(senderUntil), h.relayStarts)
+    }
+
+    @Test
+    fun explicitDurationCountsFromNow() = runTest {
+        val h = Harness()
+        val result = run(durationMs = 15 * 60_000L, senderUntilMs = null, nowMs = 10_000L, fixResult = fix, h = h)
+        assertEquals(ShareBackResult.Sent, result)
+        assertEquals(10_000L + 15 * 60_000L, h.sent.single().liveShareUntilMs)
+    }
+
+    @Test
+    fun descriptorAndRelayShareTheSameEndTime() = runTest {
+        val h = Harness()
+        run(durationMs = 60_000L, senderUntilMs = null, nowMs = 5_000L, fixResult = fix, h = h)
+        assertEquals(h.sent.single().liveShareUntilMs, h.relayStarts.single())
+    }
+
+    @Test
+    fun sentMessageIsLightweightAndOwn() = runTest {
+        val h = Harness()
+        run(durationMs = null, senderUntilMs = 90_000L, nowMs = 10_000L, fixResult = fix, h = h)
+        val d = h.sent.single()
+        assertEquals(52.5, d.lat)
+        assertEquals(13.4, d.lon)
+        assertEquals(false, d.hasImage)
+        assertNull(d.imageWidth)
+        assertNull(d.imageHeight)
+        assertNull(d.caption)
+        assertEquals("", d.address)
+    }
+
+    @Test
+    fun mirroringAnEndedShareSendsNothing() = runTest {
+        val h = Harness()
+        val result = run(durationMs = null, senderUntilMs = 9_000L, nowMs = 10_000L, fixResult = fix, h = h)
+        assertEquals(ShareBackResult.Expired, result)
+        assertTrue(h.sent.isEmpty())
+        assertTrue(h.relayStarts.isEmpty())
+    }
+
+    @Test
+    fun mirroringAMessageWithoutAWindowSendsNothing() = runTest {
+        val h = Harness()
+        val result = run(durationMs = null, senderUntilMs = null, nowMs = 10_000L, fixResult = fix, h = h)
+        assertEquals(ShareBackResult.Expired, result)
+        assertTrue(h.sent.isEmpty())
+    }
+
+    @Test
+    fun noGpsFixSendsNothing() = runTest {
+        for (failure in listOf(GpsFixResult.PermissionDenied, GpsFixResult.Unavailable, GpsFixResult.Timeout)) {
+            val h = Harness()
+            val result = run(durationMs = 60_000L, senderUntilMs = null, nowMs = 10_000L, fixResult = failure, h = h)
+            assertEquals(ShareBackResult.NoFix, result)
+            assertTrue(h.sent.isEmpty())
+            assertTrue(h.relayStarts.isEmpty())
+        }
+    }
+}

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1366,6 +1366,7 @@
     <string name="location_dashboard_stop_confirm_title">Stop all sharing?</string>
     <string name="location_dashboard_stop_confirm_body">This ends every live location share you've started.</string>
     <string name="share_live_location">Share live location</string>
+    <string name="live_share_back">Share your live location</string>
     <string name="live_share_duration_prompt">Share live location for</string>
     <string name="stop_sharing">Stop sharing</string>
     <string name="live_share_active">Live location · %1$s left</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -805,6 +805,7 @@ val appModule = module {
             stickerPermissionViewModel = get(StickerPermissionQualifier),
             liveLocationShareService = get(),
             liveShareReadiness = get(),
+            locationService = get(),
         )
     }
     viewModelOf(::ArchivedConversationsViewModel)


### PR DESCRIPTION
Part 1 of #966 (bubble reciprocity — the dedicated share screen follows in a separate PR).

## What

- **Offer on both sides (Option B):** the "Share live location" affordance now renders on *received* location bubbles too, still gated by the existing 15-min pin-freshness window (`SHARE_OFFER_WINDOW_MS`) — no offer on week-old pins.
- **One-tap share-back on a LIVE bubble:** while the sender is live-sharing, the recipient sees "Share your live location" with **no duration menu** — the share-back mirrors the sender's absolute `liveShareUntilMs` (already synced in their header descriptor), so both shares end together. On a received *static* fresh bubble the usual duration menu appears instead.
- **Lightweight own message:** a share-back never mutates the sender's message. It sends a NEW live location message of the recipient's own — header descriptor only (`hasImage=false`, no static-map payload, no geocode), live already set at creation (no post-hoc `updateMessage`) — and starts the relay with the same end-time (the roster's stop key). Stop flows through the existing `StopLiveLocationShare`.
- **Compact bubble rendering** for imageless live messages: a small "Live location" header row instead of the tall empty pin box; countdown/actions unchanged below.
- Readiness gate reused: not set up → `EnableLocationForShare` dialog; no GPS fix → snackbar, nothing sent; mirroring a share that ended between render and tap → "Live share ended" snackbar, nothing sent.

## How

- `ShareLiveLocationBack(messageId, durationMs?)` action (`null` = mirror sender's end time) → `ConversationListViewModel` → new `shareLiveLocationBack()` in `services/livelocation/` with lambda seams (readiness/message/recipients handled by the VM around it).
- `LiveShareActionArea` refactored into `LiveShareLinkRow` + `ShareLiveOfferRow` (menu) — sender behavior unchanged.
- New string `live_share_back`; VM gains a `LocationService` dep for the VM-side one-shot fix (`requestLatestGps(LiveMap)` — permission already guaranteed by the readiness gate).

## Tests

- `LiveShareBackTest` — mirror uses the sender's absolute end time (not now+duration), descriptor and relay share the same end time, lightweight descriptor shape, no send on expired window / missing fix.
- `LocationDescriptorRoundTripTest` — imageless live descriptor round-trips through `MessageContentParser` (dataType 211); `explicitNulls=false` keeps unset optionals out of the 7 KB header budget.
- Full matrix green: JVM/Android/wasmJs compile, `homebase-chat`+`homebase-common` jvmTest incl. Konsist.

## Manual verification (pending, two identities)

- [ ] Recipient one-tap share-back on a LIVE bubble → own compact live bubble on both sides, counting down to the same end time; both dots on the live map; each side's Stop only stops their own share; sender's message never edited.
- [ ] Received static fresh bubble shows the offer + duration menu; offer gone after 15 min on both sides.
- [ ] Add-on off → Enable-location dialog; airplane mode → snackbar, no phantom send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKxv1k187ynCjx6sVDC7NQ