### PR TITLE
fix(location): rename setup menu to "Settings" + title to "Location Settings" (#1061)

### DIFF
--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -1287,6 +1287,7 @@
     <!-- Location add-on -->
     <string name="location_label">Lokation</string>
     <string name="location_dashboard_title">Lokations-dashboard</string>
+    <string name="location_settings_title">Lokationsindstillinger</string>
     <string name="location_home_subtitle">Din private lokationshistorik</string>
     <string name="location_onboarding_title">Dine steder, kun dine</string>
     <string name="location_onboarding_body_1">Lokation fører en privat, krypteret historik over, hvor du har været — gemt på dit eget drev og kun synlig for dig.</string>
@@ -1316,7 +1317,7 @@
     <string name="location_status_never">Aldrig</string>
     <string name="location_menu_more">Flere muligheder</string>
     <string name="location_menu_find_device">Find enhed</string>
-    <string name="location_menu_setup">Lokationsopsætning</string>
+    <string name="location_menu_setup">Indstillinger</string>
     <string name="location_menu_dashboard">Dashboard</string>
     <string name="location_dashboard_history_section">Lokationshistorik</string>
     <string name="location_devices_section">Find min enhed</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1287,6 +1287,7 @@
     <!-- Location add-on -->
     <string name="location_label">Location</string>
     <string name="location_dashboard_title">Location Dashboard</string>
+    <string name="location_settings_title">Location Settings</string>
     <string name="location_home_subtitle">Your private location history</string>
     <string name="location_onboarding_title">Your places, only yours</string>
     <string name="location_onboarding_body_1">Location keeps a private, encrypted history of where you've been — stored on your own drive, visible to no one but you.</string>
@@ -1316,7 +1317,7 @@
     <string name="location_status_never">Never</string>
     <string name="location_menu_more">More options</string>
     <string name="location_menu_find_device">Find device</string>
-    <string name="location_menu_setup">Location setup</string>
+    <string name="location_menu_setup">Settings</string>
     <string name="location_menu_dashboard">Dashboard</string>
     <string name="location_dashboard_history_section">Location History</string>
     <string name="location_devices_section">Find my device</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
@@ -37,11 +37,11 @@ import id.homebase.api.client.location.LocationPreviewProvider
 import id.homebase.core.util.getUriHandler
 import id.homebase.resources.location_dashboard_title
 import id.homebase.resources.location_history_title
-import id.homebase.resources.location_label
 import id.homebase.resources.location_menu_dashboard
 import id.homebase.resources.location_menu_find_device
 import id.homebase.resources.location_menu_more
 import id.homebase.resources.location_menu_setup
+import id.homebase.resources.location_settings_title
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import kotlin.time.Clock
@@ -201,7 +201,7 @@ fun LocationScreen(
                     Text(
                         stringResource(
                             if (showDashboard) MR.string.location_dashboard_title
-                            else MR.string.location_label,
+                            else MR.string.location_settings_title,
                         ),
                     )
                 },


### PR DESCRIPTION
Closes #1061.

Two small label changes on the Location screen:

1. **Overflow menu** — `location_menu_setup` "Location setup" → **"Settings"** (drops the redundant "Location" prefix; we're already in Location).
2. **Settings/setup screen title** — the `else` branch of the top-bar title switch now uses a new **`location_settings_title` = "Location Settings"** instead of `location_label` ("Location").

`location_label` is unchanged (still used for nav/labels). Danish added for both new/changed strings.

## Verification
- `./gradlew :homebase-core:compileKotlinJvm` — BUILD SUCCESSFUL.
- Pure string/label change; behaviour verifiable from the diff (menu toggle + title switch untouched otherwise).

## Acceptance criteria
- [x] Overflow menu shows "Settings" (not "Location setup").
- [x] Settings/setup screen title reads "Location Settings" (not "Location").
- [x] `location_label` unchanged; new title string localized (Danish added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)