### PR TITLE
fix(location): share-screen keyboard overlap + blank first-open map (#966)

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/share/ShareLocationScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/share/ShareLocationScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -288,8 +289,9 @@ fun ShareLocationScreen(
             }
 
             // Bottom controls: live-share banner + the always-present comment/send row.
+            // imePadding lifts the bar above the keyboard while typing a comment.
             Surface(
-                modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth(),
+                modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth().imePadding(),
                 color = MaterialTheme.colorScheme.surface,
                 tonalElevation = 3.dp,
             ) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/share/ShareLocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/share/ShareLocationViewModel.kt
@@ -83,9 +83,18 @@ class ShareLocationViewModel(
     private var userMoved = false
 
     init {
-        // Seed the map on the last known position immediately (no flash of world view), then
-        // refine with a fresh fix — but only recenter while the user hasn't taken over.
-        locationService.lastKnown.value?.let { seedBbox(it.lat, it.lon) }
+        // Seed the map immediately: the last known position when we have one, else the whole
+        // world — a null bbox leaves the map BLANK (no viewport → no tiles fetched) until the
+        // first fix lands, which on a cold GPS can take many seconds or never come. Then refine
+        // with a fresh fix — but only recenter while the user hasn't taken over.
+        val last = locationService.lastKnown.value
+        if (last != null) {
+            seedBbox(last.lat, last.lon)
+        } else {
+            _uiState.update {
+                it.copy(initialBbox = WORLD_BBOX, initialBboxKey = it.initialBboxKey + 1)
+            }
+        }
         viewModelScope.launch {
             val fix = locationService.requestLatestGps(GpsRequestReason.LiveMap)
             if (fix is GpsFixResult.Success && !userMoved) seedBbox(fix.point.lat, fix.point.lon)
@@ -97,8 +106,19 @@ class ShareLocationViewModel(
         super.onCleared()
     }
 
-    /** Screen callback when location permission lands — re-arms the GPS hold (LiveMap pattern). */
-    fun onPermissionGranted() = locationService.refreshGpsHold()
+    /**
+     * Screen callback when location permission lands — re-arms the GPS hold (LiveMap pattern)
+     * and retries the initial seed: on a first-ever open the init-time fix request fails with
+     * PermissionDenied (the prompt is still up), which used to leave the map on the fallback
+     * view until the screen was reopened.
+     */
+    fun onPermissionGranted() {
+        locationService.refreshGpsHold()
+        viewModelScope.launch {
+            val fix = locationService.requestLatestGps(GpsRequestReason.LiveMap)
+            if (fix is GpsFixResult.Success && !userMoved) seedBbox(fix.point.lat, fix.point.lon)
+        }
+    }
 
     private fun seedBbox(lat: Double, lon: Double) {
         val (x, y) = WebMercator.latLonToUnit(lat, lon)
@@ -258,6 +278,8 @@ class ShareLocationViewModel(
 
     private companion object {
         const val TAG = "ShareLocationViewModel"
+        /** Unit-space bbox of the whole world — the no-fix fallback so the map never opens blank. */
+        val WORLD_BBOX = listOf(0.0, 0.0, 1.0, 1.0)
         const val GEOCODE_DEBOUNCE_MS = 700L
         const val RESOLVE_MIN_MOVE_METERS = 30.0
         const val METERS_PER_DEGREE = 111_320.0


### PR DESCRIPTION
Production-test fixes for the #966 share-location screen (per test feedback; all further fixes from this test round will be folded into this PR).

## Fixes

1. **Keyboard overlapped the comment row** — the bottom controls surface (live-share banner + comment/send) now applies `imePadding()`, so tapping the comment field lifts the whole bar above the keyboard.

2. **Map blank on first open** — two combined causes:
   - With no last-known GPS fix, `initialBbox` stayed `null` → `TiledMapView` had no viewport → **no tiles were ever fetched**. Now a whole-world bbox is seeded as the no-fix fallback, so the map always renders and the fresh fix re-fits it when it lands.
   - On a first-ever open the init-time `requestLatestGps` returns `PermissionDenied` because the permission prompt is still up, and nothing retried after the grant. `onPermissionGranted()` now re-requests a fix and seeds the map (unless the user has already panned), so granting the prompt centers the map in place instead of requiring an exit-and-reopen.

## Verification

- `:homebase-core` compiles on JVM/Android/wasmJs.
- Manual: first-install flow (permission prompt up) → map shows world, snaps to fix on grant; airplane-mode cold open → world view, pan + static send still work; comment field stays visible above the keyboard while typing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKxv1k187ynCjx6sVDC7NQ