### PR TITLE
fix(auth): open sign-up in an in-app browser on iOS (#1054)

### DIFF
--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginScreen.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.ui.platform.LocalClipboardManager
@@ -52,7 +53,9 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.api.util.cleanDomain
+import id.homebase.api.isIos
 import id.homebase.core.auth.BrowserLauncher
+import id.homebase.core.util.InAppBrowser
 import id.homebase.core.ui.assets.Homebase
 import id.homebase.core.ui.assets.HomebaseIcons
 import id.homebase.core.ui.auth.rememberAuthBrowserLauncher
@@ -135,8 +138,16 @@ fun LoginScreen(
             }
 
             is LoginUiEvent.OpenUrl -> {
+                // On iOS launchAuthBrowser is a no-op, so the sign-up URL is silently dropped
+                // (#1054). Open it in an in-app SFSafariViewController — no ASWebAuthenticationSession
+                // "…Sign In" consent prompt, which is wrong for sign-up. Other platforms open it
+                // directly. Consume only after the open is issued, never before.
+                if (isIos()) {
+                    InAppBrowser.open(uiEvent.url)
+                } else {
+                    launchAuthBrowser(uiEvent.url)
+                }
                 viewModel.eventConsumed()
-                launchAuthBrowser(uiEvent.url)
             }
 
             is LoginUiEvent.OpenAuthUrl -> {
@@ -452,7 +463,15 @@ private fun LoginForm(
         mutableStateOf(TextFieldValue(homebaseId, selection = TextRange(homebaseId.length)))
     }
 
-    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+    // Focus the ID field once on first entry — not on every re-entry/recomposition, which kept
+    // re-popping the keyboard (#1054).
+    var didFocus by rememberSaveable { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        if (!didFocus) {
+            focusRequester.requestFocus()
+            didFocus = true
+        }
+    }
 
     Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
         Text(

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/util/InAppBrowser.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/util/InAppBrowser.android.kt
@@ -1,0 +1,6 @@
+package id.homebase.core.util
+
+// iOS-only. Android opens URLs in-app via rememberAuthBrowserLauncher (Custom Tabs) in the UI layer.
+actual object InAppBrowser {
+    actual fun open(url: String) {}
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/util/InAppBrowser.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/util/InAppBrowser.kt
@@ -1,0 +1,13 @@
+package id.homebase.core.util
+
+/**
+ * Opens a URL in an in-app browser, keeping the user inside the app.
+ *
+ * iOS spawns the system SFSafariViewController — a real in-app browser with no
+ * ASWebAuthenticationSession "…Wants to Use…to Sign In" consent prompt (wrong for a sign-up
+ * flow). Other targets already open URLs in-app via [id.homebase.core.ui.auth.rememberAuthBrowserLauncher]
+ * in the UI layer, so only iOS needs this and their actual is a no-op.
+ */
+expect object InAppBrowser {
+    fun open(url: String)
+}

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/util/InAppBrowser.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/util/InAppBrowser.jvm.kt
@@ -1,0 +1,6 @@
+package id.homebase.core.util
+
+// iOS-only. Desktop opens URLs via rememberAuthBrowserLauncher (system browser) in the UI layer.
+actual object InAppBrowser {
+    actual fun open(url: String) {}
+}

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/InAppBrowser.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/InAppBrowser.native.kt
@@ -1,0 +1,21 @@
+package id.homebase.core.util
+
+import platform.Foundation.NSURL
+import platform.SafariServices.SFSafariViewController
+import platform.UIKit.UIApplication
+
+actual object InAppBrowser {
+    actual fun open(url: String) {
+        val nsUrl = NSURL.URLWithString(url) ?: return
+        var presenter = UIApplication.sharedApplication.keyWindow?.rootViewController ?: return
+        // Present from the topmost VC so an already-presented sheet doesn't swallow the call.
+        while (presenter.presentedViewController != null) {
+            presenter = presenter.presentedViewController!!
+        }
+        presenter.presentViewController(
+            SFSafariViewController(uRL = nsUrl),
+            animated = true,
+            completion = null,
+        )
+    }
+}

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/util/InAppBrowser.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/util/InAppBrowser.web.kt
@@ -1,0 +1,6 @@
+package id.homebase.core.util
+
+// iOS-only. Web opens URLs via rememberAuthBrowserLauncher (window.open) in the UI layer.
+actual object InAppBrowser {
+    actual fun open(url: String) {}
+}


### PR DESCRIPTION
Fixes #1054.

## Problem
On iOS, tapping **Create account** on the login screen did nothing. `rememberAuthBrowserLauncher`'s iOS actual is a no-op, so the sign-up URL (`homebase.id/sign-up`) was silently dropped — blocking new-user onboarding. Two secondary annoyances in the same report: the keyboard re-popped on every re-entry, and an untranslated error string.

## Fix
- **In-app browser on iOS.** Route `LoginUiEvent.OpenUrl` through a new `InAppBrowser` util. Its iOS actual presents an `SFSafariViewController` from the topmost view controller — a real in-app browser with **no `ASWebAuthenticationSession` "…Wants to Use…to Sign In" consent prompt** (that prompt is wrong for a sign-up action). Non-iOS platforms already open the URL in-app via `rememberAuthBrowserLauncher`, so their actuals are no-ops.
- **Keyboard re-pop.** Guard the ID field's auto-focus `LaunchedEffect` behind a `rememberSaveable` flag so it fires once on first entry, not on every re-entry/recomposition.

The Danish `login_error_invalid_id` string from the report was already shipped by #1057, so it's not included here.

## Files
- `homebase-auth/.../login/LoginScreen.kt` — iOS `OpenUrl` → `InAppBrowser.open()`; auto-focus guard
- `homebase-common/.../core/util/InAppBrowser.kt` (+ 4 platform actuals: iOS `SFSafariViewController`, Android/JVM/Web no-op)

## Verification
- KMP compile green across iOS Simulator ARM64, JVM, Android, WasmJs
- Full iOS app `xcodebuild` — **BUILD SUCCEEDED**
- Device-verified on iPhone 17 Pro simulator:
  - Create account → SFSafariViewController opens with `homebase.id/sign-up` in-app
  - **No "Wants to Use…to Sign In" consent dialog**
  - Close returns cleanly to the native login screen
  - Keyboard does not re-pop on return

🤖 Generated with [Claude Code](https://claude.com/claude-code)