### PR TITLE
fix(chat): send on NumPadEnter + Cmd/Ctrl+Enter in desktop composer (#1043)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
@@ -418,12 +418,16 @@ fun MessageTextFieldExpanded(
                             (keyEvent.key == Key.V && (keyEvent.isCtrlPressed || keyEvent.isMetaPressed)))
                     ) {
                         when {
-                            keyEvent.key == Key.Enter && keyEvent.isShiftPressed -> {
+                            // Shift+Enter inserts a newline; every other Enter/NumPadEnter
+                            // (incl. Cmd/Ctrl+Enter) sends. Match NumPadEnter too — macOS can
+                            // report Return as NumPadEnter, so Key.Enter alone never fired (#1043).
+                            (keyEvent.key == Key.Enter || keyEvent.key == Key.NumPadEnter) &&
+                                keyEvent.isShiftPressed -> {
                                 state.addTextAfterSelection("\n")
                                 true
                             }
 
-                            keyEvent.key == Key.Enter -> {
+                            keyEvent.key == Key.Enter || keyEvent.key == Key.NumPadEnter -> {
                                 sendMessage()
                                 true
                             }
@@ -692,12 +696,17 @@ fun MessageTextFieldCompact(
                                             (keyEvent.key == Key.V && (keyEvent.isCtrlPressed || keyEvent.isMetaPressed)))
                                     ) {
                                         when {
-                                            keyEvent.key == Key.Enter && keyEvent.isShiftPressed -> {
+                                            // Shift+Enter inserts a newline; every other
+                                            // Enter/NumPadEnter (incl. Cmd/Ctrl+Enter) sends.
+                                            // Match NumPadEnter too — macOS can report Return as
+                                            // NumPadEnter, so Key.Enter alone never fired (#1043).
+                                            (keyEvent.key == Key.Enter || keyEvent.key == Key.NumPadEnter) &&
+                                                keyEvent.isShiftPressed -> {
                                                 state.addTextAfterSelection("\n")
                                                 true
                                             }
 
-                                            keyEvent.key == Key.Enter -> {
+                                            keyEvent.key == Key.Enter || keyEvent.key == Key.NumPadEnter -> {
                                                 onSendMessage()
                                                 true
                                             }


### PR DESCRIPTION
Addresses #1043.

macOS Desktop couldn't send a message from the keyboard. Both composer `onPreviewKeyEvent` handlers (`MessageInputBar.kt`) matched **only** `Key.Enter`, so:
- if macOS reports Return as `Key.NumPadEnter` (or only delivers it with a modifier), the send never fired; and
- Ctrl+Enter only sent *incidentally* via the plain-`Key.Enter` case, so it broke together with plain Enter.

## Change
Both handlers now send on **`Key.Enter` OR `Key.NumPadEnter`**. Cmd/Ctrl+Enter sends via the same branch (only **Shift**+Enter is special → newline). This is **strictly additive** — Windows/Linux/web send-on-Enter is unchanged, and it implements the explicit modifier-send the issue asked for.

## Verification & honesty about the ceiling
- `:homebase-chat:compileKotlinJvm` — BUILD SUCCESSFUL (`Key.NumPadEnter` is standard Compose, commonMain).
- The issue's other candidate cause is that macOS never delivers the key to the **preview** handler at all (the RichText editor consuming Return before `onPreviewKeyEvent`). If that's what's happening, this additive change won't be sufficient and a follow-up moving interception higher (`onKeyEvent` / editor-level) is needed — but **this cannot regress** any platform and adds the requested modifier-send. **Device-verify on macOS is pending** (Compose Desktop isn't drivable by the tooling here). Shares a likely root with #1046's macOS Cmd+V paste.

## Acceptance criteria
- [x] Send on `Key.Enter` **or** `Key.NumPadEnter` (KeyDown), macOS included.
- [x] Cmd+Enter / Ctrl+Enter send (via the Enter branch; only Shift differs).
- [x] Shift+Enter still inserts a newline.
- [x] Both compact and expanded composer paths updated identically.
- [x] No regression to Windows/Linux/web (additive only).
- [ ] Root-cause confirmed by capturing the real macOS key event — device step pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)