### PR TITLE
fix(ios): open chat camera by hoisting the launch out of the dropdown popup

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -532,6 +532,22 @@ fun ConversationContent(
             )
         }
     }
+
+    // iOS: the camera sits in a DropdownMenu (a Popup window) in MessageInputBar, and FileKit's
+    // camera picker can't be presented while that popup is tearing down — iOS dismisses the picker
+    // along with the popup ("Take Photo opens then closes instantly"). So hoist the launch out of
+    // the menu item: the item only closes the menu and flips this flag, and we present here after
+    // the popup's exit transition has finished. A single recomposition isn't enough (the popup is
+    // still animating out); the native video path is immune, which is why only photo broke.
+    var pendingCameraLaunch by remember { mutableStateOf(false) }
+    LaunchedEffect(pendingCameraLaunch) {
+        if (pendingCameraLaunch) {
+            delay(250) // let the DropdownMenu popup finish dismissing before FileKit presents
+            cameraLauncher.launch()
+            pendingCameraLaunch = false // reset AFTER launch — resetting first cancels this effect
+        }
+    }
+
     val videoRecorderLauncher = rememberVideoRecorderManager { file ->
         file?.let {
             onUiAction(
@@ -1534,7 +1550,7 @@ fun ConversationContent(
                                     showAttachmentSheet = false
                                 },
                                 onAddAttachmentClick = { toggleAttachmentSheet() },
-                                onCameraClick = { cameraLauncher.launch() },
+                                onCameraClick = { pendingCameraLaunch = true },
                                 onVideoRecordClick = { videoRecorderLauncher.launch() },
                                 onRecordingStarted = {
                                     onUiAction(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -542,6 +542,10 @@ fun ConversationContent(
     var pendingCameraLaunch by remember { mutableStateOf(false) }
     LaunchedEffect(pendingCameraLaunch) {
         if (pendingCameraLaunch) {
+            // Closing the dropdown hands focus back to the input, which pops the keyboard up during
+            // the wait below; clear focus + hide it so the keyboard doesn't flash before the camera.
+            focusManager.clearFocus()
+            keyboardController?.hide()
             delay(250) // let the DropdownMenu popup finish dismissing before FileKit presents
             cameraLauncher.launch()
             pendingCameraLaunch = false // reset AFTER launch — resetting first cancels this effect


### PR DESCRIPTION
## Problem
On iOS, chat **Take Photo** opened the camera then closed it instantly. Chat video, gallery, Vault camera and Moments camera all worked.

## Root cause
The camera is a `DropdownMenu` item (a Popup **window**) in `MessageInputBar`. `Take Photo` launched FileKit's camera picker **synchronously while that popup was tearing down** — iOS dismisses a view controller presented over a dismissing popup, so the picker died along with the menu.

Differentials that pinned it (all device-verified on a physical iPhone, iOS 26.5):
- Chat **video** launches from the *same* dropdown and works — it uses a native `UIImagePickerController`, which is robust to the popup teardown; FileKit's camera picker is not.
- **Gallery** works because it launches from the inline attachment sheet (not a Popup window).
- **Vault** works because it removes its bottom sheet instantly, then launches into a clean hierarchy.
- A one-runloop-tick defer was **not** enough — the popup is still animating out.

## Fix
Hoist the launch out of the dropdown to the screen level in `ConversationContent.kt`: the menu item only closes the menu and flips a flag; a `LaunchedEffect` waits for the popup's exit transition to finish, then presents FileKit. FileKit is kept as-is — no native rewrite. One file changed.

## Testing
Device-verified on a physical iPhone (iOS 26.5): **Take Photo now opens and stays open**; **Record Video** still works.

> Supersedes the abandoned **#760** (closed, never merged) — so this bug was live in `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UH619ZFhaymPdtSUqV6Ar6
