### PR TITLE
fix(diagnostics): detect whole-process stalls MainThreadWatchdog's own loop can't see

### DIFF
--- a/homebase-common/build.gradle.kts
+++ b/homebase-common/build.gradle.kts
@@ -84,6 +84,7 @@ kotlin {
             api(project(":homebase-api"))
             api(project(":homebase-notifshared"))
 
+            implementation(libs.atomicfu)
             implementation(libs.jetbrains.compose.runtime)
             implementation(libs.jetbrains.compose.foundation)
             implementation(libs.jetbrains.compose.resources)

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/diagnostics/MainThreadLivenessProbe.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/diagnostics/MainThreadLivenessProbe.android.kt
@@ -1,0 +1,60 @@
+package id.homebase.core.diagnostics
+
+import android.os.Handler
+import android.os.Looper
+import kotlinx.atomicfu.atomic
+
+/**
+ * Android liveness probe for [MainThreadLivenessProbe]: a raw `Thread`, scheduled directly by
+ * the OS rather than any coroutine dispatcher, that independently posts a sentinel to the main
+ * `Looper` and polls for it. Unlike [MainThreadWatchdog]'s own coroutine loop, this thread keeps
+ * running even if `Dispatchers.Default`'s pool is fully exhausted by blocking work dispatched to
+ * it elsewhere in the app — the scenario that left two production freezes with no breadcrumb.
+ */
+private class AndroidMainThreadLivenessProbe : MainThreadLivenessProbe.Probe {
+    override fun start(
+        thresholdMs: Long,
+        pollIntervalMs: Long,
+        onStalled: (stalledMs: Long) -> Unit,
+    ): MainThreadLivenessProbe.Handle {
+        val handler = Handler(Looper.getMainLooper())
+        val running = atomic(true)
+        val thread = Thread({
+            while (running.value) {
+                val acked = atomic(false)
+                val postedAtNanos = System.nanoTime()
+                handler.post { acked.value = true }
+
+                val deadlineNanos = postedAtNanos + thresholdMs * 1_000_000
+                while (!acked.value && System.nanoTime() < deadlineNanos) {
+                    Thread.sleep(POLL_STEP_MS)
+                }
+                if (!acked.value) {
+                    // Don't pile up posts on the handler queue: wait out the real ack before
+                    // reporting/ticking again, mirroring the coroutine loop's own behavior.
+                    while (!acked.value && running.value) Thread.sleep(POLL_STEP_MS)
+                    val stalledMs = (System.nanoTime() - postedAtNanos) / 1_000_000
+                    onStalled(stalledMs)
+                }
+
+                Thread.sleep(pollIntervalMs)
+            }
+        }, "MainThreadLivenessProbe").apply {
+            isDaemon = true
+            start()
+        }
+
+        return MainThreadLivenessProbe.Handle {
+            running.value = false
+            thread.interrupt()
+        }
+    }
+
+    private companion object {
+        const val POLL_STEP_MS = 50L
+    }
+}
+
+internal actual fun installMainThreadLivenessProbe() {
+    MainThreadLivenessProbe.register(AndroidMainThreadLivenessProbe())
+}

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/diagnostics/MemoryDiagnostics.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/diagnostics/MemoryDiagnostics.android.kt
@@ -1,0 +1,34 @@
+package id.homebase.core.diagnostics
+
+import android.os.Debug
+
+/**
+ * Android memory snapshot for [MemoryDiagnostics]: JVM heap figures plus native PSS via
+ * `Debug.MemoryInfo`. Deliberately Context-free (uses `Debug.getMemoryInfo`, not
+ * `ActivityManager.MemoryInfo`, which would need an `Application`/`Context` handle) — this
+ * codebase's convention is explicit Context passing per call site
+ * (`RichNotificationDisplayer.initialize(this, ...)`), not a global Application-context holder,
+ * and this diagnostic isn't worth introducing one for.
+ */
+private class AndroidMemoryProbe : MemoryDiagnostics.Probe {
+    override fun snapshot(): MemoryDiagnostics.Snapshot {
+        val runtime = Runtime.getRuntime()
+        val info = Debug.MemoryInfo()
+        Debug.getMemoryInfo(info)
+        return MemoryDiagnostics.Snapshot(
+            freeMemoryMb = runtime.freeMemory() / BYTES_PER_MB,
+            totalMemoryMb = runtime.totalMemory() / BYTES_PER_MB,
+            maxMemoryMb = runtime.maxMemory() / BYTES_PER_MB,
+            nativePssMb = info.totalPss.toLong() / KB_PER_MB,
+        )
+    }
+
+    private companion object {
+        const val BYTES_PER_MB = 1024L * 1024L
+        const val KB_PER_MB = 1024L
+    }
+}
+
+internal actual fun installMemoryDiagnostics() {
+    MemoryDiagnostics.register(AndroidMemoryProbe())
+}

--- a/homebase-common/src/appleMain/kotlin/id/homebase/core/diagnostics/MainThreadLivenessProbe.apple.kt
+++ b/homebase-common/src/appleMain/kotlin/id/homebase/core/diagnostics/MainThreadLivenessProbe.apple.kt
@@ -1,0 +1,9 @@
+package id.homebase.core.diagnostics
+
+/**
+ * No dedicated-thread liveness probe on iOS — the coroutine loop's wall-clock-gap detection
+ * ([detectWatchdogStarvation]) is dispatcher-agnostic and covers this platform without one.
+ */
+internal actual fun installMainThreadLivenessProbe() {
+    // no-op
+}

--- a/homebase-common/src/appleMain/kotlin/id/homebase/core/diagnostics/MemoryDiagnostics.apple.kt
+++ b/homebase-common/src/appleMain/kotlin/id/homebase/core/diagnostics/MemoryDiagnostics.apple.kt
@@ -1,0 +1,10 @@
+package id.homebase.core.diagnostics
+
+/**
+ * iOS registers its [MemoryDiagnostics.Probe] explicitly from `homebase-core`'s app-init path
+ * (a different module, alongside its existing `GpuTextDiagnostics` registration), not through
+ * this installer.
+ */
+internal actual fun installMemoryDiagnostics() {
+    // no-op
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/diagnostics/MainThreadLivenessProbe.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/diagnostics/MainThreadLivenessProbe.kt
@@ -1,0 +1,47 @@
+package id.homebase.core.diagnostics
+
+import kotlin.concurrent.Volatile
+
+/**
+ * Platform hook for a UI-thread liveness check that runs on a dedicated OS thread rather than
+ * a coroutine dispatcher — see [MainThreadWatchdog]'s doc for why the coroutine-based loop alone
+ * can't detect a stall caused by [kotlinx.coroutines.Dispatchers.Default]'s own pool being
+ * exhausted (that pool starving takes the watchdog's own loop down with it).
+ *
+ * Registered by androidMain/jvmMain (a raw `Thread` posting to the real UI thread). Platforms
+ * without a registered [Probe] (iOS, wasmJs) make [startIfAvailable] a no-op; those platforms
+ * rely solely on [MainThreadWatchdog]'s coroutine-based wall-clock-gap detection, which is
+ * dispatcher-agnostic.
+ */
+object MainThreadLivenessProbe {
+    fun interface Probe {
+        /** Starts the platform liveness check; [onStalled] may be called from any thread. */
+        fun start(thresholdMs: Long, pollIntervalMs: Long, onStalled: (stalledMs: Long) -> Unit): Handle
+    }
+
+    fun interface Handle {
+        fun stop()
+    }
+
+    @Volatile
+    private var probe: Probe? = null
+
+    /** Called once by platform code during app init. Idempotent (last registration wins). */
+    fun register(probe: Probe) {
+        this.probe = probe
+    }
+
+    /** Starts the registered platform probe, or returns `null` if none is registered here. */
+    internal fun startIfAvailable(
+        thresholdMs: Long,
+        pollIntervalMs: Long,
+        onStalled: (stalledMs: Long) -> Unit,
+    ): Handle? = probe?.start(thresholdMs, pollIntervalMs, onStalled)
+}
+
+/**
+ * Registers this platform's [MainThreadLivenessProbe.Probe], if it has one. Called once from
+ * [MainThreadWatchdog.start]; a no-op on platforms without a dedicated-thread implementation
+ * (iOS, wasmJs), which rely solely on the coroutine-based wall-clock-gap detection instead.
+ */
+internal expect fun installMainThreadLivenessProbe()

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/diagnostics/MainThreadWatchdog.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/diagnostics/MainThreadWatchdog.kt
@@ -2,6 +2,7 @@ package id.homebase.core.diagnostics
 
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -13,16 +14,33 @@ import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.time.TimeSource
 
 /**
- * Cross-platform main/UI-thread stall detector.
+ * Cross-platform main/UI-thread and whole-process stall detector.
  *
- * A background coroutine (on [Dispatchers.Default], never the UI thread) posts a sentinel to
- * [Dispatchers.Main] every [tickIntervalMs]. If the sentinel does not run within [thresholdMs],
+ * A background coroutine (on [workDispatcher], never the UI thread) posts a sentinel to
+ * [mainDispatcher] every [tickIntervalMs]. If the sentinel does not run within [thresholdMs],
  * the UI thread is wedged: the watchdog captures its stack via the platform
- * [captureMainThreadStackTrace] hook and emits a single WARN (throttled to one per [throttleMs])
- * into `homebase.log` — so a freeze leaves usable evidence instead of nothing.
+ * [captureMainThreadStackTrace] hook and emits a WARN (throttled to one per [throttleMs]) into
+ * `homebase.log` — so a freeze leaves usable evidence instead of nothing.
  *
- * This replaces the Android-only `MainThreadWatchdog` so desktop and iOS get the same breadcrumb;
- * previously a desktop UI stall produced no log at all.
+ * That mechanism has a blind spot: it runs on [workDispatcher] (`Dispatchers.Default` by
+ * default), so if the *whole process* stalls — most plausibly `Dispatchers.Default`'s own
+ * limited-parallelism pool getting exhausted by blocking work dispatched to it elsewhere in the
+ * app — the watchdog's own loop never gets scheduled and can't emit anything either. Two
+ * production incidents hit exactly this: a real ~30s user-facing freeze with zero
+ * `MainThreadWatchdog` log lines. Two additional, independent detectors close that gap:
+ *
+ *  - **Wall-clock gap detection** (this loop): records a checkpoint immediately before
+ *    `delay(tickIntervalMs)` and compares it to the wall-clock gap after waking up. If the gap
+ *    vastly exceeds what was requested, the loop itself was starved — logged as
+ *    [StallKind.WatchdogStarved] the instant it recovers. Needs nothing to run *during* the
+ *    freeze.
+ *  - **[MainThreadLivenessProbe]** (Android/JVM only): a raw OS thread, scheduled directly by
+ *    the OS rather than any coroutine dispatcher, independently checks the UI thread is alive.
+ *    It survives `Dispatchers.Default` pool exhaustion that would otherwise silence this loop
+ *    entirely.
+ *
+ * Both detectors report through one shared, throttled [StallReporter], so the same incident
+ * can't produce two log lines.
  *
  * Platform notes (see `captureMainThreadStackTrace` actuals):
  *  - Android: stack comes from the main `Looper` thread, ~1s before the OS ANR cutoff.
@@ -34,55 +52,95 @@ import kotlin.time.TimeSource
 class MainThreadWatchdog(
     private val thresholdMs: Long = 4_000,
     private val tickIntervalMs: Long = 1_000,
-    private val throttleMs: Long = 30_000,
+    throttleMs: Long = 30_000,
+    private val mainDispatcher: CoroutineDispatcher = Dispatchers.Main,
+    private val workDispatcher: CoroutineDispatcher = Dispatchers.Default,
+    log: (String) -> Unit = { Logger.w(tag = TAG) { it } },
 ) {
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val scope = CoroutineScope(SupervisorJob() + workDispatcher)
+    private val timeOrigin = TimeSource.Monotonic.markNow()
+    private fun nowMs(): Long = timeOrigin.elapsedNow().inWholeMilliseconds
+
+    private val reporter = StallReporter(throttleMs = throttleMs, nowMs = ::nowMs, log = log)
+    private var livenessHandle: MainThreadLivenessProbe.Handle? = null
 
     fun start() {
-        scope.launch {
-            val timeSource = TimeSource.Monotonic
-            var lastReportMark = timeSource.markNow()
-            var hasReported = false
+        installMainThreadLivenessProbe()
+        installMemoryDiagnostics()
+        livenessHandle = MainThreadLivenessProbe.startIfAvailable(
+            thresholdMs = thresholdMs,
+            pollIntervalMs = tickIntervalMs,
+        ) { stalledMs ->
+            val stack = captureMainThreadStackTrace()
+            reporter.reportIfDue {
+                renderStallMessage(
+                    StallEvent(
+                        kind = StallKind.MainThreadBlock,
+                        source = StallSource.DedicatedThread,
+                        observedMs = stalledMs,
+                        memory = MemoryDiagnostics.capture(),
+                    ),
+                    stack = stack,
+                )
+            }
+        }
 
+        scope.launch {
             while (isActive) {
                 val pong = CompletableDeferred<Unit>()
-                val postedAt = timeSource.markNow()
+                val postedAt = nowMs()
                 // Post the sentinel to the UI dispatcher. If it's blocked, this never runs.
-                launch(Dispatchers.Main) { pong.complete(Unit) }
+                launch(mainDispatcher) { pong.complete(Unit) }
 
                 val acked = withTimeoutOrNull(thresholdMs) { pong.await() }
                 if (acked == null) {
-                    if (!hasReported || lastReportMark.elapsedNow().inWholeMilliseconds >= throttleMs) {
-                        hasReported = true
-                        lastReportMark = timeSource.markNow()
-                        val stalledMs = postedAt.elapsedNow().inWholeMilliseconds
-                        val stack = captureMainThreadStackTrace()
-                        val rendered = buildString {
-                            appendLine(
-                                "Main/UI thread stalled >${stalledMs}ms — likely a recomposition " +
-                                    "loop or blocking I/O on the UI dispatcher."
-                            )
-                            if (stack != null) {
-                                appendLine("UI thread stack at sample:")
-                                append(stack)
-                            } else {
-                                appendLine("(UI thread stack capture not supported on this platform)")
-                            }
-                        }
-                        Logger.w(tag = TAG) { rendered }
+                    val stalledMs = nowMs() - postedAt
+                    val stack = captureMainThreadStackTrace()
+                    reporter.reportIfDue {
+                        renderStallMessage(
+                            StallEvent(
+                                kind = StallKind.MainThreadBlock,
+                                source = StallSource.CoroutineLoop,
+                                observedMs = stalledMs,
+                                memory = MemoryDiagnostics.capture(),
+                            ),
+                            stack = stack,
+                        )
                     }
                     // Wait for the UI thread to recover before ticking again, so a long hang
                     // leaves only one outstanding sentinel rather than one per tick.
                     pong.await()
                 }
 
+                // Checkpoint immediately around the suspend point that depends on workDispatcher
+                // rescheduling us: if that takes far longer than requested, the watchdog's own
+                // loop — not just the UI thread — was starved.
+                val checkpointMs = nowMs()
                 delay(tickIntervalMs)
+                val actualGapMs = nowMs() - checkpointMs
+                val starvedMs = detectWatchdogStarvation(expectedGapMs = tickIntervalMs, actualGapMs = actualGapMs)
+                if (starvedMs != null) {
+                    val stack = captureMainThreadStackTrace()
+                    reporter.reportIfDue {
+                        renderStallMessage(
+                            StallEvent(
+                                kind = StallKind.WatchdogStarved,
+                                source = StallSource.CoroutineLoop,
+                                observedMs = starvedMs,
+                                memory = MemoryDiagnostics.capture(),
+                            ),
+                            stack = stack,
+                        )
+                    }
+                }
             }
         }
     }
 
     fun stop() {
         scope.cancel()
+        livenessHandle?.stop()
+        livenessHandle = null
     }
 
     companion object {

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/diagnostics/MemoryDiagnostics.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/diagnostics/MemoryDiagnostics.kt
@@ -1,0 +1,56 @@
+package id.homebase.core.diagnostics
+
+import kotlin.concurrent.Volatile
+
+/**
+ * Memory context attached to a [MainThreadWatchdog] stall breadcrumb, so a memory-pressure
+ * freeze leaves numbers to act on instead of just a duration.
+ *
+ * Follows the same registration-object shape as [GpuTextDiagnostics]: platform code registers a
+ * [Probe] during app init; [capture] is a no-op (returns `null`) wherever none is registered.
+ */
+object MemoryDiagnostics {
+    /** A point-in-time reading of whatever memory figures the platform can cheaply provide. */
+    data class Snapshot(
+        val freeMemoryMb: Long? = null,
+        val totalMemoryMb: Long? = null,
+        val maxMemoryMb: Long? = null,
+        /** Android `Debug.MemoryInfo` total PSS, MB. */
+        val nativePssMb: Long? = null,
+        /** iOS `NSProcessInfo.physicalMemory`, MB. */
+        val physicalMemoryMb: Long? = null,
+    )
+
+    fun interface Probe {
+        fun snapshot(): Snapshot
+    }
+
+    @Volatile
+    private var probe: Probe? = null
+
+    /** Called once by platform code during app init. Idempotent (last registration wins). */
+    fun register(probe: Probe) {
+        this.probe = probe
+    }
+
+    /** Takes a snapshot, or `null` when no platform [Probe] is registered. */
+    fun capture(): Snapshot? = probe?.snapshot()
+
+    /** Pure, deterministic one-line formatter — unit-tested without any platform. */
+    fun format(s: Snapshot): String = buildString {
+        s.freeMemoryMb?.let { append("freeMb=").append(it) }
+        s.totalMemoryMb?.let { append(" totalMb=").append(it) }
+        s.maxMemoryMb?.let { append(" maxMb=").append(it) }
+        s.nativePssMb?.let { append(" nativePssMb=").append(it) }
+        s.physicalMemoryMb?.let { append(" physMemMb=").append(it) }
+    }
+}
+
+/**
+ * Registers this platform's [MemoryDiagnostics.Probe], if it's self-contained (needs no
+ * `Context`/app handle). Called once from [MainThreadWatchdog.start]. Android/JVM register here;
+ * iOS registers explicitly from `homebase-core`'s app-init path instead (a different module,
+ * alongside its existing `GpuTextDiagnostics` registration) — this is a no-op there. A no-op on
+ * wasmJs too.
+ */
+internal expect fun installMemoryDiagnostics()

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/diagnostics/StallEvent.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/diagnostics/StallEvent.kt
@@ -1,0 +1,60 @@
+package id.homebase.core.diagnostics
+
+/** Why a [StallEvent] fired. */
+internal enum class StallKind { MainThreadBlock, WatchdogStarved }
+
+/** Which detector observed the [StallEvent] — lets the log line show whether the dedicated
+ *  OS-thread probe corroborated (or beat) the coroutine loop's own detection. */
+internal enum class StallSource { CoroutineLoop, DedicatedThread }
+
+internal data class StallEvent(
+    val kind: StallKind,
+    val source: StallSource,
+    val observedMs: Long,
+    val memory: MemoryDiagnostics.Snapshot? = null,
+)
+
+/**
+ * Given the gap this loop iteration expected to sleep for ([expectedGapMs], i.e.
+ * `tickIntervalMs`) and the wall-clock gap it actually observed ([actualGapMs]), decides whether
+ * the watchdog's own scheduling was delayed enough to call it starved. Returns the observed
+ * stall duration, or `null` if the gap is unremarkable.
+ */
+internal fun detectWatchdogStarvation(expectedGapMs: Long, actualGapMs: Long, slackFactor: Double = 3.0): Long? {
+    val threshold = (expectedGapMs * slackFactor).toLong()
+    return if (actualGapMs > threshold) actualGapMs else null
+}
+
+/** Pure, deterministic message renderer — unit-tested without any coroutine/platform. */
+internal fun renderStallMessage(event: StallEvent, stack: String?): String = buildString {
+    val prefix = if (event.source == StallSource.DedicatedThread) "[dedicated-thread probe] " else ""
+    when (event.kind) {
+        StallKind.MainThreadBlock -> {
+            appendLine(
+                "${prefix}Main/UI thread stalled >${event.observedMs}ms — likely a recomposition " +
+                    "loop or blocking I/O on the UI dispatcher."
+            )
+            if (stack != null) {
+                appendLine("UI thread stack at sample:")
+                append(stack)
+            } else {
+                appendLine("(UI thread stack capture not supported on this platform)")
+            }
+        }
+
+        StallKind.WatchdogStarved -> {
+            appendLine(
+                "${prefix}Process/dispatchers stalled ~${event.observedMs}ms (watchdog starved) — " +
+                    "the watchdog's own loop was delayed; likely Dispatchers.Default pool " +
+                    "exhaustion or an OS-level freeze."
+            )
+            if (stack != null) {
+                appendLine("UI thread stack at recovery:")
+                append(stack)
+            } else {
+                appendLine("(UI thread stack capture not supported on this platform)")
+            }
+        }
+    }
+    event.memory?.let { appendLine("Memory at stall: ${MemoryDiagnostics.format(it)}") }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/diagnostics/StallReporter.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/diagnostics/StallReporter.kt
@@ -1,0 +1,36 @@
+package id.homebase.core.diagnostics
+
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
+
+/**
+ * Throttled logging gate shared by every stall detector feeding [MainThreadWatchdog].
+ *
+ * More than one detector can observe the same incident independently (the coroutine loop's
+ * own wall-clock-gap check, and — on Android/JVM — the [MainThreadLivenessProbe] running on a
+ * dedicated OS thread). Both call [reportIfDue] concurrently; whichever gets there first for a
+ * given [throttleMs] window logs, the other's call is a cheap no-op. This is what prevents the
+ * same freeze from producing two log lines.
+ */
+internal class StallReporter(
+    private val throttleMs: Long,
+    private val nowMs: () -> Long,
+    private val log: (String) -> Unit,
+) {
+    private val lock = SynchronizedObject()
+    private var lastReportAtMs: Long? = null
+
+    fun reportIfDue(render: () -> String) {
+        val shouldLog = synchronized(lock) {
+            val now = nowMs()
+            val last = lastReportAtMs
+            if (last != null && now - last < throttleMs) {
+                false
+            } else {
+                lastReportAtMs = now
+                true
+            }
+        }
+        if (shouldLog) log(render())
+    }
+}

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/diagnostics/MainThreadWatchdogTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/diagnostics/MainThreadWatchdogTest.kt
@@ -1,0 +1,137 @@
+package id.homebase.core.diagnostics
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the pure logic behind #941's fix — [renderStallMessage], [detectWatchdogStarvation],
+ * and [StallReporter]'s throttle — following the same convention as [GpuTextDiagnosticsTest]:
+ * only deterministic, platform-free logic is unit-tested here. Platform capture
+ * (`captureMainThreadStackTrace`, the dedicated-thread liveness probes, memory snapshots) is
+ * exercised manually on-device, same as before this fix.
+ *
+ * A genuine `Dispatchers.Default` pool-exhaustion scenario (the actual whole-process stall from
+ * the production incidents) isn't reproduced here — that would be flaky/environment-dependent and
+ * wouldn't exercise this fix's logic, only JVM thread-pool behavior. [detectWatchdogStarvation]'s
+ * arithmetic and [StallReporter]'s throttle are what decide "was there a gap" and "do we log it
+ * exactly once," and both are covered directly below with synthetic inputs.
+ */
+class MainThreadWatchdogTest {
+
+    // --- renderStallMessage ---------------------------------------------------------------
+
+    @Test
+    fun mainThreadBlock_withStack_rendersPreservedText() {
+        val message = renderStallMessage(
+            StallEvent(StallKind.MainThreadBlock, StallSource.CoroutineLoop, observedMs = 5000),
+            stack = "    at Foo.bar(Foo.kt:1)\n",
+        )
+        assertEquals(
+            "Main/UI thread stalled >5000ms — likely a recomposition loop or blocking I/O on the UI dispatcher.\n" +
+                "UI thread stack at sample:\n" +
+                "    at Foo.bar(Foo.kt:1)\n",
+            message,
+        )
+    }
+
+    @Test
+    fun mainThreadBlock_withoutStack_rendersPreservedText() {
+        val message = renderStallMessage(
+            StallEvent(StallKind.MainThreadBlock, StallSource.CoroutineLoop, observedMs = 5000),
+            stack = null,
+        )
+        assertEquals(
+            "Main/UI thread stalled >5000ms — likely a recomposition loop or blocking I/O on the UI dispatcher.\n" +
+                "(UI thread stack capture not supported on this platform)\n",
+            message,
+        )
+    }
+
+    @Test
+    fun watchdogStarved_rendersDistinctTextFromMainThreadBlock() {
+        val blockMessage = renderStallMessage(
+            StallEvent(StallKind.MainThreadBlock, StallSource.CoroutineLoop, observedMs = 8000),
+            stack = null,
+        )
+        val starvedMessage = renderStallMessage(
+            StallEvent(StallKind.WatchdogStarved, StallSource.CoroutineLoop, observedMs = 8000),
+            stack = null,
+        )
+        assertNotEquals(blockMessage, starvedMessage)
+        assertTrue(starvedMessage.contains("watchdog starved"))
+    }
+
+    @Test
+    fun dedicatedThreadSource_prefixesTheMessage() {
+        val message = renderStallMessage(
+            StallEvent(StallKind.MainThreadBlock, StallSource.DedicatedThread, observedMs = 4200),
+            stack = null,
+        )
+        assertTrue(message.startsWith("[dedicated-thread probe] Main/UI thread stalled >4200ms"))
+    }
+
+    @Test
+    fun memorySnapshot_appendedWhenPresent_omittedWhenNull() {
+        val withMemory = renderStallMessage(
+            StallEvent(
+                kind = StallKind.MainThreadBlock,
+                source = StallSource.CoroutineLoop,
+                observedMs = 100,
+                memory = MemoryDiagnostics.Snapshot(freeMemoryMb = 12, totalMemoryMb = 256),
+            ),
+            stack = null,
+        )
+        assertTrue(withMemory.contains("Memory at stall: freeMb=12 totalMb=256"))
+
+        val withoutMemory = renderStallMessage(
+            StallEvent(StallKind.MainThreadBlock, StallSource.CoroutineLoop, observedMs = 100),
+            stack = null,
+        )
+        assertTrue(!withoutMemory.contains("Memory at stall"))
+    }
+
+    // --- detectWatchdogStarvation ----------------------------------------------------------
+
+    @Test
+    fun noGap_returnsNull() {
+        assertNull(detectWatchdogStarvation(expectedGapMs = 1000, actualGapMs = 1050))
+    }
+
+    @Test
+    fun gapWithinSlack_returnsNull() {
+        assertNull(detectWatchdogStarvation(expectedGapMs = 1000, actualGapMs = 2900, slackFactor = 3.0))
+    }
+
+    @Test
+    fun largeGap_returnsObservedStallDuration() {
+        assertEquals(9000L, detectWatchdogStarvation(expectedGapMs = 1000, actualGapMs = 9000, slackFactor = 3.0))
+    }
+
+    // --- StallReporter -----------------------------------------------------------------------
+
+    @Test
+    fun firstReportAlwaysLogs() {
+        val logged = mutableListOf<String>()
+        val reporter = StallReporter(throttleMs = 30_000, nowMs = { 0L }, log = { logged += it })
+        reporter.reportIfDue { "first" }
+        assertEquals(listOf("first"), logged)
+    }
+
+    @Test
+    fun throttleSuppressesReportsWithinWindow_andAllowsAfterItElapses() {
+        var fakeNow = 0L
+        val logged = mutableListOf<String>()
+        val reporter = StallReporter(throttleMs = 30_000, nowMs = { fakeNow }, log = { logged += it })
+
+        reporter.reportIfDue { "a" }
+        fakeNow += 10_000
+        reporter.reportIfDue { "b" } // still inside the 30s window: suppressed
+        fakeNow += 25_000
+        reporter.reportIfDue { "c" } // 35s since "a": window elapsed, logs again
+
+        assertEquals(listOf("a", "c"), logged)
+    }
+}

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/diagnostics/MainThreadLivenessProbe.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/diagnostics/MainThreadLivenessProbe.jvm.kt
@@ -1,0 +1,56 @@
+package id.homebase.core.diagnostics
+
+import kotlinx.atomicfu.atomic
+import javax.swing.SwingUtilities
+
+/**
+ * Desktop (JVM) liveness probe for [MainThreadLivenessProbe]: a raw `Thread`, scheduled directly
+ * by the OS rather than any coroutine dispatcher, that independently posts a sentinel to the AWT
+ * event-dispatch thread (Compose Desktop's `Dispatchers.Main`) and polls for it. Survives
+ * `Dispatchers.Default`'s pool being fully exhausted by blocking work dispatched to it elsewhere
+ * in the app — unlike [MainThreadWatchdog]'s own coroutine loop.
+ */
+private class JvmMainThreadLivenessProbe : MainThreadLivenessProbe.Probe {
+    override fun start(
+        thresholdMs: Long,
+        pollIntervalMs: Long,
+        onStalled: (stalledMs: Long) -> Unit,
+    ): MainThreadLivenessProbe.Handle {
+        val running = atomic(true)
+        val thread = Thread({
+            while (running.value) {
+                val acked = atomic(false)
+                val postedAtNanos = System.nanoTime()
+                SwingUtilities.invokeLater { acked.value = true }
+
+                val deadlineNanos = postedAtNanos + thresholdMs * 1_000_000
+                while (!acked.value && System.nanoTime() < deadlineNanos) {
+                    Thread.sleep(POLL_STEP_MS)
+                }
+                if (!acked.value) {
+                    while (!acked.value && running.value) Thread.sleep(POLL_STEP_MS)
+                    val stalledMs = (System.nanoTime() - postedAtNanos) / 1_000_000
+                    onStalled(stalledMs)
+                }
+
+                Thread.sleep(pollIntervalMs)
+            }
+        }, "MainThreadLivenessProbe").apply {
+            isDaemon = true
+            start()
+        }
+
+        return MainThreadLivenessProbe.Handle {
+            running.value = false
+            thread.interrupt()
+        }
+    }
+
+    private companion object {
+        const val POLL_STEP_MS = 50L
+    }
+}
+
+internal actual fun installMainThreadLivenessProbe() {
+    MainThreadLivenessProbe.register(JvmMainThreadLivenessProbe())
+}

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/diagnostics/MemoryDiagnostics.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/diagnostics/MemoryDiagnostics.jvm.kt
@@ -1,0 +1,21 @@
+package id.homebase.core.diagnostics
+
+/** Desktop (JVM) memory snapshot for [MemoryDiagnostics]: JVM heap figures only. */
+private class JvmMemoryProbe : MemoryDiagnostics.Probe {
+    override fun snapshot(): MemoryDiagnostics.Snapshot {
+        val runtime = Runtime.getRuntime()
+        return MemoryDiagnostics.Snapshot(
+            freeMemoryMb = runtime.freeMemory() / BYTES_PER_MB,
+            totalMemoryMb = runtime.totalMemory() / BYTES_PER_MB,
+            maxMemoryMb = runtime.maxMemory() / BYTES_PER_MB,
+        )
+    }
+
+    private companion object {
+        const val BYTES_PER_MB = 1024L * 1024L
+    }
+}
+
+internal actual fun installMemoryDiagnostics() {
+    MemoryDiagnostics.register(JvmMemoryProbe())
+}

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/diagnostics/MainThreadWatchdogJvmTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/diagnostics/MainThreadWatchdogJvmTest.kt
@@ -1,0 +1,54 @@
+package id.homebase.core.diagnostics
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.Executors
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Regression test for the pre-#941 behavior: a genuinely unresponsive `mainDispatcher` must still
+ * produce a [StallKind.MainThreadBlock] breadcrumb. JVM-only because it needs
+ * [java.util.concurrent.Executors] to build a deterministically wedged dispatcher (a real thread
+ * kept permanently busy, so anything posted to it never runs) — the closest practical stand-in
+ * for "the UI thread is blocked" without depending on a platform UI toolkit.
+ */
+class MainThreadWatchdogJvmTest {
+
+    @Test
+    fun detectsANonRespondingMainDispatcher() = runBlocking {
+        val logged = mutableListOf<String>()
+        val wedgedThreadPool = Executors.newSingleThreadExecutor()
+        val wedgedDispatcher = wedgedThreadPool.asCoroutineDispatcher()
+        wedgedThreadPool.submit {
+            while (!Thread.currentThread().isInterrupted) {
+                // busy-spin so nothing else posted to this dispatcher ever runs
+            }
+        }
+
+        val watchdog = MainThreadWatchdog(
+            thresholdMs = 50,
+            tickIntervalMs = 20,
+            throttleMs = 5_000,
+            mainDispatcher = wedgedDispatcher,
+            workDispatcher = Dispatchers.Default,
+            log = { logged += it },
+        )
+
+        try {
+            watchdog.start()
+            val deadline = System.nanoTime() + 2_000_000_000L
+            while (logged.isEmpty() && System.nanoTime() < deadline) {
+                delay(20)
+            }
+        } finally {
+            watchdog.stop()
+            wedgedThreadPool.shutdownNow()
+        }
+
+        assertTrue(logged.isNotEmpty(), "expected a stalled-main-thread breadcrumb")
+        assertTrue(logged.first().contains("Main/UI thread stalled"))
+    }
+}

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/diagnostics/MainThreadLivenessProbe.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/diagnostics/MainThreadLivenessProbe.web.kt
@@ -1,0 +1,6 @@
+package id.homebase.core.diagnostics
+
+/** Single-threaded browser — no dedicated-thread liveness probe applies. */
+internal actual fun installMainThreadLivenessProbe() {
+    // no-op
+}

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/diagnostics/MemoryDiagnostics.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/diagnostics/MemoryDiagnostics.web.kt
@@ -1,0 +1,6 @@
+package id.homebase.core.diagnostics
+
+/** No memory-diagnostics probe on wasmJs. */
+internal actual fun installMemoryDiagnostics() {
+    // no-op
+}

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/MainViewController.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/MainViewController.kt
@@ -22,6 +22,7 @@ import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.core.di.allModules
 import id.homebase.core.diagnostics.MainThreadWatchdog
 import id.homebase.core.diagnostics.installGpuTextDiagnostics
+import id.homebase.core.diagnostics.installMemoryDiagnostics
 import id.homebase.core.crash.CrashMetadata
 import id.homebase.core.crash.CrashReporting
 import id.homebase.core.logging.LoggerConfig
@@ -132,6 +133,9 @@ fun initializeApp() {
     // Detect main-thread stalls and log them to homebase.log. On iOS the stack itself can't be
     // captured from a background thread, but the "stalled for Nms" breadcrumb is still recorded.
     MainThreadWatchdog().start()
+
+    // Memory context attached to a MainThreadWatchdog stall breadcrumb (see MemoryDiagnostics).
+    installMemoryDiagnostics()
 
     // Field instrumentation for the intermittent iOS blank-text bug (stale GPU glyph atlas). Logs a
     // ColdStart snapshot now and observes foreground-after-idle + memory warnings — the moments it

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/MainViewController.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/MainViewController.kt
@@ -22,7 +22,7 @@ import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.core.di.allModules
 import id.homebase.core.diagnostics.MainThreadWatchdog
 import id.homebase.core.diagnostics.installGpuTextDiagnostics
-import id.homebase.core.diagnostics.installMemoryDiagnostics
+import id.homebase.core.diagnostics.installIosMemoryDiagnostics
 import id.homebase.core.crash.CrashMetadata
 import id.homebase.core.crash.CrashReporting
 import id.homebase.core.logging.LoggerConfig
@@ -135,7 +135,7 @@ fun initializeApp() {
     MainThreadWatchdog().start()
 
     // Memory context attached to a MainThreadWatchdog stall breadcrumb (see MemoryDiagnostics).
-    installMemoryDiagnostics()
+    installIosMemoryDiagnostics()
 
     // Field instrumentation for the intermittent iOS blank-text bug (stale GPU glyph atlas). Logs a
     // ColdStart snapshot now and observes foreground-after-idle + memory warnings — the moments it

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/diagnostics/IosMemoryDiagnostics.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/diagnostics/IosMemoryDiagnostics.kt
@@ -19,8 +19,14 @@ private var installed = false
 /**
  * Wire up [MemoryDiagnostics] on iOS. Call once, early — from `MainViewController.initializeApp()`,
  * alongside [installGpuTextDiagnostics]. Idempotent.
+ *
+ * Named distinctly from `homebase-common`'s internal `installMemoryDiagnostics()` expect/actual —
+ * same package, different module, and Kotlin/Native's IR linker resolves top-level function
+ * signatures by package+name+params regardless of visibility, so an identical name there caused
+ * "IrSimpleFunctionSymbolImpl is already bound" once both klibs were linked into one framework
+ * (a collision `compileKotlin<Target>` doesn't surface — only a real `linkDebugFramework*` does).
  */
-fun installMemoryDiagnostics() {
+fun installIosMemoryDiagnostics() {
     if (installed) return
     installed = true
     MemoryDiagnostics.register(IosMemoryProbe)

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/diagnostics/IosMemoryDiagnostics.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/diagnostics/IosMemoryDiagnostics.kt
@@ -1,0 +1,27 @@
+package id.homebase.core.diagnostics
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSProcessInfo
+
+/**
+ * iOS implementation of [MemoryDiagnostics] (see that class): reports device physical memory via
+ * `NSProcessInfo`, the same reading already used by [GpuTextDiagnostics]'s iOS probe.
+ */
+@OptIn(ExperimentalForeignApi::class)
+private object IosMemoryProbe : MemoryDiagnostics.Probe {
+    override fun snapshot(): MemoryDiagnostics.Snapshot = MemoryDiagnostics.Snapshot(
+        physicalMemoryMb = (NSProcessInfo.processInfo.physicalMemory / (1024uL * 1024uL)).toLong(),
+    )
+}
+
+private var installed = false
+
+/**
+ * Wire up [MemoryDiagnostics] on iOS. Call once, early — from `MainViewController.initializeApp()`,
+ * alongside [installGpuTextDiagnostics]. Idempotent.
+ */
+fun installMemoryDiagnostics() {
+    if (installed) return
+    installed = true
+    MemoryDiagnostics.register(IosMemoryProbe)
+}


### PR DESCRIPTION
## Summary
- `MainThreadWatchdog`'s detection loop runs on `Dispatchers.Default`, so when the whole process stalls (most plausibly that pool's own limited-parallelism exhaustion, possibly compounded by memory pressure) the watchdog itself gets starved and can't log anything — exactly what happened in two production freezes (~34s, ~28s) that left zero `MainThreadWatchdog` lines in `homebase.log`.
- Adds a dispatcher-agnostic wall-clock-gap check to the existing coroutine loop (fires the instant it recovers, needs nothing to run *during* the freeze), plus a dedicated-OS-thread liveness probe on Android/JVM that never touches `Dispatchers.Default` and therefore survives that pool being exhausted.
- Attaches memory context (JVM heap + Android `Debug.MemoryInfo` / iOS `NSProcessInfo.physicalMemory`) to every stall breadcrumb, and funnels both detectors through one shared, throttled reporter so the same incident can't produce two log lines.
- iOS/wasmJs keep the coroutine-only path (the wall-clock check is dispatcher-agnostic and covers them); no synchronous-file-write fallback was added — Kermit's existing writer is kept as-is.

Fixes #941.

## Test plan
- [x] `./gradlew :homebase-common:compileKotlinJvm :homebase-common:compileAndroidMain :homebase-common:compileKotlinWasmJs :homebase-common:compileKotlinIosSimulatorArm64` — all green
- [x] `./gradlew :homebase-core:compileKotlinIosSimulatorArm64` — green (new iOS memory-probe wiring)
- [x] `./gradlew :homebase-core:linkDebugFrameworkIosArm64 :homebase-core:linkDebugFrameworkIosSimulatorArm64` — green (catches the top-level-symbol IR collision a plain `compileKotlin<Target>` doesn't surface)
- [x] `./gradlew homebase-common:jvmTest --rerun-tasks` — full suite green, including new `MainThreadWatchdogTest` (pure message-rendering / gap-detection / throttle logic) and `MainThreadWatchdogJvmTest` (regression test proving the pre-existing main-thread-block detection still fires against a deliberately wedged dispatcher)
- [x] Manual on-device verification — Android (physical device, 8 cores): temporarily floods `Dispatchers.Default` with 10 busy-spin coroutines for 12s (never touching the main thread) and confirms the breadcrumb lands in `homebase.log`:
  ```
  18:32:20.932  Info: (ManualTest941) Starving Dispatchers.Default with 10 busy-spin coroutines for 12s
                ... complete log silence for ~12s (Default fully saturated) ...
  18:32:32.965  Warn: (MainThreadWatchdog) Process/dispatchers stalled ~12781ms (watchdog starved) —
                the watchdog's own loop was delayed; likely Dispatchers.Default pool exhaustion or
                an OS-level freeze.
                UI thread stack at recovery: ... (idle in Looper.loop — confirms Main itself was fine)
                Memory at stall: freeMb=22 totalMb=42 maxMb=512 nativePssMb=268
  ```
  The dedicated-thread liveness probe correctly stayed silent throughout, since only `Default` was saturated and the main thread never stopped responding.
- [x] Manual on-device verification — Desktop (macOS, 12 cores): same technique, 14 busy-spin coroutines for 12s:
  ```
  18:56:08.987  Info: (ManualTest941) Starving Dispatchers.Default with 14 busy-spin coroutines for 12s
                ... ~12s stall (other Default-scheduled work, e.g. a WS handshake timeout, delayed too) ...
  18:56:21.011  Warn: (MainThreadWatchdog) Process/dispatchers stalled ~12688ms (watchdog starved) —
                the watchdog's own loop was delayed; likely Dispatchers.Default pool exhaustion or
                an OS-level freeze.
                UI thread stack at recovery: ... (AWT-EventQueue-0 idle in EventQueue.getNextEvent —
                confirms the EDT itself was fine)
                Memory at stall: freeMb=87 totalMb=152 maxMb=4608
  ```
  Same result as Android: the JVM dedicated-thread liveness probe correctly stayed silent, since it only fires when the UI thread itself is unresponsive, not when `Default` alone is saturated.

Both manual checks used a temporary busy-flood trigger that was reverted before pushing — not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)