### PR TITLE
fix(chat): editing a message no longer moves its userDate (#900)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
@@ -419,6 +419,16 @@ class ChatMessageSenderService(
             error("VersionTag mismatch")
         }
 
+        // An edit must not move userDate: MessageUiModel.userDate is clamped for
+        // display (minOf(rawUserDate, authorSpecificDate) in MessageMapper), so
+        // re-stamping from it can lower appData.userDate below the SQL
+        // DriveMainIndex.userDate — the conversation-list preview refresh guards
+        // then reject the edit and the overview blanks (#900). Read the original
+        // value off the header file; `modified` already reflects the edit time.
+        val originalUserDateMs = chatMessageStream.getMessageFile(messageId)
+            ?.fileMetadata?.appData?.userDate
+            ?: msg.userDate.toEpochMilliseconds()
+
         val keyHeader = KeyHeader(
             iv = ByteArrayUtil.getRndByteArray(16),
             aesKey = msg.keyHeader.aesKey
@@ -459,7 +469,7 @@ class ChatMessageSenderService(
                     groupId = msg.conversationId,
                     fileType = ChatProtocol.MessageFileType,
                     dataType = msg.messageContent?.let { MessageContentParser.dataTypeFor(it) } ?: 0,
-                    userDate = msg.userDate.toEpochMilliseconds(),
+                    userDate = originalUserDateMs,
                     content = createBuilt?.headerContent ?: content,
                     previewThumbnail = msg.previewThumbnail
                 )
@@ -525,7 +535,7 @@ class ChatMessageSenderService(
                 groupId = msg.conversationId,
                 fileType = ChatProtocol.MessageFileType,
                 dataType = msg.messageContent?.let { MessageContentParser.dataTypeFor(it) } ?: 0,
-                userDate = msg.userDate.toEpochMilliseconds(),
+                userDate = originalUserDateMs,
                 content = headerContent,
                 previewThumbnail = msg.previewThumbnail
             )
@@ -736,7 +746,10 @@ class ChatMessageSenderService(
                 groupId = msg.conversationId,
                 fileType = ChatProtocol.MessageFileType,
                 dataType = file.fileMetadata.appData.dataType ?: 0,
-                userDate = msg.userDate.toEpochMilliseconds(),
+                // Keep the original un-clamped userDate on retry (#900) —
+                // msg.userDate is the clamped display value.
+                userDate = file.fileMetadata.appData.userDate
+                    ?: msg.userDate.toEpochMilliseconds(),
                 content = built.headerContent,
                 previewThumbnail = msg.previewThumbnail,
             ),
@@ -795,7 +808,10 @@ class ChatMessageSenderService(
                 groupId = msg.conversationId,
                 fileType = ChatProtocol.MessageFileType,
                 dataType = file.fileMetadata.appData.dataType ?: 0,
-                userDate = msg.userDate.toEpochMilliseconds(),
+                // Keep the original un-clamped userDate on retry (#900) —
+                // msg.userDate is the clamped display value.
+                userDate = file.fileMetadata.appData.userDate
+                    ?: msg.userDate.toEpochMilliseconds(),
                 content = built.headerContent,
                 previewThumbnail = msg.previewThumbnail,
             ),

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceUpdateMessageTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceUpdateMessageTest.kt
@@ -2,13 +2,16 @@ package id.homebase.chat.services
 
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.drives.FileSystemType
+import id.homebase.api.client.drives.HomebaseFile
 import id.homebase.api.client.drives.files.DriveOutboxUploader
 import id.homebase.api.client.drives.query.QueryBatchCursor
 import id.homebase.api.client.drives.upload.UpdateFileByUniqueIdRequest
 import id.homebase.api.client.drives.upload.UploadAppFileMetaData
 import id.homebase.api.client.drives.upload.UploadFileMetadata
+import id.homebase.api.client.drives.upload.UploadFileRequest
 import id.homebase.api.common.BatchResult
 import id.homebase.api.common.OdinId
+import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.Outbox
@@ -49,13 +52,20 @@ class ChatMessageSenderServiceUpdateMessageTest {
     private class SeedableMessageLookup : MessageLookup {
         val records = mutableListOf<MessageUiModel>()
 
+        /**
+         * `updateMessage` reads the original (un-clamped) `appData.userDate` off the
+         * header file, so tests back this with the fixture's real DriveMainIndex
+         * (see [ChatMessageSenderServiceUpdateMessageTest.dbFileLookup]).
+         */
+        var fileLookup: suspend (Uuid) -> HomebaseFile? = { null }
+
         fun seed(model: MessageUiModel) { records += model }
 
         override suspend fun getMessage(messageId: Uuid): MessageUiModel? =
             records.firstOrNull { it.id == messageId }
 
-        override suspend fun getMessageFile(messageId: Uuid) =
-            error("SeedableMessageLookup.getMessageFile not used in updateMessage tests")
+        override suspend fun getMessageFile(messageId: Uuid): HomebaseFile? =
+            fileLookup(messageId)
 
         override suspend fun getMessages(
             messageIds: List<Uuid>,
@@ -81,6 +91,25 @@ class ChatMessageSenderServiceUpdateMessageTest {
             OdinSystemSerializer.deserialize<UpdateFileByUniqueIdRequest>(this.json.decodeToString())
         } catch (_: Throwable) {
             null
+        }
+    }
+
+    /** Deserialize an outbox row as a create ([UploadFileRequest]), or null if it's a different type. */
+    private fun Outbox.asUploadFileRequestOrNull(): UploadFileRequest? {
+        if (this.uploadType != DriveOutboxUploader.UploadNewFile) return null
+        return try {
+            OdinSystemSerializer.deserialize<UploadFileRequest>(this.json.decodeToString())
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    /** Back [SeedableMessageLookup.fileLookup] with the fixture's real DriveMainIndex. */
+    private fun SeedableMessageLookup.backFilesWith(fixture: ChatMessageSenderServiceTestFixture) {
+        fileLookup = { uid ->
+            fixture.dbm.driveMainIndex.selectHomebaseFileByUnique(
+                fixture.testIdentityId, fixture.chatDriveId, uid,
+            )
         }
     }
 
@@ -110,6 +139,7 @@ class ChatMessageSenderServiceUpdateMessageTest {
             val service = fixture.build(
                 messageLookup = { _: DatabaseManager -> messageLookup },
             )
+            messageLookup.backFilesWith(fixture)
 
             val conversationId = fixture.seedConversation(others = listOf("bob.test"))
             val messageId = Uuid.random()
@@ -214,6 +244,7 @@ class ChatMessageSenderServiceUpdateMessageTest {
             val service = fixture.build(
                 messageLookup = { _: DatabaseManager -> messageLookup },
             )
+            messageLookup.backFilesWith(fixture)
 
             val conversationId = fixture.seedConversation(others = listOf("bob.test"))
             val messageId = Uuid.random()
@@ -312,6 +343,7 @@ class ChatMessageSenderServiceUpdateMessageTest {
             val service = fixture.build(
                 messageLookup = { _: DatabaseManager -> messageLookup },
             )
+            messageLookup.backFilesWith(fixture)
 
             val conversationId = fixture.seedConversation(others = listOf("bob.test"))
             val messageId = Uuid.random()
@@ -378,6 +410,203 @@ class ChatMessageSenderServiceUpdateMessageTest {
             assertTrue(reparsed.isValid(), "re-parsed Poll descriptor must be valid")
             assertTrue(reparsed.closed, "coalesced descriptor must be closed")
             assertEquals(descriptor.options, reparsed.options)
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // #900 — an edit must not move appData.userDate
+    // -----------------------------------------------------------------------
+
+    /**
+     * Regression for #900 (conversation-list preview blanks after editing the
+     * latest message): `MessageUiModel.userDate` is CLAMPED
+     * (`minOf(rawUserDate, authorSpecificDate)` in `MessageMapper.mapToMessageData`),
+     * so re-stamping the edit's `appData.userDate` from the model can LOWER it
+     * below the SQL `DriveMainIndex.userDate`. The preview-refresh guards then
+     * reject the edit re-emit and the overview keeps the blank placeholder.
+     *
+     * `updateMessage` must stamp the original un-clamped `appData.userDate` read
+     * from the header file, on both the enqueued update request and the
+     * optimistic DB write.
+     */
+    @Test
+    fun `updateMessage preserves the original unclamped userDate, not the clamped model value`() = runTest {
+        val messageLookup = SeedableMessageLookup()
+
+        ChatMessageSenderServiceTestFixture().use { fixture ->
+            val service = fixture.build(
+                messageLookup = { _: DatabaseManager -> messageLookup },
+            )
+            messageLookup.backFilesWith(fixture)
+
+            val conversationId = fixture.seedConversation(others = listOf("bob.test"))
+            val messageId = Uuid.random()
+            val versionTag = Uuid.random()
+            val keyHeader = KeyHeader.newRandom16()
+            val originalUserDate = 2_000L
+            val clampedUserDate = 1_000L
+
+            // The stored header carries the true (un-clamped) userDate.
+            fixture.optimisticWriter.writeNewFile(
+                driveId = fixture.chatDriveId,
+                keyHeader = keyHeader,
+                unecryptedMetadata = UploadFileMetadata(
+                    allowDistribution = true,
+                    isEncrypted = true,
+                    appData = UploadAppFileMetaData(
+                        uniqueId = messageId,
+                        groupId = conversationId,
+                        fileType = ChatProtocol.MessageFileType,
+                        dataType = 0,
+                        userDate = originalUserDate,
+                        content = OdinSystemSerializer.serialize(MessageAppData()),
+                    ),
+                ),
+                originalRecipientCount = 1,
+                fileSystemType = FileSystemType.Standard,
+            )
+
+            // The model the edit reads carries the clamped (lower) display value.
+            messageLookup.seed(
+                MessageUiModel(
+                    id = messageId,
+                    globalTransitId = null,
+                    fileId = Uuid.random(),
+                    conversationId = conversationId,
+                    content = "original",
+                    userDate = Instant.fromEpochMilliseconds(clampedUserDate),
+                    modified = null,
+                    created = Instant.fromEpochMilliseconds(clampedUserDate),
+                    originalAuthor = OdinId(fixture.testDomain),
+                    sender = OdinId(fixture.testDomain),
+                    displayName = fixture.testDomain,
+                    isDeleted = false,
+                    isPendingSend = false,
+                    versionTag = versionTag,
+                    messageAppData = MessageAppData(),
+                    reactionPreview = null,
+                    previewThumbnail = null,
+                    payloads = persistentListOf(),
+                    keyHeader = keyHeader,
+                    hasMore = false,
+                    messageContent = null,
+                )
+            )
+
+            service.updateMessage(
+                messageId = messageId,
+                versionTag = versionTag,
+                content = "edited",
+            )
+
+            val rows = fixture.drainOutboxInDependencyOrder()
+            val updateRow = rows.mapNotNull { it.asUpdateFileRequestOrNull() }.firstOrNull()
+            assertNotNull(updateRow, "an UpdateFileByUniqueIdRequest must be enqueued after updateMessage")
+            assertEquals(
+                originalUserDate,
+                updateRow.metadata.appData.userDate,
+                "the enqueued edit must keep the original un-clamped userDate (#900)",
+            )
+
+            val storedUserDate = fixture.dbm.driveMainIndex
+                .selectHomebaseFileByUnique(fixture.testIdentityId, fixture.chatDriveId, messageId)
+                ?.fileMetadata?.appData?.userDate
+            assertEquals(
+                originalUserDate,
+                storedUserDate,
+                "the optimistic write must keep the SQL userDate invariant across an edit (#900)",
+            )
+        }
+    }
+
+    /**
+     * Same #900 invariant on the pending-create coalesce branch: editing a
+     * message whose create is still queued must not re-stamp the create's
+     * `appData.userDate` from the clamped model value.
+     */
+    @Test
+    fun `updateMessage coalescing into a pending create preserves the original userDate`() = runTest {
+        val messageLookup = SeedableMessageLookup()
+
+        ChatMessageSenderServiceTestFixture().use { fixture ->
+            val service = fixture.build(
+                messageLookup = { _: DatabaseManager -> messageLookup },
+            )
+            messageLookup.backFilesWith(fixture)
+
+            val conversationId = fixture.seedConversation(others = listOf("bob.test"))
+            val messageId = Uuid.random()
+            val versionTag = Uuid.random()
+            val keyHeader = KeyHeader.newRandom16()
+            val originalUserDate = 2_000L
+            val clampedUserDate = 1_000L
+
+            // 1. Send with an explicit userDate but DON'T drain — the create stays
+            //    pending in the outbox, so updateMessage takes the coalesce path.
+            service.sendNewMessage(
+                messageUniqueId = messageId,
+                conversationId = conversationId,
+                messageText = "original",
+                previousMessageUniqueId = null,
+                payloadBundle = null,
+                userDate = UnixTimeUtc(originalUserDate),
+            )
+
+            // 2. The model the edit reads carries the clamped (lower) display value.
+            messageLookup.seed(
+                MessageUiModel(
+                    id = messageId,
+                    globalTransitId = null,
+                    fileId = Uuid.random(),
+                    conversationId = conversationId,
+                    content = "original",
+                    userDate = Instant.fromEpochMilliseconds(clampedUserDate),
+                    modified = null,
+                    created = Instant.fromEpochMilliseconds(clampedUserDate),
+                    originalAuthor = OdinId(fixture.testDomain),
+                    sender = OdinId(fixture.testDomain),
+                    displayName = fixture.testDomain,
+                    isDeleted = false,
+                    isPendingSend = true,
+                    versionTag = versionTag,
+                    messageAppData = MessageAppData(),
+                    reactionPreview = null,
+                    previewThumbnail = null,
+                    payloads = persistentListOf(),
+                    keyHeader = keyHeader,
+                    hasMore = false,
+                    messageContent = null,
+                )
+            )
+
+            // 3. Edit → coalesce into the pending create.
+            service.updateMessage(
+                messageId = messageId,
+                versionTag = versionTag,
+                content = "edited",
+            )
+
+            // 4. Both the amended create in the outbox and the optimistic DB row
+            //    must keep the original userDate.
+            val rows = fixture.drainOutboxInDependencyOrder()
+            val createRow = rows
+                .mapNotNull { it.asUploadFileRequestOrNull() }
+                .firstOrNull { it.metadata.appData.uniqueId == messageId }
+            assertNotNull(createRow, "the amended create must still be in the outbox")
+            assertEquals(
+                originalUserDate,
+                createRow.metadata.appData.userDate,
+                "the coalesced create must keep the original un-clamped userDate (#900)",
+            )
+
+            val storedUserDate = fixture.dbm.driveMainIndex
+                .selectHomebaseFileByUnique(fixture.testIdentityId, fixture.chatDriveId, messageId)
+                ?.fileMetadata?.appData?.userDate
+            assertEquals(
+                originalUserDate,
+                storedUserDate,
+                "the optimistic write must keep the SQL userDate invariant across a coalesced edit (#900)",
+            )
         }
     }
 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationMessageBumpTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationMessageBumpTest.kt
@@ -315,6 +315,52 @@ class ConversationMessageBumpTest {
     }
 
     /**
+     * The #900 preview-refresh contract. Editing the latest message must not
+     * move its `userDate` (the sender fix keeps the original un-clamped value),
+     * so the edit re-emits over the WS with the SAME `userDate` and new
+     * content. The `==` branch must refresh the denormalised preview text —
+     * without bumping unread or advancing the conversation timestamp.
+     */
+    @Test
+    fun editOfLastMessage_sameUserDate_refreshesPreviewText_withoutBumpingUnread() {
+        val userDateMs = 1_777_000_000_000L
+
+        // A peer message arrives and becomes the last message (unread 0→1).
+        val arrival = applyIncomingMessageBump(
+            items = listOf(convo(unread = 0)),
+            targetConversationId = convoId,
+            m = message(author = alice, userDateMs = userDateMs, content = "original"),
+            sqlUserDate = Instant.fromEpochMilliseconds(userDateMs),
+            activeDomain = me,
+        )
+        assertNotNull(arrival)
+        assertEquals("original", arrival.first().lastMessage)
+        assertEquals(1, arrival.first().unreadCount)
+
+        // The message is edited: same userDate, new content, isEdited = true.
+        val afterEdit = applyIncomingMessageBump(
+            items = arrival,
+            targetConversationId = convoId,
+            m = message(author = alice, userDateMs = userDateMs, content = "edited", isEdited = true),
+            sqlUserDate = Instant.fromEpochMilliseconds(userDateMs),
+            activeDomain = me,
+        )
+
+        assertNotNull(
+            afterEdit,
+            "a same-userDate edit re-emit must refresh the list preview",
+        )
+        val convo = afterEdit.first()
+        assertEquals("edited", convo.lastMessage, "list preview must show the edited text")
+        assertEquals(1, convo.unreadCount, "an edit re-emit must not bump unread")
+        assertEquals(
+            userDateMs,
+            convo.latestMessageTimestamp.toEpochMilliseconds(),
+            "an edit re-emit must not advance the conversation timestamp",
+        )
+    }
+
+    /**
      * Full reaction-echo lifecycle: a peer message arrives (bump 0→1),
      * then several reaction echoes arrive carrying the same userDate
      * (because reactions don't advance userDate). Unread count must


### PR DESCRIPTION
Fixes #900 — editing the latest message blanked that conversation's preview in the overview.

## Root cause

A send/edit **userDate asymmetry**. Send stamps `appData.userDate = now()` un-clamped, but `updateMessage` re-stamped it from `MessageUiModel.userDate`, which is **clamped for display** (`minOf(rawUserDate, authorSpecificDate)` in `MessageMapper.mapToMessageData`). An edit could therefore write back a *lower* `appData.userDate` than the SQL `DriveMainIndex.userDate`.

The conversation-list preview is a denormalized mirror seeded with a blank `" "` placeholder and the persisted (higher) `latestMessageTimestamp`. Both refresh paths — `ConversationUiModel.updateWithLatestMessage` (`>=` guard) and `ConversationMessageBump.applyIncomingMessageBump` (`>` / `==` guards) — rejected the edit re-emit whose userDate went backwards, so the blank placeholder stuck.

## Fix

An edit must not move `userDate` — the message keeps its place and timestamp; `modified`/`updated` already reflects the edit time.

- `updateMessage` reads the original un-clamped `appData.userDate` off the header file (`getMessageFile`) and stamps it on **both** branches (normal update + pending-create coalesce).
- `resendAsCreate` / `resendAsUpdate` had the same bug shape (a retried edit would re-lower userDate) and get the same treatment — they already had the `HomebaseFile` in scope.
- Deliberately verbatim `fileMetadata.appData.userDate`, **not** `sqlUserDateMs()`: for legacy null-userDate rows, `sqlUserDateMs()` would materialize the author's local `created.ms` onto the wire and move the *recipient's* SQL userDate backwards — the exact failure shape being fixed. Null falls back to the previous behavior.

Write-through is safe: the `DriveMainIndex` upsert guard keys solely on `excluded.modified > modified` (no userDate term), and both the optimistic write (`updated + 1 ms`) and the later server echo advance `modified`. With userDate frozen, the edit re-emit lands in the bump's same-userDate branch, which refreshes the preview text without bumping unread or reordering.

Guards are untouched — no change to reaction-echo / unread-badge semantics. Fix-forward only: rows corrupted by pre-fix edits self-heal when the next message arrives in that conversation.

## Tests

- `ChatMessageSenderServiceUpdateMessageTest`: two new regression tests (normal + coalesce branch), confirmed RED first (`expected:<2000> but was:<1000>`), asserting both the enqueued request and the optimistic DB row keep the original userDate. `SeedableMessageLookup.getMessageFile` is now backed by the fixture's real DriveMainIndex.
- `ConversationMessageBumpTest.editOfLastMessage_sameUserDate_refreshesPreviewText_withoutBumpingUnread`: pins the `==`-branch preview-refresh contract the fix relies on.
- Full `homebase-chat:jvmTest` + JVM/Android/wasmJs compile checks green.

Manual repro note: the clamp only bites when `appData.userDate > created/transitCreated` — easiest to force by setting the sender's clock ~1 min ahead of the server before sending, then send two messages and edit the last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5wCAsfXWz54JDjdcwT6bL