### PR TITLE
fix(chat): stop composer sheet infinite jitter — guard dismiss in onDismissRequest, not confirmValueChange

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/GuardedComposerSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/GuardedComposerSheet.kt
@@ -4,7 +4,6 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -27,7 +26,8 @@ import org.jetbrains.compose.resources.stringResource
  * guards against accidental data loss (#891): when the user swipes the sheet
  * down, taps the scrim, presses back, or taps the close button **while there's
  * unsaved content**, it asks "Discard changes?" instead of throwing the draft
- * away. An empty composer dismisses immediately, with no prompt.
+ * away — keeping the sheet (and the draft) if the user cancels. An empty
+ * composer dismisses immediately, with no prompt.
  *
  * [content] reports whether it currently holds unsaved content through the
  * `reportUnsaved` callback, and routes its own close button through
@@ -47,21 +47,13 @@ internal fun GuardedComposerSheet(
     var hasUnsaved by remember { mutableStateOf(false) }
     var showDiscardConfirm by remember { mutableStateOf(false) }
 
-    // confirmValueChange rejects a swipe/scrim drag toward Hidden mid-gesture —
-    // the sheet snaps back (no flash to a half-dismissed state) and we pop the
-    // confirm dialog. onDismissRequest covers the predictive-back path, which
-    // does not always route through confirmValueChange.
-    val sheetState = rememberModalBottomSheetState(
-        skipPartiallyExpanded = true,
-        confirmValueChange = { target ->
-            if (target == SheetValue.Hidden && hasUnsaved) {
-                showDiscardConfirm = true
-                false
-            } else {
-                true
-            }
-        },
-    )
+    // No confirmValueChange veto: rejecting Hidden mid-fling leaves the sheet
+    // with no anchor to absorb the velocity (skipPartiallyExpanded removes
+    // PartiallyExpanded), so it oscillates between Expanded and Hidden forever
+    // (#997). Instead the sheet settles Hidden normally; every dismissal path
+    // (swipe, scrim, back) then fires onDismissRequest, where the unsaved
+    // guard lives — cancel re-shows the sheet with the draft intact.
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     val requestClose: () -> Unit = {
         if (hasUnsaved) showDiscardConfirm = true
@@ -76,20 +68,28 @@ internal fun GuardedComposerSheet(
     }
 
     if (showDiscardConfirm) {
+        // Keep editing: a swipe/scrim/back dismissal already settled the sheet
+        // Hidden before onDismissRequest fired, so bring it back; when the
+        // dialog came from the close button the sheet is still expanded and
+        // show() is a no-op.
+        val keepEditing: () -> Unit = {
+            showDiscardConfirm = false
+            scope.launch { sheetState.show() }
+        }
         AlertDialog(
-            onDismissRequest = { showDiscardConfirm = false },
+            onDismissRequest = keepEditing,
             title = { Text(stringResource(MR.string.composer_discard_title)) },
             text = { Text(stringResource(MR.string.composer_discard_message)) },
             confirmButton = {
                 // Discard: drop the sheet outright (the host removes it from
-                // composition) — no animated hide() to fight confirmValueChange.
+                // composition; it is already Hidden on the swipe/scrim/back path).
                 TextButton(onClick = {
                     showDiscardConfirm = false
                     onDismiss()
                 }) { Text(stringResource(MR.string.composer_discard_confirm)) }
             },
             dismissButton = {
-                TextButton(onClick = { showDiscardConfirm = false }) {
+                TextButton(onClick = keepEditing) {
                     Text(stringResource(MR.string.composer_discard_keep))
                 }
             },

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/GuardedComposerSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/GuardedComposerSheet.kt
@@ -1,5 +1,6 @@
 package id.homebase.chat.widget
 
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
@@ -47,12 +48,8 @@ internal fun GuardedComposerSheet(
     var hasUnsaved by remember { mutableStateOf(false) }
     var showDiscardConfirm by remember { mutableStateOf(false) }
 
-    // No confirmValueChange veto: rejecting Hidden mid-fling leaves the sheet
-    // with no anchor to absorb the velocity (skipPartiallyExpanded removes
-    // PartiallyExpanded), so it oscillates between Expanded and Hidden forever
-    // (#997). Instead the sheet settles Hidden normally; every dismissal path
-    // (swipe, scrim, back) then fires onDismissRequest, where the unsaved
-    // guard lives — cancel re-shows the sheet with the draft intact.
+    // No confirmValueChange veto — rejecting Hidden mid-fling oscillates the
+    // sheet forever (#997); the unsaved guard lives in onDismissRequest instead.
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     val requestClose: () -> Unit = {
@@ -63,15 +60,15 @@ internal fun GuardedComposerSheet(
     ModalBottomSheet(
         onDismissRequest = { if (hasUnsaved) showDiscardConfirm = true else onDismiss() },
         sheetState = sheetState,
+        // Zero insets: the defaults pad inside the draggable surface, so sheet
+        // height tracks sheet position and the anchors oscillate on fling (#997).
+        contentWindowInsets = { WindowInsets(0, 0, 0, 0) },
     ) {
         content(sheetState, requestClose) { hasUnsaved = it }
     }
 
     if (showDiscardConfirm) {
-        // Keep editing: a swipe/scrim/back dismissal already settled the sheet
-        // Hidden before onDismissRequest fired, so bring it back; when the
-        // dialog came from the close button the sheet is still expanded and
-        // show() is a no-op.
+        // A swipe/scrim/back dismissal already settled Hidden — bring the sheet back.
         val keepEditing: () -> Unit = {
             showDiscardConfirm = false
             scope.launch { sheetState.show() }
@@ -81,8 +78,6 @@ internal fun GuardedComposerSheet(
             title = { Text(stringResource(MR.string.composer_discard_title)) },
             text = { Text(stringResource(MR.string.composer_discard_message)) },
             confirmButton = {
-                // Discard: drop the sheet outright (the host removes it from
-                // composition; it is already Hidden on the swipe/scrim/back path).
                 TextButton(onClick = {
                     showDiscardConfirm = false
                     onDismiss()


### PR DESCRIPTION
Fixes #997

## Root causes (two independent oscillation drivers)

**1. `confirmValueChange` veto.** `GuardedComposerSheet` (shared by the Event, Groodle, and Poll composers) guarded unsaved content with a `confirmValueChange` veto: `target == Hidden && hasUnsaved → false`. `confirmValueChange` arbitrates a live, velocity-driven settle — rejecting it mid-fling with `skipPartiallyExpanded = true` leaves no `PartiallyExpanded` anchor to absorb the momentum, so the sheet oscillates between `Expanded` and `Hidden`.

**2. Inset feedback loop (found during device verification — the veto removal alone did not stop the jitter).** M3's default `contentWindowInsets` are padded *inside* the surface that `draggableAnchors` moves (verified in the bundled material3 1.5.0-alpha08 bytecode). The sheet's measured height therefore depends on its own on-screen position: sheet moves → nav-bar/IME inset overlap changes → padding changes → height changes → the `Expanded` anchor (`screenHeight − sheetHeight`) moves → the sheet animates to chase it → insets change again. A fling kicks the sheet into this loop and it oscillates indefinitely; an IME open/close cycle likewise strands the sheet off-anchor (parked at the top with a scrim gap below). Observed on device: the sheet cycled between a 2000 px-tall flush-bottom phase and a 1910 px-tall top-parked phase inside a static full-screen dialog window.

## Fix (single file: `homebase-chat/.../widget/GuardedComposerSheet.kt`)
- Remove the `confirmValueChange` veto — the sheet settles normally; the unsaved-content guard lives solely in `onDismissRequest` (all three dismissal paths route through it: swipe/fling, scrim tap, back/predictive back).
- `contentWindowInsets = { WindowInsets(0, 0, 0, 0) }` — sheet height becomes a constant (drag handle + the content's stable `fillMaxHeight(0.92f)`), so anchors never move and a fling settles exactly once. Composer content already handles the keyboard itself (`imePadding()` inside the scroll area in `EventComposerSheet`), so IME behavior is unchanged.
- State machine: `onDismissRequest` with unsaved content shows the discard dialog and does **not** call the caller's `onDismiss` — the `ModalBottomSheet` stays in composition, draft intact. **Cancel / dialog-outside-tap** → `sheetState.show()` slides the sheet back up. **Confirm** → caller's `onDismiss()` removes the sheet. Nothing unsaved → dismisses immediately, as before.
- Zero changes in `EventComposerSheet.kt` / `GroodleComposerSheet.kt` / `PollComposerSheet.kt`.

## Relationship to #891
#891's discard-confirm guarantee is preserved — attempting to dismiss with unsaved content still always shows the dialog (back button, scrim tap, drag-to-dismiss, close button); only the mechanism changed (dismiss-time guard instead of the mid-gesture veto that caused the jitter). The same shared change resolves the Groodle jitter #891 originally reported.

## Verification
- `./gradlew :homebase-chat:compileKotlinJvm :homebase-chat:compileAndroidMain :homebase-chat:compileKotlinWasmJs :homebase-chat:compileKotlinIosSimulatorArm64` — BUILD SUCCESSFUL
- `./gradlew :homebase-chat:jvmTest` — green
- **Device-verified on Android (Redmi Note 5 Pro, API 30)**: Event composer with a dirty draft — drag-down + hard fling-up settles cleanly (previously oscillated forever, reproduced on the veto-only build); keyboard open/close no longer strands the sheet off-anchor; discard dialog fires on dismiss with unsaved content and *Keep editing* restores the sheet with the draft intact.
- iOS device verification still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)