### PR TITLE
fix(login): guarantee an in-app return path from Create account (#1089)

### DIFF
--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginScreen.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginScreen.kt
@@ -53,7 +53,6 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.api.util.cleanDomain
-import id.homebase.api.isIos
 import id.homebase.core.auth.BrowserLauncher
 import id.homebase.core.util.InAppBrowser
 import id.homebase.core.ui.assets.Homebase
@@ -138,15 +137,11 @@ fun LoginScreen(
             }
 
             is LoginUiEvent.OpenUrl -> {
-                // On iOS launchAuthBrowser is a no-op, so the sign-up URL is silently dropped
-                // (#1054). Open it in an in-app SFSafariViewController — no ASWebAuthenticationSession
-                // "…Sign In" consent prompt, which is wrong for sign-up. Other platforms open it
-                // directly. Consume only after the open is issued, never before.
-                if (isIos()) {
-                    InAppBrowser.open(uiEvent.url)
-                } else {
-                    launchAuthBrowser(uiEvent.url)
-                }
+                // Sign-up is a plain web page, not an OAuth callback: no shared session or token
+                // hand-back, just a page the user must be able to get back out of. That's
+                // InAppBrowser, not the auth-callback launcher. Consume only after the open is
+                // issued, never before.
+                InAppBrowser.open(uiEvent.url)
                 viewModel.eventConsumed()
             }
 

--- a/homebase-common/src/androidMain/AndroidManifest.xml
+++ b/homebase-common/src/androidMain/AndroidManifest.xml
@@ -5,6 +5,14 @@
          manifest; the app module declares the runtime permissions
          (ACCESS_BACKGROUND_LOCATION, RECEIVE_BOOT_COMPLETED). -->
     <application>
+        <!-- In-app browser (#1089). No launchMode/taskAffinity: it must stay in the caller's
+             task so Back returns to the app rather than the launcher. -->
+        <activity
+            android:name="id.homebase.core.util.InAppBrowserActivity"
+            android:exported="false"
+            android:windowSoftInputMode="adjustResize"
+            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|keyboardHidden|uiMode" />
+
         <receiver
             android:name="id.homebase.core.location.tracking.LocationUpdatesReceiver"
             android:enabled="true"

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/util/InAppBrowser.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/util/InAppBrowser.android.kt
@@ -1,6 +1,16 @@
 package id.homebase.core.util
 
-// iOS-only. Android opens URLs in-app via rememberAuthBrowserLauncher (Custom Tabs) in the UI layer.
+import android.content.Intent
+import id.homebase.api.ActivityProvider
+
 actual object InAppBrowser {
-    actual fun open(url: String) {}
+    actual fun open(url: String) {
+        // Started from the Activity, without FLAG_ACTIVITY_NEW_TASK, so the browser lands in the
+        // app's own task and Back returns here (#1089).
+        val activity = ActivityProvider.getActivity() ?: return
+        activity.startActivity(
+            Intent(activity, InAppBrowserActivity::class.java)
+                .putExtra(InAppBrowserActivity.EXTRA_URL, url)
+        )
+    }
 }

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/util/InAppBrowserActivity.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/util/InAppBrowserActivity.kt
@@ -2,26 +2,48 @@ package id.homebase.core.util
 
 import android.annotation.SuppressLint
 import android.os.Bundle
+import android.webkit.WebChromeClient
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.net.toUri
 import id.homebase.core.ui.theme.HomebaseTheme
 import id.homebase.resources.MR
 import id.homebase.resources.close
+import id.homebase.resources.in_app_browser_secure
 import org.jetbrains.compose.resources.stringResource
 
 /**
@@ -44,30 +66,90 @@ class InAppBrowserActivity : ComponentActivity() {
             finish()
             return
         }
-        val host = url.toUri().host.orEmpty()
+        val uri = url.toUri()
+        val host = uri.host.orEmpty()
+        val isSecure = uri.scheme.equals("https", ignoreCase = true)
 
         setContent {
             HomebaseTheme {
+                var pageTitle by remember { mutableStateOf(host) }
+                var progress by remember { mutableFloatStateOf(0f) }
+                val surface = MaterialTheme.colorScheme.surface
+
                 Scaffold(
                     topBar = {
-                        TopAppBar(
-                            title = { Text(host) },
-                            navigationIcon = {
-                                IconButton(onClick = ::finish) {
-                                    Icon(
-                                        imageVector = Icons.Default.Close,
-                                        contentDescription = stringResource(MR.string.close)
-                                    )
-                                }
+                        Column {
+                            TopAppBar(
+                                title = {
+                                    Column {
+                                        Text(
+                                            text = pageTitle,
+                                            style = MaterialTheme.typography.titleMedium,
+                                            fontWeight = FontWeight.SemiBold,
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis,
+                                        )
+                                        Row(
+                                            verticalAlignment = Alignment.CenterVertically,
+                                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                        ) {
+                                            if (isSecure) {
+                                                Icon(
+                                                    imageVector = Icons.Default.Lock,
+                                                    contentDescription = stringResource(MR.string.in_app_browser_secure),
+                                                    modifier = Modifier.size(12.dp),
+                                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                )
+                                            }
+                                            Text(
+                                                text = host,
+                                                style = MaterialTheme.typography.labelMedium,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                maxLines = 1,
+                                                overflow = TextOverflow.Ellipsis,
+                                            )
+                                        }
+                                    }
+                                },
+                                navigationIcon = {
+                                    IconButton(onClick = ::finish) {
+                                        Icon(
+                                            imageVector = Icons.Default.Close,
+                                            contentDescription = stringResource(MR.string.close)
+                                        )
+                                    }
+                                },
+                                colors = TopAppBarDefaults.topAppBarColors(
+                                    containerColor = MaterialTheme.colorScheme.surfaceContainer,
+                                ),
+                            )
+                            AnimatedVisibility(visible = progress < 1f) {
+                                LinearProgressIndicator(
+                                    progress = { progress },
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
                             }
-                        )
+                        }
                     }
                 ) { innerPadding ->
                     AndroidView(
                         modifier = Modifier.fillMaxSize().padding(innerPadding),
                         factory = { context ->
                             WebView(context).apply {
+                                setBackgroundColor(surface.toArgb())
                                 webViewClient = WebViewClient()
+                                webChromeClient = object : WebChromeClient() {
+                                    override fun onProgressChanged(view: WebView?, newProgress: Int) {
+                                        progress = newProgress / 100f
+                                    }
+
+                                    // WebView falls back to the raw URL when a page has no <title>.
+                                    override fun onReceivedTitle(view: WebView?, title: String?) {
+                                        if (!title.isNullOrBlank() && !title.startsWith("http")) {
+                                            pageTitle = title
+                                        }
+                                    }
+                                }
                                 settings.javaScriptEnabled = true
                                 settings.domStorageEnabled = true
                                 loadUrl(url)

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/util/InAppBrowserActivity.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/util/InAppBrowserActivity.kt
@@ -1,0 +1,85 @@
+package id.homebase.core.util
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.net.toUri
+import id.homebase.core.ui.theme.HomebaseTheme
+import id.homebase.resources.MR
+import id.homebase.resources.close
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * An in-app browser running in the app's own task, so system Back and the Close button always
+ * return to the caller. Chrome Custom Tabs delegate that guarantee to whichever browser is
+ * default: its activity's task placement is outside our control, and on some devices backing out
+ * lands on the launcher instead of the app (#1089).
+ */
+// ponytail: Back exits outright instead of walking WebView history — an SPA's pushState entries
+// would make history-back an unbounded trap, which is the thing this activity exists to prevent.
+class InAppBrowserActivity : ComponentActivity() {
+
+    @SuppressLint("SetJavaScriptEnabled")
+    @OptIn(ExperimentalMaterial3Api::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val url = intent.getStringExtra(EXTRA_URL)
+        if (url.isNullOrBlank()) {
+            finish()
+            return
+        }
+        val host = url.toUri().host.orEmpty()
+
+        setContent {
+            HomebaseTheme {
+                Scaffold(
+                    topBar = {
+                        TopAppBar(
+                            title = { Text(host) },
+                            navigationIcon = {
+                                IconButton(onClick = ::finish) {
+                                    Icon(
+                                        imageVector = Icons.Default.Close,
+                                        contentDescription = stringResource(MR.string.close)
+                                    )
+                                }
+                            }
+                        )
+                    }
+                ) { innerPadding ->
+                    AndroidView(
+                        modifier = Modifier.fillMaxSize().padding(innerPadding),
+                        factory = { context ->
+                            WebView(context).apply {
+                                webViewClient = WebViewClient()
+                                settings.javaScriptEnabled = true
+                                settings.domStorageEnabled = true
+                                loadUrl(url)
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val EXTRA_URL = "url"
+    }
+}

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="ok">Ok</string>
     <string name="cancel">Cancel</string>
     <string name="close">Close</string>
+    <string name="in_app_browser_secure">Secure connection</string>
     <string name="replying_to">Replying to %1$s</string>
     <string name="cancel_reply">Cancel reply</string>
     <string name="backspace">Backspace</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/util/InAppBrowser.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/util/InAppBrowser.kt
@@ -1,12 +1,17 @@
 package id.homebase.core.util
 
 /**
- * Opens a URL in an in-app browser, keeping the user inside the app.
+ * Opens a URL the user has to be able to come back from, keeping the app reachable.
  *
- * iOS spawns the system SFSafariViewController — a real in-app browser with no
- * ASWebAuthenticationSession "…Wants to Use…to Sign In" consent prompt (wrong for a sign-up
- * flow). Other targets already open URLs in-app via [id.homebase.core.ui.auth.rememberAuthBrowserLauncher]
- * in the UI layer, so only iOS needs this and their actual is a no-op.
+ * This is the counterpart to [id.homebase.core.ui.auth.rememberAuthBrowserLauncher], which exists
+ * for the sign-in flow: it needs a browser session that can hand a token back to the app. A page
+ * like sign-up hands nothing back, so it only needs a guaranteed return path — use this instead.
+ *
+ * - iOS: SFSafariViewController, an in-app browser with no ASWebAuthenticationSession
+ *   "…Wants to Use…to Sign In" consent prompt (which is wrong for sign-up).
+ * - Android: a WebView in our own activity/task. A Chrome Custom Tab's return path is the default
+ *   browser's to define, and on some devices Back lands on the launcher instead (#1089).
+ * - Desktop/web: the system browser / a new tab — separate windows, so the app stays reachable.
  */
 expect object InAppBrowser {
     fun open(url: String)

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/util/InAppBrowser.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/util/InAppBrowser.jvm.kt
@@ -1,6 +1,10 @@
 package id.homebase.core.util
 
-// iOS-only. Desktop opens URLs via rememberAuthBrowserLauncher (system browser) in the UI layer.
 actual object InAppBrowser {
-    actual fun open(url: String) {}
+    // Desktop has no in-app browser and needs none: the system browser is a separate window, so
+    // the app stays reachable behind it. Clipboard fallback covers the Linux setups where BROWSE
+    // is unsupported (see BrowserUtils).
+    actual fun open(url: String) {
+        BrowserUtils.openSystemBrowser(url, enableClipboardFallback = true)
+    }
 }

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/util/InAppBrowser.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/util/InAppBrowser.web.kt
@@ -1,6 +1,11 @@
 package id.homebase.core.util
 
-// iOS-only. Web opens URLs via rememberAuthBrowserLauncher (window.open) in the UI layer.
+import kotlinx.browser.window
+
 actual object InAppBrowser {
-    actual fun open(url: String) {}
+    // A plain new tab, not the sign-in popup: the SPA stays loaded in this tab, so the user gets
+    // back by switching tabs. Nothing is posted back from the page.
+    actual fun open(url: String) {
+        window.open(url, "_blank")
+    }
 }


### PR DESCRIPTION
Fixes #1089.

## The problem

"Create account" handed `homebase.id/sign-up` to a Chrome Custom Tab, which means **the return path is defined by whichever browser is default** — its activity's task placement isn't ours to control. On some devices (reported on a Samsung S22) backing out lands on the launcher instead of the app, stranding a fresh-install user with no way to reach login after an accidental tap.

## The fix

Sign-up is a plain web page, **not** an OAuth callback — nothing is handed back to the app, so it never needed Custom Tabs' shared-session machinery. It only needs a browser the user can reliably get out of.

So `OpenUrl` now routes through `InAppBrowser` on **every** platform, and that becomes the whole contract. `rememberAuthBrowserLauncher` goes back to being what it's for: the sign-in callback flow. No `isIos()`/`isAndroid()` branch left in `LoginScreen`.

| Platform | Behaviour |
|---|---|
| Android | **New** `InAppBrowserActivity` (WebView + browser chrome), started from the Activity without `NEW_TASK` → lands in MainActivity's own task |
| iOS | `SFSafariViewController` — unchanged |
| Desktop | System browser — identical to before (same `BrowserUtils.openSystemBrowser` call) |
| Web | New tab instead of the 480x720 sign-in popup |

This removes the Custom-Tab/`singleTask` variable entirely rather than tuning around it, so it holds regardless of the user's default browser — no Samsung-Internet-vs-Chrome dependency left to test.

## Android browser chrome

The first cut showed the bare host on a flat surface, which read as a generic WebView rather than a browser. It now follows `ChatPdfViewer`'s two-line top-bar convention:

- **Page title** (`titleMedium`/SemiBold, ellipsized) over a **lock + host** subtitle — the standard origin/trust affordance, and the page takes a password. Lock only on `https`. WebView falls back to the raw URL when a page has no `<title>`, so that case keeps the host instead.
- `surfaceContainer` bar so it separates from a white page, and the WebView paints on `colorScheme.surface` instead of flashing white in dark theme.
- **Determinate load bar** from `WebChromeClient.onProgressChanged`, hidden at 100% — previously a blank white screen sat there for the whole load.

Device-verified on the Pixel 9: title reads `Signup - Homebase | Homebase.id`, lock + `homebase.id` beneath, Close returns to login. Offline (airplane mode) degrades honestly to WebView's own error page with the bar and Close intact.

## Verification (Pixel 9 emulator, Android 15)

`dumpsys activity activities` with the page open — **one task, ours**:

```
Task{402f08 #12 type=standard A=10208:id.homebase.feed.debug ... sz=2}
  Hist #1: InAppBrowserActivity t12   rootOfTask=false
  Hist #0: MainActivity         t12   rootOfTask=true
```

- Back → `topResumedActivity=MainActivity`, login screen. ✅
- Close (X) → login screen. ✅
- Sign-up page renders and is usable in the WebView (JS + DOM storage on).
- Left idle 30s: same instance, same task, no self-close.
- `homebase-common:jvmTest` + `homebase-auth:jvmTest` green; Android/JVM/wasmJs/iosSimulatorArm64 all compile.

## Deliberately not done

- **`uiEvent` → `SharedFlow` (issue item 3).** The events are consumed immediately and a `StateFlow` doesn't survive process death, so the re-fire is theoretical — and moving one of four event types out is worse than leaving all four consistent. Worth doing as its own cleanup across `LoginUiEvent`.
- **Accidental-tap confirm dialog (issue item 4).** The issue calls it "cheap insurance" against an unrecoverable tap; with a guaranteed Back *and* a visible Close, the tap is already obviously reversible. A prompt in front of every sign-up would tax the common case to soften a case that no longer bites.
- **WebView history-back.** Back exits outright. Walking `canGoBack()` history would let an SPA's `pushState` entries pile up into exactly the "many backs to escape" trap this activity exists to prevent.
- The backup-rules / partial-state-transfer finding in the issue thread is untouched — the author retracted its link to this symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
