### PR TITLE
fix(notifications): disable Reply action on chat pushes until fixed (#1048)

### DIFF
--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/notifications/RichNotificationDisplayer.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/notifications/RichNotificationDisplayer.android.kt
@@ -174,31 +174,33 @@ actual class RichNotificationDisplayer actual constructor() {
     ) {
         val conversationId = data.conversationId ?: return
 
-        // Direct Reply action
-        val remoteInput = RemoteInput.Builder(EXTRA_REPLY_TEXT)
-            .setLabel("Reply")
-            .build()
+        // Direct Reply action — dormant until REPLY_FROM_NOTIFICATION_ENABLED (#1048).
+        if (REPLY_FROM_NOTIFICATION_ENABLED) {
+            val remoteInput = RemoteInput.Builder(EXTRA_REPLY_TEXT)
+                .setLabel("Reply")
+                .build()
 
-        val replyIntent = Intent(ACTION_REPLY).apply {
-            setPackage(context.packageName)
-            putExtra(EXTRA_CONVERSATION_ID, conversationId)
-            putExtra(EXTRA_NOTIFICATION_ID, data.notificationId)
+            val replyIntent = Intent(ACTION_REPLY).apply {
+                setPackage(context.packageName)
+                putExtra(EXTRA_CONVERSATION_ID, conversationId)
+                putExtra(EXTRA_NOTIFICATION_ID, data.notificationId)
+            }
+            val replyPendingIntent = PendingIntent.getBroadcast(
+                context,
+                conversationId.hashCode(),
+                replyIntent,
+                PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            )
+            val replyAction = NotificationCompat.Action.Builder(
+                android.R.drawable.ic_menu_send, "Reply", replyPendingIntent
+            )
+                .addRemoteInput(remoteInput)
+                .setSemanticAction(NotificationCompat.Action.SEMANTIC_ACTION_REPLY)
+                .setShowsUserInterface(false)
+                .build()
+
+            builder.addAction(replyAction)
         }
-        val replyPendingIntent = PendingIntent.getBroadcast(
-            context,
-            conversationId.hashCode(),
-            replyIntent,
-            PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-        )
-        val replyAction = NotificationCompat.Action.Builder(
-            android.R.drawable.ic_menu_send, "Reply", replyPendingIntent
-        )
-            .addRemoteInput(remoteInput)
-            .setSemanticAction(NotificationCompat.Action.SEMANTIC_ACTION_REPLY)
-            .setShowsUserInterface(false)
-            .build()
-
-        builder.addAction(replyAction)
 
         // Mark as Read only when the notification carries real content (#983) —
         // you can't sensibly mark-as-read a "You have a new message" placeholder.
@@ -226,6 +228,14 @@ actual class RichNotificationDisplayer actual constructor() {
     }
 
     companion object {
+        /**
+         * Reply-from-notification is disabled until the flow is hardened (#1048): the send can
+         * silently fail from a cold/headless BroadcastReceiver wake, and replying blind to the
+         * content-less "You have a new message" push (#859) is nonsensical. Flip to `true` to
+         * re-enable once those land. The receiver ([NotificationReplyReceiver]) is kept dormant.
+         */
+        const val REPLY_FROM_NOTIFICATION_ENABLED = false
+
         const val ACTION_REPLY = "id.homebase.feed.NOTIFICATION_REPLY"
         const val ACTION_MARK_READ = "id.homebase.feed.NOTIFICATION_MARK_READ"
         const val EXTRA_CONVERSATION_ID = "conversation_id"

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -53,6 +53,12 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
   }
 
   private func registerNotificationCategories() {
+      // Reply-from-notification is disabled until the flow is hardened and pushes show real
+      // content (#1048 / #859): the send can silently fail, and replying blind to the
+      // content-less "You have a new message" push is nonsensical. Flip to re-enable; the
+      // action stays defined (dormant).
+      let replyFromNotificationEnabled = false
+
       let replyAction = UNTextInputNotificationAction(
           identifier: "REPLY_ACTION",
           title: "Reply",
@@ -66,16 +72,17 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
       )
       let messageCategory = UNNotificationCategory(
           identifier: "MESSAGE_CATEGORY",
-          actions: [replyAction, markReadAction],
+          actions: replyFromNotificationEnabled ? [replyAction, markReadAction] : [markReadAction],
           intentIdentifiers: [],
           options: []
       )
       // Reply-only category for content-less pushes ("You have a new message"
       // placeholder) — no Mark as Read when there's nothing to read (#983).
-      // The extension picks between the two categories.
+      // The extension picks between the two categories. With reply disabled this
+      // carries no actions.
       let messageNoContentCategory = UNNotificationCategory(
           identifier: "MESSAGE_NO_CONTENT_CATEGORY",
-          actions: [replyAction],
+          actions: replyFromNotificationEnabled ? [replyAction] : [],
           intentIdentifiers: [],
           options: []
       )


### PR DESCRIPTION
Closes #1048.

Removes the **Reply** action from chat push notifications on **both platforms**, unconditionally (feature-off — not gated on any user/content setting), until the reply flow is hardened and notifications show real content. Two reasons: the send can silently fail from a cold/headless `BroadcastReceiver` wake (`NotificationReplyReceiver` — send on a bare `CoroutineScope(IO).launch` in a `goAsync()` window, no auth/DB guarantee, failure only logged), and replying blind to the content-less "You have a new message" push (#859) is nonsensical.

## Change
- **Android** (`RichNotificationDisplayer.android.kt`): gate the reply `Action` behind a new `REPLY_FROM_NOTIFICATION_ENABLED = false`. The action-build code and `NotificationReplyReceiver` stay **dormant** — re-enable is flipping one const.
- **iOS** (`iOSApp.swift`): a matching `replyFromNotificationEnabled = false` drops the reply action from `MESSAGE_CATEGORY` (now Mark-as-Read only) and empties `MESSAGE_NO_CONTENT_CATEGORY`; `replyAction` stays defined (dormant).

**Mark-as-Read (#983) is unchanged.** Re-enable criteria are documented in-code (reliable cold-process send + surfaced failure + real content via #859).

## Verification
- `:homebase-common:compileAndroidMain` — BUILD SUCCESSFUL.
- iOS change is a category-registration ternary (`replyAction` stays referenced; `[]`/`[markReadAction]` both infer `[UNNotificationAction]`) — provably correct; CI's iOS build compiles it. On-device push check recommended before merge.

## Acceptance criteria
- [x] No "Reply" action on chat pushes on Android or iOS.
- [x] Unconditional (feature-off), not gated on a user/content setting.
- [x] Mark-as-Read behaviour from #983 unchanged.
- [x] Receiver/handler + action code retained (dormant) for a clean one-line re-enable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)