### PR TITLE
fix(update): "Update available" banner sits below the status bar and is tappable again

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.outlined.Lock
@@ -626,9 +627,14 @@ fun AppNavHost(
                     }
                 }
 
-                Column {
+                val showUpdateBanner = isOnTopLevelScreen && uiState.updateAvailable
+                Column(
+                    // statusBarsPadding consumes the inset, so screens in the NavHost
+                    // below don't re-pad while the banner occupies the top edge.
+                    modifier = if (showUpdateBanner) Modifier.statusBarsPadding() else Modifier,
+                ) {
                     if (isOnTopLevelScreen) {
-                        if (uiState.updateAvailable) {
+                        if (showUpdateBanner) {
                             UpdateAvailableBanner(
                                 versionName = uiState.updateAvailableVersion,
                                 onUpdateClick = { viewModel.triggerUpdate() }


### PR DESCRIPTION
Fixes #1010

## Problem
On edge-to-edge Android (and since #1005 released the root Scaffold's top inset), the `Column` wrapping `UpdateAvailableBanner` in `AppNavHost` started at y=0, so the banner rendered under the status bar and its tap target was unreachable — the update could not be triggered at all.

## Fix
Pad that `Column` with `Modifier.statusBarsPadding()` **only while the banner is showing**. Because `statusBarsPadding` consumes the inset for its children, the screens inside the NavHost automatically stop padding for the status bar while the banner occupies the top edge — no double top padding. When no banner is showing the modifier is a plain `Modifier`, so layout is byte-identical to today.

One file changed: `homebase-core/.../ui/navigation/AppNavHost.kt` (commonMain — same behavior on iOS: banner sits below the notch/safe area instead of under it).

## Verification (on-device, Redmi Note 5 Pro / Android 11)
Banner temporarily force-shown (`updateAvailable = true`, not committed) to exercise the layout:
- Banner renders fully below the status bar — accessibility frame starts at y=0.046 vs status bar bottom ≈0.035; text + chevron fully visible.
- **Tappable again**: tapping the banner fired `triggerUpdate()` → `AndroidUpdateAppManager.downloadUpdate()` (confirmed via `homebase.log`: "No update available" logged at the tap timestamp — the Play re-check correctly no-ops since the banner was force-shown).
- Screen content below unaffected: chat-list header sits directly below the banner, no double padding; with the banner hidden nothing changes.
- `:homebase-core:compileKotlinJvm` + `androidApp:assembleDebug` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)