### PR TITLE
test(domain): cover dot/dash boundary matrix under both cleanDomain modes

### DIFF
--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/util/CleanDomainTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/util/CleanDomainTest.kt
@@ -57,4 +57,70 @@ class CleanDomainTest {
         // "example--" collapses to a single dash, which as the typed label stays put.
         assertEquals("example-", "example--".cleanDomain())
     }
+
+    // ---- Dot/dash boundary matrix, asserted under BOTH modes ----
+    // Interactive (default) preserves a trailing dash only on the label being typed (the last one);
+    // submit (both flags false) is the final-validation form. A domain label may not start or end
+    // with '-' and may not contain '--', so every boundary dash is cleaned once it's no longer the
+    // label being typed. Values verified against the implementation.
+
+    @Test
+    fun leadingDashOnAMiddleLabelIsStripped() {
+        // "a.-b.c": the '-b' label starts with a dash -> stripped in both modes.
+        assertEquals("a.b.c", "a.-b.c".cleanDomain())
+        assertEquals("a.b.c", "a.-b.c".cleanDomain(preserveTrailingDot = false, preserveTrailingDash = false))
+    }
+
+    @Test
+    fun trailingDashOnAMiddleLabelIsStripped() {
+        // "a.b-.c": 'b-' is not the label being typed (a '.' follows) -> dash stripped in both modes.
+        assertEquals("a.b.c", "a.b-.c".cleanDomain())
+        assertEquals("a.b.c", "a.b-.c".cleanDomain(preserveTrailingDot = false, preserveTrailingDash = false))
+    }
+
+    @Test
+    fun internalDoubleDashInAMiddleLabelCollapses() {
+        // "a.b--c.d": consecutive dashes collapse to one everywhere.
+        assertEquals("a.b-c.d", "a.b--c.d".cleanDomain())
+        assertEquals("a.b-c.d", "a.b--c.d".cleanDomain(preserveTrailingDot = false, preserveTrailingDash = false))
+    }
+
+    @Test
+    fun loneDashAfterATrailingDotIsDropped() {
+        // "a.b.-": the '-' is a leading dash of a fresh (empty) label -> dropped, both modes.
+        assertEquals("a.b", "a.b.-".cleanDomain())
+        assertEquals("a.b", "a.b.-".cleanDomain(preserveTrailingDot = false, preserveTrailingDash = false))
+        // "a.-": same shape with a single leading label.
+        assertEquals("a", "a.-".cleanDomain())
+        assertEquals("a", "a.-".cleanDomain(preserveTrailingDot = false, preserveTrailingDash = false))
+    }
+
+    @Test
+    fun loneDashThenDotKeepsTrailingDotInteractiveButNotSubmit() {
+        // "a.b.-.": the '-' label drops; interactive keeps the just-typed trailing dot, submit strips it.
+        assertEquals("a.b.", "a.b.-.".cleanDomain())
+        assertEquals("a.b", "a.b.-.".cleanDomain(preserveTrailingDot = false, preserveTrailingDash = false))
+    }
+
+    @Test
+    fun dashTypedAtEndOfAFullDomainPreservedThenCleanedOnSubmit() {
+        // The real-world case: user has typed "a.b.c" and presses '-'. Interactive keeps it so they
+        // can continue to "a.b.c-d"; submit cleans the stray trailing dash.
+        assertEquals("a.b.c-", "a.b.c-".cleanDomain())
+        assertEquals("a.b.c", "a.b.c-".cleanDomain(preserveTrailingDot = false, preserveTrailingDash = false))
+    }
+
+    @Test
+    fun trailingDashOnLastLabelPreservedInteractiveStrippedSubmit() {
+        // "a.b-": 'b-' IS the label being typed -> preserved interactively, stripped on submit.
+        assertEquals("a.b-", "a.b-".cleanDomain())
+        assertEquals("a.b", "a.b-".cleanDomain(preserveTrailingDot = false, preserveTrailingDash = false))
+    }
+
+    @Test
+    fun allDashesAndDotsCollapseToEmpty() {
+        // "-.-": every label is a lone/leading dash -> nothing survives, both modes.
+        assertEquals("", "-.-".cleanDomain())
+        assertEquals("", "-.-".cleanDomain(preserveTrailingDot = false, preserveTrailingDash = false))
+    }
 }


### PR DESCRIPTION
Follow-up to #1090 (#1088). Test-only — no production change.

The dash-eating fix guarded the core typed-dash case, but the multi-label dot/dash boundaries were untested and only `example-` was asserted under both modes. This locks the verified behavior in, each case under **both** the interactive default and the submit (`both flags false`) form.

| Input | interactive | submit |
|---|---|---|
| `a.-b.c` | `a.b.c` | `a.b.c` |
| `a.b-.c` | `a.b.c` | `a.b.c` |
| `a.b--c.d` | `a.b-c.d` | `a.b-c.d` |
| `a.b.-` / `a.-` | `a.b` / `a` | `a.b` / `a` |
| `a.b.-.` | `a.b.` | `a.b` |
| `a.b.c-` | `a.b.c-` | `a.b.c` |
| `a.b-` | `a.b-` | `a.b` |
| `-.-` | `` | `` |

`CleanDomainTest` 8 → 16 tests. Values verified against the implementation. `:homebase-api:jvmTest --tests '*CleanDomainTest*'` green (also runs under commonTest across JVM+Android+wasmJs+native).

🤖 Generated with [Claude Code](https://claude.com/claude-code)