### PR TITLE
fix(location): broken-cloud must not stick — 60s verify cache only for data-bearing Active (#985)

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
@@ -461,8 +461,9 @@ private fun PeopleListBody(
 ) {
     var expanded by remember { mutableStateOf(false) }
     // Report every open/close so the (optional) per-entry preflight loop starts on each expand and
-    // stops on collapse; per-row results younger than the TTL are skipped downstream, so a quick
-    // re-expand is cheap. Leaving composition (navigating away) counts as a close.
+    // stops on collapse; successful data-bearing results younger than the TTL are skipped
+    // downstream, so a quick re-expand is cheap — error/no-data rows re-verify on every expand
+    // so a broken cloud can't stick (#985). Leaving composition (navigating away) counts as a close.
     LaunchedEffect(expanded) { onExpandedChange?.invoke(expanded) }
     DisposableEffect(Unit) { onDispose { onExpandedChange?.invoke(false) } }
     when {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
@@ -68,10 +68,10 @@ data class LocationUiState(
  * Result of the per-entry temporal-access preflight for a "who I can locate" row. Expand-triggered
  * verifies show a spinner (visible feedback that the check is running); the periodic follow-up
  * passes while the section stays open are silent (the old value stays visible until the new result
- * lands, so the list doesn't flash spinners every minute). Resolved results carry
- * [Resolved.verifiedAtMs] so a re-expand within [LOCATE_VERIFY_TTL_MS] reuses them, while an older
- * result is re-verified (#950) — including [Unreachable], which retries on the next pass instead
- * of blanking the row.
+ * lands, so the list doesn't flash spinners every minute). Only a successful, data-bearing
+ * [Active] carries the [LOCATE_VERIFY_TTL_MS] cache ("they sent data back within 60s", #950);
+ * [Broken], [Unreachable], and a no-data [Active] re-verify on every pass so an error state
+ * clears the moment access/data returns instead of sticking across collapse/expand (#985).
  */
 sealed interface LocateVerifyStatus {
     /** Preflight in flight with the spinner requested (expand-triggered, or no prior result). */
@@ -90,13 +90,14 @@ sealed interface LocateVerifyStatus {
 
     /**
      * The verify threw (network/parse failure) — the peer's server is unreachable and access is
-     * unknown → disconnected icon. Inconclusive, so it must never look like [Broken]; being
-     * [Resolved] it is retried after the TTL like any other result.
+     * unknown → disconnected icon. Inconclusive, so it must never look like [Broken]; like every
+     * error result it is re-verified on the next pass (#985) instead of blanking the row.
      */
     data class Unreachable(override val verifiedAtMs: Long) : Resolved
 }
 
-/** Freshness window for a resolved locate-verify result: re-expands inside it reuse the cache. */
+/** Freshness window for a successful, DATA-BEARING locate-verify result: re-expands inside it
+ *  reuse the cache. Error/no-data results never cache (#985). */
 const val LOCATE_VERIFY_TTL_MS = 60_000L
 
 /** Age past which a locate row's freshness label renders in the warning (orange) color (#879). */
@@ -104,13 +105,21 @@ const val LOCATE_AGE_WARN_MS = 2 * 60 * 60_000L
 
 /**
  * Whether a verify pass over "Who you can locate" should (re-)issue the temporal verify for a row
- * in this state: never while one is in flight, not while a resolved result is younger than
- * [LOCATE_VERIFY_TTL_MS], otherwise yes (never verified, or gone stale — including a stale
- * [LocateVerifyStatus.Unreachable], so a network blip retries instead of sticking).
+ * in this state: never while one is in flight; a successful DATA-BEARING [LocateVerifyStatus.Active]
+ * younger than [LOCATE_VERIFY_TTL_MS] is reused (the #950 "they sent data back within 60s" cache);
+ * everything else — [LocateVerifyStatus.Broken], [LocateVerifyStatus.Unreachable], a no-data
+ * Active, stale, or never verified — re-verifies, so an error state never sticks across
+ * collapse/expand (#985).
  */
 fun LocateVerifyStatus?.needsReverify(nowMs: Long): Boolean = when (this) {
     LocateVerifyStatus.Loading -> false
-    is LocateVerifyStatus.Resolved -> nowMs - verifiedAtMs >= LOCATE_VERIFY_TTL_MS
+    // Only a successful, data-bearing result earned the cache. A no-data Active re-verifies so
+    // a peer whose GPS just started reporting shows up on the next expand.
+    is LocateVerifyStatus.Active ->
+        newestModifiedMs == null || nowMs - verifiedAtMs >= LOCATE_VERIFY_TTL_MS
+    // Broken / Unreachable: an error result never caches — re-verify on every pass so a broken
+    // cloud clears the moment access/data returns (#985).
+    is LocateVerifyStatus.Resolved -> true
     null -> true
 }
 

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/LocateVerifyFreshnessTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/LocateVerifyFreshnessTest.kt
@@ -5,14 +5,18 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
- * Pins the 60s freshness contract for the "who I can locate" temporal verify (#950).
+ * Pins the 60s freshness contract for the "who I can locate" temporal verify (#950, refined by
+ * #985).
  *
- * Regression: the expand guard skipped every already-resolved row for the ViewModel's whole
+ * #950 regression: the expand guard skipped every already-resolved row for the ViewModel's whole
  * lifetime, so the verify only ever ran once per contact — a re-expand showed no spinner and a
- * frozen first-expand age. The guard now keys on [needsReverify]: in-flight still short-circuits
- * (no double-fire), a resolved result younger than [LOCATE_VERIFY_TTL_MS] is reused (instant
- * re-expand by design), and anything older — or never verified / dropped as inconclusive —
- * re-issues the verify.
+ * frozen first-expand age. The guard keys on [needsReverify]: in-flight still short-circuits
+ * (no double-fire), and a never-verified row always fires.
+ *
+ * #985 refinement: the TTL cache applies ONLY to a successful, DATA-BEARING [LocateVerifyStatus.Active]
+ * ("they sent data back within 60s"). [LocateVerifyStatus.Broken], [LocateVerifyStatus.Unreachable],
+ * and a no-data Active re-verify on EVERY pass — previously a broken-cloud row was cached like a
+ * success and stuck across collapse/expand within the TTL.
  */
 class LocateVerifyFreshnessTest {
 
@@ -31,11 +35,19 @@ class LocateVerifyFreshnessTest {
     }
 
     @Test
-    fun freshResultsAreReused() {
+    fun freshDataBearingActiveIsReused() {
         val justVerified = now - 1_000
         assertFalse(LocateVerifyStatus.Active(newestModifiedMs = 123L, verifiedAtMs = justVerified).needsReverify(now))
-        assertFalse(LocateVerifyStatus.Active(newestModifiedMs = null, verifiedAtMs = justVerified).needsReverify(now))
-        assertFalse(LocateVerifyStatus.Broken(verifiedAtMs = justVerified).needsReverify(now))
+    }
+
+    @Test
+    fun freshErrorAndNoDataStatesReverify() {
+        // #985: only "they sent data back" earns the cache — a fresh Broken/Unreachable/no-data
+        // result re-verifies on the very next expansion so it clears the moment access returns.
+        val justVerified = now - 1_000
+        assertTrue(LocateVerifyStatus.Broken(verifiedAtMs = justVerified).needsReverify(now))
+        assertTrue(LocateVerifyStatus.Unreachable(verifiedAtMs = justVerified).needsReverify(now))
+        assertTrue(LocateVerifyStatus.Active(newestModifiedMs = null, verifiedAtMs = justVerified).needsReverify(now))
     }
 
     @Test
@@ -43,6 +55,7 @@ class LocateVerifyFreshnessTest {
         val stale = now - LOCATE_VERIFY_TTL_MS - 1
         assertTrue(LocateVerifyStatus.Active(newestModifiedMs = 123L, verifiedAtMs = stale).needsReverify(now))
         assertTrue(LocateVerifyStatus.Broken(verifiedAtMs = stale).needsReverify(now))
+        assertTrue(LocateVerifyStatus.Unreachable(verifiedAtMs = stale).needsReverify(now))
     }
 
     @Test
@@ -55,18 +68,5 @@ class LocateVerifyFreshnessTest {
     fun justUnderTtlIsReused() {
         val justUnder = now - LOCATE_VERIFY_TTL_MS + 1
         assertFalse(LocateVerifyStatus.Active(newestModifiedMs = 123L, verifiedAtMs = justUnder).needsReverify(now))
-    }
-
-    // Unreachable (verify threw, #879) is Resolved: a network blip is retried after the TTL like
-    // any other result, instead of the old drop-the-key-and-blank behavior.
-
-    @Test
-    fun freshUnreachableIsNotRetriedYet() {
-        assertFalse(LocateVerifyStatus.Unreachable(verifiedAtMs = now - 1_000).needsReverify(now))
-    }
-
-    @Test
-    fun staleUnreachableRetries() {
-        assertTrue(LocateVerifyStatus.Unreachable(verifiedAtMs = now - LOCATE_VERIFY_TTL_MS).needsReverify(now))
     }
 }


### PR DESCRIPTION
Closes #985.

## Bug
`needsReverify` (`LocationUiState.kt`) applied the 60s TTL to **every** `Resolved` state, so a `Broken` row (CloudOff) — and equally `Unreachable` or a no-data `Active` — was cached exactly like a successful result. Collapse → re-expand within 60s: no re-verify, broken cloud sticks.

## Fix
The #950 cache ('they **sent data back** within 60s') now applies **only to a successful, data-bearing `Active`**:

- `Active(newestModifiedMs != null)` younger than TTL → reused (instant re-expand, no POST) — unchanged.
- `Broken` / `Unreachable` / `Active(newestModifiedMs = null)` → **re-verify on every pass**: each expansion retries (spinner), and the 60s loop retries while the section stays open — the broken cloud clears the moment access/data returns.
- `Loading` still never double-fires; extra POSTs are bounded to one per row per expand + per loop tick.

No ViewModel changes — the verify loop already keys on `needsReverify`; spinner semantics (expand = spinner, periodic = silent) unchanged. KDocs on `LocateVerifyStatus`/`LOCATE_VERIFY_TTL_MS`/`needsReverify` and the `PeopleListBody` comment updated to the refined contract.

**Out of scope** (per issue): why the peer verifies `!hasAccess` in the first place — #961 territory; this PR only stops the state from sticking.

## Tests
`LocateVerifyFreshnessTest` re-pinned: fresh data-bearing Active reused; fresh Broken/Unreachable/no-data Active re-verify; stale/at-TTL/under-TTL boundaries kept. `homebase-core` jvmTest + Android + wasmJs compiles green.

Manual repro (issue steps): expand with a Broken row → collapse → re-expand within 60s → spinner + re-verify (previously: frozen broken cloud).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKxv1k187ynCjx6sVDC7NQ