### PR TITLE
fix(clipboard): paste Finder/Explorer-copied image files on Desktop (#1046)

### DIFF
--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/clipboard/ClipboardImageReader.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/clipboard/ClipboardImageReader.jvm.kt
@@ -6,8 +6,12 @@ import java.awt.datatransfer.Clipboard
 import java.awt.datatransfer.DataFlavor
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
+import java.io.File
 import java.io.InputStream
 import javax.imageio.ImageIO
+
+private val imageFileExtensions =
+    setOf("png", "jpg", "jpeg", "gif", "webp", "bmp", "heic", "heif")
 
 actual fun getImageFromClipboard(): ByteArray? =
     readImageFromClipboard(Toolkit.getDefaultToolkit().systemClipboard)
@@ -28,7 +32,12 @@ internal fun readImageFromClipboard(clipboard: Clipboard): ByteArray? {
         readRawImageBytes(clipboard, "image/gif")?.let { return it }
         readRawImageBytes(clipboard, "image/png")?.let { return it }
 
-        // 2. Fall back to the decoded image flavor, re-encoded as PNG. This covers
+        // 2. A copied image FILE (e.g. from Finder/Explorer) exposes javaFileListFlavor,
+        //    not an image flavor — the reader used to return null for it. Read the file's
+        //    bytes directly, preserving the original encoding like the raw-byte path above.
+        readImageFileBytes(clipboard)?.let { return it }
+
+        // 3. Fall back to the decoded image flavor, re-encoded as PNG. This covers
         //    in-memory bitmaps (e.g. a screenshot) that expose no raw byte flavor.
         if (!clipboard.isDataFlavorAvailable(DataFlavor.imageFlavor)) return null
         val image = clipboard.getData(DataFlavor.imageFlavor) as? Image ?: return null
@@ -65,6 +74,25 @@ private fun readRawImageBytes(clipboard: Clipboard, mimeType: String): ByteArray
         if (!clipboard.isDataFlavorAvailable(flavor)) return null
         val data = clipboard.getData(flavor) as? InputStream ?: return null
         data.use { it.readBytes() }.takeIf { it.isNotEmpty() }
+    } catch (_: Exception) {
+        null
+    }
+}
+
+/**
+ * Reads the first image FILE off the clipboard's [DataFlavor.javaFileListFlavor] — how an image
+ * copied from Finder/Explorer arrives (as a file reference, not image pixels). Returns the file's
+ * raw bytes so the original encoding is preserved, gated on a known image extension so a copied
+ * document isn't attached. Null when no image file is present.
+ */
+private fun readImageFileBytes(clipboard: Clipboard): ByteArray? {
+    return try {
+        if (!clipboard.isDataFlavorAvailable(DataFlavor.javaFileListFlavor)) return null
+        val files = clipboard.getData(DataFlavor.javaFileListFlavor) as? List<*> ?: return null
+        val imageFile = files.filterIsInstance<File>().firstOrNull {
+            it.isFile && it.extension.lowercase() in imageFileExtensions
+        } ?: return null
+        imageFile.readBytes().takeIf { it.isNotEmpty() }
     } catch (_: Exception) {
         null
     }

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/clipboard/ClipboardImageReaderJvmTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/clipboard/ClipboardImageReaderJvmTest.kt
@@ -3,7 +3,9 @@ package id.homebase.core.clipboard
 import java.awt.datatransfer.Clipboard
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.Transferable
+import java.awt.datatransfer.UnsupportedFlavorException
 import java.io.ByteArrayInputStream
+import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -48,5 +50,45 @@ class ClipboardImageReaderJvmTest {
     fun emptyClipboardReturnsNull() {
         val empty = Clipboard("empty")
         assertNull(readImageFromClipboard(empty))
+    }
+
+    private fun clipboardWithFiles(files: List<File>): Clipboard {
+        val transferable = object : Transferable {
+            override fun getTransferDataFlavors(): Array<DataFlavor> =
+                arrayOf(DataFlavor.javaFileListFlavor)
+            override fun isDataFlavorSupported(f: DataFlavor): Boolean =
+                f == DataFlavor.javaFileListFlavor
+            override fun getTransferData(f: DataFlavor): Any {
+                if (f != DataFlavor.javaFileListFlavor) throw UnsupportedFlavorException(f)
+                return files
+            }
+        }
+        return Clipboard("files").apply { setContents(transferable, null) }
+    }
+
+    @Test
+    fun copiedImageFileBytesAreReturnedUnmodified() {
+        // An image copied from Finder/Explorer arrives as a file reference, not pixels.
+        val png = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 1, 2, 3)
+        val tmp = File.createTempFile("clip", ".PNG").apply { writeBytes(png) }
+        try {
+            val result = readImageFromClipboard(clipboardWithFiles(listOf(tmp)))
+            assertTrue(
+                result != null && result.contentEquals(png),
+                "Expected the original file bytes back, got ${result?.size} bytes",
+            )
+        } finally {
+            tmp.delete()
+        }
+    }
+
+    @Test
+    fun copiedNonImageFileReturnsNull() {
+        val tmp = File.createTempFile("clip", ".txt").apply { writeText("not an image") }
+        try {
+            assertNull(readImageFromClipboard(clipboardWithFiles(listOf(tmp))))
+        } finally {
+            tmp.delete()
+        }
     }
 }


### PR DESCRIPTION
Partial fix for #1046.

## What
The Desktop clipboard reader (`ClipboardImageReader.jvm.kt`) handled raw image bytes (`image/gif`, `image/png`) and the decoded `imageFlavor` (screenshots/pixels), but an image **copied as a file from Finder/Explorer** arrives as `DataFlavor.javaFileListFlavor` — a file reference, not pixels — which the reader ignored and returned `null` for. So pasting a copied image *file* silently did nothing (the issue's "secondary flavor gap").

Now it reads the first image file's **raw bytes** (original encoding preserved, same as the raw-byte path), gated on a known image extension (`png/jpg/jpeg/gif/webp/bmp/heic/heif`) so a copied document isn't attached.

This is independent of the deferred #1043 macOS key-delivery issue — it fixes a real gap on **all** desktop platforms (Windows/Linux/macOS) for copied image files.

## Tests
`ClipboardImageReaderJvmTest` gains:
- copied image file → original bytes returned unmodified;
- copied non-image (`.txt`) file → `null` (not attached).

`:homebase-common:jvmTest` — green.

## Still remaining on #1046 (not in this PR)
- **Mobile paste affordance** (the main ask) — a UI trigger in the composer/attachment sheet for touch devices (no Cmd/Ctrl+V on a touchscreen), surfaced only when the clipboard holds an image.
- **Android reader** — `getImageFromClipboard()` is a `return null` stub; implement via `ClipboardManager`/`ContentResolver`. (Left out here since without the affordance trigger it'd be unreachable dead code.)
- **Web reader** — async Clipboard API (`navigator.clipboard.read()`).
- **macOS Cmd+V trigger** — tied to #1043's `onPreviewKeyEvent` key delivery.

These need on-device verification with a logged-in composer session; tracked to follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)