### PR TITLE
refactor(location): hoist per-profile tuning policy into commonMain

### DIFF
--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/LocationTracker.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/LocationTracker.android.kt
@@ -28,10 +28,8 @@ actual fun createLocationTracker(sink: LocationPointSink): LocationTracker =
  *   without a foreground service, at whatever cadence the OS allows.
  * - **Foreground overlay** (only for a foreground profile): a callback feeding
  *   [sink] directly for precise capture while the user has the app open. Its
- *   accuracy/cadence depends on the profile (#846): `LiveForeground` runs
- *   high-accuracy 15s/10m (a live share or the live map wants fresh fixes);
- *   `HistoryForeground` runs balanced 30s/25m (history-only doesn't need the
- *   battery cost of second-by-second precision). Removed on backgrounding; the
+ *   accuracy/cadence per profile comes from the common [TrackingProfile.spec]
+ *   table (#846, #978). Removed on backgrounding; the
  *   PendingIntent stays registered throughout so there is no gap, and the
  *   store's time/displacement dedup absorbs the overlap.
  *
@@ -67,11 +65,11 @@ private class AndroidLocationTracker(
         }
         runCatching {
             val request = LocationRequest.Builder(
-                Priority.PRIORITY_BALANCED_POWER_ACCURACY,
-                BACKGROUND_INTERVAL_MS,
+                AndroidBackgroundBaseline.ACCURACY.toFusedPriority(),
+                AndroidBackgroundBaseline.INTERVAL_MS,
             )
-                .setMaxUpdateDelayMillis(BACKGROUND_MAX_DELAY_MS)
-                .setMinUpdateDistanceMeters(BACKGROUND_MIN_DISPLACEMENT_M)
+                .setMaxUpdateDelayMillis(AndroidBackgroundBaseline.MAX_DELAY_MS)
+                .setMinUpdateDistanceMeters(AndroidBackgroundBaseline.MIN_DISPLACEMENT_M.toFloat())
                 .build()
             fusedClient.requestLocationUpdates(request, backgroundPendingIntent())
             started = true
@@ -132,13 +130,22 @@ private class AndroidLocationTracker(
 
     private data class OverlayParams(val priority: Int, val intervalMs: Long, val minDisplacementM: Float)
 
-    /** Foreground overlay params per profile; null for background profiles (no precise overlay). */
-    private fun foregroundOverlayParams(profile: TrackingProfile): OverlayParams? = when (profile) {
-        TrackingProfile.LiveForeground ->
-            OverlayParams(Priority.PRIORITY_HIGH_ACCURACY, LIVE_FG_INTERVAL_MS, LIVE_FG_MIN_DISPLACEMENT_M)
-        TrackingProfile.HistoryForeground ->
-            OverlayParams(Priority.PRIORITY_BALANCED_POWER_ACCURACY, HISTORY_FG_INTERVAL_MS, HISTORY_FG_MIN_DISPLACEMENT_M)
-        TrackingProfile.LiveBackground, TrackingProfile.HistoryBackground -> null
+    /** [TrackingProfile.spec] translated to Fused units; null for background profiles (no precise overlay). */
+    private fun foregroundOverlayParams(profile: TrackingProfile): OverlayParams? {
+        if (!profile.isForeground) return null
+        val spec = profile.spec
+        return OverlayParams(
+            priority = spec.accuracy.toFusedPriority(),
+            intervalMs = checkNotNull(spec.minIntervalMs) { "foreground spec must set minIntervalMs" },
+            minDisplacementM = spec.minDisplacementM.toFloat(),
+        )
+    }
+
+    private fun TrackingAccuracy.toFusedPriority(): Int = when (this) {
+        TrackingAccuracy.Precise -> Priority.PRIORITY_HIGH_ACCURACY
+        TrackingAccuracy.Balanced -> Priority.PRIORITY_BALANCED_POWER_ACCURACY
+        // Never registered on Android: background profiles run the baseline only (no overlay).
+        TrackingAccuracy.Coarse -> error("no Fused registration uses Coarse")
     }
 
     private fun backgroundPendingIntent(): PendingIntent {
@@ -156,19 +163,6 @@ private class AndroidLocationTracker(
 
     private companion object {
         const val PENDING_INTENT_REQUEST_CODE = 5610
-
-        const val BACKGROUND_INTERVAL_MS = 60_000L
-        const val BACKGROUND_MAX_DELAY_MS = 600_000L
-        const val BACKGROUND_MIN_DISPLACEMENT_M = 25f
-
-        // Live foreground (share or live-map view): high accuracy, frequent — fresh fixes matter.
-        const val LIVE_FG_INTERVAL_MS = 15_000L
-        const val LIVE_FG_MIN_DISPLACEMENT_M = 10f
-
-        // History-only foreground: balanced power, larger displacement. No live consumer needs
-        // second-by-second precision, so trade freshness for battery (#846). Tune on-device.
-        const val HISTORY_FG_INTERVAL_MS = 30_000L
-        const val HISTORY_FG_MIN_DISPLACEMENT_M = 25f
     }
 }
 
@@ -181,6 +175,6 @@ internal fun android.location.Location.toRawPoint(fg: Boolean): RawLocationPoint
     altAcc = if (hasVerticalAccuracy()) verticalAccuracyMeters.toDouble() else null,
     spd = if (hasSpeed()) speed.toDouble() else null,
     hdg = if (hasBearing()) bearing.toDouble() else null,
-    src = "fused",
+    src = LocationSources.FUSED,
     fg = fg,
 )

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/OneShotLocationProvider.android.kt
@@ -88,7 +88,7 @@ private object AndroidOneShotLocationProvider : OneShotLocationProvider {
         alt = if (hasAltitude()) altitude else null,
         spd = if (hasSpeed()) speed.toDouble() else null,
         hdg = if (hasBearing()) bearing.toDouble() else null,
-        src = provider ?: "gps",
+        src = provider ?: LocationSources.GPS,
         fg = true,
     )
 }

--- a/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/LocationTracker.apple.kt
+++ b/homebase-common/src/appleMain/kotlin/id/homebase/core/location/tracking/LocationTracker.apple.kt
@@ -7,6 +7,7 @@ import kotlinx.cinterop.useContents
 import kotlinx.coroutines.launch
 import platform.CoreLocation.CLActivityTypeOther
 import platform.CoreLocation.CLLocation
+import platform.CoreLocation.CLLocationAccuracy
 import platform.CoreLocation.CLLocationManager
 import platform.CoreLocation.CLLocationManagerDelegateProtocol
 import platform.CoreLocation.kCLLocationAccuracyBest
@@ -25,8 +26,8 @@ actual fun createLocationTracker(sink: LocationPointSink): LocationTracker =
  * Battery levers (the ones that demonstrably work — see the Anchor source dive):
  * - `pausesLocationUpdatesAutomatically = true` lets iOS suspend standard
  *   updates while the device is stationary.
- * - Background profile drops to hundred-meter accuracy with a 50m distance
- *   filter; foreground runs best-accuracy at 10m.
+ * - Per-profile accuracy/distance-filter comes from the common
+ *   [TrackingProfile.spec] table (#978).
  * - Significant-location-change monitoring is always on while tracking — it is
  *   the relaunch vector after the OS terminates the app
  *   (UIApplicationLaunchOptionsLocationKey → initializeApp →
@@ -49,7 +50,7 @@ private class AppleLocationTracker(
         override fun locationManager(manager: CLLocationManager, didUpdateLocations: List<*>) {
             val points = didUpdateLocations
                 .filterIsInstance<CLLocation>()
-                .map { it.toRawPoint(fg = isForegroundProfile(profile)) }
+                .map { it.toRawPoint(fg = profile.isForeground) }
             if (points.isEmpty()) return
             scope.launch { sink.submit(points) }
         }
@@ -101,30 +102,18 @@ private class AppleLocationTracker(
         // suspended/killed within minutes — it then only revives on a coarse significant-location
         // change, making a live share appear to update "only in the foreground". Passive history
         // keeps auto-pause on to save battery (a stationary user simply records fewer points).
-        val liveSharing = profile == TrackingProfile.LiveForeground ||
-            profile == TrackingProfile.LiveBackground
-        manager.pausesLocationUpdatesAutomatically = !liveSharing
-        when (profile) {
-            // Live (share / live-map view): best accuracy, tight filter — fresh fixes matter.
-            TrackingProfile.LiveForeground -> {
-                manager.desiredAccuracy = kCLLocationAccuracyBest
-                manager.distanceFilter = 10.0
-            }
-            // History-only foreground: balanced — no live consumer needs best accuracy (#846).
-            TrackingProfile.HistoryForeground -> {
-                manager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters
-                manager.distanceFilter = 25.0
-            }
-            // Background (live or history): low power, OS-throttled — unchanged.
-            TrackingProfile.LiveBackground, TrackingProfile.HistoryBackground -> {
-                manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
-                manager.distanceFilter = 50.0
-            }
-        }
+        manager.pausesLocationUpdatesAutomatically = !profile.isLive
+        val spec = profile.spec
+        manager.desiredAccuracy = spec.accuracy.toCLAccuracy()
+        manager.distanceFilter = spec.minDisplacementM
     }
 
-    private fun isForegroundProfile(profile: TrackingProfile): Boolean =
-        profile == TrackingProfile.LiveForeground || profile == TrackingProfile.HistoryForeground
+    // CL has no interval knob — spec.minIntervalMs is Android-only; iOS is distance-filtered.
+    private fun TrackingAccuracy.toCLAccuracy(): CLLocationAccuracy = when (this) {
+        TrackingAccuracy.Precise -> kCLLocationAccuracyBest
+        TrackingAccuracy.Balanced -> kCLLocationAccuracyNearestTenMeters
+        TrackingAccuracy.Coarse -> kCLLocationAccuracyHundredMeters
+    }
 }
 
 @OptIn(ExperimentalForeignApi::class)
@@ -140,7 +129,7 @@ internal fun CLLocation.toRawPoint(fg: Boolean): RawLocationPoint {
         // CL uses negative values as "invalid" sentinels.
         spd = speed.takeIf { it >= 0 },
         hdg = course.takeIf { it >= 0 },
-        src = "gps",
+        src = LocationSources.GPS,
         fg = fg,
     )
 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationPointStore.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationPointStore.kt
@@ -27,7 +27,8 @@ import kotlin.math.sqrt
  * ### Pipeline cadences (one place, see #846)
  * Five independent knobs shape the foreground capture→submit→route flow; documented here so they're
  * greppable and don't silently drift:
- *  - OS acquisition: ~15 s / 10 m foreground (Android Fused), distance-filtered (iOS) — platform trackers.
+ *  - OS acquisition: the common per-profile table [TrackingProfile.spec] (15 s / 10 m live-fg,
+ *    30 s / 25 m history-fg, coarse bg) — both platform trackers translate it.
  *  - Store stationary-noise filter: [MIN_DISPLACEMENT_M] (8 m) AND [MIN_INTERVAL_MS] (20 s) — here.
  *  - Foreground flush ticker: 120 s — `LocationTrackingCoordinator.startTicker`.
  *  - History flush rate-gate: 60 s — `LocationTrackUploaderService`.

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTracker.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTracker.kt
@@ -8,7 +8,8 @@ package id.homebase.core.location.tracking
  *
  * Today only the two FOREGROUND profiles differ in their parameters; both background profiles map to
  * the same OS-throttled low-power cadence — the background / cold-wake path is intentionally left
- * untouched (changing it is higher risk, lower value, and OS-capped anyway).
+ * untouched (changing it is higher risk, lower value, and OS-capped anyway). The per-profile tuning
+ * values live in one common table, [TrackingProfile.spec].
  */
 enum class TrackingProfile {
     /** App foreground + a live consumer: high accuracy, tight interval/displacement. */
@@ -43,7 +44,7 @@ data class RawLocationPoint(
     val spd: Double? = null,
     /** Heading/bearing in degrees. */
     val hdg: Double? = null,
-    /** Capture source: gps | net | fused | slc (significant-location-change). */
+    /** Capture source, one of [LocationSources]: gps | net | fused | slc (significant-location-change). */
     val src: String,
     /** True when captured in foreground precise mode. */
     val fg: Boolean,

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/TrackingProfileSpec.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/TrackingProfileSpec.kt
@@ -1,0 +1,63 @@
+package id.homebase.core.location.tracking
+
+/** App is in the foreground — the platform tracker runs its precise overlay/accuracy. */
+val TrackingProfile.isForeground: Boolean
+    get() = this == TrackingProfile.LiveForeground || this == TrackingProfile.HistoryForeground
+
+/** A live consumer (active share or the live-map view) is driving GPS. */
+val TrackingProfile.isLive: Boolean
+    get() = this == TrackingProfile.LiveForeground || this == TrackingProfile.LiveBackground
+
+/** Platform-agnostic accuracy tier; actuals translate to a Fused `Priority` / `kCLLocationAccuracy*`. */
+enum class TrackingAccuracy { Precise, Balanced, Coarse }
+
+/**
+ * Per-profile tuning values. [minIntervalMs] is null on the background spec: background cadence is
+ * OS-throttled (Android registers no foreground overlay there — only [AndroidBackgroundBaseline];
+ * iOS is distance-filtered only, so [minIntervalMs] is Android-only either way).
+ */
+data class TrackingProfileSpec(
+    val accuracy: TrackingAccuracy,
+    val minIntervalMs: Long?,
+    val minDisplacementM: Double,
+)
+
+/**
+ * The one per-profile tuning table both platform trackers translate, hoisted here so the values
+ * can't drift between Android and iOS (#978; same seam philosophy as
+ * [OneShotLocationProvider.getCurrentFix]).
+ */
+val TrackingProfile.spec: TrackingProfileSpec
+    get() = when (this) {
+        // Live: high accuracy, tight interval/displacement — fresh fixes matter.
+        TrackingProfile.LiveForeground ->
+            TrackingProfileSpec(TrackingAccuracy.Precise, minIntervalMs = 15_000L, minDisplacementM = 10.0)
+        // History-only: balanced power, larger displacement (#846).
+        TrackingProfile.HistoryForeground ->
+            TrackingProfileSpec(TrackingAccuracy.Balanced, minIntervalMs = 30_000L, minDisplacementM = 25.0)
+        // Both background profiles intentionally collapse to one low-power, OS-throttled spec
+        // (see [TrackingProfile] — the background / cold-wake path is deliberately untouched).
+        TrackingProfile.LiveBackground, TrackingProfile.HistoryBackground ->
+            TrackingProfileSpec(TrackingAccuracy.Coarse, minIntervalMs = null, minDisplacementM = 50.0)
+    }
+
+/**
+ * Android background baseline — the always-on batched PendingIntent registration that works
+ * without a foreground service. Part of the same policy as [TrackingProfile.spec].
+ */
+object AndroidBackgroundBaseline {
+    val ACCURACY = TrackingAccuracy.Balanced
+    const val INTERVAL_MS = 60_000L
+    const val MAX_DELAY_MS = 600_000L
+    const val MIN_DISPLACEMENT_M = 25.0
+}
+
+/** Canonical [RawLocationPoint.src] vocabulary. */
+object LocationSources {
+    const val GPS = "gps"
+    const val NET = "net"
+    const val FUSED = "fused"
+
+    /** Significant-location-change (iOS relaunch vector). */
+    const val SLC = "slc"
+}

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/tracking/TrackingProfileSpecTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/tracking/TrackingProfileSpecTest.kt
@@ -1,0 +1,60 @@
+package id.homebase.core.location.tracking
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Drift guard for #978: pins the per-profile tuning table and classifications both platform
+ * trackers translate. A change here is a deliberate tuning decision, not a refactor.
+ */
+class TrackingProfileSpecTest {
+
+    @Test
+    fun liveForegroundSpec() = assertEquals(
+        TrackingProfileSpec(TrackingAccuracy.Precise, minIntervalMs = 15_000L, minDisplacementM = 10.0),
+        TrackingProfile.LiveForeground.spec,
+    )
+
+    @Test
+    fun historyForegroundSpec() = assertEquals(
+        TrackingProfileSpec(TrackingAccuracy.Balanced, minIntervalMs = 30_000L, minDisplacementM = 25.0),
+        TrackingProfile.HistoryForeground.spec,
+    )
+
+    @Test
+    fun backgroundProfilesCollapseToOneCoarseSpec() {
+        val expected = TrackingProfileSpec(TrackingAccuracy.Coarse, minIntervalMs = null, minDisplacementM = 50.0)
+        assertEquals(expected, TrackingProfile.LiveBackground.spec)
+        assertEquals(expected, TrackingProfile.HistoryBackground.spec)
+    }
+
+    @Test
+    fun androidBackgroundBaseline() {
+        assertEquals(TrackingAccuracy.Balanced, AndroidBackgroundBaseline.ACCURACY)
+        assertEquals(60_000L, AndroidBackgroundBaseline.INTERVAL_MS)
+        assertEquals(600_000L, AndroidBackgroundBaseline.MAX_DELAY_MS)
+        assertEquals(25.0, AndroidBackgroundBaseline.MIN_DISPLACEMENT_M)
+    }
+
+    @Test
+    fun classifications() {
+        assertTrue(TrackingProfile.LiveForeground.isForeground)
+        assertTrue(TrackingProfile.LiveForeground.isLive)
+        assertTrue(TrackingProfile.HistoryForeground.isForeground)
+        assertFalse(TrackingProfile.HistoryForeground.isLive)
+        assertFalse(TrackingProfile.LiveBackground.isForeground)
+        assertTrue(TrackingProfile.LiveBackground.isLive)
+        assertFalse(TrackingProfile.HistoryBackground.isForeground)
+        assertFalse(TrackingProfile.HistoryBackground.isLive)
+    }
+
+    @Test
+    fun sourceVocabulary() {
+        assertEquals("gps", LocationSources.GPS)
+        assertEquals("net", LocationSources.NET)
+        assertEquals("fused", LocationSources.FUSED)
+        assertEquals("slc", LocationSources.SLC)
+    }
+}


### PR DESCRIPTION
Zero-behavior-change refactor in `homebase-common` only. The per-profile location-tuning policy was the same intent hand-written twice (Android `foregroundOverlayParams` + companion constants; iOS `applyProfile`), with nothing keeping them in sync.

## What moved to commonMain (`TrackingProfileSpec.kt`)

- **`TrackingProfile.spec`** — the one tuning table both trackers translate, values transcribed verbatim:
  | Profile | Accuracy | Interval | Displacement |
  |---|---|---|---|
  | `LiveForeground` | Precise | 15 000 ms | 10 m |
  | `HistoryForeground` | Balanced | 30 000 ms | 25 m |
  | `LiveBackground` / `HistoryBackground` (intentional collapse, unchanged) | Coarse | — | 50 m (iOS filter; Android runs no overlay) |
- **`AndroidBackgroundBaseline`** — the baseline PendingIntent params (Balanced, 60 s interval, ≤600 s batch, 25 m).
- **`TrackingProfile.isForeground` / `.isLive`** — replace iOS `isForegroundProfile()` + the `liveSharing` partition and Android's implicit null-overlay derivation. iOS auto-pause rule is unchanged: `pausesLocationUpdatesAutomatically = !profile.isLive`.
- **`LocationSources`** (`gps`/`net`/`fused`/`slc`) — trackers and the Android one-shot reference these instead of inline literals; persisted values are byte-identical to today's.

The platform actuals are now pure unit translators (spec → Fused `Priority`/intervals; spec → `kCLLocationAccuracy*`/`distanceFilter`). iOS-only levers stay in the actual (auto-pause rule, fixed `CLActivityTypeOther`). The #846 pipeline-cadence comment's knob 1 (`LocationPointStore.kt`) now points at the common table, and a jvmTest (`TrackingProfileSpecTest`) pins the table, the baseline, the classifications, and the vocabulary as a drift guard.

## Noted while transcribing (not fixed, per issue constraints)

- The Android one-shot's `src` is the dynamic provider name with a `gps` fallback; a network fix therefore persists as `"network"` (Android's `LocationManager.NETWORK_PROVIDER`), not the documented `"net"`. Left verbatim — only the literal fallback now comes from `LocationSources.GPS`.
- Nothing currently emits `"slc"`; the constant exists to complete the documented vocabulary.

## Verification

- `./gradlew :homebase-common:compileKotlinJvm :homebase-common:compileAndroidMain :homebase-common:compileKotlinWasmJs :homebase-common:compileKotlinIosSimulatorArm64` — BUILD SUCCESSFUL
- `./gradlew :homebase-common:jvmTest` — green, `TrackingProfileSpecTest` 6/6

Fixes #978

🤖 Generated with [Claude Code](https://claude.com/claude-code)