### PR TITLE
fix(location): dedup locatableContacts by odinId (#982)

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/contactbook/EmergencyContact.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/contactbook/EmergencyContact.kt
@@ -43,7 +43,17 @@ fun Contact.iCanLocate(): Boolean = chatAppData()?.iCanLocate == true
  * (e.g. `collectAsStateWithLifecycle`) or `stateIn` it yourself. Consumers sort.
  */
 val ContactRepository.locatableContacts: Flow<List<Contact>>
-    get() = contacts.map { list -> list.filter { it.iCanLocate() } }
+    get() = contacts.map { it.filterLocatable() }
+
+/**
+ * Filters to contacts carrying the `iCanLocate` flag, then dedups by odinId (issue #982): the same
+ * person can hold two [Contact] rows with different `uniqueId`s (e.g. a manual contact created before
+ * an identity link, later joined by a second, identity-keyed row) — [ContactRepository.contacts] only
+ * dedups by `uniqueId`, so both rows can independently end up flagged. Assumes `NewestFirst` order
+ * (mirroring [ContactRepository.contacts]'s own order), so `distinctBy` keeps the freshest row.
+ */
+internal fun List<Contact>.filterLocatable(): List<Contact> =
+    filter { it.iCanLocate() }.distinctBy { it.content.odinId }
 
 private fun Contact.chatAppData(): ChatContactAppData? =
     appDataFor(AppConfig.APP_ID)?.let {

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/contactbook/EmergencyContactTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/contactbook/EmergencyContactTest.kt
@@ -7,6 +7,7 @@ import id.homebase.api.client.contacts.ContactContent
 import id.homebase.api.client.contacts.toCanonicalAppId
 import id.homebase.core.config.AppConfig
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.uuid.ExperimentalUuidApi
@@ -48,5 +49,59 @@ class EmergencyContactTest {
     @Test
     fun malformedSlot_isNotLocatable() {
         assertFalse(contact(mapOf(ourSlot to "not json {{{")).iCanLocate())
+    }
+
+    // ── filterLocatable dedup (issue #982) ──────────────────────────────────────
+
+    private val locatableAppData = mapOf(ourSlot to """{"iCanLocate":true}""")
+
+    private fun contactWith(uniqueId: Uuid, odinId: String?, locatable: Boolean = true) = Contact(
+        uniqueId = uniqueId,
+        versionTag = null,
+        content = ContactContent(
+            odinId = odinId,
+            appData = if (locatable) locatableAppData else null,
+        ),
+    )
+
+    @Test
+    fun filterLocatable_sameOdinIdDifferentUniqueId_keepsOnlyOne() {
+        val manual = contactWith(Uuid.parse("11111111-1111-1111-1111-111111111111"), odinId = "sam.dotyou.cloud")
+        val identity = contactWith(Uuid.parse("22222222-2222-2222-2222-222222222222"), odinId = "sam.dotyou.cloud")
+
+        val result = listOf(manual, identity).filterLocatable()
+
+        assertTrue(result.size == 1)
+    }
+
+    @Test
+    fun filterLocatable_keepsNewestRowPerOdinId() {
+        val stale = contactWith(Uuid.parse("11111111-1111-1111-1111-111111111111"), odinId = "sam.dotyou.cloud")
+        val fresh = contactWith(Uuid.parse("22222222-2222-2222-2222-222222222222"), odinId = "sam.dotyou.cloud")
+
+        // Newest-first order (mirrors ContactRepository.contacts): fresh comes first.
+        val result = listOf(fresh, stale).filterLocatable()
+
+        assertEquals(listOf(fresh), result)
+    }
+
+    @Test
+    fun filterLocatable_differentOdinIds_keepsBoth() {
+        val a = contactWith(Uuid.parse("11111111-1111-1111-1111-111111111111"), odinId = "sam.dotyou.cloud")
+        val b = contactWith(Uuid.parse("22222222-2222-2222-2222-222222222222"), odinId = "frodo.dotyou.cloud")
+
+        assertEquals(listOf(a, b), listOf(a, b).filterLocatable())
+    }
+
+    @Test
+    fun filterLocatable_dropsNonLocatableContacts() {
+        val locatable = contactWith(Uuid.parse("11111111-1111-1111-1111-111111111111"), odinId = "sam.dotyou.cloud")
+        val notLocatable = contactWith(
+            Uuid.parse("22222222-2222-2222-2222-222222222222"),
+            odinId = "frodo.dotyou.cloud",
+            locatable = false,
+        )
+
+        assertEquals(listOf(locatable), listOf(locatable, notLocatable).filterLocatable())
     }
 }


### PR DESCRIPTION
A person can hold two Contact rows with different uniqueIds (e.g. a manual contact created before an identity link, joined later by a second identity-keyed row) — ContactRepository.contacts only dedups by uniqueId, so both rows could independently end up iCanLocate and show twice in "Who you can locate".