### PR TITLE
feat(location): dashboard title + group emergency contacts (#1026)

### DIFF
--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1286,6 +1286,7 @@
 
     <!-- Location add-on -->
     <string name="location_label">Location</string>
+    <string name="location_dashboard_title">Emergency Location History</string>
     <string name="location_home_subtitle">Your private location history</string>
     <string name="location_onboarding_title">Your places, only yours</string>
     <string name="location_onboarding_body_1">Location keeps a private, encrypted history of where you've been — stored on your own drive, visible to no one but you.</string>
@@ -1338,6 +1339,7 @@
     <string name="location_locate_ambush_explainer">If you believe the person might be held hostage, check this box to delay the notification to the person for 24 hours.</string>
     <string name="location_locate_confirm">Request location data</string>
     <string name="location_locate_fetch_failed">Couldn't retrieve their location data. The request notice was still sent.</string>
+    <string name="location_emergency_contacts_section">Emergency contacts</string>
     <string name="location_emergency_access_section">Who can locate you</string>
     <string name="location_emergency_access_manage">Add emergency contacts</string>
     <string name="location_emergency_access_missing">No Emergency Location Access circle yet. Tap + to set one up in your owner console.</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1286,7 +1286,7 @@
 
     <!-- Location add-on -->
     <string name="location_label">Location</string>
-    <string name="location_dashboard_title">Emergency Location History</string>
+    <string name="location_dashboard_title">Location Dashboard</string>
     <string name="location_home_subtitle">Your private location history</string>
     <string name="location_onboarding_title">Your places, only yours</string>
     <string name="location_onboarding_body_1">Location keeps a private, encrypted history of where you've been — stored on your own drive, visible to no one but you.</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
@@ -93,6 +93,7 @@ import id.homebase.resources.location_emergency_access_manage
 import id.homebase.resources.location_emergency_access_more
 import id.homebase.resources.location_emergency_access_none
 import id.homebase.resources.location_emergency_access_section
+import id.homebase.resources.location_emergency_contacts_section
 import id.homebase.resources.location_locatable_broken_cd
 import id.homebase.resources.location_locatable_none
 import id.homebase.resources.location_locatable_section
@@ -316,8 +317,16 @@ fun LocationDashboardContent(
             }
         }
 
-        // ── Who you can locate (contacts carrying our iCanLocate flag) ──
-        DashboardSection(title = stringResource(MR.string.location_locatable_section)) {
+        // ── Emergency contacts: the two halves of emergency-location access ──
+        // "Who you can locate" (contacts carrying our iCanLocate flag) and "Who can
+        // locate you" (members of our emergency-location-access circle) sit as
+        // subsections under one grouping header. The "+" (add emergency contacts)
+        // lives on the group header since it applies to this pairing as a whole.
+        DashboardSection(
+            title = stringResource(MR.string.location_emergency_contacts_section),
+            onManage = onManageEmergencyAccess,
+        ) {
+            SubsectionLabel(text = stringResource(MR.string.location_locatable_section))
             Card(modifier = Modifier.fillMaxWidth()) {
                 PeopleListBody(
                     loaded = uiState.whoICanLocateLoaded,
@@ -338,13 +347,8 @@ fun LocationDashboardContent(
                     },
                 )
             }
-        }
 
-        // ── Who can locate you (members of our emergency-location-access circle) ──
-        DashboardSection(
-            title = stringResource(MR.string.location_emergency_access_section),
-            onManage = onManageEmergencyAccess,
-        ) {
+            SubsectionLabel(text = stringResource(MR.string.location_emergency_access_section))
             Card(modifier = Modifier.fillMaxWidth()) {
                 PeopleListBody(
                     loaded = uiState.whoCanLocateMeLoaded,
@@ -462,6 +466,22 @@ private fun DashboardSection(
         HorizontalDivider()
         content()
     }
+}
+
+/**
+ * A lightweight subsection heading rendered inside a [DashboardSection]'s body — used to
+ * label the two "who can locate" halves under the shared "Emergency contacts" header
+ * without giving each the full titleMedium/divider weight of a top-level section. Mirrors
+ * the "Sharing with" / "Sharing with you" labels in the live-sharing section.
+ */
+@Composable
+private fun SubsectionLabel(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(top = 8.dp).semantics { heading() },
+    )
 }
 
 /**

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
@@ -35,6 +35,7 @@ import id.homebase.resources.location_consent_text
 import id.homebase.resources.location_consent_title
 import id.homebase.api.client.location.LocationPreviewProvider
 import id.homebase.core.util.getUriHandler
+import id.homebase.resources.location_dashboard_title
 import id.homebase.resources.location_history_title
 import id.homebase.resources.location_label
 import id.homebase.resources.location_menu_dashboard
@@ -196,7 +197,14 @@ fun LocationScreen(
             // No back arrow: Location is a top-level destination reached from the
             // bottom nav bar (which stays visible here), matching Vault/Moments.
             TopAppBar(
-                title = { Text(stringResource(MR.string.location_label)) },
+                title = {
+                    Text(
+                        stringResource(
+                            if (showDashboard) MR.string.location_dashboard_title
+                            else MR.string.location_label,
+                        ),
+                    )
+                },
                 actions = {
                     IconButton(onClick = { menuOpen = true }) {
                         Icon(


### PR DESCRIPTION
Closes #1026.

Two refinements to the Location dashboard, following on from the sectional dividers added in #1011.

## Changes

### 1. Mode-aware top-bar title
The dashboard top bar now reads **"Location Dashboard"** (new `location_dashboard_title`) instead of the generic "Location". Setup mode keeps the existing **"Location"** label.

### 2. "Emergency contacts" grouping header
"Who you can locate" and "Who can locate you" are now grouped under a single **"Emergency contacts"** section header (new `location_emergency_contacts_section`) instead of two separate top-level sections. They render as `titleSmall` subsections beneath one heading, and the "+" (add emergency contacts) affordance moves up to the group header where it applies to the pairing as a whole.

A new `SubsectionLabel` composable provides the lightweight sub-heading, mirroring the "Sharing with" / "Sharing with you" labels in the live-sharing section and keeping the #1011 divider styling intact.

Rough resulting layout:

```
Location Dashboard              ← top bar title

Live location sharing
Location History
Find my device
Emergency contacts              ← grouping header (+ = add emergency contacts)
    Who you can locate
    Who can locate you
```

## Notes
- All new user-facing text goes through `stringResource()`; no hardcoded strings.
- `:homebase-core:compileKotlinJvm` passes.

## Acceptance criteria
- [x] Dashboard top-bar title reads "Location Dashboard" (mode-aware; setup mode unchanged).
- [x] An "Emergency contacts" section header appears above the two subsections.
- [x] "Who you can locate" and "Who can locate you" render under that header as subsections.
- [x] No hardcoded strings; dividers/spacing stay consistent with #1011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)