### PR TITLE
fix(chat): pin captioned single images to Signal's 240dp width — fixes gap + char-per-line (#1028)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
@@ -92,13 +92,12 @@ fun MediaMessage(
     messageId: Uuid,
     downloadingFiles: Set<String>,
     uploadStatus: UploadStatus? = null,
-    /** #964: forwarded to [MediaGallery] so a 2+-image album stretches to the bubble width
-     *  in the caption path instead of leaving a gap. No effect on single media. */
+    /** Forwarded to [MediaGallery] so a 2+-image album stretches to the bubble width in the
+     *  caption path instead of leaving a gap. No effect on single media. */
     fillWidth: Boolean = false,
-    /** #1028: true when this message also carries a text caption. A captioned single image
-     *  is pinned to Signal's `media_bubble_max_width` (240dp) so the caption never collapses
-     *  to a sliver (char-per-line) and the image never leaves a gap beside it. No effect on
-     *  stickers, link-preview cards, or galleries. */
+    /** True when this message also carries a text caption, so a narrow single image is floored
+     *  to Signal's 240dp width — the caption can't collapse to char-per-line and the image can't
+     *  leave a gap. No effect on stickers, link-preview cards, or galleries. */
     hasCaption: Boolean = false,
 ) {
     if (payloads.isEmpty()) return
@@ -131,16 +130,11 @@ fun MediaMessage(
                 } else {
                     modifier.background(MaterialTheme.colorScheme.surfaceContainerHigh)
                 }
-                // #1028: keep a captioned image from resolving to a width that either leaves
-                // a gap beside it or (in the inline path, which clamps the caption to the media
-                // width) collapses the caption to one character per line.
-                //  - fillWidth (block-caption path): fill the bubble width and crop, so a
-                //    height-capped image reaches the caption edge (galleries do the same).
-                //  - other captions: floor the width at Signal's min_width_with_content (240dp)
-                //    ONLY for images narrower than that (portrait / square-ish / tall strips),
-                //    cropping to the height band. Wider images (landscape / panorama) keep
-                //    their natural width — they're already wide enough and must not shrink.
-                // Stickers and link-preview cards keep intrinsic sizing.
+                // A captioned image must not resolve to a width that leaves a gap beside it, or —
+                // in the inline path, which clamps the caption to the media width — collapses the
+                // caption to one char per line. The block-caption path fills and crops to the
+                // bubble width; the inline path floors a narrow image to 240dp. Landscape/panorama
+                // keep their natural width; stickers and link-preview cards keep intrinsic sizing.
                 val fillsBubble = fillWidth && !isSticker && !isLinkPreview
                 val aspect = remember(payloads) {
                     (payloads[0].thumbnails?.lastOrNull() ?: payloads[0].previewThumbnail)?.let { t ->
@@ -149,7 +143,7 @@ fun MediaMessage(
                         if (w != null && h != null && w > 0 && h > 0) w.toFloat() / h else null
                     }
                 }
-                // Height-capped natural width falls below the floor only for narrow images.
+                // Height binds at the cap, so natural width is maxHeight * aspect — floor it only when < 240dp.
                 val narrowCaptioned = hasCaption && !fillWidth && !isSticker && !isLinkPreview &&
                     aspect != null &&
                     Dimens.MediaBubble.maxHeight.value * aspect <
@@ -160,7 +154,7 @@ fun MediaMessage(
                     narrowCaptioned ->
                         widthModifier.size(
                             width = Dimens.MediaBubble.minWidthWithContent,
-                            height = (Dimens.MediaBubble.minWidthWithContent.value / aspect!!).dp
+                            height = (Dimens.MediaBubble.minWidthWithContent.value / aspect).dp
                                 .coerceIn(Dimens.MediaBubble.minHeight, Dimens.MediaBubble.maxHeight),
                         )
                     else ->

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
@@ -7,8 +7,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -92,11 +90,14 @@ fun MediaMessage(
     messageId: Uuid,
     downloadingFiles: Set<String>,
     uploadStatus: UploadStatus? = null,
-    /** #964/#1028: in the block-caption path, stretch the media to the bubble width so a
-     *  height-capped portrait/square image doesn't leave a strip beside it. Forwarded to
-     *  [MediaGallery] for a 2+-image album, and applied to a single photo here (fill + crop).
-     *  No effect on stickers or link-preview cards. */
+    /** #964: forwarded to [MediaGallery] so a 2+-image album stretches to the bubble width
+     *  in the caption path instead of leaving a gap. No effect on single media. */
     fillWidth: Boolean = false,
+    /** #1028: true when this message also carries a text caption. A captioned single image
+     *  is pinned to Signal's `media_bubble_max_width` (240dp) so the caption never collapses
+     *  to a sliver (char-per-line) and the image never leaves a gap beside it. No effect on
+     *  stickers, link-preview cards, or galleries. */
+    hasCaption: Boolean = false,
 ) {
     if (payloads.isEmpty()) return
 
@@ -128,14 +129,31 @@ fun MediaMessage(
                 } else {
                     modifier.background(MaterialTheme.colorScheme.surfaceContainerHigh)
                 }
-                // #1028: in the block-caption path (fillWidth) the bubble is sized by the
-                // caption, so a height-capped portrait/square photo would leave a blue strip
-                // beside it. Fill the bubble width and crop instead — same full-bleed
-                // convention the 2+-image gallery already uses. Stickers and link-preview
-                // cards keep their intrinsic sizing.
-                val fillsBubble = fillWidth && !isSticker && !isLinkPreview
-                val sizedModifier = if (fillsBubble) {
-                    widthModifier.fillMaxWidth().height(Dimens.MediaBubble.maxHeight)
+                // #1028: a single image WITH a caption is pinned to Signal's captioned-image
+                // width (media_bubble_max_width == min_width_with_content == 240dp). Without
+                // it a height-capped portrait/square/tall-strip image resolves to a narrow
+                // (down to a few dp) width, which either leaves a blue gap beside it (block
+                // caption) or collapses the caption to one character per line (the custom
+                // Layout clamps the caption to the media width). Height follows the aspect,
+                // clamped to [minHeight, maxHeight]; taller images crop. Stickers and
+                // link-preview cards keep intrinsic sizing.
+                val captioned = hasCaption && !isSticker && !isLinkPreview
+                val sizedModifier = if (captioned) {
+                    val aspect = (payloads[0].thumbnails?.lastOrNull() ?: payloads[0].previewThumbnail)
+                        ?.let { t ->
+                            val w = t.pixelWidth
+                            val h = t.pixelHeight
+                            if (w != null && h != null && w > 0 && h > 0) w.toFloat() / h else null
+                        }
+                    val boxHeight = aspect
+                        ?.let {
+                            (Dimens.MediaBubble.maxWidth.value / it).dp.coerceIn(
+                                Dimens.MediaBubble.minHeight,
+                                Dimens.MediaBubble.maxHeight,
+                            )
+                        }
+                        ?: Dimens.MediaBubble.maxHeight
+                    widthModifier.size(width = Dimens.MediaBubble.maxWidth, height = boxHeight)
                 } else {
                     widthModifier.heightIn(
                         min = Dimens.MediaBubble.minHeight,
@@ -152,7 +170,7 @@ fun MediaMessage(
                     keyHeader = keyHeader,
                     modifier = sizedModifier,
                     imageSize = ImageSize.THUMB_MEDIUM,
-                    preserveAspectRatio = if (fillsBubble) false else preserveAspectRatio,
+                    preserveAspectRatio = if (captioned) false else preserveAspectRatio,
                     isSticker = isSticker,
                     onClick = { onMediaClick?.invoke(payloads[0]) },
                     onLongPress = { offset -> onMediaLongPress?.invoke(payloads[0], offset) },

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -129,36 +131,43 @@ fun MediaMessage(
                 } else {
                     modifier.background(MaterialTheme.colorScheme.surfaceContainerHigh)
                 }
-                // #1028: a single image WITH a caption is pinned to Signal's captioned-image
-                // width (media_bubble_max_width == min_width_with_content == 240dp). Without
-                // it a height-capped portrait/square/tall-strip image resolves to a narrow
-                // (down to a few dp) width, which either leaves a blue gap beside it (block
-                // caption) or collapses the caption to one character per line (the custom
-                // Layout clamps the caption to the media width). Height follows the aspect,
-                // clamped to [minHeight, maxHeight]; taller images crop. Stickers and
-                // link-preview cards keep intrinsic sizing.
-                val captioned = hasCaption && !isSticker && !isLinkPreview
-                val sizedModifier = if (captioned) {
-                    val aspect = (payloads[0].thumbnails?.lastOrNull() ?: payloads[0].previewThumbnail)
-                        ?.let { t ->
-                            val w = t.pixelWidth
-                            val h = t.pixelHeight
-                            if (w != null && h != null && w > 0 && h > 0) w.toFloat() / h else null
-                        }
-                    val boxHeight = aspect
-                        ?.let {
-                            (Dimens.MediaBubble.maxWidth.value / it).dp.coerceIn(
-                                Dimens.MediaBubble.minHeight,
-                                Dimens.MediaBubble.maxHeight,
-                            )
-                        }
-                        ?: Dimens.MediaBubble.maxHeight
-                    widthModifier.size(width = Dimens.MediaBubble.maxWidth, height = boxHeight)
-                } else {
-                    widthModifier.heightIn(
-                        min = Dimens.MediaBubble.minHeight,
-                        max = Dimens.MediaBubble.maxHeight
-                    )
+                // #1028: keep a captioned image from resolving to a width that either leaves
+                // a gap beside it or (in the inline path, which clamps the caption to the media
+                // width) collapses the caption to one character per line.
+                //  - fillWidth (block-caption path): fill the bubble width and crop, so a
+                //    height-capped image reaches the caption edge (galleries do the same).
+                //  - other captions: floor the width at Signal's min_width_with_content (240dp)
+                //    ONLY for images narrower than that (portrait / square-ish / tall strips),
+                //    cropping to the height band. Wider images (landscape / panorama) keep
+                //    their natural width — they're already wide enough and must not shrink.
+                // Stickers and link-preview cards keep intrinsic sizing.
+                val fillsBubble = fillWidth && !isSticker && !isLinkPreview
+                val aspect = remember(payloads) {
+                    (payloads[0].thumbnails?.lastOrNull() ?: payloads[0].previewThumbnail)?.let { t ->
+                        val w = t.pixelWidth
+                        val h = t.pixelHeight
+                        if (w != null && h != null && w > 0 && h > 0) w.toFloat() / h else null
+                    }
+                }
+                // Height-capped natural width falls below the floor only for narrow images.
+                val narrowCaptioned = hasCaption && !fillWidth && !isSticker && !isLinkPreview &&
+                    aspect != null &&
+                    Dimens.MediaBubble.maxHeight.value * aspect <
+                    Dimens.MediaBubble.minWidthWithContent.value
+                val sizedModifier = when {
+                    fillsBubble ->
+                        widthModifier.fillMaxWidth().height(Dimens.MediaBubble.maxHeight)
+                    narrowCaptioned ->
+                        widthModifier.size(
+                            width = Dimens.MediaBubble.minWidthWithContent,
+                            height = (Dimens.MediaBubble.minWidthWithContent.value / aspect!!).dp
+                                .coerceIn(Dimens.MediaBubble.minHeight, Dimens.MediaBubble.maxHeight),
+                        )
+                    else ->
+                        widthModifier.heightIn(
+                            min = Dimens.MediaBubble.minHeight,
+                            max = Dimens.MediaBubble.maxHeight,
+                        )
                 }
                 MediaItem(
                     payload = payloads[0],
@@ -170,7 +179,7 @@ fun MediaMessage(
                     keyHeader = keyHeader,
                     modifier = sizedModifier,
                     imageSize = ImageSize.THUMB_MEDIUM,
-                    preserveAspectRatio = if (captioned) false else preserveAspectRatio,
+                    preserveAspectRatio = if (fillsBubble || narrowCaptioned) false else preserveAspectRatio,
                     isSticker = isSticker,
                     onClick = { onMediaClick?.invoke(payloads[0]) },
                     onLongPress = { offset -> onMediaLongPress?.invoke(payloads[0], offset) },

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -90,8 +92,10 @@ fun MediaMessage(
     messageId: Uuid,
     downloadingFiles: Set<String>,
     uploadStatus: UploadStatus? = null,
-    /** #964: forwarded to [MediaGallery] so a 2+-image album stretches to the bubble
-     *  width in the caption path instead of leaving a gap. No effect on single media. */
+    /** #964/#1028: in the block-caption path, stretch the media to the bubble width so a
+     *  height-capped portrait/square image doesn't leave a strip beside it. Forwarded to
+     *  [MediaGallery] for a 2+-image album, and applied to a single photo here (fill + crop).
+     *  No effect on stickers or link-preview cards. */
     fillWidth: Boolean = false,
 ) {
     if (payloads.isEmpty()) return
@@ -124,6 +128,20 @@ fun MediaMessage(
                 } else {
                     modifier.background(MaterialTheme.colorScheme.surfaceContainerHigh)
                 }
+                // #1028: in the block-caption path (fillWidth) the bubble is sized by the
+                // caption, so a height-capped portrait/square photo would leave a blue strip
+                // beside it. Fill the bubble width and crop instead — same full-bleed
+                // convention the 2+-image gallery already uses. Stickers and link-preview
+                // cards keep their intrinsic sizing.
+                val fillsBubble = fillWidth && !isSticker && !isLinkPreview
+                val sizedModifier = if (fillsBubble) {
+                    widthModifier.fillMaxWidth().height(Dimens.MediaBubble.maxHeight)
+                } else {
+                    widthModifier.heightIn(
+                        min = Dimens.MediaBubble.minHeight,
+                        max = Dimens.MediaBubble.maxHeight
+                    )
+                }
                 MediaItem(
                     payload = payloads[0],
                     fileId = fileId,
@@ -132,12 +150,9 @@ fun MediaMessage(
                         ?: payloads[0].previewThumbnail?.toEmbeddedThumb(),
                     decryptedFiles = decryptedFiles,
                     keyHeader = keyHeader,
-                    modifier = widthModifier.heightIn(
-                        min = Dimens.MediaBubble.minHeight,
-                        max = Dimens.MediaBubble.maxHeight
-                    ),
+                    modifier = sizedModifier,
                     imageSize = ImageSize.THUMB_MEDIUM,
-                    preserveAspectRatio = preserveAspectRatio,
+                    preserveAspectRatio = if (fillsBubble) false else preserveAspectRatio,
                     isSticker = isSticker,
                     onClick = { onMediaClick?.invoke(payloads[0]) },
                     onLongPress = { offset -> onMediaLongPress?.invoke(payloads[0], offset) },

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -297,7 +297,7 @@ fun MessageBubbleRaw(
                 !it.key.startsWith(ChatProtocol.DEFAULT_PAYLOAD_DESCRIPTOR_KEY)
     }
     val hasMedia = !filteredPayloads.isNullOrEmpty()
-    // #964: a 2+-image album (MediaGallery) sitting above a caption renders full-bleed —
+    // A 2+-image album (MediaGallery) sitting above a caption renders full-bleed —
     // the images run edge-to-edge to the bubble, and only the caption below keeps its
     // 12dp inset (the messenger convention, matching this app's media-only bubbles). A
     // single image already renders edge-to-edge, so it is untouched.
@@ -633,13 +633,10 @@ fun MessageBubbleRaw(
                         )
                     }
                     if (hasMedia) {
-                        // #964/#1028: in the block-caption path the bubble sizes to its widest
-                        // child (the caption), so the media fills that width edge-to-edge —
-                        // otherwise a height-capped narrow image (portrait, square, tall strip)
-                        // leaves a blue strip beside it. Applies to a gallery and a single
-                        // image; the caption below keeps its 12dp inset. (A narrow single image
-                        // in the INLINE path instead gets a 240dp min-width floor in
-                        // MediaMessage; landscape images keep their natural width in both.)
+                        // In the block-caption path the bubble sizes to its widest child (the
+                        // caption), so the media fills that width edge-to-edge — otherwise a
+                        // height-capped narrow image leaves a strip beside it. Applies to both a
+                        // gallery and a single image; the caption below keeps its 12dp inset.
                         Box(modifier = Modifier.fillMaxWidth()) {
                             MediaMessage(
                                 payloads = filteredPayloads.toPersistentList(),
@@ -744,7 +741,7 @@ fun MessageBubbleRaw(
                                 )
                             }
                             if (hasMedia) {
-                                // #964: a gallery renders full-bleed (edge-to-edge). The
+                                // A gallery renders full-bleed (edge-to-edge). The
                                 // custom Layout below clamps the caption to the media width,
                                 // and the caption Row's own 12dp padding insets the text —
                                 // so the images reach the bubble edges with no strip beside
@@ -775,9 +772,8 @@ fun MessageBubbleRaw(
                                         // the media width, so there is no gap to fill — the
                                         // gallery renders full-bleed at its album width.
                                         fillWidth = false,
-                                        // #1028: a captioned single image is pinned to 240dp, so
-                                        // the caption-to-media-width clamp can't collapse a
-                                        // tall/tiny image's caption to one char per line.
+                                        // Floors a narrow single image to 240dp so the caption
+                                        // clamp below can't collapse it to one char per line.
                                         hasCaption = true,
                                     )
                                 }
@@ -913,12 +909,11 @@ fun MessageBubbleRaw(
                         val showMoreIndex = textIndex + 1
                         val infoIndex = showMoreIndex + 1
 
-                        // #1028: measure the media FIRST so a wide group-sender name (author,
-                        // index 0) can be clamped to the media width. Otherwise the name is
-                        // measured at full width and widens a captioned image's bubble past the
-                        // image, leaving a gap beside it (issue B). Clamped, the name ellipsizes
-                        // (maxLines=1) like Signal, so the bubble hugs the image. Each measurable
-                        // is still measured exactly once.
+                        // Measure the media FIRST so a wide group-sender name (author, index 0)
+                        // can be clamped to the media width — otherwise the name is measured at
+                        // full width and widens a captioned image's bubble past the image, leaving
+                        // a gap. Clamped, the name ellipsizes (maxLines=1). Each measurable is
+                        // still measured exactly once.
                         val mediaPlaceable =
                             if (hasMedia) measurables[mediaIndex].measure(constraints) else null
                         val mediaWidth = mediaPlaceable?.width ?: 0

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -607,7 +607,17 @@ fun MessageBubbleRaw(
                 // textLayoutResult, so there is no last-line tuck to lose here:
                 // this is exactly the below-placement the custom Layout already
                 // falls back to when textLayoutResult is null.
-                Column(modifier = Modifier.wrapContentWidth()) {
+                // #1028: a single captioned image hugs Signal's captioned-image width
+                // (240dp) so the block caption wraps at the image width instead of widening
+                // the bubble past a height-capped image (gap). Galleries and text-only block
+                // messages keep their natural width.
+                Column(
+                    modifier = if (hasMedia && !isGallery) {
+                        Modifier.width(Dimens.MediaBubble.maxWidth)
+                    } else {
+                        Modifier.wrapContentWidth()
+                    }
+                ) {
                     authorName?.let {
                         Text(
                             text = it,
@@ -633,12 +643,10 @@ fun MessageBubbleRaw(
                         )
                     }
                     if (hasMedia) {
-                        // #964/#1028: in the block-caption path the bubble sizes to its
-                        // widest child (the caption), so the media must fill that width
-                        // edge-to-edge — otherwise a height-capped narrow image (portrait,
-                        // square) leaves a blue strip beside it (#1028). Applies to both a
-                        // gallery and a single image; the caption below keeps its 12dp inset.
-                        Box(modifier = Modifier.fillMaxWidth()) {
+                        // #964: a gallery fills the full bubble width edge-to-edge; the caption
+                        // below keeps its 12dp inset. A single captioned image is pinned to
+                        // 240dp by MediaMessage (#1028) and the Column above hugs that width.
+                        Box(modifier = if (isGallery) Modifier.fillMaxWidth() else Modifier) {
                             MediaMessage(
                                 payloads = filteredPayloads.toPersistentList(),
                                 decryptedFiles = decryptedFiles,
@@ -660,7 +668,8 @@ fun MessageBubbleRaw(
                                 messageId = message.id,
                                 downloadingFiles = downloadingFiles,
                                 uploadStatus = uploadStatus,
-                                fillWidth = true,
+                                fillWidth = isGallery,
+                                hasCaption = true,
                             )
                         }
                     }
@@ -772,6 +781,10 @@ fun MessageBubbleRaw(
                                         // the media width, so there is no gap to fill — the
                                         // gallery renders full-bleed at its album width.
                                         fillWidth = false,
+                                        // #1028: a captioned single image is pinned to 240dp, so
+                                        // the caption-to-media-width clamp can't collapse a
+                                        // tall/tiny image's caption to one char per line.
+                                        hasCaption = true,
                                     )
                                 }
                             }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -913,22 +913,31 @@ fun MessageBubbleRaw(
                         val showMoreIndex = textIndex + 1
                         val infoIndex = showMoreIndex + 1
 
+                        // #1028: measure the media FIRST so a wide group-sender name (author,
+                        // index 0) can be clamped to the media width. Otherwise the name is
+                        // measured at full width and widens a captioned image's bubble past the
+                        // image, leaving a gap beside it (issue B). Clamped, the name ellipsizes
+                        // (maxLines=1) like Signal, so the bubble hugs the image. Each measurable
+                        // is still measured exactly once.
+                        val mediaPlaceable =
+                            if (hasMedia) measurables[mediaIndex].measure(constraints) else null
+                        val mediaWidth = mediaPlaceable?.width ?: 0
+
                         val placeables: MutableList<Placeable> = mutableListOf()
-                        var mediaWidth = 0
                         var authorWidth = 0
 
-                        // Measure up to text content
                         for (i in 0 until textIndex) {
                             if (i == replyIndex) continue
-                            val placeable = measurables[i].measure(constraints)
+                            val placeable = when {
+                                hasMedia && i == mediaIndex -> mediaPlaceable!!
+                                authorName != null && i == 0 && mediaWidth > 0 ->
+                                    measurables[i].measure(
+                                        constraints.copy(minWidth = 0, maxWidth = mediaWidth)
+                                    )
+                                else -> measurables[i].measure(constraints)
+                            }
                             placeables += placeable
-                            if (hasMedia && i == mediaIndex) {
-                                mediaWidth = placeable.width
-                            }
-                            val authorIndex = 0
-                            if (authorName != null && i == authorIndex) {
-                                authorWidth = placeable.width
-                            }
+                            if (authorName != null && i == 0) authorWidth = placeable.width
                         }
 
                         // Measure text content

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -607,17 +607,7 @@ fun MessageBubbleRaw(
                 // textLayoutResult, so there is no last-line tuck to lose here:
                 // this is exactly the below-placement the custom Layout already
                 // falls back to when textLayoutResult is null.
-                // #1028: a single captioned image hugs Signal's captioned-image width
-                // (240dp) so the block caption wraps at the image width instead of widening
-                // the bubble past a height-capped image (gap). Galleries and text-only block
-                // messages keep their natural width.
-                Column(
-                    modifier = if (hasMedia && !isGallery) {
-                        Modifier.width(Dimens.MediaBubble.maxWidth)
-                    } else {
-                        Modifier.wrapContentWidth()
-                    }
-                ) {
+                Column(modifier = Modifier.wrapContentWidth()) {
                     authorName?.let {
                         Text(
                             text = it,
@@ -643,10 +633,14 @@ fun MessageBubbleRaw(
                         )
                     }
                     if (hasMedia) {
-                        // #964: a gallery fills the full bubble width edge-to-edge; the caption
-                        // below keeps its 12dp inset. A single captioned image is pinned to
-                        // 240dp by MediaMessage (#1028) and the Column above hugs that width.
-                        Box(modifier = if (isGallery) Modifier.fillMaxWidth() else Modifier) {
+                        // #964/#1028: in the block-caption path the bubble sizes to its widest
+                        // child (the caption), so the media fills that width edge-to-edge —
+                        // otherwise a height-capped narrow image (portrait, square, tall strip)
+                        // leaves a blue strip beside it. Applies to a gallery and a single
+                        // image; the caption below keeps its 12dp inset. (A narrow single image
+                        // in the INLINE path instead gets a 240dp min-width floor in
+                        // MediaMessage; landscape images keep their natural width in both.)
+                        Box(modifier = Modifier.fillMaxWidth()) {
                             MediaMessage(
                                 payloads = filteredPayloads.toPersistentList(),
                                 decryptedFiles = decryptedFiles,
@@ -668,7 +662,7 @@ fun MessageBubbleRaw(
                                 messageId = message.id,
                                 downloadingFiles = downloadingFiles,
                                 uploadStatus = uploadStatus,
-                                fillWidth = isGallery,
+                                fillWidth = true,
                                 hasCaption = true,
                             )
                         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -633,10 +633,12 @@ fun MessageBubbleRaw(
                         )
                     }
                     if (hasMedia) {
-                        // #964: a gallery fills the full bubble width edge-to-edge; the
-                        // caption below keeps its own 12dp inset. A single image is
-                        // rendered exactly as before.
-                        Box(modifier = if (isGallery) Modifier.fillMaxWidth() else Modifier) {
+                        // #964/#1028: in the block-caption path the bubble sizes to its
+                        // widest child (the caption), so the media must fill that width
+                        // edge-to-edge — otherwise a height-capped narrow image (portrait,
+                        // square) leaves a blue strip beside it (#1028). Applies to both a
+                        // gallery and a single image; the caption below keeps its 12dp inset.
+                        Box(modifier = Modifier.fillMaxWidth()) {
                             MediaMessage(
                                 payloads = filteredPayloads.toPersistentList(),
                                 decryptedFiles = decryptedFiles,
@@ -658,7 +660,7 @@ fun MessageBubbleRaw(
                                 messageId = message.id,
                                 downloadingFiles = downloadingFiles,
                                 uploadStatus = uploadStatus,
-                                fillWidth = isGallery,
+                                fillWidth = true,
                             )
                         }
                     }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
@@ -166,7 +166,7 @@ class BubbleLayoutInvariantTest {
         )
     }
 
-    private fun ComposeUiTest.render(case: Case) = setContent {
+    private fun ComposeUiTest.render(case: Case, authorName: String? = null) = setContent {
         Host {
             MessageBubbleRaw(
                 message = case.message(),
@@ -178,6 +178,7 @@ class BubbleLayoutInvariantTest {
                 sharedTransitionScope = null,
                 animatedVisibilityScope = null,
                 downloadingFiles = emptySet(),
+                authorName = authorName,
             )
         }
     }
@@ -335,6 +336,32 @@ class BubbleLayoutInvariantTest {
             failures.isEmpty(),
             "single-image no-gap invariant failed for these aspect ratios:\n" + failures.joinToString("\n"),
         )
+    }
+
+    /**
+     * #1028 issue B — a group message with a WIDE sender name must not widen a
+     * captioned image's bubble past the image, leaving a gap beside it. The name
+     * ellipsizes to the media width (maxLines=1), so the bubble hugs the image.
+     * Pre-fix the name was measured at full width → bubble = name width > media →
+     * gap; post-fix media.right == bubble.right.
+     */
+    @Test
+    fun singleImageWithCaption_wideAuthorName_noGap() = runComposeUiTest {
+        val longName = "Shelly Seifert Silberberg Von Habsburg Longname"
+        val failures = mutableListOf<String>()
+        for (aspect in listOf(Aspect.TALL_STRIP, Aspect.TALL_PORTRAIT, Aspect.PORTRAIT)) {
+            val case = Case(
+                name = "1img/$aspect/name", sent = false, images = 1,
+                caption = Caption.LONG, aspect = aspect,
+            )
+            render(case, authorName = longName)
+            val bubble = boundsOf(ChatBubbleTestTags.BUBBLE)
+            val media = boundsOf(ChatBubbleTestTags.MEDIA)
+            if (!approx(media.right.value, bubble.right.value))
+                failures += "[${case.name}] wide sender name left a gap beside the image: " +
+                    "media.right=${media.right.value} bubble.right=${bubble.right.value}"
+        }
+        assertTrue(failures.isEmpty(), "wide-author-name gap failures:\n" + failures.joinToString("\n"))
     }
 
     /**

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
@@ -24,6 +24,7 @@ import id.homebase.chat.data.MessageUiModel
 import id.homebase.chat.services.LocalAttachmentContextStore
 import id.homebase.chat.services.MessageAppData
 import id.homebase.chat.services.ReplyPreview
+import id.homebase.core.ui.theme.Dimens
 import id.homebase.core.ui.theme.HomebaseTheme
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.toPersistentList
@@ -107,6 +108,10 @@ class BubbleLayoutInvariantTest {
     // parameterising pixelWidth/pixelHeight. TALL_PORTRAIT is the reported screenshot
     // (a ~1080x2400 phone capture); it's the ratio that regressed.
     private enum class Aspect(val w: Int, val h: Int) {
+        // A near-1D strip. Height-capped it resolves to ~20dp wide; with a caption the
+        // inline path used to clamp the text to that width → one character per line
+        // (reported bug). Guards the captioned min-width floor.
+        TALL_STRIP(150, 2400),
         TALL_PORTRAIT(1080, 2400),
         PORTRAIT(900, 1200),   // 3:4
         SQUARE(1000, 1000),    // 1:1
@@ -278,23 +283,24 @@ class BubbleLayoutInvariantTest {
 
     /**
      * #1028 — THE aspect-ratio-complete guard the #964 suite was missing. A SINGLE
-     * image + caption must never leave a bubble-background strip beside the image,
-     * for EVERY aspect ratio — not just the landscape 4:3 that #964 happened to test.
+     * image + caption, for EVERY aspect ratio, must:
+     *  1. leave NO bubble-background strip beside the image
+     *     (media.left == bubble.left AND media.right == bubble.right), and
+     *  2. never collapse below Signal's captioned-image width
+     *     (media.width >= media_bubble_min_width_with_content = 240dp).
      *
-     * The invariant (the same "no gap" one used for the gallery and the landscape
-     * single image): the media reaches BOTH bubble edges, so there is no colored void
-     * between the image and the bubble/caption edge —
-     *   media.left == bubble.left  and  media.right == bubble.right.
-     * Whether the convention is "media fills the bubble" or "bubble hugs the media",
-     * this holds; only a height-capped narrow image under a wider caption (the #1028
-     * bug) breaks it.
+     * These are the two failure modes of the media/caption width coupling:
+     *  - a height-capped image NARROWER than a wider caption → a strip beside it
+     *    (the original #1028 report: TALL_PORTRAIT/SQUARE + BLOCK), and
+     *  - a height-capped image so narrow the inline path clamps the caption to it →
+     *    one character per line (TALL_STRIP + any caption; the follow-up report).
      *
-     * TALL_PORTRAIT + LONG/BLOCK is the reported screenshot and the first case that
-     * fails on today's code (image height-capped narrow, caption widens the bubble →
-     * right-side strip) and passes after the fix.
+     * Signal pins a captioned single image to media_bubble_max_width (== 240dp ==
+     * min_width_with_content), so both are covered by the same rule.
      */
     @Test
     fun singleImageWithCaption_noGap_everyAspectRatio() = runComposeUiTest {
+        val captionedMinWidth = Dimens.MediaBubble.minWidthWithContent.value
         val failures = mutableListOf<String>()
         for (sent in listOf(true, false))
             for (aspect in Aspect.entries)
@@ -311,6 +317,9 @@ class BubbleLayoutInvariantTest {
                         failures += "[${case.name}] left strip: media.left=${media.left.value} bubble.left=${bubble.left.value}"
                     if (!approx(media.right.value, bubble.right.value))
                         failures += "[${case.name}] right strip beside image: media.right=${media.right.value} bubble.right=${bubble.right.value}"
+                    val mediaWidth = media.right.value - media.left.value
+                    if (mediaWidth < captionedMinWidth - tol)
+                        failures += "[${case.name}] captioned image collapsed (char-per-line risk): media.width=$mediaWidth < $captionedMinWidth"
                 }
         assertTrue(
             failures.isEmpty(),

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
@@ -102,21 +102,33 @@ class BubbleLayoutInvariantTest {
         ),
     }
 
+    // #1028: the aspect-ratio dimension #964's suite was missing. The layout sizes
+    // off these descriptor pixels (no decode needed), so covering ratios is just
+    // parameterising pixelWidth/pixelHeight. TALL_PORTRAIT is the reported screenshot
+    // (a ~1080x2400 phone capture); it's the ratio that regressed.
+    private enum class Aspect(val w: Int, val h: Int) {
+        TALL_PORTRAIT(1080, 2400),
+        PORTRAIT(900, 1200),   // 3:4
+        SQUARE(1000, 1000),    // 1:1
+        LANDSCAPE(1200, 900),  // 4:3 — the only ratio #964 tested
+        PANORAMA(1920, 1080),  // 16:9
+    }
+
     private data class Case(
         val name: String,
         val sent: Boolean,
         val images: Int,
         val caption: Caption,
         val reply: Boolean = false,
+        val aspect: Aspect = Aspect.LANDSCAPE,
     )
 
-    private fun imagePayload(i: Int) = PayloadDescriptor(
+    private fun imagePayload(i: Int, aspect: Aspect = Aspect.LANDSCAPE) = PayloadDescriptor(
         key = "chat_img$i",
         contentType = "image/jpeg",
         iv = Base64.encode(ByteArray(16)),
-        // Landscape 4:3 so a single image resolves to a real (non-zero) width.
         previewThumbnail = ThumbnailDescriptor(
-            pixelWidth = 1200, pixelHeight = 900, contentType = "image/jpeg", content = "",
+            pixelWidth = aspect.w, pixelHeight = aspect.h, contentType = "image/jpeg", content = "",
         ),
     )
 
@@ -141,7 +153,7 @@ class BubbleLayoutInvariantTest {
             messageAppData = MessageAppData(replyPreview = reply),
             reactionPreview = null,
             previewThumbnail = null,
-            payloads = (0 until images).map { imagePayload(it) }.toPersistentList(),
+            payloads = (0 until images).map { imagePayload(it, aspect) }.toPersistentList(),
             keyHeader = KeyHeader(iv = ByteArray(16), aesKey = SecureByteArray(ByteArray(16))),
             versionTag = Uuid.random(),
             isPendingSend = false,
@@ -262,6 +274,48 @@ class BubbleLayoutInvariantTest {
                 failures += "[${case.name}] single image should span bubble width: media.right=${media.right.value} bubble.right=${bubble.right.value}"
         }
         assertTrue(failures.isEmpty(), "single-image invariant failures:\n" + failures.joinToString("\n"))
+    }
+
+    /**
+     * #1028 — THE aspect-ratio-complete guard the #964 suite was missing. A SINGLE
+     * image + caption must never leave a bubble-background strip beside the image,
+     * for EVERY aspect ratio — not just the landscape 4:3 that #964 happened to test.
+     *
+     * The invariant (the same "no gap" one used for the gallery and the landscape
+     * single image): the media reaches BOTH bubble edges, so there is no colored void
+     * between the image and the bubble/caption edge —
+     *   media.left == bubble.left  and  media.right == bubble.right.
+     * Whether the convention is "media fills the bubble" or "bubble hugs the media",
+     * this holds; only a height-capped narrow image under a wider caption (the #1028
+     * bug) breaks it.
+     *
+     * TALL_PORTRAIT + LONG/BLOCK is the reported screenshot and the first case that
+     * fails on today's code (image height-capped narrow, caption widens the bubble →
+     * right-side strip) and passes after the fix.
+     */
+    @Test
+    fun singleImageWithCaption_noGap_everyAspectRatio() = runComposeUiTest {
+        val failures = mutableListOf<String>()
+        for (sent in listOf(true, false))
+            for (aspect in Aspect.entries)
+                for (cap in listOf(Caption.SHORT, Caption.LONG, Caption.BLOCK)) {
+                    val case = Case(
+                        name = "1img/$aspect/$cap/${if (sent) "sent" else "recv"}",
+                        sent = sent, images = 1, caption = cap, aspect = aspect,
+                    )
+                    render(case)
+                    val bubble = boundsOf(ChatBubbleTestTags.BUBBLE)
+                    val media = boundsOf(ChatBubbleTestTags.MEDIA)
+
+                    if (!approx(media.left.value, bubble.left.value))
+                        failures += "[${case.name}] left strip: media.left=${media.left.value} bubble.left=${bubble.left.value}"
+                    if (!approx(media.right.value, bubble.right.value))
+                        failures += "[${case.name}] right strip beside image: media.right=${media.right.value} bubble.right=${bubble.right.value}"
+                }
+        assertTrue(
+            failures.isEmpty(),
+            "single-image no-gap invariant failed for these aspect ratios:\n" + failures.joinToString("\n"),
+        )
     }
 
     /**

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
@@ -286,17 +286,22 @@ class BubbleLayoutInvariantTest {
      * image + caption, for EVERY aspect ratio, must:
      *  1. leave NO bubble-background strip beside the image
      *     (media.left == bubble.left AND media.right == bubble.right), and
-     *  2. never collapse below Signal's captioned-image width
-     *     (media.width >= media_bubble_min_width_with_content = 240dp).
+     *  2. never collapse below Signal's captioned-image floor
+     *     (media.width >= media_bubble_min_width_with_content = 240dp), and
+     *  3. NOT shrink a naturally-wide image (landscape / panorama) down to that
+     *     floor — wide images keep their width.
      *
-     * These are the two failure modes of the media/caption width coupling:
+     * (1)+(2) are the two failure modes of the media/caption width coupling:
      *  - a height-capped image NARROWER than a wider caption → a strip beside it
      *    (the original #1028 report: TALL_PORTRAIT/SQUARE + BLOCK), and
      *  - a height-capped image so narrow the inline path clamps the caption to it →
      *    one character per line (TALL_STRIP + any caption; the follow-up report).
+     * (3) guards the requirement that fixing the narrow cases must not shrink
+     * landscape images (which were already fine) to 240dp.
      *
-     * Signal pins a captioned single image to media_bubble_max_width (== 240dp ==
-     * min_width_with_content), so both are covered by the same rule.
+     * The rule: 240dp is a FLOOR for narrow images (portrait / square-ish / strip);
+     * wider images keep their natural width. (Ported from Signal's
+     * media_bubble_min_width_with_content, but as a floor, not a hard cap.)
      */
     @Test
     fun singleImageWithCaption_noGap_everyAspectRatio() = runComposeUiTest {
@@ -320,6 +325,11 @@ class BubbleLayoutInvariantTest {
                     val mediaWidth = media.right.value - media.left.value
                     if (mediaWidth < captionedMinWidth - tol)
                         failures += "[${case.name}] captioned image collapsed (char-per-line risk): media.width=$mediaWidth < $captionedMinWidth"
+                    // A naturally-wide image must keep its width, not shrink to the floor.
+                    if ((aspect == Aspect.LANDSCAPE || aspect == Aspect.PANORAMA) &&
+                        mediaWidth <= captionedMinWidth + tol
+                    )
+                        failures += "[${case.name}] wide image was shrunk to the 240dp floor: media.width=$mediaWidth"
                 }
         assertTrue(
             failures.isEmpty(),

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
@@ -41,7 +41,7 @@ import kotlin.time.Instant
 import kotlin.uuid.Uuid
 
 /**
- * #964 — chat-bubble layout regression suite.
+ * Chat-bubble layout regression suite.
  *
  * Renders [MessageBubbleRaw] on the JVM host renderer (`runComposeUiTest`, same as
  * [ConversationMessagePreviewTest] / [ReactionMenuTest]) across a matrix of
@@ -103,10 +103,9 @@ class BubbleLayoutInvariantTest {
         ),
     }
 
-    // #1028: the aspect-ratio dimension #964's suite was missing. The layout sizes
-    // off these descriptor pixels (no decode needed), so covering ratios is just
-    // parameterising pixelWidth/pixelHeight. TALL_PORTRAIT is the reported screenshot
-    // (a ~1080x2400 phone capture); it's the ratio that regressed.
+    // The aspect-ratio dimension the single-image suite was missing. The layout sizes off
+    // these descriptor pixels (no decode needed), so covering ratios is just parameterising
+    // pixelWidth/pixelHeight. TALL_PORTRAIT is the reported ~1080x2400 phone capture.
     private enum class Aspect(val w: Int, val h: Int) {
         // A near-1D strip. Height-capped it resolves to ~20dp wide; with a caption the
         // inline path used to clamp the text to that width → one character per line
@@ -115,7 +114,7 @@ class BubbleLayoutInvariantTest {
         TALL_PORTRAIT(1080, 2400),
         PORTRAIT(900, 1200),   // 3:4
         SQUARE(1000, 1000),    // 1:1
-        LANDSCAPE(1200, 900),  // 4:3 — the only ratio #964 tested
+        LANDSCAPE(1200, 900),  // 4:3
         PANORAMA(1920, 1080),  // 16:9
     }
 
@@ -194,7 +193,7 @@ class BubbleLayoutInvariantTest {
     // ---- tests ------------------------------------------------------------
 
     /**
-     * THE fix (#964, full-bleed). For every 2/3/4-image gallery that sits above a
+     * Full-bleed galleries. For every 2/3/4-image gallery that sits above a
      * caption the images run EDGE-TO-EDGE to the bubble — no blue strip beside them —
      * while the caption below keeps its own 12dp inset (the messenger convention,
      * matching this app's media-only bubbles):
@@ -283,26 +282,12 @@ class BubbleLayoutInvariantTest {
     }
 
     /**
-     * #1028 — THE aspect-ratio-complete guard the #964 suite was missing. A SINGLE
-     * image + caption, for EVERY aspect ratio, must:
-     *  1. leave NO bubble-background strip beside the image
-     *     (media.left == bubble.left AND media.right == bubble.right), and
-     *  2. never collapse below Signal's captioned-image floor
-     *     (media.width >= media_bubble_min_width_with_content = 240dp), and
-     *  3. NOT shrink a naturally-wide image (landscape / panorama) down to that
-     *     floor — wide images keep their width.
+     * A single image + caption, for every aspect ratio, must:
+     *  1. leave no bubble-background strip beside the image (media edges == bubble edges),
+     *  2. never collapse below Signal's 240dp captioned-image floor (char-per-line risk), and
+     *  3. not shrink a naturally-wide image (landscape / panorama) down to that floor.
      *
-     * (1)+(2) are the two failure modes of the media/caption width coupling:
-     *  - a height-capped image NARROWER than a wider caption → a strip beside it
-     *    (the original #1028 report: TALL_PORTRAIT/SQUARE + BLOCK), and
-     *  - a height-capped image so narrow the inline path clamps the caption to it →
-     *    one character per line (TALL_STRIP + any caption; the follow-up report).
-     * (3) guards the requirement that fixing the narrow cases must not shrink
-     * landscape images (which were already fine) to 240dp.
-     *
-     * The rule: 240dp is a FLOOR for narrow images (portrait / square-ish / strip);
-     * wider images keep their natural width. (Ported from Signal's
-     * media_bubble_min_width_with_content, but as a floor, not a hard cap.)
+     * 240dp is a floor for narrow images, not a hard cap.
      */
     @Test
     fun singleImageWithCaption_noGap_everyAspectRatio() = runComposeUiTest {
@@ -339,11 +324,9 @@ class BubbleLayoutInvariantTest {
     }
 
     /**
-     * #1028 issue B — a group message with a WIDE sender name must not widen a
-     * captioned image's bubble past the image, leaving a gap beside it. The name
-     * ellipsizes to the media width (maxLines=1), so the bubble hugs the image.
-     * Pre-fix the name was measured at full width → bubble = name width > media →
-     * gap; post-fix media.right == bubble.right.
+     * A group message with a wide sender name must not widen a captioned image's bubble past
+     * the image. The name ellipsizes to the media width (maxLines=1) so the bubble hugs the
+     * image; post-fix media.right == bubble.right.
      */
     @Test
     fun singleImageWithCaption_wideAuthorName_noGap() = runComposeUiTest {


### PR DESCRIPTION
Fixes #1028 and a follow-up report (char-per-line captions). Same root cause as #964's class, for the single-image path #964's suite didn't cover.

## The bug(s) — one root cause, two failure modes
A single image's width is only height-bounded (`heightIn`), so an image whose height cap binds resolves to a **narrow** width. That narrow media then couples badly with a text caption two ways:
1. **Gap** (block-markdown caption): the block Column sizes to the caption (~400dp) while the image stays narrow (144/240/320 for tall-portrait/portrait/square) → a bubble-background strip beside the image. *(original #1028 report)*
2. **Char-per-line** (inline caption): the inline custom Layout clamps the caption to the media width. A very tall/narrow strip (~20dp wide when height-capped) clamps the caption to ~20dp → the text renders **one character per line**. *(follow-up report — see screenshot)*

## Fix — Signal's `min_width_with_content`, as a floor
Our `Dimens.MediaBubble` is a **direct port of Signal Android's dimens** (`media_bubble_min_width_with_content = 240`, `media_bubble_max_width = 240`, `media_bubble_max_height = 320`, …) — but we never applied the captioned-image floor. A captioned single image is now sized three ways:

- **block-caption path** (`fillWidth`): fills the bubble width and crops (same full-bleed convention as #964's gallery) — landscape and portrait both reach the caption edge.
- **inline + narrow** (height-capped natural width < 240dp: portrait, square-ish, tall strips): floor the width to **240dp** and crop to the `[100,320]` height band — fixes the gap **and** the char-per-line.
- **inline + wide** (landscape / panorama): **natural height-bounded width, unchanged — wide images are NOT shrunk.**

So **240dp is a floor for narrow images, not a hard cap**: landscape/panorama captioned images keep their width; only images that would otherwise be too narrow are widened to 240 (cropped). Galleries and text-only messages are unchanged.

## Test suite (aspect-ratio-complete)
`BubbleLayoutInvariantTest` drives layout off descriptor pixels (no decode) across `{sent,received} × {tall-strip, tall-portrait, portrait, square, landscape, panorama} × {short, long, block caption}`, asserting for every case:
1. no strip: `media.left == bubble.left && media.right == bubble.right`,
2. no collapse: `media.width >= 240` (min_width_with_content), and
3. no over-shrink: a wide image (LANDSCAPE / PANORAMA) is **not** reduced to the 240dp floor.

Pre-fix, `TALL_STRIP` is ~20dp wide (fails 2 → char-per-line) and `TALL_PORTRAIT/SQUARE + BLOCK` leave a gap (fails 1); post-fix all pass. Full `homebase-chat:jvmTest` green. #964's gallery cases and media-only/text-only stay green.

## Verification note
Android compiled; the JVM host-renderer suite is the behavioural check (it measures real laid-out bounds). Device screenshot verification of the original portrait case was done earlier on a Redmi; the char-per-line + landscape revisions are covered by the extended suite (device is currently PIN-locked from unrelated #1025 testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
