### PR TITLE
fix(chat): always scroll to bottom on own plain-text/reply/location sends

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -133,14 +133,14 @@ data class MessageListUiState(
      *  the screen renders [id.homebase.chat.event.EventDetailDialog] keyed off
      *  this state. Null means no host-level event detail is open. */
     val replyTargetEventDetail: ReplyTargetEventDetail? = null,
-    /** One-time "follow my own send to the bottom" token. Set to a fresh value
-     *  whenever the user sends a message through the full-screen attachment
-     *  editor (image/video/file): closing that overlay tears [ConversationContent]
-     *  — and its layout-growth auto-follow effect — out of composition, so the
-     *  effect restarts with `previousTotal = 0` and never observes the placeholder
-     *  as growth. ConversationContent collects this token on (re)mount, animates to
-     *  the latest item, and dispatches [ConversationListUiAction.ConsumeScrollToLatestRequest]
-     *  to clear it. Null once consumed, so unrelated remounts (closing the image
+    /** One-time "follow my own send to the bottom" token — a user's own send must
+     *  always scroll the list to show it (#995). Armed with the new message id by
+     *  every send arm in MessageActionsHandler (addMessage / replyToMessage /
+     *  addMessageWithFiles); a text/reply/location send adds no placeholder, so
+     *  ConversationContent waits until the id is actually present in the merged
+     *  list (see [resolveOwnSendFollowTarget]) before animating to the latest item,
+     *  then dispatches [ConversationListUiAction.ConsumeScrollToLatestRequest] to
+     *  clear it. Null once consumed, so unrelated remounts (closing the image
      *  viewer) don't re-scroll. */
     val scrollToLatestRequest: Uuid? = null,
 )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -1034,6 +1034,10 @@ internal class MessageActionsHandler(
                 registerLocalPreviewContexts(newMessageId, payloadBundle)
                 Logger.d(tag = TAG) { "addMessage: message=$newMessageId conversation=$conversationId" }
 
+                // Arm the own-send follow before the send: this path adds no placeholder,
+                // so the consuming effect waits for this id to land in the list (#995).
+                messagesUiState.update { it.copy(scrollToLatestRequest = newMessageId) }
+
                 // Location is a typed kind (= Event): the coordinate descriptor rides in the header
                 // (appData), the map PNG stays a chat_loc payload. Sending it through the typed path
                 // is what lets a live-share toggle edit the descriptor via updateMessage().
@@ -1122,6 +1126,10 @@ internal class MessageActionsHandler(
                 pendingMessageId = newMessageId
                 registerLocalPreviewContexts(newMessageId, payloadBundle)
                 Logger.d(tag = TAG) { "replyToMessage: message=$newMessageId conversation=$conversationId replyTo=${replyTo.id}" }
+
+                // Arm the own-send follow before the send: this path adds no placeholder,
+                // so the consuming effect waits for this id to land in the list (#995).
+                messagesUiState.update { it.copy(scrollToLatestRequest = newMessageId) }
 
                 chatMessageSenderService.replyToMessage(
                     messageUniqueId = newMessageId,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ScrollAnchorResolver.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ScrollAnchorResolver.kt
@@ -80,3 +80,37 @@ internal fun resolveScrollToLatestPosition(
     if (lastMessageIndex < 0) return null
     return ScrollPosition(firstVisibleItemIndex = lastMessageIndex, triggerScroll = true)
 }
+
+/**
+ * Gate for the one-time own-send follow ([MessageListUiState.scrollToLatestRequest]).
+ *
+ * A plain-text/reply/location send has no optimistic placeholder — the message
+ * reaches [messages] asynchronously via the optimistic-write round-trip — so the
+ * consuming effect in `ConversationContent` must not scroll until (a) the requested
+ * message is actually in the merged data (as a real message or a pending
+ * placeholder) and (b) the LazyColumn has laid out at least that many items.
+ * Scrolling any earlier targets the previous last item and leaves the send below
+ * the fold (#995).
+ *
+ * Returns the laid-out item count whose last index (`count - 1`) is the scroll
+ * target, or `null` while the insert/layout hasn't caught up yet.
+ */
+internal fun resolveOwnSendFollowTarget(
+    requestedId: Uuid,
+    messages: List<MessageListContentModel>,
+    pendingOutgoing: List<PendingOutgoingMessage>,
+    conversationId: Uuid,
+    laidOutItemCount: Int,
+): Int? {
+    val realIds = messages.asSequence()
+        .filterIsInstance<MessageListContentModel.Message>()
+        .mapTo(HashSet()) { it.message.id }
+    // Mirrors ConversationContent's mergedItems interleave: a placeholder counts
+    // only for this conversation and only until its real message lands.
+    val pendingForConvo = pendingOutgoing.filter {
+        it.conversationId == conversationId && it.id !in realIds
+    }
+    val present = requestedId in realIds || pendingForConvo.any { it.id == requestedId }
+    val mergedCount = messages.size + pendingForConvo.size
+    return if (present && laidOutItemCount >= mergedCount) laidOutItemCount else null
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -133,6 +133,7 @@ import id.homebase.chat.conversationlist.RecipientGroupModel
 import id.homebase.chat.conversationlist.RecipientModel
 import id.homebase.chat.conversationlist.RecipientType
 import id.homebase.chat.conversationlist.RecordingData
+import id.homebase.chat.conversationlist.resolveOwnSendFollowTarget
 import id.homebase.chat.createconversation.ContactItem
 import id.homebase.chat.createconversation.GroupOrConversationItem
 import id.homebase.chat.data.ConversationState
@@ -206,6 +207,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
@@ -218,6 +220,10 @@ import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
+
+/** Upper bound on waiting for an own send to appear in the list before the
+ *  follow token is consumed unscrolled (the send failed or was gated out). */
+private const val OWN_SEND_FOLLOW_TIMEOUT_MS = 5_000L
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
@@ -382,20 +388,37 @@ fun ConversationContent(
         }
     }
 
-    // One-time own-send follow for sends that route through the full-screen
-    // attachment editor (image/video/file). Closing that overlay remounts this
-    // composable with the pending placeholder already in the list, so the
-    // layout-growth auto-follow above starts at previousTotal = 0 and never sees
-    // growth. The ViewModel sets scrollToLatestRequest in the same update that
-    // adds the placeholder and clears the overlay; we wait for the freshly
-    // mounted list to lay out, follow it to the bottom, then consume the token.
-    // Skipped (but still consumed) when paged into history — jumpToLatestAfterOwnSend
-    // handles that case with a ScrollToLatest reload once the send completes.
+    // One-time own-send follow: every send arm sets scrollToLatestRequest so the
+    // user's own message always lands visible, even when scrolled up into history
+    // (#995). Attachment sends put a placeholder in the list in the same update
+    // that arms the token (and remount this composable, which is why the
+    // layout-growth auto-follow above can't cover them — it restarts with
+    // previousTotal = 0). Text/reply/location sends have NO placeholder — the
+    // message reaches uiState.messages asynchronously via the optimistic-write
+    // round-trip — so wait until the requested id is actually in the merged data
+    // AND laid out before following; scrolling earlier targets the previous last
+    // item. Skipped (but still consumed) when paged into history —
+    // jumpToLatestAfterOwnSend handles that case with a ScrollToLatest reload
+    // once the send completes.
+    val messagesForOwnSend = rememberUpdatedState(uiState.messages)
+    val pendingForOwnSend = rememberUpdatedState(uiState.pendingOutgoing)
     LaunchedEffect(uiState.scrollToLatestRequest) {
-        if (uiState.scrollToLatestRequest == null) return@LaunchedEffect
+        val requestedId = uiState.scrollToLatestRequest ?: return@LaunchedEffect
         if (!uiState.hasNewerMessages) {
-            val total = snapshotFlow { listState.layoutInfo.totalItemsCount }.first { it > 0 }
-            listState.animateScrollToItem(total - 1)
+            // Bounded so a failed send (whose message never arrives) can't pin
+            // the token armed forever; consume runs either way.
+            withTimeoutOrNull(OWN_SEND_FOLLOW_TIMEOUT_MS) {
+                val target = snapshotFlow {
+                    resolveOwnSendFollowTarget(
+                        requestedId = requestedId,
+                        messages = messagesForOwnSend.value,
+                        pendingOutgoing = pendingForOwnSend.value,
+                        conversationId = conversation.conversation.id,
+                        laidOutItemCount = listState.layoutInfo.totalItemsCount,
+                    ) ?: -1
+                }.first { it > 0 }
+                listState.animateScrollToItem(target - 1)
+            }
         }
         onUiAction(ConversationListUiAction.ConsumeScrollToLatestRequest)
     }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/OwnSendFollowTargetTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/OwnSendFollowTargetTest.kt
@@ -1,0 +1,187 @@
+package id.homebase.chat.conversationlist
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.common.OdinId
+import id.homebase.chat.data.MessageUiModel
+import id.homebase.chat.services.MessageAppData
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * Gate for the one-time own-send follow (#995): a plain-text/reply/location send
+ * arms [MessageListUiState.scrollToLatestRequest] but inserts its message
+ * asynchronously (no placeholder), so [resolveOwnSendFollowTarget] must hold the
+ * scroll back until the requested id is actually in the merged data AND the
+ * LazyColumn has laid out at least that many items — scrolling earlier targets
+ * the previous last item and leaves the send below the fold.
+ */
+class OwnSendFollowTargetTest {
+
+    private val alice = OdinId("alice.test")
+    private val baseTime = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+    private val convoId = Uuid.random()
+
+    private fun message(id: Uuid = Uuid.random()): MessageListContentModel.Message =
+        MessageListContentModel.Message(
+            message = MessageUiModel(
+                id = id,
+                globalTransitId = null,
+                fileId = Uuid.random(),
+                conversationId = convoId,
+                content = "test",
+                userDate = baseTime,
+                modified = null,
+                created = baseTime,
+                originalAuthor = alice,
+                sender = alice,
+                displayName = alice.domainName,
+                localReadTimestamp = null,
+                isDeleted = false,
+                isPendingSend = false,
+                versionTag = Uuid.NIL,
+                messageAppData = MessageAppData(),
+                reactionPreview = null,
+                previewThumbnail = null,
+                payloads = null,
+                keyHeader = KeyHeader.empty(),
+                hasMore = false,
+            ),
+        )
+
+    private fun pending(
+        id: Uuid = Uuid.random(),
+        conversationId: Uuid = convoId,
+    ) = PendingOutgoingMessage(
+        id = id,
+        conversationId = conversationId,
+        text = "pending",
+        attachmentCount = 0,
+        sentAt = baseTime,
+    )
+
+    @Test
+    fun notInListYet_returnsNull() {
+        // Armed at send time, but the optimistic round-trip hasn't landed the
+        // message yet — must NOT scroll (that's the pre-fix race: it would
+        // target the previous last item).
+        val list = listOf<MessageListContentModel>(MessageListContentModel.Header, message())
+        assertNull(
+            resolveOwnSendFollowTarget(
+                requestedId = Uuid.random(),
+                messages = list,
+                pendingOutgoing = emptyList(),
+                conversationId = convoId,
+                laidOutItemCount = list.size,
+            )
+        )
+    }
+
+    @Test
+    fun presentAndLaidOut_returnsCount() {
+        val sent = message()
+        val list = listOf<MessageListContentModel>(
+            MessageListContentModel.Header, message(), sent,
+        )
+        assertEquals(
+            3,
+            resolveOwnSendFollowTarget(
+                requestedId = sent.message.id,
+                messages = list,
+                pendingOutgoing = emptyList(),
+                conversationId = convoId,
+                laidOutItemCount = 3,
+            )
+        )
+    }
+
+    @Test
+    fun presentInDataButLayoutStale_returnsNull() {
+        // The message reached uiState.messages but the LazyColumn hasn't
+        // re-measured yet — scrolling now would land on the old last item.
+        val sent = message()
+        val list = listOf<MessageListContentModel>(
+            MessageListContentModel.Header, message(), sent,
+        )
+        assertNull(
+            resolveOwnSendFollowTarget(
+                requestedId = sent.message.id,
+                messages = list,
+                pendingOutgoing = emptyList(),
+                conversationId = convoId,
+                laidOutItemCount = 2,
+            )
+        )
+    }
+
+    @Test
+    fun presentAsPendingPlaceholder_returnsCount() {
+        // Attachment path: the placeholder is registered in the same update
+        // that arms the token, so the follow fires as soon as layout catches up.
+        val placeholder = pending()
+        val list = listOf<MessageListContentModel>(MessageListContentModel.Header, message())
+        assertEquals(
+            3,
+            resolveOwnSendFollowTarget(
+                requestedId = placeholder.id,
+                messages = list,
+                pendingOutgoing = listOf(placeholder),
+                conversationId = convoId,
+                laidOutItemCount = 3,
+            )
+        )
+    }
+
+    @Test
+    fun placeholderSupersededByRealMessage_notDoubleCounted() {
+        // mergedItems drops a placeholder once its real message lands; the
+        // expected count must do the same or layout could never "catch up".
+        val sent = message()
+        val list = listOf<MessageListContentModel>(MessageListContentModel.Header, sent)
+        assertEquals(
+            2,
+            resolveOwnSendFollowTarget(
+                requestedId = sent.message.id,
+                messages = list,
+                pendingOutgoing = listOf(pending(id = sent.message.id)),
+                conversationId = convoId,
+                laidOutItemCount = 2,
+            )
+        )
+    }
+
+    @Test
+    fun pendingFromOtherConversation_ignored() {
+        val other = pending(conversationId = Uuid.random())
+        val list = listOf<MessageListContentModel>(MessageListContentModel.Header, message())
+        assertNull(
+            resolveOwnSendFollowTarget(
+                requestedId = other.id,
+                messages = list,
+                pendingOutgoing = listOf(other),
+                conversationId = convoId,
+                laidOutItemCount = 2,
+            )
+        )
+    }
+
+    @Test
+    fun extraNonMergedRows_followsToRealEnd() {
+        // The LazyColumn can hold rows beyond mergedItems (the empty-chat info
+        // row); the target is always the laid-out end, not the merged count.
+        val sent = message()
+        val list = listOf<MessageListContentModel>(MessageListContentModel.Header, sent)
+        assertEquals(
+            3,
+            resolveOwnSendFollowTarget(
+                requestedId = sent.message.id,
+                messages = list,
+                pendingOutgoing = emptyList(),
+                conversationId = convoId,
+                laidOutItemCount = 3,
+            )
+        )
+    }
+}


### PR DESCRIPTION
Fixes #995

## Root cause
`ConversationContent` has two scroll mechanisms: (A) a layout-growth auto-follow (`snapshotFlow` on `layoutInfo`) and (B) a one-time follow token `scrollToLatestRequest`. Attachment sends arm (B) and scroll reliably; **plain-text `addMessage` and `replyToMessage` armed nothing** and relied entirely on (A). (A) is racy for text sends: it is keyed on `layoutInfo` only while the bottom key comes from `uiState.messages` (different schedules), so a non-growth emission can consume the bottom-key transition (`previousBottomKey = bottomKey`) before the growth emission arrives — with the user scrolled up, nothing scrolls. Text sends also insert asynchronously (OptimisticWriter → eventBus → `ChatMessageStream` → `uiState.messages`), so at send time the message isn't in the list at all.

## Fix
- **Arm the token on every own send**: `MessageActionsHandler.addMessage` (covers plain text, location, and link-preview sends) and `replyToMessage` now set `scrollToLatestRequest = newMessageId` at send time, mirroring `addMessageWithFiles`.
- **Harden the consuming effect**: since these paths add no placeholder, the effect no longer scrolls on `total > 0`. A new pure gate, `resolveOwnSendFollowTarget` (in `ScrollAnchorResolver.kt`), holds the scroll until the requested id is **actually present** in the merged data (real message or pending placeholder, mirroring the `mergedItems` interleave) **and** the LazyColumn has laid out at least that many items — so the scroll can never target the previous last item. Reads go through `rememberUpdatedState` holders so the armed effect sees fresh state; the `snapshotFlow` emits a plain `Int` (cheap built-in dedup, no `distinctUntilChanged`, no unbounded index reads — per the CLAUDE.md `ConversationContent` gotchas).
- The wait is bounded (5 s) so a failed send still consumes the token; `hasNewerMessages` still defers to the existing `ScrollToLatest` reload (`jumpToLatestAfterOwnSend`); the layout-growth auto-follow for incoming-while-at-bottom is untouched, as is the attachment-send path.

## Files
- `homebase-chat/.../conversationlist/MessageActionsHandler.kt` — arm token in `addMessage` / `replyToMessage`
- `homebase-chat/.../conversationlist/ScrollAnchorResolver.kt` — new `resolveOwnSendFollowTarget` gate
- `homebase-chat/.../widget/ConversationContent.kt` — hardened consuming effect + timeout const
- `homebase-chat/.../conversationlist/ConversationListUiState.kt` — `scrollToLatestRequest` doc update
- `homebase-chat/src/jvmTest/.../OwnSendFollowTargetTest.kt` — 7 tests pinning the gate (not-inserted-yet, layout-stale, placeholder path, placeholder/real dedup, other-conversation pending, extra non-merged rows)

## Verification
- `:homebase-chat:compileKotlinJvm` / `compileAndroidMain` / `compileKotlinWasmJs` / `compileKotlinIosSimulatorArm64` — all green
- `:homebase-chat:jvmTest --rerun-tasks` — full suite green (new `OwnSendFollowTargetTest`: 7/7)
- **Device-verified on Android (Redmi Note 5 Pro, API 30)**: with the conversation scrolled several screens up into history, sending a plain text message scrolls the list to the bottom and the sent message is visible (previously the list stayed parked in history). Sends while already at the bottom keep following as before. Reply-path arming is covered by the unit tests; not separately exercised on device.
- iOS device verification still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)