### PR TITLE
feat(location): per-hop logging on the push→capture→upload chain (#988)

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/DriveFcmService.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/DriveFcmService.kt
@@ -7,6 +7,7 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
+import co.touchlab.kermit.Logger
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import id.homebase.core.notifications.NotificationService
@@ -23,6 +24,16 @@ class DriveFcmService : FirebaseMessagingService() {
     }
 
     override fun onMessageReceived(message: RemoteMessage) {
+        // Hop 1 of the push→capture chain (#988). priority vs originalPriority exposes an
+        // FCM/Doze downgrade (high requested, normal delivered = deferred delivery, #986).
+        // Kermit is initialized in MainApplication.onCreate, which always precedes service
+        // callbacks in this process.
+        Logger.i(tag = "PushCapture") {
+            val downgraded = if (message.priority != message.originalPriority) " (DOWNGRADED)" else ""
+            "received: priority=${pri(message.priority)} originalPriority=${pri(message.originalPriority)}" +
+                "$downgraded dataKeys=${message.data.size} notif=${message.notification != null}"
+        }
+
         // Hand the FCM payload to the shared NotificationEntry via a worker —
         // the worker runs the same onPushArrived(...) body iOS calls inline,
         // and WorkManager gives us OS-budgeted background guarantees that
@@ -30,6 +41,7 @@ class DriveFcmService : FirebaseMessagingService() {
         val inputData = Data.Builder().apply {
             putString(KEY_TITLE, message.notification?.title)
             putString(KEY_BODY, message.notification?.body)
+            putLong(KEY_ENQUEUED_AT_MS, System.currentTimeMillis())
             for ((k, v) in message.data) putString("$KEY_DATA_PREFIX$k", v)
         }.build()
 
@@ -47,6 +59,19 @@ class DriveFcmService : FirebaseMessagingService() {
                     .setInputData(inputData)
                     .build()
             )
+        // KEEP policy: a `received:`+`enqueue:` pair with NO subsequent "doWork: starting"
+        // means this push was coalesced into already-pending work (its payload dropped) —
+        // previously invisible in the log (#988).
+        Logger.i(tag = "PushCapture") {
+            "enqueue: uniqueWork=$WORK_TAG policy=KEEP expedited=downgradable-to-regular"
+        }
+    }
+
+    /** FCM priority ints per RemoteMessage: 1=high, 2=normal, 0=unknown. */
+    private fun pri(p: Int): String = when (p) {
+        RemoteMessage.PRIORITY_HIGH -> "high"
+        RemoteMessage.PRIORITY_NORMAL -> "normal"
+        else -> "unknown($p)"
     }
 
     companion object {
@@ -54,5 +79,6 @@ class DriveFcmService : FirebaseMessagingService() {
         const val KEY_TITLE = "fcm_title"
         const val KEY_BODY = "fcm_body"
         const val KEY_DATA_PREFIX = "fcm_data_"
+        const val KEY_ENQUEUED_AT_MS = "fcm_enqueued_at_ms"
     }
 }

--- a/androidApp/src/main/kotlin/id/homebase/feed/DriveSyncWorker.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/DriveSyncWorker.kt
@@ -17,7 +17,14 @@ class DriveSyncWorker(appContext: Context, params: WorkerParameters) :
     CoroutineWorker(appContext, params), KoinComponent {
 
     override suspend fun doWork(): Result {
-        Logger.i(tag = "DriveSyncWorker") { "doWork: starting (attempt=$runAttemptCount)" }
+        // queueLatencyMs = push-received → worker-run delay (#988). Under ExistingWorkPolicy.KEEP
+        // the stamp belongs to the FIRST enqueue of a coalesced group, so a large value alongside
+        // multiple "enqueue:" lines is coalescing/deferral evidence, not a clock bug.
+        val enqueuedAtMs = inputData.getLong(DriveFcmService.KEY_ENQUEUED_AT_MS, -1L)
+        Logger.i(tag = "DriveSyncWorker") {
+            val latency = if (enqueuedAtMs > 0) "${System.currentTimeMillis() - enqueuedAtMs}" else "unknown"
+            "doWork: starting (attempt=$runAttemptCount queueLatencyMs=$latency)"
+        }
         val title = inputData.getString(DriveFcmService.KEY_TITLE)
         val body = inputData.getString(DriveFcmService.KEY_BODY)
         val data = inputData.keyValueMap

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
@@ -227,7 +227,8 @@ class OutboxSync(
 
                 // if successful we remove it from the database
                 databaseManager.outbox.deleteByRowId(outboxRecord.rowId)
-                Logger.i("OutboxSync: completed uniqueId=${outboxRecord.uniqueId} uploadType=${outboxRecord.uploadTypeLabel()}")
+                // driveId included so a location-drive completion is directly greppable (#988).
+                Logger.i("OutboxSync: completed uniqueId=${outboxRecord.uniqueId} uploadType=${outboxRecord.uploadTypeLabel()} driveId=${outboxRecord.driveId}")
 
                 // We sent the item, send an event
                 eventBus.emit(

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LocationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LocationService.kt
@@ -191,7 +191,7 @@ class LocationService(
             nowMs = nowMs,
         )
         if (result is GpsFixResult.Success) {
-            router.submit(listOf(result.point)) // route so the fetched fix isn't wasted
+            router.submit(listOf(result.point), reason) // route so the fetched fix isn't wasted
             logger.i { "requestLatestGps($reason): fetched & routed (src=${result.point.src})" }
         } else {
             logger.i { "requestLatestGps($reason): fetch did not yield a fix ($result)" }
@@ -206,10 +206,14 @@ class LocationService(
      * Returns null when nothing wants a capture.
      */
     suspend fun forceCaptureIfTracking(reason: GpsRequestReason): GpsFixResult? {
+        // Info (not debug): a closed gate is the most common reason a push produced no fresh
+        // point (#988), and only Info+ lines mirror into Crashlytics breadcrumbs. Frequency is
+        // bounded by the triggers (push arrival, app-open) — no spam risk.
         if (!coordinator.isCaptureWanted()) {
-            logger.d { "forceCaptureIfTracking($reason): skipped — no persistent consumer wants GPS" }
+            logger.i { "forceCaptureIfTracking($reason): skipped — ${coordinator.captureGateExplanation()}" }
             return null
         }
+        logger.i { "forceCaptureIfTracking($reason): gate open — requesting fix" }
         return requestLatestGps(reason)
     }
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationFixRouter.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationFixRouter.kt
@@ -1,6 +1,7 @@
 package id.homebase.core.location.tracking
 
 import co.touchlab.kermit.Logger
+import id.homebase.core.location.GpsRequestReason
 
 /**
  * THE single home of the "what does a captured GPS fix do?" decision (issue #835). Every capture
@@ -24,13 +25,22 @@ import co.touchlab.kermit.Logger
 class LocationFixRouter(
     private val store: LocationPointStore,
     private val allowHistory: () -> Boolean,
-    private val persistAsHistory: suspend (List<RawLocationPoint>) -> Unit,
+    private val persistAsHistory: suspend (List<RawLocationPoint>, GpsRequestReason?) -> Unit,
     private val relayLatest: suspend (RawLocationPoint) -> Unit,
 ) : LocationPointSink {
 
     private val logger = Logger.withTag("LocationFixRouter")
 
-    override suspend fun submit(points: List<RawLocationPoint>) {
+    /** Continuous-tracker / background-batch path: no one-shot reason. */
+    override suspend fun submit(points: List<RawLocationPoint>) = submit(points, null)
+
+    /**
+     * [reason] is log-only context threaded through persist→flush (#988): a one-shot capture
+     * (e.g. [GpsRequestReason.PushReceived]) tags every downstream hop line and lets the
+     * uploader log its skip-gates at Info for push-triggered flushes without spamming the
+     * steady-state tracker path (null). No routing decision reads it.
+     */
+    suspend fun submit(points: List<RawLocationPoint>, reason: GpsRequestReason?) {
         val accepted = store.dedup(points)
         if (accepted.isEmpty()) {
             if (points.isNotEmpty()) {
@@ -46,7 +56,7 @@ class LocationFixRouter(
         // 2. History — only when allowed.
         val persisted = allowHistory()
         if (persisted) {
-            runCatching { persistAsHistory(accepted) }
+            runCatching { persistAsHistory(accepted, reason) }
                 .onFailure { logger.e(it) { "persistAsHistory failed" } }
         }
 
@@ -56,7 +66,7 @@ class LocationFixRouter(
 
         logger.i {
             val verb = if (persisted) "Routed" else "Routed (history off)"
-            "$verb ${accepted.size}/${points.size} fixes (last src=${latest.src})"
+            "$verb ${accepted.size}/${points.size} fixes (last src=${latest.src} reason=${reason ?: "tracker"})"
         }
     }
 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTrackingCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTrackingCoordinator.kt
@@ -111,6 +111,15 @@ class LocationTrackingCoordinator(
     fun isCaptureWanted(): Boolean =
         (preferences.allowLocationHistory.value || liveShareActive()) && canRunGps()
 
+    /**
+     * The [isCaptureWanted] inputs spelled out for the log, so a skipped push-capture line
+     * says WHICH condition closed the gate (#988) instead of just "skipped". All four reads
+     * are the same cheap, non-suspending calls [applyGpsHold] performs on every re-eval.
+     */
+    fun captureGateExplanation(): String =
+        "allowHistory=${preferences.allowLocationHistory.value} liveShare=${liveShareActive()} " +
+            "trackerAvailable=${tracker.isAvailable} permission=${isLocationPermissionGranted()}"
+
     /** The acquisition profile for the current foreground state + consumers (#846). */
     private fun currentProfile(): TrackingProfile =
         demand.resolveProfile(isForeground, preferences.allowLocationHistory.value, liveShareActive())

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.kt
@@ -1,5 +1,6 @@
 package id.homebase.core.location.tracking
 
+import co.touchlab.kermit.Logger
 import id.homebase.core.permissions.isLocationPermissionGranted
 import kotlin.time.Clock
 
@@ -51,14 +52,44 @@ interface OneShotLocationProvider {
         cacheOnly: Boolean = false,
         nowMs: () -> Long = { Clock.System.now().toEpochMilliseconds() },
     ): GpsFixResult {
-        if (!isLocationPermissionGranted()) return GpsFixResult.PermissionDenied
+        // Result logging lives HERE, in the shared policy method, so Android and iOS emit
+        // identical fix/timeout lines by construction (#988) — the platform actuals keep only
+        // their own low-level I/O breadcrumbs. Info level: these mirror into Crashlytics
+        // breadcrumbs and only fire behind LocationService's staleness + battery gates.
+        if (!isLocationPermissionGranted()) {
+            Logger.i(tag = TAG) { "getCurrentFix: permission denied" }
+            return GpsFixResult.PermissionDenied
+        }
         val cached = lastKnownFix()
         // Battery saver: serve whatever the OS already has and never power the radio.
-        if (cacheOnly) return cached?.let { GpsFixResult.Success(it) } ?: GpsFixResult.Unavailable
+        if (cacheOnly) {
+            val result = cached?.let { GpsFixResult.Success(it) } ?: GpsFixResult.Unavailable
+            Logger.i(tag = TAG) {
+                "getCurrentFix: battery-saver cache-only → " +
+                    (cached?.let { "cached fix (age=${nowMs() - it.t}ms)" } ?: "Unavailable")
+            }
+            return result
+        }
         // A cache fresher than the staleness tolerance avoids the radio; an older one falls through
         // so a force-on-stale capture actually acquires a fresh fix instead of echoing stale cache.
-        if (cached != null && nowMs() - cached.t <= maxAgeMs) return GpsFixResult.Success(cached)
-        return acquireFreshFix(timeoutMs)
+        if (cached != null && nowMs() - cached.t <= maxAgeMs) {
+            Logger.i(tag = TAG) {
+                "getCurrentFix: served cached fix (age=${nowMs() - cached.t}ms ≤ maxAge=${maxAgeMs}ms)"
+            }
+            return GpsFixResult.Success(cached)
+        }
+        Logger.d(tag = TAG) {
+            "getCurrentFix: acquiring fresh (timeoutMs=$timeoutMs cachedAgeMs=${cached?.let { nowMs() - it.t } ?: "none"})"
+        }
+        val fresh = acquireFreshFix(timeoutMs)
+        Logger.i(tag = TAG) {
+            "getCurrentFix: fresh result=" + when (fresh) {
+                is GpsFixResult.Success -> "Success src=${fresh.point.src}"
+                GpsFixResult.Timeout -> "Timeout (timeoutMs=$timeoutMs)"
+                else -> "$fresh"
+            }
+        }
+        return fresh
     }
 
     companion object {
@@ -66,6 +97,9 @@ interface OneShotLocationProvider {
 
         /** Default max age for accepting an OS last-known fix before forcing a live acquisition. */
         const val DEFAULT_MAX_AGE_MS = 15_000L
+
+        /** Shared tag for the policy-level result lines (platform actuals keep their own tags). */
+        const val TAG = "OneShotLocation"
     }
 }
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationEntry.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationEntry.kt
@@ -4,12 +4,14 @@ import co.touchlab.kermit.Logger
 import id.homebase.core.auth.AuthConnectionCoordinator
 import id.homebase.core.location.GpsRequestReason
 import id.homebase.core.location.LocationService
+import id.homebase.core.location.tracking.GpsFixResult
 import id.homebase.core.sync.BackgroundSyncOrchestrator
 import id.homebase.core.sync.SyncOutcome
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.koin.mp.KoinPlatformTools
+import kotlin.time.Clock
 
 /**
  * Single shared entry point that every platform glue funnels into for the two
@@ -62,8 +64,19 @@ class NotificationEntry(
         // tracking is on and the last one is stale (#878). Best-effort within the short FCM window
         // (the primitive uses a short background timeout + last-known fallback); never fail the push
         // sync over it. Won't help the no-signal case (no cell → no push), but adds samples whenever
-        // the user is reachable.
+        // the user is reachable. The result is logged here (#988) so the push tag alone answers
+        // "did this push produce a point" without cross-referencing LocationService lines.
         runCatching { locationService.forceCaptureIfTracking(GpsRequestReason.PushReceived) }
+            .onSuccess { fix ->
+                Logger.i(tag = "PushCapture") {
+                    "capture(PushReceived): " + when (fix) {
+                        null -> "skipped (gate closed — see forceCaptureIfTracking line)"
+                        is GpsFixResult.Success ->
+                            "fix src=${fix.point.src} ageMs=${Clock.System.now().toEpochMilliseconds() - fix.point.t}"
+                        else -> "$fix"
+                    }
+                }
+            }
             .onFailure { Logger.w(tag = "NotificationEntry", throwable = it) { "push force-capture failed" } }
         return outcome
     }
@@ -94,8 +107,15 @@ class NotificationEntry(
         onComplete: (success: Boolean) -> Unit,
     ) {
         CoroutineScope(Dispatchers.Default).launch {
+            Logger.i(tag = "PushCapture") { "handler: onPushArrivedAsync entered dataKeys=${data.size}" }
             val outcome = runCatching { onPushArrived(title, body, data) }
                 .getOrElse { SyncOutcome.Failed(it) }
+            // Ordering of this line vs LocationTrackUploader's "Hour-file upload confirmed"
+            // answers "did the upload land before iOS suspended us" (#988): a confirm line
+            // AFTER this one means the outbox was still draining past the fetch window.
+            Logger.i(tag = "PushCapture") {
+                "handler: complete success=${outcome is SyncOutcome.Success} outcome=${outcome::class.simpleName}"
+            }
             onComplete(outcome is SyncOutcome.Success)
         }
     }

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/LocationServiceTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/LocationServiceTest.kt
@@ -23,6 +23,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * Pins [LocationService.requestLatestGps] / [LocationService.forceCaptureIfTracking]: the
@@ -37,6 +38,9 @@ import kotlin.test.assertNull
 class LocationServiceTest {
 
     private val now = 1_000_000L
+
+    /** Reasons observed by the fixture's persistAsHistory (cleared per runServiceTest). */
+    private val persistReasons = mutableListOf<GpsRequestReason?>()
 
     private fun point(t: Long, lon: Double = 13.0) =
         RawLocationPoint(t = t, lat = 52.0, lon = lon, acc = 10.0, src = "gps", fg = true)
@@ -101,13 +105,17 @@ class LocationServiceTest {
             readDispatcher = dispatcher,
         )
         try {
+            persistReasons.clear()
             val preferences = LocationPreferences(db)
             if (allowHistory) preferences.setAllowLocationHistory(true)
             val store = LocationPointStore(db, NoSensors())
             val router = LocationFixRouter(
                 store = store,
                 allowHistory = { preferences.allowLocationHistory.value },
-                persistAsHistory = { store.persistHistory(it) },
+                persistAsHistory = { points, reason ->
+                    persistReasons += reason
+                    store.persistHistory(points)
+                },
                 relayLatest = { },
             )
             val coordinator = LocationTrackingCoordinator(preferences, tracker, this)
@@ -357,6 +365,42 @@ class LocationServiceTest {
             assertIs<GpsFixResult.Success>(result)
             assertEquals(1, oneShot.freshCalls)
             assertEquals(990_000, store.lastPoint.value?.t) // routed + persisted (history on)
+            // #988: the capture reason threads all the way through router → persist,
+            // so the uploader's hop lines carry PushReceived.
+            assertEquals(listOf<GpsRequestReason?>(GpsRequestReason.PushReceived), persistReasons)
+        }
+    }
+
+    // ── captureGateExplanation (#988): the skipped-capture log breakdown ──
+
+    @Test
+    fun captureGateExplanationNamesTheClosedCondition() {
+        val oneShot = FakeOneShot()
+        runServiceTest(permission = true, oneShot = oneShot, tracker = UnavailableTracker) { service, _, _ ->
+            service.forceCaptureIfTracking(GpsRequestReason.PushReceived) // exercise the skip path
+        }
+        // Direct coordinator assertions (pure string; no service needed).
+        runTest {
+            val db = DatabaseManager(
+                { JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY) },
+                dispatcher = StandardTestDispatcher(testScheduler),
+                readDispatcher = StandardTestDispatcher(testScheduler),
+            )
+            try {
+                val preferences = LocationPreferences(db)
+                val closed = LocationTrackingCoordinator(preferences, UnavailableTracker, this)
+                    .captureGateExplanation()
+                assertTrue("trackerAvailable=false" in closed, closed)
+                assertTrue("allowHistory=false" in closed, closed)
+
+                preferences.setAllowLocationHistory(true)
+                val open = LocationTrackingCoordinator(preferences, AvailableTracker, this)
+                    .captureGateExplanation()
+                assertTrue("allowHistory=true" in open, open)
+                assertTrue("trackerAvailable=true" in open, open)
+            } finally {
+                db.close()
+            }
         }
     }
 

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/tracking/LocationFixRouterTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/tracking/LocationFixRouterTest.kt
@@ -2,6 +2,7 @@ package id.homebase.core.location.tracking
 
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.core.location.GpsRequestReason
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -28,6 +29,7 @@ class LocationFixRouterTest {
 
     private class Captured {
         val persisted = mutableListOf<List<RawLocationPoint>>()
+        val persistReasons = mutableListOf<GpsRequestReason?>()
         val relayed = mutableListOf<RawLocationPoint>()
     }
 
@@ -47,7 +49,10 @@ class LocationFixRouterTest {
             val router = LocationFixRouter(
                 store = store,
                 allowHistory = { allowHistory },
-                persistAsHistory = { cap.persisted += it },
+                persistAsHistory = { points, reason ->
+                    cap.persisted += points
+                    cap.persistReasons += reason
+                },
                 relayLatest = { cap.relayed += it },
             )
             body(router, store, cap)
@@ -96,5 +101,20 @@ class LocationFixRouterTest {
         router.submit(emptyList())
         assertTrue(cap.persisted.isEmpty())
         assertTrue(cap.relayed.isEmpty())
+    }
+
+    @Test
+    fun oneShotReason_isForwardedToPersist() = runRouterTest(allowHistory = true) { router, _, cap ->
+        // #988: the capture reason threads through persist so the uploader can tag its
+        // hop lines (and log skip-gates at Info for push-triggered flushes).
+        router.submit(listOf(point(t = 1_000)), GpsRequestReason.PushReceived)
+        assertEquals(listOf<GpsRequestReason?>(GpsRequestReason.PushReceived), cap.persistReasons)
+    }
+
+    @Test
+    fun interfaceSubmit_forwardsNullReason() = runRouterTest(allowHistory = true) { router, _, cap ->
+        // The continuous-tracker path (LocationPointSink interface) carries no reason.
+        router.submit(listOf(point(t = 1_000)))
+        assertEquals(listOf<GpsRequestReason?>(null), cap.persistReasons)
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -255,10 +255,11 @@ val appModule = module {
             // persist iff history on; a live share's fixes relay but aren't recorded (#823).
             allowHistory = { get<LocationPreferences>().allowLocationHistory.value },
             // History: persist + drain to hour files (rate-gated). Lazy get() avoids the
-            // construction-time cycle; runs only when history is on.
-            persistAsHistory = { points ->
+            // construction-time cycle; runs only when history is on. The reason is log-only
+            // context (#988): push-triggered flushes log their skip-gates at Info.
+            persistAsHistory = { points, reason ->
                 get<LocationPointStore>().persistHistory(points)
-                get<LocationTrackUploaderService>().flushIfDue()
+                get<LocationTrackUploaderService>().flushIfDue(reason)
             },
             // Live: relay the latest fix. Rides this same background-capable seam (NOT a UI Flow) so
             // it fires on cold-woken background points; self-gates on the share roster.

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationTrackUploaderService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationTrackUploaderService.kt
@@ -22,6 +22,7 @@ import id.homebase.api.sync.database.enqueued
 import id.homebase.upload.PayloadBundle
 import id.homebase.core.config.locationLabeledDrive
 import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.core.location.GpsRequestReason
 import id.homebase.core.location.tracking.LocationDeviceId
 import id.homebase.core.location.tracking.deviceDisplayName
 import id.homebase.core.location.tracking.devicePlatform
@@ -117,10 +118,23 @@ class LocationTrackUploaderService(
         deviceProfileEnsured = false
     }
 
-    /** Rate-gated flush — the entry point for tickers and background batch wakes. */
-    suspend fun flushIfDue() {
+    /**
+     * Rate-gated flush — the entry point for tickers and background batch wakes.
+     *
+     * [reason] is log-only (#988): a one-shot capture reason (e.g. PushReceived) promotes the
+     * skip-gate lines to Info so a dropped push-capture upload is diagnosable from the log,
+     * while the steady-state tracker/ticker path (null) keeps them at debug — this method runs
+     * on every persisted point batch, so unconditional Info would spam.
+     */
+    suspend fun flushIfDue(reason: GpsRequestReason? = null) {
         val now = nowMs()
-        if (now - lastFlushAttemptMs < MIN_FLUSH_INTERVAL_MS) return
+        if (now - lastFlushAttemptMs < MIN_FLUSH_INTERVAL_MS) {
+            logSkip(reason) {
+                "flushIfDue(${reason ?: "periodic"}): rate-gated " +
+                    "(nextEligibleInMs=${MIN_FLUSH_INTERVAL_MS - (now - lastFlushAttemptMs)})"
+            }
+            return
+        }
         val powerSave = powerSaveMode()
         val foreground = isAppForeground()
         // Battery saver + backgrounded → defer uploads to save power; local capture still persists
@@ -134,23 +148,31 @@ class LocationTrackUploaderService(
             false
         }
         if (shouldDeferBackgroundFlush(powerSave, foreground, hasStaleBacklog)) {
-            logger.d { "Flush deferred: battery saver on + backgrounded, no >${STALE_BACKLOG_MS}ms un-uploaded backlog" }
+            logSkip(reason) {
+                "Flush deferred: battery saver on + backgrounded, no >${STALE_BACKLOG_MS}ms " +
+                    "un-uploaded backlog (reason=${reason ?: "periodic"})"
+            }
             return
         }
-        flush()
+        flush(reason)
     }
 
-    suspend fun flush() {
+    /** Info for one-shot (push) triggered flushes, debug for the steady-state path (#988). */
+    private inline fun logSkip(reason: GpsRequestReason?, crossinline message: () -> String) {
+        if (reason != null) logger.i { message() } else logger.d { message() }
+    }
+
+    suspend fun flush(reason: GpsRequestReason? = null) {
         flushMutex.withLock {
             val now = nowMs()
             lastFlushAttemptMs = now
             if (!optionalDriveActivation.isActivated(locationLabeledDrive)) {
-                logger.d { "Flush skipped: Location add-on not activated (drive not mounted)" }
+                logSkip(reason) { "Flush skipped: Location add-on not activated (drive not mounted) reason=${reason ?: "periodic"}" }
                 return
             }
             if (credentialsManager.getActiveCredentials() == null) {
                 // Logged out / not yet logged in: points stay buffered.
-                logger.d { "Flush skipped: no active credentials — points stay buffered" }
+                logSkip(reason) { "Flush skipped: no active credentials — points stay buffered reason=${reason ?: "periodic"}" }
                 return
             }
             val hours = runCatching { buffer.selectPendingHours() }
@@ -172,7 +194,7 @@ class LocationTrackUploaderService(
                 // viewer devices (desktop/web) never reach this branch.
                 runCatching { ensureDeviceProfile() }
                     .onFailure { logger.e(it) { "ensureDeviceProfile failed" } }
-                logger.d { "Flush: ${hours.size} pending hour(s), ${finalizeHours.size} closed to finalize" }
+                logger.d { "Flush: ${hours.size} pending hour(s), ${finalizeHours.size} closed to finalize reason=${reason ?: "periodic"}" }
             }
             for (hourBucket in hours + finalizeHours) {
                 runCatching { flushHour(hourBucket * HOUR_MS) }

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/notifications/PushChainLogging.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/notifications/PushChainLogging.kt
@@ -1,0 +1,18 @@
+package id.homebase.core.notifications
+
+import co.touchlab.kermit.Logger
+
+/**
+ * Swift-callable breadcrumb for the push→capture→upload chain (#988) — lands in
+ * homebase.log via Kermit's file writer (initialized by `initializeApp()` in
+ * `didFinishLaunchingWithOptions`, which UIKit guarantees runs before any
+ * `didReceiveRemoteNotification` delivery). Mirrors the `logPrevention` pattern
+ * (IosGpuTextDiagnostics). Exported as `PushChainLoggingKt.logPushChain(hop:detail:)`.
+ *
+ * Hops 2+ are logged by the shared commonMain pipeline (NotificationEntry →
+ * LocationService → uploader) under the same tag — Swift only owns hop 1 (arrival),
+ * the single genuinely platform-specific step.
+ */
+fun logPushChain(hop: String, detail: String) {
+    Logger.i(tag = "PushCapture") { "$hop: $detail" }
+}

--- a/iosApp/NotificationServiceExtension/NotificationService.swift
+++ b/iosApp/NotificationServiceExtension/NotificationService.swift
@@ -1,6 +1,7 @@
 import UserNotifications
 import Intents
 import FirebaseCore
+import os
 #if canImport(HomebaseNotifKit)
 import HomebaseNotifKit
 #endif
@@ -21,6 +22,14 @@ class NotificationService: UNNotificationServiceExtension {
         if FirebaseApp.app() == nil {
             FirebaseApp.configure()
         }
+
+        // Push-chain breadcrumb (#988), Console.app-only by design: the NSE is a separate
+        // process — Kermit/homebase.log is not initialized here and two-process writes to
+        // the rolling log file are unsafe. The NSE only decorates the visible notification;
+        // the capture chain (onPushArrived → forceCapture → upload) runs in the main app's
+        // didReceiveRemoteNotification, whose hops DO land in homebase.log.
+        os_log("NSE didReceive: mutable-content push arrived (dataKeys=%d)",
+               (request.content.userInfo.count))
 
         self.contentHandler = contentHandler
         bestAttemptContent = request.content.mutableCopy() as? UNMutableNotificationContent

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -181,6 +181,13 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
           guard let key = k as? String, key != "aps" else { continue }
           if let str = v as? String { data[key] = str }
       }
+      // Hop 1 of the push→capture chain (#988) — lands in homebase.log via the exported
+      // Kotlin bridge (Kermit is up: initializeApp ran in didFinishLaunching). appState
+      // raw values: 0=active, 1=inactive, 2=background. The delegate runs on the main
+      // thread, so reading applicationState here is legal.
+      PushChainLoggingKt.logPushChain(
+          hop: "received(ios)",
+          detail: "appState=\(application.applicationState.rawValue) hasAps=\(aps != nil) dataKeys=\(data.count)")
       let entry = NotificationEntry.companion.fromKoin()
       entry.onPushArrivedAsync(title: title, body: body, data: data) { success in
           completionHandler(success == true ? .newData : .failed)


### PR DESCRIPTION
Closes #988.

## What

Every hop of the push→capture→upload chain now logs — reading `homebase.log` alone answers "did the push produce a fresh point, and if not, which hop dropped it." New lines use tag **`PushCapture`** at Info (Info+ mirrors into Crashlytics breadcrumbs); the full chain greps with:

```
grep -E "PushCapture|PushReceived|Hour-file upload|OutboxSync: (sending|completed)" homebase.log
```

| Hop | Line |
|---|---|
| 1 received (Android) | `PushCapture: received: priority=normal originalPriority=high (DOWNGRADED) dataKeys=6 notif=false` |
| 1b handoff | `PushCapture: enqueue: uniqueWork=drive_fcm_sync policy=KEEP expedited=downgradable-to-regular` |
| 1 received (iOS) | `PushCapture: received(ios): appState=2 hasAps=true dataKeys=4` |
| 2 handler (Android) | `doWork: starting (attempt=0 queueLatencyMs=843)` |
| 2 handler (common) | `PushCapture: handler: onPushArrivedAsync entered dataKeys=4` |
| 3b capture result | `PushCapture: capture(PushReceived): fix src=gps ageMs=1204` |
| 3c handler done | `PushCapture: handler: complete success=true outcome=Success` |
| 4 gate | `forceCaptureIfTracking(PushReceived): skipped — allowHistory=false liveShare=false trackerAvailable=true permission=true` |
| 5 fix | `OneShotLocation: getCurrentFix: fresh result=Timeout (timeoutMs=5000)` |
| 6 flush skip | `flushIfDue(PushReceived): rate-gated (nextEligibleInMs=41200)` — **previously logged NOTHING** |
| 7 confirm | `OutboxSync: completed uniqueId=… driveId=…` + existing `Hour-file upload confirmed uid=…` |

## Streamlining (platform-drift reduction)

- **Reason threading**: `GpsRequestReason?` flows capture→`LocationFixRouter.submit`→`persistAsHistory`→`flushIfDue` (log-only; `null` = continuous tracker). Push-triggered flushes log their skip-gates at **Info**; the steady-state per-batch path stays at debug — no spam (`flushIfDue` runs every ~15–30 s during foreground tracking).
- **Hop-5 lives in common `getCurrentFix`** (the #886 policy seam, previously unlogged) — both platforms emit identical fix/timeout lines by construction. The Android timeout path is visible for the first time.
- **One Swift→Kotlin bridge** (`PushChainLoggingKt.logPushChain`, `logPrevention` pattern) — iOS hop-1 lands in homebase.log.

## Previously-invisible failure modes now visible

- FCM priority downgrade (`(DOWNGRADED)` marker — #986 evidence straight from a tester log).
- KEEP-coalescing: a `received:`+`enqueue:` pair with no following `doWork: starting` = push swallowed by pending work.
- Worker deferral: `queueLatencyMs` (stamp = first enqueue of a coalesced group — commented).
- Closed capture gate WITH the failing condition named (`captureGateExplanation`).
- iOS suspension race: `handler: complete` vs `Hour-file upload confirmed` line ordering.
- NSE: `os_log` breadcrumb only, with a comment (separate process — Kermit/homebase.log not initialized there; it never runs the capture chain).

## Tests / verification
- `LocationFixRouterTest`: reason forwarded (PushReceived + interface-null paths).
- `LocationServiceTest`: end-to-end threading (`forceCaptureProceedsWhenHistoryOn` asserts persist saw `PushReceived`); `captureGateExplanation` names closed/open conditions.
- `homebase-common`/`core`/`api` jvmTest green; Android + wasmJs + `:androidApp:compileDebugKotlin` green.
- ⚠️ iOS leg (nativeMain `PushChainLogging.kt` + the two Swift edits) needs a macOS/Xcode compile — Linux host here; please let CI/Mac verify before merge.

## Out of scope (unchanged behavior)
Awaiting capture+upload before the iOS `completionHandler` (#953), FCM priority fix (#986), `KEEP`→`APPEND` policy change, NSE→homebase.log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKxv1k187ynCjx6sVDC7NQ
