### PR TITLE
fix(startup): decouple notify socket + profile from the security-context fetch — background grant reconcile (#1079)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
@@ -114,7 +114,7 @@ class OdinWebSocketClient(
     @Volatile
     private var handshakeDone = false
 
-    private val unauthorizedDriveAliases = mutableSetOf<Uuid>()
+    private val unauthorizedDriveIds = mutableSetOf<Uuid>()
 
     private val notificationBuffer =
         mutableListOf<ClientNotificationPayload>()
@@ -787,7 +787,7 @@ class OdinWebSocketClient(
         if (match != null) {
             val alias = runCatching { Uuid.parse(match.groupValues[1]) }.getOrNull()
             if (alias != null) {
-                unauthorizedDriveAliases.add(alias)
+                unauthorizedDriveIds.add(alias)
                 Logger.w("Drive $alias excluded from future WebSocket subscriptions")
             }
         }
@@ -873,7 +873,7 @@ class OdinWebSocketClient(
      * Send EstablishConnectionRequest to server
      */
     suspend fun establishConnectionRequest() {
-        val activeDrives = drives.filter { it.alias !in unauthorizedDriveAliases }
+        val activeDrives = drives.filter { it.alias !in unauthorizedDriveIds }
         if (activeDrives.isEmpty()) {
             Logger.e("No authorized drives for WebSocket subscription")
             return

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -24,6 +24,7 @@ import id.homebase.core.avatars.AppConnectionStatus
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -35,7 +36,6 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.concurrent.Volatile
 import kotlin.uuid.Uuid
 
@@ -140,6 +140,9 @@ class AuthConnectionCoordinator(
      * hiding drives.
      */
     @Volatile private var grantedDriveIds: Set<String>? = null
+
+    // Background grant-refresh + prune (#1079); cancel-and-relaunched on foreground promotion.
+    private var grantReconcileJob: Job? = null
     // endregion
 
     /**
@@ -213,7 +216,15 @@ class AuthConnectionCoordinator(
                 // drive makes the server 403 the REST query-batch AND close the whole notify
                 // WebSocket — one unauthorized drive in EstablishConnectionRequest tears down the
                 // socket, which surfaced as a dropped initial handshake + premature "connected".
-                refreshGrantedDriveIds()
+                //
+                // The grant fetch does NOT run here anymore (#1079): it's a network call that on a
+                // bad network burned ~2.5 min and, upstream of connect()/loadProfile() in this same
+                // coroutine, stalled the socket + avatar. Optional drives ~never lose a grant, so we
+                // connect immediately with the local registry (retainGrantedDrives is a no-op while
+                // grantedDriveIds is null) and reconcile in the background — see
+                // [scheduleGrantReconcile], kicked after connect(). The rare "in registry but grant
+                // revoked" drive is pruned then (and is also self-healed reactively by the DriveSync
+                // 403 unmount + the WS unauthorizedDriveIds drop).
 
                 // Pre-mount the granted optional drives so they're in driveSyncs when
                 // onConnected fires start() + syncAll(). mountDrive() defers the network kick
@@ -260,6 +271,9 @@ class AuthConnectionCoordinator(
                     initialBaseline = initialDrives.mapTo(HashSet()) { it.drive.alias },
                 )
                 loadProfile()
+                // Resolve read grants off the critical path and prune any live drive we've lost
+                // the grant for (rare). Kicked after connect() so the WS refresh has a client.
+                scheduleGrantReconcile()
             }
             is YouAuthState.Initializing -> {
                 // ignore
@@ -330,6 +344,9 @@ class AuthConnectionCoordinator(
                 initialBaseline = drives.mapTo(HashSet()) { it.drive.alias },
             )
             loadProfile()
+            // Retry point: a cold background wake may have missed the grant fetch on a dead
+            // network; the first real foreground open re-runs it (cancel-and-relaunch) and prunes.
+            scheduleGrantReconcile()
         }
     }
 
@@ -628,27 +645,17 @@ class AuthConnectionCoordinator(
     }
 
     /**
-     * Refresh [grantedDriveIds] from the security context. Called once per Authenticated
-     * transition, before any optional drive is mounted/subscribed. On failure OR timeout it leaves
-     * the filter disabled (null) so we degrade to mounting everything rather than hiding a granted
-     * drive on a transient fetch error.
-     *
-     * The security-context GET (`/auth/context`) has no app-level retry; on a failing network its
-     * whole HttpTimeout budget (~2.5 min under OkHttp DNS-retry) would otherwise block this
-     * suspend call — and, because it runs upstream of `connect()`/`loadProfile()` in the same
-     * coroutine, the notify socket and the profile/avatar with it (#1079). Bounding the fetch with
-     * [SECURITY_CONTEXT_TIMEOUT_MS] maps a slow/dead network onto the existing null-degrade: the
-     * filter is applied before the first connect on a good network (<1s), and a bad network
-     * connects unfiltered after ~10s instead of ~2.5 min (self-healing — the WS reactively drops
-     * any drive it gets a 401/403 for and reconnects).
+     * Refresh [grantedDriveIds] from the security context. Runs in the **background** (via
+     * [scheduleGrantReconcile]), off the connect/loadProfile critical path — the security-context
+     * GET (`/auth/context`) has no app-level retry and on a failing network burns its whole
+     * HttpTimeout budget (~2.5 min under OkHttp DNS-retry), which used to stall the socket + avatar
+     * (#1079). On failure it leaves the set null (prune nothing — degrade to the local registry).
      */
     private suspend fun refreshGrantedDriveIds() {
-        val ctx = withTimeoutOrNull(SECURITY_CONTEXT_TIMEOUT_MS) {
-            securityContextProvider.getSecurityContext()
-        }
+        val ctx = securityContextProvider.getSecurityContext()
         if (ctx == null) {
             Logger.w(tag = "AuthLifecycle") {
-                "AuthCC: security context unavailable or timed out — drive-grant filter disabled this cycle"
+                "AuthCC: security context unavailable — drive-grant filter disabled this cycle"
             }
             grantedDriveIds = null
             return
@@ -659,6 +666,29 @@ class AuthConnectionCoordinator(
             .mapTo(mutableSetOf()) { normalizeDriveId(it.permissionedDrive.drive.alias) }
         grantedDriveIds = readable
         Logger.i(tag = "AuthLifecycle") { "AuthCC: readable drive grants resolved (count=${readable.size})" }
+    }
+
+    /**
+     * Resolve read grants in the background and prune any *live* optional drive we've lost the
+     * grant for. Never gates startup. Cancel-and-relaunch so a foreground reopen after a
+     * dead-network cold start retries with a fresh fetch. Pruning uses [unmountDrive] with
+     * `persist = false` — it stops DriveSync + rebuilds the WS subscription filtered, but leaves the
+     * persisted DriveRegistry intact (the drive re-mounts on a later startup if the grant returns).
+     */
+    private fun scheduleGrantReconcile() {
+        grantReconcileJob?.cancel()
+        grantReconcileJob = scope.launch {
+            refreshGrantedDriveIds()
+            val granted = grantedDriveIds ?: return@launch // grants unknown → prune nothing
+            val mandatory = mandatorySyncDrives.mapTo(HashSet()) { it.drive.alias }
+            val toPrune = drivesToPrune(driveSyncManager.driveStatuses.value.keys, mandatory, granted)
+            for (driveId in toPrune) {
+                Logger.w(tag = "AuthLifecycle") {
+                    "AuthCC: read grant revoked — pruning drive $driveId from the live session"
+                }
+                unmountDrive(driveId, persist = false)
+            }
+        }
     }
 
     /**
@@ -680,19 +710,22 @@ class AuthConnectionCoordinator(
         }
     }
 
-    // Match compareStringUuId's normalization so drive ids compare regardless of hyphen/case format.
-    private fun normalizeDriveId(driveId: String): String = driveId.lowercase().replace("-", "")
 
     companion object {
         private const val REFRESH_DEBOUNCE_MS = 500L
-
-        // Cap the security-context fetch so it can't hold the Authenticated coroutine (and with it
-        // the notify socket + profile load) for the full ~2.5 min HttpTimeout budget on a
-        // failing network (#1079). A timeout degrades to the same "filter disabled this cycle"
-        // path as a fetch failure. Generous enough to succeed on a slow-but-working network.
-        private const val SECURITY_CONTEXT_TIMEOUT_MS = 10_000L
     }
 }
+
+// Match compareStringUuId's normalization so drive ids compare regardless of hyphen/case format.
+internal fun normalizeDriveId(driveId: String): String = driveId.lowercase().replace("-", "")
+
+/**
+ * The live optional drives to prune because their read grant was revoked (#1079): [active] drives
+ * (from DriveSyncManager.driveStatuses) that are not mandatory and not in the [granted] set.
+ * Mandatory drives (chat/contacts/profile) are never pruned.
+ */
+internal fun drivesToPrune(active: Set<Uuid>, mandatory: Set<Uuid>, granted: Set<String>): List<Uuid> =
+    active.filter { it !in mandatory && normalizeDriveId(it.toString()) !in granted }
 
 @Immutable
 data class AuthConnectionState(

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.concurrent.Volatile
 import kotlin.uuid.Uuid
 
@@ -132,12 +133,13 @@ class AuthConnectionCoordinator(
     private val postAuthGate = kotlinx.coroutines.sync.Mutex()
 
     /**
-     * Normalized (lowercased, hyphen-stripped) aliases of the drives this app token can READ,
+     * Normalized (lowercased, hyphen-stripped) ids of the drives this app token can READ,
      * resolved from the security context on each Authenticated transition. Null when unknown
-     * (security-context fetch failed) — in that case [retainGrantedDrives] does not filter, so a
-     * transient fetch failure degrades to the pre-existing behaviour rather than hiding drives.
+     * (security-context fetch failed or timed out) — in that case [retainGrantedDrives] does not
+     * filter, so a transient fetch failure degrades to the pre-existing behaviour rather than
+     * hiding drives.
      */
-    @Volatile private var grantedDriveAliases: Set<String>? = null
+    @Volatile private var grantedDriveIds: Set<String>? = null
     // endregion
 
     /**
@@ -211,7 +213,7 @@ class AuthConnectionCoordinator(
                 // drive makes the server 403 the REST query-batch AND close the whole notify
                 // WebSocket — one unauthorized drive in EstablishConnectionRequest tears down the
                 // socket, which surfaced as a dropped initial handshake + premature "connected".
-                refreshGrantedDriveAliases()
+                refreshGrantedDriveIds()
 
                 // Pre-mount the granted optional drives so they're in driveSyncs when
                 // onConnected fires start() + syncAll(). mountDrive() defers the network kick
@@ -626,37 +628,48 @@ class AuthConnectionCoordinator(
     }
 
     /**
-     * Refresh [grantedDriveAliases] from the security context. Called once per Authenticated
-     * transition, before any optional drive is mounted/subscribed. On failure it leaves the
-     * filter disabled (null) so we degrade to mounting everything rather than hiding a granted
+     * Refresh [grantedDriveIds] from the security context. Called once per Authenticated
+     * transition, before any optional drive is mounted/subscribed. On failure OR timeout it leaves
+     * the filter disabled (null) so we degrade to mounting everything rather than hiding a granted
      * drive on a transient fetch error.
+     *
+     * The security-context GET (`/auth/context`) has no app-level retry; on a failing network its
+     * whole HttpTimeout budget (~2.5 min under OkHttp DNS-retry) would otherwise block this
+     * suspend call — and, because it runs upstream of `connect()`/`loadProfile()` in the same
+     * coroutine, the notify socket and the profile/avatar with it (#1079). Bounding the fetch with
+     * [SECURITY_CONTEXT_TIMEOUT_MS] maps a slow/dead network onto the existing null-degrade: the
+     * filter is applied before the first connect on a good network (<1s), and a bad network
+     * connects unfiltered after ~10s instead of ~2.5 min (self-healing — the WS reactively drops
+     * any drive it gets a 401/403 for and reconnects).
      */
-    private suspend fun refreshGrantedDriveAliases() {
-        val ctx = securityContextProvider.getSecurityContext()
+    private suspend fun refreshGrantedDriveIds() {
+        val ctx = withTimeoutOrNull(SECURITY_CONTEXT_TIMEOUT_MS) {
+            securityContextProvider.getSecurityContext()
+        }
         if (ctx == null) {
             Logger.w(tag = "AuthLifecycle") {
-                "AuthCC: security context unavailable — drive-grant filter disabled this cycle"
+                "AuthCC: security context unavailable or timed out — drive-grant filter disabled this cycle"
             }
-            grantedDriveAliases = null
+            grantedDriveIds = null
             return
         }
         val readable = ctx.permissionContext.permissionGroups
             .flatMap { it.driveGrants ?: emptyList() }
             .filter { (it.permissionedDrive.permission.sumOf { p -> p.value } and DrivePermission.Read.value) != 0 }
-            .mapTo(mutableSetOf()) { normalizeAlias(it.permissionedDrive.drive.alias) }
-        grantedDriveAliases = readable
+            .mapTo(mutableSetOf()) { normalizeDriveId(it.permissionedDrive.drive.alias) }
+        grantedDriveIds = readable
         Logger.i(tag = "AuthLifecycle") { "AuthCC: readable drive grants resolved (count=${readable.size})" }
     }
 
     /**
-     * Drop drives this app token has no read grant for (see [grantedDriveAliases]). No-op when the
+     * Drop drives this app token has no read grant for (see [grantedDriveIds]). No-op when the
      * grant set is unknown. Applied to optional/registry drives only — mandatory drives are always
      * required and are never filtered here.
      */
     private fun List<LabeledDrive>.retainGrantedDrives(): List<LabeledDrive> {
-        val granted = grantedDriveAliases ?: return this
+        val granted = grantedDriveIds ?: return this
         return filter { ld ->
-            val ok = normalizeAlias(ld.drive.alias.toString()) in granted
+            val ok = normalizeDriveId(ld.drive.alias.toString()) in granted
             if (!ok) {
                 Logger.w(tag = "AuthLifecycle") {
                     "AuthCC: skipping drive '${ld.label}' (${ld.drive.alias}) — app token has no read " +
@@ -667,11 +680,17 @@ class AuthConnectionCoordinator(
         }
     }
 
-    // Match compareStringUuId's normalization so aliases compare regardless of hyphen/case format.
-    private fun normalizeAlias(alias: String): String = alias.lowercase().replace("-", "")
+    // Match compareStringUuId's normalization so drive ids compare regardless of hyphen/case format.
+    private fun normalizeDriveId(driveId: String): String = driveId.lowercase().replace("-", "")
 
     companion object {
         private const val REFRESH_DEBOUNCE_MS = 500L
+
+        // Cap the security-context fetch so it can't hold the Authenticated coroutine (and with it
+        // the notify socket + profile load) for the full ~2.5 min HttpTimeout budget on a
+        // failing network (#1079). A timeout degrades to the same "filter disabled this cycle"
+        // path as a fetch failure. Generous enough to succeed on a slow-but-working network.
+        private const val SECURITY_CONTEXT_TIMEOUT_MS = 10_000L
     }
 }
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/DriveRegistry.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/DriveRegistry.kt
@@ -92,10 +92,10 @@ class DriveRegistry(
     private var bootstrapInFlight: CompletableDeferred<List<LabeledDrive>>? = null
 
     /**
-     * Alias-set of drives last surfaced to callers. The diff baseline for the observer.
+     * Id-set of drives last surfaced to callers. The diff baseline for the observer.
      * Guarded by [stateMutex].
      */
-    private var currentDriveAliases: Set<Uuid> = emptySet()
+    private var currentDriveIds: Set<Uuid> = emptySet()
 
     /**
      * Optional drives currently registered by this identity. Pure local-DB read — safe
@@ -274,7 +274,7 @@ class DriveRegistry(
         val baseline = initialBaseline
             ?: loadDrives().mapTo(HashSet()) { it.drive.alias }
         stateMutex.withLock {
-            currentDriveAliases = baseline
+            currentDriveIds = baseline
         }
         observerJob = scope.launch {
             eventBus.events.collect { event ->
@@ -322,7 +322,7 @@ class DriveRegistry(
         observerJob?.cancel()
         observerJob = null
         stateMutex.withLock {
-            currentDriveAliases = emptySet()
+            currentDriveIds = emptySet()
         }
     }
 
@@ -331,13 +331,13 @@ class DriveRegistry(
         onUnmount: suspend (Uuid) -> Unit,
     ) {
         val fresh = loadDrives()
-        val freshAliases = fresh.mapTo(HashSet()) { it.drive.alias }
+        val freshDriveIds = fresh.mapTo(HashSet()) { it.drive.alias }
         val added: List<LabeledDrive>
         val removed: List<Uuid>
         stateMutex.withLock {
-            added = fresh.filter { it.drive.alias !in currentDriveAliases }
-            removed = (currentDriveAliases - freshAliases).toList()
-            currentDriveAliases = freshAliases
+            added = fresh.filter { it.drive.alias !in currentDriveIds }
+            removed = (currentDriveIds - freshDriveIds).toList()
+            currentDriveIds = freshDriveIds
         }
         for (drive in added) onMount(drive)
         for (alias in removed) onUnmount(alias)

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/auth/GrantReconcileTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/auth/GrantReconcileTest.kt
@@ -1,0 +1,57 @@
+package id.homebase.core.auth
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * Locks the background grant-reconcile prune set (#1079): given the live optional drives and the
+ * freshly-resolved read grants, decide which live drives to unmount. Mandatory drives are never
+ * pruned; grant comparison is hyphen/case-insensitive (normalized).
+ */
+class GrantReconcileTest {
+
+    private val chat = Uuid.random()
+    private val contacts = Uuid.random()
+    private val granted1 = Uuid.random()
+    private val revoked = Uuid.random()
+    private val mandatory = setOf(chat, contacts)
+
+    private fun norm(u: Uuid) = normalizeDriveId(u.toString())
+
+    @Test
+    fun prunesAnActiveOptionalDriveNotInTheGrantSet() {
+        val active = setOf(chat, granted1, revoked)
+        val granted = setOf(norm(granted1)) // chat is mandatory; revoked has no grant
+        assertEquals(listOf(revoked), drivesToPrune(active, mandatory, granted))
+    }
+
+    @Test
+    fun neverPrunesMandatoryDrivesEvenIfNotGranted() {
+        val active = setOf(chat, contacts, granted1)
+        val granted = setOf(norm(granted1)) // chat/contacts absent from grants but mandatory
+        assertTrue(drivesToPrune(active, mandatory, granted).isEmpty())
+    }
+
+    @Test
+    fun keepsAllWhenEveryActiveDriveIsGranted() {
+        val active = setOf(chat, granted1)
+        val granted = setOf(norm(granted1))
+        assertTrue(drivesToPrune(active, mandatory, granted).isEmpty())
+    }
+
+    @Test
+    fun emptyGrantSetPrunesEveryNonMandatoryDrive() {
+        val active = setOf(chat, granted1, revoked)
+        assertEquals(setOf(granted1, revoked), drivesToPrune(active, mandatory, emptySet()).toSet())
+    }
+
+    @Test
+    fun grantMatchIsHyphenAndCaseInsensitive() {
+        // grant stored normalized (lowercased, hyphen-stripped); active drive id has hyphens/upper.
+        val active = setOf(granted1)
+        val granted = setOf(granted1.toString().lowercase().replace("-", ""))
+        assertTrue(drivesToPrune(active, mandatory, granted).isEmpty())
+    }
+}


### PR DESCRIPTION
Fixes #1079.

## Problem

Cold start on a slow/failing network (airplane wifi, DNS failing for the owner domain): no avatar/identity, and the notify **WebSocket isn't even attempted for ~2.5 min**. `AuthConnectionCoordinator`'s `Authenticated` branch ran sequentially — `refreshGrantedDriveAliases()` (a `GET /auth/context` security-context fetch, no app-level retry → the full ~2.5 min `HttpTimeout` × OkHttp DNS-retry) sat upstream of `connect()` + `loadProfile()` in the same coroutine, blocking both.

## Fix — the grant refresh is now a background reconcile, not a startup gate

Optional drives ~never lose a grant, so startup shouldn't wait on re-confirming grants at all:

- **Remove** the synchronous grant fetch from the `Authenticated` branch. `connect()` + `loadProfile()` now run **immediately** using the local drive registry (`retainGrantedDrives()` is a no-op while `grantedDriveIds` is null → subscribe/mount the full local registry).
- **`scheduleGrantReconcile()`** runs the fetch in the **background** (kicked after `connect()` in both the `Authenticated` tail and `promoteToForeground` — cancel-and-relaunch so a foreground reopen retries after a dead-network cold start). Its only job: prune a drive whose read grant was **revoked** (rare).
- Pruning uses **`unmountDrive(driveId, persist = false)`** — stops DriveSync **and** rebuilds the WS subscription filtered, but **leaves the persisted DriveRegistry intact** (no reconcile flap; the drive re-mounts on a later startup if regranted). Verified: `DriveRegistry.reconcile()` diffs the registry *file* vs baseline, not live mounts.
- Backstops already exist reactively as belt-and-suspenders: DriveSync self-unmounts on a 403, and the WS drops any drive it gets an auth error for (`unauthorizedDriveIds`). The reconcile just does it proactively once grants are known.

**Accepted trade:** startup connects unfiltered from the local registry; the rare good-network lost-grant case now takes one self-healed socket bounce instead of a pre-connect filter. **Net:** startup is immediate on any network (no ~2.5 min stall, and no 10s cap either).

## Rename (bundled): `DriveAliases` → `DriveIds`

"Alias" is outdated — a drive **Id** is the GUID pointing to the drive. All private, no wire/JSON impact:
- `AuthConnectionCoordinator`: `refreshGrantedDriveAliases`→`refreshGrantedDriveIds`, `grantedDriveAliases`→`grantedDriveIds`, `normalizeAlias`→`normalizeDriveId`
- `DriveRegistry`: `currentDriveAliases`→`currentDriveIds`
- `OdinWebSocketClient`: `unauthorizedDriveAliases`→`unauthorizedDriveIds`

The serialized `TargetDrive.alias` / `DriveReference.alias` wire property is deliberately untouched.

## Testing

- Compiles: `homebase-api` (JVM/Android), `homebase-common` (Android), `homebase-core` (Android/JVM). ✅
- `homebase-common:jvmTest` (new `GrantReconcileTest` for `drivesToPrune` — mandatory never pruned, revoked pruned, granted kept, normalization) + `homebase-api:jvmTest` (incl. `DriveRegistryTest`). ✅
- Behavioral (needs a bad network + a real revoked grant to fully exercise): cold start → `connect()`/`loadProfile()` fire immediately; common case logs `readable drive grants resolved` in the background with no prune/reconnect (zero churn); revoked case logs `read grant revoked — pruning drive …`, the drive stops syncing + drops off the socket, and stays in the persisted registry.

Complementary to #1075 (seed owner session from local data), not a duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)