### PR TITLE
fix(location): route hour-file to create when it lacks a usable versionTag (#1077)

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationTrackUploaderService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationTrackUploaderService.kt
@@ -272,7 +272,14 @@ class LocationTrackUploaderService(
         val (headerJson, stored) = LocationTrackCodec.encodeHeader(deviceId.value, hourStartMs, points)
         val overflow = stored.size < points.size
 
-        val existing = findExistingFile(uid)
+        // Only treat the file as updatable when it carries a usable versionTag. A local index row
+        // can exist for an hour whose CREATE never landed server-side (offline): it has no
+        // versionTag until the server assigns one on a successful create. Updating such a file
+        // would send a null tag → 400 MissingVersionTag → outbox drop → re-flush into the same
+        // failing update forever (#1077). Nulling it here routes to create (coalesces via
+        // replace=true; self-heals to an update via DriveOutboxUploader.retryAsUpdate if it does
+        // exist server-side).
+        val existing = findExistingFile(uid)?.takeIf { isUsableVersionTag(it.fileMetadata.versionTag) }
         val enqueued = if (existing == null) {
             enqueueCreate(uid, hourStartMs, headerJson, if (overflow) points else null)
         } else {
@@ -614,6 +621,13 @@ internal enum class HourFlushOutcome {
  */
 internal fun shouldKickDrain(outcomes: List<HourFlushOutcome>): Boolean =
     outcomes.any { it == HourFlushOutcome.Enqueued || it == HourFlushOutcome.Refused }
+
+/**
+ * Whether [tag] can back a file *update*: present and not the all-zero placeholder. A local index
+ * row whose CREATE never landed server-side carries no versionTag; updating it sends a null tag →
+ * 400 MissingVersionTag → a permanent-drop/re-flush loop (#1077). Such a file is routed to create.
+ */
+internal fun isUsableVersionTag(tag: Uuid?): Boolean = tag != null && tag != Uuid.NIL
 
 /** What an outbox event means for the location point buffer. */
 internal enum class BufferAction {

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/LocationVersionTagGateTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/LocationVersionTagGateTest.kt
@@ -1,0 +1,32 @@
+package id.homebase.core.ui.screens.location
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * Locks the create-vs-update gate (#1077): an hour file is only *updatable* when it carries a
+ * usable versionTag. A local index row whose CREATE never landed server-side (offline) has none;
+ * updating it sends a null tag → 400 MissingVersionTag → permanent-drop/re-flush loop. Such a file
+ * must be routed to create instead, which converges (create coalesces via replace=true and
+ * self-heals to an update if the file does exist server-side).
+ */
+class LocationVersionTagGateTest {
+
+    @Test
+    fun nullTagIsNotUsable() {
+        // The exact bug: optimistic local row, create never landed, versionTag still null.
+        assertFalse(isUsableVersionTag(null))
+    }
+
+    @Test
+    fun allZeroPlaceholderTagIsNotUsable() {
+        assertFalse(isUsableVersionTag(Uuid.NIL))
+    }
+
+    @Test
+    fun realTagIsUsable() {
+        assertTrue(isUsableVersionTag(Uuid.random()))
+    }
+}


### PR DESCRIPTION
Fixes #1077.

## Problem

A location **hour-file update** could be sent with **no versionTag** → server **400 `MissingVersionTag`** → the outbox drops it as a permanent failure → the uploader unmarks the hour's rows to re-flush → the next flush re-issues the *same* tag-less update → **stuck hour** (repeating permanent-fail, one wasted round-trip per cycle).

## Root cause

The create-vs-update choice was `if (existing == null) create else update` (`LocationTrackUploaderService.kt`), where `existing` is a **local index row**. The create path writes an *optimistic* local row with **no versionTag** — the server assigns one only on a successful create response (written back afterward). So a create enqueued offline that never lands leaves a local row with a null tag; the next flush finds it, takes the **update** branch, and reads `existing.fileMetadata.versionTag == null`. The decision to update was decoupled from whether a usable versionTag actually exists.

## Fix

Gate the update branch on a **usable** versionTag:

```kotlin
val existing = findExistingFile(uid)?.takeIf { isUsableVersionTag(it.fileMetadata.versionTag) }
```

A tag-less local row is treated as "not yet created" and routed to `enqueueCreate`. **Self-healing:**
- File truly not on the server → the re-flushed create lands (coalesces via `replace=true`), a versionTag is written back, future flushes update correctly. **Loop broken.**
- File *does* exist server-side (create landed but local tag still null) → the create 400s `ExistingFileWithUniqueId`, which `DriveOutboxUploader.uploadNewFile` **already** routes to `retryAsUpdate` (re-fetches the header → real versionTag → updates).

New `internal fun isUsableVersionTag(tag: Uuid?)` = present and not `Uuid.NIL`.

Deliberately minimal: no changes to the outbox event/error plumbing (the source fix makes the drop handler's blind re-flush harmless — it now re-flushes a *create*), and no generic `UploadValidation` guard (would only convert a server 400 to a client 400, still a drop).

## Testing

- `:homebase-core:compileAndroidMain` + `:homebase-core:compileKotlinJvm` ✅
- `homebase-core:jvmTest` — new `LocationVersionTagGateTest` (null / `Uuid.NIL` → not usable; real UUID → usable) ✅
- Bug isn't reproducible on demand (offline race). After the fix, a stuck hour re-flushes as `mode=create` and lands/self-heals; the repeating `MissingVersionTag … DROPPING` for one `uid` stops. Repro if wanted: seed a `driveMainIndex` row for an hour uid with `versionTag = null`, flush, and confirm the enqueue is `UploadNewFile` not `UpdateFile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)