### PR TITLE
feat(location): purple sharing pin on the chat top bars (#816)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
@@ -380,5 +380,11 @@ sealed interface ConversationListUiAction {
      *  can't start because location isn't ready. */
     data object OpenLocationSetup : ConversationListUiAction
 
+    /** Tap on the top-bar "you're sharing" pin (#816) — opens the location dashboard, which lists
+     *  every outgoing live share with per-person stop + stop-all. Routes through the same
+     *  navigation as [OpenLocationSetup]; an active share implies the add-on is activated, so it
+     *  lands on the dashboard rather than onboarding. */
+    data object OpenLocationDashboard : ConversationListUiAction
+
     // endregion
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -43,6 +43,14 @@ data class ConversationListUiState(
     val connectionStatus: AppConnectionStatus = AppConnectionStatus.Connecting,
     val driveIsSyncing: Boolean = false,
     val hasDriveError: Boolean = false,
+    /**
+     * Latest end-time across ALL my active outgoing live shares, else null — drives the purple
+     * sharing pin in the chat-list top bar (#816). Raw deadline: the pin composable derives
+     * visibility from `now < untilMs` with its own ticker, so a stale past-value after expiry is
+     * harmless until the next roster emission. See [MessageListUiState.ownLiveShareInConversationUntilMs]
+     * for the per-conversation (ANY-coverage) variant.
+     */
+    val ownLiveShareAnyUntilMs: Long? = null,
     val uiDialog: ConversationListUiDialog? = null,
     val uiEvent: ConversationListUiEvent? = null,
     /** Non-null while a long-ish service op is in flight. Drives the full-screen
@@ -103,12 +111,20 @@ data class MessageListUiState(
      *  ScrollToLatest branch, and gates auto-follow on incoming messages. */
     val hasNewerMessages: Boolean = false,
     /**
-     * When MY live share fully covers this conversation's recipients: the absolute end of that
+     * When MY live share FULLY covers this conversation's recipients: the absolute end of that
      * coverage, else null. While set (and in the future), location bubbles hide their "share
      * live location" offers — no invitations to start a share that's already running (#966
-     * follow-up; the app-wide sharing indicator is #816).
+     * follow-up). Deliberately a different predicate from [ownLiveShareInConversationUntilMs]
+     * (ANY-coverage, the #816 pin) — don't unify them.
      */
     val ownLiveShareUntilMs: Long? = null,
+    /**
+     * Latest end-time among my active shares to ANY participant of this conversation, else null —
+     * drives the purple sharing pin in the conversation top bar (#816). ANY-coverage: sharing
+     * with one member of a group lights the pin, while [ownLiveShareUntilMs] (FULL coverage,
+     * offer suppression) stays null. Raw deadline; the pin composable handles expiry itself.
+     */
+    val ownLiveShareInConversationUntilMs: Long? = null,
     /** A loadOlder fetch is in flight; suppresses re-entry. */
     val isLoadingOlder: Boolean = false,
     /** A loadNewer fetch is in flight; suppresses re-entry. */

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -33,6 +33,7 @@ import id.homebase.chat.services.LocalAttachmentContextStore
 import id.homebase.chat.services.content.MessageContent
 import id.homebase.chat.services.content.MessageContentParser
 import id.homebase.chat.services.livelocation.ShareBackResult
+import id.homebase.chat.services.livelocation.liveShareAnyUntilMs
 import id.homebase.chat.services.livelocation.liveShareCoverageUntilMs
 import id.homebase.chat.services.livelocation.shareLiveLocationBack
 import id.homebase.core.location.GpsRequestReason
@@ -354,27 +355,37 @@ class ConversationListViewModel(
             }
         }
 
-        // Track whether MY live share already covers the open conversation. While it does, the
-        // bubbles hide their "share live location" offers — inviting the user to start a share
-        // they're already running is confusing, and a second tap would create a duplicate live
-        // message (#966 follow-up; the app-wide "you're sharing" indicator is #816).
+        // Track MY live-share state against the open conversation and globally. FULL coverage
+        // hides the bubbles' "share live location" offers (starting a share that's already
+        // running is confusing, and a second tap would create a duplicate live message — #966
+        // follow-up). ANY coverage + the global value drive the purple sharing pins in the
+        // conversation and chat-list top bars (#816). No ticker here: the pin/bubble composables
+        // derive visibility from `now < untilMs` with their own exact-deadline tickers.
         viewModelScope.launch {
             combine(
                 ActiveConversation.conversation,
                 liveLocationShareService.recipients,
             ) { conversationId, roster -> conversationId to roster }
                 .collectLatest { (conversationId, roster) ->
-                    val untilMs = conversationId?.let { id ->
-                        val recipients = runCatching {
+                    val nowMs = Clock.System.now().toEpochMilliseconds()
+                    _uiState.update {
+                        it.copy(ownLiveShareAnyUntilMs = liveShareAnyUntilMs(roster, null, nowMs))
+                    }
+                    var fullUntilMs: Long? = null
+                    var anyUntilMs: Long? = null
+                    conversationId?.let { id ->
+                        val recipientIds = runCatching {
                             conversationStream.getRecipients(id, emptyList(), null)
-                        }.getOrDefault(emptyList())
-                        liveShareCoverageUntilMs(
-                            roster = roster,
-                            recipientIds = recipients.map { it.domainName },
-                            nowMs = Clock.System.now().toEpochMilliseconds(),
+                        }.getOrDefault(emptyList()).map { it.domainName }
+                        fullUntilMs = liveShareCoverageUntilMs(roster, recipientIds, nowMs)
+                        anyUntilMs = liveShareAnyUntilMs(roster, recipientIds, nowMs)
+                    }
+                    _messagesUiState.update {
+                        it.copy(
+                            ownLiveShareUntilMs = fullUntilMs,
+                            ownLiveShareInConversationUntilMs = anyUntilMs,
                         )
                     }
-                    _messagesUiState.update { it.copy(ownLiveShareUntilMs = untilMs) }
                 }
         }
 
@@ -903,6 +914,12 @@ class ConversationListViewModel(
             }
 
             is ConversationListUiAction.OpenLocationSetup -> {
+                sendEvent(ConversationListUiEvent.NavigateToLocationSetup)
+            }
+
+            is ConversationListUiAction.OpenLocationDashboard -> {
+                // Same navigation as setup: openLocation routes to the dashboard when the add-on
+                // is activated — always true while a share is running (the pin's only tap path).
                 sendEvent(ConversationListUiEvent.NavigateToLocationSetup)
             }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/livelocation/LiveShareCoverage.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/livelocation/LiveShareCoverage.kt
@@ -29,3 +29,24 @@ fun liveShareCoverageUntilMs(
     }
     return coverageEnd
 }
+
+/**
+ * When my live share reaches ANY of [recipientIds] (or anyone at all when null), and until when:
+ * the latest `endTimeMs` among matching active roster entries, or null when none. A scoped call
+ * with an EMPTY recipient list returns null (a conversation with no participants), distinct from
+ * `null` = unscoped (the chat-list pin: "am I sharing with anyone at all").
+ *
+ * Deliberately a different predicate from [liveShareCoverageUntilMs]: the sharing INDICATOR (#816
+ * pin) answers "am I sharing with anyone here" (ANY), while offer suppression answers "would
+ * starting a share still add someone" (FULL). Don't unify them.
+ */
+fun liveShareAnyUntilMs(
+    roster: List<TimedRecipient>,
+    recipientIds: List<String>? = null,
+    nowMs: Long,
+): Long? {
+    if (recipientIds != null && recipientIds.isEmpty()) return null
+    return roster
+        .filter { it.endTimeMs > nowMs && (recipientIds == null || it.odinId in recipientIds) }
+        .maxOfOrNull { it.endTimeMs }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -735,6 +735,12 @@ fun ConversationContent(
                 },
                 actions = {
                     if (!uiState.isSearchActive) {
+                        LiveShareIndicator(
+                            untilMs = uiState.ownLiveShareInConversationUntilMs,
+                            onClick = {
+                                onUiAction(ConversationListUiAction.OpenLocationDashboard)
+                            },
+                        )
                         IconButton(onClick = { showConversationMenu = true }) {
                             Icon(
                                 imageVector = Icons.Default.MoreVert,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
@@ -221,6 +221,12 @@ fun ConversationListPane(
                         }
                     }, actions = {
                         if (!uiState.isSearchActive) {
+                            LiveShareIndicator(
+                                untilMs = uiState.ownLiveShareAnyUntilMs,
+                                onClick = {
+                                    onUiAction(ConversationListUiAction.OpenLocationDashboard)
+                                },
+                            )
                             IconButton(
                                 onClick = {
                                     onUiAction(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LiveShareIndicator.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LiveShareIndicator.kt
@@ -1,0 +1,57 @@
+package id.homebase.chat.widget
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import id.homebase.core.ui.theme.HomebaseTheme
+import id.homebase.resources.MR
+import id.homebase.resources.location_sharing_indicator_cd
+import kotlinx.coroutines.delay
+import kotlin.time.Clock
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * The purple "you're sharing your live location" pin for the chat top bars (#816). Renders an
+ * [IconButton] while `now < untilMs`, nothing otherwise — including flipping itself off at the
+ * exact moment the share expires (the relay roster emits no event at expiry, so the deadline is
+ * watched here with a ticker, same pattern as the location bubble's countdown). Tap opens the
+ * location dashboard, where every outgoing share is listed with stop controls.
+ *
+ * Filled glyph deliberately (the outlined pin is the passive Location nav icon; filled signals
+ * an ACTIVE broadcast), tinted with the theme's `liveSharing` token — never a hardcoded color.
+ */
+@Composable
+fun LiveShareIndicator(
+    untilMs: Long?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (untilMs == null) return
+    // Coarse ticker (≤30 s steps) that lands exactly on the deadline, then stops.
+    var nowMs by remember(untilMs) { mutableStateOf(Clock.System.now().toEpochMilliseconds()) }
+    LaunchedEffect(untilMs) {
+        while (true) {
+            val now = Clock.System.now().toEpochMilliseconds()
+            nowMs = now
+            if (now >= untilMs) break
+            delay(minOf(untilMs - now, 30_000L) + 50)
+        }
+    }
+    if (nowMs >= untilMs) return
+
+    IconButton(onClick = onClick, modifier = modifier) {
+        Icon(
+            imageVector = Icons.Default.LocationOn,
+            contentDescription = stringResource(MR.string.location_sharing_indicator_cd),
+            tint = HomebaseTheme.extendedColors.liveSharing,
+        )
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/livelocation/LiveShareAnyTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/livelocation/LiveShareAnyTest.kt
@@ -1,0 +1,87 @@
+package id.homebase.chat.services.livelocation
+
+import id.homebase.api.client.liverelay.TimedRecipient
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Pins [liveShareAnyUntilMs] — the #816 sharing-pin predicate. ANY-coverage: one active entry to
+ * a matching recipient suffices, the LATEST expiry wins (contrast [liveShareCoverageUntilMs]:
+ * every recipient covered, the EARLIEST full-coverage end wins).
+ */
+class LiveShareAnyTest {
+
+    private val now = 100_000L
+
+    @Test
+    fun globalReturnsLatestExpiryAcrossAllEntries() {
+        val roster = listOf(
+            TimedRecipient("alice.com", endTimeMs = now + 30_000),
+            TimedRecipient("bob.com", endTimeMs = now + 60_000),
+        )
+        assertEquals(now + 60_000, liveShareAnyUntilMs(roster, null, now))
+    }
+
+    @Test
+    fun globalNullWhenRosterEmpty() {
+        assertNull(liveShareAnyUntilMs(emptyList(), null, now))
+    }
+
+    @Test
+    fun globalNullWhenAllEntriesExpired() {
+        val roster = listOf(TimedRecipient("alice.com", endTimeMs = now - 1))
+        assertNull(liveShareAnyUntilMs(roster, null, now))
+    }
+
+    @Test
+    fun scopedAnyOneActiveParticipantSuffices() {
+        // Sharing with only ONE of two conversation participants: the pin shows (ANY)…
+        val roster = listOf(TimedRecipient("alice.com", endTimeMs = now + 60_000))
+        val participants = listOf("alice.com", "bob.com")
+        assertEquals(now + 60_000, liveShareAnyUntilMs(roster, participants, now))
+        // …while the FULL-coverage predicate (offer suppression) correctly says "not covered".
+        assertNull(liveShareCoverageUntilMs(roster, participants, now))
+    }
+
+    @Test
+    fun scopedReturnsLatestAmongParticipants() {
+        // Two covered participants: ANY reports the LATEST end (coverage would report the earliest).
+        val roster = listOf(
+            TimedRecipient("alice.com", endTimeMs = now + 30_000),
+            TimedRecipient("bob.com", endTimeMs = now + 60_000),
+        )
+        assertEquals(now + 60_000, liveShareAnyUntilMs(roster, listOf("alice.com", "bob.com"), now))
+        assertEquals(now + 30_000, liveShareCoverageUntilMs(roster, listOf("alice.com", "bob.com"), now))
+    }
+
+    @Test
+    fun scopedIgnoresNonParticipantEntries() {
+        val roster = listOf(TimedRecipient("carol.com", endTimeMs = now + 60_000))
+        assertNull(liveShareAnyUntilMs(roster, listOf("alice.com"), now))
+    }
+
+    @Test
+    fun scopedNullWhenNoParticipantActive() {
+        val roster = listOf(
+            TimedRecipient("alice.com", endTimeMs = now - 1), // expired participant entry
+            TimedRecipient("carol.com", endTimeMs = now + 60_000), // active non-participant
+        )
+        assertNull(liveShareAnyUntilMs(roster, listOf("alice.com"), now))
+    }
+
+    @Test
+    fun scopedEmptyRecipientListReturnsNull() {
+        val roster = listOf(TimedRecipient("alice.com", endTimeMs = now + 60_000))
+        assertNull(liveShareAnyUntilMs(roster, emptyList(), now))
+    }
+
+    @Test
+    fun duplicatePerRecipientEntriesLatestWins() {
+        val roster = listOf(
+            TimedRecipient("alice.com", endTimeMs = now + 10_000),
+            TimedRecipient("alice.com", endTimeMs = now + 90_000),
+        )
+        assertEquals(now + 90_000, liveShareAnyUntilMs(roster, listOf("alice.com"), now))
+    }
+}

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1353,6 +1353,7 @@
     <string name="live_location_marker_cd">%1$s's live location</string>
     <string name="live_location_you">You</string>
     <string name="live_location_age_minutes">%1$dm</string>
+    <string name="location_sharing_indicator_cd">You're sharing your live location</string>
     <string name="location_dashboard_live_section">Live location sharing</string>
     <string name="location_dashboard_live_open">Open live map</string>
     <string name="location_dashboard_live_empty">There's no live location data at the moment.</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/theme/Color.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/theme/Color.kt
@@ -147,6 +147,9 @@ object ExtendedColors {
     val Warning = Color(0xFFFF9800)
     val Info = Color(0xFF2196F3)
 
+    // Live-location sharing indicator (#816) — Homebase purple, same value both themes.
+    val LiveSharing = Color(0xFF9C27B0)
+
     // Requests banner
     val RequestBanner = Color(0xFFFFD9A3)
     val OnRequestBanner = Color(0xFF3D2C1A)

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/theme/Theme.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/theme/Theme.kt
@@ -87,6 +87,8 @@ data class HomebaseExtendedColors(
         val bubbleSentSurface: androidx.compose.ui.graphics.Color,
         val bubbleSentOnSurface: androidx.compose.ui.graphics.Color,
         val warning: androidx.compose.ui.graphics.Color,
+        /** Live-location sharing indicator (#816) — Homebase purple, same value both themes. */
+        val liveSharing: androidx.compose.ui.graphics.Color,
 )
 
 private val LightExtendedColors =
@@ -110,6 +112,7 @@ private val LightExtendedColors =
                 bubbleSentSurface = LightColors.Primary,
                 bubbleSentOnSurface = LightColors.OnPrimary,
                 warning = ExtendedColors.Warning,
+                liveSharing = ExtendedColors.LiveSharing,
         )
 
 private val DarkExtendedColors =
@@ -133,6 +136,7 @@ private val DarkExtendedColors =
                 bubbleSentSurface = LightColors.Primary,
                 bubbleSentOnSurface = LightColors.OnPrimary,
                 warning = ExtendedColors.Warning,
+                liveSharing = ExtendedColors.LiveSharing,
         )
 
 val LocalHomebaseExtendedColors = staticCompositionLocalOf { LightExtendedColors }


### PR DESCRIPTION
Closes #816.

Implements #816 as re-scoped in discussion: not app-wide chrome (there is no shared top bar — Feed/Home have none), but the **two main chat screens**, actions region, left-most of the cluster.

## What

- **Chat-list top bar**: purple pin (pin → Search → ⋯) whenever ≥1 outgoing live share is active.
- **Conversation top bar**: purple pin (pin → ⋯) when you're sharing with **any participant** of that conversation — ANY-coverage, deliberately different from the FULL-coverage predicate that suppresses the bubbles' share offers. Sharing with one member of a group lights the pin while the offers stay visible.
- **Outgoing shares only** (incoming indication deliberately excluded — the pin is a privacy signal: "you are broadcasting").
- **Tap → location dashboard** (`Route.Location`) via a new `OpenLocationDashboard` action reusing the existing `NavigateToLocationSetup` event/nav chain — the dashboard (#812) lists every share with per-person stop + stop-all.
- **Expiry-exact**: the relay roster emits nothing when a share lapses, so `LiveShareIndicator` watches the deadline itself (≤30s ticker landing exactly on it, the location-bubble pattern) and disappears on time with no interaction. VM stays tick-free.
- Theme: new `HomebaseExtendedColors.liveSharing` token (#9C27B0 both themes, the `warning` role precedent); filled `LocationOn` glyph (outlined = the passive nav icon), contentDescription `location_sharing_indicator_cd`.

## How

`liveShareAnyUntilMs(roster, recipientIds?, nowMs)` pure helper next to `liveShareCoverageUntilMs` (null recipientIds = global); computed in the existing roster + active-conversation collector in `ConversationListViewModel`; two new UiState fields with cross-referencing KDoc so the ANY/FULL divergence stays documented.

## Tests

`LiveShareAnyTest` — global latest-expiry / empty / all-expired; scoped one-participant-suffices (contrasted against coverage=null in the same test), latest-vs-earliest divergence from the coverage helper, non-participant ignored, empty-list vs null distinction, duplicate-entry latest-wins. Full matrix green: JVM/Android/wasmJs compiles, chat+common jvmTest incl. Konsist.

## Manual verification (pending, Android)

- [ ] 1:1 share → pin on chat list + that conversation; other conversations unaffected.
- [ ] Group, sharing with one member → conversation pin on, bubble offers still visible (predicates diverge as designed).
- [ ] Tap pin (both screens) → dashboard; stop-all → back → pins gone.
- [ ] Short share, app idle in foreground → pin vanishes at the deadline on its own.
- [ ] Light/dark purple; search mode hides the pin; tablet split shows the two pins independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKxv1k187ynCjx6sVDC7NQ