### PR TITLE
fix(chat): sending clock (not Sent check) for stuck-outgoing last message in list (#1076)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/ConversationUiModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/ConversationUiModel.kt
@@ -34,12 +34,6 @@ data class ConversationUiModel(
     val dirty: Boolean = false,
     val avatarModel: ConversationAvatarModel,
     val lastMessageDeliveryStatus: Int? = null,
-    /**
-     * True when the last message is still sitting in the outbox (pending send) —
-     * the same [MessageUiModel.isPendingSend] signal the bubble uses. Without it
-     * the list would map [lastMessageDeliveryStatus] (which defaults to Sent) to a
-     * single check for a message that never actually sent. See issue #1076.
-     */
     val lastMessageIsPendingSend: Boolean = false,
     val lastMessageIsDeleted: Boolean = false,
     val lastMessageFirstPayload: PayloadDescriptor? = null,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/ConversationUiModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/ConversationUiModel.kt
@@ -34,6 +34,13 @@ data class ConversationUiModel(
     val dirty: Boolean = false,
     val avatarModel: ConversationAvatarModel,
     val lastMessageDeliveryStatus: Int? = null,
+    /**
+     * True when the last message is still sitting in the outbox (pending send) —
+     * the same [MessageUiModel.isPendingSend] signal the bubble uses. Without it
+     * the list would map [lastMessageDeliveryStatus] (which defaults to Sent) to a
+     * single check for a message that never actually sent. See issue #1076.
+     */
+    val lastMessageIsPendingSend: Boolean = false,
     val lastMessageIsDeleted: Boolean = false,
     val lastMessageFirstPayload: PayloadDescriptor? = null,
     val lastMessageHasMultiplePayloads: Boolean = false,
@@ -175,6 +182,7 @@ data class ConversationUiModel(
                     lastMessage = msg.content.truncateToCodePoints(40),
                     latestMessageTimestamp = candidate,
                     lastMessageDeliveryStatus = msg.messageAppData.deliveryStatus,
+                    lastMessageIsPendingSend = msg.isPendingSend,
                     lastMessageIsDeleted = msg.isDeleted,
                     lastMessageFirstPayload = msg.payloads?.firstOrNull(),
                     lastMessageHasMultiplePayloads = (msg.payloads?.size ?: 0) > 1,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMessageBump.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMessageBump.kt
@@ -88,6 +88,7 @@ internal fun applyIncomingMessageBump(
     fun ConversationUiModel.withPreviewOf() = copy(
         lastMessage = m.content.truncateToCodePoints(40),
         lastMessageDeliveryStatus = m.messageAppData.deliveryStatus,
+        lastMessageIsPendingSend = m.isPendingSend,
         lastMessageIsDeleted = m.isDeleted,
         lastMessageFirstPayload = m.payloads?.firstOrNull(),
         lastMessageHasMultiplePayloads = (m.payloads?.size ?: 0) > 1,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -590,6 +590,7 @@ class ConversationStream(
                         lastRead = UnixTimeUtc(0).toInstant(),
                         avatarModel = placeholderAvatar,
                         lastMessageDeliveryStatus = m.messageAppData.deliveryStatus,
+                        lastMessageIsPendingSend = m.isPendingSend,
                         lastMessageIsDeleted = m.isDeleted,
                         lastMessageFirstPayload = m.payloads?.firstOrNull(),
                         lastMessageHasMultiplePayloads = (m.payloads?.size ?: 0) > 1,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationItem.kt
@@ -223,7 +223,7 @@ fun ConversationItem(
                 } else if (enrichedData.conversation.lastMessageIsFromActiveUser && enrichedData.conversation.lastMessageDeliveryStatus != null) {
                     Spacer(modifier = Modifier.width(4.dp))
                     DeliveryStatus(
-                        isPendingSend = false,
+                        isPendingSend = enrichedData.conversation.lastMessageIsPendingSend,
                         deliveryStatus = enrichedData.conversation.lastMessageDeliveryStatus,
                         contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
                     )

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/data/ConversationUiModelUpdateWithLatestMessageTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/data/ConversationUiModelUpdateWithLatestMessageTest.kt
@@ -121,8 +121,6 @@ class ConversationUiModelUpdateWithLatestMessageTest {
         assertEquals(ahead, result.latestMessageTimestamp.toEpochMilliseconds())
     }
 
-    /** #1076: a last message still stuck in the outbox must carry its pending-send
-     *  flag into the list model, so the row shows the clock — not a single check. */
     @Test
     fun propagates_isPendingSend_forStuckOutgoingLastMessage() {
         val convo = convo(latestMs = 0L)

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/data/ConversationUiModelUpdateWithLatestMessageTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/data/ConversationUiModelUpdateWithLatestMessageTest.kt
@@ -52,7 +52,7 @@ class ConversationUiModelUpdateWithLatestMessageTest {
     )
 
     /** Mimics what `mapToMessageData` returns for a peer message: userDate clamped to transitCreated. */
-    private fun peerMessage(clampedUserDateMs: Long) = MessageUiModel(
+    private fun peerMessage(clampedUserDateMs: Long, isPendingSend: Boolean = false) = MessageUiModel(
         id = Uuid.random(),
         globalTransitId = null,
         fileId = Uuid.random(),
@@ -66,7 +66,7 @@ class ConversationUiModelUpdateWithLatestMessageTest {
         displayName = "alice",
         localReadTimestamp = null as UnixTimeUtc?,
         isDeleted = false,
-        isPendingSend = false,
+        isPendingSend = isPendingSend,
         versionTag = Uuid.NIL,
         messageAppData = MessageAppData(),
         reactionPreview = null,
@@ -119,5 +119,17 @@ class ConversationUiModelUpdateWithLatestMessageTest {
 
         // Equality not required; the contract is "no regression".
         assertEquals(ahead, result.latestMessageTimestamp.toEpochMilliseconds())
+    }
+
+    /** #1076: a last message still stuck in the outbox must carry its pending-send
+     *  flag into the list model, so the row shows the clock — not a single check. */
+    @Test
+    fun propagates_isPendingSend_forStuckOutgoingLastMessage() {
+        val convo = convo(latestMs = 0L)
+        val pending = peerMessage(clampedUserDateMs = 1_776_843_935_755L, isPendingSend = true)
+
+        val result = convo.updateWithLatestMessage(msg = pending, activeUserDomain = me)
+
+        assertEquals(true, result.lastMessageIsPendingSend)
     }
 }


### PR DESCRIPTION
Closes #1076.

## Problem

On a spotty network, a 1:1 message stuck in the outbox (never sent) showed a **single check (Sent)** in the conversation-list row. The row hardcoded `isPendingSend = false` and rendered the tick purely from `lastMessageDeliveryStatus` — which **defaults to Sent** (`MessageAppData.deliveryStatus`). The bubble and message-info screen get this right because they read `MessageUiModel.isPendingSend`; the list model carried no such flag.

## Fix

Give the list the same pending-send signal the bubble uses:

- Add `lastMessageIsPendingSend: Boolean` to `ConversationUiModel`, set from `MessageUiModel.isPendingSend` at all three preview-write sites — cold-load enrichment (`updateWithLatestMessage`), live arrival (`applyIncomingMessageBump.withPreviewOf`), and the orphan placeholder in `ConversationStream` — right next to `lastMessageDeliveryStatus`.
- Pass it into `DeliveryStatus(isPendingSend = …)` in `ConversationItem`, replacing the hardcoded `false`.

The flag is written in the same statement as `lastMessageDeliveryStatus` everywhere, so the two stay coupled. The `sqlUserDate == existing.latestMessageTimestamp` re-emit branch in `applyIncomingMessageBump` already refreshes the preview on a delivery-status change, so **the clock self-clears to a check once the send settles** — no stale-clock risk.

## Verification

- `:homebase-chat:compileKotlinJvm` + `:homebase-chat:compileAndroidMain` — BUILD SUCCESSFUL.
- `:homebase-chat:jvmTest` green, including a new regression case `propagates_isPendingSend_forStuckOutgoingLastMessage` in `ConversationUiModelUpdateWithLatestMessageTest`.
- Device repro (send under airplane/slow wifi so the message stays in the outbox, then view the list) recommended before merge.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)