### PR TITLE
perf(location): parallel backlog drain on push wakes — GPS wait becomes free network time (#987 follow-up)

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/PushCaptureUploader.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/PushCaptureUploader.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
@@ -22,10 +23,14 @@ import kotlin.uuid.Uuid
  * enqueued hour-file would sit in the outbox until the next foreground connect — the
  * sender's "Who you can locate" stays stale even though the capture ran.
  *
- * Flow: gated capture (all existing gates respected) → find the ACTUAL pending hour-file
- * row (the capture may have enqueued nothing — served-from-cache / rate-gated — while an
- * EARLIER stranded row may still be waiting; the row is the truth) → forced bounded outbox
- * drain (`send(force = true)`) → row-verified confirmation.
+ * Flow: backlog drain kicked IMMEDIATELY (the GPS radio wait is free network time — the
+ * two don't contend, so stranded rows upload while the fix acquires; and every wake drains
+ * the backlog even when the capture gate is closed or the flush is rate-gated) ∥ gated
+ * capture (all existing gates respected) → find the ACTUAL pending hour-file row (the
+ * capture may have enqueued nothing — served-from-cache / rate-gated — while an EARLIER
+ * stranded row may still be waiting; the row is the truth) → re-kick + row-verified
+ * confirmation. Backlog POSTs beyond the awaited fresh-row confirm race process freeze
+ * exactly as before — best-effort; rows survive for the next wake.
  *
  * Why row-verified: the hour-file uid is deterministic (`locationHourFileUid`), and the
  * EventBus replays one event — a stale `ItemCompleted` for the SAME uid from an earlier
@@ -61,7 +66,22 @@ class PushCaptureUploader(
         }
     }
 
-    private suspend fun run(startMs: Long, budgetMs: Long) {
+    private suspend fun run(startMs: Long, budgetMs: Long): Unit = coroutineScope {
+        // Backlog drain kicks IMMEDIATELY, concurrent with the capture: the GPS radio wait
+        // (up to 5s) is free network time, and this also guarantees every push wake drains
+        // stranded rows (old hour-files, chat queued offline) even when the capture gate is
+        // closed or the flush is rate-gated — paths that previously sent nothing. drain()
+        // (send(force=true)) only SPAWNS the worker on the outbox's own scope, so this
+        // launch returns fast and never holds the wake budget hostage; the connectivity
+        // circuit-breaker bounds the genuinely-offline cost to one uncharged probe.
+        // UNDISPATCHED: run the kick to its first suspension point NOW — a plain launch
+        // only queues it, and on a single-threaded dispatcher capture() would start first.
+        launch(start = CoroutineStart.UNDISPATCHED) {
+            logger.i { "drain: backlog kick at wake start" }
+            runCatching { drain() }
+                .onFailure { logger.w(throwable = it) { "drain: backlog kick failed" } }
+        }
+
         val fix = capture()
         logger.i {
             "capture(PushReceived): " + when (fix) {
@@ -71,7 +91,7 @@ class PushCaptureUploader(
                 else -> "$fix"
             }
         }
-        if (fix == null) return // tracking off / no consumer — no location rows expected
+        if (fix == null) return@coroutineScope // tracking off / no consumer — no location rows expected
 
         // The fix's own timestamp decides its hour file; the current hour covers the
         // hour-boundary and served-from-cache cases. A pending row may also predate this
@@ -84,7 +104,7 @@ class PushCaptureUploader(
         val pendingUid = candidates.firstOrNull { pendingRow(it) }
         if (pendingUid == null) {
             logger.i { "drain: nothing pending (rate-gated, deferred, served-from-cache, or already sent)" }
-            return
+            return@coroutineScope
         }
 
         val confirmed: Boolean? = coroutineScope {

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/PushCaptureUploaderTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/PushCaptureUploaderTest.kt
@@ -55,20 +55,42 @@ class PushCaptureUploaderTest {
         )
 
     @Test
-    fun gateClosed_returnsFast_noDrain() = runTest {
+    fun gateClosed_stillKicksBacklogDrain() = runTest {
         val h = Harness()
         h.captureResult = null
         buildUploader(h).captureAndUpload(budgetMs = 10_000)
-        assertEquals(0, h.drainCalls)
+        // The wake-start backlog kick fires even with the capture gate closed — a user
+        // with tracking off and chat stranded from an offline evening still drains.
+        assertEquals(1, h.drainCalls)
     }
 
     @Test
-    fun noPendingRow_returnsFast_noDrain() = runTest {
+    fun noPendingRow_stillKicksBacklogDrain() = runTest {
         val h = Harness()
         h.captureResult = fix(nowFixed - 1_000)
-        // pending stays empty: rate-gated / served-from-cache / already sent.
+        // pending stays empty: rate-gated / served-from-cache / already sent — the
+        // wake-start kick still ran; only the confirm-path drain is skipped.
         buildUploader(h).captureAndUpload(budgetMs = 10_000)
-        assertEquals(0, h.drainCalls)
+        assertEquals(1, h.drainCalls)
+    }
+
+    @Test
+    fun backlogKick_firesBeforeCapture() = runTest {
+        val h = Harness()
+        var drainsSeenAtCapture = -1
+        val uploader = PushCaptureUploader(
+            capture = { drainsSeenAtCapture = h.drainCalls; null },
+            pendingRow = { uid -> uid in h.pending },
+            drain = { h.drainCalls++; h.onDrain() },
+            events = h.events,
+            locationDriveId = driveId,
+            hourUid = ::uidFor,
+            nowMs = { nowFixed },
+        )
+        uploader.captureAndUpload(budgetMs = 10_000)
+        // Ordering pin: the backlog kick is launched before capture() runs, so the GPS
+        // wait overlaps the network drain instead of serializing in front of it.
+        assertEquals(1, drainsSeenAtCapture)
     }
 
     @Test
@@ -87,7 +109,8 @@ class PushCaptureUploaderTest {
 
         buildUploader(h).captureAndUpload(budgetMs = 10_000)
 
-        assertEquals(1, h.drainCalls)
+        // Wake-start backlog kick + the confirm-path re-kick.
+        assertEquals(2, h.drainCalls)
         assertFalse(uid in h.pending)
     }
 
@@ -171,7 +194,10 @@ class PushCaptureUploaderTest {
 
         buildUploader(h, nowMs = prevHourStart + HOUR_MS + 10_000).captureAndUpload(budgetMs = 10_000)
 
-        assertEquals(1, h.drainCalls, "the previous hour's pending row must be found and drained")
+        // 2 = wake-start backlog kick + confirm-path re-kick: the previous hour's
+        // pending row was found (otherwise no re-kick) and confirmed via the events.
+        assertEquals(2, h.drainCalls, "the previous hour's pending row must be found and drained")
+        assertFalse(prevUid in h.pending)
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #992 (the commit landed on that branch after its merge — re-homed here).

## What
The push wake was sequential: GPS capture first (up to 5s of the 8s/15s budget), outbox drain after. The location radio and network POSTs don't contend — last night's field log showed 3.8s of `getCurrentFix: acquiring fresh` with the network idle while ready-to-send rows waited. The drain now kicks (`CoroutineStart.UNDISPATCHED`) at wake start:

- stranded rows upload **during** the GPS wait,
- the fresh fix's priority-0 row jumps the still-running drain's queue when it lands (~4s in),
- the confirm-path re-kick + row-verified await are unchanged.

## Also fixes two send-nothing paths
Gate-closed (tracking off) and rate-gated-flush-with-no-pending-location-row previously returned **without draining anything** — chat messages stranded from an offline evening got a push wake that sent nothing. Every wake now drains the backlog unconditionally; the #992 circuit breaker keeps the genuinely-offline cost at one uncharged probe.

## Unchanged (explicit decision)
The capture path is byte-identical — staleness gating stays fixed per reason (`PushReceived` 120s / `AppForeground` 60s / `LiveMap` 30s). Live sharing keeps the cache fresh via the continuous tracker's live profile, so a dynamic threshold was deliberately not added.

## Tests / verification
- Updated `PushCaptureUploaderTest`: gate-closed and no-pending-row now assert the backlog kick fires (previously asserted no drain); happy-path/hour-boundary pin the double-kick shape; new ordering pin `backlogKick_firesBeforeCapture`.
- `homebase-core` jvmTest + Android/wasmJs + `:androidApp:compileDebugKotlin` green. iOS Kotlin: macOS/CI compile as usual.
- Log signature to verify on device: `drain: backlog kick at wake start` BEFORE `forceCaptureIfTracking(PushReceived)`, with `OutboxSync: sending` lines inside the `acquiring fresh` window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKxv1k187ynCjx6sVDC7NQ