### PR TITLE
fix(ci): dev TestFlight upload controlled by dispatch checkbox, not branch gate

### DIFF
--- a/.github/workflows/build-mobile-release-dev.yml
+++ b/.github/workflows/build-mobile-release-dev.yml
@@ -8,6 +8,11 @@ on:
 
     # Allow manual triggering from GitHub UI
     workflow_dispatch:
+      inputs:
+        upload_to_testflight:
+          description: "Upload the IPA to TestFlight (untick for experiment/CI-debug runs)"
+          type: boolean
+          default: true
 
 #  push:
 #    branches: [main]
@@ -306,18 +311,19 @@ jobs:
           name: ios-app
           path: iosApp.ipa
 
-      # main only (schedule and normal dispatch both run on main): a
-      # workflow_dispatch on an experiment branch must never push its IPA to
-      # TestFlight.
+      # Nightlies always upload; manual dispatches are controlled by the
+      # upload_to_testflight checkbox (default ON — branch dispatches to test a
+      # feature build on the dev TestFlight app keep working; untick it for
+      # experiment/CI-debug runs). The prod workflow is stricter: main/tags only.
       - name: Setup App Store Connect API key
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'schedule' || inputs.upload_to_testflight == true
         run: |
           mkdir -p "${{ runner.temp }}/private_keys"
           echo "${{ secrets.APPSTORE_API_PRIVATE_KEY }}" > \
             "${{ runner.temp }}/private_keys/AuthKey_${{ secrets.APPSTORE_API_KEY_ID }}.p8"
 
       - name: Upload to TestFlight
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'schedule' || inputs.upload_to_testflight == true
         run: |
           xcrun altool --upload-app \
             --type ios \

--- a/IOS_RELEASE_LINK_OOM.md
+++ b/IOS_RELEASE_LINK_OOM.md
@@ -129,9 +129,12 @@ open with Eclipse MAT, look at the dominator tree). This is how every number
 in this document was obtained — keep it working.
 
 Related workflow hardening that rode along with this fix: the TestFlight
-upload steps are gated to `main`/tags, because `workflow_dispatch` on an
-experiment branch used to run them unconditionally and would have shipped an
-experimental IPA to testers.
+upload steps used to run unconditionally, so a `workflow_dispatch` on an
+experiment branch would have shipped an experimental IPA to testers. Now:
+**prod** uploads only from `main`/tags; **dev** uploads on nightlies always,
+and on manual dispatch per the `upload_to_testflight` checkbox (default on, so
+dispatching a feature branch to test it on the dev TestFlight app still works —
+untick it for experiment/CI-debug runs).
 
 ## If it OOMs again
 


### PR DESCRIPTION
Follow-up to #1037, which gated both workflows' TestFlight uploads to main/tags. That's right for **prod** (an experimental IPA must never reach real testers), but too strict for **dev**: dispatching `build-mobile-release-dev.yml` on a feature branch to test it via the dev TestFlight app is a legitimate workflow.

This replaces the dev workflow's branch gate with a `workflow_dispatch` checkbox:

- **Manual dispatch (any branch): uploads by default** — pre-#1037 behavior restored; untick `upload_to_testflight` for experiment/CI-debug runs.
- **Nightly scheduled builds: always upload** (unchanged).
- **Prod keeps the strict main/tags gate** (unchanged).

Also updates `IOS_RELEASE_LINK_OOM.md`'s hardening note to describe the split behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LN2VqMAkC1ckYSzWVcx7fu