### PR TITLE
Redesign profile edit screen: Public/Vetted sections, per-attribute save

### DIFF
--- a/.github/workflows/build-mobile-release-prod.yml
+++ b/.github/workflows/build-mobile-release-prod.yml
@@ -211,15 +211,18 @@ jobs:
           # release link starts with a clean heap instead of inheriting 45+
           # minutes of accumulated daemon heap (build 27400310875 OOM).
           kotlin.native.disableCompilerDaemon=true
-          # 8g, not less: run 27407420160's GC log proved ~5.1 GB is genuinely
-          # live during linkReleaseFrameworkIosArm64 (full GC clearing soft refs
-          # reclaimed nothing at a 6g cap). 8g exceeds the runner's 7 GB RAM;
-          # macOS swap absorbs it, proven even with xcodebuild resident: run
-          # 27414487423's in-Xcode link completed at 8g. (A pre-build step that
-          # linked before fastlane was removed — embedAndSignAppleFrameworkForXcode
-          # configures the link differently, so the pre-built framework was not
-          # UP-TO-DATE and the ~60 min link ran twice.)
-          kotlin.native.jvmArgs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/Users/runner/work/jvm-dumps -Xlog:gc*:file=/Users/runner/work/jvm-dumps/kn-gc-%p.log
+          # 12g, not 8g: run 28881233018's GC log (kn-gc-46490.log) showed the
+          # heap pinned at ~8187-8189M against the old 8g cap for ~20 minutes
+          # across 9 consecutive Full GCs (30-165s each), each reclaiming
+          # near-zero bytes — G1 "GC overhead limit exceeded" thrashing, not a
+          # hard live-set wall. The final Full GC did free the heap down to
+          # 2935M, proving the peak working set (whole-program IR/analysis
+          # before final emission) is transient and reclaimable — it just
+          # needs more headroom than 8g to get through that peak without
+          # stalling out. 12g exceeds the runner's 7 GB RAM; macOS swap
+          # absorbed an 8g cap fine before (run 27414487423), so the extra 4g
+          # is expected to cost more wall-clock via swapping, not fail outright.
+          kotlin.native.jvmArgs=-Xmx12g -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/Users/runner/work/jvm-dumps -Xlog:gc*:file=/Users/runner/work/jvm-dumps/kn-gc-%p.log
           EOF
           echo "Appended CI memory overrides to gradle.properties:"
           tail -n 15 gradle.properties

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/MessageMapper.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/MessageMapper.kt
@@ -570,7 +570,8 @@ internal suspend fun renderStatusMessage(
             else TranslationUtil.getString(MR.string.chat_poll_ended_other, name, q)
         }
 
-        StatusMessage.EmergencyContactDesignated ->
+        StatusMessage.EmergencyContactDesignated,
+        StatusMessage.EmergencyContactDesignatedNotice ->
             when {
                 authorIsYou && subject != null ->
                     TranslationUtil.getString(MR.string.system_emergency_contact_designated_you, subject)
@@ -580,7 +581,8 @@ internal suspend fun renderStatusMessage(
                     TranslationUtil.getString(MR.string.system_emergency_contact_designated, name)
             }
 
-        StatusMessage.EmergencyContactRevoked ->
+        StatusMessage.EmergencyContactRevoked,
+        StatusMessage.EmergencyContactRevokedNotice ->
             when {
                 authorIsYou && subject != null ->
                     TranslationUtil.getString(MR.string.system_emergency_contact_revoked_you, subject)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/StatusMessage.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/StatusMessage.kt
@@ -48,6 +48,18 @@ enum class StatusMessage() {
      *  side-effect that clears the recipient's can-locate flag for the SENDER (core `clearICanLocate`). */
     EmergencyContactRevoked,
 
+    /** Visible-only twin of [EmergencyContactDesignated], sent immediately after it in the same
+     *  conversation. [EmergencyContactDesignated] itself never reaches the receiver's chat history —
+     *  [id.homebase.core.contactbook.EmergencyContactReceiveService] soft-deletes it on receipt so a
+     *  re-delivery can't re-apply a stale designation. This twin carries no side-effect and is never
+     *  matched by [id.homebase.chat.services.convo.ConversationStream]'s designation dispatcher, so it
+     *  is never consumed — it renders the normal "X added you as an emergency contact" status line and
+     *  stays in history like any other status message. */
+    EmergencyContactDesignatedNotice,
+
+    /** Visible-only twin of [EmergencyContactRevoked] — see [EmergencyContactDesignatedNotice]. */
+    EmergencyContactRevokedNotice,
+
     /** Sent by an emergency contact (the message's `originalAuthor`) when they activate the
      *  emergency locate function against the recipient and retrieve their location history.
      *  Carries [StatusMessageData.emergencyLocateExplanation] (the requester's justification),

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -404,7 +404,10 @@ class ConversationService(
      * (created if it doesn't exist yet). [StatusMessageData.subject] carries [recipient] so the
      * sender's own copy renders "You added {recipient}…"; the receiver's copy renders "{sender}
      * added you…" and drives the receive-side bit (see
-     * [id.homebase.chat.services.convo.ConversationStream.onEmergencyContactDesignated]).
+     * [id.homebase.chat.services.convo.ConversationStream.onEmergencyContactDesignated]) — then that
+     * copy is immediately soft-deleted/consumed, so it never sits in the receiver's history. A second
+     * [StatusMessage.EmergencyContactDesignatedNotice] status is chained right after it with the same
+     * text: it drives no side-effect and is never consumed, so it's what the receiver actually sees.
      *
      * Unlike the "conversation started" status this is posted on every designation (not just a
      * freshly-created thread). Best-effort: returns the conversation id on success, or null on
@@ -417,12 +420,22 @@ class ConversationService(
                 title = null,
                 payloadBundle = null,
             )
+            val designationMessageId = Uuid.random()
             chatMessageSenderService.sendStatusMessage(
-                messageUniqueId = Uuid.random(),
+                messageUniqueId = designationMessageId,
                 conversationId = result.conversationId,
                 previousMessageUniqueId = result.conversationId,
                 statusMessage = StatusMessageData(
                     statusMessage = StatusMessage.EmergencyContactDesignated,
+                    subject = recipient,
+                ),
+            )
+            chatMessageSenderService.sendStatusMessage(
+                messageUniqueId = Uuid.random(),
+                conversationId = result.conversationId,
+                previousMessageUniqueId = designationMessageId,
+                statusMessage = StatusMessageData(
+                    statusMessage = StatusMessage.EmergencyContactDesignatedNotice,
                     subject = recipient,
                 ),
             )
@@ -486,8 +499,10 @@ class ConversationService(
      * Mirror of [sendEmergencyContactDesignation]: notifies [recipient] that the local user has
      * removed them from their emergency circle, by posting a [StatusMessage.EmergencyContactRevoked]
      * status into their 1:1. Drives the receiver's [ConversationStream.onEmergencyContactRevoked]
-     * side-effect (clears the can-locate flag). Best-effort; returns the conversation id or null on
-     * failure (logged). Rethrows cancellation.
+     * side-effect (clears the can-locate flag) and is then consumed the same way the designation is —
+     * so a second, never-consumed [StatusMessage.EmergencyContactRevokedNotice] is chained right after
+     * it to give the receiver a visible "X removed you as an emergency contact" status line.
+     * Best-effort; returns the conversation id or null on failure (logged). Rethrows cancellation.
      */
     suspend fun sendEmergencyContactRevocation(recipient: OdinId): Uuid? {
         return try {
@@ -496,12 +511,22 @@ class ConversationService(
                 title = null,
                 payloadBundle = null,
             )
+            val revocationMessageId = Uuid.random()
             chatMessageSenderService.sendStatusMessage(
-                messageUniqueId = Uuid.random(),
+                messageUniqueId = revocationMessageId,
                 conversationId = result.conversationId,
                 previousMessageUniqueId = result.conversationId,
                 statusMessage = StatusMessageData(
                     statusMessage = StatusMessage.EmergencyContactRevoked,
+                    subject = recipient,
+                ),
+            )
+            chatMessageSenderService.sendStatusMessage(
+                messageUniqueId = Uuid.random(),
+                conversationId = result.conversationId,
+                previousMessageUniqueId = revocationMessageId,
+                statusMessage = StatusMessageData(
+                    statusMessage = StatusMessage.EmergencyContactRevokedNotice,
                     subject = recipient,
                 ),
             )

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1575,7 +1575,6 @@
 
     <!-- Profile editor -->
     <string name="profile_edit_title">Edit profile</string>
-    <string name="profile_edit_save">Save</string>
     <string name="profile_edit_load_failed">Couldn't load your profile.</string>
     <string name="profile_edit_retry">Retry</string>
     <string name="profile_edit_error_forbidden">This app doesn't have permission to edit your profile. Re-grant access by extending permissions in the owner console, then try again.</string>
@@ -1615,8 +1614,11 @@
     <string name="profile_edit_preview_section_public">Public</string>
     <string name="profile_edit_preview_section_public_desc">Visible to everyone, including people you haven't connected with.</string>
     <string name="profile_edit_preview_section_vetted">Vetted</string>
-    <string name="profile_edit_preview_section_vetted_desc">Visible to your vetted (confirmed) connections.</string>
+    <string name="profile_edit_preview_section_vetted_desc">Additional Attributes visible to your vetted (confirmed) connections.</string>
     <string name="profile_edit_preview_empty">Nothing is visible at this level yet.</string>
+    <string name="profile_edit_field_not_set">Not set</string>
+    <string name="profile_edit_add_attribute">Add attribute</string>
+    <string name="profile_edit_add_attribute_title">Add a field</string>
 
     <!-- Avatar editor -->
     <string name="profile_avatar_edit_title">Change photo</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/profile/ProfileEditScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/profile/ProfileEditScreen.kt
@@ -2,13 +2,12 @@
 
 package id.homebase.core.ui.screens.profile
 
-import androidx.compose.foundation.ScrollState
-import androidx.compose.foundation.background
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -16,19 +15,33 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.outlined.AlternateEmail
+import androidx.compose.material.icons.outlined.Badge
+import androidx.compose.material.icons.outlined.Cake
+import androidx.compose.material.icons.outlined.Call
+import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material.icons.outlined.Email
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Visibility
-import androidx.compose.material3.Button
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -37,32 +50,39 @@ import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.api.client.profile.ProfileAttributeTypes
 import id.homebase.api.client.profile.ProfileVisibility
+import id.homebase.core.ui.screens.contactbook.ContactFieldValidation
+import id.homebase.core.ui.screens.contactbook.components.AdaptiveSheet
 import id.homebase.core.ui.screens.contactbook.components.PhoneNumberField
+import id.homebase.core.ui.screens.contactbook.components.formatPhoneForDisplay
 import id.homebase.resources.MR
-import id.homebase.resources.contactbook_detail_tab_about
-import id.homebase.resources.contactbook_detail_tab_details
+import id.homebase.resources.cancel
+import id.homebase.resources.contactbook_detail_location
+import id.homebase.resources.contactbook_detail_name
 import id.homebase.resources.contactbook_error_email
 import id.homebase.resources.contactbook_error_phone
 import id.homebase.resources.menu_back
+import id.homebase.resources.profile_edit_add_attribute
+import id.homebase.resources.profile_edit_add_attribute_title
 import id.homebase.resources.profile_edit_additional_name
 import id.homebase.resources.profile_edit_address1
 import id.homebase.resources.profile_edit_address2
@@ -79,6 +99,7 @@ import id.homebase.resources.profile_edit_email_label_hint
 import id.homebase.resources.profile_edit_error_forbidden
 import id.homebase.resources.profile_edit_error_save
 import id.homebase.resources.profile_edit_facebook
+import id.homebase.resources.profile_edit_field_not_set
 import id.homebase.resources.profile_edit_given_name
 import id.homebase.resources.profile_edit_instagram
 import id.homebase.resources.profile_edit_linkedin
@@ -90,9 +111,12 @@ import id.homebase.resources.profile_edit_phone_label_hint
 import id.homebase.resources.profile_edit_postcode
 import id.homebase.resources.profile_edit_preview_enter
 import id.homebase.resources.profile_edit_preview_exit
+import id.homebase.resources.profile_edit_preview_section_public
+import id.homebase.resources.profile_edit_preview_section_public_desc
+import id.homebase.resources.profile_edit_preview_section_vetted
+import id.homebase.resources.profile_edit_preview_section_vetted_desc
 import id.homebase.resources.profile_edit_public_hint
 import id.homebase.resources.profile_edit_retry
-import id.homebase.resources.profile_edit_save
 import id.homebase.resources.profile_edit_status
 import id.homebase.resources.profile_edit_surname
 import id.homebase.resources.profile_edit_tiktok
@@ -100,6 +124,7 @@ import id.homebase.resources.profile_edit_title
 import id.homebase.resources.profile_edit_twitter
 import id.homebase.resources.profile_edit_visibility_connected
 import id.homebase.resources.profile_edit_visibility_public
+import id.homebase.resources.save
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 
@@ -118,7 +143,8 @@ fun ProfileEditScreen(
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
             when (event) {
-                ProfileEditEvent.Saved, ProfileEditEvent.Back -> onBack()
+                is ProfileEditEvent.AttributeSaved -> Unit // rows collapse themselves on tap of the checkmark.
+                ProfileEditEvent.Back -> onBack()
                 ProfileEditEvent.Forbidden -> snackbarHostState.showSnackbar(errForbidden)
                 ProfileEditEvent.Error -> snackbarHostState.showSnackbar(errSave)
             }
@@ -164,11 +190,16 @@ fun ProfileEditScreen(
                 uiState = uiState,
                 modifier = Modifier.fillMaxSize().padding(padding),
             )
-            else -> ProfileForm(
-                uiState = uiState,
-                onAction = viewModel::onAction,
-                modifier = Modifier.fillMaxSize().padding(padding),
-            )
+            else -> Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+                if (uiState.savingAttributes.isNotEmpty()) {
+                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                }
+                ProfileForm(
+                    uiState = uiState,
+                    onAction = viewModel::onAction,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
         }
     }
 }
@@ -199,62 +230,317 @@ private fun LoadFailedState(modifier: Modifier, onRetry: () -> Unit) {
     }
 }
 
-/** Mirrors [id.homebase.core.ui.screens.contactbook.detail.ContactDetailScreen]'s Details/About
- *  tabs, so the owner's own profile reads the same way any other identity's profile does. */
-private enum class ProfileFormTab(val labelRes: StringResource) {
-    DETAILS(MR.string.contactbook_detail_tab_details),
-    ABOUT(MR.string.contactbook_detail_tab_about),
-}
-
+/**
+ * Mirrors [ProfilePreview]'s Public/Vetted split: everyone-visible fields first, then everything a
+ * vetted (connected) contact can see. There's no screen-wide Save — tapping a row expands it in
+ * place with a Public|Vetted toggle (defaulting to that row's own section) and its field(s); the
+ * checkmark persists just that one attribute at whichever tier is currently selected.
+ */
 @Composable
 private fun ProfileForm(
     uiState: ProfileEditUiState,
     onAction: (ProfileEditAction) -> Unit,
     modifier: Modifier,
 ) {
-    var selectedTab by remember { mutableStateOf(ProfileFormTab.DETAILS) }
+    // Which (section tier, attribute type) rows are currently expanded — keeps a row mounted (and
+    // visible) for the whole edit session once it has a value. Blank attributes are never opened
+    // this way — they're only added via the FAB's dialog, below.
+    val editingRows = remember { mutableStateMapOf<Pair<ProfileVisibility, String>, Boolean>() }
+    var showAddSheet by remember { mutableStateOf(false) }
+    var addDialogTarget by remember { mutableStateOf<Pair<AttributeSpec, ProfileVisibility>?>(null) }
 
-    Column(modifier = modifier) {
-        TabRow(selectedTabIndex = selectedTab.ordinal) {
-            ProfileFormTab.entries.forEach { tab ->
-                Tab(
-                    selected = tab == selectedTab,
-                    onClick = { selectedTab = tab },
-                    text = { Text(stringResource(tab.labelRes)) },
+    val missingPublic = ATTRIBUTE_SPECS.filter { displayValueFor(it.type, uiState.anonymousValues) == null }
+    val missingVetted = ATTRIBUTE_SPECS.filter { displayValueFor(it.type, uiState.connectedValues) == null }
+    val hasMissing = missingPublic.isNotEmpty() || missingVetted.isNotEmpty()
+
+    Box(modifier = modifier) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .imePadding(),
+        ) {
+            Spacer(Modifier.height(8.dp))
+            ProfileFieldsSection(
+                tier = ProfileVisibility.ANONYMOUS,
+                title = stringResource(MR.string.profile_edit_preview_section_public),
+                description = stringResource(MR.string.profile_edit_preview_section_public_desc),
+                uiState = uiState,
+                onAction = onAction,
+                editingRows = editingRows,
+            )
+
+            HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp))
+
+            ProfileFieldsSection(
+                tier = ProfileVisibility.CONNECTED,
+                title = stringResource(MR.string.profile_edit_preview_section_vetted),
+                description = stringResource(MR.string.profile_edit_preview_section_vetted_desc),
+                uiState = uiState,
+                onAction = onAction,
+                editingRows = editingRows,
+            )
+            // Clearance so the last row isn't hidden behind the floating action button.
+            Spacer(Modifier.height(88.dp))
+        }
+
+        if (hasMissing) {
+            FloatingActionButton(
+                onClick = { showAddSheet = true },
+                modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp),
+            ) {
+                Icon(
+                    Icons.Filled.Add,
+                    contentDescription = stringResource(MR.string.profile_edit_add_attribute),
                 )
             }
         }
+    }
 
-        // Fresh scroll position per tab.
-        val scroll = remember(selectedTab) { ScrollState(0) }
-        Column(
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
-                .verticalScroll(scroll)
-                .imePadding()
-                .padding(horizontal = 16.dp),
-        ) {
-            Spacer(Modifier.height(12.dp))
-            when (selectedTab) {
-                ProfileFormTab.DETAILS -> DetailsFields(uiState, onAction)
-                ProfileFormTab.ABOUT -> AboutFields(uiState, onAction)
+    if (showAddSheet) {
+        AddAttributeSheet(
+            missingPublic = missingPublic,
+            missingVetted = missingVetted,
+            onPick = { spec, tier ->
+                showAddSheet = false
+                addDialogTarget = spec to tier
+            },
+            onDismiss = { showAddSheet = false },
+        )
+    }
+
+    addDialogTarget?.let { (spec, tier) ->
+        AddAttributeDialog(
+            spec = spec,
+            initialTier = tier,
+            onSave = { savedTier, values ->
+                ProfileEditViewModel.TYPE_FIELDS[spec.type].orEmpty().forEach { (field, _) ->
+                    onAction(ProfileEditAction.FieldChanged(field, savedTier, values[field].orEmpty()))
+                }
+                onAction(ProfileEditAction.SaveAttribute(spec.type, savedTier))
+                addDialogTarget = null
+            },
+            onDismiss = { addDialogTarget = null },
+        )
+    }
+}
+
+@Composable
+private fun ProfileFieldsSection(
+    tier: ProfileVisibility,
+    title: String,
+    description: String,
+    uiState: ProfileEditUiState,
+    onAction: (ProfileEditAction) -> Unit,
+    editingRows: SnapshotStateMap<Pair<ProfileVisibility, String>, Boolean>,
+) {
+    val values = if (tier == ProfileVisibility.ANONYMOUS) uiState.anonymousValues else uiState.connectedValues
+    val v: (ProfileField) -> String = { values[it].orEmpty() }
+    fun vf(editTier: ProfileVisibility, field: ProfileField): String =
+        (if (editTier == ProfileVisibility.ANONYMOUS) uiState.anonymousValues else uiState.connectedValues)[field].orEmpty()
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        SectionHeader(title, description)
+
+        val nameDisplay = profileNameValue(values)
+        if (nameDisplay != null || editingRows[tier to ProfileAttributeTypes.NAME] == true) {
+            EditableFieldGroup(
+                sectionTier = tier,
+                type = ProfileAttributeTypes.NAME,
+                icon = Icons.Outlined.Person,
+                label = stringResource(MR.string.contactbook_detail_name),
+                displayValue = nameDisplay,
+                editingRows = editingRows,
+                onAction = onAction,
+            ) { editTier ->
+                AttributeFields(ProfileAttributeTypes.NAME, { vf(editTier, it) }) { field, v ->
+                    onAction(ProfileEditAction.FieldChanged(field, editTier, v))
+                }
             }
-            Spacer(Modifier.height(16.dp))
         }
 
-        // Save applies to edits from both tabs together, so it stays outside the tabbed/scrolling
-        // area rather than being duplicated per tab or scrolling away.
-        Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
-            Button(
-                onClick = { onAction(ProfileEditAction.SaveClicked) },
-                enabled = uiState.canSave,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                if (uiState.isSaving) {
-                    CircularProgressIndicator(modifier = Modifier.height(20.dp), strokeWidth = 2.dp)
-                } else {
-                    Text(stringResource(MR.string.profile_edit_save))
+        val nicknameDisplay = v(ProfileField.NICKNAME).ifBlank { null }
+        if (nicknameDisplay != null || editingRows[tier to ProfileAttributeTypes.NICKNAME] == true) {
+            EditableFieldGroup(
+                sectionTier = tier,
+                type = ProfileAttributeTypes.NICKNAME,
+                icon = Icons.Outlined.Badge,
+                label = stringResource(MR.string.profile_edit_nickname),
+                displayValue = nicknameDisplay,
+                editingRows = editingRows,
+                onAction = onAction,
+            ) { editTier ->
+                AttributeFields(ProfileAttributeTypes.NICKNAME, { vf(editTier, it) }) { field, v ->
+                    onAction(ProfileEditAction.FieldChanged(field, editTier, v))
+                }
+            }
+        }
+
+        val statusDisplay = v(ProfileField.STATUS).ifBlank { null }
+        if (statusDisplay != null || editingRows[tier to ProfileAttributeTypes.STATUS] == true) {
+            EditableFieldGroup(
+                sectionTier = tier,
+                type = ProfileAttributeTypes.STATUS,
+                icon = Icons.Outlined.Info,
+                label = stringResource(MR.string.profile_edit_status),
+                displayValue = statusDisplay,
+                editingRows = editingRows,
+                onAction = onAction,
+            ) { editTier ->
+                AttributeFields(ProfileAttributeTypes.STATUS, { vf(editTier, it) }) { field, v ->
+                    onAction(ProfileEditAction.FieldChanged(field, editTier, v))
+                }
+            }
+        }
+
+        val birthdayDisplay = v(ProfileField.BIRTHDAY).ifBlank { null }
+        if (birthdayDisplay != null || editingRows[tier to ProfileAttributeTypes.BIRTHDAY] == true) {
+            EditableFieldGroup(
+                sectionTier = tier,
+                type = ProfileAttributeTypes.BIRTHDAY,
+                icon = Icons.Outlined.Cake,
+                label = stringResource(MR.string.profile_edit_birthday),
+                displayValue = birthdayDisplay,
+                editingRows = editingRows,
+                onAction = onAction,
+            ) { editTier ->
+                AttributeFields(ProfileAttributeTypes.BIRTHDAY, { vf(editTier, it) }) { field, v ->
+                    onAction(ProfileEditAction.FieldChanged(field, editTier, v))
+                }
+            }
+        }
+
+        val emailDisplay = v(ProfileField.EMAIL).ifBlank { null }
+        if (emailDisplay != null || editingRows[tier to ProfileAttributeTypes.EMAIL] == true) {
+            EditableFieldGroup(
+                sectionTier = tier,
+                type = ProfileAttributeTypes.EMAIL,
+                icon = Icons.Outlined.Email,
+                label = stringResource(MR.string.profile_edit_email),
+                displayValue = emailDisplay,
+                editingRows = editingRows,
+                onAction = onAction,
+                isValidForSave = { et -> isAttributeValid(ProfileAttributeTypes.EMAIL) { vf(et, it) } },
+            ) { editTier ->
+                AttributeFields(ProfileAttributeTypes.EMAIL, { vf(editTier, it) }) { field, v ->
+                    onAction(ProfileEditAction.FieldChanged(field, editTier, v))
+                }
+            }
+        }
+
+        val phoneRaw = v(ProfileField.PHONE)
+        val phoneDisplay = phoneRaw.ifBlank { null }?.let { formatPhoneForDisplay(it) }
+        if (phoneDisplay != null || editingRows[tier to ProfileAttributeTypes.PHONE] == true) {
+            EditableFieldGroup(
+                sectionTier = tier,
+                type = ProfileAttributeTypes.PHONE,
+                icon = Icons.Outlined.Call,
+                label = stringResource(MR.string.profile_edit_phone),
+                displayValue = phoneDisplay,
+                editingRows = editingRows,
+                onAction = onAction,
+                isValidForSave = { et -> isAttributeValid(ProfileAttributeTypes.PHONE) { vf(et, it) } },
+            ) { editTier ->
+                AttributeFields(ProfileAttributeTypes.PHONE, { vf(editTier, it) }) { field, v ->
+                    onAction(ProfileEditAction.FieldChanged(field, editTier, v))
+                }
+            }
+        }
+
+        val addressDisplay = profileAddressValue(values)
+        if (addressDisplay != null || editingRows[tier to ProfileAttributeTypes.ADDRESS] == true) {
+            EditableFieldGroup(
+                sectionTier = tier,
+                type = ProfileAttributeTypes.ADDRESS,
+                icon = Icons.Outlined.LocationOn,
+                label = stringResource(MR.string.contactbook_detail_location),
+                displayValue = addressDisplay,
+                editingRows = editingRows,
+                onAction = onAction,
+            ) { editTier ->
+                AttributeFields(ProfileAttributeTypes.ADDRESS, { vf(editTier, it) }) { field, v ->
+                    onAction(ProfileEditAction.FieldChanged(field, editTier, v))
+                }
+            }
+        }
+
+        val twitterDisplay = v(ProfileField.TWITTER).ifBlank { null }
+        if (twitterDisplay != null || editingRows[tier to ProfileAttributeTypes.TWITTER] == true) {
+            EditableFieldGroup(
+                sectionTier = tier,
+                type = ProfileAttributeTypes.TWITTER,
+                icon = Icons.Outlined.AlternateEmail,
+                label = stringResource(MR.string.profile_edit_twitter),
+                displayValue = twitterDisplay,
+                editingRows = editingRows,
+                onAction = onAction,
+            ) { editTier ->
+                AttributeFields(ProfileAttributeTypes.TWITTER, { vf(editTier, it) }) { field, v ->
+                    onAction(ProfileEditAction.FieldChanged(field, editTier, v))
+                }
+            }
+        }
+        val facebookDisplay = v(ProfileField.FACEBOOK).ifBlank { null }
+        if (facebookDisplay != null || editingRows[tier to ProfileAttributeTypes.FACEBOOK] == true) {
+            EditableFieldGroup(
+                sectionTier = tier,
+                type = ProfileAttributeTypes.FACEBOOK,
+                icon = Icons.Outlined.AlternateEmail,
+                label = stringResource(MR.string.profile_edit_facebook),
+                displayValue = facebookDisplay,
+                editingRows = editingRows,
+                onAction = onAction,
+            ) { editTier ->
+                AttributeFields(ProfileAttributeTypes.FACEBOOK, { vf(editTier, it) }) { field, v ->
+                    onAction(ProfileEditAction.FieldChanged(field, editTier, v))
+                }
+            }
+        }
+        val instagramDisplay = v(ProfileField.INSTAGRAM).ifBlank { null }
+        if (instagramDisplay != null || editingRows[tier to ProfileAttributeTypes.INSTAGRAM] == true) {
+            EditableFieldGroup(
+                sectionTier = tier,
+                type = ProfileAttributeTypes.INSTAGRAM,
+                icon = Icons.Outlined.AlternateEmail,
+                label = stringResource(MR.string.profile_edit_instagram),
+                displayValue = instagramDisplay,
+                editingRows = editingRows,
+                onAction = onAction,
+            ) { editTier ->
+                AttributeFields(ProfileAttributeTypes.INSTAGRAM, { vf(editTier, it) }) { field, v ->
+                    onAction(ProfileEditAction.FieldChanged(field, editTier, v))
+                }
+            }
+        }
+        val tiktokDisplay = v(ProfileField.TIKTOK).ifBlank { null }
+        if (tiktokDisplay != null || editingRows[tier to ProfileAttributeTypes.TIKTOK] == true) {
+            EditableFieldGroup(
+                sectionTier = tier,
+                type = ProfileAttributeTypes.TIKTOK,
+                icon = Icons.Outlined.AlternateEmail,
+                label = stringResource(MR.string.profile_edit_tiktok),
+                displayValue = tiktokDisplay,
+                editingRows = editingRows,
+                onAction = onAction,
+            ) { editTier ->
+                AttributeFields(ProfileAttributeTypes.TIKTOK, { vf(editTier, it) }) { field, v ->
+                    onAction(ProfileEditAction.FieldChanged(field, editTier, v))
+                }
+            }
+        }
+        val linkedinDisplay = v(ProfileField.LINKEDIN).ifBlank { null }
+        if (linkedinDisplay != null || editingRows[tier to ProfileAttributeTypes.LINKEDIN] == true) {
+            EditableFieldGroup(
+                sectionTier = tier,
+                type = ProfileAttributeTypes.LINKEDIN,
+                icon = Icons.Outlined.AlternateEmail,
+                label = stringResource(MR.string.profile_edit_linkedin),
+                displayValue = linkedinDisplay,
+                editingRows = editingRows,
+                onAction = onAction,
+            ) { editTier ->
+                AttributeFields(ProfileAttributeTypes.LINKEDIN, { vf(editTier, it) }) { field, v ->
+                    onAction(ProfileEditAction.FieldChanged(field, editTier, v))
                 }
             }
         }
@@ -262,195 +548,128 @@ private fun ProfileForm(
 }
 
 @Composable
-private fun DetailsFields(uiState: ProfileEditUiState, onAction: (ProfileEditAction) -> Unit) {
-    FieldGroup(ProfileAttributeTypes.NAME, uiState, showDividerAbove = false) { tier ->
-        val v: (ProfileField) -> String = { uiState.value(it, tier) }
-        ProfileField(
-            v(ProfileField.GIVEN_NAME),
-            stringResource(MR.string.profile_edit_given_name),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            onAction(ProfileEditAction.FieldChanged(ProfileField.GIVEN_NAME, tier, it))
-        }
-        ProfileField(
-            v(ProfileField.SURNAME),
-            stringResource(MR.string.profile_edit_surname),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            onAction(ProfileEditAction.FieldChanged(ProfileField.SURNAME, tier, it))
-        }
-        ProfileField(
-            v(ProfileField.ADDITIONAL_NAME),
-            stringResource(MR.string.profile_edit_additional_name),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            onAction(ProfileEditAction.FieldChanged(ProfileField.ADDITIONAL_NAME, tier, it))
-        }
-    }
-    FieldGroup(ProfileAttributeTypes.NICKNAME, uiState) { tier ->
-        ProfileField(
-            uiState.value(ProfileField.NICKNAME, tier),
-            stringResource(MR.string.profile_edit_nickname),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            onAction(ProfileEditAction.FieldChanged(ProfileField.NICKNAME, tier, it))
-        }
-    }
-    FieldGroup(ProfileAttributeTypes.PHONE, uiState) { tier ->
-        val v: (ProfileField) -> String = { uiState.value(it, tier) }
-        val phoneValue = v(ProfileField.PHONE)
-        PhoneNumberField(
-            e164Value = phoneValue,
-            onValueChange = { onAction(ProfileEditAction.FieldChanged(ProfileField.PHONE, tier, it)) },
-            label = stringResource(MR.string.profile_edit_phone),
-            isError = phoneValue.isNotBlank() && !uiState.phoneValid,
-            errorText = stringResource(MR.string.contactbook_error_phone),
-            modifier = Modifier.fillMaxWidth(),
+private fun SectionHeader(title: String, description: String) {
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.primary,
+            textAlign = TextAlign.Center,
         )
-        ProfileField(
-            value = v(ProfileField.PHONE_LABEL),
-            label = stringResource(MR.string.profile_edit_phone_label),
-            placeholder = stringResource(MR.string.profile_edit_phone_label_hint),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            onAction(ProfileEditAction.FieldChanged(ProfileField.PHONE_LABEL, tier, it))
-        }
+        Text(
+            text = description,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
     }
-    FieldGroup(ProfileAttributeTypes.EMAIL, uiState) { tier ->
-        val v: (ProfileField) -> String = { uiState.value(it, tier) }
-        val emailValue = v(ProfileField.EMAIL)
-        ProfileField(
-            value = emailValue,
-            label = stringResource(MR.string.profile_edit_email),
-            keyboardType = KeyboardType.Email,
-            isError = emailValue.isNotBlank() && !uiState.emailValid,
-            errorText = stringResource(MR.string.contactbook_error_email),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            onAction(ProfileEditAction.FieldChanged(ProfileField.EMAIL, tier, it))
-        }
-        ProfileField(
-            value = v(ProfileField.EMAIL_LABEL),
-            label = stringResource(MR.string.profile_edit_email_label),
-            placeholder = stringResource(MR.string.profile_edit_email_label_hint),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            onAction(ProfileEditAction.FieldChanged(ProfileField.EMAIL_LABEL, tier, it))
-        }
-    }
-    FieldGroup(ProfileAttributeTypes.ADDRESS, uiState) { tier ->
-        val v: (ProfileField) -> String = { uiState.value(it, tier) }
-        ProfileField(
-            value = v(ProfileField.ADDRESS_LABEL),
-            label = stringResource(MR.string.profile_edit_address_label),
-            placeholder = stringResource(MR.string.profile_edit_address_label_hint),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            onAction(ProfileEditAction.FieldChanged(ProfileField.ADDRESS_LABEL, tier, it))
-        }
-        ProfileField(
-            value = v(ProfileField.ADDRESS1),
-            label = stringResource(MR.string.profile_edit_address1),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            onAction(ProfileEditAction.FieldChanged(ProfileField.ADDRESS1, tier, it))
-        }
-        ProfileField(
-            value = v(ProfileField.ADDRESS2),
-            label = stringResource(MR.string.profile_edit_address2),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            onAction(ProfileEditAction.FieldChanged(ProfileField.ADDRESS2, tier, it))
-        }
-        ProfileField(
-            value = v(ProfileField.POSTCODE),
-            label = stringResource(MR.string.profile_edit_postcode),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            onAction(ProfileEditAction.FieldChanged(ProfileField.POSTCODE, tier, it))
-        }
-        ProfileField(
-            value = v(ProfileField.CITY),
-            label = stringResource(MR.string.profile_edit_city),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            onAction(ProfileEditAction.FieldChanged(ProfileField.CITY, tier, it))
-        }
-        ProfileField(
-            value = v(ProfileField.COUNTRY),
-            label = stringResource(MR.string.profile_edit_country),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            onAction(ProfileEditAction.FieldChanged(ProfileField.COUNTRY, tier, it))
-        }
-    }
-    FieldGroup(ProfileAttributeTypes.BIRTHDAY, uiState) { tier ->
-        ProfileField(
-            value = uiState.value(ProfileField.BIRTHDAY, tier),
-            label = stringResource(MR.string.profile_edit_birthday),
-            placeholder = stringResource(MR.string.profile_edit_birthday_hint),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            onAction(ProfileEditAction.FieldChanged(ProfileField.BIRTHDAY, tier, it))
+}
+
+/**
+ * One profile attribute rendered contact-detail style — icon, label, current value. Tapping the row
+ * expands it in place with a Public|Vetted toggle (defaulting to [sectionTier], the section it's
+ * listed under) and [content]'s field(s) for whichever tier is currently selected. The checkmark
+ * dispatches [ProfileEditAction.SaveAttribute] for that (type, tier) and collapses immediately —
+ * [content]'s fields already write straight through as they change, so the value shown is correct
+ * the instant it collapses regardless of when the save actually lands; a failure surfaces as a
+ * screen-level snackbar and the row can simply be reopened to retry.
+ */
+@Composable
+private fun EditableFieldGroup(
+    sectionTier: ProfileVisibility,
+    type: String,
+    icon: ImageVector,
+    label: String,
+    displayValue: String?,
+    editingRows: SnapshotStateMap<Pair<ProfileVisibility, String>, Boolean>,
+    onAction: (ProfileEditAction) -> Unit,
+    isValidForSave: (ProfileVisibility) -> Boolean = { true },
+    content: @Composable ColumnScope.(editTier: ProfileVisibility) -> Unit,
+) {
+    val key = sectionTier to type
+    val editing = editingRows[key] == true
+    var selectedTier by remember(editing) { mutableStateOf(sectionTier) }
+    val notSet = stringResource(MR.string.profile_edit_field_not_set)
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        ListItem(
+            modifier = if (editing) {
+                Modifier.fillMaxWidth()
+            } else {
+                Modifier.fillMaxWidth().clickable { editingRows[key] = true }
+            },
+            leadingContent = { Icon(icon, contentDescription = null) },
+            overlineContent = { Text(label) },
+            headlineContent = {
+                Text(
+                    text = displayValue?.ifBlank { null } ?: notSet,
+                    color = if (displayValue.isNullOrBlank()) {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    } else {
+                        MaterialTheme.colorScheme.onSurface
+                    },
+                )
+            },
+            trailingContent = if (editing) {
+                {
+                    TextButton(
+                        enabled = isValidForSave(selectedTier),
+                        onClick = {
+                            onAction(ProfileEditAction.SaveAttribute(type, selectedTier))
+                            editingRows[key] = false
+                        },
+                    ) {
+                        Icon(Icons.Outlined.Check, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Spacer(Modifier.width(4.dp))
+                        Text(stringResource(MR.string.save))
+                    }
+                }
+            } else {
+                null
+            },
+        )
+        AnimatedVisibility(visible = editing) {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, bottom = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                TierToggle(selected = selectedTier, onSelect = { selectedTier = it })
+                Text(
+                    text = stringResource(
+                        if (selectedTier == ProfileVisibility.ANONYMOUS) {
+                            MR.string.profile_edit_public_hint
+                        } else {
+                            MR.string.profile_edit_connected_fallback_hint
+                        }
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                content(selectedTier)
+            }
         }
     }
 }
 
+/** Picks which of an attribute's two independent tier records a row's [content] shows/edits. */
 @Composable
-private fun AboutFields(uiState: ProfileEditUiState, onAction: (ProfileEditAction) -> Unit) {
-    FieldGroup(ProfileAttributeTypes.STATUS, uiState, showDividerAbove = false) { tier ->
-        ProfileField(
-            uiState.value(ProfileField.STATUS, tier),
-            stringResource(MR.string.profile_edit_status),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            onAction(ProfileEditAction.FieldChanged(ProfileField.STATUS, tier, it))
-        }
-    }
-    FieldGroup(ProfileAttributeTypes.TWITTER, uiState) { tier ->
-        ProfileField(
-            uiState.value(ProfileField.TWITTER, tier),
-            stringResource(MR.string.profile_edit_twitter),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            onAction(ProfileEditAction.FieldChanged(ProfileField.TWITTER, tier, it))
-        }
-    }
-    FieldGroup(ProfileAttributeTypes.FACEBOOK, uiState) { tier ->
-        ProfileField(
-            uiState.value(ProfileField.FACEBOOK, tier),
-            stringResource(MR.string.profile_edit_facebook),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            onAction(ProfileEditAction.FieldChanged(ProfileField.FACEBOOK, tier, it))
-        }
-    }
-    FieldGroup(ProfileAttributeTypes.INSTAGRAM, uiState) { tier ->
-        ProfileField(
-            uiState.value(ProfileField.INSTAGRAM, tier),
-            stringResource(MR.string.profile_edit_instagram),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            onAction(ProfileEditAction.FieldChanged(ProfileField.INSTAGRAM, tier, it))
-        }
-    }
-    FieldGroup(ProfileAttributeTypes.TIKTOK, uiState) { tier ->
-        ProfileField(
-            uiState.value(ProfileField.TIKTOK, tier),
-            stringResource(MR.string.profile_edit_tiktok),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            onAction(ProfileEditAction.FieldChanged(ProfileField.TIKTOK, tier, it))
-        }
-    }
-    FieldGroup(ProfileAttributeTypes.LINKEDIN, uiState) { tier ->
-        ProfileField(
-            uiState.value(ProfileField.LINKEDIN, tier),
-            stringResource(MR.string.profile_edit_linkedin),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            onAction(ProfileEditAction.FieldChanged(ProfileField.LINKEDIN, tier, it))
-        }
+private fun TierToggle(selected: ProfileVisibility, onSelect: (ProfileVisibility) -> Unit) {
+    SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+        SegmentedButton(
+            selected = selected == ProfileVisibility.ANONYMOUS,
+            onClick = { onSelect(ProfileVisibility.ANONYMOUS) },
+            shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+            label = { Text(stringResource(MR.string.profile_edit_visibility_public)) },
+        )
+        SegmentedButton(
+            selected = selected == ProfileVisibility.CONNECTED,
+            onClick = { onSelect(ProfileVisibility.CONNECTED) },
+            shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+            label = { Text(stringResource(MR.string.profile_edit_visibility_connected)) },
+        )
     }
 }
 
@@ -478,86 +697,320 @@ private fun ProfileField(
     )
 }
 
-/**
- * Groups a profile attribute's fields (e.g. email + its "Personal"/"Work" label, or an address's
- * parts) so the set reads as one unit, separated from its neighbors by a divider line rather than
- * a bordered card. Each attribute is backed by up to two independent records — Anonymous and
- * Connected — so this owns which tier's values [content] is currently showing/editing via a tab
- * control; switching tabs is a pure display choice, not something that itself needs saving.
- */
+/** One attribute type the "add attribute" FAB can offer — icon/label only; the actual editable
+ *  fields for each [type] live in [ProfileFieldsSection]'s per-attribute blocks. */
+private data class AttributeSpec(val type: String, val icon: ImageVector, val labelRes: StringResource)
+
+private val ATTRIBUTE_SPECS = listOf(
+    AttributeSpec(ProfileAttributeTypes.NAME, Icons.Outlined.Person, MR.string.contactbook_detail_name),
+    AttributeSpec(ProfileAttributeTypes.NICKNAME, Icons.Outlined.Badge, MR.string.profile_edit_nickname),
+    AttributeSpec(ProfileAttributeTypes.STATUS, Icons.Outlined.Info, MR.string.profile_edit_status),
+    AttributeSpec(ProfileAttributeTypes.BIRTHDAY, Icons.Outlined.Cake, MR.string.profile_edit_birthday),
+    AttributeSpec(ProfileAttributeTypes.EMAIL, Icons.Outlined.Email, MR.string.profile_edit_email),
+    AttributeSpec(ProfileAttributeTypes.PHONE, Icons.Outlined.Call, MR.string.profile_edit_phone),
+    AttributeSpec(ProfileAttributeTypes.ADDRESS, Icons.Outlined.LocationOn, MR.string.contactbook_detail_location),
+    AttributeSpec(ProfileAttributeTypes.TWITTER, Icons.Outlined.AlternateEmail, MR.string.profile_edit_twitter),
+    AttributeSpec(ProfileAttributeTypes.FACEBOOK, Icons.Outlined.AlternateEmail, MR.string.profile_edit_facebook),
+    AttributeSpec(ProfileAttributeTypes.INSTAGRAM, Icons.Outlined.AlternateEmail, MR.string.profile_edit_instagram),
+    AttributeSpec(ProfileAttributeTypes.TIKTOK, Icons.Outlined.AlternateEmail, MR.string.profile_edit_tiktok),
+    AttributeSpec(ProfileAttributeTypes.LINKEDIN, Icons.Outlined.AlternateEmail, MR.string.profile_edit_linkedin),
+)
+
+/** Whether [type] has a value in [values] — the same blank check each [ProfileFieldsSection] block
+ *  uses to decide whether to render, kept as one pure function so the FAB's "missing" list can
+ *  never drift from what's actually hidden. */
+private fun displayValueFor(type: String, values: Map<ProfileField, String>): String? = when (type) {
+    ProfileAttributeTypes.NAME -> profileNameValue(values)
+    ProfileAttributeTypes.NICKNAME -> values[ProfileField.NICKNAME]?.ifBlank { null }
+    ProfileAttributeTypes.STATUS -> values[ProfileField.STATUS]?.ifBlank { null }
+    ProfileAttributeTypes.BIRTHDAY -> values[ProfileField.BIRTHDAY]?.ifBlank { null }
+    ProfileAttributeTypes.EMAIL -> values[ProfileField.EMAIL]?.ifBlank { null }
+    ProfileAttributeTypes.PHONE -> values[ProfileField.PHONE]?.ifBlank { null }
+    ProfileAttributeTypes.ADDRESS -> profileAddressValue(values)
+    ProfileAttributeTypes.TWITTER -> values[ProfileField.TWITTER]?.ifBlank { null }
+    ProfileAttributeTypes.FACEBOOK -> values[ProfileField.FACEBOOK]?.ifBlank { null }
+    ProfileAttributeTypes.INSTAGRAM -> values[ProfileField.INSTAGRAM]?.ifBlank { null }
+    ProfileAttributeTypes.TIKTOK -> values[ProfileField.TIKTOK]?.ifBlank { null }
+    ProfileAttributeTypes.LINKEDIN -> values[ProfileField.LINKEDIN]?.ifBlank { null }
+    else -> null
+}
+
 @Composable
-private fun FieldGroup(
-    type: String,
-    uiState: ProfileEditUiState,
-    showDividerAbove: Boolean = true,
-    content: @Composable ColumnScope.(tier: ProfileVisibility) -> Unit,
+private fun AddAttributeSheet(
+    missingPublic: List<AttributeSpec>,
+    missingVetted: List<AttributeSpec>,
+    onPick: (AttributeSpec, ProfileVisibility) -> Unit,
+    onDismiss: () -> Unit,
 ) {
-    var activeTier by remember(type) { mutableStateOf(ProfileVisibility.ANONYMOUS) }
-    val hasConnectedContent = remember(uiState.connectedValues, type) {
-        ProfileEditViewModel.TYPE_FIELDS[type].orEmpty()
-            .any { (field, _) -> uiState.connectedValues[field]?.isNotBlank() == true }
-    }
-    if (showDividerAbove) {
-        HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
-    }
-    Column(
-        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        TierTabs(
-            selected = activeTier,
-            hasConnectedContent = hasConnectedContent,
-            onSelect = { activeTier = it },
-            modifier = Modifier.align(Alignment.End),
-        )
-        Text(
-            text = stringResource(
-                if (activeTier == ProfileVisibility.ANONYMOUS) MR.string.profile_edit_public_hint
-                else MR.string.profile_edit_connected_fallback_hint
-            ),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        content(activeTier)
+    AdaptiveSheet(onDismiss = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 24.dp),
+        ) {
+            Text(
+                text = stringResource(MR.string.profile_edit_add_attribute_title),
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.padding(vertical = 8.dp),
+            )
+            if (missingPublic.isNotEmpty()) {
+                Text(
+                    text = stringResource(MR.string.profile_edit_preview_section_public),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(top = 8.dp, bottom = 4.dp),
+                )
+                missingPublic.forEach { spec ->
+                    AddAttributeRow(spec) { onPick(spec, ProfileVisibility.ANONYMOUS) }
+                }
+            }
+            if (missingVetted.isNotEmpty()) {
+                Text(
+                    text = stringResource(MR.string.profile_edit_preview_section_vetted),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(top = 16.dp, bottom = 4.dp),
+                )
+                missingVetted.forEach { spec ->
+                    AddAttributeRow(spec) { onPick(spec, ProfileVisibility.CONNECTED) }
+                }
+            }
+        }
     }
 }
 
-/** Which tier of a [FieldGroup]'s two independent records is currently shown/edited. A small dot
- *  marks the Connected tab when it already holds a value, so switching isn't required to know. */
 @Composable
-private fun TierTabs(
-    selected: ProfileVisibility,
-    hasConnectedContent: Boolean,
-    onSelect: (ProfileVisibility) -> Unit,
-    modifier: Modifier = Modifier,
+private fun AddAttributeRow(spec: AttributeSpec, onClick: () -> Unit) {
+    ListItem(
+        leadingContent = { Icon(spec.icon, contentDescription = null) },
+        headlineContent = { Text(stringResource(spec.labelRes)) },
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+    )
+}
+
+/**
+ * Captures a brand-new attribute's value entirely as a local draft — nothing is written to
+ * [ProfileEditUiState] (and so nothing appears in either section) until [onSave] fires, unlike an
+ * existing row's inline editor which writes through [ProfileEditAction.FieldChanged] as you type.
+ */
+@Composable
+private fun AddAttributeDialog(
+    spec: AttributeSpec,
+    initialTier: ProfileVisibility,
+    onSave: (ProfileVisibility, Map<ProfileField, String>) -> Unit,
+    onDismiss: () -> Unit,
 ) {
-    SingleChoiceSegmentedButtonRow(modifier = modifier) {
-        SegmentedButton(
-            selected = selected == ProfileVisibility.ANONYMOUS,
-            onClick = { onSelect(ProfileVisibility.ANONYMOUS) },
-            shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
-            label = { Text(stringResource(MR.string.profile_edit_visibility_public)) },
-        )
-        SegmentedButton(
-            selected = selected == ProfileVisibility.CONNECTED,
-            onClick = { onSelect(ProfileVisibility.CONNECTED) },
-            shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
-            label = {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                ) {
-                    Text(stringResource(MR.string.profile_edit_visibility_connected))
-                    if (hasConnectedContent) {
-                        Box(
-                            modifier = Modifier
-                                .size(6.dp)
-                                .clip(CircleShape)
-                                .background(MaterialTheme.colorScheme.primary),
-                        )
-                    }
-                }
-            },
-        )
+    var tier by remember { mutableStateOf(initialTier) }
+    val draft = remember { mutableStateMapOf<ProfileField, String>() }
+    val value: (ProfileField) -> String = { draft[it].orEmpty() }
+    val onChange: (ProfileField, String) -> Unit = { field, v -> draft[field] = v }
+    val valid = isAttributeValid(spec.type, value)
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(spec.labelRes)) },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                TierToggle(selected = tier, onSelect = { tier = it })
+                Text(
+                    text = stringResource(
+                        if (tier == ProfileVisibility.ANONYMOUS) {
+                            MR.string.profile_edit_public_hint
+                        } else {
+                            MR.string.profile_edit_connected_fallback_hint
+                        }
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                AttributeFields(spec.type, value, onChange)
+            }
+        },
+        confirmButton = {
+            TextButton(enabled = valid, onClick = { onSave(tier, draft) }) {
+                Text(stringResource(MR.string.save))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(MR.string.cancel))
+            }
+        },
+    )
+}
+
+/** Whether [type]'s current draft is well-formed enough to save — only Email/Phone constrain
+ *  format; every other attribute type accepts anything (including blank, which just no-ops). */
+private fun isAttributeValid(type: String, value: (ProfileField) -> String): Boolean = when (type) {
+    ProfileAttributeTypes.EMAIL -> ContactFieldValidation.isValidEmail(value(ProfileField.EMAIL))
+    ProfileAttributeTypes.PHONE -> ContactFieldValidation.isValidPhone(value(ProfileField.PHONE))
+    else -> true
+}
+
+/**
+ * The editable field(s) for one attribute type, bound generically via [value]/[onChange] so both an
+ * existing row's inline editor (live [ProfileEditUiState]) and [AddAttributeDialog] (local draft)
+ * can share the exact same field UI.
+ */
+@Composable
+private fun AttributeFields(
+    type: String,
+    value: (ProfileField) -> String,
+    onChange: (ProfileField, String) -> Unit,
+) {
+    when (type) {
+        ProfileAttributeTypes.NAME -> {
+            ProfileField(
+                value(ProfileField.GIVEN_NAME),
+                stringResource(MR.string.profile_edit_given_name),
+                modifier = Modifier.fillMaxWidth(),
+            ) { onChange(ProfileField.GIVEN_NAME, it) }
+            ProfileField(
+                value(ProfileField.SURNAME),
+                stringResource(MR.string.profile_edit_surname),
+                modifier = Modifier.fillMaxWidth(),
+            ) { onChange(ProfileField.SURNAME, it) }
+            ProfileField(
+                value(ProfileField.ADDITIONAL_NAME),
+                stringResource(MR.string.profile_edit_additional_name),
+                modifier = Modifier.fillMaxWidth(),
+            ) { onChange(ProfileField.ADDITIONAL_NAME, it) }
+        }
+
+        ProfileAttributeTypes.NICKNAME -> {
+            ProfileField(
+                value(ProfileField.NICKNAME),
+                stringResource(MR.string.profile_edit_nickname),
+                modifier = Modifier.fillMaxWidth(),
+            ) { onChange(ProfileField.NICKNAME, it) }
+        }
+
+        ProfileAttributeTypes.STATUS -> {
+            ProfileField(
+                value(ProfileField.STATUS),
+                stringResource(MR.string.profile_edit_status),
+                modifier = Modifier.fillMaxWidth(),
+            ) { onChange(ProfileField.STATUS, it) }
+        }
+
+        ProfileAttributeTypes.BIRTHDAY -> {
+            ProfileField(
+                value = value(ProfileField.BIRTHDAY),
+                label = stringResource(MR.string.profile_edit_birthday),
+                placeholder = stringResource(MR.string.profile_edit_birthday_hint),
+                modifier = Modifier.fillMaxWidth(),
+            ) { onChange(ProfileField.BIRTHDAY, it) }
+        }
+
+        ProfileAttributeTypes.EMAIL -> {
+            val emailValue = value(ProfileField.EMAIL)
+            ProfileField(
+                value = emailValue,
+                label = stringResource(MR.string.profile_edit_email),
+                keyboardType = KeyboardType.Email,
+                isError = emailValue.isNotBlank() && !ContactFieldValidation.isValidEmail(emailValue),
+                errorText = stringResource(MR.string.contactbook_error_email),
+                modifier = Modifier.fillMaxWidth(),
+            ) { onChange(ProfileField.EMAIL, it) }
+            ProfileField(
+                value = value(ProfileField.EMAIL_LABEL),
+                label = stringResource(MR.string.profile_edit_email_label),
+                placeholder = stringResource(MR.string.profile_edit_email_label_hint),
+                modifier = Modifier.fillMaxWidth(),
+            ) { onChange(ProfileField.EMAIL_LABEL, it) }
+        }
+
+        ProfileAttributeTypes.PHONE -> {
+            val phoneValue = value(ProfileField.PHONE)
+            PhoneNumberField(
+                e164Value = phoneValue,
+                onValueChange = { onChange(ProfileField.PHONE, it) },
+                label = stringResource(MR.string.profile_edit_phone),
+                isError = phoneValue.isNotBlank() && !ContactFieldValidation.isValidPhone(phoneValue),
+                errorText = stringResource(MR.string.contactbook_error_phone),
+                modifier = Modifier.fillMaxWidth(),
+            )
+            ProfileField(
+                value = value(ProfileField.PHONE_LABEL),
+                label = stringResource(MR.string.profile_edit_phone_label),
+                placeholder = stringResource(MR.string.profile_edit_phone_label_hint),
+                modifier = Modifier.fillMaxWidth(),
+            ) { onChange(ProfileField.PHONE_LABEL, it) }
+        }
+
+        ProfileAttributeTypes.ADDRESS -> {
+            ProfileField(
+                value = value(ProfileField.ADDRESS_LABEL),
+                label = stringResource(MR.string.profile_edit_address_label),
+                placeholder = stringResource(MR.string.profile_edit_address_label_hint),
+                modifier = Modifier.fillMaxWidth(),
+            ) { onChange(ProfileField.ADDRESS_LABEL, it) }
+            ProfileField(
+                value = value(ProfileField.ADDRESS1),
+                label = stringResource(MR.string.profile_edit_address1),
+                modifier = Modifier.fillMaxWidth(),
+            ) { onChange(ProfileField.ADDRESS1, it) }
+            ProfileField(
+                value = value(ProfileField.ADDRESS2),
+                label = stringResource(MR.string.profile_edit_address2),
+                modifier = Modifier.fillMaxWidth(),
+            ) { onChange(ProfileField.ADDRESS2, it) }
+            ProfileField(
+                value = value(ProfileField.POSTCODE),
+                label = stringResource(MR.string.profile_edit_postcode),
+                modifier = Modifier.fillMaxWidth(),
+            ) { onChange(ProfileField.POSTCODE, it) }
+            ProfileField(
+                value = value(ProfileField.CITY),
+                label = stringResource(MR.string.profile_edit_city),
+                modifier = Modifier.fillMaxWidth(),
+            ) { onChange(ProfileField.CITY, it) }
+            ProfileField(
+                value = value(ProfileField.COUNTRY),
+                label = stringResource(MR.string.profile_edit_country),
+                modifier = Modifier.fillMaxWidth(),
+            ) { onChange(ProfileField.COUNTRY, it) }
+        }
+
+        ProfileAttributeTypes.TWITTER -> {
+            ProfileField(
+                value(ProfileField.TWITTER),
+                stringResource(MR.string.profile_edit_twitter),
+                modifier = Modifier.fillMaxWidth(),
+            ) { onChange(ProfileField.TWITTER, it) }
+        }
+        ProfileAttributeTypes.FACEBOOK -> {
+            ProfileField(
+                value(ProfileField.FACEBOOK),
+                stringResource(MR.string.profile_edit_facebook),
+                modifier = Modifier.fillMaxWidth(),
+            ) { onChange(ProfileField.FACEBOOK, it) }
+        }
+        ProfileAttributeTypes.INSTAGRAM -> {
+            ProfileField(
+                value(ProfileField.INSTAGRAM),
+                stringResource(MR.string.profile_edit_instagram),
+                modifier = Modifier.fillMaxWidth(),
+            ) { onChange(ProfileField.INSTAGRAM, it) }
+        }
+        ProfileAttributeTypes.TIKTOK -> {
+            ProfileField(
+                value(ProfileField.TIKTOK),
+                stringResource(MR.string.profile_edit_tiktok),
+                modifier = Modifier.fillMaxWidth(),
+            ) { onChange(ProfileField.TIKTOK, it) }
+        }
+        ProfileAttributeTypes.LINKEDIN -> {
+            ProfileField(
+                value(ProfileField.LINKEDIN),
+                stringResource(MR.string.profile_edit_linkedin),
+                modifier = Modifier.fillMaxWidth(),
+            ) { onChange(ProfileField.LINKEDIN, it) }
+        }
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/profile/ProfileEditUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/profile/ProfileEditUiState.kt
@@ -3,7 +3,6 @@ package id.homebase.core.ui.screens.profile
 import androidx.compose.runtime.Immutable
 import id.homebase.api.client.profile.ProfileAttribute
 import id.homebase.api.client.profile.ProfileVisibility
-import id.homebase.core.ui.screens.contactbook.ContactFieldValidation
 
 /**
  * Form state for the owner's standard-profile editor. Every field has an independent value per
@@ -13,13 +12,16 @@ import id.homebase.core.ui.screens.contactbook.ContactFieldValidation
  * back to the Anonymous value at *display* time (see [id.homebase.core.ui.screens.profile.ProfilePreview]),
  * not here — [value] never substitutes across tiers.
  *
+ * There's no screen-wide Save: each attribute persists individually (see
+ * [ProfileEditAction.SaveAttribute]), so [savingAttributes] tracks in-flight saves per
+ * (attribute type, tier) pair rather than a single global flag.
+ *
  * The loaded attributes (id / versionTag / unmodelled data keys, per tier) live in the ViewModel,
  * not here — this state is purely what the form shows and binds to.
  */
 @Immutable
 data class ProfileEditUiState(
     val isLoading: Boolean = true,
-    val isSaving: Boolean = false,
     /** True when the initial attribute read failed (e.g. missing ProfileDrive grant) — show retry. */
     val loadFailed: Boolean = false,
 
@@ -31,25 +33,21 @@ data class ProfileEditUiState(
      *  avatar editor ([ProfileAvatarEditViewModel]); read-only here, just for [ProfilePreview]. */
     val anonymousPhoto: ProfileAttribute? = null,
     val connectedPhoto: ProfileAttribute? = null,
+
+    /** (attribute type, tier) pairs whose [ProfileEditAction.SaveAttribute] is currently in flight. */
+    val savingAttributes: Set<Pair<String, ProfileVisibility>> = emptySet(),
 ) {
     /** Raw per-tier lookup — no cross-tier fallback; "" if [field] has no value in [tier]. */
     fun value(field: ProfileField, tier: ProfileVisibility): String =
         (if (tier == ProfileVisibility.ANONYMOUS) anonymousValues else connectedValues)[field].orEmpty()
 
-    val emailValid: Boolean get() =
-        ContactFieldValidation.isValidEmail(value(ProfileField.EMAIL, ProfileVisibility.ANONYMOUS)) &&
-            ContactFieldValidation.isValidEmail(value(ProfileField.EMAIL, ProfileVisibility.CONNECTED))
-    val phoneValid: Boolean get() =
-        ContactFieldValidation.isValidPhone(value(ProfileField.PHONE, ProfileVisibility.ANONYMOUS)) &&
-            ContactFieldValidation.isValidPhone(value(ProfileField.PHONE, ProfileVisibility.CONNECTED))
-
-    // Legacy data may not be E.164/well-formed; show it but block Save until corrected.
-    val canSave: Boolean get() = !isLoading && !isSaving && !loadFailed && emailValid && phoneValid
+    fun isSaving(type: String, tier: ProfileVisibility): Boolean = (type to tier) in savingAttributes
 }
 
 sealed interface ProfileEditAction {
     data class FieldChanged(val field: ProfileField, val tier: ProfileVisibility, val value: String) : ProfileEditAction
-    data object SaveClicked : ProfileEditAction
+    /** Persists just this one attribute type's [tier] record — fired by a row's checkmark. */
+    data class SaveAttribute(val type: String, val tier: ProfileVisibility) : ProfileEditAction
     data object RetryLoadClicked : ProfileEditAction
     data object BackClicked : ProfileEditAction
 }
@@ -65,11 +63,11 @@ enum class ProfileField {
 }
 
 sealed interface ProfileEditEvent {
-    /** All changed attributes saved — pop back. */
-    data object Saved : ProfileEditEvent
+    /** [ProfileEditAction.SaveAttribute] for (type, tier) finished successfully — collapse its row. */
+    data class AttributeSaved(val type: String, val tier: ProfileVisibility) : ProfileEditEvent
     /** 403 — the app lacks the ManageProfile permission. */
     data object Forbidden : ProfileEditEvent
-    /** A save failed for some other reason; the form stays open for retry. */
+    /** A [ProfileEditAction.SaveAttribute] failed for some other reason; its row stays open for retry. */
     data object Error : ProfileEditEvent
     data object Back : ProfileEditEvent
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/profile/ProfileEditViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/profile/ProfileEditViewModel.kt
@@ -37,8 +37,9 @@ import kotlin.uuid.ExperimentalUuidApi
  *
  * Load: reads every standard-profile attribute from the ProfileDrive and buckets each type's
  * fields into [ProfileEditUiState.anonymousValues]/[ProfileEditUiState.connectedValues].
- * Save: for each (type, tier) pair, rebuilds its `data` object (merging the edited keys over the
- * keys we read so unmodelled fields survive), then writes only the ones that actually changed via
+ * Save: there's no screen-wide Save — [saveAttribute] persists one (type, tier) at a time, fired
+ * per-row by the Screen. It rebuilds that record's `data` object (merging the edited keys over the
+ * keys we read so unmodelled fields survive) and, only if it actually changed, writes it via
  * [ProfileRepository.save] (which round-trips the versionTag and re-reads on a 409).
  *
  * v1 simplification: a single attribute per (type, tier). If multiple of one type/tier exist on
@@ -68,7 +69,7 @@ class ProfileEditViewModel(
     fun onAction(action: ProfileEditAction) {
         when (action) {
             is ProfileEditAction.FieldChanged -> updateField(action.field, action.tier, action.value)
-            ProfileEditAction.SaveClicked -> save()
+            is ProfileEditAction.SaveAttribute -> saveAttribute(action.type, action.tier)
             ProfileEditAction.RetryLoadClicked -> load()
             ProfileEditAction.BackClicked -> _events.tryEmit(ProfileEditEvent.Back)
         }
@@ -129,78 +130,65 @@ class ProfileEditViewModel(
         }
     }
 
-    private fun save() {
-        val s = _state.value
-        if (!s.canSave) return
-        _state.update { it.copy(isSaving = true) }
+    /**
+     * Persists just one attribute type's [tier] record — the unit of work a row's checkmark
+     * triggers. [ProfileEditUiState.savingAttributes] tracks the in-flight (type, tier) pair so the
+     * row can show a spinner; [ProfileEditEvent.AttributeSaved] tells the Screen to collapse that
+     * row back to its read-only display once the save (or no-op) completes.
+     */
+    private fun saveAttribute(type: String, tier: ProfileVisibility) {
+        val key = type to tier
+        val edit = attributeEditFor(_state.value, loadedAnonymous, loadedConnected, type, tier)
+        if (edit == null) {
+            // Nothing actually changed vs. what's persisted — just close the row.
+            _events.tryEmit(ProfileEditEvent.AttributeSaved(type, tier))
+            return
+        }
 
+        _state.update { it.copy(savingAttributes = it.savingAttributes + key) }
         viewModelScope.launch {
-            val edits = pendingEdits(s)
-            if (edits.isEmpty()) {
-                _state.update { it.copy(isSaving = false) }
-                _events.tryEmit(ProfileEditEvent.Saved)
-                return@launch
-            }
-
-            var forbidden = false
-            var failed = false
-            for (edit in edits) {
-                try {
-                    val existing = if (edit.visibility == ProfileVisibility.ANONYMOUS) {
-                        loadedAnonymous[edit.type]
-                    } else {
-                        loadedConnected[edit.type]
-                    }
-                    val response = repository.save(
-                        type = edit.type,
-                        data = edit.data,
-                        visibility = edit.visibility,
-                        knownId = existing?.id,
-                        knownVersionTag = existing?.versionTag,
-                    )
-                    // Remember the new id/versionTag so a follow-up save in the same session edits
-                    // (not re-creates) this attribute.
-                    val newAttr = ProfileAttribute(
-                        id = response.id,
-                        type = edit.type,
-                        versionTag = response.versionTag,
-                        visibility = edit.visibility,
-                        data = edit.data,
-                    )
-                    if (edit.visibility == ProfileVisibility.ANONYMOUS) {
-                        loadedAnonymous = loadedAnonymous + (edit.type to newAttr)
-                    } else {
-                        loadedConnected = loadedConnected + (edit.type to newAttr)
-                    }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: ForbiddenException) {
-                    forbidden = true
-                    break
-                } catch (e: Exception) {
-                    Logger.w(e) { "Failed to save profile attribute ${edit.type} (${edit.visibility})" }
-                    failed = true
+            try {
+                val existing = if (tier == ProfileVisibility.ANONYMOUS) loadedAnonymous[type] else loadedConnected[type]
+                val response = repository.save(
+                    type = edit.type,
+                    data = edit.data,
+                    visibility = edit.visibility,
+                    knownId = existing?.id,
+                    knownVersionTag = existing?.versionTag,
+                )
+                // Remember the new id/versionTag so a follow-up save in the same session edits
+                // (not re-creates) this attribute.
+                val newAttr = ProfileAttribute(
+                    id = response.id,
+                    type = edit.type,
+                    versionTag = response.versionTag,
+                    visibility = edit.visibility,
+                    data = edit.data,
+                )
+                if (tier == ProfileVisibility.ANONYMOUS) {
+                    loadedAnonymous = loadedAnonymous + (type to newAttr)
+                } else {
+                    loadedConnected = loadedConnected + (type to newAttr)
                 }
-            }
-
-            _state.update { it.copy(isSaving = false) }
-            when {
-                forbidden -> _events.tryEmit(ProfileEditEvent.Forbidden)
-                failed -> _events.tryEmit(ProfileEditEvent.Error)
-                else -> _events.tryEmit(ProfileEditEvent.Saved)
+                _state.update { it.copy(savingAttributes = it.savingAttributes - key) }
+                _events.tryEmit(ProfileEditEvent.AttributeSaved(type, tier))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: ForbiddenException) {
+                _state.update { it.copy(savingAttributes = it.savingAttributes - key) }
+                _events.tryEmit(ProfileEditEvent.Forbidden)
+            } catch (e: Exception) {
+                Logger.w(e) { "Failed to save profile attribute $type ($tier)" }
+                _state.update { it.copy(savingAttributes = it.savingAttributes - key) }
+                _events.tryEmit(ProfileEditEvent.Error)
             }
         }
     }
 
-    /** See the pure companion overload for the actual logic — this just supplies instance state. */
-    private fun pendingEdits(s: ProfileEditUiState): List<AttributeEdit> =
-        pendingEdits(s, loadedAnonymous, loadedConnected)
-
     companion object {
         /**
          * The one source of truth for which [ProfileField]s make up each [ProfileAttributeTypes]
-         * type and which data key each maps to — shared by [applyLoaded], [pendingEdits], and the
-         * Screen's per-group "does the Connected tab already have content" indicator.
+         * type and which data key each maps to — shared by [applyLoaded] and [attributeEditFor].
          */
         internal val TYPE_FIELDS: Map<String, List<Pair<ProfileField, String>>> = mapOf(
             ProfileAttributeTypes.NAME to listOf(
@@ -298,6 +286,23 @@ class ProfileEditViewModel(
         }
 
         /**
+         * The (type, tier) attribute's edit vs. what's loaded, or null if nothing changed — the same
+         * per-attribute computation both [saveAttribute] (production, one pair at a time) and
+         * [pendingEdits] (tests, all pairs at once) run, so they can never drift apart.
+         */
+        internal fun attributeEditFor(
+            s: ProfileEditUiState,
+            loadedAnonymous: Map<String, ProfileAttribute>,
+            loadedConnected: Map<String, ProfileAttribute>,
+            type: String,
+            tier: ProfileVisibility,
+        ): AttributeEdit? {
+            val existing = if (tier == ProfileVisibility.ANONYMOUS) loadedAnonymous[type] else loadedConnected[type]
+            val updates = TYPE_FIELDS[type].orEmpty().associate { (field, key) -> key to s.value(field, tier) }
+            return computeAttributeEdit(existing, type, updates, tier)
+        }
+
+        /**
          * Builds the list of (type, tier) attributes whose data actually changed vs. what's loaded —
          * up to two per type (Anonymous and Connected are independent). Pure and dependency-free
          * (like [computeAttributeEdit]) so the "an untouched legacy attribute's visibility never
@@ -307,24 +312,11 @@ class ProfileEditViewModel(
             s: ProfileEditUiState,
             loadedAnonymous: Map<String, ProfileAttribute>,
             loadedConnected: Map<String, ProfileAttribute>,
-        ): List<AttributeEdit> {
-            fun editForTier(
-                type: String,
-                tier: ProfileVisibility,
-                fields: List<Pair<ProfileField, String>>,
-            ): AttributeEdit? {
-                val existing = if (tier == ProfileVisibility.ANONYMOUS) loadedAnonymous[type] else loadedConnected[type]
-                val updates = fields.associate { (field, key) -> key to s.value(field, tier) }
-                return computeAttributeEdit(existing, type, updates, tier)
-            }
-
-            val candidates = TYPE_FIELDS.flatMap { (type, fields) ->
-                listOf(
-                    editForTier(type, ProfileVisibility.ANONYMOUS, fields),
-                    editForTier(type, ProfileVisibility.CONNECTED, fields),
-                )
-            }
-            return candidates.filterNotNull()
+        ): List<AttributeEdit> = TYPE_FIELDS.keys.flatMap { type ->
+            listOfNotNull(
+                attributeEditFor(s, loadedAnonymous, loadedConnected, type, ProfileVisibility.ANONYMOUS),
+                attributeEditFor(s, loadedAnonymous, loadedConnected, type, ProfileVisibility.CONNECTED),
+            )
         }
 
         private fun mergeData(existing: JsonObject?, updates: Map<String, String>): JsonObject {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/profile/ProfilePreview.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/profile/ProfilePreview.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.profile.ProfileAttribute
@@ -58,6 +59,24 @@ import org.jetbrains.compose.resources.stringResource
 /** One resolved field, ready to render the way contact details are: icon, label, single-line value. */
 private data class PreviewRow(val icon: ImageVector, val label: String, val value: String)
 
+/** Given/additional/surname joined into one display line — shared with [ProfileEditScreen]'s
+ *  per-attribute-group row display so both screens agree on what "the name" reads as. */
+internal fun profileNameValue(values: Map<ProfileField, String>): String? = listOfNotNull(
+    values[ProfileField.GIVEN_NAME]?.ifBlank { null },
+    values[ProfileField.ADDITIONAL_NAME]?.ifBlank { null },
+    values[ProfileField.SURNAME]?.ifBlank { null },
+).joinToString(" ").ifBlank { null }
+
+/** Street lines, then "postcode city", then country, comma-joined — same single-line format
+ *  ContactBookEntry.location uses for contact addresses. Shared with [ProfileEditScreen]. */
+internal fun profileAddressValue(values: Map<ProfileField, String>): String? = listOfNotNull(
+    values[ProfileField.ADDRESS1]?.ifBlank { null },
+    values[ProfileField.ADDRESS2]?.ifBlank { null },
+    listOfNotNull(values[ProfileField.POSTCODE]?.ifBlank { null }, values[ProfileField.CITY]?.ifBlank { null })
+        .joinToString(" ").ifBlank { null },
+    values[ProfileField.COUNTRY]?.ifBlank { null },
+).joinToString(", ").ifBlank { null }
+
 /**
  * Read-only simulation of the owner's profile, rendered contact-detail style. Public — what
  * everyone sees — is listed first; Vetted below shows everything a vetted contact sees: their own
@@ -82,24 +101,8 @@ internal fun ProfilePreview(
     val lblTiktok = stringResource(MR.string.profile_edit_tiktok)
     val lblLinkedin = stringResource(MR.string.profile_edit_linkedin)
 
-    fun nameValue(values: Map<ProfileField, String>): String? = listOfNotNull(
-        values[ProfileField.GIVEN_NAME]?.ifBlank { null },
-        values[ProfileField.ADDITIONAL_NAME]?.ifBlank { null },
-        values[ProfileField.SURNAME]?.ifBlank { null },
-    ).joinToString(" ").ifBlank { null }
-
-    // Street lines, then "postcode city", then country, comma-joined — same single-line format
-    // ContactBookEntry.location uses for contact addresses.
-    fun addressValue(values: Map<ProfileField, String>): String? = listOfNotNull(
-        values[ProfileField.ADDRESS1]?.ifBlank { null },
-        values[ProfileField.ADDRESS2]?.ifBlank { null },
-        listOfNotNull(values[ProfileField.POSTCODE]?.ifBlank { null }, values[ProfileField.CITY]?.ifBlank { null })
-            .joinToString(" ").ifBlank { null },
-        values[ProfileField.COUNTRY]?.ifBlank { null },
-    ).joinToString(", ").ifBlank { null }
-
     fun rowsFor(values: Map<ProfileField, String>): List<PreviewRow> = buildList {
-        nameValue(values)?.let { add(PreviewRow(Icons.Outlined.Person, lblName, it)) }
+        profileNameValue(values)?.let { add(PreviewRow(Icons.Outlined.Person, lblName, it)) }
         values[ProfileField.NICKNAME]?.takeIf { it.isNotBlank() }
             ?.let { add(PreviewRow(Icons.Outlined.Badge, lblNickname, it)) }
         values[ProfileField.STATUS]?.takeIf { it.isNotBlank() }
@@ -114,7 +117,7 @@ internal fun ProfilePreview(
             val label = values[ProfileField.PHONE_LABEL]?.takeIf { l -> l.isNotBlank() } ?: lblPhone
             add(PreviewRow(Icons.Outlined.Call, label, formatPhoneForDisplay(it)))
         }
-        addressValue(values)?.let {
+        profileAddressValue(values)?.let {
             val label = values[ProfileField.ADDRESS_LABEL]?.takeIf { l -> l.isNotBlank() } ?: lblLocation
             add(PreviewRow(Icons.Outlined.LocationOn, label, it))
         }
@@ -206,16 +209,21 @@ private fun PreviewPhoto(photo: ProfileAttribute?) {
 
 @Composable
 private fun PreviewSectionHeader(title: String, description: String) {
-    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)) {
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
         Text(
             text = title,
             style = MaterialTheme.typography.titleSmall,
             color = MaterialTheme.colorScheme.primary,
+            textAlign = TextAlign.Center,
         )
         Text(
             text = description,
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
         )
     }
 }

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/profile/ProfileEditUiStateTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/profile/ProfileEditUiStateTest.kt
@@ -28,65 +28,19 @@ class ProfileEditUiStateTest {
     }
 
     @Test
-    fun emailValid_malformedInAnonymous_false() {
-        val state = ProfileEditUiState(anonymousValues = mapOf(ProfileField.EMAIL to "not-an-email"))
-        assertTrue(!state.emailValid)
-    }
-
-    @Test
-    fun emailValid_malformedInConnected_false() {
-        val state = ProfileEditUiState(connectedValues = mapOf(ProfileField.EMAIL to "not-an-email"))
-        assertTrue(!state.emailValid)
-    }
-
-    @Test
-    fun emailValid_bothBlank_true() {
-        assertTrue(ProfileEditUiState().emailValid)
-    }
-
-    @Test
-    fun emailValid_bothWellFormed_true() {
+    fun isSaving_pairInSavingAttributes_true() {
         val state = ProfileEditUiState(
-            anonymousValues = mapOf(ProfileField.EMAIL to "public@example.com"),
-            connectedValues = mapOf(ProfileField.EMAIL to "private@example.com"),
+            savingAttributes = setOf("nickname" to ProfileVisibility.CONNECTED),
         )
-        assertTrue(state.emailValid)
+        assertTrue(state.isSaving("nickname", ProfileVisibility.CONNECTED))
     }
 
     @Test
-    fun phoneValid_malformedInAnonymous_false() {
-        val state = ProfileEditUiState(anonymousValues = mapOf(ProfileField.PHONE to "555-1234"))
-        assertTrue(!state.phoneValid)
-    }
-
-    @Test
-    fun phoneValid_malformedInConnected_false() {
-        val state = ProfileEditUiState(connectedValues = mapOf(ProfileField.PHONE to "555-1234"))
-        assertTrue(!state.phoneValid)
-    }
-
-    @Test
-    fun phoneValid_bothBlank_true() {
-        assertTrue(ProfileEditUiState().phoneValid)
-    }
-
-    @Test
-    fun canSave_falseWhileLoading() {
-        assertTrue(!ProfileEditUiState(isLoading = true).canSave)
-    }
-
-    @Test
-    fun canSave_trueWhenLoadedAndValid() {
-        val state = ProfileEditUiState(isLoading = false)
-        assertTrue(state.canSave)
-    }
-
-    @Test
-    fun canSave_falseWithMalformedEmail() {
+    fun isSaving_pairNotInSavingAttributes_false() {
         val state = ProfileEditUiState(
-            isLoading = false,
-            anonymousValues = mapOf(ProfileField.EMAIL to "not-an-email"),
+            savingAttributes = setOf("nickname" to ProfileVisibility.CONNECTED),
         )
-        assertTrue(!state.canSave)
+        assertTrue(!state.isSaving("nickname", ProfileVisibility.ANONYMOUS))
+        assertTrue(!state.isSaving("email", ProfileVisibility.CONNECTED))
     }
 }


### PR DESCRIPTION
## Summary
- Replace the Details/About tabbed editor with a layout mirroring `ProfilePreview`: a Public section and a Vetted section, each listing an attribute only when it has a value in that tier.
- Tap-to-expand rows (pencils removed): each row's expanded editor shows a Public|Vetted toggle (defaulting to its own section) plus the field(s), and a "Save" button that persists just that one attribute (`ProfileEditAction.SaveAttribute`) — no more screen-wide Save button/action.
- Add a FAB that surfaces attributes still missing a value; picking one opens a dialog with its own local draft state (Public|Vetted toggle + fields + Save/Cancel) so nothing is written until Save is pressed.
- Extracted `AttributeFields`/`isAttributeValid` so the inline row editor and the add-attribute dialog share the same per-type field UI instead of duplicating it.
- Center-aligned the section headers on both the edit screen and the preview screen.
- `ProfileEditUiState` drops the old batch-save fields (`isSaving`, `canSave`, `emailValid`, `phoneValid`) in favor of `savingAttributes`/`isSaving(type, tier)`; a thin `LinearProgressIndicator` shows while any attribute save is in flight.

## Test plan
- [x] `:homebase-core:compileKotlinJvm` / `:homebase-core:compileAndroidMain`
- [x] `:homebase-core:jvmTest --tests "id.homebase.core.ui.screens.profile.*"` (ViewModel compute-edit + UiState tests)
- [ ] Manual pass on device/emulator: add a new attribute via FAB, edit an existing one inline, switch the Public|Vetted toggle mid-edit, verify Preview mode still matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)