### PR TITLE
fix(location): remember position across restarts + center-out tile cap (#966)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -102,6 +102,13 @@ data class MessageListUiState(
      *  trim discards the newer slice; drives the bottom spinner, the FAB's
      *  ScrollToLatest branch, and gates auto-follow on incoming messages. */
     val hasNewerMessages: Boolean = false,
+    /**
+     * When MY live share fully covers this conversation's recipients: the absolute end of that
+     * coverage, else null. While set (and in the future), location bubbles hide their "share
+     * live location" offers — no invitations to start a share that's already running (#966
+     * follow-up; the app-wide sharing indicator is #816).
+     */
+    val ownLiveShareUntilMs: Long? = null,
     /** A loadOlder fetch is in flight; suppresses re-entry. */
     val isLoadingOlder: Boolean = false,
     /** A loadNewer fetch is in flight; suppresses re-entry. */

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -33,6 +33,7 @@ import id.homebase.chat.services.LocalAttachmentContextStore
 import id.homebase.chat.services.content.MessageContent
 import id.homebase.chat.services.content.MessageContentParser
 import id.homebase.chat.services.livelocation.ShareBackResult
+import id.homebase.chat.services.livelocation.liveShareCoverageUntilMs
 import id.homebase.chat.services.livelocation.shareLiveLocationBack
 import id.homebase.core.location.GpsRequestReason
 import id.homebase.chat.services.convo.ConversationEnricher
@@ -351,6 +352,30 @@ class ConversationListViewModel(
                 _uiState.update { it.copy(ownerSession = session) }
                 _messagesUiState.update { it.copy(ownerSession = session) }
             }
+        }
+
+        // Track whether MY live share already covers the open conversation. While it does, the
+        // bubbles hide their "share live location" offers — inviting the user to start a share
+        // they're already running is confusing, and a second tap would create a duplicate live
+        // message (#966 follow-up; the app-wide "you're sharing" indicator is #816).
+        viewModelScope.launch {
+            combine(
+                ActiveConversation.conversation,
+                liveLocationShareService.recipients,
+            ) { conversationId, roster -> conversationId to roster }
+                .collectLatest { (conversationId, roster) ->
+                    val untilMs = conversationId?.let { id ->
+                        val recipients = runCatching {
+                            conversationStream.getRecipients(id, emptyList(), null)
+                        }.getOrDefault(emptyList())
+                        liveShareCoverageUntilMs(
+                            roster = roster,
+                            recipientIds = recipients.map { it.domainName },
+                            nowMs = Clock.System.now().toEpochMilliseconds(),
+                        )
+                    }
+                    _messagesUiState.update { it.copy(ownLiveShareUntilMs = untilMs) }
+                }
         }
 
         // Post-create preflight collector. CreateConversationGroupViewModel emits the

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/livelocation/LiveShareCoverage.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/livelocation/LiveShareCoverage.kt
@@ -1,0 +1,31 @@
+package id.homebase.chat.services.livelocation
+
+import id.homebase.api.client.liverelay.TimedRecipient
+
+/**
+ * When my live-location share fully covers a conversation, and until when. Returns the moment
+ * full coverage ends — the minimum, across [recipientIds], of each recipient's latest active
+ * roster entry — or null when the conversation is not fully covered (any recipient without an
+ * active entry) or has no recipients.
+ *
+ * Used to hide the "share live location" offers on a conversation's bubbles while a share to
+ * everyone in it is already running (#966 follow-up): partial coverage keeps the offers, because
+ * starting a share then still adds someone (duplicate roster entries for the already-covered
+ * recipients are harmless — the relay de-duplicates per identity).
+ */
+fun liveShareCoverageUntilMs(
+    roster: List<TimedRecipient>,
+    recipientIds: List<String>,
+    nowMs: Long,
+): Long? {
+    if (recipientIds.isEmpty()) return null
+    var coverageEnd = Long.MAX_VALUE
+    for (recipient in recipientIds) {
+        val end = roster
+            .filter { it.odinId == recipient && it.endTimeMs > nowMs }
+            .maxOfOrNull { it.endTimeMs }
+            ?: return null
+        if (end < coverageEnd) coverageEnd = end
+    }
+    return coverageEnd
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -1110,6 +1110,7 @@ fun ConversationContent(
                                                 searchQuery = uiState.searchQuery,
                                                 isCurrentSearchResult = isFocused,
                                                 chainCap = chainCap,
+                                                ownLiveShareUntilMs = uiState.ownLiveShareUntilMs,
                                             )
                                         }
                                     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LiveLocationBubbleControls.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LiveLocationBubbleControls.kt
@@ -19,4 +19,10 @@ data class LiveLocationBubbleControls(
     val onStop: () -> Unit,
     val onStartShareBack: (durationMs: Long?) -> Unit,
     val onOpenMap: () -> Unit,
+    /**
+     * When MY live share already fully covers this conversation: the absolute end of that
+     * coverage, else null. While set and in the future, the bubble hides its "share live
+     * location" offers — no invitation to start a share that's already running (#966 follow-up).
+     */
+    val ownShareUntilMs: Long? = null,
 )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LocationPreview.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LocationPreview.kt
@@ -304,6 +304,10 @@ fun LocationPreviewCard(
     val remainingMs = if (until != null) (until - nowMs).coerceAtLeast(0L) else 0L
     // The share-live offer is available only while the pin is fresh (or un-gated when createdAtMs null).
     val canStartShare = shareOfferDeadline == null || nowMs < shareOfferDeadline
+    // My live share already covers this conversation — hide every start offer (inviting the user
+    // to share what they're already sharing is confusing, and a second tap would create a
+    // duplicate live message). The app-wide "you're sharing" indicator + stop lives in #816.
+    val ownShareActive = liveControls?.ownShareUntilMs?.let { nowMs < it } == true
 
     val onCardTap = {
         if (isLive && liveControls != null) liveControls.onOpenMap() else uriHandler.openUri(geoUri)
@@ -402,7 +406,8 @@ fun LocationPreviewCard(
                             isEnded = isEnded,
                             remainingMs = remainingMs,
                             contentColor = contentColor,
-                            canStart = canStartShare,
+                            canStart = canStartShare && !ownShareActive,
+                            showShareBack = !ownShareActive,
                         )
                     }
                     // No caption ⇒ the timestamp (+ delivery status) sits muted at the bottom of the card.
@@ -469,6 +474,8 @@ private fun LiveShareActionArea(
     contentColor: Color,
     /** Whether the static "Share live location" offer is still available (pin fresh enough). */
     canStart: Boolean,
+    /** False while my own share already covers this conversation — hides the share-back link. */
+    showShareBack: Boolean = true,
 ) {
     val mutedColor = contentColor.copy(alpha = 0.7f)
     Box {
@@ -477,6 +484,7 @@ private fun LiveShareActionArea(
                 // Both sides show the live caption + time left; the sender gets the Stop link, the
                 // receiver gets a single-tap "share your live location" — no duration menu; the
                 // share-back mirrors the sender's remaining window (#966) so both end together.
+                // Hidden while my own share already covers this conversation (showShareBack=false).
                 Column {
                     if (controls.sentByYou) {
                         Row(
@@ -498,7 +506,7 @@ private fun LiveShareActionArea(
                                 color = MaterialTheme.colorScheme.error,
                             )
                         }
-                    } else {
+                    } else if (showShareBack) {
                         LiveShareLinkRow(
                             label = stringResource(MR.string.live_share_back),
                             contentColor = contentColor,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageItem.kt
@@ -43,6 +43,7 @@ fun MessageItem(
     searchQuery: String = "",
     isCurrentSearchResult: Boolean = false,
     chainCap: Int? = null,
+    ownLiveShareUntilMs: Long? = null,
 ) {
     val odinId: OdinId? = try {
         OdinId(currentOdinId)
@@ -60,7 +61,7 @@ fun MessageItem(
     // Live-location controls for the location bubble (ignored by non-location media). State (LIVE/
     // ENDED) is read from the message descriptor in the bubble; this only carries side + actions.
     val sentByYou = message.isAuthoredBy(odinId)
-    val liveLocationControls = remember(message.id, sentByYou) {
+    val liveLocationControls = remember(message.id, sentByYou, ownLiveShareUntilMs) {
         LiveLocationBubbleControls(
             sentByYou = sentByYou,
             onStart = { durationMs ->
@@ -71,6 +72,7 @@ fun MessageItem(
                 onUiAction(ConversationListUiAction.ShareLiveLocationBack(message.id, durationMs))
             },
             onOpenMap = { onUiAction(ConversationListUiAction.OpenLiveLocationMap) },
+            ownShareUntilMs = ownLiveShareUntilMs,
         )
     }
 

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/livelocation/LiveShareCoverageTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/livelocation/LiveShareCoverageTest.kt
@@ -1,0 +1,63 @@
+package id.homebase.chat.services.livelocation
+
+import id.homebase.api.client.liverelay.TimedRecipient
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Pins [liveShareCoverageUntilMs]: the "am I already live-sharing to this conversation" check
+ * that hides the per-bubble share offers (#966 follow-up). Coverage requires EVERY recipient to
+ * have an active roster entry; the coverage horizon is the minimum across recipients of each
+ * recipient's latest entry.
+ */
+class LiveShareCoverageTest {
+
+    private val now = 100_000L
+
+    @Test
+    fun fullCoverageReturnsTheEarliestExpiry() {
+        val roster = listOf(
+            TimedRecipient("alice.com", endTimeMs = now + 60_000),
+            TimedRecipient("bob.com", endTimeMs = now + 30_000),
+        )
+        assertEquals(
+            now + 30_000,
+            liveShareCoverageUntilMs(roster, listOf("alice.com", "bob.com"), now),
+        )
+    }
+
+    @Test
+    fun partialCoverageReturnsNull() {
+        val roster = listOf(TimedRecipient("alice.com", endTimeMs = now + 60_000))
+        assertNull(liveShareCoverageUntilMs(roster, listOf("alice.com", "bob.com"), now))
+    }
+
+    @Test
+    fun expiredEntriesDoNotCount() {
+        val roster = listOf(TimedRecipient("alice.com", endTimeMs = now - 1))
+        assertNull(liveShareCoverageUntilMs(roster, listOf("alice.com"), now))
+    }
+
+    @Test
+    fun perRecipientLatestEntryWins() {
+        // Duplicate entries per recipient are legal (roster is additive); the newest one counts.
+        val roster = listOf(
+            TimedRecipient("alice.com", endTimeMs = now + 10_000),
+            TimedRecipient("alice.com", endTimeMs = now + 90_000),
+        )
+        assertEquals(now + 90_000, liveShareCoverageUntilMs(roster, listOf("alice.com"), now))
+    }
+
+    @Test
+    fun unrelatedRosterEntriesAreIgnored() {
+        val roster = listOf(TimedRecipient("carol.com", endTimeMs = now + 60_000))
+        assertNull(liveShareCoverageUntilMs(roster, listOf("alice.com"), now))
+    }
+
+    @Test
+    fun emptyRecipientsReturnsNull() {
+        val roster = listOf(TimedRecipient("alice.com", endTimeMs = now + 60_000))
+        assertNull(liveShareCoverageUntilMs(roster, emptyList(), now))
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LocationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LocationService.kt
@@ -87,6 +87,36 @@ class LocationService(
     private var lastAcquireStartMs = 0L
 
     /**
+     * The best cached coordinate available RIGHT NOW, at ANY age, without powering the radio —
+     * the "where should a map start" primitive (#966 share screen). [lastKnown] is memory-only
+     * and null after a process restart even though the device knew its position seconds ago;
+     * this consults the cold sources too, newest wins:
+     *  1. the in-memory last point (warm process — instant),
+     *  2. the latest persisted history row (cold process, history on),
+     *  3. the OS last-known fix (cold process; on Android this survives app restarts).
+     * The winner is published back into [lastKnown], so subsequent calls — and every other
+     * consumer of the store (live-map self dot, relay hydration) — see it immediately. Returns
+     * null only when no source has ever seen a position (fresh install / permission never
+     * granted / GPS never on). Callers that need a FRESH position use [requestLatestGps]; the
+     * two compose: seed a map from this, then refine with a fresh fix.
+     */
+    suspend fun lastKnownCoordinates(): RawLocationPoint? {
+        lastKnown.value?.let { return it }
+        runCatching { pointStore.refresh() }
+            .onFailure { logger.d(it) { "lastKnownCoordinates: history re-seed failed" } }
+        val persisted = lastKnown.value
+        val osFix = if (permissionGranted()) {
+            runCatching { oneShot.lastKnownFix() }
+                .onFailure { logger.d(it) { "lastKnownCoordinates: OS last-known failed" } }
+                .getOrNull()
+        } else null
+        val best = listOfNotNull(persisted, osFix).maxByOrNull { it.t } ?: return null
+        if (best !== persisted) pointStore.publishLastKnown(best)
+        logger.d { "lastKnownCoordinates: served (age=${nowMs() - best.t}ms src=${best.src})" }
+        return best
+    }
+
+    /**
      * Get the current position, idempotently and battery-aware. Returns the cached [lastKnown] if it's
      * fresher than [GpsRequestReason.staleAfterMs]; otherwise does a one-shot fetch (capped by
      * [GpsRequestReason.timeoutMs]). Does NOT request permission — returns [GpsFixResult.PermissionDenied]

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/LocationServiceTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/LocationServiceTest.kt
@@ -359,4 +359,60 @@ class LocationServiceTest {
             assertEquals(990_000, store.lastPoint.value?.t) // routed + persisted (history on)
         }
     }
+
+    // ── lastKnownCoordinates (#966): the any-age cached-coordinate primitive ──
+
+    @Test
+    fun lastKnownCoordinatesServesWarmMemoryWithoutTouchingProviders() {
+        val oneShot = FakeOneShot(cached = point(t = now - 500L))
+        runServiceTest(permission = true, oneShot = oneShot) { service, store, _ ->
+            store.publishLastKnown(point(t = now - 3_600_000)) // an hour old — still served
+            val result = service.lastKnownCoordinates()
+            assertEquals(now - 3_600_000, result?.t)
+            assertEquals(0, oneShot.lastKnownCalls) // memory short-circuits
+            assertEquals(0, oneShot.freshCalls)
+        }
+    }
+
+    @Test
+    fun lastKnownCoordinatesColdStartServesOsFixAtAnyAgeAndHydratesStore() {
+        val osFix = point(t = now - 7_200_000, lon = 9.0) // 2h old — a map seed doesn't care
+        val oneShot = FakeOneShot(cached = osFix)
+        runServiceTest(permission = true, oneShot = oneShot) { service, store, _ ->
+            val result = service.lastKnownCoordinates()
+            assertEquals(osFix, result)
+            assertEquals(0, oneShot.freshCalls) // never powers the radio
+            assertEquals(osFix, store.lastPoint.value) // hydrated for every other consumer
+        }
+    }
+
+    @Test
+    fun lastKnownCoordinatesPrefersNewestOfPersistedAndOsFix() {
+        val osFix = point(t = now - 10_000, lon = 9.0)
+        val oneShot = FakeOneShot(cached = osFix)
+        runServiceTest(permission = true, oneShot = oneShot, allowHistory = true) { service, store, _ ->
+            store.persistHistory(listOf(point(t = now - 60_000, lon = 8.0))) // older persisted row
+            assertEquals(osFix, service.lastKnownCoordinates())
+        }
+    }
+
+    @Test
+    fun lastKnownCoordinatesWithoutPermissionUsesPersistedHistoryOnly() {
+        val oneShot = FakeOneShot(cached = point(t = now, lon = 9.0))
+        runServiceTest(permission = false, oneShot = oneShot, allowHistory = true) { service, store, _ ->
+            store.persistHistory(listOf(point(t = now - 60_000, lon = 8.0)))
+            val result = service.lastKnownCoordinates()
+            assertEquals(8.0, result?.lon)
+            assertEquals(0, oneShot.lastKnownCalls) // OS cache not consulted without permission
+        }
+    }
+
+    @Test
+    fun lastKnownCoordinatesReturnsNullWhenNoSourceHasEverSeenAPosition() {
+        val oneShot = FakeOneShot(cached = null)
+        runServiceTest(permission = true, oneShot = oneShot) { service, _, _ ->
+            assertNull(service.lastKnownCoordinates())
+            assertEquals(0, oneShot.freshCalls)
+        }
+    }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/map/MapProjection.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/map/MapProjection.kt
@@ -74,14 +74,24 @@ internal fun visibleTileKeys(vp: MapViewport, canvasSize: IntSize): List<MapTile
         val y1 = ceil((vp.centerY + halfH) * n).toInt().coerceIn(0, n - 1)
         val count = (x1 - x0 + 1) * (y1 - y0 + 1)
         if (count > MAX_TILES_PER_VIEW && zoom > MIN_TILE_ZOOM) continue
-        return buildList {
+        val keys = buildList {
             for (y in y0..y1) {
-                for (x in x0..x1) {
-                    add(MapTileKey(zoom, x, y))
-                    if (size >= MAX_TILES_PER_VIEW) return@buildList
-                }
+                for (x in x0..x1) add(MapTileKey(zoom, x, y))
             }
         }
+        if (keys.size <= MAX_TILES_PER_VIEW) return keys
+        // Over budget even at MIN_TILE_ZOOM (a portrait world view needs ~64 tiles). Keep the
+        // tiles NEAREST THE VIEWPORT CENTER rather than the first rows — a top-anchored cut
+        // rendered only the top band of the world with the rest of the screen bare (the "half
+        // a world map" on the #966 share screen's no-fix fallback). Center-out also fetches
+        // what the user is looking at first.
+        val cx = vp.centerX * n
+        val cy = vp.centerY * n
+        return keys.sortedBy { key ->
+            val dx = key.x + 0.5 - cx
+            val dy = key.y + 0.5 - cy
+            dx * dx + dy * dy
+        }.take(MAX_TILES_PER_VIEW)
     }
     return emptyList()
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/share/ShareLocationScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/share/ShareLocationScreen.kt
@@ -79,6 +79,7 @@ import id.homebase.resources.share_location_recenter_cd
 import id.homebase.resources.share_location_resolving
 import id.homebase.resources.share_location_send_cd
 import id.homebase.resources.share_location_title
+import kotlin.time.Clock
 import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
@@ -296,51 +297,57 @@ fun ShareLocationScreen(
                 tonalElevation = 3.dp,
             ) {
                 Column {
-                    var durationMenuExpanded by remember { mutableStateOf(false) }
-                    Box {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable(enabled = !uiState.isSending) { durationMenuExpanded = true }
-                                .padding(start = 16.dp, top = 14.dp, end = 16.dp, bottom = 14.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.LocationOn,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.size(22.dp),
-                            )
-                            Spacer(modifier = Modifier.width(10.dp))
-                            Text(
-                                text = stringResource(MR.string.share_location_live_banner),
-                                style = MaterialTheme.typography.titleSmall,
-                                color = MaterialTheme.colorScheme.primary,
-                            )
-                        }
-                        DropdownMenu(
-                            expanded = durationMenuExpanded,
-                            onDismissRequest = { durationMenuExpanded = false },
-                        ) {
-                            Text(
-                                text = stringResource(MR.string.live_share_duration_prompt),
-                                style = MaterialTheme.typography.labelMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                            )
-                            HorizontalDivider()
-                            LIVE_SHARE_DURATION_OPTIONS.forEach { (labelRes, durationMs) ->
-                                DropdownMenuItem(
-                                    text = { Text(stringResource(labelRes)) },
-                                    onClick = {
-                                        durationMenuExpanded = false
-                                        viewModel.startLiveShare(durationMs)
-                                    },
+                    // Hidden while my live share already covers this conversation — no invitation
+                    // to start what's already running (#966 follow-up; app-wide indicator = #816).
+                    val ownShareActive = uiState.ownLiveShareUntilMs
+                        ?.let { Clock.System.now().toEpochMilliseconds() < it } == true
+                    if (!ownShareActive) {
+                        var durationMenuExpanded by remember { mutableStateOf(false) }
+                        Box {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable(enabled = !uiState.isSending) { durationMenuExpanded = true }
+                                    .padding(start = 16.dp, top = 14.dp, end = 16.dp, bottom = 14.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.LocationOn,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier.size(22.dp),
+                                )
+                                Spacer(modifier = Modifier.width(10.dp))
+                                Text(
+                                    text = stringResource(MR.string.share_location_live_banner),
+                                    style = MaterialTheme.typography.titleSmall,
+                                    color = MaterialTheme.colorScheme.primary,
                                 )
                             }
+                            DropdownMenu(
+                                expanded = durationMenuExpanded,
+                                onDismissRequest = { durationMenuExpanded = false },
+                            ) {
+                                Text(
+                                    text = stringResource(MR.string.live_share_duration_prompt),
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                                )
+                                HorizontalDivider()
+                                LIVE_SHARE_DURATION_OPTIONS.forEach { (labelRes, durationMs) ->
+                                    DropdownMenuItem(
+                                        text = { Text(stringResource(labelRes)) },
+                                        onClick = {
+                                            durationMenuExpanded = false
+                                            viewModel.startLiveShare(durationMs)
+                                        },
+                                    )
+                                }
+                            }
                         }
+                        HorizontalDivider()
                     }
-                    HorizontalDivider()
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/share/ShareLocationUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/share/ShareLocationUiState.kt
@@ -26,6 +26,13 @@ data class ShareLocationUiState(
     val isSending: Boolean = false,
     val isAcquiringFix: Boolean = false,
     val showEnableLocationDialog: Boolean = false,
+    /**
+     * When MY live share already fully covers this conversation: the absolute end of that
+     * coverage, else null. While set (and in the future), the "Share live location" banner is
+     * hidden — no invitation to start a share that's already running (#966 follow-up; the
+     * app-wide sharing indicator is #816). Static send + comment stay available.
+     */
+    val ownLiveShareUntilMs: Long? = null,
     /** One-shot camera move (GPS re-center); the screen applies it and calls recenterConsumed(). */
     val recenterTarget: RecenterTarget? = null,
 )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/share/ShareLocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/share/ShareLocationViewModel.kt
@@ -13,6 +13,7 @@ import id.homebase.chat.services.content.MessageContent
 import id.homebase.chat.services.convo.ConversationStream
 import id.homebase.chat.services.livelocation.LiveLocationShareService
 import id.homebase.chat.services.livelocation.LiveShareReadiness
+import id.homebase.chat.services.livelocation.liveShareCoverageUntilMs
 import id.homebase.core.location.GpsRequestReason
 import id.homebase.core.location.LocationMapProvider
 import id.homebase.core.location.LocationPreferences
@@ -30,6 +31,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.math.PI
@@ -98,6 +100,20 @@ class ShareLocationViewModel(
             it.copy(initialBbox = WORLD_BBOX, initialBboxKey = it.initialBboxKey + 1)
         }
         viewModelScope.launch { seedFromCachedThenFresh() }
+        // Hide the live banner while my share already covers this conversation (#966 follow-up).
+        viewModelScope.launch {
+            liveLocationShareService.recipients.collectLatest { roster ->
+                val recipients = runCatching {
+                    conversationStream.getRecipients(conversationId, emptyList(), null)
+                }.getOrDefault(emptyList())
+                val untilMs = liveShareCoverageUntilMs(
+                    roster = roster,
+                    recipientIds = recipients.map { it.domainName },
+                    nowMs = Clock.System.now().toEpochMilliseconds(),
+                )
+                _uiState.update { it.copy(ownLiveShareUntilMs = untilMs) }
+            }
+        }
     }
 
     override fun onCleared() {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/share/ShareLocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/share/ShareLocationViewModel.kt
@@ -81,24 +81,23 @@ class ShareLocationViewModel(
     private var recenterSeq = 0
     /** Set once the user pans/zooms — a late first fix must not yank the map away anymore. */
     private var userMoved = false
+    /**
+     * Set once the map was seeded on an actual position (cached or fresh). Until then — the
+     * world-view fallback — the viewport center (Null Island) is meaningless: no pin, no
+     * geocode, no send.
+     */
+    private var hasRealPosition = false
 
     init {
-        // Seed the map immediately: the last known position when we have one, else the whole
-        // world — a null bbox leaves the map BLANK (no viewport → no tiles fetched) until the
-        // first fix lands, which on a cold GPS can take many seconds or never come. Then refine
-        // with a fresh fix — but only recenter while the user hasn't taken over.
-        val last = locationService.lastKnown.value
-        if (last != null) {
-            seedBbox(last.lat, last.lon)
-        } else {
-            _uiState.update {
-                it.copy(initialBbox = WORLD_BBOX, initialBboxKey = it.initialBboxKey + 1)
-            }
+        // Seed the map immediately with a world view — a null bbox leaves the map BLANK (no
+        // viewport → no tiles fetched). Then position it in two steps: the best CACHED
+        // coordinate at any age (memory / persisted history / OS last-known — instant, no
+        // radio; a map seed doesn't need freshness), then a fresh fix to refine. Each step
+        // recenters only while the user hasn't taken over.
+        _uiState.update {
+            it.copy(initialBbox = WORLD_BBOX, initialBboxKey = it.initialBboxKey + 1)
         }
-        viewModelScope.launch {
-            val fix = locationService.requestLatestGps(GpsRequestReason.LiveMap)
-            if (fix is GpsFixResult.Success && !userMoved) seedBbox(fix.point.lat, fix.point.lon)
-        }
+        viewModelScope.launch { seedFromCachedThenFresh() }
     }
 
     override fun onCleared() {
@@ -108,19 +107,25 @@ class ShareLocationViewModel(
 
     /**
      * Screen callback when location permission lands — re-arms the GPS hold (LiveMap pattern)
-     * and retries the initial seed: on a first-ever open the init-time fix request fails with
+     * and retries the initial seed: on a first-ever open the init-time attempts fail with
      * PermissionDenied (the prompt is still up), which used to leave the map on the fallback
      * view until the screen was reopened.
      */
     fun onPermissionGranted() {
         locationService.refreshGpsHold()
-        viewModelScope.launch {
-            val fix = locationService.requestLatestGps(GpsRequestReason.LiveMap)
-            if (fix is GpsFixResult.Success && !userMoved) seedBbox(fix.point.lat, fix.point.lon)
+        viewModelScope.launch { seedFromCachedThenFresh() }
+    }
+
+    private suspend fun seedFromCachedThenFresh() {
+        locationService.lastKnownCoordinates()?.let {
+            if (!userMoved) seedBbox(it.lat, it.lon)
         }
+        val fix = locationService.requestLatestGps(GpsRequestReason.LiveMap)
+        if (fix is GpsFixResult.Success && !userMoved) seedBbox(fix.point.lat, fix.point.lon)
     }
 
     private fun seedBbox(lat: Double, lon: Double) {
+        hasRealPosition = true
         val (x, y) = WebMercator.latLonToUnit(lat, lon)
         _uiState.update {
             it.copy(
@@ -137,6 +142,10 @@ class ShareLocationViewModel(
      */
     fun onMapCenterChanged(unitX: Double, unitY: Double, byUser: Boolean) {
         if (byUser) userMoved = true
+        // World-view fallback and the user hasn't picked a spot: the center is Null Island, not
+        // a location anyone means to share. Keep the pin unset (send stays disabled) and don't
+        // geocode — no "0.0, 0.0" chip.
+        if (!userMoved && !hasRealPosition) return
         val (lat, lon) = WebMercator.unitToLatLon(unitX, unitY)
         _uiState.update { it.copy(pinLat = lat, pinLon = lon) }
 

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/map/MapProjectionTruncationTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/map/MapProjectionTruncationTest.kt
@@ -1,0 +1,52 @@
+package id.homebase.core.ui.screens.location.map
+
+import androidx.compose.ui.unit.IntSize
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the over-budget tile truncation in [visibleTileKeys]: when the visible grid exceeds
+ * MAX_TILES_PER_VIEW even at the minimum zoom (a portrait world view needs ~64 tiles), the kept
+ * tiles must surround the VIEWPORT CENTER — a top-anchored cut rendered only the top band of the
+ * world with the rest of the screen bare (the "half a world map" on the #966 share screen's
+ * no-fix fallback).
+ */
+class MapProjectionTruncationTest {
+
+    @Test
+    fun overBudgetWorldViewKeepsTilesNearestTheViewportCenter() {
+        // Portrait phone fitting the whole world: idealZoom clamps to MIN_TILE_ZOOM and the full
+        // grid (64 tiles) exceeds the 24-tile budget → truncation kicks in.
+        val vp = MapViewport(centerX = 0.5, centerY = 0.5, unitsPerPx = 1.0 / 900.0)
+        val keys = visibleTileKeys(vp, IntSize(1080, 2200))
+
+        assertTrue(keys.isNotEmpty())
+        assertTrue(keys.size <= 24, "budget respected, got ${keys.size}")
+        val zoom = keys.first().zoom
+        val n = 1 shl zoom
+        // The four tiles around the viewport center must be kept…
+        for (x in (n / 2 - 1)..(n / 2)) {
+            for (y in (n / 2 - 1)..(n / 2)) {
+                assertTrue(keys.contains(MapTileKey(zoom, x, y)), "missing center tile ($x,$y)")
+            }
+        }
+        // …and the far corner (which the old top-anchored cut kept) must be dropped.
+        assertFalse(keys.contains(MapTileKey(zoom, 0, 0)), "corner tile should be dropped")
+    }
+
+    @Test
+    fun withinBudgetGridIsUntouched() {
+        // A city-level viewport fits comfortably in the budget — full grid, no truncation.
+        val vp = MapViewport(centerX = 0.53, centerY = 0.33, unitsPerPx = 1e-6)
+        val keys = visibleTileKeys(vp, IntSize(1080, 2200))
+        assertTrue(keys.isNotEmpty())
+        assertTrue(keys.size <= 24)
+        // Grid is rectangular and contiguous (no holes from sorting).
+        val xs = keys.map { it.x }.distinct().sorted()
+        val ys = keys.map { it.y }.distinct().sorted()
+        assertTrue(xs == (xs.first()..xs.last()).toList(), "x range contiguous")
+        assertTrue(ys == (ys.first()..ys.last()).toList(), "y range contiguous")
+        assertTrue(keys.size == xs.size * ys.size, "full rectangular grid")
+    }
+}


### PR DESCRIPTION
Continuation of the #966 production-test fixes — this commit was pushed to the `fix-location-share-screen-966` branch a few minutes **after** #974 was merged, so it needs its own PR (a merged PR doesn't reopen on new pushes). This PR is now the collection point for further fixes from this test round.

## What (second test round: kill-and-reopen opened on a half-drawn world map at 0,0)

- **New centralized cached-coordinate API** — `LocationService.lastKnownCoordinates()`: memory → persisted history row → OS last-known fix (survives app kills on Android), newest wins, ANY age, never powers the radio; hydrates the store for all consumers. Root cause was position amnesia: the in-memory last point is null after a process kill (its DB re-seed helper was never called by anyone) and nothing consulted the OS cache beyond the 30 s freshness window — so the screen waited on the GPS radio. The share screen now seeds from the cached coordinate instantly, then refines with a fresh fix.
- **"Half a world map" fixed** — the shared `MAX_TILES_PER_VIEW` (24) truncated an over-budget grid top-down, drawing only the top band of a portrait world view with the pin floating below it. Truncation is now center-out; benefits every map surface (live map, History, Find Device).
- **No bogus 0,0** — on the world fallback with no real position the pin stays unset: send disabled, no geocode, no "0.0, 0.0" chip; panning arms everything as usual.

## Tests

`LocationServiceTest` matrix for `lastKnownCoordinates` (warm-memory short-circuit, cold-start OS-fix hydration + store publish, newest-of-persisted-vs-OS, no-permission → history only, no-source → null) and `MapProjectionTruncationTest` (center-out cut keeps the four center tiles and drops corners; within-budget grids untouched). Compile green on JVM/Android/wasmJs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKxv1k187ynCjx6sVDC7NQ