### PR TITLE
fix(chat): never silently send local-only into a real conversation; ticks can't contradict transfer history (#934)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
@@ -211,6 +211,44 @@ class ChatMessageSenderService(
         dataType = id.homebase.chat.services.content.MessageContentParser.dataTypeFor(content),
     )
 
+    private data class ResolvedRecipients(val recipients: List<OdinId>, val isLocalOnly: Boolean)
+
+    /**
+     * Local-only is an explicit decision, never an inference from an empty lookup (#934):
+     *  1. recipientOverride != null        -> caller forced the set (heal's emptyList() = intentional local-only)
+     *  2. id == ConversationWithYourselfId -> note-to-self
+     *  3. participants non-empty, all self -> legacy self-1:1
+     * Anything else resolving to zero recipients (even after the stream's DB re-hydration
+     * inside getRecipients) is a corrupt/placeholder conversation: throw instead of
+     * uploading with allowDistribution=false — a real 1:1 must never be silently
+     * misclassified as note-to-self and left undelivered.
+     */
+    private suspend fun resolveRecipients(
+        conversationId: Uuid,
+        additionalRecipients: List<OdinId> = emptyList(),
+        recipientOverride: List<OdinId>? = null,
+    ): ResolvedRecipients {
+        val recipients = conversationStream.getRecipients(
+            conversationId = conversationId,
+            additionalRecipients = additionalRecipients,
+            recipientOverride = recipientOverride,
+        )
+        if (recipients.isNotEmpty()) return ResolvedRecipients(recipients, isLocalOnly = false)
+        if (recipientOverride != null) return ResolvedRecipients(recipients, isLocalOnly = true)
+        if (conversationId == ChatProtocol.ConversationWithYourselfId) {
+            return ResolvedRecipients(recipients, isLocalOnly = true)
+        }
+        // Re-read AFTER getRecipients — its hydration may have replaced the in-memory row.
+        val participants = conversationStream.getConversationById(conversationId)?.participants
+        if (!participants.isNullOrEmpty()) {
+            return ResolvedRecipients(recipients, isLocalOnly = true) // all-self legacy 1:1
+        }
+        error(
+            "No recipients resolved for conversation $conversationId (participants missing) — " +
+                "refusing local-only send"
+        )
+    }
+
     private suspend fun sendMessageInternal(
         messageUniqueId: Uuid,
         conversationId: Uuid,
@@ -237,12 +275,11 @@ class ChatMessageSenderService(
         }
 
         val keyHeader = KeyHeader.newRandom16()
-        val recipients = conversationStream.getRecipients(
+        val (recipients, isLocalOnly) = resolveRecipients(
             conversationId = conversationId,
             additionalRecipients = additionalRecipients,
             recipientOverride = recipientOverride,
         )
-        val isLocalOnly = recipients.isEmpty() // self-conversation: no distribution
 
         val effectiveNotificationText = if (recipients.size > 1) {
             val groupName = conversation.name
@@ -387,8 +424,7 @@ class ChatMessageSenderService(
             aesKey = msg.keyHeader.aesKey
         )
 
-        val recipients = conversationStream.getRecipients(msg.conversationId)
-        val isLocalOnly = recipients.isEmpty() // self-conversation: no distribution
+        val (recipients, isLocalOnly) = resolveRecipients(msg.conversationId)
 
         // If the original create is still queued (never reached the server),
         // editing must keep it a *create*. Downgrading to an UpdateFile would
@@ -641,8 +677,12 @@ class ChatMessageSenderService(
             fileOperationsProvider = fileOperationsProvider,
         )
 
-        val recipients = conversationStream.getRecipients(msg.conversationId)
-        val isLocalOnly = recipients.isEmpty()
+        val (recipients, isLocalOnly) = try {
+            resolveRecipients(msg.conversationId)
+        } catch (e: IllegalStateException) {
+            Logger.e(throwable = e, tag = TAG) { "resendMessage: recipient resolution failed uniqueId=$messageId" }
+            return ResendOutcome.Failed(e)
+        }
 
         val enqueueOutcome = try {
             when (recoverability) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/MessageMapper.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/MessageMapper.kt
@@ -71,13 +71,16 @@ import kotlin.uuid.Uuid
 
 internal fun getDeliveryStatus(header: HomebaseFile): ChatDeliveryStatus {
 
+    // Self/no-recipient uploads never transit, so the honest ceiling is Sent (single
+    // tick): a double tick must always be corroborated by a non-empty per-recipient
+    // transfer history, which these files can never have (#934).
     if (header.fileMetadata.appData.groupId == ChatProtocol.ConversationWithYourselfId) {
-        return ChatDeliveryStatus.Read
+        return ChatDeliveryStatus.Sent
     }
 
     val count = header.serverMetadata.originalRecipientCount
     if (count == 0) {
-        return ChatDeliveryStatus.Read
+        return ChatDeliveryStatus.Sent
     }
     val transferSummary =
         header.serverMetadata.transferHistory?.summary ?: return ChatDeliveryStatus.Sent

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -269,6 +269,13 @@ class ConversationService(
             } else {
                 audit.info("existing file is in usable state, no revive needed")
             }
+            // Re-map the DB file into the in-memory list: the row may be missing or a
+            // participants=[] placeholder (e.g. archived 1:1 opened via Contacts), and
+            // an immediate send would otherwise resolve zero recipients (#934).
+            runCatching { conversationStream.loadConversation(newConversationId) }
+                .onFailure { e ->
+                    Logger.w(e) { "createConversation: loadConversation($newConversationId) failed after existing-file return" }
+                }
             audit.checkPass("existingFileBranch")
             audit.finish("returned wasNewlyCreated=false (path=existing-file)")
             return CreateConversationResult(newConversationId, wasNewlyCreated = false)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -1494,12 +1494,25 @@ class ConversationStream(
     ): List<OdinId> {
 
         val domain = credentialsManager.requireActiveDomain()
-        val base = recipientOverride
-            ?: getConversationById(conversationId)?.participants
-            ?: return listOf()
-        val recipients =
-            (base + additionalRecipients).filter { it != domain }.distinct()
-        return recipients
+        fun compute(): List<OdinId>? {
+            val base = recipientOverride
+                ?: getConversationById(conversationId)?.participants
+                ?: return null
+            return (base + additionalRecipients).filter { it != domain }.distinct()
+        }
+
+        val first = compute()
+        if (recipientOverride == null &&
+            conversationId != ChatProtocol.ConversationWithYourselfId &&
+            first.isNullOrEmpty()
+        ) {
+            // The in-memory row may be a placeholder/Invalid map (participants=[]) or
+            // missing entirely (e.g. an archived 1:1 opened via Contacts) while the DB
+            // conversation file maps fine — re-map it into memory and try once more (#934).
+            loadConversation(conversationId)
+            return compute() ?: emptyList()
+        }
+        return first ?: emptyList()
     }
 
     private suspend fun updateShareCache(

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceRecipientRuleTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceRecipientRuleTest.kt
@@ -1,0 +1,250 @@
+package id.homebase.chat.services
+
+import id.homebase.api.client.drives.files.DriveOutboxUploader
+import id.homebase.api.client.drives.upload.UploadFileRequest
+import id.homebase.api.common.OdinId
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.sync.database.Outbox
+import id.homebase.chat.data.ConversationState
+import id.homebase.chat.data.ConversationUiModel
+import id.homebase.core.avatars.ConversationAvatarModel
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * Pins the explicit local-only rule in `ChatMessageSenderService.resolveRecipients`
+ * (#934). Local-only must be a deliberate classification, never an inference from
+ * an empty participant lookup:
+ *  - recipientOverride != null        -> caller forced the set (heal's emptyList())
+ *  - id == ConversationWithYourselfId -> note-to-self
+ *  - participants non-empty, all self -> legacy self-1:1
+ *  - anything else with zero resolved recipients -> throw; nothing enqueued.
+ *
+ * The regression this guards: an existing archived 1:1 whose in-memory row had
+ * empty participants was misclassified as note-to-self and uploaded with
+ * allowDistribution=false — "sent" locally, never delivered.
+ */
+class ChatMessageSenderServiceRecipientRuleTest {
+
+    /** Deserialize an outbox row as [UploadFileRequest], or null if it's a different type. */
+    private fun Outbox.asUploadFileRequestOrNull(): UploadFileRequest? {
+        if (this.uploadType != DriveOutboxUploader.UploadNewFile) return null
+        return try {
+            OdinSystemSerializer.deserialize<UploadFileRequest>(this.json.decodeToString())
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    /** Register a conversation whose in-memory row carries NO participants —
+     *  the corrupt/placeholder shape that used to be mistaken for note-to-self. */
+    private fun ChatMessageSenderServiceTestFixture.seedParticipantlessConversation(
+        conversationId: Uuid = Uuid.random(),
+    ): Uuid {
+        conversationLookup.register(
+            ConversationUiModel(
+                id = conversationId,
+                name = "broken",
+                lastMessage = "",
+                latestMessageTimestamp = Instant.fromEpochMilliseconds(0),
+                admins = setOf(OdinId(testDomain)),
+                unreadCount = 0,
+                avatarTiny = null,
+                avatarInitials = "",
+                avatarUrl = "",
+                participants = emptyList(),
+                lastRead = Instant.fromEpochMilliseconds(0),
+                avatarModel = ConversationAvatarModel(type = ConversationAvatarModel.Type.GroupFallback),
+                isGroup = false,
+                conversationState = ConversationState.Active,
+            )
+        )
+        return conversationId
+    }
+
+    @Test
+    fun participantlessConversation_sendThrows_andNothingIsEnqueued() = runTest {
+        ChatMessageSenderServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val conversationId = fixture.seedParticipantlessConversation()
+
+            assertFailsWith<IllegalStateException> {
+                service.sendNewMessage(
+                    messageUniqueId = Uuid.random(),
+                    conversationId = conversationId,
+                    messageText = "hi",
+                    previousMessageUniqueId = null,
+                    payloadBundle = null,
+                )
+            }
+            assertEquals(
+                0, fixture.outboxRowCount(),
+                "a refused send must not leave anything in the outbox"
+            )
+        }
+    }
+
+    @Test
+    fun legacySelfOneToOne_participantsAllSelf_isLocalOnly() = runTest {
+        ChatMessageSenderServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            // participants = [testDomain] only — a legacy chat-with-your-own-identity.
+            val conversationId = fixture.seedConversation(others = emptyList())
+
+            val messageId = Uuid.random()
+            service.sendNewMessage(
+                messageUniqueId = messageId,
+                conversationId = conversationId,
+                messageText = "to myself",
+                previousMessageUniqueId = null,
+                payloadBundle = null,
+            )
+
+            val request = fixture.drainOutboxInDependencyOrder()
+                .single { it.uniqueId == messageId }
+                .asUploadFileRequestOrNull()
+            assertNotNull(request)
+            assertFalse(request.metadata.allowDistribution, "self conversation must stay local-only")
+            assertTrue(request.transitOptions?.recipients.isNullOrEmpty())
+        }
+    }
+
+    @Test
+    fun noteToSelf_wellKnownId_isLocalOnly() = runTest {
+        ChatMessageSenderServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val conversationId = fixture.seedConversation(
+                conversationId = ChatProtocol.ConversationWithYourselfId,
+                others = emptyList(),
+            )
+
+            val messageId = Uuid.random()
+            service.sendNewMessage(
+                messageUniqueId = messageId,
+                conversationId = conversationId,
+                messageText = "note",
+                previousMessageUniqueId = null,
+                payloadBundle = null,
+            )
+
+            val request = fixture.drainOutboxInDependencyOrder()
+                .single { it.uniqueId == messageId }
+                .asUploadFileRequestOrNull()
+            assertNotNull(request)
+            assertFalse(request.metadata.allowDistribution)
+            assertTrue(request.transitOptions?.recipients.isNullOrEmpty())
+        }
+    }
+
+    @Test
+    fun explicitEmptyRecipientOverride_healContract_isLocalOnlyAndDoesNotThrow() = runTest {
+        ChatMessageSenderServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            // Conversation HAS a peer — the override must still win (GroupHealService
+            // forces a local-only status write with recipientOverride = emptyList()).
+            val conversationId = fixture.seedConversation(others = listOf("alice.test"))
+
+            val messageId = Uuid.random()
+            service.sendStatusMessage(
+                messageUniqueId = messageId,
+                conversationId = conversationId,
+                statusMessage = StatusMessageData(StatusMessage.GroupHealLocalCleanup),
+                previousMessageUniqueId = null,
+                payloadBundle = null,
+                additionalRecipients = emptyList(),
+                recipientOverride = emptyList(),
+            )
+
+            val request = fixture.drainOutboxInDependencyOrder()
+                .single { it.uniqueId == messageId }
+                .asUploadFileRequestOrNull()
+            assertNotNull(request)
+            assertFalse(request.metadata.allowDistribution, "explicit empty override = intentional local-only")
+            assertTrue(request.transitOptions?.recipients.isNullOrEmpty())
+        }
+    }
+
+    @Test
+    fun participantlessConversation_updateMessageThrows() = runTest {
+        ChatMessageSenderServiceTestFixture().use { fixture ->
+            val messageId = Uuid.random()
+            val versionTag = Uuid.random()
+            val conversationId = Uuid.random()
+            val keyHeader = id.homebase.api.client.KeyHeader.newRandom16()
+
+            val seededMessage = id.homebase.chat.data.MessageUiModel(
+                id = messageId,
+                globalTransitId = null,
+                fileId = Uuid.random(),
+                conversationId = conversationId,
+                content = "original",
+                userDate = Instant.fromEpochMilliseconds(1_000L),
+                modified = null,
+                created = Instant.fromEpochMilliseconds(1_000L),
+                originalAuthor = OdinId(fixture.testDomain),
+                sender = OdinId(fixture.testDomain),
+                displayName = fixture.testDomain,
+                isDeleted = false,
+                isPendingSend = false,
+                versionTag = versionTag,
+                messageAppData = MessageAppData(),
+                reactionPreview = null,
+                previewThumbnail = null,
+                payloads = kotlinx.collections.immutable.persistentListOf(),
+                keyHeader = keyHeader,
+                hasMore = false,
+            )
+            val service = fixture.build(
+                scope = this,
+                messageLookup = { _ ->
+                    object : MessageLookup by FakeMessageLookup() {
+                        override suspend fun getMessage(messageId: Uuid) =
+                            seededMessage.takeIf { it.id == messageId }
+                    }
+                },
+            )
+            fixture.seedParticipantlessConversation(conversationId)
+
+            assertFailsWith<IllegalStateException> {
+                service.updateMessage(
+                    messageId = messageId,
+                    versionTag = versionTag,
+                    content = "edited",
+                )
+            }
+            assertEquals(0, fixture.outboxRowCount(), "a refused edit must not enqueue anything")
+        }
+    }
+
+    @Test
+    fun normalOneToOne_distributesToPeer() = runTest {
+        ChatMessageSenderServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val conversationId = fixture.seedConversation(others = listOf("alice.test"))
+
+            val messageId = Uuid.random()
+            service.sendNewMessage(
+                messageUniqueId = messageId,
+                conversationId = conversationId,
+                messageText = "hello",
+                previousMessageUniqueId = null,
+                payloadBundle = null,
+            )
+
+            val request = fixture.drainOutboxInDependencyOrder()
+                .single { it.uniqueId == messageId }
+                .asUploadFileRequestOrNull()
+            assertNotNull(request)
+            assertTrue(request.metadata.allowDistribution)
+            assertEquals(listOf(OdinId("alice.test")), request.transitOptions?.recipients)
+            assertEquals(true, request.transitOptions?.useAppNotification)
+        }
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/MessageMapperDeliveryStatusTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/MessageMapperDeliveryStatusTest.kt
@@ -11,10 +11,12 @@ import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
 /**
- * Pure-function coverage for [getDeliveryStatus]. The 5 branches:
- *  - groupId == ConversationWithYourselfId → Read (chat with yourself never
- *    has a wire delivery story).
- *  - originalRecipientCount == 0 → Read (no one to deliver to).
+ * Pure-function coverage for [getDeliveryStatus]. The branches:
+ *  - groupId == ConversationWithYourselfId → Sent (chat with yourself never
+ *    has a wire delivery story — a double tick would contradict the empty
+ *    per-recipient transfer history, #934).
+ *  - originalRecipientCount == 0 → Sent (uploaded, nothing on the wire —
+ *    never double-tick).
  *  - transferHistory.summary == null → Sent (no information yet, optimistic).
  *  - summary.totalFailed > 0 → Failed (one failure poisons the whole
  *    message; the bubble shows the error).
@@ -25,25 +27,28 @@ import kotlin.uuid.Uuid
 class MessageMapperDeliveryStatusTest {
 
     @Test
-    fun groupIdIsConversationWithYourself_returnsRead() {
+    fun groupIdIsConversationWithYourself_returnsSent() {
         val header = buildHeader(
             groupId = ChatProtocol.ConversationWithYourselfId,
             originalRecipientCount = 0,
             transferHistoryJson = "null",
         )
-        assertEquals(ChatDeliveryStatus.Read, getDeliveryStatus(header))
+        assertEquals(ChatDeliveryStatus.Sent, getDeliveryStatus(header))
     }
 
     @Test
-    fun zeroRecipients_returnsRead() {
+    fun zeroRecipients_returnsSent() {
         // Some 1:1 conversations with self end up here too via originalRecipientCount=0
-        // even when groupId differs — the function falls through to this guard.
+        // even when groupId differs — the function falls through to this guard. A
+        // zero-recipient upload has an empty per-recipient transfer history, so the
+        // honest ceiling is a single tick: Read/Delivered here would render a double
+        // tick that message-info can never corroborate (#934).
         val header = buildHeader(
             groupId = Uuid.random(),
             originalRecipientCount = 0,
             transferHistoryJson = "null",
         )
-        assertEquals(ChatDeliveryStatus.Read, getDeliveryStatus(header))
+        assertEquals(ChatDeliveryStatus.Sent, getDeliveryStatus(header))
     }
 
     @Test


### PR DESCRIPTION
Closes #934.

## Bug A — silent local-only send

`isLocalOnly` was inferred from `recipients.isEmpty()`, and recipients came from the **in-memory** conversation list. An existing **archived** 1:1 opened via Contacts → Send message had a missing/participant-less in-memory row, so a real 1:1 was misclassified as note-to-self and uploaded with `allowDistribution=false` — "sent" locally, never delivered. Only a later *inbound* message repaired the state.

**Fix (three layers):**
1. **`ConversationStream.getRecipients`** — when the in-memory row is missing or has no participants (and there's no `recipientOverride`, and it's not note-to-self), re-map the DB conversation file into memory via `loadConversation` and recompute once. The DB file was always fine in the reported case — it was the in-memory copy that was stale.
2. **`ChatMessageSenderService.resolveRecipients`** — local-only is now an explicit decision, never an inference:
   - `recipientOverride != null` → caller forced the set (GroupHeal's `emptyList()` contract preserved)
   - `id == ConversationWithYourselfId` → note-to-self
   - participants non-empty but all-self → legacy self-1:1
   - anything else resolving to zero recipients **throws** — a real conversation can never be silently uploaded with "(no recipients)". The throw surfaces through the existing send/edit/resend error paths ("Failed to send message…" toast with input retained, "Failed to edit message…", `msg_retry_failed`). Applied at all 3 sites: `sendMessageInternal`, `updateMessage`, `resendMessage`.
3. **`createConversation` existing-file branch** — now re-maps the DB file into the in-memory list before returning, so the Contacts → archived-1:1 flow has participants at open time (layer 1 remains the send-time backstop).

## Bug B — two ticks with empty transfer history

`getDeliveryStatus` returned **`Read`** for `originalRecipientCount == 0` (and for the note-to-self groupId), so the zero-recipient upload rendered a read double-tick while message-info's per-recipient transfer history was correctly empty. Both guards now return **`Sent`** (single tick). Invariant: a double tick now requires `summary counts ≥ count > 0` ⇒ a non-empty transfer history — the two surfaces can no longer contradict.

Note: this visibly flips existing note-to-self / self-1:1 messages from double to single tick (bubble + conversation-list preview) — intended per the issue's acceptance criteria. Historical mis-sent messages stay undelivered but now show a truthful single tick.

## Tests
- `MessageMapperDeliveryStatusTest` — the two pinning tests updated to `Sent`.
- New `ChatMessageSenderServiceRecipientRuleTest` — participant-less send throws with zero outbox rows; legacy self-1:1 and note-to-self stay local-only; heal's `recipientOverride=emptyList()` contract unchanged; normal 1:1 regression (allowDistribution, recipients, useAppNotification); participant-less `updateMessage` throws.
- Full `:homebase-chat:jvmTest` green; JVM/Android/wasmJs compile green.

## Follow-up (not in this PR)
Moments has the same `isLocalOnly = recipients.isEmpty()` anti-pattern (`MomentsPostSenderService.kt:142/471/876/978`) — worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKxv1k187ynCjx6sVDC7NQ
