### PR TITLE
fix(notifications): hide Mark-as-read on content-less pushes (#983)

### DIFF
--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/notifications/RichNotificationDisplayer.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/notifications/RichNotificationDisplayer.android.kt
@@ -198,7 +198,12 @@ actual class RichNotificationDisplayer actual constructor() {
             .setShowsUserInterface(false)
             .build()
 
-        // Mark as Read action
+        builder.addAction(replyAction)
+
+        // Mark as Read only when the notification carries real content (#983) —
+        // you can't sensibly mark-as-read a "You have a new message" placeholder.
+        if (!data.hasContent) return
+
         val readIntent = Intent(ACTION_MARK_READ).apply {
             setPackage(context.packageName)
             putExtra(EXTRA_CONVERSATION_ID, conversationId)
@@ -217,7 +222,6 @@ actual class RichNotificationDisplayer actual constructor() {
             .setShowsUserInterface(false)
             .build()
 
-        builder.addAction(replyAction)
         builder.addAction(readAction)
     }
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
@@ -102,6 +102,12 @@ internal val COMPANION_APP_IDS = setOf(COMMUNITY_APP_ID, OWNER_APP_ID, MAIL_APP_
 private val COMPANION_AUTH_RESTORE_TIMEOUT = 2.seconds
 
 /**
+ * Sender-side placeholder body for chat pushes (ChatMessageSenderService) — not real
+ * content. Keep in sync with the same literal in the iOS NotificationServiceExtension.
+ */
+private const val CONTENTLESS_PLACEHOLDER = "You have a new message"
+
+/**
  * Resolves the companion-app redirect event, AWAITING auth restoration so a tap
  * from a killed app isn't dropped while `YouAuthFlowManager.restoreSession()` is
  * still loading credentials — the cold-start counterpart of the background-sync
@@ -383,6 +389,11 @@ class NotificationService(
                 // Attempt to decrypt notification body (placeholder for future encrypted support)
                 val decryptedMessage = decryptNotificationBody(notification)
 
+                // Real content only — not the sender-side placeholder (and not the
+                // NotificationBodyFormer fallback used when decryptedMessage is null).
+                val hasContent = !decryptedMessage.isNullOrEmpty() &&
+                        decryptedMessage != CONTENTLESS_PLACEHOLDER
+
                 val appName = notification.appDisplayName ?: "Homebase"
 
                 // Use decrypted message if available, otherwise format from payload
@@ -436,6 +447,7 @@ class NotificationService(
                     timestamp = notification.created,
                     payloadData = payloadMap,
                     silent = !shouldAlert,
+                    hasContent = hasContent,
                 )
 
                 if (isAppInForeground) {

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/RichNotificationData.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/RichNotificationData.kt
@@ -24,6 +24,12 @@ data class RichNotificationData(
     val groupTitle: String? = null,
     /** When true, the notification should not play a sound (chime cooldown active). */
     val silent: Boolean = false,
+    /**
+     * True only when [body] is a real (decrypted) message — not the sender-side
+     * "You have a new message" placeholder or a NotificationBodyFormer fallback.
+     * Gates the Mark-as-Read action (#983); set once notification decryption lands (#859).
+     */
+    val hasContent: Boolean = false,
 )
 
 /** Extension to generate a stable notification ID from the conversation ID or a random one. */

--- a/iosApp/NotificationServiceExtension/NotificationService.swift
+++ b/iosApp/NotificationServiceExtension/NotificationService.swift
@@ -74,10 +74,13 @@ class NotificationService: UNNotificationServiceExtension {
         )
         content.sound = .default
 
-        // Group by conversation for chat notifications
+        // Group by conversation for chat notifications. Content-less pushes get the
+        // Reply-only category — no Mark as Read when there's nothing to read (#983).
         if isChatNotification(appId: appId) {
             content.threadIdentifier = typeId
-            content.categoryIdentifier = "MESSAGE_CATEGORY"
+            content.categoryIdentifier = hasRealContent(unEncryptedMessage)
+                ? "MESSAGE_CATEGORY"
+                : "MESSAGE_NO_CONTENT_CATEGORY"
         }
 
         // Fetch sender avatar and apply Communication style
@@ -243,6 +246,16 @@ class NotificationService: UNNotificationServiceExtension {
 
     private func isChatNotification(appId: String) -> Bool {
         [Self.chatAppId, Self.chatAppIdUuid, Self.mailAppId, Self.communityAppId].contains(appId)
+    }
+
+    /// Sender-side placeholder body for chat pushes — not real content. Keep in
+    /// sync with `CONTENTLESS_PLACEHOLDER` in the shared NotificationService.kt.
+    private static let contentlessPlaceholder = "You have a new message"
+
+    /// Mirrors the `hasContent` test in the shared NotificationService.kt.
+    private func hasRealContent(_ unEncryptedMessage: String?) -> Bool {
+        guard let message = unEncryptedMessage, !message.isEmpty else { return false }
+        return message != Self.contentlessPlaceholder
     }
 
     private func formatBody(

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -70,7 +70,18 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
           intentIdentifiers: [],
           options: []
       )
-      UNUserNotificationCenter.current().setNotificationCategories([messageCategory])
+      // Reply-only category for content-less pushes ("You have a new message"
+      // placeholder) — no Mark as Read when there's nothing to read (#983).
+      // The extension picks between the two categories.
+      let messageNoContentCategory = UNNotificationCategory(
+          identifier: "MESSAGE_NO_CONTENT_CATEGORY",
+          actions: [replyAction],
+          intentIdentifiers: [],
+          options: []
+      )
+      UNUserNotificationCenter.current().setNotificationCategories(
+          [messageCategory, messageNoContentCategory]
+      )
   }
 
   // Present notifications while the app is in the foreground


### PR DESCRIPTION
Fixes #983

A push notification whose body is the sender-side **"You have a new message"** placeholder carries nothing the user could have read, so it no longer offers a **Mark as Read** action.

## Changes

- **`RichNotificationData.hasContent`** (new, default `false`) — set in `NotificationService.handleIncomingPayload` where the body resolves: `true` only when `decryptNotificationBody` returned a real message, not the `"You have a new message"` placeholder (shared `CONTENTLESS_PLACEHOLDER` const) and not the `NotificationBodyFormer` fallback (null body).
- **Android** (`RichNotificationDisplayer.android.kt`): `addNotificationActions` adds Mark-as-Read (and its `PendingIntent`) only when `data.hasContent`. Reply is added unconditionally.
- **iOS**: `iOSApp.swift` registers a second, Reply-only `MESSAGE_NO_CONTENT_CATEGORY`; the Notification Service Extension picks it over `MESSAGE_CATEGORY` when `unEncryptedMessage` is empty/missing or equals the placeholder — `hasRealContent(_:)` mirrors the Kotlin test against the same literal (kept-in-sync comments on both sides).
- Desktop/web: untouched (they never attached these actions).

## Design decision: Reply stays

Per the issue's recommendation, only Mark-as-Read is gated — you can't sensibly mark-as-read something you can't see, but replying to a conversation doesn't require having seen the specific message, so Reply remains on content-less pushes (both platforms).

## Interaction with #859

Notification-body decryption is still a stub, and chat sends always set `unEncryptedMessage = "You have a new message"` — so today `hasContent` is `false` for **all** chat pushes and Mark-as-Read disappears everywhere. That is the intended behavior: `hasContent` is exactly the signal #859 will set, and the action returns automatically once real decrypted content flows.

## Verification

- `:homebase-common:compileKotlinJvm` / `compileAndroidMain` / `compileKotlinWasmJs` / `compileKotlinIosSimulatorArm64` — BUILD SUCCESSFUL
- `:homebase-common:jvmTest` — BUILD SUCCESSFUL
- Swift files pass `swiftc -parse`; **iOS needs an Xcode build + a device push to verify** the category selection end-to-end (not built here to avoid signing/dylib pitfalls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)