### PR TITLE
fix(chat): remove blank line above desktop rich-text toolbar (#1039)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
@@ -626,7 +626,6 @@ fun MessageTextFieldCompact(
         ) {
             Column {
                 if (isDesktopOrWeb()) {
-                    Spacer(modifier = Modifier.height(8.dp))
                     RichTextEditorButtons(
                         modifier = Modifier.fillMaxWidth(),
                         state = state,


### PR DESCRIPTION
Fixes #1039

## Problem
The Desktop/Web chat composer showed an empty blank line between the expand chevron and the rich-text formatting toolbar.

## Cause
`MessageTextFieldCompact` rendered a hardcoded `Spacer(Modifier.height(8.dp))` directly above `RichTextEditorButtons` (desktop/web only). The expanded editor (`MessageTextFieldExpanded`) already renders the toolbar flush with no such spacer.

## Fix
Remove the spacer so the compact composer's toolbar sits flush, matching the expanded editor. One-line change; `Spacer`/`height` remain used elsewhere in the file.

## Verification
Desktop app built and launched from this branch. Visual eyeball of the composer is best done by a human (couldn't screencapture programmatically — macOS Screen Recording permission).

🤖 Generated with [Claude Code](https://claude.com/claude-code)