### PR TITLE
fix(domain): stop eating the dash while typing a domain (#1088)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/util/StringExtensions.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/util/StringExtensions.kt
@@ -103,14 +103,17 @@ fun String.codePointCount(): Int {
  * characters, and enforcing domain rules. Supports Unicode characters for IDNs (to be
  * Punycode-converted later) and handles common user input typos. It's intended to be called with
  * each character being input interactively (or pasted).
- * @param preserveTrailingDot If true, allows a single trailing dot (for interactive typing).
- * ```
- *                            If false, removes trailing dots (for final validation).
- * @return
- * ```
- * The cleaned domain string in lowercase.
+ * @param preserveTrailingDot If true, allows a single trailing dot (for interactive typing). If
+ *   false, removes trailing dots (for final validation).
+ * @param preserveTrailingDash If true, keeps a single trailing dash on the label being typed (so a
+ *   dash you just pressed isn't eaten mid-type). If false, strips it (for final validation). Mirrors
+ *   [preserveTrailingDot].
+ * @return The cleaned domain string in lowercase.
  */
-fun String.cleanDomain(preserveTrailingDot: Boolean = true): String {
+fun String.cleanDomain(
+    preserveTrailingDot: Boolean = true,
+    preserveTrailingDash: Boolean = true,
+): String {
     if (this.isEmpty()) {
         return ""
     }
@@ -162,12 +165,20 @@ fun String.cleanDomain(preserveTrailingDot: Boolean = true): String {
     // Step 4: Replace multiple consecutive periods with a single period
     cleanedString = cleanedString.replace(Regex("\\.{2,}"), ".")
 
-    // Step 5: Enforce per-label rules (no start/end with '-', no consecutive '-')
+    // Step 5: Enforce per-label rules (no start/end with '-', no consecutive '-'). A single
+    // trailing dash on the last label (the one being typed) is preserved when preserveTrailingDash
+    // is true, so a just-pressed '-' survives as-you-type — mirrors the trailing-dot handling below.
     val labels = cleanedString.split(".")
+    val lastIndex = labels.lastIndex
     val cleanedLabels =
-        labels.map { label ->
-            // Remove leading/trailing '-', replace consecutive '-'
-            label.replace(Regex("^-+|-+$"), "").replace(Regex("-{2,}"), "-")
+        labels.mapIndexed { index, label ->
+            // Always strip a leading '-' and collapse consecutive '-'.
+            var l = label.replace(Regex("^-+"), "").replace(Regex("-{2,}"), "-")
+            // Strip a trailing '-' except on the label being typed (last) when preserving.
+            if (!(preserveTrailingDash && index == lastIndex)) {
+                l = l.replace(Regex("-+$"), "")
+            }
+            l
         }
     cleanedString =
         cleanedLabels.filter { it.isNotEmpty() }.joinToString(".") // Remove empty labels

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/util/CleanDomainTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/util/CleanDomainTest.kt
@@ -1,0 +1,60 @@
+package id.homebase.api.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Locks the dash-handling contract of [cleanDomain] (#1088). The function runs on every keystroke,
+ * so a dash the user just pressed lands as a *trailing* dash on the label being typed and must
+ * survive while `preserveTrailingDash` is true (the interactive default) — mirroring the existing
+ * `preserveTrailingDot` behavior. Submit paths pass `false` to strip a stray trailing dash.
+ */
+class CleanDomainTest {
+
+    @Test
+    fun internalDashPreserved() {
+        assertEquals("my-domain.com", "my-domain.com".cleanDomain())
+    }
+
+    @Test
+    fun justTypedTrailingDashPreservedByDefault() {
+        // The bug: pressing '-' after "example" used to yield "example" (dash eaten). Now kept.
+        assertEquals("example-", "example-".cleanDomain())
+    }
+
+    @Test
+    fun submitStripsTrailingDash() {
+        assertEquals(
+            "example",
+            "example-".cleanDomain(preserveTrailingDot = false, preserveTrailingDash = false),
+        )
+    }
+
+    @Test
+    fun consecutiveDashesStillCollapse() {
+        assertEquals("a-b.com", "a--b.com".cleanDomain())
+    }
+
+    @Test
+    fun leadingDashStillStripped() {
+        assertEquals("a.com", "-a.com".cleanDomain())
+    }
+
+    @Test
+    fun typingProgressionKeepsDash() {
+        assertEquals("my-", "my-".cleanDomain())
+        assertEquals("my-domain", "my-domain".cleanDomain())
+    }
+
+    @Test
+    fun trailingDashOnlyPreservedOnLastLabel() {
+        // A dash left trailing on a non-last label (before a dot) is still cleaned interactively.
+        assertEquals("a.b", "a-.b".cleanDomain())
+    }
+
+    @Test
+    fun collapsedTrailingDashesLeaveSinglePreservedDash() {
+        // "example--" collapses to a single dash, which as the typed label stays put.
+        assertEquals("example-", "example--".cleanDomain())
+    }
+}

--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginScreen.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginScreen.kt
@@ -509,13 +509,13 @@ private fun LoginForm(
             placeholder = { Text(stringResource(MR.string.login_id_placeholder)) },
             focusRequester = focusRequester,
             imeAction = ImeAction.Done,
-            onImeAction = { onLoginClick(homebaseIdField.text.cleanDomain(preserveTrailingDot = false)) },
+            onImeAction = { onLoginClick(homebaseIdField.text.cleanDomain(preserveTrailingDot = false, preserveTrailingDash = false)) },
         )
 
         Spacer(modifier = Modifier.height(24.dp))
 
         Button(
-            onClick = { onLoginClick(homebaseIdField.text.cleanDomain(preserveTrailingDot = false)) },
+            onClick = { onLoginClick(homebaseIdField.text.cleanDomain(preserveTrailingDot = false, preserveTrailingDash = false)) },
             modifier = Modifier.fillMaxWidth().testTag(if (errorMessage != null) "try_again_button" else "login_button"),
         ) {
             if (errorMessage != null) Text(stringResource(MR.string.login_try_again_button)) else Text(stringResource(MR.string.login_sign_in_button))

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/core/connections/ConnectRequestBottomSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/core/connections/ConnectRequestBottomSheet.kt
@@ -213,7 +213,7 @@ private fun ComposeRequestSheetContent(
             onValueChange = { incoming ->
                 val normalizedSpaces = incoming.text.cleanDomain().replace('.', ' ')
                 fieldValue = incoming.copy(text = normalizedSpaces)
-                val dotted = normalizedSpaces.cleanDomain(preserveTrailingDot = false)
+                val dotted = normalizedSpaces.cleanDomain(preserveTrailingDot = false, preserveTrailingDash = false)
                 if (dotted != recipient) onRecipientChange(dotted)
             },
             label = { Text(stringResource(MR.string.connections_recipient_label)) },

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactScreen.kt
@@ -300,7 +300,7 @@ private fun ByIdentitySection(
         onValueChange = { incoming ->
             val normalizedSpaces = incoming.text.cleanDomain().replace('.', ' ')
             fieldValue = incoming.copy(text = normalizedSpaces)
-            val dotted = normalizedSpaces.cleanDomain(preserveTrailingDot = false)
+            val dotted = normalizedSpaces.cleanDomain(preserveTrailingDot = false, preserveTrailingDash = false)
             if (dotted != uiState.draft.odinId) onAction(AddContactAction.OdinIdChanged(dotted))
         },
         label = { Text(stringResource(MR.string.add_contact_odinid_label)) },

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/ContactEditSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/ContactEditSheet.kt
@@ -186,7 +186,7 @@ fun ContactEditSheet(
                     val normalizedSpaces = incoming.text.cleanDomain().replace('.', ' ')
                     odinIdField = incoming.copy(text = normalizedSpaces)
                     draft = draft.copy(
-                        odinId = normalizedSpaces.cleanDomain(preserveTrailingDot = false),
+                        odinId = normalizedSpaces.cleanDomain(preserveTrailingDot = false, preserveTrailingDash = false),
                     )
                 },
                 label = { Text(stringResource(MR.string.contactbook_edit_odinid)) },


### PR DESCRIPTION
Fixes #1088

## Problem
`cleanDomain()` runs on every keystroke, and Step 5 stripped a trailing `-` from each label. The dash of the label being typed (e.g. `example-`) was removed the instant it was pressed, so dashed domains like `my-domain.com` could never be entered.

## Fix — centralized, mirroring `preserveTrailingDot`
- Added `preserveTrailingDash: Boolean = true` to `cleanDomain`. When preserving (the interactive default) a single trailing dash on the label being typed survives; leading-dash strip and consecutive-dash collapse are unchanged.
- **All four domain-input fields share this display path and are fixed by the one change** — Login ID, Add-contact odinId, Edit-contact odinId, Connect-request recipient.
- Each field's **submit** path now passes `preserveTrailingDash = false` alongside the existing `preserveTrailingDot = false`, so a stray trailing dash is still cleaned on final validation.
- `HomebaseIdField` (shared widget) does no keystroke filtering of its own, so nothing else eats the dash.

## Tests
New `CleanDomainTest` (commonTest → JVM+Android+wasmJs+native): typed-dash regression, submit stripping, `--` collapse, leading strip, per-label boundary, typing progression.

## Verification
- `:homebase-api:jvmTest --tests '*CleanDomainTest*'` green.
- `homebase-api` / `homebase-auth` / `homebase-core` / `homebase-chat` compile clean on JVM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)