### PR TITLE
fix(share): surface Note to Self when searching own name in share picker (#984)

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/share/SharePickerScreen.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/SharePickerScreen.kt
@@ -57,11 +57,14 @@ import id.homebase.chat.services.convo.ConversationEnricher
 import id.homebase.chat.services.convo.ConversationStream
 import id.homebase.chat.services.convo.EnrichedConversationUiModel
 import id.homebase.chat.services.convo.contact.ContactService
+import id.homebase.chat.services.convo.matchesShareQuery
+import id.homebase.chat.services.convo.selfDisplayLabel
 import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.ConversationAvatar
 import id.homebase.core.widget.StyledSearchTextField
 import id.homebase.resources.MR
 import id.homebase.resources.chat_search_placeholder
+import id.homebase.resources.contactbook_self_you
 import id.homebase.resources.contacts
 import id.homebase.resources.conversations_selected
 import id.homebase.resources.groups
@@ -116,10 +119,12 @@ fun SharePickerScreen(
     // Gating on `ownerSession != null` left the conversation list empty while the
     // New Moment row (which only needs dataReady) still showed: the user could
     // share to a moment but not to a conversation.
+    val effectiveSession by remember {
+        derivedStateOf { synthesizeOwnerSession(ownerSession, credentials) }
+    }
     val enrichedConversations by remember {
         derivedStateOf {
-            val session = synthesizeOwnerSession(ownerSession, credentials)
-                ?: return@derivedStateOf emptyList()
+            val session = effectiveSession ?: return@derivedStateOf emptyList()
             val contactMap = contactsState.associateBy { it.odinId }
             conversationsData.items.map { enricher.enrich(it, contactMap, session) }
         }
@@ -138,7 +143,7 @@ fun SharePickerScreen(
                 enrichedConversations
             } else {
                 enrichedConversations.filter {
-                    it.getDisplayName().contains(searchQuery, ignoreCase = true)
+                    it.matchesShareQuery(searchQuery, effectiveSession)
                 }
             }
         }
@@ -263,6 +268,11 @@ fun SharePickerScreen(
                     CircularProgressIndicator()
                 }
             } else if (isSearchActive) {
+                // The surfaced self row reads as the user ("Name (you)"), consistent with
+                // the create-conversation self-search affordance (#902).
+                val selfLabel = effectiveSession?.let {
+                    stringResource(MR.string.contactbook_self_you, it.selfDisplayLabel())
+                }
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
                     items(
                         items = filteredConversations,
@@ -270,6 +280,7 @@ fun SharePickerScreen(
                     ) { enriched ->
                         ConversationPickerItem(
                             enriched = enriched,
+                            selfLabel = selfLabel,
                             isSelected = enriched.conversation.id in selectedIds,
                             onClick = {
                                 selectedIds = if (enriched.conversation.id in selectedIds) {
@@ -442,6 +453,7 @@ private fun ConversationPickerItem(
     enriched: EnrichedConversationUiModel,
     isSelected: Boolean,
     onClick: () -> Unit,
+    selfLabel: String? = null,
 ) {
     val conversation = enriched.conversation
     Row(
@@ -468,7 +480,7 @@ private fun ConversationPickerItem(
 
         Column(modifier = Modifier.weight(1f)) {
             Text(
-                text = enriched.getDisplayName(),
+                text = if (conversation.isWithSelf && selfLabel != null) selfLabel else enriched.getDisplayName(),
                 style = MaterialTheme.typography.bodyLarge,
                 fontWeight = FontWeight.Medium,
                 maxLines = 1,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/createconversation/CreateConversationViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/createconversation/CreateConversationViewModel.kt
@@ -14,6 +14,8 @@ import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.convo.ConversationService
 import id.homebase.chat.services.convo.contact.ConnectionService
 import id.homebase.chat.services.convo.contact.ContactService
+import id.homebase.chat.services.convo.matchesSelfQuery
+import id.homebase.chat.services.convo.selfDisplayLabel
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -182,12 +184,7 @@ internal fun filterAndGroup(
 }
 
 /** True when [query] hits the signed-in user's own display name or handle (case-insensitive). */
-internal fun OwnerSession?.matchesQuery(query: String): Boolean {
-    if (this == null || query.isBlank()) return false
-    return displayName?.contains(query, ignoreCase = true) == true ||
-        odinId.toString().contains(query, ignoreCase = true)
-}
+internal fun OwnerSession?.matchesQuery(query: String): Boolean = matchesSelfQuery(query)
 
 /** Display label for the signed-in user: their name, or their handle when the name isn't loaded. */
-internal fun OwnerSession.displayLabel(): String =
-    displayName?.ifBlank { null } ?: odinId.domainName
+internal fun OwnerSession.displayLabel(): String = selfDisplayLabel()

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -1551,7 +1551,12 @@ class ConversationStream(
             }
             _shareableConversations.value = shareable
             val momentsActivated = optionalDriveActivation.isActivated(momentsLabeledDrive)
-            shareCacheWriter.updateCache(shareable, domain, momentsActivated)
+            shareCacheWriter.updateCache(
+                shareable,
+                domain,
+                momentsActivated,
+                ownerDisplayName = ownerSessionRepository.user.value?.displayName,
+            )
 
             // Pre-cache group avatar images for the iOS share extension
             for (convo in conversations) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/SelfSearch.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/SelfSearch.kt
@@ -1,0 +1,23 @@
+package id.homebase.chat.services.convo
+
+import id.homebase.api.client.auth.OwnerSession
+
+/** True when [query] hits the signed-in user's own display name or handle (case-insensitive). */
+fun OwnerSession?.matchesSelfQuery(query: String): Boolean {
+    if (this == null || query.isBlank()) return false
+    return displayName?.contains(query, ignoreCase = true) == true ||
+        odinId.toString().contains(query, ignoreCase = true)
+}
+
+/** Display label for the signed-in user: their name, or their handle when the name isn't loaded. */
+fun OwnerSession.selfDisplayLabel(): String =
+    displayName?.ifBlank { null } ?: odinId.domainName
+
+/**
+ * Share-picker search predicate: a conversation matches on its display name, or — for the
+ * self conversation, whose display name is the literal "You" label — when the query hits the
+ * owner's own name/handle, so searching your own name surfaces Note to Self (#984).
+ */
+fun EnrichedConversationUiModel.matchesShareQuery(query: String, self: OwnerSession?): Boolean =
+    getDisplayName().contains(query, ignoreCase = true) ||
+        (conversation.isWithSelf && self.matchesSelfQuery(query))

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ShareSelfMatchTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ShareSelfMatchTest.kt
@@ -1,0 +1,104 @@
+package id.homebase.chat.services.convo
+
+import id.homebase.api.client.auth.OwnerSession
+import id.homebase.api.common.OdinId
+import id.homebase.chat.data.ContactUiModel
+import id.homebase.chat.data.ConversationState
+import id.homebase.chat.data.ConversationUiModel
+import id.homebase.chat.services.ChatProtocol
+import id.homebase.core.avatars.ConversationAvatarModel
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * The share-picker search seam (#984): searching your own name/handle surfaces the self
+ * conversation (whose display name is the literal "You" label) via [matchesShareQuery],
+ * while non-self rows keep matching on display name only.
+ */
+class ShareSelfMatchTest {
+
+    private val me = OdinId("samwise.gamgee.demo.rocks")
+    private val alice = OdinId("alice.test")
+
+    private val session = OwnerSession(
+        odinId = me,
+        displayName = "Samwise Gamgee",
+        firstName = null,
+        surName = null,
+        profileImageFileId = null,
+        profileImageFileKey = null,
+        profileImagePreviewThumbnail = null,
+        profileImageLastModified = null,
+        status = null,
+    )
+
+    private fun convo(id: Uuid, name: String, participants: List<OdinId>) = ConversationUiModel(
+        id = id,
+        name = name,
+        lastMessage = " ",
+        latestMessageTimestamp = Instant.fromEpochMilliseconds(0),
+        avatarInitials = "",
+        avatarTiny = null,
+        participants = participants,
+        lastRead = Instant.fromEpochMilliseconds(0),
+        avatarModel = ConversationAvatarModel(
+            type = ConversationAvatarModel.Type.Connection,
+            odinId = alice,
+        ),
+        admins = emptySet(),
+        conversationState = ConversationState.Active,
+    )
+
+    private fun selfRow() = EnrichedConversationUiModel(
+        conversation = convo(ChatProtocol.ConversationWithYourselfId, "", listOf(me)),
+        participants = emptyList(),
+        missingConnections = emptyList(),
+    )
+
+    private fun aliceRow() = EnrichedConversationUiModel(
+        conversation = convo(Uuid.random(), "alice.test", listOf(me, alice)),
+        participants = listOf(
+            ContactUiModel(id = Uuid.random(), odinId = alice, name = "Alice", avatarInitials = ""),
+        ),
+        missingConnections = emptyList(),
+    )
+
+    @Test
+    fun selfRow_matchesOwnerName() {
+        assertTrue(selfRow().matchesShareQuery("samwise", session))
+    }
+
+    @Test
+    fun selfRow_matchesOwnerHandle() {
+        assertTrue(selfRow().matchesShareQuery("gamgee.demo", session))
+    }
+
+    @Test
+    fun selfRow_stillMatchesYouLabel() {
+        assertTrue(selfRow().matchesShareQuery("you", session))
+    }
+
+    @Test
+    fun selfRow_noMatch_whenQueryHitsNothing() {
+        assertFalse(selfRow().matchesShareQuery("mordor", session))
+    }
+
+    @Test
+    fun selfRow_withoutSession_matchesOnlyYouLabel() {
+        assertFalse(selfRow().matchesShareQuery("samwise", null))
+        assertTrue(selfRow().matchesShareQuery("you", null))
+    }
+
+    @Test
+    fun nonSelfRow_neverMatchesOwnerName() {
+        assertFalse(aliceRow().matchesShareQuery("samwise", session))
+    }
+
+    @Test
+    fun nonSelfRow_matchesDisplayName() {
+        assertTrue(aliceRow().matchesShareQuery("alice", session))
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/share/ShareConversationCacheWriter.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/share/ShareConversationCacheWriter.kt
@@ -16,6 +16,7 @@ class ShareConversationCacheWriter(
         conversations: List<ShareableConversation>,
         userDomain: String,
         momentsActivated: Boolean,
+        ownerDisplayName: String? = null,
     ) {
         try {
             val data = ShareConversationCacheData(
@@ -23,6 +24,7 @@ class ShareConversationCacheWriter(
                 updatedAt = kotlin.time.Clock.System.now().toEpochMilliseconds(),
                 userDomain = userDomain,
                 momentsActivated = momentsActivated,
+                ownerDisplayName = ownerDisplayName,
             )
             val encoded = json.encodeToString(data)
             cacheStorage.writeConversationCache(encoded)

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/share/ShareableConversation.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/share/ShareableConversation.kt
@@ -32,4 +32,7 @@ data class ShareConversationCacheData(
     // destination (it can't reach the main app's DB). Defaults false so older
     // caches deserialize cleanly.
     val momentsActivated: Boolean = false,
+    // Owner's display name, so the iOS share extension can surface Note to Self
+    // when the user searches their own name (#984). Nullable for older caches.
+    val ownerDisplayName: String? = null,
 )

--- a/iosApp/ShareExtension/ShareConversationCacheReader.swift
+++ b/iosApp/ShareExtension/ShareConversationCacheReader.swift
@@ -18,6 +18,8 @@ struct ShareConversationCacheSwift: Codable {
     let userDomain: String
     /// Optional so caches written before this field existed still decode.
     let momentsActivated: Bool?
+    /// Owner's display name for self-search (#984). Optional for older caches.
+    let ownerDisplayName: String?
 }
 
 /// Reads the conversation cache from the App Group container.
@@ -27,25 +29,31 @@ struct ShareConversationCacheReader {
     static let appGroupId = Bundle.main.infoDictionary?["AppGroupIdentifier"] as? String ?? "group.id.homebase.feed"
     static let cacheFileName = "share_conversation_cache.json"
 
-    static func load() -> (conversations: [ShareableConversationSwift], updatedAt: Date?, momentsActivated: Bool) {
+    static func load() -> (
+        conversations: [ShareableConversationSwift],
+        updatedAt: Date?,
+        momentsActivated: Bool,
+        ownerDomain: String,
+        ownerDisplayName: String?
+    ) {
         guard let containerURL = FileManager.default
             .containerURL(forSecurityApplicationGroupIdentifier: appGroupId)
         else {
-            return ([], nil, false)
+            return ([], nil, false, "", nil)
         }
 
         let cacheURL = containerURL.appendingPathComponent(cacheFileName)
 
         guard let data = try? Data(contentsOf: cacheURL) else {
-            return ([], nil, false)
+            return ([], nil, false, "", nil)
         }
 
         guard let cache = try? JSONDecoder().decode(ShareConversationCacheSwift.self, from: data)
         else {
-            return ([], nil, false)
+            return ([], nil, false, "", nil)
         }
 
         let date = Date(timeIntervalSince1970: TimeInterval(cache.updatedAt) / 1000.0)
-        return (cache.conversations, date, cache.momentsActivated ?? false)
+        return (cache.conversations, date, cache.momentsActivated ?? false, cache.userDomain, cache.ownerDisplayName)
     }
 }

--- a/iosApp/ShareExtension/SharePickerView.swift
+++ b/iosApp/ShareExtension/SharePickerView.swift
@@ -3,6 +3,9 @@ import UIKit
 
 private let recentsCount = 5
 
+/// Mirrors ChatProtocol.ConversationWithYourselfId in KMP.
+private let selfConversationId = "e4ef2382-ab3c-405d-a8b5-ad3e09e980dd"
+
 /// Conversation picker UI for the share extension.
 /// Displays conversations in categorized sections: Recents, Contacts, Groups.
 /// Supports multi-select — user taps conversations to toggle selection, then taps Send.
@@ -10,6 +13,9 @@ struct SharePickerView: View {
     let conversations: [ShareableConversationSwift]
     /// Whether to offer "New Moment" as a destination (media present + Moments activated).
     var showMomentOption: Bool = false
+    /// Owner identity so searching your own name/handle surfaces Note to Self (#984).
+    var ownerDisplayName: String? = nil
+    var ownerDomain: String = ""
     let onSelect: ([String]) -> Void
     var onSelectMoment: () -> Void = {}
     let onCancel: () -> Void
@@ -23,8 +29,36 @@ struct SharePickerView: View {
 
     private var filtered: [ShareableConversationSwift] {
         conversations.filter {
-            $0.displayName.localizedCaseInsensitiveContains(searchText)
+            $0.displayName.localizedCaseInsensitiveContains(searchText) ||
+                ($0.id == selfConversationId && matchesSelfQuery(searchText))
         }
+    }
+
+    /// Mirrors KMP SelfSearch.matchesSelfQuery: query hits the owner's name or handle.
+    private func matchesSelfQuery(_ query: String) -> Bool {
+        if query.isEmpty { return false }
+        if let name = ownerDisplayName, name.localizedCaseInsensitiveContains(query) { return true }
+        return ownerDomain.localizedCaseInsensitiveContains(query)
+    }
+
+    /// "Name (you)" label for the self row, matching the Android picker.
+    private var selfLabel: String? {
+        let name = ownerDisplayName.flatMap { $0.isEmpty ? nil : $0 }
+            ?? (ownerDomain.isEmpty ? nil : ownerDomain)
+        return name.map { "\($0) (you)" }
+    }
+
+    private func displayModel(_ conversation: ShareableConversationSwift) -> ShareableConversationSwift {
+        guard conversation.id == selfConversationId, let label = selfLabel else { return conversation }
+        return ShareableConversationSwift(
+            id: conversation.id,
+            displayName: label,
+            avatarInitials: conversation.avatarInitials,
+            isGroup: conversation.isGroup,
+            participantCount: conversation.participantCount,
+            lastMessageTimestamp: conversation.lastMessageTimestamp,
+            avatarUrl: conversation.avatarUrl
+        )
     }
 
     private var recents: [ShareableConversationSwift] {
@@ -172,7 +206,7 @@ struct SharePickerView: View {
     private func conversationButton(_ conversation: ShareableConversationSwift) -> some View {
         Button(action: { toggleSelection(conversation.id) }) {
             ShareConversationRow(
-                conversation: conversation,
+                conversation: displayModel(conversation),
                 isSelected: selectedIds.contains(conversation.id)
             )
         }

--- a/iosApp/ShareExtension/ShareViewController.swift
+++ b/iosApp/ShareExtension/ShareViewController.swift
@@ -34,7 +34,8 @@ class ShareViewController: UIViewController {
         }
 
         // 3. Load conversation cache from App Group
-        let (conversations, _, momentsActivated) = ShareConversationCacheReader.load()
+        let (conversations, _, momentsActivated, ownerDomain, ownerDisplayName) =
+            ShareConversationCacheReader.load()
 
         // "New Moment" needs media and an activated Moments feature — mirror the
         // Android picker's gating.
@@ -44,6 +45,8 @@ class ShareViewController: UIViewController {
         let pickerView = SharePickerView(
             conversations: conversations,
             showMomentOption: momentsActivated && hasMedia,
+            ownerDisplayName: ownerDisplayName,
+            ownerDomain: ownerDomain,
             onSelect: { [weak self] conversationIds in
                 self?.handleSelection(conversationIds: conversationIds)
             },


### PR DESCRIPTION
Fixes #984

## Problem
In the Android share-target picker, searching your own name found nothing: the self conversation's display name is the literal "You", and the filter only checked `getDisplayName().contains(query)` — so there was no way to reach Note to Self by searching your name or handle.

## Fix
Reuses the already-merged create-conversation self-search precedent (#895/#902):

- **Promoted the self-match helpers to a shared file** — `homebase-chat/.../services/convo/SelfSearch.kt` now holds `OwnerSession?.matchesSelfQuery(query)` (name or handle, case-insensitive) and `OwnerSession.selfDisplayLabel()`, plus the new share predicate `EnrichedConversationUiModel.matchesShareQuery(query, self)`. `CreateConversationViewModel`'s `matchesQuery`/`displayLabel` delegate to them, so the two screens can't drift and the existing `SelfSearchMatchTest` (11 tests) stays green untouched.
- **`SharePickerScreen` filter** — an item now passes on a display-name match OR (`conversation.isWithSelf` AND the owner session matches the query). The effective session is the same `synthesizeOwnerSession(ownerSession, credentials)` fallback the enricher already uses, so the match works during the share-activity cold start too.
- **Label** — the surfaced self row renders as "Name (you)" via the existing `contactbook_self_you` resource (same one create-conversation uses), only in search results. The unfiltered list still shows "You", and non-self searches are unchanged.

## Tests
New `ShareSelfMatchTest` (7 tests, jvmTest) pins the predicate: self row matches owner name/handle/"you" label, no match without a session, non-self rows never match the owner's name.

## iOS share extension — same fix, mirrored (second commit)
`iosApp/ShareExtension/SharePickerView.swift` had the identical filter gap, fed by the App Group JSON cache which carried `userDomain` but not the owner's display name. Now:
- `ShareConversationCacheData` gains `ownerDisplayName: String? = null` (older caches still decode); `ConversationStream` fills it from the owner session on every cache rewrite; the Swift `Codable` model mirrors it.
- `SharePickerView` mirrors KMP `SelfSearch`: the self row is identified by the fixed `ConversationWithYourselfId` UUID (`e4ef2382-…`, hardcoded mirror of `ChatProtocol`), `matchesSelfQuery` matches the owner's name or handle case-insensitively, and the row renders as "Name (you)" like the Android picker.
- Note: iOS self-search activates after the main app runs once post-update (the cache needs one rewrite to carry `ownerDisplayName`).

## Verification
- `:homebase-chat:` + `:homebase-common:` `compileKotlinJvm` / `compileAndroidMain` / `compileKotlinWasmJs` / `compileKotlinIosSimulatorArm64` — all green
- `:androidApp:compileDebugKotlin` — green; `jvmTest` — green (ShareSelfMatchTest 7/7, SelfSearchMatchTest 11/11)
- Swift extension sources pass `swiftc -parse` against the iOS simulator SDK
- **Device-verified on Android (Redmi Note 5 Pro)**: shared a text into the app, searched own name in the picker → "Bishwajeet Parhi (you)" surfaces Note to Self
- iOS extension end-to-end pending a device pass (needs the share sheet from another app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)