### PR TITLE
fix(location): keep iOS app alive for background live-share (disable auto-pause while sharing)

### DIFF
--- a/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/LocationTracker.apple.kt
+++ b/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/LocationTracker.apple.kt
@@ -63,6 +63,7 @@ private class AppleLocationTracker(
         CLLocationManager().apply {
             delegate = this@AppleLocationTracker.delegate
             allowsBackgroundLocationUpdates = true
+            // Battery-friendly default; applyProfile() flips this to false while live-sharing.
             pausesLocationUpdatesAutomatically = true
             activityType = CLActivityTypeOther
         }
@@ -94,6 +95,15 @@ private class AppleLocationTracker(
     }
 
     private fun applyProfile(profile: TrackingProfile) {
+        // Keep the app alive and streaming in the background ONLY while live-sharing. Leaving
+        // pausesLocationUpdatesAutomatically on lets iOS pause updates when it deems the device
+        // stationary, which drops the active-location assertion so the backgrounded app is
+        // suspended/killed within minutes — it then only revives on a coarse significant-location
+        // change, making a live share appear to update "only in the foreground". Passive history
+        // keeps auto-pause on to save battery (a stationary user simply records fewer points).
+        val liveSharing = profile == TrackingProfile.LiveForeground ||
+            profile == TrackingProfile.LiveBackground
+        manager.pausesLocationUpdatesAutomatically = !liveSharing
         when (profile) {
             // Live (share / live-map view): best accuracy, tight filter — fresh fixes matter.
             TrackingProfile.LiveForeground -> {


### PR DESCRIPTION
## Problem

On iOS, a live location share (and background history capture) appeared to update **only in the foreground** — recipients saw the sender's position freeze while backgrounded and jump only when the app was reopened.

## Root cause (device-log evidence)

Instrumented dev-build logs on a physical iPhone showed the app was **terminated within ~7 minutes** of being backgrounded during a share: the tracker heartbeat stopped, then a fresh process start appeared **20–36 minutes later**, revived only by a coarse significant-location-change relaunch — leaving large holes with no location.

The upload path was healthy the whole time (background relays and history flushes both POSTed successfully). The problem was purely that **the app wasn't staying alive to capture GPS**.

`pausesLocationUpdatesAutomatically = true` lets iOS pause the location stream when it deems the device stationary, which drops the active-location assertion that keeps an app running in the background — so iOS suspends and then kills it.

## Fix

Disable auto-pause **only while live-sharing** (the `Live*` profiles), so the app stays alive and streams continuously to the recipient. Passive all-day history keeps auto-pause **on** to save battery — a stationary user just records fewer points, which is the intended trade.

```kotlin
val liveSharing = profile == TrackingProfile.LiveForeground ||
    profile == TrackingProfile.LiveBackground
manager.pausesLocationUpdatesAutomatically = !liveSharing
```

- **Permission-agnostic** — no "Always" requirement; works on "While Using" (with the standard blue "using location" bar while a share is active). "Always" stays an optional upgrade, only useful for surviving a full app-kill/reboot.
- Scoped so passive history behaviour and battery are unchanged.

## Validation

Device-tested on a physical iPhone 15:
- **Before:** app died ~7 min after backgrounding (even on "Always").
- **After:** app stayed alive **80 minutes** backgrounded on **"While Using"** — heartbeat continuous (max gap 16 s), no death. Fixes flow while moving; when stationary it correctly records nothing new.

## Not in this PR (follow-ups)

- When the sender is stationary, the recipient sees a stale timestamp (nothing new to send). A small **keepalive re-send** of the last position while sharing would keep the recipient's "updated Xs ago" fresh.
- Optionally finer background accuracy for live shares (currently `hundredMeters` / 50 m filter).
- A Live Activity (Dynamic Island / Lock Screen) as a nicer "sharing is active" indicator — display only, does not affect background runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwWrcALRZpEgtWtyHUj1gb