### PR TITLE
feat(theme): theme-aware edge-to-edge system chrome via shared UpdateEdgeToEdge

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
@@ -1,18 +1,12 @@
 package id.homebase.feed
 
 import android.content.Intent
-import android.graphics.Color
 import android.os.Bundle
-import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import co.touchlab.kermit.Logger
 import com.mmk.kmpnotifier.extensions.onCreateOrOnNewIntent
@@ -33,14 +27,11 @@ import id.homebase.core.notifications.decideNotificationIntent
 import id.homebase.core.notifications.isReplayedFromHistory
 import id.homebase.feed.crash.NativeCrashRecovery
 import id.homebase.feed.share.ShareShortcutPublisher
-import id.homebase.core.settings.ThemeState
-import id.homebase.core.settings.UserPreferences
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.dialogs.init
 import io.github.vinceglb.filekit.manualFileKitCoreInitialization
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
-import org.koin.compose.koinInject
 
 class MainActivity : AppCompatActivity() {
 
@@ -90,33 +81,8 @@ class MainActivity : AppCompatActivity() {
         // Marked here (not inside the composable body, which re-fires per recomposition):
         // setContent → "App() first composition" is the first-frame / composition cost.
         StartupLogger.checkpoint("setContent")
-        setContent {
-            val userPreferences = koinInject<UserPreferences>()
-            val prefState by userPreferences.preferenceState.collectAsStateWithLifecycle()
-            val isDarkTheme = when (prefState.theme) {
-                ThemeState.System -> isSystemInDarkTheme()
-                ThemeState.Dark -> true
-                ThemeState.Light -> false
-            }
-
-            DisposableEffect(isDarkTheme) {
-                enableEdgeToEdge(
-                    statusBarStyle = if (isDarkTheme) {
-                        SystemBarStyle.dark(Color.TRANSPARENT)
-                    } else {
-                        SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT)
-                    },
-                    navigationBarStyle = if (isDarkTheme) {
-                        SystemBarStyle.dark(Color.TRANSPARENT)
-                    } else {
-                        SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT)
-                    },
-                )
-                onDispose {}
-            }
-
-            App()
-        }
+        // Theme-aware system bars are applied by HomebaseTheme (UpdateEdgeToEdge).
+        setContent { App() }
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
@@ -249,7 +249,10 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
                 }
             }
 
-            HomebaseTheme(darkTheme = isDarkTheme) {
+            HomebaseTheme(
+                darkTheme = isDarkTheme,
+                followsSystemTheme = prefState.theme == ThemeState.System,
+            ) {
                 Box(modifier = Modifier.fillMaxSize()) {
                 when (val state = screenState) {
                     is ShareScreenState.Picking -> {

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/ui/theme/UpdateEdgeToEdge.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/ui/theme/UpdateEdgeToEdge.android.kt
@@ -1,0 +1,32 @@
+package id.homebase.core.ui.theme
+
+import android.content.Context
+import android.content.ContextWrapper
+import android.graphics.Color
+import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.platform.LocalView
+
+@Composable
+internal actual fun UpdateEdgeToEdge(darkTheme: Boolean, followsSystemTheme: Boolean) {
+    val view = LocalView.current
+    if (view.isInEditMode) return
+    val activity = view.context.findComponentActivity() ?: return
+    SideEffect {
+        // Explicit light/dark, not SystemBarStyle.auto — auto lets the system
+        // scrim the nav bar in 3-button mode instead of using these colors.
+        val style =
+            if (darkTheme) SystemBarStyle.dark(Color.TRANSPARENT)
+            else SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT)
+        activity.enableEdgeToEdge(statusBarStyle = style, navigationBarStyle = style)
+    }
+}
+
+private tailrec fun Context.findComponentActivity(): ComponentActivity? = when (this) {
+    is ComponentActivity -> this
+    is ContextWrapper -> baseContext.findComponentActivity()
+    else -> null
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/theme/Theme.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/theme/Theme.kt
@@ -145,12 +145,20 @@ val LocalHomebaseExtendedColors = staticCompositionLocalOf { LightExtendedColors
  * Homebase app theme with dark/light mode support. Uses Signal-based color palette.
  *
  * @param darkTheme Whether to use dark theme. Defaults to system setting.
+ * @param followsSystemTheme Whether [darkTheme] merely mirrors the OS setting (the
+ * user picked "System") rather than forcing a variant — see [UpdateEdgeToEdge].
  * @param content The content to display with this theme.
  */
 @Composable
-fun HomebaseTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
+fun HomebaseTheme(
+        darkTheme: Boolean = isSystemInDarkTheme(),
+        followsSystemTheme: Boolean = true,
+        content: @Composable () -> Unit
+) {
         val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
         val extendedColors = if (darkTheme) DarkExtendedColors else LightExtendedColors
+
+        UpdateEdgeToEdge(darkTheme, followsSystemTheme)
 
         CompositionLocalProvider(LocalHomebaseExtendedColors provides extendedColors) {
                 MaterialTheme(

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/theme/UpdateEdgeToEdge.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/theme/UpdateEdgeToEdge.kt
@@ -1,0 +1,15 @@
+package id.homebase.core.ui.theme
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Keeps the platform system chrome in sync with the app theme. Android re-applies
+ * transparent edge-to-edge bars with icon contrast matching [darkTheme]; iOS
+ * overrides the window's interface style so the status bar follows a forced
+ * Light/Dark preference. [followsSystemTheme] must be true when the user picked
+ * "System": iOS then clears the override — pinning a concrete style there would
+ * freeze the trait collection and stop isSystemInDarkTheme() from tracking the
+ * OS setting. Desktop/Web have no app-managed system chrome and no-op.
+ */
+@Composable
+internal expect fun UpdateEdgeToEdge(darkTheme: Boolean, followsSystemTheme: Boolean)

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/ui/theme/UpdateEdgeToEdge.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/ui/theme/UpdateEdgeToEdge.jvm.kt
@@ -1,0 +1,6 @@
+package id.homebase.core.ui.theme
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal actual fun UpdateEdgeToEdge(darkTheme: Boolean, followsSystemTheme: Boolean) = Unit

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/ui/theme/UpdateEdgeToEdge.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/ui/theme/UpdateEdgeToEdge.native.kt
@@ -1,0 +1,21 @@
+package id.homebase.core.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import platform.UIKit.UIApplication
+import platform.UIKit.UIUserInterfaceStyle
+import platform.UIKit.UIWindow
+
+@Composable
+internal actual fun UpdateEdgeToEdge(darkTheme: Boolean, followsSystemTheme: Boolean) {
+    SideEffect {
+        val style = when {
+            followsSystemTheme -> UIUserInterfaceStyle.UIUserInterfaceStyleUnspecified
+            darkTheme -> UIUserInterfaceStyle.UIUserInterfaceStyleDark
+            else -> UIUserInterfaceStyle.UIUserInterfaceStyleLight
+        }
+        UIApplication.sharedApplication.windows.forEach {
+            (it as? UIWindow)?.overrideUserInterfaceStyle = style
+        }
+    }
+}

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/ui/theme/UpdateEdgeToEdge.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/ui/theme/UpdateEdgeToEdge.web.kt
@@ -1,0 +1,6 @@
+package id.homebase.core.ui.theme
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal actual fun UpdateEdgeToEdge(darkTheme: Boolean, followsSystemTheme: Boolean) = Unit

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/App.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/App.kt
@@ -32,7 +32,10 @@ fun App(
     val prefState by userPreferences.preferenceState.collectAsStateWithLifecycle()
     val isDarkTheme = if (prefState.theme == ThemeState.System) isSystemInDarkTheme() else if (prefState.theme == ThemeState.Dark) true else false
 
-    HomebaseTheme(darkTheme = isDarkTheme) {
+    HomebaseTheme(
+        darkTheme = isDarkTheme,
+        followsSystemTheme = prefState.theme == ThemeState.System,
+    ) {
         AppNavHost(
             viewModel = koinInject(),
             navController = navController,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -12,7 +12,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -31,6 +33,7 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.NavigationRail
 import androidx.compose.material3.NavigationRailItem
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
@@ -544,6 +547,10 @@ fun AppNavHost(
 
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
+        // Leave the top inset to each screen: consuming it here pads everything
+        // below the status bar, so no screen's TopAppBar can extend behind it.
+        contentWindowInsets = ScaffoldDefaults.contentWindowInsets
+            .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom),
         bottomBar = {
             if (showBottomNavigationBar) {
                 NavigationBar {


### PR DESCRIPTION
Implements [theme-aware edge-to-edge](https://jadarma.github.io/blog/posts/2024/04/theme-aware-edge-to-edge-in-compose/) as a shared concern of `HomebaseTheme`, instead of per-Activity plumbing.

## What was wrong
- `MainActivity` already applied themed `enableEdgeToEdge` (explicit transparent light/dark styles keyed on the in-app theme preference), but the logic was Activity-local and duplicated the theme resolution `App()` already does.
- `ShareReceiverActivity` only ever called the plain un-themed `enableEdgeToEdge()` — wrong status/nav-bar icon contrast whenever the app theme differed from the system theme.
- iOS had no equivalent at all: the status bar text color followed the OS theme, so forcing Dark in-app on a light-mode phone gave black status-bar text over the app's dark background.

## Change
New `internal expect fun UpdateEdgeToEdge(darkTheme, followsSystemTheme)` in `homebase-common`'s theme package, called once from `HomebaseTheme` — every host on every platform gets theme-synced system chrome automatically:

- **Android** (`UpdateEdgeToEdge.android.kt`): unwraps `LocalView`'s context to the hosting `ComponentActivity` and re-applies `enableEdgeToEdge` with explicit transparent `SystemBarStyle.dark`/`light` in a `SideEffect`. Explicit styles, not `SystemBarStyle.auto` — auto lets the system scrim the nav bar in 3-button mode (the blog's gotcha). Guards previews (`isInEditMode`) and non-activity hosts.
- **iOS** (`UpdateEdgeToEdge.native.kt`): sets `window.overrideUserInterfaceStyle` — `Dark`/`Light` when the user forces a variant, `Unspecified` for System. The System case is why `followsSystemTheme` exists: pinning a concrete style would freeze the trait collection and `isSystemInDarkTheme()` would stop tracking the OS setting. Side benefit: UIKit-presented chrome (alerts, pickers) matches a forced app theme too.
- **Desktop / Web**: no app-managed system chrome — no-op actuals (the `skiaMain` intermediate can't host them since iOS needs its own).
- `MainActivity`'s 25-line themed-bars block collapses to `setContent { App() }`; `ShareReceiverActivity` is fixed with only the new parameter passed through. `HomebaseTheme` gains `followsSystemTheme: Boolean = true`.

**Deliberately not adopted from the post:** the large `android:configChanges` list — it changes activity-recreation semantics app-wide, and recreation on a system theme change already re-applies the bars correctly through this path.

## Follow-up in this PR: app bars now actually extend
The root `Scaffold` in `AppNavHost` consumed the status-bar inset and padded every screen below it, so no screen's `TopAppBar` could draw behind the status bar (visible seam above the chat app bar). It now releases the **top** inset (`contentWindowInsets = defaults minus Top`; bottom/horizontal unchanged) — each screen's own Scaffold/`TopAppBar` consumes it and extends. Screens without a top bar (e.g. the chats list) keep their own Scaffold's top padding, so nothing underlaps.

## Verification
- Compile gate: `:homebase-common:` + `:homebase-core:` `compileKotlinJvm` / `compileAndroidMain` / `compileKotlinWasmJs` / `compileKotlinIosSimulatorArm64`, plus `:androidApp:compileDebugKotlin` — all green.
- **Device-verified on Android (Redmi Note 5 Pro, API 30, system in light mode)**: Settings → Appearance → Theme → Dark flips the status-bar icons to white live (no Activity restart); Light flips them back; System restores following the OS. Chat screen's app bar surface extends behind the status bar; chats list (no top bar) lays out correctly.
- **Simulator-verified on iOS (iPhone 17 Pro, iOS 26.5, system in dark mode)**: forcing Light flips the status-bar text to black over the light UI (previously stayed white — unreadable); restoring System returns to following the OS (the `Unspecified` override keeps `isSystemInDarkTheme()` tracking). Chat app bar extends behind the status bar on iOS too.
- CLI sim-build note: `xcodebuild` needs `ONLY_ACTIVE_ARCH=YES` or CMP's `syncComposeResourcesForIos` fails on the two-arch `ARCHS`; Xcode GUI sets it automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)