### PR TITLE
feat(notifications): stack real chat messages instead of "$N new messages" at content level

### DIFF
--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/notifications/RichNotificationDisplayer.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/notifications/RichNotificationDisplayer.android.kt
@@ -46,15 +46,7 @@ actual class RichNotificationDisplayer actual constructor() {
 
         // Use MessagingStyle for chat/community conversations
         if (data.conversationId != null) {
-            val style = NotificationCompat.MessagingStyle(person)
-                .addMessage(data.body, data.timestamp, person)
-
-            if (data.isGroupConversation && data.groupTitle != null) {
-                style.isGroupConversation = true
-                style.conversationTitle = data.groupTitle
-            }
-
-            builder.setStyle(style)
+            builder.setStyle(buildMessagingStyle(context, data, person))
             builder.setGroup(data.conversationId)
             builder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY)
         } else {
@@ -100,6 +92,49 @@ actual class RichNotificationDisplayer actual constructor() {
         if (data.conversationId != null) {
             postSummaryNotification(context, nm, data)
         }
+    }
+
+    /**
+     * Builds the conversation's MessagingStyle. When real content is shown
+     * ([RichNotificationData.showsRealContent] — the name_content_actions level), seed from the
+     * conversation's currently-showing notification so its recent messages keep displaying and the
+     * new one stacks on top. Android stores the messages in the live notification for us, so this
+     * survives a cold-process push with no in-memory buffer. History is capped at
+     * [MAX_STACKED_MESSAGES]. At redacted levels [base] is null, so it degrades to the prior
+     * single-message behaviour (the collapsed "$N new messages" body from NotificationService).
+     */
+    private fun buildMessagingStyle(
+        context: Context,
+        data: RichNotificationData,
+        person: Person,
+    ): NotificationCompat.MessagingStyle {
+        val base = if (data.showsRealContent) {
+            extractActiveMessagingStyle(context, data.notificationId)
+        } else {
+            null
+        }
+
+        val style = NotificationCompat.MessagingStyle(base?.user ?: person)
+        val history = base?.messages.orEmpty() +
+                NotificationCompat.MessagingStyle.Message(data.body, data.timestamp, person)
+        history.takeLast(MAX_STACKED_MESSAGES).forEach { style.addMessage(it) }
+
+        if (data.isGroupConversation && data.groupTitle != null) {
+            style.isGroupConversation = true
+            style.conversationTitle = data.groupTitle
+        }
+        return style
+    }
+
+    /** The MessagingStyle of the conversation's currently-showing notification, or null if none. */
+    private fun extractActiveMessagingStyle(
+        context: Context,
+        notificationId: Int,
+    ): NotificationCompat.MessagingStyle? {
+        val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val existing = nm.activeNotifications.firstOrNull { it.id == notificationId } ?: return null
+        return NotificationCompat.MessagingStyle
+            .extractMessagingStyleFromNotification(existing.notification)
     }
 
     private fun buildPerson(name: String, key: String, imageBytes: ByteArray?): Person {
@@ -238,6 +273,9 @@ actual class RichNotificationDisplayer actual constructor() {
          * re-enable once those land. The receiver ([NotificationReplyReceiver]) is kept dormant.
          */
         const val REPLY_FROM_NOTIFICATION_ENABLED = false
+
+        /** Recent messages kept in a conversation's stacked notification (Android shows ~7). */
+        private const val MAX_STACKED_MESSAGES = 6
 
         const val ACTION_REPLY = "id.homebase.feed.NOTIFICATION_REPLY"
         const val ACTION_MARK_READ = "id.homebase.feed.NOTIFICATION_MARK_READ"

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
@@ -424,18 +424,20 @@ class NotificationService(
                     "no_name_or_content" -> Pair("Homebase", "New notification")
                     else -> Pair(appName, bodyText)
                 }
+                // Full content is shown at name_content_actions (and the default/unknown case,
+                // which fromCode() treats as that level) — never at the redacted levels.
+                val showsRealContent =
+                    contentLevel != "name_only" && contentLevel != "no_name_or_content"
 
                 // Track per-conversation message count for summary display
                 val messageCount = if (conversationId != null) {
                     counts.increment(conversationId)
                 } else 1
 
-                // Override body with count summary when multiple messages accumulated
-                val finalBody = if (messageCount > 1) {
-                    "$messageCount new messages"
-                } else {
-                    displayBody
-                }
+                // When real content is shown, keep the per-message body and let the Android
+                // displayer stack the recent messages (MessagingStyle). Only collapse to a
+                // count at the redacted levels, where there's no content to show anyway.
+                val finalBody = notificationBody(displayBody, messageCount, showsRealContent)
 
                 // Chime cooldown: suppress alert sound if one played recently
                 val shouldAlert = lastAlertMark.elapsedNow() >= ALERT_COOLDOWN
@@ -459,6 +461,7 @@ class NotificationService(
                     payloadData = payloadMap,
                     silent = !shouldAlert,
                     hasContent = hasContent,
+                    showsRealContent = showsRealContent,
                 )
 
                 if (isAppInForeground) {
@@ -925,6 +928,20 @@ internal fun resolveMomentsTap(typeId: String, tagId: String): MomentsTapTarget?
 /** Convenience predicate over [resolveMomentsTap]. */
 internal fun isMomentsTap(typeId: String, tagId: String): Boolean =
     resolveMomentsTap(typeId, tagId) != null
+
+/**
+ * The body to display for a chat notification. When real content is shown
+ * ([showsRealContent] — the name_content_actions level), always the message itself: the Android
+ * displayer stacks multiple per-conversation messages via MessagingStyle, so no count summary is
+ * needed. At the redacted levels, collapse to a "$count new messages" summary once more than one
+ * message has accumulated (there's no content to stack there anyway).
+ */
+internal fun notificationBody(
+    displayBody: String,
+    messageCount: Int,
+    showsRealContent: Boolean,
+): String =
+    if (!showsRealContent && messageCount > 1) "$messageCount new messages" else displayBody
 
 /**
  * Reserved offset so a conversation's group-summary id never collides with a

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/RichNotificationData.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/RichNotificationData.kt
@@ -30,6 +30,12 @@ data class RichNotificationData(
      * Gates the Mark-as-Read action (#983); set once notification decryption lands (#859).
      */
     val hasContent: Boolean = false,
+    /**
+     * True only at the `name_content_actions` content level, where real message text is shown.
+     * Tells the Android displayer to stack the conversation's recent messages (MessagingStyle
+     * history) instead of collapsing to a "$N new messages" count. Redacted levels keep the count.
+     */
+    val showsRealContent: Boolean = false,
 )
 
 /** Extension to generate a stable notification ID from the conversation ID or a random one. */

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/NotificationBodyTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/NotificationBodyTest.kt
@@ -1,0 +1,32 @@
+package id.homebase.core.notifications
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * [notificationBody]: at the content level that shows real text, the body is always the message
+ * itself (the Android displayer stacks multiples via MessagingStyle); at redacted levels it
+ * collapses to a "$N new messages" count once more than one has accumulated.
+ */
+class NotificationBodyTest {
+
+    @Test
+    fun realContent_keepsMessage_evenWhenMultiple() {
+        assertEquals("Hey there", notificationBody("Hey there", messageCount = 3, showsRealContent = true))
+    }
+
+    @Test
+    fun realContent_singleMessage_keepsMessage() {
+        assertEquals("Hey there", notificationBody("Hey there", messageCount = 1, showsRealContent = true))
+    }
+
+    @Test
+    fun redacted_multiple_collapsesToCount() {
+        assertEquals("3 new messages", notificationBody("New notification", messageCount = 3, showsRealContent = false))
+    }
+
+    @Test
+    fun redacted_single_keepsBody() {
+        assertEquals("New notification", notificationBody("New notification", messageCount = 1, showsRealContent = false))
+    }
+}


### PR DESCRIPTION
Now that #1070 decrypts real chat content into Android notifications, the
"**$N new messages**" grouping placeholder is no longer the best we can do at the
`Name, Content, and Actions` level. This stacks the actual recent messages instead.

## Change
A conversation posts **one notification, updated in place** (`notificationId =
conversationId.hashCode()`), so multiple messages previously collapsed to a
`"$N new messages"` count. Now, **only at `name_content_actions`**, the notification shows
the real messages stacked; the redacted levels are unchanged.

- **`NotificationService.kt`** — new `showsRealContent` flag (true only at the content level;
  the default/unknown case counts as content too, mirroring `NotificationContentLevel.fromCode`).
  The body decision moves into a pure, testable `notificationBody(displayBody, count,
  showsRealContent)`: the real message when content is shown, `"$N new messages"` only at the
  redacted levels (where there's nothing to stack).
- **`RichNotificationData.kt`** — carries `showsRealContent` to the platform displayer.
- **`RichNotificationDisplayer.android.kt`** — when `showsRealContent`, rebuild `MessagingStyle`
  from the conversation's **live** notification (`activeNotifications` +
  `extractMessagingStyleFromNotification`) and append the new message, capped at the last 6.
  Android stores the messages in the posted notification for us, so this **survives a
  cold-process push** — no in-memory buffer. At redacted levels it degrades to the prior
  single-line behaviour.

## Verification
- `:homebase-common:compileAndroidMain` — **BUILD SUCCESSFUL**.
- `:homebase-common:jvmTest` — **green**, incl. new `NotificationBodyTest` (content level keeps
  the message even when several accumulate; redacted levels collapse to the count).
- **Device-verify pending**: at `Name, Content, and Actions`, 2–3 messages to one conversation
  (unopened) should stack the real texts; `Name Only` / `No Name or Content` should still show
  `"$N new messages"`.

Builds on #1070 / #859. Android-only (iOS notification content is tracked in #1091).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
