### PR TITLE
fix(chat): show Preparing overlay always; Sending spinner only when online (#948 follow-up)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -69,6 +69,11 @@ data class MessageListUiState(
     val decryptedFiles: ImmutableMap<DecryptedFileKey, String> = persistentMapOf(),
     val userDefaultReactions: ImmutableList<String> = persistentListOf(),
     val uploadProgress: ImmutableMap<Uuid, UploadStatus> = persistentMapOf(),
+    /** True once the app is online. Gates the media upload overlay's "Sending" spinner:
+     *  offline a queued item shows only the corner outbox icon, never a perpetual spinner
+     *  (#948). Defaults true so legitimate online feedback isn't hidden before the first
+     *  connection-state emission arrives. */
+    val isConnected: Boolean = true,
     val isLoadingMessages: Boolean = true,
     val scrollPosition: ScrollPosition? = null,
     val fullScreenOverlay: FullScreenOverlay? = null,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -69,10 +69,6 @@ data class MessageListUiState(
     val decryptedFiles: ImmutableMap<DecryptedFileKey, String> = persistentMapOf(),
     val userDefaultReactions: ImmutableList<String> = persistentListOf(),
     val uploadProgress: ImmutableMap<Uuid, UploadStatus> = persistentMapOf(),
-    /** True once the app is online. Gates the media upload overlay's "Sending" spinner:
-     *  offline a queued item shows only the corner outbox icon, never a perpetual spinner
-     *  (#948). Defaults true so legitimate online feedback isn't hidden before the first
-     *  connection-state emission arrives. */
     val isConnected: Boolean = true,
     val isLoadingMessages: Boolean = true,
     val scrollPosition: ScrollPosition? = null,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -44,6 +44,7 @@ import id.homebase.core.audio.AudioWaveFormGenerator
 import id.homebase.core.auth.AuthConnectionCoordinator
 import id.homebase.core.clipboard.platformFileFromPath
 import id.homebase.core.auth.toConnectionStatus
+import id.homebase.core.avatars.AppConnectionStatus
 import id.homebase.core.config.AppConfig
 import id.homebase.core.config.chatTargetDrive
 import id.homebase.core.config.stickerLabeledDrive
@@ -658,7 +659,10 @@ class ConversationListViewModel(
         viewModelScope.launch {
             authConnectionCoordinator.connectionState
                 .collectLatest { state ->
-                    _uiState.update { it.copy(connectionStatus = state.toConnectionStatus()) }
+                    val status = state.toConnectionStatus()
+                    _uiState.update { it.copy(connectionStatus = status) }
+                    // Drives the media upload overlay's online-only "Sending" spinner (#948).
+                    _messagesUiState.update { it.copy(isConnected = status == AppConnectionStatus.Connected) }
                 }
         }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -699,6 +699,7 @@ fun ConversationContent(
 
     CompositionLocalProvider(
         LocalCurrentOdinId provides (uiState.ownerSession?.odinId?.domainName ?: ""),
+        LocalUploadConnected provides uiState.isConnected,
     ) {
     Scaffold(
         modifier = Modifier,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -173,7 +174,7 @@ fun MediaMessage(
             }
         }
 
-        if (uploadStatus != null && uploadStatus.showsMediaOverlay() && !isLinkPreview) {
+        if (uploadStatus != null && uploadStatus.showsMediaOverlay(LocalUploadConnected.current) && !isLinkPreview) {
             UploadProgressOverlay(
                 status = uploadStatus,
                 modifier = Modifier.matchParentSize(),
@@ -182,13 +183,23 @@ fun MediaMessage(
     }
 }
 
-// Only draw the dark scrim + big spinner while real work is in flight (video transcode,
-// active upload) or on the brief completion tick. Preparing/Sending are shown by the
-// bottom-right outbox indicator alone — an offline-queued item durably enqueues as
-// Sending and never progresses, so gating it here stops the endless spinner (#948).
-internal fun UploadStatus.showsMediaOverlay(): Boolean = when (this) {
-    UploadStatus.Preparing, UploadStatus.Sending -> false
-    is UploadStatus.Processing, is UploadStatus.Uploading, UploadStatus.Completed -> true
+/** True when the app is online. Provided by [ConversationContent]; gates the "Sending"
+ *  overlay so an offline-queued item shows only the bottom-right outbox indicator, never
+ *  a perpetual spinner (#948). Defaults to true (online) when no provider is present. */
+internal val LocalUploadConnected = compositionLocalOf { true }
+
+// The dark scrim + big spinner is for real work: local prep (thumbnail/resize/compress/
+// encrypt = Preparing), video transcode (Processing), the active transfer (Uploading — %
+// then Finalizing), and the brief completion tick (Completed). "Sending" is the durably-
+// queued handoff waiting for the network: shown while online, but hidden offline — there
+// it never progresses (airplane mode) and would spin forever, so the bottom-right outbox
+// indicator represents it instead (#948).
+internal fun UploadStatus.showsMediaOverlay(isConnected: Boolean): Boolean = when (this) {
+    UploadStatus.Sending -> isConnected
+    UploadStatus.Preparing,
+    is UploadStatus.Processing,
+    is UploadStatus.Uploading,
+    UploadStatus.Completed -> true
 }
 
 @Composable

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
@@ -183,9 +183,6 @@ fun MediaMessage(
     }
 }
 
-/** True when the app is online. Provided by [ConversationContent]; gates the "Sending"
- *  overlay so an offline-queued item shows only the bottom-right outbox indicator, never
- *  a perpetual spinner (#948). Defaults to true (online) when no provider is present. */
 internal val LocalUploadConnected = compositionLocalOf { true }
 
 // The dark scrim + big spinner is for real work: local prep (thumbnail/resize/compress/

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/UploadOverlayVisibilityTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/UploadOverlayVisibilityTest.kt
@@ -8,17 +8,24 @@ import kotlin.test.assertTrue
 class UploadOverlayVisibilityTest {
 
     @Test
-    fun stagedAndQueuedStatesHideOverlay() {
-        // Offline-queued media stays on Sending forever; neither it nor Preparing may
-        // draw the scrim + spinner (#948) — the outbox corner icon covers them.
-        assertFalse(UploadStatus.Preparing.showsMediaOverlay())
-        assertFalse(UploadStatus.Sending.showsMediaOverlay())
+    fun sendingShowsOverlayOnlyWhenOnline() {
+        // "Sending" = durably queued waiting for the network. Offline it never progresses
+        // (airplane mode) and would spin forever, so it shows only the corner outbox icon.
+        // Online it's a brief handoff to the active upload, so the spinner shows (#948).
+        assertFalse(UploadStatus.Sending.showsMediaOverlay(isConnected = false))
+        assertTrue(UploadStatus.Sending.showsMediaOverlay(isConnected = true))
     }
 
     @Test
-    fun inFlightAndCompletedStatesShowOverlay() {
-        assertTrue(UploadStatus.Processing(progress = 0.5f).showsMediaOverlay())
-        assertTrue(UploadStatus.Uploading(progress = 0.5f).showsMediaOverlay())
-        assertTrue(UploadStatus.Completed.showsMediaOverlay())
+    fun localWorkAndInFlightStatesAlwaysShowOverlay() {
+        // Preparing = local prep (thumbnail/resize/compress/encrypt); Processing = video
+        // transcode; Uploading = active transfer; Completed = brief tick. All show the
+        // overlay regardless of connectivity — Preparing is real work even offline.
+        for (connected in listOf(true, false)) {
+            assertTrue(UploadStatus.Preparing.showsMediaOverlay(connected))
+            assertTrue(UploadStatus.Processing(progress = 0.5f).showsMediaOverlay(connected))
+            assertTrue(UploadStatus.Uploading(progress = 0.5f).showsMediaOverlay(connected))
+            assertTrue(UploadStatus.Completed.showsMediaOverlay(connected))
+        }
     }
 }


### PR DESCRIPTION
Follow-up to #967 (which closed #948). #967 over-suppressed the media upload overlay by hiding it for **both** `Preparing` and `Sending`, so online you saw no feedback until `Uploading`, and `Preparing` (real local work) never showed even offline.

## Corrected model
| State | Meaning | Overlay |
|---|---|---|
| `Preparing` | local work — thumbnail / resize / compress / encrypt | **always show** (incl. offline) |
| `Processing` | video transcode | always show |
| `Uploading` | active transfer (`%` then Finalizing) | always show |
| `Completed` | brief checkmark | always show |
| `Sending` | durably queued, waiting for network | **show only when online**; offline → corner outbox icon only |

Only `Sending` sticks forever offline (airplane mode), so it's the sole state gated on connectivity. `Preparing` always finishes and moves on, so showing it can't hang.

## Change
```kotlin
internal fun UploadStatus.showsMediaOverlay(isConnected: Boolean): Boolean = when (this) {
    UploadStatus.Sending -> isConnected
    UploadStatus.Preparing, is UploadStatus.Processing, is UploadStatus.Uploading, UploadStatus.Completed -> true
}
```
Connectivity reaches the deep overlay without threading a boolean through five composables:
`MessageListUiState.isConnected` (fed from the VM's existing `connectionState` collector: `status == AppConnectionStatus.Connected`) → **`LocalUploadConnected`** CompositionLocal (provided once in `ConversationContent`) → the gate reads `LocalUploadConnected.current`.

## Test
`UploadOverlayVisibilityTest` updated: `Sending` hidden offline / shown online; `Preparing` + `Processing`/`Uploading`/`Completed` shown regardless of connectivity.

## Verification
- `:homebase-chat:compileKotlinJvm` + `:compileAndroidMain` — BUILD SUCCESSFUL
- `:homebase-chat:jvmTest --tests '*UploadOverlayVisibility*'` — 2/2 green
- Installed on Redmi Note 5 Pro (debug) — device check of online full-progression + offline corner-icon in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
