### PR TITLE
fix(location): "Who you can locate" spins up to 15s waiting for online before showing the broken cloud (#998)

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -891,6 +891,7 @@ val appModule = module {
             liveShareService = get(),
             conversationService = get(),
             emergencyLocateService = get(),
+            authConnectionCoordinator = get(),
         )
     }
     // Manual block: the optional peerDomain (emergency-locate peer mode) arrives as a Koin

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
@@ -105,6 +105,10 @@ const val LOCATE_VERIFY_TTL_MS = 60_000L
 /** Age past which a locate row's freshness label renders in the warning (orange) color (#879). */
 const val LOCATE_AGE_WARN_MS = 2 * 60 * 60_000L
 
+/** How long a locate verify waits for the app to come online before attempting the POST, so an
+ *  expand right after cold start spins instead of flashing broken clouds (#998). */
+const val LOCATE_VERIFY_ONLINE_WAIT_MS = 15_000L
+
 /**
  * Whether a verify pass over "Who you can locate" should (re-)issue the temporal verify for a row
  * in this state: never while one is in flight; a successful DATA-BEARING [LocateVerifyStatus.Active]

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
@@ -14,6 +14,7 @@ import id.homebase.chat.services.convo.ConversationService
 import id.homebase.chat.services.convo.contact.ConnectionService
 import id.homebase.chat.services.convo.contact.ContactService
 import id.homebase.chat.services.livelocation.LiveLocationShareService
+import id.homebase.core.auth.AuthConnectionCoordinator
 import id.homebase.core.config.EMERGENCY_LOCATION_CIRCLE_ID
 import id.homebase.core.config.locationLabeledDrive
 import id.homebase.core.contactbook.locatableContacts
@@ -41,12 +42,15 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.time.Clock
 
 class LocationViewModel(
@@ -66,6 +70,7 @@ class LocationViewModel(
     private val liveShareService: LiveLocationShareService,
     private val conversationService: ConversationService,
     private val emergencyLocateService: EmergencyLocateService,
+    private val authConnectionCoordinator: AuthConnectionCoordinator,
     tracker: LocationTracker,
 ) : ViewModel() {
 
@@ -309,11 +314,23 @@ class LocationViewModel(
      * Collapsed: cancel the loop (and any in-flight verifies with it) and sweep Loading
      * placeholders — a cancelled first verify must not leave a stuck Loading that blocks the next
      * expand forever (needsReverify(Loading) == false).
+     *
+     * A sibling collector re-runs a silent pass whenever the app comes online, so a row that
+     * timed out to Unreachable while offline clears the moment the connection arrives instead of
+     * waiting out the TTL (#998). Rows still inside their online-wait are in Loading →
+     * needsReverify == false → the reconnect pass skips them while their own in-flight verify
+     * wakes on the same transition.
      */
     private fun setLocatableExpanded(expanded: Boolean) {
         if (expanded) {
             if (locatableVerifyJob?.isActive == true) return
             locatableVerifyJob = viewModelScope.launch {
+                launch {
+                    authConnectionCoordinator.isOnline
+                        .drop(1) // skip the replayed current value; react to transitions only
+                        .filter { it }
+                        .collect { verifyLocatablePass(showSpinner = false) }
+                }
                 var expandTriggered = true
                 while (true) {
                     verifyLocatablePass(showSpinner = expandTriggered)
@@ -341,9 +358,12 @@ class LocationViewModel(
      * [LOCATE_VERIFY_TTL_MS] are skipped (#950). [showSpinner] (the expand-triggered pass) marks
      * each verifying row Loading so the user sees the verify happen; the periodic follow-up passes
      * pass false and keep the old value visible until the new result lands, so an open list never
-     * flashes spinners every minute. A row with no prior result always spins. A network/parse
-     * failure is inconclusive → [LocateVerifyStatus.Unreachable] (disconnected icon, retried after
-     * the TTL), never [Broken]; this mirrors [EmergencyContactReconciler]'s leave-untouched rule.
+     * flashes spinners every minute. A row with no prior result always spins. Each verify first
+     * waits up to [LOCATE_VERIFY_ONLINE_WAIT_MS] for the app to be online (#998) — a no-op when it
+     * already is — so an expand right after cold start spins instead of flashing broken clouds. A
+     * network/parse failure after that is inconclusive → [LocateVerifyStatus.Unreachable]
+     * (disconnected icon, retried after the TTL), never [Broken]; this mirrors
+     * [EmergencyContactReconciler]'s leave-untouched rule.
      */
     private suspend fun verifyLocatablePass(showSpinner: Boolean) {
         val now = Clock.System.now().toEpochMilliseconds()
@@ -358,6 +378,14 @@ class LocationViewModel(
                     }
                 }
                 launch {
+                    // Just-opened app: hold the row in Loading for up to
+                    // LOCATE_VERIFY_ONLINE_WAIT_MS while the connection comes up, so a
+                    // not-online-yet expand spins instead of flashing broken clouds (#998).
+                    // Already online → first{} returns immediately; still offline after the
+                    // wait → the verify throws and records Unreachable as before.
+                    withTimeoutOrNull(LOCATE_VERIFY_ONLINE_WAIT_MS) {
+                        authConnectionCoordinator.isOnline.first { it }
+                    }
                     val status = try {
                         temporalDriveReadProvider.verifyTemporalAccess(member.odinId, locationDrive)
                     } catch (e: CancellationException) {


### PR DESCRIPTION
Closes #998.

## Problem

Expanding "Who you can locate" right after opening the app — before the WebSocket handshake completes — made every row's `verifyTemporalAccess` POST throw, which `verifyLocatablePass` caught to `null` and immediately mapped to `LocateVerifyStatus.Unreachable` (the `CloudOff` "broken cloud"). Technically correct, but it reads as an error for a transient "not online yet" state, and the only recovery was the 60s TTL loop.

## Change

- **Inject the online signal**: `LocationViewModel` now takes `AuthConnectionCoordinator` (precedent: `MomentsFeedViewModel` / `ContactBookViewModel`); DI wired in `AppModule.kt`.
- **Wait ≤15s for online inside each per-row verify**: before the POST, `withTimeoutOrNull(LOCATE_VERIFY_ONLINE_WAIT_MS) { isOnline.first { it } }`. The row stays `Loading` (spinner) during the wait because its verify is still in flight — and `needsReverify(Loading) == false` keeps concurrent passes off it. Already online → zero added latency. Still offline after 15s → the POST throws → `Unreachable`, as today, just not instantly.
- **Re-verify on reconnect while expanded**: a sibling collector in `locatableVerifyJob` runs a silent pass on every offline→online transition (`isOnline.drop(1).filter { it }`), so a row that timed out to `Unreachable` clears the moment the connection arrives instead of after the 60s TTL. Collapse cancels the collector with the job.
- New constant `LOCATE_VERIFY_ONLINE_WAIT_MS = 15_000L` in `LocationUiState.kt`.

Genuine no-access (`Broken`/`LinkOff`) is untouched — the wait happens before the POST, and `Broken` is only reached when the server actually answered `!hasAccess`. The `needsReverify` TTL contract (#950/#985) is not modified.

## Testing

- `:homebase-core:compileKotlinJvm`, `:compileAndroidMain`, `:compileKotlinWasmJs` — green (iOS compile left to CI; Linux host).
- `homebase-core:jvmTest --rerun-tasks` — green (`LocateVerifyFreshnessTest` still pins the `needsReverify` contract).
- Manual Android/iOS script (from the issue's acceptance criteria): open the app in airplane mode, expand the section → spinners, not broken clouds; restore connectivity within 15s → rows resolve; stay offline >15s → broken clouds, which clear immediately on reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)