### PR TITLE
feat(location): full-screen share-location screen (#966)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/location/LocationPreviewProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/location/LocationPreviewProvider.kt
@@ -52,10 +52,15 @@ class LocationPreviewProvider(
         lat: Double,
         lon: Double,
         zoom: Int = 15,
+        /**
+         * Address the caller already resolved (e.g. the share-location screen's live pan
+         * geocoding) — skips the Nominatim round-trip entirely. Blank/null ⇒ resolve here.
+         */
+        knownAddress: String? = null,
     ): LocationPreview {
         cache[CacheKey(lat, lon, zoom)]?.let { return it }
 
-        val address = try {
+        val address = knownAddress?.takeIf { it.isNotBlank() } ?: try {
             reverseGeocode(lat, lon, zoom) ?: formatLatLon(lat, lon)
         } catch (e: Exception) {
             Logger.w(throwable = e, tag = TAG) { "reverseGeocode threw — falling back to lat/lon" }
@@ -84,7 +89,29 @@ class LocationPreviewProvider(
         return preview
     }
 
-    private suspend fun reverseGeocode(lat: Double, lon: Double, zoom: Int): String? {
+    /**
+     * Reverse-geocode a point to a display address (Nominatim `display_name`), or null when the
+     * lookup fails or the point has no address. Cached by coordinates rounded to ~11 m so pan
+     * jitter (the share-location screen re-resolving as the map settles) doesn't re-query; the
+     * remote call is rate-limited to Nominatim's 1 req/s budget. Callers doing continuous lookups
+     * (address-follows-pan) must ALSO debounce on their side — the rate limiter queues, it
+     * doesn't shed.
+     */
+    suspend fun reverseGeocode(lat: Double, lon: Double, zoom: Int = 18): String? {
+        val key = AddressKey(roundCoord(lat), roundCoord(lon), zoom)
+        addressCacheMutex.withLock { addressCache[key] }?.let { return it }
+        val resolved = reverseGeocodeRemote(lat, lon, zoom) ?: return null
+        addressCacheMutex.withLock {
+            addressCache[key] = resolved
+            // Insertion-order eviction — good enough for a pan cache.
+            while (addressCache.size > ADDRESS_CACHE_MAX) {
+                addressCache.remove(addressCache.keys.first())
+            }
+        }
+        return resolved
+    }
+
+    private suspend fun reverseGeocodeRemote(lat: Double, lon: Double, zoom: Int): String? {
         // Nominatim usage policy: max 1 req/sec, identifying User-Agent. We add a touch of
         // headroom (1.1s) so we never miss the budget if the wall clock is slightly skewed.
         nominatimMutex.withLock {
@@ -211,7 +238,12 @@ class LocationPreviewProvider(
         return "$latStr, $lonStr"
     }
 
+    /** ~11 m grid (4 decimals) — close enough that one address serves the whole cell. */
+    private fun roundCoord(v: Double): Double = (v * 1e4).toLong() / 1e4
+
     private data class CacheKey(val lat: Double, val lon: Double, val zoom: Int)
+
+    private data class AddressKey(val lat: Double, val lon: Double, val zoom: Int)
 
     private data class TileKey(val zoom: Int, val x: Int, val y: Int)
 
@@ -230,6 +262,11 @@ class LocationPreviewProvider(
         private val cache = mutableMapOf<CacheKey, LocationPreview>()
         private val nominatimMutex = Mutex()
         private var lastNominatimCallAt: TimeSource.Monotonic.ValueTimeMark? = null
+
+        // Resolved-address cache for pan-follows-address lookups (share-location screen).
+        private const val ADDRESS_CACHE_MAX = 128
+        private val addressCache = LinkedHashMap<AddressKey, String>()
+        private val addressCacheMutex = Mutex()
 
         // Raw-tile cache for the Location history basemap (~64 tiles ≈ 1-2MB).
         private const val TILE_CACHE_MAX = 64

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/location/WebMercator.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/location/WebMercator.kt
@@ -1,9 +1,11 @@
 package id.homebase.api.client.location
 
 import kotlin.math.PI
+import kotlin.math.atan
 import kotlin.math.cos
 import kotlin.math.floor
 import kotlin.math.ln
+import kotlin.math.sinh
 import kotlin.math.tan
 
 /**
@@ -23,6 +25,13 @@ object WebMercator {
         val latRad = lat * PI / 180.0
         val y = (1.0 - ln(tan(latRad) + 1.0 / cos(latRad)) / PI) / 2.0
         return x to y
+    }
+
+    /** Inverse of [latLonToUnit]: unit-space world position back to (lat, lon) degrees. */
+    fun unitToLatLon(x: Double, y: Double): Pair<Double, Double> {
+        val lon = x * 360.0 - 180.0
+        val lat = atan(sinh(PI * (1.0 - 2.0 * y))) * 180.0 / PI
+        return lat to lon
     }
 
     /** Tile index along one axis for a unit coordinate at [zoom], clamped to the grid. */

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/client/location/WebMercatorRoundTripTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/client/location/WebMercatorRoundTripTest.kt
@@ -1,0 +1,34 @@
+package id.homebase.api.client.location
+
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Pins [WebMercator.unitToLatLon] as the true inverse of [WebMercator.latLonToUnit] across the
+ * Web-Mercator domain (|lat| ≤ 85) — the share-location screen relies on it to turn the panned
+ * viewport center back into the coordinates it sends.
+ */
+class WebMercatorRoundTripTest {
+
+    @Test
+    fun unitToLatLonInvertsLatLonToUnit() {
+        for (lat in -85..85 step 5) {
+            for (lon in -180..175 step 5) {
+                val (x, y) = WebMercator.latLonToUnit(lat.toDouble(), lon.toDouble())
+                val (latBack, lonBack) = WebMercator.unitToLatLon(x, y)
+                assertTrue(abs(latBack - lat) < 1e-9, "lat $lat → $latBack (lon=$lon)")
+                assertTrue(abs(lonBack - lon) < 1e-9, "lon $lon → $lonBack (lat=$lat)")
+            }
+        }
+    }
+
+    @Test
+    fun unitCornersMapToDomainEdges() {
+        val (latTop, lonLeft) = WebMercator.unitToLatLon(0.0, 0.0)
+        assertTrue(latTop > 85.0, "top of unit space is the Mercator max latitude, got $latTop")
+        assertTrue(abs(lonLeft - (-180.0)) < 1e-9)
+        val (latMid, lonMid) = WebMercator.unitToLatLon(0.5, 0.5)
+        assertTrue(abs(latMid) < 1e-9 && abs(lonMid) < 1e-9, "unit center is (0,0), got $latMid,$lonMid")
+    }
+}

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/location/LocationPreviewProviderKnownAddressTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/location/LocationPreviewProviderKnownAddressTest.kt
@@ -1,0 +1,63 @@
+package id.homebase.api.client.location
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins the #966 `knownAddress` contract on the DEV-STUB provider: when the caller already
+ * resolved the address (the share-location screen's pan geocoding), `getLocationPreview` must
+ * NOT hit Nominatim again — only the tile fetch goes out. Coordinates are unique per test
+ * because the provider's caches are companion-level (shared across instances).
+ */
+class LocationPreviewProviderKnownAddressTest {
+
+    private val requestedHosts = mutableListOf<String>()
+
+    // >500 bytes so the blank-tile guard doesn't discard the fake tile.
+    private val tileBytes = ByteArray(1024) { it.toByte() }
+
+    private fun provider(): LocationPreviewProvider {
+        val engine = MockEngine { request ->
+            requestedHosts += request.url.host
+            when (request.url.host) {
+                "tile.openstreetmap.org" -> respond(tileBytes, HttpStatusCode.OK)
+                "nominatim.openstreetmap.org" ->
+                    respond("""{"display_name":"Remote Street 1"}""", HttpStatusCode.OK)
+                else -> respond("", HttpStatusCode.NotFound)
+            }
+        }
+        return LocationPreviewProvider(HttpClient(engine))
+    }
+
+    @Test
+    fun knownAddressSkipsNominatim() = runTest {
+        val preview = provider().getLocationPreview(
+            lat = 47.11111,
+            lon = 8.22222,
+            knownAddress = "Panned Street 42, Testville",
+        )
+        assertEquals("Panned Street 42, Testville", preview.address)
+        assertTrue(
+            requestedHosts.none { it == "nominatim.openstreetmap.org" },
+            "knownAddress must skip the geocode; requests went to: $requestedHosts",
+        )
+        assertTrue(requestedHosts.any { it == "tile.openstreetmap.org" }, "static map tile still fetched")
+    }
+
+    @Test
+    fun blankKnownAddressStillGeocodes() = runTest {
+        val preview = provider().getLocationPreview(
+            lat = -13.33333,
+            lon = 27.44444,
+            knownAddress = "",
+        )
+        assertEquals("Remote Street 1", preview.address)
+        assertTrue(requestedHosts.any { it == "nominatim.openstreetmap.org" })
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -122,6 +122,7 @@ fun ConversationListScreen(
     onNavigateToNewConversation: () -> Unit,
     onNavigateToLiveLocationMap: () -> Unit = {},
     onNavigateToLocationSetup: () -> Unit = {},
+    onNavigateToShareLocation: (conversationId: String) -> Unit = {},
     onNavigateToContactInfo: (odinId: String) -> Unit,
     onNavigateToConversationSettings: (conversationId: String) -> Unit,
     onNavigateToGroupSettings: (conversationId: String) -> Unit,
@@ -192,6 +193,11 @@ fun ConversationListScreen(
             is ConversationListUiEvent.NavigateToLocationSetup -> {
                 viewModel.eventConsumed()
                 onNavigateToLocationSetup()
+            }
+
+            is ConversationListUiEvent.NavigateToShareLocation -> {
+                viewModel.eventConsumed()
+                onNavigateToShareLocation(event.conversationId)
             }
 
             is ConversationListUiEvent.NavigateToContactInfo -> {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
@@ -373,6 +373,9 @@ sealed interface ConversationListUiAction {
     /** Open the Live Location map (tap a live location bubble's map). */
     data object OpenLiveLocationMap : ConversationListUiAction
 
+    /** Open the full-screen share-location screen (attachment sheet → Location). */
+    data class OpenShareLocation(val conversationId: Uuid) : ConversationListUiAction
+
     /** Open the location setup screen — from the "set up location" prompt shown when a live share
      *  can't start because location isn't ready. */
     data object OpenLocationSetup : ConversationListUiAction

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiEvent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiEvent.kt
@@ -35,6 +35,9 @@ sealed interface ConversationListUiEvent {
     /** Open the Live Location map (from tapping a live location bubble's map). */
     data object NavigateToLiveLocationMap : ConversationListUiEvent
 
+    /** Open the full-screen share-location screen for a conversation (attachment sheet → Location). */
+    data class NavigateToShareLocation(val conversationId: String) : ConversationListUiEvent
+
     /** Open the location setup screen (from the "set up location" prompt before a live share). */
     data object NavigateToLocationSetup : ConversationListUiEvent
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -869,6 +869,10 @@ class ConversationListViewModel(
                 sendEvent(ConversationListUiEvent.NavigateToLiveLocationMap)
             }
 
+            is ConversationListUiAction.OpenShareLocation -> {
+                sendEvent(ConversationListUiEvent.NavigateToShareLocation(action.conversationId.toString()))
+            }
+
             is ConversationListUiAction.OpenLocationSetup -> {
                 sendEvent(ConversationListUiEvent.NavigateToLocationSetup)
             }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -112,7 +112,6 @@ import id.homebase.api.client.profile.PublicProfileProvider
 import id.homebase.api.common.OdinId
 import id.homebase.chat.conversationlist.AutoConnectRowState
 import id.homebase.chat.conversationlist.ConversationListUiAction
-import id.homebase.api.client.location.LocationPreviewProvider
 import co.touchlab.kermit.Logger
 import id.homebase.chat.dice.BattleRollSheet
 import id.homebase.chat.dice.DiceRollComposerSheet
@@ -124,13 +123,7 @@ import id.homebase.chat.groodle.GroodleComposerSheet
 import id.homebase.chat.poll.PollComposerSheet
 import id.homebase.chat.event.EventDetailDialog
 import id.homebase.chat.event.EventRsvp
-import id.homebase.core.location.rememberCurrentGps
-import id.homebase.core.location.tracking.GpsFixResult
-import id.homebase.resources.chat_location_map_preview_unavailable
-import id.homebase.resources.chat_location_permission_denied
-import id.homebase.resources.chat_location_unavailable
 import id.homebase.chat.services.renderer.PayloadRenderer
-import id.homebase.chat.services.renderer.LocationPreviewRenderer
 import id.homebase.chat.conversationlist.MessageClusterPosition
 import id.homebase.chat.conversationlist.MessageListContentModel
 import id.homebase.chat.conversationlist.MessageListUiSheet
@@ -265,54 +258,7 @@ fun ConversationContent(
     // too, via `MessageInputBar`'s onPayloadRenderersChange callback.
     var payloadRenderers by remember { mutableStateOf<List<PayloadRenderer>>(emptyList()) }
 
-    // Location-share flow. Triggered from the AttachmentOptions sheet → GPS launcher → fetch
-    // a static map preview from the (dev-stub) provider → append a LocationPreviewRenderer to
-    // the composer's staging slot. The composer renders/cancels it via the same path as link
-    // previews; nothing here knows the bubble shape.
-    val locationPreviewProvider: LocationPreviewProvider = koinInject()
-    var isFetchingLocation by remember { mutableStateOf(false) }
     val snackbarHostState = remember { SnackbarHostState() }
-    val locationPermissionDeniedMsg = stringResource(MR.string.chat_location_permission_denied)
-    val locationUnavailableMsg = stringResource(MR.string.chat_location_unavailable)
-    val locationMapPreviewUnavailableMsg = stringResource(MR.string.chat_location_map_preview_unavailable)
-    val currentLocationLauncher = rememberCurrentGps { result ->
-        isFetchingLocation = false
-        when (result) {
-            is GpsFixResult.Success -> {
-                Logger.d(tag = "LocationShare") {
-                    "fix received lat=${result.point.lat} lon=${result.point.lon} → fetching preview"
-                }
-                coroutineScope.launch {
-                    isFetchingLocation = true
-                    try {
-                        val preview = locationPreviewProvider.getLocationPreview(
-                            result.point.lat, result.point.lon,
-                        )
-                        // Always stage — coordinates alone are useful even without a map image.
-                        payloadRenderers = payloadRenderers.filterNot { it is LocationPreviewRenderer } +
-                            LocationPreviewRenderer(preview)
-                        if (preview.imageUrl == null) {
-                            Logger.w(tag = "LocationShare") {
-                                "preview returned with no image (map service down or offline) — coords-only"
-                            }
-                            snackbarHostState.showSnackbar(locationMapPreviewUnavailableMsg)
-                        }
-                    } finally {
-                        isFetchingLocation = false
-                    }
-                }
-            }
-            is GpsFixResult.PermissionDenied -> {
-                Logger.d(tag = "LocationShare") { "permission denied" }
-                coroutineScope.launch { snackbarHostState.showSnackbar(locationPermissionDeniedMsg) }
-            }
-            is GpsFixResult.Unavailable,
-            is GpsFixResult.Timeout -> {
-                Logger.d(tag = "LocationShare") { "fix unavailable" }
-                coroutineScope.launch { snackbarHostState.showSnackbar(locationUnavailableMsg) }
-            }
-        }
-    }
 
     LaunchedEffect(uiState.isSearchActive) {
         if (uiState.isSearchActive) {
@@ -1502,7 +1448,7 @@ fun ConversationContent(
                             editExistingMode = uiState.isEditingMessageId != null,
                             showSendButton = showSendButton,
                             isRecordingActive = isRecordingActive,
-                            isSendingMessage = uiState.isSendingMessage || isFetchingLocation,
+                            isSendingMessage = uiState.isSendingMessage,
                             onSendMessage = {
                                 performSend(textFieldState.toMarkdown(), payloadRenderers)
                             },
@@ -1518,7 +1464,7 @@ fun ConversationContent(
                                 focusRequester = focusRequester,
                                 editExistingMode = uiState.isEditingMessageId != null,
                                 showingEmojiSheet = showEmojiSheet,
-                                isSendingMessage = uiState.isSendingMessage || isFetchingLocation,
+                                isSendingMessage = uiState.isSendingMessage,
                                 showActionButtons = false,
                                 onSendStateChanged = { showSendButton = it },
                                 onRecordingStateChanged = { isRecordingActive = it },
@@ -1637,8 +1583,9 @@ fun ConversationContent(
                     }, onLocationClick = {
                         Logger.d(tag = "LocationShare") { "share location clicked" }
                         showAttachmentSheet = false
-                        isFetchingLocation = true
-                        currentLocationLauncher.launch()
+                        onUiAction(
+                            ConversationListUiAction.OpenShareLocation(conversation.conversation.id)
+                        )
                     }, onEventClick = {
                         showAttachmentSheet = false
                         showEventComposer = true

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LocationPreview.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LocationPreview.kt
@@ -51,6 +51,8 @@ import id.homebase.api.client.drives.upload.EmbeddedThumb
 import id.homebase.api.client.location.LocationPreview
 import id.homebase.chat.services.builder.LocationPreviewDescriptor
 import id.homebase.core.image.HomebaseImage
+import id.homebase.core.location.LIVE_SHARE_DURATION_OPTIONS
+import id.homebase.core.location.formatLiveShareRemaining
 import id.homebase.core.image.HomebaseImageData
 import id.homebase.core.image.ImageSize
 import id.homebase.core.ui.theme.Dimens
@@ -58,12 +60,6 @@ import id.homebase.resources.MR
 import id.homebase.resources.cancel
 import id.homebase.resources.cd_location_pin
 import id.homebase.resources.chat_location_attachment
-import id.homebase.resources.live_share_15m
-import id.homebase.resources.live_share_1h
-import id.homebase.resources.live_share_2h
-import id.homebase.resources.live_share_30m
-import id.homebase.resources.live_share_24h
-import id.homebase.resources.live_share_4h
 import id.homebase.resources.live_location_title
 import id.homebase.resources.live_share_active
 import id.homebase.resources.live_share_back
@@ -510,7 +506,7 @@ private fun LiveShareActionArea(
                         )
                     }
                     Text(
-                        text = stringResource(MR.string.live_share_active, formatRemaining(remainingMs)),
+                        text = stringResource(MR.string.live_share_active, formatLiveShareRemaining(remainingMs)),
                         style = MaterialTheme.typography.labelSmall,
                         color = mutedColor,
                     )
@@ -597,7 +593,7 @@ private fun ShareLiveOfferRow(
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
             )
             HorizontalDivider()
-            DURATION_OPTIONS.forEach { (labelRes, durationMs) ->
+            LIVE_SHARE_DURATION_OPTIONS.forEach { (labelRes, durationMs) ->
                 DropdownMenuItem(
                     text = { Text(stringResource(labelRes)) },
                     onClick = {
@@ -612,27 +608,6 @@ private fun ShareLiveOfferRow(
 
 /** How long after a location pin is sent the "Share live location" offer stays available. */
 private const val SHARE_OFFER_WINDOW_MS = 15 * 60_000L
-
-private val DURATION_OPTIONS = listOf(
-    MR.string.live_share_15m to 15 * 60_000L,
-    MR.string.live_share_30m to 30 * 60_000L,
-    MR.string.live_share_1h to 60 * 60_000L,
-    MR.string.live_share_2h to 2 * 60 * 60_000L,
-    MR.string.live_share_4h to 4 * 60 * 60_000L,
-    // All-day sharing (festivals etc.) — #889. Window is absolute-endTime
-    // driven, so this is just a larger value; formatRemaining renders it as
-    // "24h"/"23h". Backgrounded GPS freshness is governed separately by #878.
-    MR.string.live_share_24h to 24L * 60 * 60_000L,
-)
-
-/** Compact "time left" label: "42m", "1h", "1h 20m". */
-private fun formatRemaining(remainingMs: Long): String {
-    val totalMin = (remainingMs / 60_000L).coerceAtLeast(0L)
-    if (totalMin < 60) return "${totalMin}m"
-    val h = totalMin / 60
-    val m = totalMin % 60
-    return if (m == 0L) "${h}h" else "${h}h ${m}m"
-}
 
 // ─── Compact list row (the "See all" locations tab) ──────────────────────────
 

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1377,6 +1377,12 @@
     <string name="live_share_2h">2 hours</string>
     <string name="live_share_4h">4 hours</string>
     <string name="live_share_24h">24 hours</string>
+    <string name="share_location_title">Share location</string>
+    <string name="share_location_recenter_cd">Center on your current location</string>
+    <string name="share_location_resolving">Finding address…</string>
+    <string name="share_location_comment_hint">Add a comment</string>
+    <string name="share_location_live_banner">Share live location</string>
+    <string name="share_location_send_cd">Send location</string>
     <string name="live_share_enable_location_title">Turn on location to share</string>
     <string name="live_share_enable_location_body">To share your live location, set up location on this device first so it can send your position.</string>
     <string name="live_share_enable_location_cta">Set up location</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LiveShareDurations.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LiveShareDurations.kt
@@ -1,0 +1,34 @@
+package id.homebase.core.location
+
+import id.homebase.resources.MR
+import id.homebase.resources.live_share_15m
+import id.homebase.resources.live_share_1h
+import id.homebase.resources.live_share_24h
+import id.homebase.resources.live_share_2h
+import id.homebase.resources.live_share_30m
+import id.homebase.resources.live_share_4h
+import org.jetbrains.compose.resources.StringResource
+
+/**
+ * The selectable live-location share durations (label resource → duration millis), shared by the
+ * chat bubble's duration menu and the share-location screen so both offer the identical set.
+ * 24h is the all-day option (festivals etc., #889) — the share window is absolute-endTime driven,
+ * so it's just a larger value; backgrounded GPS freshness is governed separately by #878.
+ */
+val LIVE_SHARE_DURATION_OPTIONS: List<Pair<StringResource, Long>> = listOf(
+    MR.string.live_share_15m to 15 * 60_000L,
+    MR.string.live_share_30m to 30 * 60_000L,
+    MR.string.live_share_1h to 60 * 60_000L,
+    MR.string.live_share_2h to 2 * 60 * 60_000L,
+    MR.string.live_share_4h to 4 * 60 * 60_000L,
+    MR.string.live_share_24h to 24L * 60 * 60_000L,
+)
+
+/** Compact "time left" label: "42m", "1h", "1h 20m". */
+fun formatLiveShareRemaining(remainingMs: Long): String {
+    val totalMin = (remainingMs / 60_000L).coerceAtLeast(0L)
+    if (totalMin < 60) return "${totalMin}m"
+    val h = totalMin / 60
+    val m = totalMin % 60
+    return if (m == 0L) "${h}h" else "${h}h ${m}m"
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
@@ -203,6 +203,10 @@ sealed class Route {
     data class LocationFindDevice(val deviceId: String? = null) : Route()
 
     @Serializable
+    @SerialName("location-share")
+    data class LocationShare(val conversationId: String) : Route()
+
+    @Serializable
     @SerialName("crop")
     data class Crop(val requestId: String) : Route()
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -173,6 +173,7 @@ import id.homebase.core.ui.screens.location.devices.FindDeviceViewModel
 import id.homebase.core.ui.screens.location.devices.LocationDeviceDirectory
 import id.homebase.core.ui.screens.location.history.LocationHistoryViewModel
 import id.homebase.core.ui.screens.location.livelocation.LiveLocationViewModel
+import id.homebase.core.ui.screens.location.share.ShareLocationViewModel
 
 val VaultPermissionQualifier = named("vaultPermission")
 
@@ -869,6 +870,19 @@ val appModule = module {
             pointStore = get(),
             credentialsManager = get(),
             locationService = get(),
+        )
+    }
+    viewModel { params ->
+        ShareLocationViewModel(
+            conversationId = params.get(),
+            previewProvider = get(),
+            locationService = get(),
+            locationPreferences = get(),
+            liveShareReadiness = get(),
+            liveLocationShareService = get(),
+            chatMessageSenderService = get(),
+            conversationStream = get(),
+            fileOperationsProvider = get(),
         )
     }
     viewModelOf(::ContactBookViewModel)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -113,6 +113,7 @@ import id.homebase.core.ui.screens.location.devices.FindDeviceScreen
 import id.homebase.core.ui.screens.location.history.LocationHistoryScreen
 import id.homebase.core.ui.screens.location.livelocation.LiveLocationScreen
 import id.homebase.core.ui.screens.location.onboarding.LocationOnboardingScreen
+import id.homebase.core.ui.screens.location.share.ShareLocationScreen
 import id.homebase.core.ui.screens.notifications.NotificationSettingsScreen
 import id.homebase.core.ui.screens.settings.SettingsScreen
 import androidx.compose.material3.CircularProgressIndicator
@@ -901,6 +902,9 @@ fun AppNavHost(
                                     // the add-on isn't activated, else the dashboard (which requests
                                     // permission) — covers both "not set up" gate-fail cases.
                                     onNavigateToLocationSetup = openLocation,
+                                    onNavigateToShareLocation = { conversationId ->
+                                        navController.navigate(Route.LocationShare(conversationId))
+                                    },
                                     onNavigateToContactInfo = {
                                         // 1:1 contact info is the full contact-detail screen
                                         // (keyed by the contact uniqueId = md5(odinId)).
@@ -1334,6 +1338,26 @@ fun AppNavHost(
                                     onNavigateBack = { navController.popBackStack() },
                                     // Maps-off CTA → location/maps setup (Route.Location when
                                     // activated, else onboarding), reusing the shared nav lambda.
+                                    onOpenSetup = openLocation,
+                                )
+                            }
+                        }
+
+                        composable<Route.LocationShare> { backStackEntry ->
+                            if (isAuthenticated) {
+                                val route = backStackEntry.toRoute<Route.LocationShare>()
+                                ShareLocationScreen(
+                                    viewModel = koinViewModel(
+                                        key = route.conversationId,
+                                        parameters = {
+                                            org.koin.core.parameter.parametersOf(
+                                                Uuid.parse(route.conversationId)
+                                            )
+                                        },
+                                    ),
+                                    onNavigateBack = { navController.popBackStack() },
+                                    // Maps-off / enable-location CTA → location setup (dashboard or
+                                    // onboarding), reusing the shared nav lambda.
                                     onOpenSetup = openLocation,
                                 )
                             }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/MapsOffState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/MapsOffState.kt
@@ -1,0 +1,64 @@
+package id.homebase.core.ui.screens.location
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Map
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import id.homebase.resources.MR
+import id.homebase.resources.location_maps_off_cta
+import id.homebase.resources.location_maps_off_title
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Shown on a map screen when no map provider is enabled: a tile-less canvas is just blank, so
+ * render a tappable "turn on maps" CTA into location setup instead (#811). Shared by the live
+ * map and the share-location screen.
+ */
+@Composable
+internal fun MapsOffState(
+    onOpenSetup: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.padding(horizontal = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Map,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(48.dp),
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(MR.string.location_maps_off_title),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = stringResource(MR.string.location_maps_off_cta),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.primary,
+            textDecoration = TextDecoration.Underline,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.clickable { onOpenSetup() },
+        )
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationScreen.kt
@@ -1,18 +1,11 @@
 package id.homebase.core.ui.screens.location.livelocation
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.outlined.Map
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -31,14 +24,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.api.client.location.LocationPreviewProvider
+import id.homebase.core.ui.screens.location.MapsOffState
 import id.homebase.core.permissions.PermissionStatus
 import id.homebase.core.permissions.PermissionType
 import id.homebase.core.permissions.createPermissionsManager
@@ -50,8 +42,6 @@ import id.homebase.resources.live_location_enable_gps_dismiss
 import id.homebase.resources.live_location_enable_gps_text
 import id.homebase.resources.live_location_enable_gps_title
 import id.homebase.resources.live_location_title
-import id.homebase.resources.location_maps_off_cta
-import id.homebase.resources.location_maps_off_title
 import id.homebase.resources.menu_back
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
@@ -161,41 +151,5 @@ fun LiveLocationScreen(
                 )
             }
         }
-    }
-}
-
-/** Shown on the live map when no map provider is enabled: a tappable CTA into location setup. */
-@Composable
-private fun MapsOffState(
-    onOpenSetup: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        modifier = modifier.padding(horizontal = 32.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-    ) {
-        Icon(
-            imageVector = Icons.Outlined.Map,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.size(48.dp),
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        Text(
-            text = stringResource(MR.string.location_maps_off_title),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center,
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = stringResource(MR.string.location_maps_off_cta),
-            style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.primary,
-            textDecoration = TextDecoration.Underline,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.clickable { onOpenSetup() },
-        )
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/map/MapCameraState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/map/MapCameraState.kt
@@ -1,0 +1,56 @@
+package id.homebase.core.ui.screens.location.map
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+
+/**
+ * Hoisted camera for [TiledMapView]: lets a screen observe where the map is looking and move it
+ * programmatically — the share-location screen reads [centerUnit] to resolve the address under
+ * its fixed center pin and calls [centerOn] for the GPS re-center button.
+ *
+ * Create with [rememberMapCameraState] and pass to [TiledMapView]'s `cameraState`. Callers that
+ * don't need camera access pass nothing — the map keeps a private instance and behaves exactly
+ * as before.
+ *
+ * Coordinates are Web-Mercator unit space (`WebMercator.latLonToUnit`/`unitToLatLon`).
+ */
+@Stable
+class MapCameraState {
+
+    /** User/programmatic viewport override; null = the map fits its `bbox`. */
+    internal var viewport by mutableStateOf<MapViewport?>(null)
+
+    /**
+     * The viewport the map actually rendered last composition — the override when one is set,
+     * else the bbox fit (null until the canvas is measured). Written by [TiledMapView].
+     */
+    internal var effective by mutableStateOf<MapViewport?>(null)
+
+    /** Current view center in unit space, or null until the map has measured. */
+    val centerUnit: Pair<Double, Double>?
+        get() = effective?.let { it.centerX to it.centerY }
+
+    /**
+     * True once a gesture (or [centerOn]) has overridden the bbox fit — i.e. the view no longer
+     * follows programmatic bbox updates. Lets a screen refine its initial position from a late
+     * GPS fix only while the user hasn't taken over.
+     */
+    val isUserPositioned: Boolean
+        get() = viewport != null
+
+    /**
+     * Move the view center to a unit-space point, keeping the current zoom. No-op until the map
+     * has rendered once (there is no zoom to keep yet — the initial bbox fit covers that frame).
+     */
+    fun centerOn(unitX: Double, unitY: Double) {
+        val base = viewport ?: effective ?: return
+        viewport = base.copy(centerX = unitX, centerY = unitY)
+    }
+}
+
+@Composable
+fun rememberMapCameraState(): MapCameraState = remember { MapCameraState() }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/map/TiledMapView.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/map/TiledMapView.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
@@ -44,6 +45,9 @@ import kotlin.math.roundToInt
  * @param resetViewportOn when this key changes the user's pan/zoom is dropped and the view re-fits to
  *   [bbox]. History passes its `traces` (new day re-fits); the live map passes `Unit` (preserve
  *   pan/zoom across store updates).
+ * @param cameraState optional hoisted camera ([rememberMapCameraState]) for callers that need to
+ *   observe the view center or move it programmatically (share-location screen). Null = the map
+ *   keeps a private camera; behavior is unchanged.
  */
 @Composable
 fun TiledMapView(
@@ -55,12 +59,16 @@ fun TiledMapView(
     resetViewportOn: Any? = Unit,
     onDrawOverlay: (DrawScope.(project: (Double, Double) -> Offset) -> Unit)? = null,
     markerContent: (@Composable (project: (Double, Double) -> Offset, ready: Boolean) -> Unit)? = null,
+    cameraState: MapCameraState? = null,
 ) {
     var canvasSize by remember { mutableStateOf(IntSize.Zero) }
-    // User pan/zoom override; null = fit the bbox. Reset when resetViewportOn changes.
-    var userViewport by remember(resetViewportOn) { mutableStateOf<MapViewport?>(null) }
+    val camera = cameraState ?: remember { MapCameraState() }
+    // Drop the user pan/zoom override (re-fit to bbox) whenever the reset key changes — same
+    // semantics the pre-camera `remember(resetViewportOn) { mutableStateOf(null) }` had.
+    remember(resetViewportOn, camera) { camera.viewport = null }
 
-    val viewport = userViewport ?: fitViewport(bbox, canvasSize)
+    val viewport = camera.viewport ?: fitViewport(bbox, canvasSize)
+    SideEffect { camera.effective = viewport }
 
     // ── Tile layer state ──
     val tileBitmaps = remember { mutableStateMapOf<MapTileKey, ImageBitmap>() }
@@ -83,9 +91,9 @@ fun TiledMapView(
     }
 
     val gestureModifier = if (!interactive) Modifier else {
-        Modifier.pointerInput(resetViewportOn) {
+        Modifier.pointerInput(resetViewportOn, camera) {
             detectTransformGestures { centroid, pan, zoom, _ ->
-                val current = userViewport ?: fitViewport(bbox, canvasSize) ?: return@detectTransformGestures
+                val current = camera.viewport ?: fitViewport(bbox, canvasSize) ?: return@detectTransformGestures
                 val newUnitsPerPx = (current.unitsPerPx / zoom)
                     .coerceIn(MIN_UNITS_PER_PX, MAX_UNITS_PER_PX)
                 // Keep the gesture centroid anchored while zooming, then pan.
@@ -93,7 +101,7 @@ fun TiledMapView(
                 val cy = centroid.y - size.height / 2f
                 val anchoredX = current.centerX + cx * (current.unitsPerPx - newUnitsPerPx)
                 val anchoredY = current.centerY + cy * (current.unitsPerPx - newUnitsPerPx)
-                userViewport = MapViewport(
+                camera.viewport = MapViewport(
                     centerX = anchoredX - pan.x * newUnitsPerPx,
                     centerY = anchoredY - pan.y * newUnitsPerPx,
                     unitsPerPx = newUnitsPerPx,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/share/ShareLocationScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/share/ShareLocationScreen.kt
@@ -1,0 +1,378 @@
+package id.homebase.core.ui.screens.location.share
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.MyLocation
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.homebase.api.client.location.LocationPreviewProvider
+import id.homebase.core.location.LIVE_SHARE_DURATION_OPTIONS
+import id.homebase.core.permissions.PermissionStatus
+import id.homebase.core.permissions.PermissionType
+import id.homebase.core.permissions.createPermissionsManager
+import id.homebase.core.permissions.isLocationPermissionGranted
+import id.homebase.core.ui.screens.location.MapsOffState
+import id.homebase.core.ui.screens.location.map.TiledMapView
+import id.homebase.core.ui.screens.location.map.rememberMapCameraState
+import id.homebase.resources.MR
+import id.homebase.resources.cancel
+import id.homebase.resources.cd_location_pin
+import id.homebase.resources.live_location_enable_gps_confirm
+import id.homebase.resources.live_location_enable_gps_dismiss
+import id.homebase.resources.live_location_enable_gps_text
+import id.homebase.resources.live_location_enable_gps_title
+import id.homebase.resources.live_share_duration_prompt
+import id.homebase.resources.live_share_enable_location_body
+import id.homebase.resources.live_share_enable_location_cta
+import id.homebase.resources.live_share_enable_location_title
+import id.homebase.resources.menu_back
+import id.homebase.resources.share_location_comment_hint
+import id.homebase.resources.share_location_live_banner
+import id.homebase.resources.share_location_recenter_cd
+import id.homebase.resources.share_location_resolving
+import id.homebase.resources.share_location_send_cd
+import id.homebase.resources.share_location_title
+import org.jetbrains.compose.resources.getString
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
+
+/**
+ * Full-screen share-location screen (#966): pan the map under a fixed center pin (the address
+ * follows), re-center on GPS from the upper-right button, optionally start a live share via the
+ * bottom banner's duration menu, and send with an always-present comment row.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ShareLocationScreen(
+    viewModel: ShareLocationViewModel,
+    onNavigateBack: () -> Unit,
+    onOpenSetup: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val previewProvider = koinInject<LocationPreviewProvider>()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    // Location permission prompt on entry — NON-blocking: denial still allows picking a point by
+    // panning and sending a static pin; only the GPS conveniences (entry fix, re-center) and the
+    // live share (re-gated by LiveShareReadiness) need it. Same lifecycle dance as the live map.
+    var permanentlyDenied by remember { mutableStateOf(false) }
+    var showEnableGpsDialog by remember { mutableStateOf(false) }
+    val permissionsManager = createPermissionsManager { type, status, deniedForever ->
+        if (type != PermissionType.LOCATION) return@createPermissionsManager
+        if (status == PermissionStatus.GRANTED) {
+            showEnableGpsDialog = false
+            viewModel.onPermissionGranted()
+        } else {
+            permanentlyDenied = deniedForever
+        }
+    }
+    LaunchedEffect(Unit) {
+        if (!isLocationPermissionGranted()) showEnableGpsDialog = true
+    }
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME && isLocationPermissionGranted()) {
+                showEnableGpsDialog = false
+                viewModel.onPermissionGranted()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is ShareLocationUiEvent.MessageSent -> onNavigateBack()
+                is ShareLocationUiEvent.ShowError ->
+                    snackbarHostState.showSnackbar(getString(event.res))
+            }
+        }
+    }
+
+    if (showEnableGpsDialog) {
+        AlertDialog(
+            onDismissRequest = { showEnableGpsDialog = false },
+            title = { Text(stringResource(MR.string.live_location_enable_gps_title)) },
+            text = { Text(stringResource(MR.string.live_location_enable_gps_text)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    if (permanentlyDenied) permissionsManager.launchSettings()
+                    else permissionsManager.askPermission(PermissionType.LOCATION)
+                }) { Text(stringResource(MR.string.live_location_enable_gps_confirm)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showEnableGpsDialog = false }) {
+                    Text(stringResource(MR.string.live_location_enable_gps_dismiss))
+                }
+            },
+        )
+    }
+
+    // Live share blocked: location add-on not set up / permission missing → setup CTA.
+    if (uiState.showEnableLocationDialog) {
+        AlertDialog(
+            onDismissRequest = { viewModel.dismissEnableLocationDialog() },
+            title = { Text(stringResource(MR.string.live_share_enable_location_title)) },
+            text = { Text(stringResource(MR.string.live_share_enable_location_body)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.dismissEnableLocationDialog()
+                    onOpenSetup()
+                }) { Text(stringResource(MR.string.live_share_enable_location_cta)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { viewModel.dismissEnableLocationDialog() }) {
+                    Text(stringResource(MR.string.cancel))
+                }
+            },
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(MR.string.share_location_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(MR.string.menu_back),
+                        )
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(innerPadding)
+                .padding(innerPadding),
+        ) {
+            if (!uiState.showMapTiles) {
+                MapsOffState(
+                    onOpenSetup = onOpenSetup,
+                    modifier = Modifier.align(Alignment.Center),
+                )
+            } else {
+                val camera = rememberMapCameraState()
+
+                TiledMapView(
+                    bbox = uiState.initialBbox?.toDoubleArray(),
+                    showMapTiles = true,
+                    fetchTile = { z, x, y -> previewProvider.getTilePng(z, x, y) },
+                    resetViewportOn = uiState.initialBboxKey,
+                    cameraState = camera,
+                )
+
+                // Pin follows the viewport center; the VM debounces the geocode, so per-gesture
+                // restarts of this effect are cheap.
+                val center = camera.centerUnit
+                LaunchedEffect(center) {
+                    center?.let { (x, y) ->
+                        viewModel.onMapCenterChanged(x, y, camera.isUserPositioned)
+                    }
+                }
+                // One-shot GPS re-center handed back from the VM.
+                LaunchedEffect(uiState.recenterTarget) {
+                    uiState.recenterTarget?.let { target ->
+                        camera.centerOn(target.unitX, target.unitY)
+                        viewModel.recenterConsumed()
+                    }
+                }
+
+                // Fixed center pin. Offset up half its size so the pin TIP marks the center.
+                Icon(
+                    imageVector = Icons.Default.LocationOn,
+                    contentDescription = stringResource(MR.string.cd_location_pin),
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .size(40.dp)
+                        .offset(y = (-20).dp),
+                )
+
+                // Address chip — resolves as the user pans.
+                val addressText = when {
+                    uiState.isResolvingAddress -> stringResource(MR.string.share_location_resolving)
+                    else -> uiState.address
+                }
+                if (addressText.isNotEmpty()) {
+                    Surface(
+                        modifier = Modifier
+                            .align(Alignment.TopCenter)
+                            .padding(start = 16.dp, top = 12.dp, end = 72.dp),
+                        shape = MaterialTheme.shapes.medium,
+                        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        tonalElevation = 2.dp,
+                    ) {
+                        Text(
+                            text = addressText,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                        )
+                    }
+                }
+
+                // GPS re-center — upper-right corner.
+                FilledTonalIconButton(
+                    onClick = { viewModel.onRecenter() },
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(top = 12.dp, end = 12.dp),
+                ) {
+                    if (uiState.isAcquiringFix) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(20.dp),
+                            strokeWidth = 2.dp,
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Default.MyLocation,
+                            contentDescription = stringResource(MR.string.share_location_recenter_cd),
+                        )
+                    }
+                }
+            }
+
+            // Bottom controls: live-share banner + the always-present comment/send row.
+            Surface(
+                modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth(),
+                color = MaterialTheme.colorScheme.surface,
+                tonalElevation = 3.dp,
+            ) {
+                Column {
+                    var durationMenuExpanded by remember { mutableStateOf(false) }
+                    Box {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable(enabled = !uiState.isSending) { durationMenuExpanded = true }
+                                .padding(start = 16.dp, top = 14.dp, end = 16.dp, bottom = 14.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.LocationOn,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(22.dp),
+                            )
+                            Spacer(modifier = Modifier.width(10.dp))
+                            Text(
+                                text = stringResource(MR.string.share_location_live_banner),
+                                style = MaterialTheme.typography.titleSmall,
+                                color = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                        DropdownMenu(
+                            expanded = durationMenuExpanded,
+                            onDismissRequest = { durationMenuExpanded = false },
+                        ) {
+                            Text(
+                                text = stringResource(MR.string.live_share_duration_prompt),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                            )
+                            HorizontalDivider()
+                            LIVE_SHARE_DURATION_OPTIONS.forEach { (labelRes, durationMs) ->
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(labelRes)) },
+                                    onClick = {
+                                        durationMenuExpanded = false
+                                        viewModel.startLiveShare(durationMs)
+                                    },
+                                )
+                            }
+                        }
+                    }
+                    HorizontalDivider()
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(start = 16.dp, top = 8.dp, end = 12.dp, bottom = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        OutlinedTextField(
+                            value = uiState.comment,
+                            onValueChange = { viewModel.onCommentChanged(it) },
+                            placeholder = { Text(stringResource(MR.string.share_location_comment_hint)) },
+                            modifier = Modifier.weight(1f),
+                            maxLines = 3,
+                            shape = MaterialTheme.shapes.large,
+                        )
+                        Spacer(modifier = Modifier.width(10.dp))
+                        FilledIconButton(
+                            onClick = { viewModel.sendStaticPin() },
+                            enabled = uiState.pinLat != null && !uiState.isSending,
+                        ) {
+                            if (uiState.isSending) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(20.dp),
+                                    strokeWidth = 2.dp,
+                                )
+                            } else {
+                                Icon(
+                                    imageVector = Icons.AutoMirrored.Filled.Send,
+                                    contentDescription = stringResource(MR.string.share_location_send_cd),
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/share/ShareLocationUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/share/ShareLocationUiState.kt
@@ -1,0 +1,41 @@
+package id.homebase.core.ui.screens.location.share
+
+import org.jetbrains.compose.resources.StringResource
+
+/**
+ * State for the full-screen share-location screen (#966): a pannable map with a fixed center pin
+ * whose address resolves as the user pans, plus static-send and live-share controls.
+ */
+data class ShareLocationUiState(
+    val showMapTiles: Boolean = true,
+    /**
+     * Unit-space `[minX,minY,maxX,maxY]` the map fits on entry (a zero-span point bbox — the
+     * map widens it to a city-block zoom). List (not DoubleArray) so data-class equality works.
+     * Null until a position source exists; the map shows the world view meanwhile.
+     */
+    val initialBbox: List<Double>? = null,
+    /** Bumped to re-fit the map to [initialBbox] (e.g. a late first GPS fix refines the seed). */
+    val initialBboxKey: Int = 0,
+    /** The panned-to coordinates under the center pin — what a static send will share. */
+    val pinLat: Double? = null,
+    val pinLon: Double? = null,
+    /** Resolved address for the pin ("" until the first resolve). */
+    val address: String = "",
+    val isResolvingAddress: Boolean = false,
+    val comment: String = "",
+    val isSending: Boolean = false,
+    val isAcquiringFix: Boolean = false,
+    val showEnableLocationDialog: Boolean = false,
+    /** One-shot camera move (GPS re-center); the screen applies it and calls recenterConsumed(). */
+    val recenterTarget: RecenterTarget? = null,
+)
+
+/** Unit-space camera target; [seq] distinguishes consecutive re-centers to the same spot. */
+data class RecenterTarget(val unitX: Double, val unitY: Double, val seq: Int)
+
+sealed interface ShareLocationUiEvent {
+    /** The location message went out — the screen pops back to the conversation. */
+    data object MessageSent : ShareLocationUiEvent
+
+    data class ShowError(val res: StringResource) : ShareLocationUiEvent
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/share/ShareLocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/share/ShareLocationViewModel.kt
@@ -1,0 +1,267 @@
+package id.homebase.core.ui.screens.location.share
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
+import id.homebase.api.client.location.LocationPreviewProvider
+import id.homebase.api.client.location.WebMercator
+import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.util.truncateToCodePoints
+import id.homebase.chat.services.ChatMessageSenderService
+import id.homebase.chat.services.builder.LocationPreviewPayloadBuilder
+import id.homebase.chat.services.content.MessageContent
+import id.homebase.chat.services.convo.ConversationStream
+import id.homebase.chat.services.livelocation.LiveLocationShareService
+import id.homebase.chat.services.livelocation.LiveShareReadiness
+import id.homebase.core.location.GpsRequestReason
+import id.homebase.core.location.LocationMapProvider
+import id.homebase.core.location.LocationPreferences
+import id.homebase.core.location.LocationService
+import id.homebase.core.location.tracking.DemandReason
+import id.homebase.core.location.tracking.GpsFixResult
+import id.homebase.resources.MR
+import id.homebase.resources.chat_location_unavailable
+import id.homebase.resources.error_unknown
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.cos
+import kotlin.time.Clock
+import kotlin.uuid.Uuid
+
+/**
+ * Drives the full-screen share-location screen (#966). The map owns the viewport; this VM owns
+ * the pin (viewport center → lat/lon), the debounced address resolve, and the two send paths:
+ *
+ *  - **Static pin** — the panned-to coordinates + resolved address + comment, sent as a typed
+ *    location message with the static-map payload (same shape the old attachment flow produced).
+ *  - **Live share** — the user's ACTUAL position (a fresh fix; the panned pin is deliberately
+ *    ignored), sent as an own location message that is live already at creation
+ *    (`liveShareUntilMs` set — no post-hoc updateMessage), plus the relay roster armed with the
+ *    SAME absolute end-time (the {recipient, endTime} pair is the stop key).
+ */
+class ShareLocationViewModel(
+    private val conversationId: Uuid,
+    private val previewProvider: LocationPreviewProvider,
+    private val locationService: LocationService,
+    private val locationPreferences: LocationPreferences,
+    private val liveShareReadiness: LiveShareReadiness,
+    private val liveLocationShareService: LiveLocationShareService,
+    private val chatMessageSenderService: ChatMessageSenderService,
+    private val conversationStream: ConversationStream,
+    private val fileOperationsProvider: FileOperationsProvider,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(
+        ShareLocationUiState(
+            showMapTiles = locationPreferences.mapProvider.value == LocationMapProvider.OpenStreetMap,
+        )
+    )
+    val uiState: StateFlow<ShareLocationUiState> = _uiState.asStateFlow()
+
+    private val _events = MutableSharedFlow<ShareLocationUiEvent>(extraBufferCapacity = 8)
+    val events: SharedFlow<ShareLocationUiEvent> = _events.asSharedFlow()
+
+    // Hold GPS while the screen is open (same transient demand the live map uses) so the entry
+    // fix and the re-center button have a warm provider. No-op without permission.
+    private val demandToken = locationService.acquireDemand(DemandReason.LiveMapOpen)
+
+    private var geocodeJob: Job? = null
+    private var lastResolvedLat: Double? = null
+    private var lastResolvedLon: Double? = null
+    private var recenterSeq = 0
+    /** Set once the user pans/zooms — a late first fix must not yank the map away anymore. */
+    private var userMoved = false
+
+    init {
+        // Seed the map on the last known position immediately (no flash of world view), then
+        // refine with a fresh fix — but only recenter while the user hasn't taken over.
+        locationService.lastKnown.value?.let { seedBbox(it.lat, it.lon) }
+        viewModelScope.launch {
+            val fix = locationService.requestLatestGps(GpsRequestReason.LiveMap)
+            if (fix is GpsFixResult.Success && !userMoved) seedBbox(fix.point.lat, fix.point.lon)
+        }
+    }
+
+    override fun onCleared() {
+        demandToken.release()
+        super.onCleared()
+    }
+
+    /** Screen callback when location permission lands — re-arms the GPS hold (LiveMap pattern). */
+    fun onPermissionGranted() = locationService.refreshGpsHold()
+
+    private fun seedBbox(lat: Double, lon: Double) {
+        val (x, y) = WebMercator.latLonToUnit(lat, lon)
+        _uiState.update {
+            it.copy(
+                initialBbox = listOf(x, y, x, y),
+                initialBboxKey = it.initialBboxKey + 1,
+            )
+        }
+    }
+
+    /**
+     * The map's viewport center moved (gesture or re-fit). Updates the pin instantly; the address
+     * resolve is debounced (Nominatim budget) and skipped when the pin settled within ~30 m of
+     * the last resolved point.
+     */
+    fun onMapCenterChanged(unitX: Double, unitY: Double, byUser: Boolean) {
+        if (byUser) userMoved = true
+        val (lat, lon) = WebMercator.unitToLatLon(unitX, unitY)
+        _uiState.update { it.copy(pinLat = lat, pinLon = lon) }
+
+        val last = lastResolvedLat
+        if (last != null && lastResolvedLon != null &&
+            approxDistanceMeters(last, lastResolvedLon!!, lat, lon) < RESOLVE_MIN_MOVE_METERS
+        ) {
+            return
+        }
+        _uiState.update { it.copy(isResolvingAddress = true) }
+        geocodeJob?.cancel()
+        geocodeJob = viewModelScope.launch {
+            delay(GEOCODE_DEBOUNCE_MS)
+            val address = runCatching { previewProvider.reverseGeocode(lat, lon) }.getOrNull()
+            lastResolvedLat = lat
+            lastResolvedLon = lon
+            _uiState.update {
+                it.copy(
+                    address = address ?: formatLatLon(lat, lon),
+                    isResolvingAddress = false,
+                )
+            }
+        }
+    }
+
+    fun onCommentChanged(text: String) = _uiState.update { it.copy(comment = text) }
+
+    /** GPS re-center button: fresh fix → one-shot camera target the screen applies. */
+    fun onRecenter() {
+        if (_uiState.value.isAcquiringFix) return
+        _uiState.update { it.copy(isAcquiringFix = true) }
+        viewModelScope.launch {
+            val fix = locationService.requestLatestGps(GpsRequestReason.LiveMap)
+            if (fix is GpsFixResult.Success) {
+                val (x, y) = WebMercator.latLonToUnit(fix.point.lat, fix.point.lon)
+                _uiState.update {
+                    it.copy(isAcquiringFix = false, recenterTarget = RecenterTarget(x, y, ++recenterSeq))
+                }
+            } else {
+                _uiState.update { it.copy(isAcquiringFix = false) }
+                _events.emit(ShareLocationUiEvent.ShowError(MR.string.chat_location_unavailable))
+            }
+        }
+    }
+
+    fun recenterConsumed() = _uiState.update { it.copy(recenterTarget = null) }
+
+    fun dismissEnableLocationDialog() = _uiState.update { it.copy(showEnableLocationDialog = false) }
+
+    /** Send the panned-to pin (+ comment) as a static location message, then pop. */
+    fun sendStaticPin() {
+        val state = _uiState.value
+        val lat = state.pinLat ?: return
+        val lon = state.pinLon ?: return
+        if (state.isSending) return
+        _uiState.update { it.copy(isSending = true) }
+        viewModelScope.launch {
+            try {
+                // The pan-resolved address rides along so the provider skips a second geocode.
+                val preview = previewProvider.getLocationPreview(
+                    lat = lat,
+                    lon = lon,
+                    knownAddress = state.address.takeIf { !state.isResolvingAddress },
+                )
+                val descriptor = LocationPreviewPayloadBuilder.descriptorFor(preview)
+                    .copy(caption = captionOrNull())
+                chatMessageSenderService.sendNewTypedMessage(
+                    messageUniqueId = Uuid.random(),
+                    conversationId = conversationId,
+                    content = MessageContent.Location(descriptor),
+                    previousMessageUniqueId = null,
+                    payloadBundle = LocationPreviewPayloadBuilder.build(preview, fileOperationsProvider),
+                )
+                _events.emit(ShareLocationUiEvent.MessageSent)
+            } catch (e: Exception) {
+                Logger.e(throwable = e, tag = TAG) { "static pin send failed" }
+                _uiState.update { it.copy(isSending = false) }
+                _events.emit(ShareLocationUiEvent.ShowError(MR.string.error_unknown))
+            }
+        }
+    }
+
+    /**
+     * Start a live share for [durationMs]: own live-at-creation message (from the ACTUAL current
+     * position) + relay roster, both on the same absolute end-time. Gated on share readiness.
+     */
+    fun startLiveShare(durationMs: Long) {
+        if (_uiState.value.isSending) return
+        _uiState.update { it.copy(isSending = true) }
+        viewModelScope.launch {
+            try {
+                if (!liveShareReadiness.isReady()) {
+                    _uiState.update { it.copy(isSending = false, showEnableLocationDialog = true) }
+                    return@launch
+                }
+                val fix = locationService.requestLatestGps(GpsRequestReason.LiveMap)
+                if (fix !is GpsFixResult.Success) {
+                    _uiState.update { it.copy(isSending = false) }
+                    _events.emit(ShareLocationUiEvent.ShowError(MR.string.chat_location_unavailable))
+                    return@launch
+                }
+                val untilMs = Clock.System.now().toEpochMilliseconds() + durationMs
+                val preview = previewProvider.getLocationPreview(fix.point.lat, fix.point.lon)
+                val descriptor = LocationPreviewPayloadBuilder.descriptorFor(preview)
+                    .copy(caption = captionOrNull(), liveShareUntilMs = untilMs)
+                val recipients = conversationStream.getRecipients(conversationId, emptyList(), null)
+                chatMessageSenderService.sendNewTypedMessage(
+                    messageUniqueId = Uuid.random(),
+                    conversationId = conversationId,
+                    content = MessageContent.Location(descriptor),
+                    previousMessageUniqueId = null,
+                    payloadBundle = LocationPreviewPayloadBuilder.build(preview, fileOperationsProvider),
+                )
+                liveLocationShareService.start(recipients, untilMs)
+                _events.emit(ShareLocationUiEvent.MessageSent)
+            } catch (e: Exception) {
+                Logger.e(throwable = e, tag = TAG) { "live share start failed" }
+                _uiState.update { it.copy(isSending = false) }
+                _events.emit(ShareLocationUiEvent.ShowError(MR.string.error_unknown))
+            }
+        }
+    }
+
+    private fun captionOrNull(): String? =
+        _uiState.value.comment.trim().ifBlank { null }?.truncateToCodePoints(CAPTION_MAX_CODEPOINTS)
+
+    /** Small-distance approximation — plenty for a "did the pin really move" check. */
+    private fun approxDistanceMeters(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
+        val dLat = abs(lat2 - lat1) * METERS_PER_DEGREE
+        val dLon = abs(lon2 - lon1) * METERS_PER_DEGREE * cos(lat1 * PI / 180.0)
+        return dLat + dLon
+    }
+
+    private fun formatLatLon(lat: Double, lon: Double): String {
+        val latStr = ((lat * 1e5).toLong() / 1e5).toString()
+        val lonStr = ((lon * 1e5).toLong() / 1e5).toString()
+        return "$latStr, $lonStr"
+    }
+
+    private companion object {
+        const val TAG = "ShareLocationViewModel"
+        const val GEOCODE_DEBOUNCE_MS = 700L
+        const val RESOLVE_MIN_MOVE_METERS = 30.0
+        const val METERS_PER_DEGREE = 111_320.0
+        // Same cap the composer-caption path uses (7 KB header budget).
+        const val CAPTION_MAX_CODEPOINTS = 2000
+    }
+}


### PR DESCRIPTION
Part 2 of #966. **Stacked on #971** (bubble reciprocity) — merge that first; GitHub retargets this to main automatically when the base branch is deleted.

## What

The attachment sheet's Location entry no longer instant-grabs a GPS fix into the composer. It opens a dedicated full-screen share screen:

- **Pannable map, fixed center pin** — the pin stays centered; panning moves the world under it. The panned-to coordinates are what a static send shares.
- **Address follows the pan** — debounced 700 ms after the map settles, skipped under ~30 m of movement, cached on an ~11 m grid, all on top of the provider's existing 1 req/s Nominatim mutex.
- **GPS re-center button** (upper-right) — fresh fix → camera snaps back; snackbar when no fix.
- **"Share live location" banner** with the shared duration menu (15m…24h) — sends the user's **actual** position (panned pin deliberately ignored) as an own message already live at creation, and arms the relay with the same absolute end-time.
- **Always-present comment row + send** — the comment becomes the descriptor `caption` (2000-codepoint cap) for both static and live sends.
- Maps-off → shared `MapsOffState` CTA; permission prompt on entry is **non-blocking** (denied ⇒ pan + static send still work); live share re-gated by `LiveShareReadiness` with the enable-location dialog.

## Building blocks

- `WebMercator.unitToLatLon` inverse (+ round-trip property test).
- `LocationPreviewProvider.reverseGeocode` promoted to public with a rounded-coordinate LRU; `getLocationPreview(knownAddress)` skips the second geocode when the screen already resolved the address (mock-engine test). DEV-STUB signatures stay additive for the future backend swap.
- `TiledMapView` gains an optional hoisted `MapCameraState` (`centerUnit`, `centerOn`, `isUserPositioned`); all four existing map surfaces compile unchanged via the default.
- `DURATION_OPTIONS`/`formatRemaining` extracted to `homebase-common` `LiveShareDurations.kt` (bubble + screen share one list); `MapsOffState` extracted from the live map.
- `Route.LocationShare(conversationId)` + chat `OpenShareLocation` action → `NavigateToShareLocation` event → AppNavHost. `ShareLocationViewModel` lives in homebase-core (needs core's map + chat's services; core depends on chat).

## Tests

`WebMercatorRoundTripTest`, `LocationPreviewProviderKnownAddressTest`; full matrix green (JVM/Android/wasmJs compile; api+chat+common jvmTest incl. Konsist).

## Manual verification (pending, Android)

- [ ] Attachment → Location → opens on current fix; pan → address updates; re-center snaps back; comment + send → static bubble with panned coords + caption; screen pops.
- [ ] Live banner → duration → own bubble arrives already LIVE; recipient sees the dot on the live map within seconds.
- [ ] Airplane mode / GPS off → snackbars, no phantom sends; maps off → MapsOffState; permission denied → static send still possible.
- [ ] Regression: History, Find Device, dashboard preview, Live map pan/zoom unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKxv1k187ynCjx6sVDC7NQ