### PR TITLE
Live location: indefinite share — "Until you turn it off" replaces 24h (#1013)

### DIFF
--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/client/liverelay/LiveShareRosterTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/client/liverelay/LiveShareRosterTest.kt
@@ -98,6 +98,20 @@ class LiveShareRosterTest {
     }
 
     @Test
+    fun indefiniteSentinelEntryIsAlwaysLiveAndRemovableOnlyByMatchingStop() {
+        // The reserved indefinite end-time (LIVE_SHARE_INDEFINITE in homebase-common — a fixed
+        // 2100-01-01 timestamp; this module doesn't depend on it, so the literal is used). The
+        // roster's generic `endTimeMs > nowMs` math must keep it live at any realistic now and
+        // never prune it — only an exact {recipient, end-time} stop removes it.
+        val indefinite = 4_102_444_800_000L
+        val roster = LiveShareRoster.add(emptyList(), listOf("a"), endTimeMs = indefinite, nowMs = 0)
+        val decadesLater = 3_000_000_000_000L // year ~2065
+        assertEquals(roster, LiveShareRoster.live(roster, nowMs = decadesLater))
+        assertEquals(listOf("a"), LiveShareRoster.liveRecipientIds(roster, nowMs = decadesLater))
+        assertTrue(LiveShareRoster.remove(roster, recipients = listOf("a"), endTimeMs = indefinite).isEmpty())
+    }
+
+    @Test
     fun removeRecipients_removesSeveralPeopleAndIsNoOpForUnknown() {
         val roster = listOf(TimedRecipient("a", 100), TimedRecipient("b", 200), TimedRecipient("c", 300))
         // A subset of people drops all their entries...

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
@@ -346,7 +346,11 @@ sealed interface ConversationListUiAction {
 
     // region Live location sharing
 
-    /** Start (or extend) a live share on [messageId]'s location: sets liveShareUntilMs = now + duration. */
+    /**
+     * Start (or extend) a live share on [messageId]'s location: sets liveShareUntilMs to the
+     * absolute end-time derived from [durationMs] via liveShareEndTimeMs — [durationMs] may be
+     * the LIVE_SHARE_INDEFINITE sentinel (share until explicitly stopped).
+     */
     data class StartLiveLocationShare(
         val messageId: Uuid,
         val durationMs: Long,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -38,6 +38,7 @@ import id.homebase.chat.services.livelocation.globalLiveSharePinUntilMs
 import id.homebase.chat.services.livelocation.liveShareCoverageUntilMs
 import id.homebase.chat.services.livelocation.shareLiveLocationBack
 import id.homebase.core.location.GpsRequestReason
+import id.homebase.core.location.liveShareEndTimeMs
 import id.homebase.chat.services.convo.ConversationEnricher
 import id.homebase.chat.services.convo.ConversationService
 import id.homebase.chat.services.convo.ConversationStream
@@ -948,7 +949,7 @@ class ConversationListViewModel(
                     _uiState.update { it.copy(uiDialog = ConversationListUiDialog.EnableLocationForShare) }
                     return@launch
                 }
-                val untilMs = Clock.System.now().toEpochMilliseconds() + action.durationMs
+                val untilMs = liveShareEndTimeMs(Clock.System.now().toEpochMilliseconds(), action.durationMs)
                 val msg = chatMessageStream.getMessage(action.messageId) ?: return@launch
                 val recipients = conversationStream.getRecipients(msg.conversationId, emptyList(), null)
                 updateLocationLiveShare(action.messageId, untilMs) // synced declaration → bubbles flip LIVE

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/LocationPreviewDescriptor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/LocationPreviewDescriptor.kt
@@ -24,6 +24,11 @@ data class LocationPreviewDescriptor(
      * now >= value = ENDED. Set/cleared by updating this message's descriptor (see the live-share UX).
      * Defaults null + `explicitNulls = false` ⇒ omitted from JSON for static shares and ignored by
      * older clients.
+     *
+     * The value `LIVE_SHARE_INDEFINITE` (`id.homebase.core.location`, a fixed 2100-01-01 timestamp)
+     * is reserved: it marks an indefinite share (#1013) that stays LIVE until explicitly stopped.
+     * Consumers must equality-match it and show "until stopped" — never render it as a countdown
+     * or a date.
      */
     val liveShareUntilMs: Long? = null,
     /**

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/livelocation/LiveShareBack.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/livelocation/LiveShareBack.kt
@@ -1,6 +1,7 @@
 package id.homebase.chat.services.livelocation
 
 import id.homebase.chat.services.builder.LocationPreviewDescriptor
+import id.homebase.core.location.liveShareEndTimeMs
 import id.homebase.core.location.tracking.GpsFixResult
 
 /** Outcome of a share-back attempt — the caller maps these to user feedback. */
@@ -23,7 +24,8 @@ enum class ShareBackResult {
  * [durationMs] null = mirror [senderLiveShareUntilMs], the sender's absolute end-time synced in
  * their header descriptor — a single tap on a LIVE bubble shares back for exactly the sender's
  * remaining window so both shares end together. Non-null = picked from the duration menu on a
- * received static (fresh) bubble.
+ * received static (fresh) bubble. Either path may carry the [LIVE_SHARE_INDEFINITE] sentinel
+ * (an indefinite pick, or mirroring a sender's indefinite share) — it passes through unchanged.
  *
  * [send] receives the ready descriptor; [startRelay] receives the SAME absolute end-time the
  * descriptor carries — the {recipient, endTime} pair is the roster's stop key, so the two halves
@@ -37,7 +39,7 @@ suspend fun shareLiveLocationBack(
     send: suspend (LocationPreviewDescriptor) -> Unit,
     startRelay: suspend (untilMs: Long) -> Unit,
 ): ShareBackResult {
-    val untilMs = durationMs?.let { nowMs + it } ?: senderLiveShareUntilMs
+    val untilMs = durationMs?.let { liveShareEndTimeMs(nowMs, it) } ?: senderLiveShareUntilMs
     if (untilMs == null || untilMs <= nowMs) return ShareBackResult.Expired
     val fix = getFix()
     if (fix !is GpsFixResult.Success) return ShareBackResult.NoFix

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LiveLocationBubbleControls.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LiveLocationBubbleControls.kt
@@ -7,10 +7,12 @@ package id.homebase.chat.widget
  * (`LocationPreviewDescriptor.liveShareUntilMs`). This only carries the side + the action callbacks.
  *
  * - [sentByYou] gates the start/stop links (you can only share/stop your own location message).
- * - [onStart]/[onStop] update this message's descriptor (set/clear the live window).
+ * - [onStart]/[onStop] update this message's descriptor (set/clear the live window). The duration
+ *   may be the `LIVE_SHARE_INDEFINITE` sentinel (indefinite pick from the menu, #1013).
  * - [onStartShareBack] shares YOUR live location from someone else's bubble — sends a new own
  *   message instead of touching theirs. Null duration = mirror the sender's live end-time
- *   (single tap on a LIVE bubble); non-null = picked from the menu on a fresh static bubble.
+ *   (single tap on a LIVE bubble); non-null = picked from the menu on a fresh static bubble —
+ *   either path may carry the indefinite sentinel.
  * - [onOpenMap] opens the Live Location map (used by either side when the share is live).
  */
 data class LiveLocationBubbleControls(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LiveShareIndicator.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LiveShareIndicator.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import id.homebase.core.location.LIVE_SHARE_INDEFINITE
 import id.homebase.core.ui.theme.HomebaseTheme
 import id.homebase.resources.MR
 import id.homebase.resources.location_sharing_indicator_cd
@@ -22,8 +23,10 @@ import org.jetbrains.compose.resources.stringResource
  * The purple "you're sharing your live location" pin for the chat top bars (#816). Renders an
  * [IconButton] while `now < untilMs`, nothing otherwise — including flipping itself off at the
  * exact moment the share expires (the relay roster emits no event at expiry, so the deadline is
- * watched here with a ticker, same pattern as the location bubble's countdown). Tap opens the
- * location dashboard, where every outgoing share is listed with stop controls.
+ * watched here with a ticker, same pattern as the location bubble's countdown). An indefinite
+ * share ([LIVE_SHARE_INDEFINITE]) has no deadline to watch — the ticker is skipped and the pin
+ * stays lit until an explicit stop swaps [untilMs]. Tap opens the location dashboard, where
+ * every outgoing share is listed with stop controls.
  *
  * Filled glyph deliberately (the outlined pin is the passive Location nav icon; filled signals
  * an ACTIVE broadcast), tinted with the theme's `liveSharing` token — never a hardcoded color.
@@ -38,6 +41,7 @@ fun LiveShareIndicator(
     // Coarse ticker (≤30 s steps) that lands exactly on the deadline, then stops.
     var nowMs by remember(untilMs) { mutableStateOf(Clock.System.now().toEpochMilliseconds()) }
     LaunchedEffect(untilMs) {
+        if (untilMs == LIVE_SHARE_INDEFINITE) return@LaunchedEffect
         while (true) {
             val now = Clock.System.now().toEpochMilliseconds()
             nowMs = now

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LocationPreview.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/LocationPreview.kt
@@ -52,6 +52,7 @@ import id.homebase.api.client.location.LocationPreview
 import id.homebase.chat.services.builder.LocationPreviewDescriptor
 import id.homebase.core.image.HomebaseImage
 import id.homebase.core.location.LIVE_SHARE_DURATION_OPTIONS
+import id.homebase.core.location.LIVE_SHARE_INDEFINITE
 import id.homebase.core.location.formatLiveShareRemaining
 import id.homebase.core.image.HomebaseImageData
 import id.homebase.core.image.ImageSize
@@ -62,6 +63,7 @@ import id.homebase.resources.cd_location_pin
 import id.homebase.resources.chat_location_attachment
 import id.homebase.resources.live_location_title
 import id.homebase.resources.live_share_active
+import id.homebase.resources.live_share_active_indefinite
 import id.homebase.resources.live_share_back
 import id.homebase.resources.live_share_duration_prompt
 import id.homebase.resources.live_share_ended
@@ -286,12 +288,16 @@ fun LocationPreviewCard(
     // Derive STATIC / LIVE / ENDED from the descriptor's window vs now. While live, a coarse ticker
     // (<=30s) refreshes the "time left" caption; the loop lands exactly on `until` to flip to ENDED.
     // When static, the same ticker lands on the share-offer deadline so the link self-hides at 15 min.
+    // An indefinite share (reserved LIVE_SHARE_INDEFINITE end-time) is constant-LIVE with no
+    // countdown, so there is nothing to tick toward — the effect bails out.
     val until = descriptor.liveShareUntilMs
+    val isIndefinite = until == LIVE_SHARE_INDEFINITE
     val shareOfferDeadline = if (until == null) createdAtMs?.let { it + SHARE_OFFER_WINDOW_MS } else null
     val tickerDeadline = until ?: shareOfferDeadline
     var nowMs by remember(tickerDeadline) { mutableStateOf(Clock.System.now().toEpochMilliseconds()) }
     LaunchedEffect(tickerDeadline) {
         val u = tickerDeadline ?: return@LaunchedEffect
+        if (u == LIVE_SHARE_INDEFINITE) return@LaunchedEffect
         while (true) {
             val now = Clock.System.now().toEpochMilliseconds()
             nowMs = now
@@ -404,6 +410,7 @@ fun LocationPreviewCard(
                             controls = liveControls,
                             isLive = isLive,
                             isEnded = isEnded,
+                            isIndefinite = isIndefinite,
                             remainingMs = remainingMs,
                             contentColor = contentColor,
                             canStart = canStartShare && !ownShareActive,
@@ -470,6 +477,8 @@ private fun LiveShareActionArea(
     controls: LiveLocationBubbleControls,
     isLive: Boolean,
     isEnded: Boolean,
+    /** Reserved-sentinel share (LIVE_SHARE_INDEFINITE): live until stopped, no countdown. */
+    isIndefinite: Boolean,
     remainingMs: Long,
     contentColor: Color,
     /** Whether the static "Share live location" offer is still available (pin fresh enough). */
@@ -514,7 +523,11 @@ private fun LiveShareActionArea(
                         )
                     }
                     Text(
-                        text = stringResource(MR.string.live_share_active, formatLiveShareRemaining(remainingMs)),
+                        text = if (isIndefinite) {
+                            stringResource(MR.string.live_share_active_indefinite)
+                        } else {
+                            stringResource(MR.string.live_share_active, formatLiveShareRemaining(remainingMs))
+                        },
                         style = MaterialTheme.typography.labelSmall,
                         color = mutedColor,
                     )

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/content/LocationDescriptorRoundTripTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/content/LocationDescriptorRoundTripTest.kt
@@ -2,6 +2,7 @@ package id.homebase.chat.services.content
 
 import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.builder.LocationPreviewDescriptor
+import id.homebase.core.location.LIVE_SHARE_INDEFINITE
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -50,6 +51,23 @@ class LocationDescriptorRoundTripTest {
         assertFalse("caption" in json, "explicitNulls=false should omit unset caption: $json")
         assertFalse("imageWidth" in json, "explicitNulls=false should omit null imageWidth: $json")
         assertTrue("liveShareUntilMs" in json)
+    }
+
+    @Test
+    fun indefiniteSentinelEndTimeRoundTripsExactly() {
+        val descriptor = LocationPreviewDescriptor(
+            lat = 52.5,
+            lon = 13.4,
+            address = "",
+            hasImage = false,
+            imageWidth = null,
+            imageHeight = null,
+            liveShareUntilMs = LIVE_SHARE_INDEFINITE,
+        )
+        val json = MessageContentParser.serialize(MessageContent.Location(descriptor))
+        val parsed = MessageContentParser.parse(ChatProtocol.ChatLocationMessageDataType, json)
+        assertIs<MessageContent.Location>(parsed)
+        assertEquals(LIVE_SHARE_INDEFINITE, parsed.descriptor?.liveShareUntilMs)
     }
 
     @Test

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/livelocation/LiveLocationShareServiceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/livelocation/LiveLocationShareServiceTest.kt
@@ -4,6 +4,7 @@ import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import id.homebase.api.common.OdinId
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.OdinDatabase
+import id.homebase.core.location.LIVE_SHARE_INDEFINITE
 import id.homebase.core.location.tracking.DeviceSensors
 import id.homebase.core.location.tracking.LocationPointStore
 import id.homebase.core.location.tracking.RawLocationPoint
@@ -38,6 +39,15 @@ class LiveLocationShareServiceTest {
     private fun runShareTest(
         clock: () -> Long,
         body: suspend (LiveLocationShareService, Harness) -> Unit,
+    ) = runShareTestWithFactory(clock) { makeService, h -> body(makeService(), h) }
+
+    /**
+     * Like [runShareTest] but hands the body a service *factory* on one shared DB — building a
+     * second instance simulates a process restart (the constructor re-reads the persisted roster).
+     */
+    private fun runShareTestWithFactory(
+        clock: () -> Long,
+        body: suspend (makeService: () -> LiveLocationShareService, Harness) -> Unit,
     ) = runTest {
         val dispatcher = StandardTestDispatcher(testScheduler)
         val db = DatabaseManager(
@@ -51,14 +61,16 @@ class LiveLocationShareServiceTest {
         )
         try {
             val h = Harness()
-            val service = LiveLocationShareService(
-                relay = { _, recipients, _ -> h.relayed += recipients; true },
-                locationPointStore = LocationPointStore(db, NoSensors()),
-                databaseManager = db,
-                onLiveShareChanged = { h.holdChanges++ },
-                nowMs = clock,
-            )
-            body(service, h)
+            val makeService = {
+                LiveLocationShareService(
+                    relay = { _, recipients, _ -> h.relayed += recipients; true },
+                    locationPointStore = LocationPointStore(db, NoSensors()),
+                    databaseManager = db,
+                    onLiveShareChanged = { h.holdChanges++ },
+                    nowMs = clock,
+                )
+            }
+            body(makeService, h)
         } finally {
             db.close()
         }
@@ -109,6 +121,58 @@ class LiveLocationShareServiceTest {
             assertTrue(h.relayed.isEmpty())
             // The roster emptied on this fix → coordinator told to re-evaluate (drop the GPS hold).
             assertTrue(h.holdChanges > holdChangesAfterStart)
+        }
+    }
+
+    // ── Indefinite shares (#1013): the reserved LIVE_SHARE_INDEFINITE end-time never auto-expires ──
+
+    @Test
+    fun indefiniteShareStillRelaysAfterAYear() {
+        var now = 5_000L
+        runShareTest({ now }) { service, h ->
+            service.start(listOf(OdinId("alice.com")), endTimeMs = LIVE_SHARE_INDEFINITE)
+            now += 365L * 24 * 60 * 60_000L
+            service.relayLatest(point(t = now))
+            assertEquals(listOf(listOf("alice.com")), h.relayed)
+            assertTrue(service.hasLiveShare())
+        }
+    }
+
+    @Test
+    fun indefiniteShareSurvivesProcessRestartAndReset() {
+        var now = 5_000L
+        runShareTestWithFactory({ now }) { makeService, h ->
+            makeService().start(listOf(OdinId("alice.com")), endTimeMs = LIVE_SHARE_INDEFINITE)
+            now = 90_000_000L // "days later", fresh process
+            val restarted = makeService()
+            assertTrue(restarted.hasLiveShare(), "persisted indefinite roster must reload on construction")
+            restarted.reset() // the onPostAuthenticated bootstrap must NOT prune it
+            assertTrue(restarted.hasLiveShare())
+            restarted.relayLatest(point(t = now))
+            assertEquals(listOf(listOf("alice.com")), h.relayed)
+        }
+    }
+
+    @Test
+    fun indefiniteShareEndsOnlyViaExplicitStop() {
+        var now = 5_000L
+        runShareTest({ now }) { service, h ->
+            service.start(listOf(OdinId("alice.com")), endTimeMs = LIVE_SHARE_INDEFINITE)
+            service.stop(listOf(OdinId("alice.com")), endTimeMs = LIVE_SHARE_INDEFINITE)
+            assertTrue(!service.hasLiveShare())
+            now = 10_000L
+            service.relayLatest(point(t = now))
+            assertTrue(h.relayed.isEmpty())
+        }
+    }
+
+    @Test
+    fun stopAllEndsIndefiniteShare() {
+        var now = 5_000L
+        runShareTest({ now }) { service, _ ->
+            service.start(listOf(OdinId("alice.com")), endTimeMs = LIVE_SHARE_INDEFINITE)
+            service.stopAll()
+            assertTrue(!service.hasLiveShare())
         }
     }
 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/livelocation/LiveShareBackTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/livelocation/LiveShareBackTest.kt
@@ -1,6 +1,7 @@
 package id.homebase.chat.services.livelocation
 
 import id.homebase.chat.services.builder.LocationPreviewDescriptor
+import id.homebase.core.location.LIVE_SHARE_INDEFINITE
 import id.homebase.core.location.tracking.GpsFixResult
 import id.homebase.core.location.tracking.RawLocationPoint
 import kotlinx.coroutines.test.runTest
@@ -78,6 +79,30 @@ class LiveShareBackTest {
         assertNull(d.imageHeight)
         assertNull(d.caption)
         assertEquals("", d.address)
+    }
+
+    @Test
+    fun indefinitePickPassesTheSentinelThroughUnchanged() = runTest {
+        // An indefinite duration pick must NOT flow through `now + duration` — the sentinel IS the
+        // absolute end-time, and descriptor + relay must both carry it exactly (the stop key).
+        val h = Harness()
+        val result = run(
+            durationMs = LIVE_SHARE_INDEFINITE, senderUntilMs = null, nowMs = 10_000L, fixResult = fix, h = h,
+        )
+        assertEquals(ShareBackResult.Sent, result)
+        assertEquals(LIVE_SHARE_INDEFINITE, h.sent.single().liveShareUntilMs)
+        assertEquals(listOf(LIVE_SHARE_INDEFINITE), h.relayStarts)
+    }
+
+    @Test
+    fun mirroringAnIndefiniteShareNeverReadsExpired() = runTest {
+        // Single-tap share-back on a sender's indefinite bubble mirrors the sentinel.
+        val h = Harness()
+        val result = run(
+            durationMs = null, senderUntilMs = LIVE_SHARE_INDEFINITE, nowMs = 10_000L, fixResult = fix, h = h,
+        )
+        assertEquals(ShareBackResult.Sent, result)
+        assertEquals(LIVE_SHARE_INDEFINITE, h.sent.single().liveShareUntilMs)
     }
 
     @Test

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1378,6 +1378,7 @@
     <string name="location_dashboard_sharing_with">Sharing with</string>
     <string name="location_dashboard_sharing_with_you">Sharing with you</string>
     <string name="location_dashboard_share_until">until %1$s</string>
+    <string name="location_dashboard_share_until_stopped">until stopped</string>
     <string name="location_dashboard_stop_one_cd">Stop sharing with %1$s</string>
     <string name="location_dashboard_stop_everyone">Stop sharing with everyone</string>
     <string name="location_dashboard_stop_confirm_title">Stop all sharing?</string>
@@ -1387,13 +1388,14 @@
     <string name="live_share_duration_prompt">Share live location for</string>
     <string name="stop_sharing">Stop sharing</string>
     <string name="live_share_active">Live location · %1$s left</string>
+    <string name="live_share_active_indefinite">Live location · until stopped</string>
     <string name="live_share_ended">Live share ended</string>
     <string name="live_share_15m">15 minutes</string>
     <string name="live_share_30m">30 minutes</string>
     <string name="live_share_1h">1 hour</string>
     <string name="live_share_2h">2 hours</string>
     <string name="live_share_4h">4 hours</string>
-    <string name="live_share_24h">24 hours</string>
+    <string name="live_share_indefinite">Until you turn it off</string>
     <string name="share_location_title">Share location</string>
     <string name="share_location_recenter_cd">Center on your current location</string>
     <string name="share_location_resolving">Finding address…</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LiveShareDurations.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/LiveShareDurations.kt
@@ -3,17 +3,40 @@ package id.homebase.core.location
 import id.homebase.resources.MR
 import id.homebase.resources.live_share_15m
 import id.homebase.resources.live_share_1h
-import id.homebase.resources.live_share_24h
 import id.homebase.resources.live_share_2h
 import id.homebase.resources.live_share_30m
 import id.homebase.resources.live_share_4h
+import id.homebase.resources.live_share_indefinite
 import org.jetbrains.compose.resources.StringResource
+
+/**
+ * Reserved sentinel meaning "share until explicitly stopped" (#1013). Doubles as both the menu
+ * *duration* value and the absolute *end-time* written to the descriptor/roster: because every
+ * liveness check is `now < endTimeMs`, this end-time always reads LIVE, is never pruned by the
+ * roster's expiry sweep (so it survives restarts), and ends only via explicit stop/stopAll.
+ * UI must equality-match it and show "until stopped" — never feed it to
+ * [formatLiveShareRemaining] or render it as a date.
+ *
+ * The value is a fixed far-future timestamp (2100-01-01T00:00Z) rather than Long.MAX_VALUE:
+ * it stays exact when a non-Kotlin client parses the synced header as a JS double (< 2^53, so
+ * cross-client equality checks work) and can't overflow if offset arithmetic ever touches it.
+ */
+const val LIVE_SHARE_INDEFINITE: Long = 4_102_444_800_000L
+
+/**
+ * The only correct way to turn a picked menu duration into an absolute share end-time.
+ * The indefinite sentinel is a fixed point (it IS the end-time, not a duration) —
+ * `now + LIVE_SHARE_INDEFINITE` would produce a meaningless, unrecognizable timestamp.
+ */
+fun liveShareEndTimeMs(nowMs: Long, durationMs: Long): Long =
+    if (durationMs == LIVE_SHARE_INDEFINITE) LIVE_SHARE_INDEFINITE else nowMs + durationMs
 
 /**
  * The selectable live-location share durations (label resource → duration millis), shared by the
  * chat bubble's duration menu and the share-location screen so both offer the identical set.
- * 24h is the all-day option (festivals etc., #889) — the share window is absolute-endTime driven,
- * so it's just a larger value; backgrounded GPS freshness is governed separately by #878.
+ * The last entry is the indefinite share (#1013): its value is [LIVE_SHARE_INDEFINITE], not a real
+ * duration — convert picks with [liveShareEndTimeMs]. Backgrounded GPS freshness is governed
+ * separately by #878.
  */
 val LIVE_SHARE_DURATION_OPTIONS: List<Pair<StringResource, Long>> = listOf(
     MR.string.live_share_15m to 15 * 60_000L,
@@ -21,7 +44,7 @@ val LIVE_SHARE_DURATION_OPTIONS: List<Pair<StringResource, Long>> = listOf(
     MR.string.live_share_1h to 60 * 60_000L,
     MR.string.live_share_2h to 2 * 60 * 60_000L,
     MR.string.live_share_4h to 4 * 60 * 60_000L,
-    MR.string.live_share_24h to 24L * 60 * 60_000L,
+    MR.string.live_share_indefinite to LIVE_SHARE_INDEFINITE,
 )
 
 /** Compact "time left" label: "42m", "1h", "1h 20m". */

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/LiveShareDurationsTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/location/LiveShareDurationsTest.kt
@@ -1,0 +1,41 @@
+package id.homebase.core.location
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins the #1013 indefinite-share contract: [liveShareEndTimeMs] is the only duration→end-time
+ * conversion, and the [LIVE_SHARE_INDEFINITE] sentinel is its fixed point — it must never flow
+ * through `now + duration` (that would yield an unrecognizable timestamp no consumer could
+ * special-case as "until stopped").
+ */
+class LiveShareDurationsTest {
+
+    @Test
+    fun finiteDurationCountsFromNow() {
+        assertEquals(10_000L + 15 * 60_000L, liveShareEndTimeMs(nowMs = 10_000L, durationMs = 15 * 60_000L))
+    }
+
+    @Test
+    fun indefiniteSentinelIsAFixedPointNotAnOffset() {
+        assertEquals(LIVE_SHARE_INDEFINITE, liveShareEndTimeMs(nowMs = 10_000L, durationMs = LIVE_SHARE_INDEFINITE))
+    }
+
+    @Test
+    fun sentinelIsTheReserved2100Timestamp() {
+        // 2100-01-01T00:00Z — fixed so every consumer (and non-Kotlin clients parsing the synced
+        // header as a double, < 2^53) can equality-match it. Changing it breaks recognition of
+        // already-sent indefinite shares.
+        assertEquals(4_102_444_800_000L, LIVE_SHARE_INDEFINITE)
+    }
+
+    @Test
+    fun pickerEndsWithTheIndefiniteOptionAndStaysSixEntries() {
+        assertEquals(6, LIVE_SHARE_DURATION_OPTIONS.size)
+        assertEquals(LIVE_SHARE_INDEFINITE, LIVE_SHARE_DURATION_OPTIONS.last().second)
+        // Every other entry is a real (small) relative duration, safe for `now + duration`.
+        LIVE_SHARE_DURATION_OPTIONS.dropLast(1).forEach { (_, durationMs) ->
+            check(durationMs in 1..24L * 60 * 60_000L) { "unexpected duration $durationMs" }
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
@@ -58,6 +58,7 @@ import id.homebase.api.common.OdinId
 import id.homebase.chat.data.ContactUiModel
 import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.PublicAvatar
+import id.homebase.core.location.LIVE_SHARE_INDEFINITE
 import id.homebase.core.ui.screens.location.devices.LocationDeviceInfo
 import id.homebase.core.ui.screens.location.history.LocationTraceCanvas
 import id.homebase.core.ui.screens.location.livelocation.AGE_LABEL_AFTER_MS
@@ -74,6 +75,7 @@ import id.homebase.resources.location_dashboard_live_open
 import id.homebase.resources.location_dashboard_live_section
 import id.homebase.resources.location_dashboard_perm_banner
 import id.homebase.resources.location_dashboard_share_until
+import id.homebase.resources.location_dashboard_share_until_stopped
 import id.homebase.resources.location_dashboard_sharing_with
 import id.homebase.resources.location_dashboard_sharing_with_you
 import id.homebase.resources.location_dashboard_stop_confirm_body
@@ -617,10 +619,14 @@ private fun OutgoingShareRowItem(
                 style = MaterialTheme.typography.bodyLarge,
             )
             Text(
-                text = stringResource(
-                    MR.string.location_dashboard_share_until,
-                    formatUntilTime(Instant.fromEpochMilliseconds(row.untilMs)),
-                ),
+                text = if (row.untilMs == LIVE_SHARE_INDEFINITE) {
+                    stringResource(MR.string.location_dashboard_share_until_stopped)
+                } else {
+                    stringResource(
+                        MR.string.location_dashboard_share_until,
+                        formatUntilTime(Instant.fromEpochMilliseconds(row.untilMs)),
+                    )
+                },
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/share/ShareLocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/share/ShareLocationViewModel.kt
@@ -18,6 +18,7 @@ import id.homebase.core.location.GpsRequestReason
 import id.homebase.core.location.LocationMapProvider
 import id.homebase.core.location.LocationPreferences
 import id.homebase.core.location.LocationService
+import id.homebase.core.location.liveShareEndTimeMs
 import id.homebase.core.location.tracking.DemandReason
 import id.homebase.core.location.tracking.GpsFixResult
 import id.homebase.resources.MR
@@ -247,6 +248,7 @@ class ShareLocationViewModel(
     /**
      * Start a live share for [durationMs]: own live-at-creation message (from the ACTUAL current
      * position) + relay roster, both on the same absolute end-time. Gated on share readiness.
+     * [durationMs] may be the [LIVE_SHARE_INDEFINITE] sentinel (share until explicitly stopped).
      */
     fun startLiveShare(durationMs: Long) {
         if (_uiState.value.isSending) return
@@ -263,7 +265,7 @@ class ShareLocationViewModel(
                     _events.emit(ShareLocationUiEvent.ShowError(MR.string.chat_location_unavailable))
                     return@launch
                 }
-                val untilMs = Clock.System.now().toEpochMilliseconds() + durationMs
+                val untilMs = liveShareEndTimeMs(Clock.System.now().toEpochMilliseconds(), durationMs)
                 val preview = previewProvider.getLocationPreview(fix.point.lat, fix.point.lon)
                 val descriptor = LocationPreviewPayloadBuilder.descriptorFor(preview)
                     .copy(caption = captionOrNull(), liveShareUntilMs = untilMs)


### PR DESCRIPTION
Closes #1013.

## What

Adds an **indefinite** live-location share option — the share runs until the user explicitly stops it. Per design decision, it **replaces the 24h entry** in the duration picker (still 6 entries: 15m / 30m / 1h / 2h / 4h / *Until you turn it off*).

## How

Modeled as a reserved sentinel absolute end-time, per the issue — with one deviation:

- `LIVE_SHARE_INDEFINITE = 4_102_444_800_000L` (**2100-01-01T00:00Z**), not `Long.MAX_VALUE`. A fixed timestamp keeps exact equality when a non-Kotlin client parses the synced header as a double (< 2^53) and can't overflow if offset arithmetic ever touches it, while keeping every sentinel property: `now < until` always reads LIVE, the roster's `endTimeMs > now` prune never drops it (survives restarts), and only explicit stop/stopAll ends it. No new descriptor field.
- New `liveShareEndTimeMs(nowMs, durationMs)` helper is the single duration→end-time conversion; the sentinel is its fixed point. All three former `now + durationMs` sites converted (`ShareLocationViewModel`, `ConversationListViewModel`, `LiveShareBack`). Mirror share-back of an indefinite share passes the sender's sentinel through unchanged.
- UI special-cases so nothing renders a bogus countdown/date:
  - bubble caption: **"Live location · until stopped"** (neutral — same bubble is seen by both sides)
  - dashboard row: **"until stopped"** (also avoids `Instant.fromEpochMilliseconds` garbage)
  - the bubble's and purple pin's 30s deadline tickers skip for the sentinel (nothing to tick toward)
- `LiveLocationShareService` / `LiveShareRoster` needed **no changes** — sentinel safety is proven by tests instead of assumed.

## Tests

- Service: indefinite share still relays a year later; survives process restart + `reset()` (new two-services-on-one-DB harness); removed by `stop`/`stopAll`
- Roster (commonTest, also run on wasmJs): sentinel entry always live, removable only by matching stop
- Share-back: indefinite pick and mirror-of-indefinite both carry the sentinel exactly (descriptor == relay stop key)
- Descriptor JSON round-trip of the sentinel
- New `LiveShareDurationsTest` pins the helper, the reserved value, and the picker shape

Verified: JVM/Android/wasmJs compiles for homebase-common/chat/core; `homebase-chat:jvmTest homebase-common:jvmTest homebase-api:jvmTest --rerun-tasks` and `homebase-api:wasmJsTest` all green.

## Notes

- **Other Odin clients** (web/React) rendering this header will show "until Jan 1, 2100" until they special-case the sentinel — needs a companion note/issue there.
- The issue's "periodic still-sharing reminder" open question is out of scope (privacy follow-up).
- On-device Android + iOS verification from the acceptance criteria still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JY2U8Nhcw4uo6TgtTHuxsy