### PR TITLE
fix(db): bump schema to v6 — LocationPoint steps/bat shipped without a version bump (Location-tab crash)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
@@ -181,15 +181,26 @@ class DatabaseManager(
         val journalMode = readPragmaString("PRAGMA journal_mode") ?: "?"
         val busyTimeoutMs = readPragmaLong("PRAGMA busy_timeout") ?: -1L
         val synchronous = readPragmaLong("PRAGMA synchronous") ?: -1L
+        // schemaAtOpen: the '-- Version: N' stamp found on disk BEFORE any rebuild
+        // (-1 = fresh install). Logged unconditionally so a field crash report shows
+        // which schema shape the install was actually running — the stale-rebuild
+        // line above only fires when the versions differ.
         logger.i {
             "DB pragmas: journal_mode=$journalMode busy_timeout=${busyTimeoutMs}ms " +
-                "synchronous=$synchronous readParallelism=$READ_PARALLELISM"
+                "synchronous=$synchronous readParallelism=$READ_PARALLELISM " +
+                "schemaAtOpen=v$schemaVersionAtOpen current=v$DATABASE_VERSION"
         }
     }
 
     companion object {
-        private const val DATABASE_VERSION =
-            5  // Increase to wipe the database and rebuild all tables
+        // Increase to wipe the database and rebuild all tables. MUST be bumped together
+        // with the `-- Version: N` stamp in DriveMainIndex.sq WHENEVER any .sq CREATE
+        // TABLE shape changes: Schema.create() is CREATE IF NOT EXISTS, so on existing
+        // installs an un-bumped column addition leaves the old table in place while the
+        // generated queries reference the new columns — "no such column" crash at the
+        // first query (fileState on v5; LocationPoint.steps/bat on v6). SchemaVersionGuardTest
+        // pins both the stamp equality and the CREATE TABLE shapes.
+        internal const val DATABASE_VERSION = 6L
 
         // Max concurrent reads on [readDispatcher]. Kept in step with iOS
         // NativeSqliteDriver.maxReaderConnections=4 so the dispatcher doesn't admit more

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/DriveMainIndex.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/DriveMainIndex.sq
@@ -1,6 +1,6 @@
 import kotlin.uuid.Uuid;
 
-CREATE TABLE IF NOT EXISTS DriveMainIndex( -- Version: 5
+CREATE TABLE IF NOT EXISTS DriveMainIndex( -- Version: 6
    rowId INTEGER PRIMARY KEY AUTOINCREMENT,
    identityId BLOB AS Uuid NOT NULL,
    driveId BLOB AS Uuid NOT NULL,

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/SchemaVersionGuardTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/SchemaVersionGuardTest.kt
@@ -1,0 +1,95 @@
+package id.homebase.api.sync.database
+
+import java.io.File
+import java.security.MessageDigest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Drift guard for the wipe-on-version-bump migration model (no .sqm migrations here).
+ *
+ * `OdinDatabase.Schema.create()` runs `CREATE TABLE IF NOT EXISTS`, so on an EXISTING
+ * install a table whose .sq shape changed keeps its old on-disk shape — while the
+ * generated queries reference the new columns. The first such query throws
+ * "no such column" (fatal in any scope without a handler). This shipped twice:
+ * `DriveMainIndex.fileState` (fixed by the v5 bump) and `LocationPoint.steps/bat`
+ * (added 2026-06-14 with NO bump — crashed production testers opening the Location
+ * tab, fixed by the v6 bump).
+ *
+ * The rule this test enforces: ANY change to a CREATE TABLE shape must ride a
+ * version bump. On failure, do all three together:
+ *  1. bump [DatabaseManager.DATABASE_VERSION],
+ *  2. bump the `-- Version: N` stamp on DriveMainIndex.sq's CREATE TABLE,
+ *  3. update [EXPECTED_TABLE_SHAPE_SHA256] below.
+ * (CREATE INDEX changes are exempt: an index over existing columns applies cleanly
+ * to an old-shape table, and an index over a NEW column implies a table-shape
+ * change this hash already catches.)
+ */
+class SchemaVersionGuardTest {
+
+    @Test
+    fun versionStampInDriveMainIndexSq_matchesDatabaseVersionConstant() {
+        val stamped = Regex("-- Version: (\\d+)")
+            .find(driveMainIndexSq().readText())
+            ?.groupValues?.get(1)?.toLong()
+        assertEquals(
+            DatabaseManager.DATABASE_VERSION, stamped,
+            "DriveMainIndex.sq's '-- Version: N' stamp must equal DatabaseManager.DATABASE_VERSION — " +
+                "the on-disk stamp is what the stale-schema rebuild compares against",
+        )
+    }
+
+    @Test
+    fun createTableShapes_requireVersionBumpWhenChanged() {
+        val statements = sqldelightDir().walkTopDown()
+            .filter { it.isFile && it.extension == "sq" }
+            .sortedBy { it.name }
+            .flatMap { file ->
+                val noComments = file.readLines().joinToString("\n") { it.substringBefore("--") }
+                Regex("CREATE TABLE[^;]*;", RegexOption.DOT_MATCHES_ALL)
+                    .findAll(noComments)
+                    .map { it.value.split(Regex("\\s+")).joinToString(" ").trim() }
+            }
+            .toList()
+
+        assertEquals(
+            DatabaseManager.TABLE_NAMES.size, statements.size,
+            "CREATE TABLE count no longer matches DatabaseManager.TABLE_NAMES — " +
+                "a new table must be added there too (wipeAndRecreate/logout skips it otherwise)",
+        )
+
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest(statements.joinToString("\n").toByteArray())
+            .joinToString("") { "%02x".format(it) }
+        assertEquals(
+            EXPECTED_TABLE_SHAPE_SHA256, digest,
+            "A CREATE TABLE shape changed. Existing installs keep the OLD table shape " +
+                "(Schema.create is CREATE IF NOT EXISTS) and will crash with 'no such column' " +
+                "unless the schema version is bumped. Bump DatabaseManager.DATABASE_VERSION AND " +
+                "the '-- Version: N' stamp in DriveMainIndex.sq, then update this hash.",
+        )
+    }
+
+    private fun sqldelightDir(): File {
+        // Gradle runs jvmTest with the module directory as the working dir, but be
+        // tolerant of a repo-root working dir too.
+        val candidates = listOf(
+            File("src/commonMain/sqldelight"),
+            File("homebase-api/src/commonMain/sqldelight"),
+        )
+        val dir = candidates.firstOrNull { it.isDirectory }
+        assertTrue(dir != null, "could not locate the sqldelight source dir from ${File(".").absolutePath}")
+        return dir
+    }
+
+    private fun driveMainIndexSq(): File =
+        sqldelightDir().walkTopDown().first { it.name == "DriveMainIndex.sq" }
+
+    private companion object {
+        // SHA-256 over all CREATE TABLE statements (comments stripped, whitespace
+        // collapsed, files ordered by name). See the class kdoc before changing.
+        const val EXPECTED_TABLE_SHAPE_SHA256 =
+            "e1e996613607e0cc8584294f852d45a9d75b4f42772b22531648dce9497e1bb2"
+    }
+}


### PR DESCRIPTION
## Crash
Production tester (razr 60 ultra, 1.4.1765) crashed opening the Location tab: `SQLiteException: no such column: steps` compiling `LocationPointWrapper.selectLatest`, uncaught on main.

## Root cause (proven via git archaeology)
- `-- Version: 5` was stamped 2026-05-15 (`f555d9816`). The `LocationPoint` table didn't exist yet — it was introduced later **without a version bump**, created lazily on existing installs by `Schema.create()`'s `CREATE TABLE IF NOT EXISTS`.
- 2026-06-14 (`7e1210463`) added `steps`/`bat` columns to `LocationPoint.sq` — again **no bump**.
- A device whose `LocationPoint` table was created before June 14 keeps the old shape forever (`CREATE IF NOT EXISTS` no-ops, `5 == 5` skips the rebuild), while every generated query now selects `steps, bat` → crash on the first LocationPoint read. Same failure class as the documented `fileState` incident that motivated the v5 bump.
- Devs never saw it because our DBs were (re)created after June 14.

## Fix
- **v5 → v6** (`DATABASE_VERSION` + the `-- Version:` stamp): affected installs drop-and-rebuild once on next launch via the established mechanism (local DB is a resyncable cache; upgrade snackbar already exists). Un-flushed location points and queued outbox rows on stale installs are lost in the rebuild — inherent to the wipe model, same as every prior bump.
- **`SchemaVersionGuardTest`** (jvmTest): pins stamp == constant and a SHA-256 of every CREATE TABLE shape (comments stripped). Any future table-shape change without a bump fails CI with instructions instead of crashing testers. CREATE INDEX changes are deliberately exempt (safe on old shapes; an index over a new column implies a table change the hash catches).
- **Observability**: the always-on `DB pragmas:` log line now includes `schemaAtOpen=vN current=vM` — this crash report only let us *infer* v5 from the absence of the rebuild line.

## Verification
- `:homebase-api:jvmTest` green (guard included), JVM/Android/wasmJs compile green.
- Upgrade path: install a pre-June-14 build, use it, update to this build → one-time rebuild + snackbar, Location tab works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKxv1k187ynCjx6sVDC7NQ