### PR TITLE
fix(location): show every received live point — drop 30-min filter + post-auth reset race (#1072)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/livelocation/LiveLocationReceiveStore.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/livelocation/LiveLocationReceiveStore.kt
@@ -97,10 +97,12 @@ class LiveLocationReceiveStore(
     /**
      * Drop all positions (logout / new identity). The collector is NOT cancelled — it stays
      * subscribed for the app's lifetime; positions rehydrate from the server's flush-on-connect
-     * after the next login. Called in-stream on [BackendEvent.SessionEnded] and from the post-auth
-     * bootstrap for a clean slate.
+     * after the next login. Called in-stream on [BackendEvent.SessionEnded] (same coroutine as the
+     * flush, so it can't race it). [reason] is logged so a clear landing right after a
+     * `RECV-DECODED` — the fingerprint of a flush being clobbered (#1072) — is diagnosable.
      */
-    fun reset() {
+    fun reset(reason: String = "sessionEnded") {
+        logger.i { "reset(reason=$reason) clearing ${_positions.value.size} sender(s)" }
         _positions.value = emptyMap()
     }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -511,13 +511,14 @@ val appModule = module {
             // a missing promoteToForeground() can't hang the app on "syncing".
             startsHeadless = get<PlatformInfo>().supportsBackgroundWake,
             onPostAuthenticated = {
-                // Live Relay receive store: clear any prior identity's positions for a clean
-                // slate (they rehydrate from the server's flush-on-connect). Resolved FIRST and
-                // independent of the other services so its app-lifetime init{} collector is
-                // guaranteed up — a throw in a later location reset() below can't prevent the
-                // consumer from existing when relay packets arrive (bug #824). The collector is
-                // never cancelled here; logout clears it in-stream via SessionEnded.
-                get<LiveLocationReceiveStore>().reset()
+                // Live Relay receive store: resolve it FIRST and independent of the other services
+                // so its app-lifetime init{} collector is guaranteed up — a throw in a later
+                // location reset() below can't prevent the consumer from existing when relay packets
+                // arrive (bug #824). We deliberately do NOT clear it here: clearing on this (auth)
+                // coroutine raced the server's flush-on-connect populating it on the collector
+                // coroutine, wiping a just-received peer at cold reopen (#1072). Logout clears it
+                // in-stream via SessionEnded, so no clear is needed on this path.
+                get<LiveLocationReceiveStore>()
                 // Emergency-retrieved peer location history is memory-only and per-identity —
                 // clear any prior identity's retrievals (same in-stream SessionEnded backstop).
                 get<EmergencyLocateStore>().reset()

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
@@ -28,7 +28,6 @@ import id.homebase.core.ui.screens.location.devices.LocationDeviceDirectory
 import id.homebase.core.ui.screens.location.history.localDayStart
 import id.homebase.core.ui.screens.location.history.shiftDay
 import id.homebase.chat.services.livelocation.LiveLocationReceiveStore
-import id.homebase.core.ui.screens.location.livelocation.LIVE_STALE_MS
 import id.homebase.core.util.initials
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
@@ -257,9 +256,10 @@ class LocationViewModel(
                     }
                     .sortedBy { it.name.lowercase() }
 
-                // Incoming: people whose last fix is still fresh, with its age.
+                // Incoming: everyone whose last fix we've received, with its age. No staleness
+                // cutoff — the server won't flush an evicted point, so we show whatever it gave us
+                // and let the age label convey freshness (#1072).
                 val incoming = positions.values
-                    .filter { now - it.receivedAtMs <= LIVE_STALE_MS }
                     .map { lp ->
                         val id = lp.senderOdinId.domainName
                         val contact = resolveContact(lp.senderOdinId)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationUiState.kt
@@ -31,11 +31,5 @@ data class LiveLocationUiState(
     val showMapTiles: Boolean = true,
 )
 
-/**
- * A live position is shown for up to 30 minutes after receipt; past that it's dropped from the map
- * and the dashboard "Live location sharing" section. Same window for both, by design.
- */
-const val LIVE_STALE_MS: Long = 30 * 60 * 1000L
-
 /** A dot older than 2 minutes gets a small "Nm" age label beside it. Fresher dots show none. */
 const val AGE_LABEL_AFTER_MS: Long = 2 * 60 * 1000L

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/livelocation/LiveLocationViewModel.kt
@@ -2,6 +2,7 @@ package id.homebase.core.ui.screens.location.livelocation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.common.OdinId
 import id.homebase.chat.services.convo.contact.ContactService
@@ -24,9 +25,11 @@ import kotlin.time.Clock
 
 /**
  * Drives the live-location map: turns the in-memory [LiveLocationReceiveStore] into a list of
- * [LiveMarker]s (others + an optional "you"), filtering out positions older than [LIVE_STALE_MS] and
- * resolving each sender's avatar. Recomputes on every store emission and on a 30 s ticker (so dots
- * age-label and drop even with no new packets).
+ * [LiveMarker]s (others + an optional "you"), resolving each sender's avatar. Every received point
+ * is shown — the server is the source of truth for what's worth displaying (it won't flush an
+ * evicted point), so the client doesn't second-guess it with a staleness cutoff (#1072); freshness
+ * is conveyed by the [LiveMarker.ageMs] label instead. Recomputes on every store emission and on a
+ * 30 s ticker (so age labels stay current even with no new packets).
  */
 class LiveLocationViewModel(
     private val receiveStore: LiveLocationReceiveStore,
@@ -37,6 +40,8 @@ class LiveLocationViewModel(
     private val locationService: LocationService,
     private val nowMs: () -> Long = { Clock.System.now().toEpochMilliseconds() },
 ) : ViewModel() {
+
+    private val logger = Logger.withTag("LiveRelay")
 
     private val ownOdinId = MutableStateFlow<OdinId?>(null)
 
@@ -75,9 +80,13 @@ class LiveLocationViewModel(
         combine(receiveStore.positions, ownOdinId, pointStore.lastPoint, ticker) { positions, ownId, myFix, _ ->
             val now = nowMs()
             val others = positions.values
-                .filter { now - it.receivedAtMs <= LIVE_STALE_MS }
                 .map { lp ->
                     val contact = contactService.resolveByOdinId(lp.senderOdinId)
+                    // Every received sender is shown; log its age so upstream sparsity (peer stopped
+                    // transmitting) is visible in the log even though the point is no longer dropped.
+                    logger.i {
+                        "map sender=${lp.senderOdinId.domainName} ageMs=${now - lp.receivedAtMs} -> SHOW"
+                    }
                     LiveMarker(
                         key = lp.senderOdinId.domainName,
                         lat = lp.point.lat,


### PR DESCRIPTION
Fixes #1072.

## Problem

A contact's live-shared position arrives — the server flushes each sender's last-known point on WS (re)connect (confirmed: a point *was* received) — yet the live map showed only "me." The point was received into the in-memory `LiveLocationReceiveStore` and then discarded client-side by **two** mechanisms. The server is the source of truth for what's worth showing (it won't flush an evicted point, ~5 min TTL), so the client must stop second-guessing it. No local persistence — flush-on-connect is good enough.

## Changes

**A — remove the 30-min staleness filter**
- Deleted `.filter { now - it.receivedAtMs <= LIVE_STALE_MS }` in `LiveLocationViewModel` (map) and `LocationViewModel` (dashboard "incoming shares"). Every received sender is shown; freshness is conveyed by the existing `ageMs` age label instead of by deletion.
- Retired the now-dead `LIVE_STALE_MS` const; `AGE_LABEL_AFTER_MS` still drives the label.

**B — drop the post-auth `reset()` race**
- `onPostAuthenticated` cleared the store via `_positions.value = emptyMap()` on the **auth** coroutine while the flush populates it via `_positions.update {}` on the **collector** coroutine — last-writer-wins could wipe a just-received peer at cold reopen. Removed the clear; the store is still *resolved* there so its app-lifetime `init{}` collector starts (bug #824). Logout clears it in-stream via `SessionEnded`, so no clear is needed on that path.

**Diagnostics**
- `reset(reason)` now logs `clearing N sender(s)`, and the VM logs each shown sender's `ageMs`, so any future flush/clear race or upstream sparsity is diagnosable from `homebase.log`.

## Tradeoff
In-memory store is last-value-wins, cleared only on logout, so a peer who shared once and stopped could linger until overwritten or app restart. Bounded in practice; accepted by product owner. If ancient ghosts prove annoying, reintroduce a filter set to hours (not 30 min).

## Testing
- `:homebase-chat:compileKotlinJvm` + `:homebase-core:compileKotlinJvm` ✅
- `homebase-chat:jvmTest homebase-core:jvmTest --rerun-tasks` ✅ BUILD SUCCESSFUL
- Device check pending: on Android, PEER shares → background/lock → reopen map; expect PEER's dot from flush-on-connect with an age label, and no `reset(...) clearing N` right after `RECV-DECODED`.

_Out of scope: why PEER's fresh points are sometimes sparse upstream (peer device may stop transmitting when backgrounded)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)