### PR TITLE
fix(chat): refresh list preview when the last message is soft-deleted (#1023)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMessageBump.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMessageBump.kt
@@ -13,19 +13,30 @@ import kotlin.uuid.Uuid
  * in-memory conversation list.
  *
  * Returns `null` when the message doesn't require a UI change (the
- * targeted conversation isn't in the list, or the message's
- * `userDate` is not strictly newer than the conversation's current
- * `latestMessageTimestamp`). Returns the new list otherwise.
+ * targeted conversation isn't in the list, or a re-emit of the current
+ * last message left every denormalised field unchanged). Returns the
+ * new list otherwise.
  *
- * The strict `>` (rather than `>=`) check is the guard against
- * reaction-driven re-emits. When someone reacts to a message, the
- * server pushes the modified message file (with the new
- * `reactionPreview` baked into the header) over the WS. That
- * re-emit has the SAME `userDate` as the original message
- * (`userDate` is the message's authored time — reactions don't
- * change it), so a `>=` check would incorrectly bump unread every
- * time anyone reacts. Strict `>` rejects re-emits and only accepts
- * messages with a newer `userDate` than the conversation has seen.
+ * Three cases on the message's `userDate` vs the conversation's current
+ * `latestMessageTimestamp`:
+ *
+ *  - **newer (`>`)** — a genuinely new last message. Advance the
+ *    timestamp, refresh the preview, and bump unread (non-self,
+ *    non-edit, non-status).
+ *  - **equal (`==`)** — a re-emit of the *current* last message
+ *    (soft-delete, delivery-status change, or reaction fan-out; a
+ *    reaction re-emit carries the original `userDate` because reactions
+ *    don't change authored time). Refresh the preview so a deletion
+ *    flips `lastMessageIsDeleted` and clears the stale text (#1023), but
+ *    **never** bump unread or advance the timestamp. A reaction echo
+ *    doesn't touch any conversation-level field, so it stays a no-op and
+ *    returns null.
+ *  - **older (`<`)** — not the last message; leave the preview and
+ *    unread untouched.
+ *
+ * The old code used a single strict `>` guard, which correctly rejected
+ * reaction echoes but also swallowed the same-`userDate` soft-delete
+ * re-emit, freezing the list preview on the pre-deletion text (#1023).
  *
  * Why this is its own function: the equivalent logic used to
  * delegate to [ConversationStream.updateConversation], which
@@ -70,39 +81,79 @@ internal fun applyIncomingMessageBump(
     val increment =
         if (!m.isEdited && !m.isAuthoredBy(activeDomain) && !m.isStatusMessage) 1 else 0
 
+    // Denormalised last-message preview fields, recomputed from `m`. Shared by
+    // the "new message" and "same-userDate re-emit" branches so the preview is
+    // identical whether a message first arrives or is later re-pushed
+    // (deletion / delivery-status / reaction).
+    fun ConversationUiModel.withPreviewOf() = copy(
+        lastMessage = m.content.truncateToCodePoints(40),
+        lastMessageDeliveryStatus = m.messageAppData.deliveryStatus,
+        lastMessageIsDeleted = m.isDeleted,
+        lastMessageFirstPayload = m.payloads?.firstOrNull(),
+        lastMessageHasMultiplePayloads = (m.payloads?.size ?: 0) > 1,
+        lastMessageContent = m.messageContent,
+        lastMessageIsFromActiveUser = m.isFromActiveUser(activeDomain),
+        lastMessageSender = m.originalAuthor,
+    )
+
     var didChange = false
     val updated = items.map { existing ->
         if (existing.id != targetConversationId) return@map existing
-        // Strict > so reaction-driven re-emits (which carry the same
-        // userDate as the original message) don't bump unread.
-        if (sqlUserDate <= existing.latestMessageTimestamp) return@map existing
-        didChange = true
-        val next = existing.copy(
-            unreadCount = existing.unreadCount + increment,
-            latestMessageTimestamp = sqlUserDate,
-            lastMessage = m.content.truncateToCodePoints(40),
-            lastMessageDeliveryStatus = m.messageAppData.deliveryStatus,
-            lastMessageIsDeleted = m.isDeleted,
-            lastMessageFirstPayload = m.payloads?.firstOrNull(),
-            lastMessageHasMultiplePayloads = (m.payloads?.size ?: 0) > 1,
-            lastMessageContent = m.messageContent,
-            lastMessageIsFromActiveUser = m.isFromActiveUser(activeDomain),
-            lastMessageSender = m.originalAuthor,
-        )
-        // Diagnostic for the asymmetric-badge investigation (plan
-        // snazzy-frolicking-crown). Fires only when the strict-> check
-        // passes, so reaction re-emits stay silent. Pairs with the
-        // UnreadDiag lines in ConversationStream.enrichUnreadLocked
-        // and is what lets us distinguish hypotheses H1 (lastRead
-        // saturated) vs H2 (SQL excluded the row) on a real capture.
-        Logger.d(tag = "UnreadDiag") {
-            "bump convo=$targetConversationId sqlUserDateMs=${sqlUserDate.toEpochMilliseconds()} " +
-                "originalAuthor=${m.originalAuthor?.domainName ?: "null"} " +
-                "isAuthoredBy(self)=${m.isAuthoredBy(activeDomain)} " +
-                "isEdited=${m.isEdited} isStatusMessage=${m.isStatusMessage} " +
-                "increment=$increment unreadCount=${next.unreadCount}"
+
+        when {
+            // Strictly newer → a genuinely new last message. Advance the
+            // timestamp, refresh the preview and bump unread (for non-self,
+            // non-edit, non-status arrivals).
+            sqlUserDate > existing.latestMessageTimestamp -> {
+                didChange = true
+                val next = existing
+                    .copy(
+                        unreadCount = existing.unreadCount + increment,
+                        latestMessageTimestamp = sqlUserDate,
+                    )
+                    .withPreviewOf()
+                // Diagnostic for the asymmetric-badge investigation (plan
+                // snazzy-frolicking-crown). Fires only on a real bump, so
+                // re-emits stay silent. Pairs with the UnreadDiag lines in
+                // ConversationStream.enrichUnreadLocked and is what lets us
+                // distinguish hypotheses H1 (lastRead saturated) vs H2 (SQL
+                // excluded the row) on a real capture.
+                Logger.d(tag = "UnreadDiag") {
+                    "bump convo=$targetConversationId sqlUserDateMs=${sqlUserDate.toEpochMilliseconds()} " +
+                        "originalAuthor=${m.originalAuthor?.domainName ?: "null"} " +
+                        "isAuthoredBy(self)=${m.isAuthoredBy(activeDomain)} " +
+                        "isEdited=${m.isEdited} isStatusMessage=${m.isStatusMessage} " +
+                        "increment=$increment unreadCount=${next.unreadCount}"
+                }
+                next
+            }
+
+            // Same userDate as the current last message → a re-emit of THAT
+            // message (soft-delete, delivery-status change, or reaction
+            // fan-out — reactions don't advance userDate). Refresh the preview
+            // so a deletion flips lastMessageIsDeleted and clears the stale
+            // text (#1023), but never bump unread or advance the timestamp:
+            // that's exactly what the old strict `>` guard protected against
+            // for reaction echoes. A reaction echo carries an unchanged
+            // preview (reactionPreview isn't a conversation field), so it
+            // stays a no-op here and still returns null.
+            //
+            // ponytail: keyed on userDate equality, not message id — the
+            // conversation model doesn't denormalise the last message's id.
+            // Two distinct messages sharing the same millisecond would let an
+            // older re-emit overwrite the preview; astronomically rare in one
+            // thread and self-heals on the next message / cold-load. Add a
+            // lastMessageId field if it ever bites.
+            sqlUserDate == existing.latestMessageTimestamp -> {
+                val next = existing.withPreviewOf()
+                if (next != existing) didChange = true
+                next
+            }
+
+            // Older than the last message → not the last message; leave the
+            // preview and unread untouched.
+            else -> existing
         }
-        next
     }
     return if (didChange) updated else null
 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationMessageBumpTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationMessageBumpTest.kt
@@ -74,6 +74,7 @@ class ConversationMessageBumpTest {
         content: String = "hi",
         isEdited: Boolean = false,
         isStatusMessage: Boolean = false,
+        isDeleted: Boolean = false,
     ) = MessageUiModel(
         id = Uuid.random(),
         globalTransitId = null,
@@ -88,7 +89,7 @@ class ConversationMessageBumpTest {
         displayName = author.domainName,
         localReadTimestamp = null as UnixTimeUtc?,
         isEdited = isEdited,
-        isDeleted = false,
+        isDeleted = isDeleted,
         isPendingSend = false,
         isStatusMessage = isStatusMessage,
         versionTag = Uuid.NIL,
@@ -229,24 +230,87 @@ class ConversationMessageBumpTest {
      */
     @Test
     fun reactionEcho_sameUserDate_returnsNull_noUnreadBump() {
-        // Convo's latestMessageTimestamp was set to T by the original
-        // peer message arrival. The reaction echo carries the same T.
+        // Seed realistically: the original peer message arrival sets the
+        // preview (content "hi", sender alice) and unread=1. The reaction
+        // echo re-emits the SAME message with the SAME userDate — reactions
+        // change reactionPreview, which is not a conversation-level field, so
+        // the recomputed preview is identical and the re-emit is a true no-op
+        // (returns null, no unread bump).
         val originalUserDateMs = 1_777_000_000_000L
-        val items = listOf(convo(latestMs = originalUserDateMs, unread = 1))
-        val msg = message(author = alice, userDateMs = originalUserDateMs)
+        val arrival = applyIncomingMessageBump(
+            items = listOf(convo(unread = 0)),
+            targetConversationId = convoId,
+            m = message(author = alice, userDateMs = originalUserDateMs, content = "hi"),
+            sqlUserDate = Instant.fromEpochMilliseconds(originalUserDateMs),
+            activeDomain = me,
+        )
+        assertNotNull(arrival)
+        assertEquals(1, arrival.first().unreadCount)
 
         val updated = applyIncomingMessageBump(
-            items = items,
+            items = arrival,
             targetConversationId = convoId,
-            m = msg,
+            m = message(author = alice, userDateMs = originalUserDateMs, content = "hi"),
             sqlUserDate = Instant.fromEpochMilliseconds(originalUserDateMs),
             activeDomain = me,
         )
 
         assertNull(
             updated,
-            "reaction-driven re-emit (same userDate as conversation's latestMessageTimestamp) " +
-                "must not bump unread",
+            "reaction-driven re-emit (same userDate, unchanged preview) must be a no-op",
+        )
+        assertEquals(1, arrival.first().unreadCount)
+    }
+
+    /**
+     * THE #1023 regression guard. When the current last message is
+     * soft-deleted, the modified file re-emits over the WS with the SAME
+     * `userDate` (deletion doesn't change authored time) but `isDeleted =
+     * true`. The pre-fix strict `>` guard hit the `<=` branch and
+     * early-returned, so the Chats-list preview stayed frozen on the
+     * pre-deletion text ("You: where is the event?") while the open thread
+     * correctly showed "This message was deleted". The fix refreshes the
+     * denormalised preview on a same-`userDate` re-emit — flipping
+     * `lastMessageIsDeleted` — without bumping unread or advancing the
+     * timestamp.
+     */
+    @Test
+    fun deletionOfLastMessage_sameUserDate_refreshesPreview_withoutBumpingUnread() {
+        val userDateMs = 1_777_000_000_000L
+
+        // A peer message arrives and becomes the last message (unread 0→1).
+        val arrival = applyIncomingMessageBump(
+            items = listOf(convo(unread = 0)),
+            targetConversationId = convoId,
+            m = message(author = alice, userDateMs = userDateMs, content = "where is the event?"),
+            sqlUserDate = Instant.fromEpochMilliseconds(userDateMs),
+            activeDomain = me,
+        )
+        assertNotNull(arrival)
+        assertEquals("where is the event?", arrival.first().lastMessage)
+        assertEquals(false, arrival.first().lastMessageIsDeleted)
+        assertEquals(1, arrival.first().unreadCount)
+
+        // The message is soft-deleted: same userDate, isDeleted = true.
+        val afterDelete = applyIncomingMessageBump(
+            items = arrival,
+            targetConversationId = convoId,
+            m = message(author = alice, userDateMs = userDateMs, content = "", isDeleted = true),
+            sqlUserDate = Instant.fromEpochMilliseconds(userDateMs),
+            activeDomain = me,
+        )
+
+        assertNotNull(
+            afterDelete,
+            "a same-userDate soft-delete re-emit must refresh the list preview",
+        )
+        val convo = afterDelete.first()
+        assertEquals(true, convo.lastMessageIsDeleted, "list preview must reflect the deletion")
+        assertEquals(1, convo.unreadCount, "a re-emit must not bump unread")
+        assertEquals(
+            userDateMs,
+            convo.latestMessageTimestamp.toEpochMilliseconds(),
+            "a re-emit must not advance the conversation timestamp",
         )
     }
 


### PR DESCRIPTION
Fixes #1023.

## Problem
When the most recent message in a conversation is deleted, the **Chats-list preview** kept showing the deleted message's original text (e.g. `You: where is the event?`) instead of the "message deleted" status. Opening the thread correctly showed "⊘ This message was deleted".

## Root cause
A soft-delete re-emits the same message file over the WS with the **same `userDate`**. `applyIncomingMessageBump` used a single strict `>` guard (`sqlUserDate > latestMessageTimestamp`), so the same-`userDate` re-emit hit the `<=` branch and early-returned — the denormalised `lastMessage` / `lastMessageIsDeleted` fields kept their pre-deletion values. The strict `>` was there to stop reaction re-emits (which also share the original `userDate`) from bumping unread, but it also swallowed the deletion state change.

## Fix
Three-way branch on `userDate` vs `latestMessageTimestamp`:
- **newer (`>`)** — new last message: advance timestamp, refresh preview, bump unread.
- **equal (`==`)** — re-emit of the current last message (soft-delete / delivery-status / reaction fan-out): refresh the denormalised preview (flips `lastMessageIsDeleted`, clears stale text) **without** bumping unread or advancing the timestamp. A reaction echo carries an unchanged preview, so it stays a no-op and still returns `null` — the old guard's behaviour is preserved.
- **older (`<`)** — not the last message: untouched.

Cold-load path already used the `>=` variant (`updateWithLatestMessage`) and the last-message SQL selection includes the soft-deleted row, so a restart was already correct — verified on device.

## Tests
- Extended `ConversationMessageBumpTest` with `deletionOfLastMessage_sameUserDate_refreshesPreview_withoutBumpingUnread` (the mandatory failing→passing guard; pre-fix it returns `null` and the assertion fails).
- Reworked the reaction-echo test to seed realistically (arrive-then-echo) so it remains a true no-op.
- `homebase-chat:jvmTest` green.

## Verification
Device-verified on Redmi Note 5 Pro (Android):
- Deleting the last message flips the list preview to "⊘ This message was deleted" immediately.
- The preview persists as deleted across a full app restart (cold-load path — no stale-text resurrection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)