### PR TITLE
Add/remove emergency contacts in-app via circle-membership API

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/ForbiddenException.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/ForbiddenException.kt
@@ -1,4 +1,5 @@
 package id.homebase.api.client
 
-class ForbiddenException :
-    OdinApiException(403, "Forbidden")
+class ForbiddenException(
+    problem: ProblemDetails? = null
+) : OdinApiException(403, problem?.title ?: "Forbidden", problem = problem)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/OdinApiProviderBase.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/OdinApiProviderBase.kt
@@ -538,7 +538,14 @@ abstract class OdinApiProviderBase(
 
             401 -> throw UnauthorizedException()
 
-            403 -> throw ForbiddenException()
+            403 -> {
+                // OdinSecurityException carries no errorCode (always NoErrorCode/0), but its
+                // title is a real, specific reason ("Forbidden: sam.example.com must have valid
+                // connection to be added to a circle") — parse it best-effort for logging/support
+                // triage. Never branch app logic on this text; there's no structured code to match.
+                val problem = runCatching { deserialize<ProblemDetails>(response.body) }.getOrNull()
+                throw ForbiddenException(problem)
+            }
 
             404 -> throw NotFoundException()
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/OdinException.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/OdinException.kt
@@ -125,6 +125,12 @@ enum class OdinClientErrorCode(val value: Int) {
     MissingPayloadKeys(4170),
     ThumbnailTooLarge(4171),
     MustRotateKeyHeaderIvWhenUpdating(4172),
+    /** Circle-add rejected because this app lacks the storage key for one of the drives the
+     *  circle grants — the app genuinely can't be granted this circle, not a transient/generic
+     *  403. Server sends this as the errorCode on an otherwise-opaque 403 Forbidden response
+     *  (POST /connections/circles/add), unlike every other 403 cause on that endpoint (missing
+     *  ManageCircleMembership, contact not connected), which stay codeless. */
+    CannotSourceDriveStorageKeyForGrant(4173),
 
     // Connection errors 50xx
     NotAnAutoConnection(5001),

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/connections/ProviderTypes.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/connections/ProviderTypes.kt
@@ -3,7 +3,13 @@ package id.homebase.api.client.connections
 import id.homebase.api.client.drives.TargetDrive
 import id.homebase.api.common.OdinId
 import id.homebase.api.youauth.DrivePermissionSet
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlin.uuid.Uuid
 import kotlinx.serialization.SerialName
 
@@ -111,12 +117,18 @@ data class RedactedIdentityConnectionRegistration(
 data class RedactedAccessExchangeGrant(
     val isRevoked: Boolean,
     val circleGrants: List<RedactedCircleGrant> = emptyList(),
-    val appGrants: Map<Uuid, List<RedactedAppCircleGrant>> = emptyMap()
+    val appGrants: Map<Uuid, List<RedactedAppCircleGrant>> = emptyMap(),
+    /**
+     * Circle-add deposits that haven't converted into a real [circleGrants] entry yet — sealed
+     * but not yet actioned by the owner or the contact's server. Standard hyphenated GUIDs (this
+     * field is backed by a plain Guid server-side, unlike [RedactedCircleGrant.circleId]).
+     */
+    val pendingCircleIds: List<Uuid> = emptyList()
 )
 
 @Serializable
 data class RedactedCircleGrant(
-    val circleId: Uuid,
+    @Serializable(with = GuidIdUuidSerializer::class) val circleId: Uuid,
     val permissionSet: PermissionSet? = null,
     val driveGrants: List<RedactedDriveGrant> = emptyList()
 )
@@ -124,10 +136,34 @@ data class RedactedCircleGrant(
 @Serializable
 data class RedactedAppCircleGrant(
     val appId: Uuid,
-    val circleId: Uuid,
+    @Serializable(with = GuidIdUuidSerializer::class) val circleId: Uuid,
     val permissionSet: PermissionSet? = null,
     val driveGrants: List<RedactedDriveGrant> = emptyList()
 )
+
+/**
+ * [RedactedCircleGrant.circleId] and [RedactedAppCircleGrant.circleId] are backed by the server's
+ * `GuidId` type, which always serializes as a 32-char hex string with no hyphens (e.g.
+ * "550e8400e29b41d4a716446655440000") — unlike a plain Guid, which is always hyphenated. The
+ * standard [kotlin.uuid.Uuid] parser only accepts the hyphenated form and throws on this shape.
+ */
+object GuidIdUuidSerializer : KSerializer<Uuid> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("GuidIdUuid", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: Uuid) {
+        encoder.encodeString(value.toString())
+    }
+
+    override fun deserialize(decoder: Decoder): Uuid {
+        val raw = decoder.decodeString()
+        return if (raw.length == 32 && raw.none { it == '-' }) {
+            Uuid.parseHex(raw)
+        } else {
+            Uuid.parse(raw)
+        }
+    }
+}
 
 @Serializable
 data class RedactedDriveGrant(
@@ -164,7 +200,7 @@ enum class ConnectionStatus {
     Unknown,
 
     @SerialName("none")
-    Pending,
+    None,
 
     @SerialName("connected")
     Connected,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ConnectionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ConnectionService.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import co.touchlab.kermit.Logger
+import kotlin.uuid.Uuid
 
 /** Debounce window for push-driven refreshes — long enough to swallow a fan-out burst, short
  *  enough that the contact-detail / circles UI updates promptly after an external change. */
@@ -263,5 +264,30 @@ class ConnectionService(
 
     fun get(odinId: OdinId): RedactedIdentityConnectionRegistration? {
         return _connections.value.map[odinId]
+    }
+
+    /**
+     * Live (uncached) status read for [odinId] straight from the server — the only way to learn
+     * whether a circle grant is still a sealed deposit (`accessGrant.pendingCircleIds`) rather
+     * than a real [CircleWithMembers] entry, since there is no bulk "list pending" endpoint.
+     */
+    suspend fun getConnectionStatus(odinId: OdinId): RedactedIdentityConnectionRegistration? =
+        provider.getConnectionStatus(odinId)
+
+    /**
+     * Grant [odinId] membership in [circleId]. May land as a real [CircleWithMembers] entry
+     * immediately or as a sealed deposit (`pendingCircleIds` on their `/connections/status`) —
+     * the caller decides how to represent that. Refreshes immediately after success so
+     * [circles] reflects a landed grant without waiting on the debounced websocket refresh.
+     */
+    suspend fun addToCircle(circleId: Uuid, odinId: OdinId) {
+        provider.addToCircle(circleId, odinId)
+        refresh()
+    }
+
+    /** Revoke [odinId]'s membership in [circleId] — also drops any still-pending deposit. */
+    suspend fun removeFromCircle(circleId: Uuid, odinId: OdinId) {
+        provider.removeFromCircle(circleId, odinId)
+        refresh()
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ConnectionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ConnectionService.kt
@@ -8,22 +8,31 @@ import id.homebase.api.client.connections.RedactedIdentityConnectionRegistration
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.common.OdinId
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import co.touchlab.kermit.Logger
 import kotlin.uuid.Uuid
 
 /** Debounce window for push-driven refreshes — long enough to swallow a fan-out burst, short
  *  enough that the contact-detail / circles UI updates promptly after an external change. */
 private const val REFRESH_DEBOUNCE_MS = 300L
+
+/** How long [ConnectionService.findPendingMembers] waits for [ConnectionService.connections]/
+ *  [ConnectionService.circles] to complete their first real load before reading them — bounds a
+ *  cold-start caller against racing [ConnectionService.start]'s async hydrate+refresh. */
+private const val CONNECTIONS_LOAD_WAIT_MS = 15_000L
 
 data class ConnectionState(
     val isLoaded: Boolean,
@@ -289,5 +298,50 @@ class ConnectionService(
     suspend fun removeFromCircle(circleId: Uuid, odinId: OdinId) {
         provider.removeFromCircle(circleId, odinId)
         refresh()
+    }
+
+    /**
+     * Live per-contact fan-out to find who currently has [circleId] sealed as a pending deposit
+     * (`accessGrant.pendingCircleIds`) rather than a real member — there is no bulk "list
+     * pending members of a circle" endpoint, so this is the only way to learn it, for ANY
+     * circle. Never cached: every call re-derives the answer from the server. Scoped to
+     * current, Connected identities that aren't already a real member of [circleId] (real
+     * membership is cheap and authoritative from the already-loaded [circles] bulk read, so
+     * there's no need to re-verify it here).
+     *
+     * Waits (bounded) for [connections]/[circles] to have completed at least one real load
+     * before reading them. A caller invoked right on cold start — e.g. the Location dashboard's
+     * resume-triggered check — otherwise races [start]'s async hydrate+refresh: [connections]
+     * and [circles] still hold their empty initial `isLoaded = false` state, so every candidate
+     * list comes back empty and this silently reports "nobody pending" for someone who
+     * genuinely has a pending grant. That's not an exception, so nothing above this catches or
+     * logs it — it just looks like an empty, correct answer. If the wait times out (e.g.
+     * offline), proceeds best-effort against whatever's loaded rather than blocking forever.
+     */
+    suspend fun findPendingMembers(circleId: Uuid): List<OdinId> = coroutineScope {
+        withTimeoutOrNull(CONNECTIONS_LOAD_WAIT_MS) {
+            connections.first { it.isLoaded }
+            circles.first { it.isLoaded }
+        }
+
+        val realMembers = circles.value.membersOf(circleId.toHexString())
+        val candidates = connections.value.map.values
+            .filter { it.status == ConnectionStatus.Connected }
+            .map { it.odinId }
+            .filterNot { realMembers.contains(it.domainName.lowercase()) }
+
+        candidates.map { odinId ->
+            async {
+                val status = try {
+                    getConnectionStatus(odinId)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Logger.w(e) { "ConnectionService: getConnectionStatus failed for $odinId while finding pending members of $circleId" }
+                    null
+                }
+                odinId.takeIf { status?.accessGrant?.pendingCircleIds?.contains(circleId) == true }
+            }
+        }.awaitAll().filterNotNull()
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ConnectionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ConnectionService.kt
@@ -344,4 +344,27 @@ class ConnectionService(
             }
         }.awaitAll().filterNotNull()
     }
+
+    /**
+     * Live read of which circles [odinId] currently has sealed as a pending deposit — the
+     * inverse of [findPendingMembers]: one identity, many circles, so this is a single
+     * `/connections/status` read rather than a fan-out. Filtered to circle ids that actually
+     * exist in the already-loaded bulk circle list, defending against a stale/removed id.
+     */
+    suspend fun findPendingCircles(odinId: OdinId): List<Uuid> {
+        withTimeoutOrNull(CONNECTIONS_LOAD_WAIT_MS) { circles.first { it.isLoaded } }
+
+        val status = try {
+            getConnectionStatus(odinId)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Logger.w(e) { "ConnectionService: getConnectionStatus failed for $odinId while finding pending circles" }
+            return emptyList()
+        }
+        val known = circles.value.circles
+            .mapNotNull { runCatching { Uuid.parseHex(it.circle.id) }.getOrNull() }
+            .toSet()
+        return status?.accessGrant?.pendingCircleIds.orEmpty().filter { it in known }
+    }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ContactService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/contact/ContactService.kt
@@ -49,7 +49,7 @@ class ContactService(
                         connection == null -> ContactConnectionState.NotConnected
                         connection.status == ConnectionStatus.Blocked -> ContactConnectionState.Blocked
                         connection.status == ConnectionStatus.Connected -> ContactConnectionState.Connected
-                        connection.status == ConnectionStatus.Pending -> ContactConnectionState.Pending
+                        connection.status == ConnectionStatus.None -> ContactConnectionState.Pending
                         else -> ContactConnectionState.Unknown
                     }
 

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1358,9 +1358,10 @@
     <string name="location_emergency_access_none">No one can locate you yet. Tap + to add people.</string>
     <string name="location_emergency_access_more">+%1$d</string>
     <string name="location_emergency_add_title">Add emergency contacts</string>
-    <string name="location_emergency_add_none_eligible">No eligible contacts to add. Contacts must be connected and confirmed first.</string>
+    <string name="location_emergency_add_none_eligible">No eligible contacts to add. Contacts must be connected first.</string>
     <string name="location_emergency_add_succeeded">Added</string>
     <string name="location_emergency_add_already_member">Already added</string>
+    <string name="location_emergency_add_unvetted_reason">Not yet confirmed — can't be added yet</string>
     <string name="location_emergency_add_failed">Failed</string>
     <string name="location_emergency_status_pending">Pending</string>
     <string name="location_emergency_remove_cd">Remove %1$s</string>
@@ -1468,7 +1469,8 @@
     <string name="contactbook_circle_members_count_with_pending">%1$d members, %2$d pending</string>
     <string name="contactbook_circle_add_member">Add member</string>
     <string name="circle_member_add_title">Add to %1$s</string>
-    <string name="circle_member_add_none_eligible">No eligible contacts to add. Contacts must be connected and confirmed first.</string>
+    <string name="circle_member_add_none_eligible">No eligible contacts to add. Contacts must be connected first.</string>
+    <string name="circle_member_add_unvetted_reason">Not yet confirmed — can't be added to a circle</string>
     <string name="circle_member_add_succeeded">Added</string>
     <string name="circle_member_add_already_member">Already added</string>
     <string name="circle_member_add_drive_access_denied">This circle includes a drive Chat doesn't have access to, so it can't be added here.</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1357,6 +1357,16 @@
     <string name="location_emergency_access_missing">No Emergency Location Access circle yet. Tap + to set one up in your owner console.</string>
     <string name="location_emergency_access_none">No one can locate you yet. Tap + to add people.</string>
     <string name="location_emergency_access_more">+%1$d</string>
+    <string name="location_emergency_add_title">Add emergency contacts</string>
+    <string name="location_emergency_add_none_eligible">No eligible contacts to add. Contacts must be connected and confirmed first.</string>
+    <string name="location_emergency_add_succeeded">Added</string>
+    <string name="location_emergency_add_already_member">Already added</string>
+    <string name="location_emergency_add_failed">Failed</string>
+    <string name="location_emergency_status_pending">Pending</string>
+    <string name="location_emergency_remove_cd">Remove %1$s</string>
+    <string name="location_emergency_remove_confirm_title">Remove emergency contact?</string>
+    <string name="location_emergency_remove_confirm_body">%1$s will no longer be able to locate you in an emergency.</string>
+    <string name="location_emergency_action_failed">Something went wrong. Please try again.</string>
     <string name="location_device_this_device">This device</string>
     <string name="location_device_no_fix">No recent location</string>
     <string name="location_device_unnamed">Device %1$s</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1465,6 +1465,17 @@
     <string name="contactbook_circle_unvetted">Unvetted</string>
     <string name="contactbook_circle_members_empty">This circle has no members.</string>
     <string name="contactbook_circle_members_count">%1$d members</string>
+    <string name="contactbook_circle_members_count_with_pending">%1$d members, %2$d pending</string>
+    <string name="contactbook_circle_add_member">Add member</string>
+    <string name="circle_member_add_title">Add to %1$s</string>
+    <string name="circle_member_add_none_eligible">No eligible contacts to add. Contacts must be connected and confirmed first.</string>
+    <string name="circle_member_add_succeeded">Added</string>
+    <string name="circle_member_add_already_member">Already added</string>
+    <string name="circle_member_add_failed">Failed</string>
+    <string name="circle_member_pending">Pending</string>
+    <string name="circle_member_remove_cd">Remove member</string>
+    <string name="circle_member_remove_confirm_title">Remove circle member?</string>
+    <string name="circle_member_remove_confirm_body">%1$s will lose the access granted by %2$s.</string>
 
     <string name="contactbook_search_hint">Search</string>
     <string name="contactbook_filter_all">All</string>
@@ -1568,6 +1579,7 @@
     <string name="contactbook_error_photo">The contact was saved, but the photo couldn't be uploaded.</string>
     <string name="contactbook_error_message">Couldn't open the chat.</string>
     <string name="contactbook_error_clear_unsupported">Clearing a contact field isn't supported yet, so that field was kept.</string>
+    <string name="contactbook_error_circle_action">Something went wrong. Please try again.</string>
 
     <string name="contactbook_action_blocked">Contact blocked.</string>
     <string name="contactbook_action_unblocked">Contact unblocked.</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1471,11 +1471,17 @@
     <string name="circle_member_add_none_eligible">No eligible contacts to add. Contacts must be connected and confirmed first.</string>
     <string name="circle_member_add_succeeded">Added</string>
     <string name="circle_member_add_already_member">Already added</string>
+    <string name="circle_member_add_drive_access_denied">This circle includes a drive Chat doesn't have access to, so it can't be added here.</string>
+    <string name="circle_member_add_generic_failed">Something went wrong. Please try again.</string>
     <string name="circle_member_add_failed">Failed</string>
     <string name="circle_member_pending">Pending</string>
+    <string name="circle_member_status_member">Status in this circle: Member</string>
+    <string name="circle_member_status_pending">Status in this circle: Pending</string>
     <string name="circle_member_remove_cd">Remove member</string>
     <string name="circle_member_remove_confirm_title">Remove circle member?</string>
     <string name="circle_member_remove_confirm_body">%1$s will lose the access granted by %2$s.</string>
+    <string name="circle_drives_section_title">Drives this circle can access</string>
+    <string name="circle_drive_unknown">Unknown drive</string>
 
     <string name="contactbook_search_hint">Search</string>
     <string name="contactbook_filter_all">All</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
@@ -220,6 +220,12 @@ sealed class Route {
     @SerialName("location-share")
     data class LocationShare(val conversationId: String) : Route()
 
+    /** In-app picker to grant emergency-location-access circle membership to one or more
+     *  contacts — replaces the old owner-console browser deep link. */
+    @Serializable
+    @SerialName("location-emergency-contact-add")
+    data object LocationEmergencyContactAdd : Route()
+
     @Serializable
     @SerialName("crop")
     data class Crop(val requestId: String, val lockedAspect: String? = null) : Route()

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
@@ -134,6 +134,12 @@ sealed class Route {
     @SerialName("contactbook-detail")
     data class ContactBookDetail(val uniqueId: String, val odinId: String? = null) : Route()
 
+    /** Generic "add contact to circle" picker — reachable from any circle in the Contact
+     *  Book's Circles tab, not just emergency location access. */
+    @Serializable
+    @SerialName("contactbook-circle-member-add")
+    data class CircleMemberAdd(val circleId: String, val circleName: String) : Route()
+
     @Serializable
     @SerialName("contactbook-add")
     // identityOnly: launched from a chat flow, where a contact is only useful if it has a

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -177,6 +177,7 @@ import id.homebase.core.location.tracking.LocationTracker
 import id.homebase.core.location.tracking.LocationTrackingCoordinator
 import id.homebase.core.location.tracking.createLocationTracker
 import id.homebase.core.ui.screens.location.LocationTrackUploaderService
+import id.homebase.core.ui.screens.location.EmergencyContactPickerViewModel
 import id.homebase.core.ui.screens.location.LocationViewModel
 import id.homebase.core.ui.screens.location.PushCaptureUploader
 import id.homebase.core.ui.screens.location.model.locationHourFileUid
@@ -906,6 +907,7 @@ val appModule = module {
             authConnectionCoordinator = get(),
         )
     }
+    viewModelOf(::EmergencyContactPickerViewModel)
     // Manual block: the optional peerDomain (emergency-locate peer mode) arrives as a Koin
     // runtime parameter from the LocationPeerHistory route; the own-history call site passes none.
     viewModel { params ->

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -85,6 +85,7 @@ import id.homebase.api.client.contacts.ContactRepository
 import id.homebase.core.contactbook.ContactOverrideStore
 import id.homebase.core.contactbook.EmergencyContactReceiveService
 import id.homebase.core.contactbook.EmergencyContactReconciler
+import id.homebase.core.ui.screens.contactbook.CircleMemberPickerViewModel
 import id.homebase.core.ui.screens.contactbook.ContactBookViewModel
 import id.homebase.core.ui.screens.contactbook.add.AddContactViewModel
 import id.homebase.core.ui.screens.contactbook.detail.ContactDetailViewModel
@@ -944,6 +945,16 @@ val appModule = module {
         )
     }
     viewModelOf(::ContactBookViewModel)
+    // Manual block: circleId/circleName arrive as Koin runtime parameters from the
+    // CircleMemberAdd route — viewModelOf would try to autowire them from the DI graph.
+    viewModel { params ->
+        CircleMemberPickerViewModel(
+            circleId = params.get(),
+            circleName = params.get(),
+            repo = get(),
+            connectionService = get(),
+        )
+    }
     viewModelOf(::ContactDetailViewModel)
     viewModelOf(::AddContactViewModel)
     viewModelOf(::ContactBookSettingsViewModel)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -110,6 +110,7 @@ import id.homebase.core.ui.screens.moments.MomentsViewModel
 import id.homebase.core.moments.MomentsPreferences
 import id.homebase.core.moments.services.MomentsFeedService
 import id.homebase.core.location.LocationPreferences
+import id.homebase.core.ui.screens.location.EmergencyContactPickerScreen
 import id.homebase.core.ui.screens.location.LocationScreen
 import id.homebase.core.ui.screens.location.LocationUiEvent
 import id.homebase.core.ui.screens.location.LocationViewModel
@@ -147,6 +148,7 @@ import id.homebase.resources.nav_chats
 import id.homebase.resources.nav_feed
 import id.homebase.resources.nav_home
 import id.homebase.resources.location_label
+import id.homebase.resources.location_emergency_action_failed
 import id.homebase.resources.location_locate_fetch_failed
 import id.homebase.resources.vault_label
 import org.jetbrains.compose.resources.stringResource
@@ -512,6 +514,7 @@ fun AppNavHost(
 
     // Translate Location onboarding one-shot events into nav-stack changes.
     val locateFetchFailedMsg = stringResource(MR.string.location_locate_fetch_failed)
+    val emergencyContactActionFailedMsg = stringResource(MR.string.location_emergency_action_failed)
     LaunchedEffect(Unit) {
         locationViewModel.events.collect { event ->
             when (event) {
@@ -533,6 +536,11 @@ fun AppNavHost(
 
                 LocationUiEvent.LocateFetchFailed -> snackbarHostState.showSnackbar(
                     message = locateFetchFailedMsg,
+                    duration = SnackbarDuration.Long,
+                )
+
+                LocationUiEvent.EmergencyContactActionFailed -> snackbarHostState.showSnackbar(
+                    message = emergencyContactActionFailedMsg,
                     duration = SnackbarDuration.Long,
                 )
             }
@@ -1382,6 +1390,18 @@ fun AppNavHost(
                                     onNavigateToLiveMap = {
                                         navController.navigate(Route.LocationLive)
                                     },
+                                    onNavigateToEmergencyContactAdd = {
+                                        navController.navigate(Route.LocationEmergencyContactAdd)
+                                    },
+                                )
+                            }
+                        }
+
+                        composable<Route.LocationEmergencyContactAdd> {
+                            if (isAuthenticated) {
+                                EmergencyContactPickerScreen(
+                                    viewModel = koinViewModel(),
+                                    onNavigateBack = { navController.popBackStack() },
                                 )
                             }
                         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -136,6 +136,7 @@ import id.homebase.core.ui.screens.storage.StorageSettingsScreen
 import id.homebase.core.ui.screens.widget.RichTextExample
 import id.homebase.core.vault.VaultPreferences
 import id.homebase.core.contactbook.ContactBookPreferences
+import id.homebase.core.ui.screens.contactbook.CircleMemberPickerScreen
 import id.homebase.core.ui.screens.contactbook.ContactBookScreen
 import id.homebase.core.ui.screens.contactbook.add.AddContactScreen
 import id.homebase.core.ui.screens.contactbook.ContactBookUiEvent
@@ -372,6 +373,8 @@ fun AppNavHost(
                     navController.navigate(Route.ContactBookDetail(event.uniqueId, event.odinId))
                 ContactBookUiEvent.OpenAddContact ->
                     navController.navigate(Route.AddContact())
+                is ContactBookUiEvent.OpenCircleMemberAdd ->
+                    navController.navigate(Route.CircleMemberAdd(event.circleId, event.circleName))
                 ContactBookUiEvent.CloseOnboarding ->
                     navController.popBackStack(Route.ChatList, inclusive = false)
                 else -> { /* Error handled by ContactBookScreen */ }
@@ -831,6 +834,24 @@ fun AppNavHost(
                                         },
                                     )
                                 }
+                            }
+                        }
+
+                        composable<Route.CircleMemberAdd> { backStackEntry ->
+                            if (isAuthenticated) {
+                                val route = backStackEntry.toRoute<Route.CircleMemberAdd>()
+                                CircleMemberPickerScreen(
+                                    viewModel = koinViewModel(
+                                        key = route.circleId,
+                                        parameters = {
+                                            org.koin.core.parameter.parametersOf(
+                                                Uuid.parseHex(route.circleId),
+                                                route.circleName,
+                                            )
+                                        },
+                                    ),
+                                    onNavigateBack = { navController.popBackStack() },
+                                )
                             }
                         }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -897,6 +897,9 @@ fun AppNavHost(
                                     onSeeAllMedia = { conversationId ->
                                         navController.navigate(Route.ConversationMedia(conversationId))
                                     },
+                                    onOpenContact = { uniqueId, odinId ->
+                                        navController.navigate(Route.ContactBookDetail(uniqueId, odinId))
+                                    },
                                 )
                             }
                         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleAddFailureReason.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleAddFailureReason.kt
@@ -1,0 +1,37 @@
+package id.homebase.core.ui.screens.contactbook
+
+import id.homebase.api.client.ForbiddenException
+import id.homebase.api.client.OdinClientErrorCode
+import id.homebase.api.client.errorCodeEnum
+
+/**
+ * Why a single contact's `circles/add` call failed, shaped so the UI layer (not this ViewModel-
+ * agnostic classification) resolves the actual display string via `stringResource` — a
+ * ViewModel can't call that directly. [Raw] carries real, server-provided text (a 400
+ * ClientException's message already is the server's title); the two 403 cases need distinct
+ * copy because only one of them is user-actionable.
+ */
+sealed interface CircleAddFailureReason {
+    /** A 400 (or any other exception whose message is already a real, useful explanation). */
+    data class Raw(val message: String) : CircleAddFailureReason
+
+    /** 403 with errorCode 4173 (CannotSourceDriveStorageKeyForGrant) — this app genuinely can't
+     *  be granted this circle because it includes a drive the app doesn't have access to. Real,
+     *  user-facing, not transient — don't offer a retry. */
+    data object DriveAccessDenied : CircleAddFailureReason
+
+    /** Any other 403 (missing ManageCircleMembership, contact not connected, etc) — the server
+     *  gives no code to distinguish these from each other, and per the API contract they're
+     *  client-side/config bugs, not user-facing outcomes. Log the real reason; show a generic
+     *  message rather than surfacing (possibly cryptic) internal detail as if it explained
+     *  anything actionable. */
+    data object OpaqueForbidden : CircleAddFailureReason
+}
+
+/** Classifies a `connectionService.addToCircle` failure into a [CircleAddFailureReason]. */
+fun Throwable.toCircleAddFailureReason(): CircleAddFailureReason = when {
+    this is ForbiddenException && problem?.errorCodeEnum() == OdinClientErrorCode.CannotSourceDriveStorageKeyForGrant ->
+        CircleAddFailureReason.DriveAccessDenied
+    this is ForbiddenException -> CircleAddFailureReason.OpaqueForbidden
+    else -> CircleAddFailureReason.Raw(message ?: "Failed")
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleDriveResolver.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleDriveResolver.kt
@@ -1,0 +1,48 @@
+package id.homebase.core.ui.screens.contactbook
+
+import id.homebase.api.client.connections.RedactedCircleDefinition
+import id.homebase.core.config.LabeledDrive
+import id.homebase.core.config.chatLabeledDrive
+import id.homebase.core.config.contactLabeledDrive
+import id.homebase.core.config.locationLabeledDrive
+import id.homebase.core.config.momentsLabeledDrive
+import id.homebase.core.config.stickerLabeledDrive
+import id.homebase.core.config.vaultLabeledDrive
+
+/** One drive a circle grants access to. [label] is null when the drive alias doesn't match any
+ *  of this app's own known drives (a system drive, another app's drive, or a placeholder GUID
+ *  pending server provisioning) — the caller falls back to a generic "unknown drive" string. */
+data class CircleDriveUi(val label: String?, val permission: String)
+
+private fun String.normalizedGuid(): String = replace("-", "").lowercase()
+
+/**
+ * This app's own known drives, keyed by normalized (no-hyphen, lowercase) alias, for matching
+ * against a circle's drive grants. `RedactedTargetDrive.alias` has no prior consumer in this
+ * codebase (unlike `RedactedCircleGrant.circleId`, which needed `GuidIdUuidSerializer` because
+ * the server's GuidId type always serializes hyphen-less) — its wire format is unconfirmed, so
+ * both sides are normalized defensively before comparing rather than assuming either shape.
+ */
+private val knownDrives: List<LabeledDrive> = listOf(
+    chatLabeledDrive,
+    contactLabeledDrive,
+    locationLabeledDrive,
+    vaultLabeledDrive,
+    stickerLabeledDrive,
+    momentsLabeledDrive,
+)
+
+private val knownDrivesByAlias: Map<String, String> by lazy {
+    knownDrives.associate { it.drive.alias.toString().normalizedGuid() to it.label }
+}
+
+/** Resolves [circle]'s drive grants to friendly labels where recognized. Order follows the
+ *  server's own driveGrants order; permission is the raw camelCase string (e.g. "read" or
+ *  "read,write") since it's already a stable, small vocabulary not worth re-parsing here. */
+fun resolveCircleDrives(circle: RedactedCircleDefinition): List<CircleDriveUi> =
+    circle.driveGrants.orEmpty().mapNotNull { grant ->
+        val permissionedDrive = grant.permissionedDrive ?: return@mapNotNull null
+        val alias = permissionedDrive.drive?.alias ?: return@mapNotNull null
+        val permission = permissionedDrive.permission ?: return@mapNotNull null
+        CircleDriveUi(label = knownDrivesByAlias[alias.normalizedGuid()], permission = permission)
+    }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleMemberPickerScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleMemberPickerScreen.kt
@@ -47,6 +47,7 @@ import id.homebase.resources.circle_member_add_generic_failed
 import id.homebase.resources.circle_member_add_none_eligible
 import id.homebase.resources.circle_member_add_succeeded
 import id.homebase.resources.circle_member_add_title
+import id.homebase.resources.circle_member_add_unvetted_reason
 import id.homebase.resources.menu_back
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
@@ -164,15 +165,18 @@ private fun CircleMemberPickerUi(
                     Text(text = stringResource(MR.string.circle_member_add_none_eligible))
                 }
             } else {
+                val unvettedReason = stringResource(MR.string.circle_member_add_unvetted_reason)
                 LazyColumn(
                     modifier = Modifier.weight(1f),
                     contentPadding = PaddingValues(vertical = 8.dp),
                 ) {
-                    items(uiState.candidates, key = { it.uniqueId.toString() }) { entry ->
+                    items(uiState.candidates, key = { it.entry.uniqueId.toString() }) { candidate ->
+                        val entry = candidate.entry
                         val isSelected = uiState.selected.contains(entry)
                         ContactBookRow(
                             entry = entry,
                             onClick = { onUiAction(CircleMemberPickerUiAction.ContactClicked(entry)) },
+                            disabledReason = if (!candidate.eligible) unvettedReason else null,
                             trailing = if (isSelected) {
                                 {
                                     Icon(

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleMemberPickerScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleMemberPickerScreen.kt
@@ -42,6 +42,8 @@ import id.homebase.core.widget.StyledSearchTextField
 import id.homebase.resources.MR
 import id.homebase.resources.chat_new_conversation_search_placeholder
 import id.homebase.resources.circle_member_add_already_member
+import id.homebase.resources.circle_member_add_drive_access_denied
+import id.homebase.resources.circle_member_add_generic_failed
 import id.homebase.resources.circle_member_add_none_eligible
 import id.homebase.resources.circle_member_add_succeeded
 import id.homebase.resources.circle_member_add_title
@@ -60,18 +62,29 @@ fun CircleMemberPickerScreen(
 
     val addedLabel = stringResource(MR.string.circle_member_add_succeeded)
     val alreadyMemberLabel = stringResource(MR.string.circle_member_add_already_member)
+    val driveAccessDeniedLabel = stringResource(MR.string.circle_member_add_drive_access_denied)
+    val genericFailedLabel = stringResource(MR.string.circle_member_add_generic_failed)
 
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
             when (event) {
                 CircleMemberPickerUiEvent.Back -> onNavigateBack()
                 is CircleMemberPickerUiEvent.AddCompleted -> {
-                    // Failures lead with the actual reason (server title / exception message) —
-                    // a bare "Failed: 1" told the user nothing happened worth acting on.
+                    // Failures lead with the actual reason — a bare "Failed: 1" told the user
+                    // nothing happened worth acting on. Only DriveAccessDenied and a real 400's
+                    // message are genuinely explanatory; an opaque 403 gets a generic message
+                    // rather than surfacing internal detail as if it were actionable.
                     val parts = buildList {
                         if (event.added > 0) add("$addedLabel: ${event.added}")
                         if (event.alreadyMember > 0) add("$alreadyMemberLabel: ${event.alreadyMember}")
-                        event.failures.forEach { add("${it.name}: ${it.reason}") }
+                        event.failures.forEach { f ->
+                            val reason = when (val r = f.reason) {
+                                is CircleAddFailureReason.Raw -> r.message
+                                CircleAddFailureReason.DriveAccessDenied -> driveAccessDeniedLabel
+                                CircleAddFailureReason.OpaqueForbidden -> genericFailedLabel
+                            }
+                            add("${f.name}: $reason")
+                        }
                     }
                     if (parts.isNotEmpty()) {
                         scope.launch {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleMemberPickerScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleMemberPickerScreen.kt
@@ -1,0 +1,178 @@
+package id.homebase.core.ui.screens.contactbook
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.homebase.core.ui.screens.contactbook.components.ContactBookRow
+import id.homebase.core.widget.StyledSearchTextField
+import id.homebase.resources.MR
+import id.homebase.resources.chat_new_conversation_search_placeholder
+import id.homebase.resources.circle_member_add_already_member
+import id.homebase.resources.circle_member_add_none_eligible
+import id.homebase.resources.circle_member_add_succeeded
+import id.homebase.resources.circle_member_add_title
+import id.homebase.resources.menu_back
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun CircleMemberPickerScreen(
+    viewModel: CircleMemberPickerViewModel,
+    onNavigateBack: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+
+    val addedLabel = stringResource(MR.string.circle_member_add_succeeded)
+    val alreadyMemberLabel = stringResource(MR.string.circle_member_add_already_member)
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                CircleMemberPickerUiEvent.Back -> onNavigateBack()
+                is CircleMemberPickerUiEvent.AddCompleted -> {
+                    // Failures lead with the actual reason (server title / exception message) —
+                    // a bare "Failed: 1" told the user nothing happened worth acting on.
+                    val parts = buildList {
+                        if (event.added > 0) add("$addedLabel: ${event.added}")
+                        if (event.alreadyMember > 0) add("$alreadyMemberLabel: ${event.alreadyMember}")
+                        event.failures.forEach { add("${it.name}: ${it.reason}") }
+                    }
+                    if (parts.isNotEmpty()) {
+                        scope.launch {
+                            snackbarHostState.showSnackbar(
+                                message = parts.joinToString(" · "),
+                                duration = if (event.failures.isNotEmpty()) SnackbarDuration.Long
+                                else SnackbarDuration.Short,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    CircleMemberPickerUi(
+        snackbarHostState = snackbarHostState,
+        uiState = uiState,
+        searchTextState = viewModel.searchTextState,
+        onUiAction = viewModel::onUiAction,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CircleMemberPickerUi(
+    snackbarHostState: SnackbarHostState,
+    uiState: CircleMemberPickerUiState,
+    searchTextState: TextFieldState,
+    onUiAction: (CircleMemberPickerUiAction) -> Unit,
+) {
+    Scaffold(
+        modifier = Modifier.imePadding(),
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(MR.string.circle_member_add_title, uiState.circleName)) },
+                navigationIcon = {
+                    IconButton(onClick = { onUiAction(CircleMemberPickerUiAction.BackClicked) }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(MR.string.menu_back),
+                        )
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            if (uiState.selected.isNotEmpty()) {
+                Button(
+                    onClick = { onUiAction(CircleMemberPickerUiAction.AddClicked) },
+                    modifier = Modifier.defaultMinSize(minWidth = 56.dp),
+                    enabled = !uiState.submitting,
+                    shape = CircleShape,
+                ) {
+                    if (uiState.submitting) {
+                        CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+                    } else {
+                        Icon(Icons.Default.Check, contentDescription = stringResource(MR.string.circle_member_add_title, uiState.circleName))
+                    }
+                }
+            }
+        },
+    ) { paddingValues ->
+        Column(modifier = Modifier.padding(paddingValues)) {
+            StyledSearchTextField(
+                modifier = Modifier.padding(horizontal = 16.dp).fillMaxWidth(),
+                textFieldState = searchTextState,
+                showSearchIcon = false,
+                placeHolderText = stringResource(MR.string.chat_new_conversation_search_placeholder),
+            )
+            if (uiState.candidates.isEmpty()) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(top = 24.dp, start = 16.dp, end = 16.dp),
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    Text(text = stringResource(MR.string.circle_member_add_none_eligible))
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier.weight(1f),
+                    contentPadding = PaddingValues(vertical = 8.dp),
+                ) {
+                    items(uiState.candidates, key = { it.uniqueId.toString() }) { entry ->
+                        val isSelected = uiState.selected.contains(entry)
+                        ContactBookRow(
+                            entry = entry,
+                            onClick = { onUiAction(CircleMemberPickerUiAction.ContactClicked(entry)) },
+                            trailing = if (isSelected) {
+                                {
+                                    Icon(
+                                        imageVector = Icons.Default.CheckCircle,
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.primary,
+                                    )
+                                }
+                            } else null,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleMemberPickerUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleMemberPickerUiState.kt
@@ -1,0 +1,35 @@
+package id.homebase.core.ui.screens.contactbook
+
+import id.homebase.core.ui.screens.contactbook.model.ContactBookEntry
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
+
+data class CircleMemberPickerUiState(
+    val circleName: String = "",
+    val candidates: PersistentList<ContactBookEntry> = persistentListOf(),
+    val selected: PersistentList<ContactBookEntry> = persistentListOf(),
+    val submitting: Boolean = false,
+)
+
+sealed interface CircleMemberPickerUiAction {
+    data class ContactClicked(val entry: ContactBookEntry) : CircleMemberPickerUiAction
+    data object AddClicked : CircleMemberPickerUiAction
+    data object BackClicked : CircleMemberPickerUiAction
+}
+
+/** One failed add attempt, carrying the actual server/client reason so the user sees why —
+ *  not just that something failed. */
+data class CircleMemberAddFailure(val name: String, val reason: String)
+
+sealed interface CircleMemberPickerUiEvent {
+    data object Back : CircleMemberPickerUiEvent
+
+    /** [added] landed as real or pending grants; [alreadyMember] were no-ops (already a member
+     *  or already pending); [failures] hit a real error (network, forbidden, an unrecognized
+     *  400, etc) — kept selected on the picker so the user can see who still needs attention. */
+    data class AddCompleted(
+        val added: Int,
+        val alreadyMember: Int,
+        val failures: List<CircleMemberAddFailure>,
+    ) : CircleMemberPickerUiEvent
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleMemberPickerUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleMemberPickerUiState.kt
@@ -6,9 +6,18 @@ import kotlinx.collections.immutable.persistentListOf
 
 data class CircleMemberPickerUiState(
     val circleName: String = "",
-    val candidates: PersistentList<ContactBookEntry> = persistentListOf(),
+    val candidates: PersistentList<CircleMemberCandidate> = persistentListOf(),
     val selected: PersistentList<ContactBookEntry> = persistentListOf(),
     val submitting: Boolean = false,
+)
+
+/** A connected identity shown in the add-to-circle picker. [eligible] is false for a connected
+ *  but unvetted (unconfirmed) identity — the server rejects circles/add for those with
+ *  CannotGrantAutoConnectedMoreCircles, so the row is shown (not hidden) but disabled, with a
+ *  reason, rather than silently vanishing from the list. */
+data class CircleMemberCandidate(
+    val entry: ContactBookEntry,
+    val eligible: Boolean,
 )
 
 sealed interface CircleMemberPickerUiAction {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleMemberPickerUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleMemberPickerUiState.kt
@@ -19,7 +19,7 @@ sealed interface CircleMemberPickerUiAction {
 
 /** One failed add attempt, carrying the actual server/client reason so the user sees why —
  *  not just that something failed. */
-data class CircleMemberAddFailure(val name: String, val reason: String)
+data class CircleMemberAddFailure(val name: String, val reason: CircleAddFailureReason)
 
 sealed interface CircleMemberPickerUiEvent {
     data object Back : CircleMemberPickerUiEvent

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleMemberPickerViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleMemberPickerViewModel.kt
@@ -122,7 +122,10 @@ class CircleMemberPickerViewModel(
                 for (entry in targets) {
                     val odinId = entry.odinId?.let(::OdinId)
                     if (odinId == null) {
-                        failures += CircleMemberAddFailure(entry.displayName, "No Homebase ID on file")
+                        failures += CircleMemberAddFailure(
+                            entry.displayName,
+                            CircleAddFailureReason.Raw("No Homebase ID on file"),
+                        )
                         stillFailed += entry
                         continue
                     }
@@ -134,12 +137,12 @@ class CircleMemberPickerViewModel(
                             alreadyMember++
                         } else {
                             Logger.w(e, TAG) { "addToCircle failed for $odinId: ${e.errorCode}" }
-                            failures += CircleMemberAddFailure(entry.displayName, e.message ?: "Failed")
+                            failures += CircleMemberAddFailure(entry.displayName, e.toCircleAddFailureReason())
                             stillFailed += entry
                         }
                     } catch (e: Exception) {
                         Logger.w(e, TAG) { "addToCircle failed for $odinId" }
-                        failures += CircleMemberAddFailure(entry.displayName, e.message ?: "Failed")
+                        failures += CircleMemberAddFailure(entry.displayName, e.toCircleAddFailureReason())
                         stillFailed += entry
                     }
                 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleMemberPickerViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleMemberPickerViewModel.kt
@@ -32,12 +32,14 @@ private const val TAG = "CircleMemberPickerViewModel"
 
 /**
  * Generic "add contact to circle" picker — works for any circle by [circleId], not just
- * emergency-location access. Candidate list: connected AND vetted identities (auto-connected/
- * unconfirmed identities 400 on add — CannotGrantAutoConnectedMoreCircles), excluding anyone
- * already a real member of [circleId] (cheap, from the already-loaded bulk circle-members
- * read). A duplicate add on a still-pending contact simply hits the server's real
- * IdentityAlreadyMemberOfCircle response (handled in [addSelected]) rather than being
- * pre-filtered from a guess.
+ * emergency-location access. Candidate list: every connected identity, excluding anyone already
+ * a real member of [circleId] (cheap, from the already-loaded bulk circle-members read). A
+ * connected-but-unvetted (unconfirmed) identity is still shown — hiding it entirely made it look
+ * like the contact didn't exist, which was confusing — but marked ineligible ([CircleMemberCandidate.eligible]
+ * = false) and can't be selected, since the server 400s circles/add for those identities
+ * (CannotGrantAutoConnectedMoreCircles). A duplicate add on a still-pending contact simply hits
+ * the server's real IdentityAlreadyMemberOfCircle response (handled in [addSelected]) rather than
+ * being pre-filtered from a guess.
  */
 class CircleMemberPickerViewModel(
     private val circleId: Uuid,
@@ -67,16 +69,18 @@ class CircleMemberPickerViewModel(
                     .filter { !it.odinId.isNullOrBlank() }
                     .associateBy { it.odinId!!.lowercase() }
 
-                val eligibleDomains = connectionState.map.values
-                    .filter { it.status == ConnectionStatus.Connected && it.vetted }
-                    .map { it.odinId.domainName.lowercase() }
-                    .filterNot { members.contains(it) }
+                val connectedRegistrations = connectionState.map.values
+                    .filter { it.status == ConnectionStatus.Connected }
+                    .filterNot { members.contains(it.odinId.domainName.lowercase()) }
 
                 val q = query.trim().lowercase()
-                eligibleDomains
-                    .map { domain -> byOdin[domain] ?: syntheticEntry(domain) }
-                    .filter { q.isEmpty() || it.displayName.lowercase().contains(q) || it.odinId?.lowercase()?.contains(q) == true }
-                    .sortedBy { it.displayName.lowercase() }
+                connectedRegistrations
+                    .map { reg ->
+                        val domain = reg.odinId.domainName.lowercase()
+                        CircleMemberCandidate(entry = byOdin[domain] ?: syntheticEntry(domain), eligible = reg.vetted)
+                    }
+                    .filter { q.isEmpty() || it.entry.displayName.lowercase().contains(q) || it.entry.odinId?.lowercase()?.contains(q) == true }
+                    .sortedBy { it.entry.displayName.lowercase() }
             }.collect { candidates ->
                 _uiState.update { it.copy(candidates = candidates.toPersistentList()) }
             }
@@ -98,9 +102,13 @@ class CircleMemberPickerViewModel(
     fun onUiAction(action: CircleMemberPickerUiAction) {
         when (action) {
             is CircleMemberPickerUiAction.ContactClicked -> {
-                val selected = uiState.value.selected.toMutableList()
-                if (!selected.remove(action.entry)) selected.add(action.entry)
-                _uiState.update { it.copy(selected = selected.toPersistentList()) }
+                val eligible = uiState.value.candidates
+                    .firstOrNull { it.entry.uniqueId == action.entry.uniqueId }?.eligible == true
+                if (eligible) {
+                    val selected = uiState.value.selected.toMutableList()
+                    if (!selected.remove(action.entry)) selected.add(action.entry)
+                    _uiState.update { it.copy(selected = selected.toPersistentList()) }
+                }
             }
 
             CircleMemberPickerUiAction.AddClicked -> addSelected()
@@ -132,6 +140,8 @@ class CircleMemberPickerViewModel(
                     try {
                         connectionService.addToCircle(circleId, odinId)
                         added++
+                    } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+                        throw e
                     } catch (e: ClientException) {
                         if (e.errorCode == OdinClientErrorCode.IdentityAlreadyMemberOfCircle) {
                             alreadyMember++

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleMemberPickerViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleMemberPickerViewModel.kt
@@ -1,0 +1,157 @@
+package id.homebase.core.ui.screens.contactbook
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.runtime.snapshotFlow
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
+import id.homebase.api.client.ClientException
+import id.homebase.api.client.OdinClientErrorCode
+import id.homebase.api.client.connections.ConnectionStatus
+import id.homebase.api.client.contacts.ContactRepository
+import id.homebase.api.crypto.Md5
+import id.homebase.api.common.OdinId
+import id.homebase.chat.services.convo.contact.ConnectionService
+import id.homebase.core.ui.screens.contactbook.model.ContactBookEntry
+import id.homebase.core.ui.screens.contactbook.model.ContactBookSource
+import id.homebase.core.ui.screens.contactbook.model.toContactBookEntry
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlin.uuid.Uuid
+
+private const val TAG = "CircleMemberPickerViewModel"
+
+/**
+ * Generic "add contact to circle" picker — works for any circle by [circleId], not just
+ * emergency-location access. Candidate list: connected AND vetted identities (auto-connected/
+ * unconfirmed identities 400 on add — CannotGrantAutoConnectedMoreCircles), excluding anyone
+ * already a real member of [circleId] (cheap, from the already-loaded bulk circle-members
+ * read). A duplicate add on a still-pending contact simply hits the server's real
+ * IdentityAlreadyMemberOfCircle response (handled in [addSelected]) rather than being
+ * pre-filtered from a guess.
+ */
+class CircleMemberPickerViewModel(
+    private val circleId: Uuid,
+    circleName: String,
+    private val repo: ContactRepository,
+    private val connectionService: ConnectionService,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CircleMemberPickerUiState(circleName = circleName))
+    val uiState: StateFlow<CircleMemberPickerUiState> = _uiState.asStateFlow()
+    val searchTextState = TextFieldState()
+
+    private val _events = MutableSharedFlow<CircleMemberPickerUiEvent>(extraBufferCapacity = 4)
+    val events: SharedFlow<CircleMemberPickerUiEvent> = _events.asSharedFlow()
+
+    init {
+        viewModelScope.launch {
+            combine(
+                repo.contacts,
+                connectionService.connections,
+                connectionService.circles,
+                snapshotFlow { searchTextState.text.toString() },
+            ) { contacts, connectionState, circleState, query ->
+                val members = circleState.membersOf(circleId.toHexString())
+                val bookEntries = contacts.mapNotNull { it.toContactBookEntry() }
+                val byOdin = bookEntries
+                    .filter { !it.odinId.isNullOrBlank() }
+                    .associateBy { it.odinId!!.lowercase() }
+
+                val eligibleDomains = connectionState.map.values
+                    .filter { it.status == ConnectionStatus.Connected && it.vetted }
+                    .map { it.odinId.domainName.lowercase() }
+                    .filterNot { members.contains(it) }
+
+                val q = query.trim().lowercase()
+                eligibleDomains
+                    .map { domain -> byOdin[domain] ?: syntheticEntry(domain) }
+                    .filter { q.isEmpty() || it.displayName.lowercase().contains(q) || it.odinId?.lowercase()?.contains(q) == true }
+                    .sortedBy { it.displayName.lowercase() }
+            }.collect { candidates ->
+                _uiState.update { it.copy(candidates = candidates.toPersistentList()) }
+            }
+        }
+    }
+
+    private fun syntheticEntry(domain: String): ContactBookEntry {
+        val uid = Md5.toGuidId(domain.lowercase())
+        return ContactBookEntry(
+            uniqueId = uid,
+            fileId = uid,
+            versionTag = null,
+            odinId = domain,
+            displayName = domain,
+            source = ContactBookSource.CONNECTION,
+        )
+    }
+
+    fun onUiAction(action: CircleMemberPickerUiAction) {
+        when (action) {
+            is CircleMemberPickerUiAction.ContactClicked -> {
+                val selected = uiState.value.selected.toMutableList()
+                if (!selected.remove(action.entry)) selected.add(action.entry)
+                _uiState.update { it.copy(selected = selected.toPersistentList()) }
+            }
+
+            CircleMemberPickerUiAction.AddClicked -> addSelected()
+            CircleMemberPickerUiAction.BackClicked -> _events.tryEmit(CircleMemberPickerUiEvent.Back)
+        }
+    }
+
+    private fun addSelected() {
+        if (uiState.value.submitting) return
+        val targets = uiState.value.selected
+        if (targets.isEmpty()) return
+        _uiState.update { it.copy(submitting = true) }
+        viewModelScope.launch {
+            var added = 0
+            var alreadyMember = 0
+            val failures = mutableListOf<CircleMemberAddFailure>()
+            val stillFailed = mutableListOf<ContactBookEntry>()
+            try {
+                for (entry in targets) {
+                    val odinId = entry.odinId?.let(::OdinId)
+                    if (odinId == null) {
+                        failures += CircleMemberAddFailure(entry.displayName, "No Homebase ID on file")
+                        stillFailed += entry
+                        continue
+                    }
+                    try {
+                        connectionService.addToCircle(circleId, odinId)
+                        added++
+                    } catch (e: ClientException) {
+                        if (e.errorCode == OdinClientErrorCode.IdentityAlreadyMemberOfCircle) {
+                            alreadyMember++
+                        } else {
+                            Logger.w(e, TAG) { "addToCircle failed for $odinId: ${e.errorCode}" }
+                            failures += CircleMemberAddFailure(entry.displayName, e.message ?: "Failed")
+                            stillFailed += entry
+                        }
+                    } catch (e: Exception) {
+                        Logger.w(e, TAG) { "addToCircle failed for $odinId" }
+                        failures += CircleMemberAddFailure(entry.displayName, e.message ?: "Failed")
+                        stillFailed += entry
+                    }
+                }
+            } finally {
+                // Only drop entries that actually resolved (succeeded or already-member) from
+                // the selection — a failed one stays selected and visible so the user can see
+                // who still needs attention and retry, instead of the selection silently
+                // vanishing and the failure reading as "nothing happened".
+                _uiState.update { it.copy(submitting = false, selected = stillFailed.toPersistentList()) }
+                _events.tryEmit(CircleMemberPickerUiEvent.AddCompleted(added, alreadyMember, failures))
+                if (failures.isEmpty()) _events.tryEmit(CircleMemberPickerUiEvent.Back)
+            }
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookScreen.kt
@@ -56,6 +56,7 @@ import id.homebase.core.ui.screens.contactbook.components.CircleMembersSheet
 import id.homebase.core.ui.screens.contactbook.components.ContactEditSheet
 import id.homebase.resources.MR
 import id.homebase.resources.contactbook_action_add
+import id.homebase.resources.contactbook_error_circle_action
 import id.homebase.resources.contactbook_error_delete
 import id.homebase.resources.contactbook_error_forbidden
 import id.homebase.resources.contactbook_error_clear_unsupported
@@ -90,6 +91,7 @@ fun ContactBookScreen(
     val errMessage = stringResource(MR.string.contactbook_error_message)
     val errClearUnsupported = stringResource(MR.string.contactbook_error_clear_unsupported)
     val errForbidden = stringResource(MR.string.contactbook_error_forbidden)
+    val errCircleAction = stringResource(MR.string.contactbook_error_circle_action)
 
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
@@ -97,6 +99,7 @@ fun ContactBookScreen(
                 is ContactBookUiEvent.OpenConversation -> { /* navigation handled in AppNavHost */ }
                 is ContactBookUiEvent.OpenDetail -> { /* navigation handled in AppNavHost */ }
                 ContactBookUiEvent.OpenAddContact -> { /* navigation handled in AppNavHost */ }
+                is ContactBookUiEvent.OpenCircleMemberAdd -> { /* navigation handled in AppNavHost */ }
                 is ContactBookUiEvent.Error -> {
                     val msg = when (event.error) {
                         ContactBookError.SaveFailed -> errSave
@@ -105,6 +108,7 @@ fun ContactBookScreen(
                         ContactBookError.PhotoFailed -> errPhoto
                         ContactBookError.MessageFailed -> errMessage
                         ContactBookError.ClearUnsupported -> errClearUnsupported
+                        ContactBookError.CircleActionFailed -> errCircleAction
                     }
                     snackbarHostState.showSnackbar(msg)
                 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -46,6 +47,9 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.api.client.auth.initials
 import id.homebase.core.avatars.AvatarOptions
@@ -115,6 +119,20 @@ fun ContactBookScreen(
                 ContactBookUiEvent.CloseOnboarding -> { /* handled in AppNavHost */ }
             }
         }
+    }
+
+    // Returning here from the circle-member-add picker (or any other screen) needs to re-check
+    // an open circle sheet's pending badge explicitly — a pending-only add doesn't change any
+    // circle's real member list, so ConnectionService.circles' StateFlow conflates the
+    // assignment and never notifies the reactive collector in the ViewModel's init (#1096).
+    // Mirrors LocationScreen's resume-triggered refresh.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) viewModel.refreshOpenCircle()
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     val onContacts = uiState.selectedTab == ContactTab.CONTACTS
@@ -288,7 +306,17 @@ fun ContactBookScreen(
     }
 
     uiState.circleMembers?.let { members ->
-        CircleMembersSheet(state = members, onAction = viewModel::onAction)
+        CircleMembersSheet(
+            state = members,
+            onDismiss = { viewModel.onAction(ContactBookUiAction.CircleMembersDismiss) },
+            onMemberClick = { viewModel.onAction(ContactBookUiAction.ContactClicked(it)) },
+            onAddMemberClick = {
+                viewModel.onAction(ContactBookUiAction.CircleAddMemberClicked(members.circleId, members.circleName))
+            },
+            onRemoveMemberClick = {
+                viewModel.onAction(ContactBookUiAction.CircleRemoveMemberClicked(members.circleId, it))
+            },
+        )
     }
 
     // Compose-a-new-request sheet, opened by the FAB while the Requests pill is active.

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookUiState.kt
@@ -63,7 +63,19 @@ data class CircleMembersUi(
     /** uniqueIds currently being removed — drives a per-row spinner in place of the remove "X"
      *  so a tap has visible feedback while the call is in flight. */
     val removingMemberIds: Set<Uuid> = emptySet(),
+    /** Drives this circle grants access to — sourced synchronously from the circle definition
+     *  already loaded with [members], no extra network call. */
+    val drives: List<CircleDriveUi> = emptyList(),
+    /** Set when this sheet is opened "from one contact's perspective" (contact detail) — that
+     *  contact's own status in this circle, shown as a header line. Null when opened from the
+     *  Circles tab, where there's no single "viewer" contact. */
+    val viewerStatus: CircleMemberStatus? = null,
+    /** uniqueId of the [viewerStatus] contact — excluded from the rendered "who else is in this
+     *  circle" roster so the viewer's own row (already summarized in the header) isn't repeated. */
+    val viewerContactId: Uuid? = null,
 )
+
+enum class CircleMemberStatus { Member, Pending }
 
 /** A sheet/dialog shown over the contact list. (Detail is a full-screen route now.) */
 sealed interface ContactBookOverlay {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookUiState.kt
@@ -60,6 +60,9 @@ data class CircleMembersUi(
     val pendingMembers: List<ContactBookEntry> = emptyList(),
     /** True while the open-triggered pending-status fan-out is in flight. */
     val pendingChecking: Boolean = false,
+    /** uniqueIds currently being removed — drives a per-row spinner in place of the remove "X"
+     *  so a tap has visible feedback while the call is in flight. */
+    val removingMemberIds: Set<Uuid> = emptySet(),
 )
 
 /** A sheet/dialog shown over the contact list. (Detail is a full-screen route now.) */

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookUiState.kt
@@ -43,9 +43,23 @@ data class PendingRequestEntry(
 /** Members of one circle, shown in a sheet/dialog. */
 @Immutable
 data class CircleMembersUi(
+    val circleId: String,
     val circleName: String,
+    /** Whether this circle's membership can be managed here — false for the system-managed
+     *  Confirmed/Auto-connected circles (see [id.homebase.core.config.CONFIRMED_CONNECTIONS_CIRCLE_ID]
+     *  / [id.homebase.core.config.AUTO_CONNECTIONS_CIRCLE_ID]), which are computed by the vetting
+     *  flow rather than manually curated. */
+    val manageable: Boolean = true,
     val members: List<ContactBookEntry> = emptyList(),
     val isLoading: Boolean = true,
+    /**
+     * Contacts whose grant on this circle is still a sealed deposit rather than a real [members]
+     * entry — live-read via a per-contact `/connections/status` fan-out triggered when the sheet
+     * opens (there is no bulk "list pending" endpoint), never cached across app restarts.
+     */
+    val pendingMembers: List<ContactBookEntry> = emptyList(),
+    /** True while the open-triggered pending-status fan-out is in flight. */
+    val pendingChecking: Boolean = false,
 )
 
 /** A sheet/dialog shown over the contact list. (Detail is a full-screen route now.) */
@@ -129,6 +143,13 @@ sealed interface ContactBookUiAction {
     data class TabSelected(val tab: ContactTab) : ContactBookUiAction
     data class CircleClicked(val circle: CircleWithMembers) : ContactBookUiAction
     data object CircleMembersDismiss : ContactBookUiAction
+    /** "Add member" tapped in the circle-members sheet — opens the picker for this circle. */
+    data class CircleAddMemberClicked(val circleId: String, val circleName: String) : ContactBookUiAction
+    /** Revoke [member]'s membership (real or still-pending) in the circle [circleId]. */
+    data class CircleRemoveMemberClicked(
+        val circleId: String,
+        val member: ContactBookEntry,
+    ) : ContactBookUiAction
     data class SearchChanged(val query: String) : ContactBookUiAction
     data class FilterChanged(val filter: ContactFilter) : ContactBookUiAction
     data class ContactClicked(val entry: ContactBookEntry) : ContactBookUiAction
@@ -158,6 +179,8 @@ sealed interface ContactBookUiEvent {
     data class OpenDetail(val uniqueId: String, val odinId: String?) : ContactBookUiEvent
     /** Open the full-screen Add Contact flow (lead-with-Homebase-ID). */
     data object OpenAddContact : ContactBookUiEvent
+    /** Open the generic circle-member picker for [circleId]/[circleName]. */
+    data class OpenCircleMemberAdd(val circleId: String, val circleName: String) : ContactBookUiEvent
     data class Error(val error: ContactBookError) : ContactBookUiEvent
     /** User skipped onboarding — pop back out of the contacts tab. */
     data object CloseOnboarding : ContactBookUiEvent
@@ -170,4 +193,5 @@ enum class ContactBookError {
     PhotoFailed,
     MessageFailed,
     ClearUnsupported,
+    CircleActionFailed,
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookViewModel.kt
@@ -451,10 +451,23 @@ class ContactBookViewModel(
 
     // region Circles
 
-    /** Nudges a fresh network pull when the user looks at the Circles tab. [circles]/
-     *  [circleMembers] are otherwise kept live by the collector in [init], not by this call. */
+    /**
+     * Nudges a fresh network pull when the user looks at the Circles tab. [circles]/
+     * [circleMembers] are otherwise kept live by the collector in [init], not by this call —
+     * but [_circlesLoading] is reset here directly (not solely from that collector) because
+     * ConnectionService.refresh() swallows its own failures and leaves circles unchanged: a
+     * failed FIRST load would otherwise never produce a new emission, permanently stranding
+     * _circlesLoading at true and disabling this exact retry gesture.
+     */
     private fun loadCircles() {
-        viewModelScope.launch { connectionService.refresh() }
+        _circlesLoading.value = true
+        viewModelScope.launch {
+            try {
+                connectionService.refresh()
+            } finally {
+                _circlesLoading.value = false
+            }
+        }
     }
 
     private var circlePendingJob: Job? = null
@@ -468,7 +481,7 @@ class ContactBookViewModel(
         val members = entriesForDomains(domains, entries.value).sortedBy { it.sortKey }
         // System circles (Confirmed/Auto-connected) are computed by the vetting flow, not
         // manually curated — hide the add/remove affordances for those, editable for the rest.
-        val manageable = circle.circle.id !in setOf(AUTO_CONNECTIONS_CIRCLE_ID, CONFIRMED_CONNECTIONS_CIRCLE_ID)
+        val manageable = !isSystemCircleId(circle.circle.id)
         _circleMembers.value = CircleMembersUi(
             circleId = circle.circle.id,
             circleName = circle.circle.name,
@@ -558,6 +571,8 @@ class ContactBookViewModel(
                         removingMemberIds = it.removingMemberIds - member.uniqueId,
                     )
                 }
+            } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Logger.w(e, "ContactBookViewModel") { "removeFromCircle failed for $odinId" }
                 _circleMembers.update {
@@ -617,13 +632,19 @@ private fun CircleWithMembers.matchesQuery(query: String): Boolean {
         circle.description?.lowercase()?.contains(q) == true
 }
 
+/** Matches ContactDetailViewModel's equivalent check — case-insensitive since nothing
+ *  guarantees the server always returns these ids in the same casing. */
+private fun isSystemCircleId(id: String): Boolean =
+    id.equals(AUTO_CONNECTIONS_CIRCLE_ID, ignoreCase = true) ||
+        id.equals(CONFIRMED_CONNECTIONS_CIRCLE_ID, ignoreCase = true)
+
 /**
  * Sort bucket for the Circles tab: the auto-connected ("Unvetted") system circle first, the
  * user's own circles (including Emergency Location Access — a user circle, not a system one)
  * in the middle, and the confirmed-connected system circle last.
  */
-private fun String.circleSortRank(): Int = when (this) {
-    AUTO_CONNECTIONS_CIRCLE_ID -> 0
-    CONFIRMED_CONNECTIONS_CIRCLE_ID -> 2
+private fun String.circleSortRank(): Int = when {
+    equals(AUTO_CONNECTIONS_CIRCLE_ID, ignoreCase = true) -> 0
+    equals(CONFIRMED_CONNECTIONS_CIRCLE_ID, ignoreCase = true) -> 2
     else -> 1
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookViewModel.kt
@@ -8,7 +8,6 @@ import co.touchlab.kermit.Logger
 import id.homebase.api.client.auth.OwnerSession
 import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.api.client.connections.CircleWithMembers
-import id.homebase.api.client.connections.ConnectionNetworkProvider
 import id.homebase.api.client.connections.ConnectionStatus
 import id.homebase.api.client.contacts.ContactRepository
 import id.homebase.api.client.eventbus.BackendEvent
@@ -71,7 +70,6 @@ class ContactBookViewModel(
     private val conversationService: ConversationService,
     private val connectionService: ConnectionService,
     private val connectionRequestService: ConnectionRequestService,
-    private val connectionNetworkProvider: ConnectionNetworkProvider,
     private val overrideStore: ContactOverrideStore,
     ownerSessionRepository: OwnerSessionRepository,
     authConnectionCoordinator: AuthConnectionCoordinator,
@@ -137,6 +135,31 @@ class ContactBookViewModel(
                         else -> Unit
                     }
                 }
+        }
+        // Circles tab + any open CircleMembersSheet now derive from ConnectionService.circles
+        // directly instead of a one-shot fetch taken at the moment the circle was tapped —
+        // previously an add/remove from the picker (a different ViewModel instance) updated
+        // ConnectionService.refresh()'s data but never reached this screen's own snapshot,
+        // so the sheet just sat there stale until closed and reopened (#1096).
+        viewModelScope.launch {
+            connectionService.circles.collect { circleState ->
+                val circles = circleState.circles
+                    .filterNot { it.circle.disabled }
+                    .sortedWith(compareBy({ it.circle.id.circleSortRank() }, { it.circle.name.lowercase() }))
+                _circles.value = circles
+                _circlesLoading.value = !circleState.isLoaded
+
+                val open = _circleMembers.value ?: return@collect
+                val match = circles.firstOrNull { it.circle.id == open.circleId } ?: return@collect
+                val domains = match.members.map { it.domainName }.toSet()
+                _circleMembers.update {
+                    it?.copy(members = entriesForDomains(domains, entries.value).sortedBy { m -> m.sortKey })
+                }
+                // A fresh circles emission is exactly when someone might have just converted
+                // from pending to real (or a brand-new pending deposit landed) — re-derive the
+                // pending badge for the open sheet too, not just its real-member list.
+                if (open.manageable) checkCirclePending(match)
+            }
         }
     }
 
@@ -423,36 +446,19 @@ class ContactBookViewModel(
 
     // region Circles
 
+    /** Nudges a fresh network pull when the user looks at the Circles tab. [circles]/
+     *  [circleMembers] are otherwise kept live by the collector in [init], not by this call. */
     private fun loadCircles() {
-        _circlesLoading.value = true
-        viewModelScope.launch {
-            val circles = try {
-                connectionNetworkProvider.getCirclesWithMembers().filterNot { it.circle.disabled }
-            } catch (e: kotlin.coroutines.cancellation.CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Logger.w(e, "ContactBookViewModel") { "getCirclesWithMembers failed" }
-                emptyList()
-            }
-            // Pin the auto-connected ("Unvetted") system circle to the top, sink the confirmed-
-            // connected system circle to the bottom, and keep the user's own circles (including
-            // Emergency Location Access, which is a user circle, not a system one) alphabetical
-            // in between.
-            _circles.value = circles.sortedWith(
-                compareBy(
-                    { it.circle.id.circleSortRank() },
-                    { it.circle.name.lowercase() },
-                ),
-            )
-            _circlesLoading.value = false
-        }
+        viewModelScope.launch { connectionService.refresh() }
     }
 
     private var circlePendingJob: Job? = null
 
     private fun handleCircleClicked(circle: CircleWithMembers) {
         // Members are bundled with the circle list — resolve them to contact entries
-        // synchronously, no second network call.
+        // synchronously, no second network call. The init collector on connectionService.circles
+        // keeps this in sync going forward (an add/remove from elsewhere no longer leaves this
+        // sheet stale, #1096).
         val domains = circle.members.map { it.domainName }.toSet()
         val members = entriesForDomains(domains, entries.value).sortedBy { it.sortKey }
         // System circles (Confirmed/Auto-connected) are computed by the vetting flow, not
@@ -466,8 +472,14 @@ class ContactBookViewModel(
             isLoading = false,
             pendingChecking = manageable,
         )
-        if (!manageable) return
+        if (manageable) checkCirclePending(circle)
+    }
 
+    /** Live pending-status re-check for whichever circle's sheet is currently open — called on
+     *  first open and again whenever connectionService.circles refreshes (e.g. right after an
+     *  add/remove lands), so a just-added pending contact doesn't wait on the user closing and
+     *  reopening the sheet to appear (#1096). */
+    private fun checkCirclePending(circle: CircleWithMembers) {
         circlePendingJob?.cancel()
         circlePendingJob = viewModelScope.launch {
             val circleId = try {
@@ -500,6 +512,10 @@ class ContactBookViewModel(
 
     private fun handleCircleRemoveMember(circleIdRaw: String, member: ContactBookEntry) {
         val odinId = member.odinId?.let(::OdinId) ?: return
+        if (member.uniqueId in (_circleMembers.value?.removingMemberIds ?: emptySet())) return
+        _circleMembers.update {
+            it?.copy(removingMemberIds = it.removingMemberIds + member.uniqueId)
+        }
         viewModelScope.launch {
             try {
                 connectionService.removeFromCircle(Uuid.parseHex(circleIdRaw), odinId)
@@ -508,10 +524,15 @@ class ContactBookViewModel(
                     else it.copy(
                         members = it.members.filterNot { m -> m.uniqueId == member.uniqueId },
                         pendingMembers = it.pendingMembers.filterNot { m -> m.uniqueId == member.uniqueId },
+                        removingMemberIds = it.removingMemberIds - member.uniqueId,
                     )
                 }
             } catch (e: Exception) {
                 Logger.w(e, "ContactBookViewModel") { "removeFromCircle failed for $odinId" }
+                _circleMembers.update {
+                    if (it?.circleId != circleIdRaw) it
+                    else it.copy(removingMemberIds = it.removingMemberIds - member.uniqueId)
+                }
                 _events.tryEmit(ContactBookUiEvent.Error(ContactBookError.CircleActionFailed))
             }
         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookViewModel.kt
@@ -34,6 +34,7 @@ import id.homebase.core.ui.screens.contactbook.model.ContactBookSource
 import id.homebase.core.ui.screens.contactbook.model.ContactFieldOverlay
 import id.homebase.core.ui.screens.contactbook.model.toContactBookEntry
 import io.github.vinceglb.filekit.PlatformFile
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -335,6 +336,11 @@ class ContactBookViewModel(
             }
             is ContactBookUiAction.CircleClicked -> handleCircleClicked(action.circle)
             ContactBookUiAction.CircleMembersDismiss -> _circleMembers.value = null
+            is ContactBookUiAction.CircleAddMemberClicked -> _events.tryEmit(
+                ContactBookUiEvent.OpenCircleMemberAdd(action.circleId, action.circleName)
+            )
+            is ContactBookUiAction.CircleRemoveMemberClicked ->
+                handleCircleRemoveMember(action.circleId, action.member)
             is ContactBookUiAction.SearchChanged -> _searchQuery.value = action.query
             is ContactBookUiAction.FilterChanged -> _filter.value = action.filter
             is ContactBookUiAction.ContactClicked -> {
@@ -442,16 +448,73 @@ class ContactBookViewModel(
         }
     }
 
+    private var circlePendingJob: Job? = null
+
     private fun handleCircleClicked(circle: CircleWithMembers) {
         // Members are bundled with the circle list — resolve them to contact entries
         // synchronously, no second network call.
         val domains = circle.members.map { it.domainName }.toSet()
         val members = entriesForDomains(domains, entries.value).sortedBy { it.sortKey }
+        // System circles (Confirmed/Auto-connected) are computed by the vetting flow, not
+        // manually curated — hide the add/remove affordances for those, editable for the rest.
+        val manageable = circle.circle.id !in setOf(AUTO_CONNECTIONS_CIRCLE_ID, CONFIRMED_CONNECTIONS_CIRCLE_ID)
         _circleMembers.value = CircleMembersUi(
+            circleId = circle.circle.id,
             circleName = circle.circle.name,
+            manageable = manageable,
             members = members,
             isLoading = false,
+            pendingChecking = manageable,
         )
+        if (!manageable) return
+
+        circlePendingJob?.cancel()
+        circlePendingJob = viewModelScope.launch {
+            val circleId = try {
+                Uuid.parseHex(circle.circle.id)
+            } catch (e: Exception) {
+                Logger.w(e, "ContactBookViewModel") { "bad circle id ${circle.circle.id}" }
+                _circleMembers.update { it?.copy(pendingChecking = false) }
+                return@launch
+            }
+            val pending = try {
+                connectionService.findPendingMembers(circleId)
+            } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Logger.w(e, "ContactBookViewModel") { "findPendingMembers failed for ${circle.circle.id}" }
+                emptyList()
+            }
+            val pendingEntries = entriesForDomains(
+                pending.map { it.domainName }.toSet(),
+                entries.value,
+            ).sortedBy { it.sortKey }
+            // Only apply if the sheet is still open on the same circle (the user may have
+            // dismissed or switched to another circle while this was in flight).
+            _circleMembers.update {
+                if (it?.circleId == circle.circle.id) it.copy(pendingMembers = pendingEntries, pendingChecking = false)
+                else it
+            }
+        }
+    }
+
+    private fun handleCircleRemoveMember(circleIdRaw: String, member: ContactBookEntry) {
+        val odinId = member.odinId?.let(::OdinId) ?: return
+        viewModelScope.launch {
+            try {
+                connectionService.removeFromCircle(Uuid.parseHex(circleIdRaw), odinId)
+                _circleMembers.update {
+                    if (it?.circleId != circleIdRaw) it
+                    else it.copy(
+                        members = it.members.filterNot { m -> m.uniqueId == member.uniqueId },
+                        pendingMembers = it.pendingMembers.filterNot { m -> m.uniqueId == member.uniqueId },
+                    )
+                }
+            } catch (e: Exception) {
+                Logger.w(e, "ContactBookViewModel") { "removeFromCircle failed for $odinId" }
+                _events.tryEmit(ContactBookUiEvent.Error(ContactBookError.CircleActionFailed))
+            }
+        }
     }
 
     // endregion

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookViewModel.kt
@@ -153,11 +153,16 @@ class ContactBookViewModel(
                 val match = circles.firstOrNull { it.circle.id == open.circleId } ?: return@collect
                 val domains = match.members.map { it.domainName }.toSet()
                 _circleMembers.update {
-                    it?.copy(members = entriesForDomains(domains, entries.value).sortedBy { m -> m.sortKey })
+                    it?.copy(
+                        members = entriesForDomains(domains, entries.value).sortedBy { m -> m.sortKey },
+                        drives = resolveCircleDrives(match.circle),
+                    )
                 }
-                // A fresh circles emission is exactly when someone might have just converted
-                // from pending to real (or a brand-new pending deposit landed) — re-derive the
-                // pending badge for the open sheet too, not just its real-member list.
+                // Best-effort: a fresh emission here means someone's real membership actually
+                // changed, so re-derive the pending badge too. This does NOT catch a pending-only
+                // add — the real member list is unchanged, so StateFlow conflates the assignment
+                // and this block never runs for that case. refreshOpenCircle() is the reliable
+                // path (#1096); this just keeps things fresher between resumes when it does fire.
                 if (open.manageable) checkCirclePending(match)
             }
         }
@@ -471,14 +476,30 @@ class ContactBookViewModel(
             members = members,
             isLoading = false,
             pendingChecking = manageable,
+            drives = resolveCircleDrives(circle.circle),
         )
         if (manageable) checkCirclePending(circle)
     }
 
+    /**
+     * Re-derive the open circle sheet's pending badge and real-member list on screen resume
+     * (e.g. returning from the add picker). The `init` collector on connectionService.circles
+     * re-checks pending automatically whenever that flow actually emits, but a pending-only add
+     * doesn't change any circle's real member list — so the resulting CircleMembershipState is
+     * `equals()` to the prior one, and MutableStateFlow silently conflates the assignment,
+     * never notifying collectors at all (#1096). This resume-triggered call doesn't depend on
+     * the flow re-emitting; it always re-checks.
+     */
+    fun refreshOpenCircle() {
+        val open = _circleMembers.value ?: return
+        viewModelScope.launch { connectionService.refresh() }
+        val match = _circles.value.firstOrNull { it.circle.id == open.circleId } ?: return
+        if (open.manageable) checkCirclePending(match)
+    }
+
     /** Live pending-status re-check for whichever circle's sheet is currently open — called on
-     *  first open and again whenever connectionService.circles refreshes (e.g. right after an
-     *  add/remove lands), so a just-added pending contact doesn't wait on the user closing and
-     *  reopening the sheet to appear (#1096). */
+     *  first open, again whenever connectionService.circles happens to emit a structurally
+     *  different value, and explicitly on screen resume via [refreshOpenCircle] (#1096). */
     private fun checkCirclePending(circle: CircleWithMembers) {
         circlePendingJob?.cancel()
         circlePendingJob = viewModelScope.launch {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactBookViewModel.kt
@@ -523,10 +523,20 @@ class ContactBookViewModel(
                 entries.value,
             ).sortedBy { it.sortKey }
             // Only apply if the sheet is still open on the same circle (the user may have
-            // dismissed or switched to another circle while this was in flight).
+            // dismissed or switched to another circle while this was in flight). Re-excludes
+            // against the CURRENT members at update time, not the snapshot this fan-out started
+            // from — cancel() on the superseded job is cooperative, so a stale fan-out that's
+            // already past its last suspension point can still land its update after a fresher
+            // one already promoted someone from pending to real, putting them in both lists at
+            // once and crashing CircleMembersSheet's keyed LazyColumn (real crash, not cosmetic:
+            // #1096 in the Location dashboard's plain Column was the same race, just invisible).
             _circleMembers.update {
-                if (it?.circleId == circle.circle.id) it.copy(pendingMembers = pendingEntries, pendingChecking = false)
-                else it
+                if (it?.circleId == circle.circle.id) {
+                    it.copy(
+                        pendingMembers = pendingEntries.filterNot { p -> it.members.any { m -> m.uniqueId == p.uniqueId } },
+                        pendingChecking = false,
+                    )
+                } else it
             }
         }
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/CircleMembersSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/CircleMembersSheet.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -121,6 +122,7 @@ fun CircleMembersSheet(
                                     {
                                         CircleMemberTrailing(
                                             pending = pendingIds.contains(entry.uniqueId),
+                                            removing = state.removingMemberIds.contains(entry.uniqueId),
                                             onRemoveClick = { confirmRemove = entry },
                                         )
                                     }
@@ -158,21 +160,28 @@ fun CircleMembersSheet(
 /** Trailing content for a circle-member row: an optional "Pending" label (a sealed deposit
  *  that hasn't converted into a real grant yet) plus a remove button. */
 @Composable
-private fun CircleMemberTrailing(pending: Boolean, onRemoveClick: () -> Unit) {
+private fun CircleMemberTrailing(pending: Boolean, removing: Boolean, onRemoveClick: () -> Unit) {
     Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-        if (pending) {
+        if (pending && !removing) {
             Text(
                 text = stringResource(MR.string.circle_member_pending),
                 style = MaterialTheme.typography.labelMedium,
                 color = HomebaseTheme.extendedColors.warning,
             )
         }
-        IconButton(onClick = onRemoveClick) {
-            Icon(
-                imageVector = Icons.Default.Close,
-                contentDescription = stringResource(MR.string.circle_member_remove_cd),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        if (removing) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(24.dp).padding(4.dp),
+                strokeWidth = 2.dp,
             )
+        } else {
+            IconButton(onClick = onRemoveClick) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = stringResource(MR.string.circle_member_remove_cd),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/CircleMembersSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/CircleMembersSheet.kt
@@ -101,7 +101,12 @@ fun CircleMembersSheet(
                     modifier = Modifier.padding(bottom = 8.dp),
                 )
             }
+            // distinctBy is a final guard, not the fix — the ViewModels already keep members/
+            // pendingMembers mutually exclusive at update time. This just makes the keyed
+            // LazyColumn below immune to any future regression of that invariant: a duplicate
+            // key here is a hard crash (unlike a plain Column, which would just double-render).
             val allMembers = (state.members + state.pendingMembers)
+                .distinctBy { it.uniqueId }
                 .filterNot { it.uniqueId == state.viewerContactId }
             val pendingIds = remember(state.pendingMembers) { state.pendingMembers.map { it.uniqueId }.toSet() }
             when {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/CircleMembersSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/CircleMembersSheet.kt
@@ -109,6 +109,11 @@ fun CircleMembersSheet(
                 .distinctBy { it.uniqueId }
                 .filterNot { it.uniqueId == state.viewerContactId }
             val pendingIds = remember(state.pendingMembers) { state.pendingMembers.map { it.uniqueId }.toSet() }
+            // Counts must match what's actually rendered below (allMembers excludes the viewer's
+            // own row when this sheet is opened from a contact's page) — otherwise the header
+            // says "3 members" while only 2 rows are visible.
+            val realCount = state.members.count { it.uniqueId != state.viewerContactId }
+            val pendingCount = state.pendingMembers.count { it.uniqueId != state.viewerContactId }
             when {
                 state.isLoading -> Box(
                     modifier = Modifier.fillMaxWidth().heightIn(min = 120.dp),
@@ -125,13 +130,13 @@ fun CircleMembersSheet(
                 else -> {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Text(
-                            text = if (state.pendingMembers.isEmpty()) {
-                                stringResource(MR.string.contactbook_circle_members_count, state.members.size)
+                            text = if (pendingCount == 0) {
+                                stringResource(MR.string.contactbook_circle_members_count, realCount)
                             } else {
                                 stringResource(
                                     MR.string.contactbook_circle_members_count_with_pending,
-                                    state.members.size,
-                                    state.pendingMembers.size,
+                                    realCount,
+                                    pendingCount,
                                 )
                             },
                             style = MaterialTheme.typography.labelMedium,
@@ -148,6 +153,7 @@ fun CircleMembersSheet(
                         items(allMembers, key = { it.uniqueId.toString() }) { entry ->
                             ContactBookRow(
                                 entry = entry,
+                                connected = true,
                                 onClick = { onMemberClick(entry) },
                                 trailing = if (state.manageable) {
                                     {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/CircleMembersSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/CircleMembersSheet.kt
@@ -28,31 +28,46 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import id.homebase.core.ui.screens.contactbook.CircleDriveUi
+import id.homebase.core.ui.screens.contactbook.CircleMemberStatus
 import id.homebase.core.ui.screens.contactbook.CircleMembersUi
-import id.homebase.core.ui.screens.contactbook.ContactBookUiAction
 import id.homebase.core.ui.screens.contactbook.model.ContactBookEntry
 import id.homebase.core.ui.theme.HomebaseTheme
 import id.homebase.resources.MR
 import id.homebase.resources.cancel
+import id.homebase.resources.circle_drive_unknown
+import id.homebase.resources.circle_drives_section_title
 import id.homebase.resources.circle_member_pending
-import id.homebase.resources.contactbook_circle_add_member
 import id.homebase.resources.circle_member_remove_cd
 import id.homebase.resources.circle_member_remove_confirm_body
 import id.homebase.resources.circle_member_remove_confirm_title
+import id.homebase.resources.circle_member_status_member
+import id.homebase.resources.circle_member_status_pending
+import id.homebase.resources.contactbook_circle_add_member
 import id.homebase.resources.contactbook_circle_members_count
 import id.homebase.resources.contactbook_circle_members_count_with_pending
 import id.homebase.resources.contactbook_circle_members_empty
 import id.homebase.resources.remove
 import org.jetbrains.compose.resources.stringResource
 
+/**
+ * Circle detail — one circle's roster (real + live-pending), the drives it grants, and (when
+ * opened "from one contact's perspective," e.g. contact detail) that contact's own status as a
+ * header line. Reused by both the Circles tab (manageable, no single viewer) and contact detail
+ * (view-only — [onAddMemberClick]/[onRemoveMemberClick] are simply never invoked when
+ * [CircleMembersUi.manageable] is false, since the affordances that would call them are hidden).
+ */
 @Composable
 fun CircleMembersSheet(
     state: CircleMembersUi,
-    onAction: (ContactBookUiAction) -> Unit,
+    onDismiss: () -> Unit,
+    onMemberClick: (ContactBookEntry) -> Unit,
+    onAddMemberClick: () -> Unit,
+    onRemoveMemberClick: (ContactBookEntry) -> Unit,
 ) {
     var confirmRemove by remember { mutableStateOf<ContactBookEntry?>(null) }
 
-    AdaptiveSheet(onDismiss = { onAction(ContactBookUiAction.CircleMembersDismiss) }) {
+    AdaptiveSheet(onDismiss = onDismiss) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -69,14 +84,25 @@ fun CircleMembersSheet(
                     modifier = Modifier.weight(1f),
                 )
                 if (state.manageable) {
-                    IconButton(onClick = {
-                        onAction(ContactBookUiAction.CircleAddMemberClicked(state.circleId, state.circleName))
-                    }) {
+                    IconButton(onClick = onAddMemberClick) {
                         Icon(imageVector = Icons.Default.Add, contentDescription = stringResource(MR.string.contactbook_circle_add_member))
                     }
                 }
             }
-            val allMembers = state.members + state.pendingMembers
+            state.viewerStatus?.let { status ->
+                Text(
+                    text = stringResource(
+                        if (status == CircleMemberStatus.Member) MR.string.circle_member_status_member
+                        else MR.string.circle_member_status_pending
+                    ),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = if (status == CircleMemberStatus.Pending) HomebaseTheme.extendedColors.warning
+                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(bottom = 8.dp),
+                )
+            }
+            val allMembers = (state.members + state.pendingMembers)
+                .filterNot { it.uniqueId == state.viewerContactId }
             val pendingIds = remember(state.pendingMembers) { state.pendingMembers.map { it.uniqueId }.toSet() }
             when {
                 state.isLoading -> Box(
@@ -117,7 +143,7 @@ fun CircleMembersSheet(
                         items(allMembers, key = { it.uniqueId.toString() }) { entry ->
                             ContactBookRow(
                                 entry = entry,
-                                onClick = { onAction(ContactBookUiAction.ContactClicked(entry)) },
+                                onClick = { onMemberClick(entry) },
                                 trailing = if (state.manageable) {
                                     {
                                         CircleMemberTrailing(
@@ -132,6 +158,9 @@ fun CircleMembersSheet(
                     }
                 }
             }
+            if (state.drives.isNotEmpty()) {
+                CircleDrivesSection(state.drives)
+            }
         }
     }
 
@@ -145,7 +174,7 @@ fun CircleMembersSheet(
             confirmButton = {
                 TextButton(onClick = {
                     confirmRemove = null
-                    onAction(ContactBookUiAction.CircleRemoveMemberClicked(state.circleId, member))
+                    onRemoveMemberClick(member)
                 }) { Text(stringResource(MR.string.remove)) }
             },
             dismissButton = {
@@ -180,6 +209,35 @@ private fun CircleMemberTrailing(pending: Boolean, removing: Boolean, onRemoveCl
                     imageVector = Icons.Default.Close,
                     contentDescription = stringResource(MR.string.circle_member_remove_cd),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+/** Which drives this circle grants access to — sourced synchronously from the circle definition,
+ *  no extra network call. Unrecognized drives (not one of this app's own known drives) fall back
+ *  to a generic label rather than a raw GUID. */
+@Composable
+private fun CircleDrivesSection(drives: List<CircleDriveUi>) {
+    Text(
+        text = stringResource(MR.string.circle_drives_section_title),
+        style = MaterialTheme.typography.titleSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(top = 16.dp, bottom = 4.dp),
+    )
+    val unknownLabel = stringResource(MR.string.circle_drive_unknown)
+    Column {
+        drives.forEach { drive ->
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(text = drive.label ?: unknownLabel, style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    text = drive.permission.split(",").joinToString(", ") { it.trim().replaceFirstChar(Char::uppercase) },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/CircleMembersSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/CircleMembersSheet.kt
@@ -158,9 +158,9 @@ fun CircleMembersSheet(
                     }
                 }
             }
-            if (state.drives.isNotEmpty()) {
-                CircleDrivesSection(state.drives)
-            }
+//            if (state.drives.isNotEmpty()) {
+//                CircleDrivesSection(state.drives)
+//            }
         }
     }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/CircleMembersSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/CircleMembersSheet.kt
@@ -1,24 +1,47 @@
 package id.homebase.core.ui.screens.contactbook.components
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import id.homebase.core.ui.screens.contactbook.CircleMembersUi
 import id.homebase.core.ui.screens.contactbook.ContactBookUiAction
+import id.homebase.core.ui.screens.contactbook.model.ContactBookEntry
+import id.homebase.core.ui.theme.HomebaseTheme
 import id.homebase.resources.MR
+import id.homebase.resources.cancel
+import id.homebase.resources.circle_member_pending
+import id.homebase.resources.contactbook_circle_add_member
+import id.homebase.resources.circle_member_remove_cd
+import id.homebase.resources.circle_member_remove_confirm_body
+import id.homebase.resources.circle_member_remove_confirm_title
 import id.homebase.resources.contactbook_circle_members_count
+import id.homebase.resources.contactbook_circle_members_count_with_pending
 import id.homebase.resources.contactbook_circle_members_empty
+import id.homebase.resources.remove
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -26,6 +49,8 @@ fun CircleMembersSheet(
     state: CircleMembersUi,
     onAction: (ContactBookUiAction) -> Unit,
 ) {
+    var confirmRemove by remember { mutableStateOf<ContactBookEntry?>(null) }
+
     AdaptiveSheet(onDismiss = { onAction(ContactBookUiAction.CircleMembersDismiss) }) {
         Column(
             modifier = Modifier
@@ -33,18 +58,32 @@ fun CircleMembersSheet(
                 .padding(horizontal = 16.dp)
                 .padding(bottom = 24.dp),
         ) {
-            Text(
-                text = state.circleName,
-                style = MaterialTheme.typography.titleLarge,
-                modifier = Modifier.padding(vertical = 8.dp),
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = state.circleName,
+                    style = MaterialTheme.typography.titleLarge,
+                    modifier = Modifier.weight(1f),
+                )
+                if (state.manageable) {
+                    IconButton(onClick = {
+                        onAction(ContactBookUiAction.CircleAddMemberClicked(state.circleId, state.circleName))
+                    }) {
+                        Icon(imageVector = Icons.Default.Add, contentDescription = stringResource(MR.string.contactbook_circle_add_member))
+                    }
+                }
+            }
+            val allMembers = state.members + state.pendingMembers
+            val pendingIds = remember(state.pendingMembers) { state.pendingMembers.map { it.uniqueId }.toSet() }
             when {
                 state.isLoading -> Box(
                     modifier = Modifier.fillMaxWidth().heightIn(min = 120.dp),
                     contentAlignment = Alignment.Center,
                 ) { CircularProgressIndicator() }
 
-                state.members.isEmpty() -> Text(
+                allMembers.isEmpty() && !state.pendingChecking -> Text(
                     text = stringResource(MR.string.contactbook_circle_members_empty),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -52,24 +91,88 @@ fun CircleMembersSheet(
                 )
 
                 else -> {
-                    Text(
-                        text = stringResource(
-                            MR.string.contactbook_circle_members_count, state.members.size
-                        ),
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = if (state.pendingMembers.isEmpty()) {
+                                stringResource(MR.string.contactbook_circle_members_count, state.members.size)
+                            } else {
+                                stringResource(
+                                    MR.string.contactbook_circle_members_count_with_pending,
+                                    state.members.size,
+                                    state.pendingMembers.size,
+                                )
+                            },
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        if (state.pendingChecking) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.padding(start = 8.dp).heightIn(max = 12.dp),
+                                strokeWidth = 2.dp,
+                            )
+                        }
+                    }
                     LazyColumn(modifier = Modifier.fillMaxWidth().heightIn(max = 420.dp)) {
-                        items(state.members, key = { it.uniqueId.toString() }) { entry ->
+                        items(allMembers, key = { it.uniqueId.toString() }) { entry ->
                             ContactBookRow(
                                 entry = entry,
                                 onClick = { onAction(ContactBookUiAction.ContactClicked(entry)) },
-                                connected = true,
+                                trailing = if (state.manageable) {
+                                    {
+                                        CircleMemberTrailing(
+                                            pending = pendingIds.contains(entry.uniqueId),
+                                            onRemoveClick = { confirmRemove = entry },
+                                        )
+                                    }
+                                } else null,
                             )
                         }
                     }
                 }
             }
+        }
+    }
+
+    confirmRemove?.let { member ->
+        AlertDialog(
+            onDismissRequest = { confirmRemove = null },
+            title = { Text(stringResource(MR.string.circle_member_remove_confirm_title)) },
+            text = {
+                Text(stringResource(MR.string.circle_member_remove_confirm_body, member.displayName, state.circleName))
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    confirmRemove = null
+                    onAction(ContactBookUiAction.CircleRemoveMemberClicked(state.circleId, member))
+                }) { Text(stringResource(MR.string.remove)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { confirmRemove = null }) {
+                    Text(stringResource(MR.string.cancel))
+                }
+            },
+        )
+    }
+}
+
+/** Trailing content for a circle-member row: an optional "Pending" label (a sealed deposit
+ *  that hasn't converted into a real grant yet) plus a remove button. */
+@Composable
+private fun CircleMemberTrailing(pending: Boolean, onRemoveClick: () -> Unit) {
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        if (pending) {
+            Text(
+                text = stringResource(MR.string.circle_member_pending),
+                style = MaterialTheme.typography.labelMedium,
+                color = HomebaseTheme.extendedColors.warning,
+            )
+        }
+        IconButton(onClick = onRemoveClick) {
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = stringResource(MR.string.circle_member_remove_cd),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/ContactBookRow.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/ContactBookRow.kt
@@ -30,13 +30,17 @@ fun ContactBookRow(
     entry: ContactBookEntry,
     onClick: () -> Unit,
     connected: Boolean = false,
+    /** When non-null, the row renders dimmed, is unclickable, and this text replaces the normal
+     *  subtitle line — e.g. explaining why an otherwise-visible contact can't be picked here. */
+    disabledReason: String? = null,
     /** Optional trailing content (e.g. a pending-request marker). Replaces the connected check. */
     trailing: (@Composable () -> Unit)? = null,
 ) {
+    val disabled = disabledReason != null
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
+            .clickable(enabled = !disabled, onClick = onClick)
             .padding(horizontal = 16.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -51,10 +55,11 @@ fun ContactBookRow(
             Text(
                 text = name,
                 style = MaterialTheme.typography.bodyLarge,
+                color = if (disabled) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
-            val subtitle = entry.subtitle
+            val subtitle = disabledReason ?: entry.subtitle
             if (subtitle != null) {
                 Spacer(modifier = Modifier.height(2.dp))
                 Text(

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -63,6 +64,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.api.client.connections.ConnectionStatus
 import id.homebase.api.common.OdinId
@@ -70,6 +74,7 @@ import id.homebase.chat.widget.ChatMediaFullScreenHost
 import id.homebase.core.config.chatTargetDrive
 import id.homebase.core.connections.ConnectRequestAction
 import id.homebase.core.connections.ConnectRequestBottomSheet
+import id.homebase.core.ui.screens.contactbook.components.CircleMembersSheet
 import id.homebase.core.connections.ConnectRequestViewModel
 import id.homebase.core.ui.screens.contactbook.RequestDirection
 import id.homebase.core.ui.screens.contactbook.components.ContactBookAvatar
@@ -137,6 +142,7 @@ fun ContactDetailScreen(
     onBack: () -> Unit,
     onOpenConversation: (Uuid) -> Unit,
     onSeeAllMedia: (conversationId: String) -> Unit,
+    onOpenContact: (uniqueId: String, odinId: String?) -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -181,8 +187,22 @@ fun ContactDetailScreen(
                 ContactDetailEvent.RequestRejected -> snackbarHostState.showSnackbar(msgRequestRejected)
                 ContactDetailEvent.RequestCancelled -> snackbarHostState.showSnackbar(msgRequestCancelled)
                 ContactDetailEvent.RequestWithdrawn -> snackbarHostState.showSnackbar(msgRequestWithdrawn)
+                is ContactDetailEvent.OpenOtherContact -> onOpenContact(event.uniqueId, event.odinId)
             }
         }
+    }
+
+    // Returning here (e.g. from another contact's detail opened via the circle-detail dialog)
+    // needs to re-check pending circles explicitly — same StateFlow-conflation gap as the
+    // Contact Book's circle sheet: a pending-only change doesn't alter real membership, so
+    // ConnectionService.circles never re-emits and the reactive path alone can't catch it (#1096).
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) viewModel.refreshPendingCircles()
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     Scaffold(
@@ -299,6 +319,9 @@ fun ContactDetailScreen(
                                         CirclesSection(
                                             circles = uiState.circles,
                                             isConnected = uiState.isConnected,
+                                            onCircleClicked = {
+                                                viewModel.onAction(ContactDetailAction.CircleClicked(it))
+                                            },
                                         )
                                     }
                                 }
@@ -388,6 +411,16 @@ fun ContactDetailScreen(
             },
             onDismiss = { viewModel.onAction(ContactDetailAction.CloseEdit) },
             odinIdLocked = uiState.isConnected,
+        )
+    }
+
+    uiState.circleDetail?.let { detail ->
+        CircleMembersSheet(
+            state = detail,
+            onDismiss = { viewModel.onAction(ContactDetailAction.CircleDetailDismiss) },
+            onMemberClick = { viewModel.onAction(ContactDetailAction.CircleMemberClicked(it)) },
+            onAddMemberClick = {},
+            onRemoveMemberClick = {},
         )
     }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailScreen.kt
@@ -484,7 +484,7 @@ private fun DetailHeader(
     val status = uiState.connectionStatus
     val connected = status == ConnectionStatus.Connected
     val blocked = status == ConnectionStatus.Blocked
-    val pending = status == ConnectionStatus.Pending
+    val pending = status == ConnectionStatus.None
     val requestIncoming = uiState.requestDirection == RequestDirection.INCOMING
     val requestOutgoing = uiState.requestDirection == RequestDirection.OUTGOING
     // Has a Homebase identity but no active connection, pending request, or block.

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailSections.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailSections.kt
@@ -70,8 +70,10 @@ import id.homebase.core.ui.screens.contactbook.components.formatPhoneForDisplay
 import id.homebase.api.client.contacts.ContactExperience
 import id.homebase.api.client.contacts.ContactSocialNetwork
 import id.homebase.core.ui.screens.contactbook.model.ContactBookEntry
+import id.homebase.core.ui.theme.HomebaseTheme
 import id.homebase.core.util.getUriHandler
 import id.homebase.resources.MR
+import id.homebase.resources.circle_member_pending
 import id.homebase.resources.contactbook_detail_bio
 import id.homebase.resources.contactbook_detail_social
 import id.homebase.resources.contactbook_detail_circles
@@ -192,12 +194,13 @@ fun GroupsInCommonSection(
 }
 
 /**
- * User-defined circles this contact belongs to, as chips. Always shows the header; falls
- * back to an empty state, or a "must be connected" hint when [isConnected] is false.
+ * User-defined circles this contact belongs to (real or pending), as tappable chips — tap opens
+ * the circle-detail dialog. Always shows the header; falls back to an empty state, or a "must be
+ * connected" hint when [isConnected] is false.
  */
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-fun CirclesSection(circles: List<String>, isConnected: Boolean) {
+fun CirclesSection(circles: List<ContactCircleUi>, isConnected: Boolean, onCircleClicked: (String) -> Unit) {
     Spacer(modifier = Modifier.height(20.dp))
     Text(
         text = stringResource(MR.string.contactbook_detail_circles),
@@ -211,7 +214,7 @@ fun CirclesSection(circles: List<String>, isConnected: Boolean) {
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            circles.forEach { name -> CircleChip(name) }
+            circles.forEach { circle -> CircleChip(circle, onClick = { onCircleClicked(circle.id) }) }
         }
 
         !isConnected -> SectionHint(stringResource(MR.string.contactbook_detail_circles_connect))
@@ -219,19 +222,29 @@ fun CirclesSection(circles: List<String>, isConnected: Boolean) {
     }
 }
 
-/** Non-interactive pill showing a circle name (these are display tags, not actions). */
+/** Tappable pill showing a circle name, with a "Pending" mark when this contact's grant on it
+ *  is still a sealed deposit rather than a real membership. */
 @Composable
-private fun CircleChip(name: String) {
+private fun CircleChip(circle: ContactCircleUi, onClick: () -> Unit) {
     Surface(
         shape = RoundedCornerShape(8.dp),
         color = MaterialTheme.colorScheme.secondaryContainer,
         contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        modifier = Modifier.clickable(onClick = onClick),
     ) {
-        Text(
-            text = name,
-            style = MaterialTheme.typography.labelLarge,
+        Row(
             modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
-        )
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text(text = circle.name, style = MaterialTheme.typography.labelLarge)
+            if (circle.pending) {
+                Text(
+                    text = stringResource(MR.string.circle_member_pending),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = HomebaseTheme.extendedColors.warning,
+                )
+            }
+        }
     }
 }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailUiState.kt
@@ -9,6 +9,7 @@ import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.chat.conversationsettings.ConversationOverview
 import id.homebase.chat.conversationsettings.GroupInCommonItem
 import id.homebase.chat.conversationsettings.SharedMediaItem
+import id.homebase.core.ui.screens.contactbook.CircleMembersUi
 import id.homebase.core.ui.screens.contactbook.ContactDraft
 import id.homebase.core.ui.screens.contactbook.RequestDirection
 import id.homebase.core.ui.screens.contactbook.model.ContactBookEntry
@@ -18,14 +19,23 @@ import kotlin.uuid.Uuid
 /** A pending destructive action awaiting confirmation. */
 enum class ContactDetailConfirm { BLOCK, DISCONNECT, DELETE }
 
+/** One circle chip on the contact-detail screen. [pending] means this contact's grant on that
+ *  circle is still a sealed deposit — live-read via [id.homebase.chat.services.convo.contact.ConnectionService.findPendingCircles],
+ *  never cached across app restarts, since there's no bulk "list this contact's pending circles"
+ *  endpoint either. */
+data class ContactCircleUi(val id: String, val name: String, val pending: Boolean)
+
 @Immutable
 data class ContactDetailUiState(
     val entry: ContactBookEntry? = null,
     val isLoading: Boolean = true,
     /** Connection status for this contact's odinId; null when not a connection / unknown. */
     val connectionStatus: ConnectionStatus? = null,
-    /** User-defined circles this contact belongs to (system circles excluded), A–Z. */
-    val circles: List<String> = emptyList(),
+    /** User-defined circles this contact belongs to, real or pending (system circles excluded), A–Z. */
+    val circles: List<ContactCircleUi> = emptyList(),
+    /** Open circle-detail dialog (tapped a chip in [circles]), or null when dismissed. View-only
+     *  from this screen — [CircleMembersUi.manageable] is always false here. */
+    val circleDetail: CircleMembersUi? = null,
     /** The existing 1:1 conversation, if one exists (never created just to view details). */
     val conversationId: Uuid? = null,
     val overview: ConversationOverview? = null,
@@ -110,6 +120,11 @@ sealed interface ContactDetailAction {
     data object SeeAllMediaClicked : ContactDetailAction
     data class OpenGroup(val conversationId: Uuid) : ContactDetailAction
     data object BackClicked : ContactDetailAction
+    /** Tapped a circle chip — opens the circle-detail dialog for [circleId]. */
+    data class CircleClicked(val circleId: String) : ContactDetailAction
+    data object CircleDetailDismiss : ContactDetailAction
+    /** Tapped another contact's row inside the circle-detail dialog. */
+    data class CircleMemberClicked(val entry: ContactBookEntry) : ContactDetailAction
 }
 
 sealed interface ContactDetailEvent {
@@ -140,4 +155,6 @@ sealed interface ContactDetailEvent {
     data object RequestCancelled : ContactDetailEvent
     /** Accept failed because the sender already withdrew the request (server-confirmed gone). */
     data object RequestWithdrawn : ContactDetailEvent
+    /** Tapped another contact's row inside the circle-detail dialog — navigate to their detail. */
+    data class OpenOtherContact(val uniqueId: String, val odinId: String?) : ContactDetailEvent
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailViewModel.kt
@@ -352,9 +352,16 @@ class ContactDetailViewModel(
                 pending.map { it.domainName }.toSet(),
                 latestContacts,
             ).sortedBy { it.sortKey }
+            // Re-excludes against the CURRENT members at update time, not the snapshot this
+            // fan-out started from — cancel() on the superseded job is cooperative, so a stale
+            // fan-out already past its last suspension point can still land its update after a
+            // fresher one already promoted someone from pending to real, putting them in both
+            // lists at once and crashing CircleMembersSheet's keyed LazyColumn.
             _uiState.update {
-                if (it.circleDetail?.circleId == circle.circle.id) {
-                    it.copy(circleDetail = it.circleDetail.copy(pendingMembers = pendingEntries, pendingChecking = false))
+                val current = it.circleDetail
+                if (current?.circleId == circle.circle.id) {
+                    val deduped = pendingEntries.filterNot { p -> current.members.any { m -> m.uniqueId == p.uniqueId } }
+                    it.copy(circleDetail = current.copy(pendingMembers = deduped, pendingChecking = false))
                 } else it
             }
         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailViewModel.kt
@@ -16,6 +16,7 @@ import id.homebase.api.client.connections.ConnectionNetworkProvider
 import id.homebase.api.client.connections.ConnectionRequestOrigin
 import id.homebase.api.client.peer.temporal.TemporalDriveReadProvider
 import id.homebase.api.common.OdinId
+import id.homebase.api.crypto.Md5
 import id.homebase.chat.conversationsettings.GroupInCommonItem
 import id.homebase.chat.conversationsettings.collectConversationOverview
 import id.homebase.chat.services.ChatMessageStream
@@ -35,15 +36,20 @@ import id.homebase.core.contactbook.ReconcileAction
 import id.homebase.core.contactbook.reconcileAction
 import id.homebase.core.contactbook.setICanLocate
 import id.homebase.core.ui.navigation.Route
+import id.homebase.core.ui.screens.contactbook.CircleMemberStatus
+import id.homebase.core.ui.screens.contactbook.CircleMembersUi
 import id.homebase.core.ui.screens.contactbook.RequestDirection
 import id.homebase.core.ui.screens.contactbook.model.ContactBookEntry
 import id.homebase.core.ui.screens.contactbook.ContactSaveResult
 import id.homebase.core.ui.screens.contactbook.model.ContactBookSource
 import id.homebase.core.ui.screens.contactbook.model.toContactBookEntry
+import id.homebase.core.ui.screens.contactbook.resolveCircleDrives
 import id.homebase.core.ui.screens.contactbook.saveContactDraft
 import id.homebase.core.ui.screens.contactbook.saveContactEdit
 import id.homebase.core.ui.screens.contactbook.withOverride
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -81,6 +87,21 @@ class ContactDetailViewModel(
 
     /** (uniqueId, versionTag) we last fetched ext_data for, to avoid re-fetching unchanged. */
     private var extLoadedFor: Pair<Uuid, Uuid?>? = null
+
+    /** Live-read circle ids this contact has as a pending deposit — see [refreshPendingCircles]. */
+    private val _pendingCircleIds = MutableStateFlow<Set<String>>(emptySet())
+
+    /** domain we last fetched pending circles for, so the init collector only triggers a fresh
+     *  network read once per contact rather than on every combine emission. */
+    private var pendingCirclesLoadedFor: String? = null
+    private var pendingCirclesJob: Job? = null
+    private var circleDetailPendingJob: Job? = null
+
+    /** Latest circle-membership snapshot + contact list, cached from the init collector so
+     *  [onCircleClicked]/[refreshPendingCircles] can build the circle-detail dialog without
+     *  re-subscribing to the flows themselves. */
+    private var latestCirc: id.homebase.chat.services.convo.contact.CircleMembershipState? = null
+    private var latestContacts: List<ContactBookEntry> = emptyList()
 
     /**
      * Fetches the on-demand `ext_data` payload (Experience / Bio rich-text) once per contact version
@@ -147,10 +168,14 @@ class ContactDetailViewModel(
                     DetailBundle(contacts, conn, circ, incoming, outgoing)
                 },
                 overrideStore.overrides,
-            ) { bundle, overrides -> bundle to overrides }.collect { (bundle, overrides) ->
+                _pendingCircleIds,
+            ) { bundle, overrides, pendingCircleIds -> Triple(bundle, overrides, pendingCircleIds) }
+                .collect { (bundle, overrides, pendingCircleIds) ->
                 val contacts = bundle.contacts
                 val conn = bundle.conn
                 val circ = bundle.circ
+                latestCirc = circ
+                latestContacts = contacts
                 val synced = contacts.find { it.uniqueId.toString() == route.uniqueId }
                     ?: syntheticEntry()
                 syncedEntry = synced
@@ -189,29 +214,39 @@ class ContactDetailViewModel(
                     }
                 }
                 // User-defined circles only — the Confirmed/Auto system circles are surfaced
-                // through the connection status, not as chips.
-                val circleNames = domain?.let { d ->
-                    circ.circlesFor(d)
-                        .filterNot { it.disabled }
-                        .filterNot {
-                            it.id.equals(CONFIRMED_CONNECTIONS_CIRCLE_ID, ignoreCase = true) ||
-                                it.id.equals(AUTO_CONNECTIONS_CIRCLE_ID, ignoreCase = true)
-                        }
-                        .map { it.name }
-                        .filter { it.isNotBlank() }
-                        .distinct()
-                        .sorted()
-                }.orEmpty()
+                // through the connection status, not as chips. Real membership is reactive
+                // (circ.circlesFor); pending membership is a live-read snapshot (pendingCircleIds,
+                // refreshed by refreshPendingCircles) merged in here, since there's no bulk
+                // "list this contact's pending circles" endpoint to observe reactively.
+                fun isSystemCircle(id: String) = id.equals(CONFIRMED_CONNECTIONS_CIRCLE_ID, ignoreCase = true) ||
+                    id.equals(AUTO_CONNECTIONS_CIRCLE_ID, ignoreCase = true)
+                val realCircles = domain?.let { d -> circ.circlesFor(d) }.orEmpty()
+                    .filterNot { it.disabled || isSystemCircle(it.id) }
+                val realIds = realCircles.map { it.id.lowercase() }.toSet()
+                val pendingCircles = pendingCircleIds
+                    .mapNotNull { pid -> circ.circles.map { it.circle }.firstOrNull { it.id.equals(pid, ignoreCase = true) } }
+                    .filterNot { it.disabled || isSystemCircle(it.id) || it.id.lowercase() in realIds }
+                val circleItems = (
+                    realCircles.map { ContactCircleUi(it.id, it.name, pending = false) } +
+                        pendingCircles.map { ContactCircleUi(it.id, it.name, pending = true) }
+                    )
+                    .filter { it.name.isNotBlank() }
+                    .distinctBy { it.id.lowercase() }
+                    .sortedBy { it.name.lowercase() }
                 _uiState.update {
                     it.copy(
                         entry = entry,
                         connectionStatus = status,
-                        circles = circleNames,
+                        circles = circleItems,
                         isLoading = false,
                         isSelf = isSelf,
                         requestDirection = requestDirection,
                         introducedByName = introducedByName,
                     )
+                }
+                if (domain != null && pendingCirclesLoadedFor != domain) {
+                    pendingCirclesLoadedFor = domain
+                    refreshPendingCircles()
                 }
             }
         }
@@ -230,6 +265,126 @@ class ContactDetailViewModel(
             source = ContactBookSource.CONNECTION,
         )
     }
+
+    // region Circles
+
+    /**
+     * Live re-check of this contact's pending circles — always re-derives from the server
+     * (never relies on [connectionService].circles re-emitting, which StateFlow silently skips
+     * when a pending-only change doesn't alter the real member list; see ContactBookViewModel's
+     * refreshOpenCircle for the same lesson, #1096). Called once per contact from the init
+     * collector, and again on screen resume via [id.homebase.core.ui.screens.contactbook.detail.ContactDetailScreen]'s
+     * lifecycle observer. Also re-checks the open circle-detail dialog's own "who else" pending
+     * roster, if one is open.
+     */
+    fun refreshPendingCircles() {
+        val domain = odinId
+        if (domain != null) {
+            pendingCirclesJob?.cancel()
+            pendingCirclesJob = viewModelScope.launch {
+                val pending = try {
+                    connectionService.findPendingCircles(OdinId(domain))
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Logger.w(e, TAG) { "findPendingCircles failed for $domain" }
+                    emptyList()
+                }
+                _pendingCircleIds.value = pending.map { it.toHexString() }.toSet()
+            }
+        }
+        val open = _uiState.value.circleDetail ?: return
+        val match = latestCirc?.circles?.firstOrNull { it.circle.id.equals(open.circleId, ignoreCase = true) }
+            ?: return
+        checkCircleDetailPending(match)
+    }
+
+    /** Opens the circle-detail dialog for [circleId] — real members synchronously (already
+     *  bundled with the loaded circle list), then an async pending-roster fan-out. Always
+     *  view-only from this screen (manageable = false): circle membership is managed from the
+     *  Circles tab, not from a contact's page. */
+    fun onCircleClicked(circleId: String) {
+        val circ = latestCirc ?: return
+        val match = circ.circles.firstOrNull { it.circle.id.equals(circleId, ignoreCase = true) } ?: return
+        val domain = odinId
+        val memberDomains = match.members.map { it.domainName }.toSet()
+        val members = resolveCircleContactEntries(memberDomains, latestContacts).sortedBy { it.sortKey }
+        val isRealMember = domain != null && memberDomains.any { it.equals(domain, ignoreCase = true) }
+        val viewerEntry = domain?.let { d -> latestContacts.firstOrNull { it.odinId.equals(d, ignoreCase = true) } }
+            ?: syncedEntry
+        _uiState.update {
+            it.copy(
+                circleDetail = CircleMembersUi(
+                    circleId = match.circle.id,
+                    circleName = match.circle.name,
+                    manageable = false,
+                    members = members,
+                    isLoading = false,
+                    pendingChecking = true,
+                    drives = resolveCircleDrives(match.circle),
+                    viewerStatus = if (isRealMember) CircleMemberStatus.Member else CircleMemberStatus.Pending,
+                    viewerContactId = viewerEntry?.uniqueId,
+                ),
+            )
+        }
+        checkCircleDetailPending(match)
+    }
+
+    private fun checkCircleDetailPending(circle: id.homebase.api.client.connections.CircleWithMembers) {
+        circleDetailPendingJob?.cancel()
+        circleDetailPendingJob = viewModelScope.launch {
+            val circleId = try {
+                Uuid.parseHex(circle.circle.id)
+            } catch (e: Exception) {
+                Logger.w(e, TAG) { "bad circle id ${circle.circle.id}" }
+                _uiState.update { it.copy(circleDetail = it.circleDetail?.copy(pendingChecking = false)) }
+                return@launch
+            }
+            val pending = try {
+                connectionService.findPendingMembers(circleId)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Logger.w(e, TAG) { "findPendingMembers failed for ${circle.circle.id}" }
+                emptyList()
+            }
+            val pendingEntries = resolveCircleContactEntries(
+                pending.map { it.domainName }.toSet(),
+                latestContacts,
+            ).sortedBy { it.sortKey }
+            _uiState.update {
+                if (it.circleDetail?.circleId == circle.circle.id) {
+                    it.copy(circleDetail = it.circleDetail.copy(pendingMembers = pendingEntries, pendingChecking = false))
+                } else it
+            }
+        }
+    }
+
+    fun onCircleDetailDismiss() {
+        _uiState.update { it.copy(circleDetail = null) }
+    }
+
+    private fun resolveCircleContactEntries(
+        domains: Set<String>,
+        contacts: List<ContactBookEntry>,
+    ): List<ContactBookEntry> {
+        val byOdin = contacts.filter { !it.odinId.isNullOrBlank() }.associateBy { it.odinId!!.lowercase() }
+        return domains.map { domain -> byOdin[domain.lowercase()] ?: syntheticCircleContactEntry(domain) }
+    }
+
+    private fun syntheticCircleContactEntry(domain: String): ContactBookEntry {
+        val uid = Md5.toGuidId(domain.lowercase())
+        return ContactBookEntry(
+            uniqueId = uid,
+            fileId = uid,
+            versionTag = null,
+            odinId = domain,
+            displayName = domain,
+            source = ContactBookSource.CONNECTION,
+        )
+    }
+
+    // endregion
 
     /** Loads media + groups-in-common ONLY when a 1:1 conversation already exists. */
     private fun loadConversationOverview() {
@@ -289,6 +444,11 @@ class ContactDetailViewModel(
             is ContactDetailAction.OpenGroup ->
                 _events.tryEmit(ContactDetailEvent.OpenConversation(action.conversationId))
             ContactDetailAction.BackClicked -> _events.tryEmit(ContactDetailEvent.Back)
+            is ContactDetailAction.CircleClicked -> onCircleClicked(action.circleId)
+            ContactDetailAction.CircleDetailDismiss -> onCircleDetailDismiss()
+            is ContactDetailAction.CircleMemberClicked -> _events.tryEmit(
+                ContactDetailEvent.OpenOtherContact(action.entry.uniqueId.toString(), action.entry.odinId)
+            )
         }
     }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailViewModel.kt
@@ -97,6 +97,12 @@ class ContactDetailViewModel(
     private var pendingCirclesJob: Job? = null
     private var circleDetailPendingJob: Job? = null
 
+    /** Bumped on every [refreshPendingCircles] call; a stale fan-out's tail checks its captured
+     *  generation before writing [_pendingCircleIds] so a slow call for a previous contact can't
+     *  land after a fresher one and overwrite it with the wrong domain's data — cancel() on the
+     *  superseded job is only cooperative, not immediate. */
+    private var pendingCirclesGeneration = 0
+
     /** Latest circle-membership snapshot + contact list, cached from the init collector so
      *  [onCircleClicked]/[refreshPendingCircles] can build the circle-detail dialog without
      *  re-subscribing to the flows themselves. */
@@ -281,6 +287,7 @@ class ContactDetailViewModel(
         val domain = odinId
         if (domain != null) {
             pendingCirclesJob?.cancel()
+            val generation = ++pendingCirclesGeneration
             pendingCirclesJob = viewModelScope.launch {
                 val pending = try {
                     connectionService.findPendingCircles(OdinId(domain))
@@ -290,7 +297,9 @@ class ContactDetailViewModel(
                     Logger.w(e, TAG) { "findPendingCircles failed for $domain" }
                     emptyList()
                 }
-                _pendingCircleIds.value = pending.map { it.toHexString() }.toSet()
+                if (generation == pendingCirclesGeneration) {
+                    _pendingCircleIds.value = pending.map { it.toHexString() }.toSet()
+                }
             }
         }
         val open = _uiState.value.circleDetail ?: return
@@ -332,6 +341,7 @@ class ContactDetailViewModel(
 
     private fun checkCircleDetailPending(circle: id.homebase.api.client.connections.CircleWithMembers) {
         circleDetailPendingJob?.cancel()
+        val domain = odinId
         circleDetailPendingJob = viewModelScope.launch {
             val circleId = try {
                 Uuid.parseHex(circle.circle.id)
@@ -352,6 +362,11 @@ class ContactDetailViewModel(
                 pending.map { it.domainName }.toSet(),
                 latestContacts,
             ).sortedBy { it.sortKey }
+            // The viewer's own status was frozen at dialog-open time (onCircleClicked) — recompute
+            // it from this fresh read so a pending grant that converts to real membership (or vice
+            // versa) between opens is reflected instead of showing a stale "Pending"/"Member" label.
+            val isRealMember = domain != null && circle.members.any { it.domainName.equals(domain, ignoreCase = true) }
+            val isPendingMember = domain != null && pending.any { it.domainName.equals(domain, ignoreCase = true) }
             // Re-excludes against the CURRENT members at update time, not the snapshot this
             // fan-out started from — cancel() on the superseded job is cooperative, so a stale
             // fan-out already past its last suspension point can still land its update after a
@@ -361,7 +376,17 @@ class ContactDetailViewModel(
                 val current = it.circleDetail
                 if (current?.circleId == circle.circle.id) {
                     val deduped = pendingEntries.filterNot { p -> current.members.any { m -> m.uniqueId == p.uniqueId } }
-                    it.copy(circleDetail = current.copy(pendingMembers = deduped, pendingChecking = false))
+                    it.copy(
+                        circleDetail = current.copy(
+                            pendingMembers = deduped,
+                            pendingChecking = false,
+                            viewerStatus = when {
+                                isRealMember -> CircleMemberStatus.Member
+                                isPendingMember -> CircleMemberStatus.Pending
+                                else -> current.viewerStatus
+                            },
+                        ),
+                    )
                 } else it
             }
         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyContactPickerScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyContactPickerScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.InputChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -52,7 +53,6 @@ import id.homebase.resources.chat_new_conversation_search_placeholder
 import id.homebase.resources.chat_search_result_empty
 import id.homebase.resources.contacts
 import id.homebase.resources.location_emergency_add_already_member
-import id.homebase.resources.location_emergency_add_failed
 import id.homebase.resources.location_emergency_add_none_eligible
 import id.homebase.resources.location_emergency_add_succeeded
 import id.homebase.resources.location_emergency_add_title
@@ -72,20 +72,27 @@ fun EmergencyContactPickerScreen(
 
     val addedLabel = stringResource(MR.string.location_emergency_add_succeeded)
     val alreadyMemberLabel = stringResource(MR.string.location_emergency_add_already_member)
-    val failedLabel = stringResource(MR.string.location_emergency_add_failed)
 
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
             when (event) {
                 EmergencyContactPickerUiEvent.Back -> onNavigateBack()
                 is EmergencyContactPickerUiEvent.AddCompleted -> {
+                    // Failures lead with the actual reason (server title / exception message) —
+                    // a bare "Failed: 1" told the user nothing happened worth acting on.
                     val parts = buildList {
                         if (event.added > 0) add("$addedLabel: ${event.added}")
                         if (event.alreadyMember > 0) add("$alreadyMemberLabel: ${event.alreadyMember}")
-                        if (event.failed > 0) add("$failedLabel: ${event.failed}")
+                        event.failures.forEach { add("${it.name}: ${it.reason}") }
                     }
                     if (parts.isNotEmpty()) {
-                        scope.launch { snackbarHostState.showSnackbar(message = parts.joinToString(" · ")) }
+                        scope.launch {
+                            snackbarHostState.showSnackbar(
+                                message = parts.joinToString(" · "),
+                                duration = if (event.failures.isNotEmpty()) SnackbarDuration.Long
+                                else SnackbarDuration.Short,
+                            )
+                        }
                     }
                 }
             }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyContactPickerScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyContactPickerScreen.kt
@@ -1,0 +1,240 @@
+package id.homebase.core.ui.screens.location
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.InputChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.homebase.chat.createconversation.ContactItem
+import id.homebase.core.avatars.AvatarOptions
+import id.homebase.core.avatars.ContactAvatar
+import id.homebase.core.widget.StyledSearchTextField
+import id.homebase.resources.MR
+import id.homebase.resources.chat_new_conversation_search_placeholder
+import id.homebase.resources.chat_search_result_empty
+import id.homebase.resources.contacts
+import id.homebase.resources.location_emergency_add_already_member
+import id.homebase.resources.location_emergency_add_failed
+import id.homebase.resources.location_emergency_add_none_eligible
+import id.homebase.resources.location_emergency_add_succeeded
+import id.homebase.resources.location_emergency_add_title
+import id.homebase.resources.menu_back
+import id.homebase.resources.remove
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun EmergencyContactPickerScreen(
+    viewModel: EmergencyContactPickerViewModel,
+    onNavigateBack: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+
+    val addedLabel = stringResource(MR.string.location_emergency_add_succeeded)
+    val alreadyMemberLabel = stringResource(MR.string.location_emergency_add_already_member)
+    val failedLabel = stringResource(MR.string.location_emergency_add_failed)
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                EmergencyContactPickerUiEvent.Back -> onNavigateBack()
+                is EmergencyContactPickerUiEvent.AddCompleted -> {
+                    val parts = buildList {
+                        if (event.added > 0) add("$addedLabel: ${event.added}")
+                        if (event.alreadyMember > 0) add("$alreadyMemberLabel: ${event.alreadyMember}")
+                        if (event.failed > 0) add("$failedLabel: ${event.failed}")
+                    }
+                    if (parts.isNotEmpty()) {
+                        scope.launch { snackbarHostState.showSnackbar(message = parts.joinToString(" · ")) }
+                    }
+                }
+            }
+        }
+    }
+
+    EmergencyContactPickerUi(
+        snackbarHostState = snackbarHostState,
+        uiState = uiState,
+        searchTextState = viewModel.searchTextState,
+        onUiAction = viewModel::onUiAction,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun EmergencyContactPickerUi(
+    snackbarHostState: SnackbarHostState,
+    uiState: EmergencyContactPickerUiState,
+    searchTextState: TextFieldState,
+    onUiAction: (EmergencyContactPickerUiAction) -> Unit,
+) {
+    Scaffold(
+        modifier = Modifier.imePadding(),
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(MR.string.location_emergency_add_title)) },
+                navigationIcon = {
+                    IconButton(onClick = { onUiAction(EmergencyContactPickerUiAction.BackClicked) }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(MR.string.menu_back),
+                        )
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            if (uiState.selectedContacts.isNotEmpty()) {
+                Button(
+                    onClick = { onUiAction(EmergencyContactPickerUiAction.AddClicked) },
+                    modifier = Modifier.defaultMinSize(minWidth = 56.dp),
+                    enabled = !uiState.submitting,
+                    shape = CircleShape,
+                ) {
+                    if (uiState.submitting) {
+                        CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+                    } else {
+                        Icon(Icons.Default.Check, contentDescription = stringResource(MR.string.location_emergency_add_title))
+                    }
+                }
+            }
+        },
+    ) { paddingValues ->
+        Column(modifier = Modifier.padding(paddingValues)) {
+            StyledSearchTextField(
+                modifier = Modifier.padding(horizontal = 16.dp).fillMaxWidth(),
+                textFieldState = searchTextState,
+                showSearchIcon = false,
+                placeHolderText = stringResource(MR.string.chat_new_conversation_search_placeholder),
+            )
+            if (uiState.selectedContacts.isNotEmpty()) {
+                LazyRow(contentPadding = PaddingValues(vertical = 8.dp, horizontal = 16.dp)) {
+                    items(uiState.selectedContacts) { contact ->
+                        InputChip(
+                            modifier = Modifier.widthIn(max = 200.dp).padding(end = 8.dp),
+                            onClick = {},
+                            label = {
+                                Text(text = contact.name, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                            },
+                            selected = true,
+                            leadingIcon = {
+                                ContactAvatar(
+                                    odinId = contact.odinId,
+                                    profileImageData = null,
+                                    initials = contact.avatarInitials,
+                                    options = AvatarOptions(size = 28.dp, fontSize = 12.sp),
+                                    sharedTransitionScope = null,
+                                    animatedVisibilityScope = null,
+                                )
+                            },
+                            trailingIcon = {
+                                Icon(
+                                    modifier = Modifier.clickable {
+                                        onUiAction(EmergencyContactPickerUiAction.ContactClicked(contact))
+                                    },
+                                    imageVector = Icons.Default.Close,
+                                    contentDescription = stringResource(MR.string.remove),
+                                )
+                            },
+                        )
+                    }
+                }
+            }
+            LazyColumn(
+                modifier = Modifier.weight(1f),
+                contentPadding = PaddingValues(16.dp),
+            ) {
+                if (uiState.displayItems.isEmpty()) {
+                    item {
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(top = 24.dp),
+                            horizontalArrangement = Arrangement.Center,
+                        ) {
+                            Text(
+                                text = if (searchTextState.text.isNotEmpty()) {
+                                    stringResource(MR.string.chat_search_result_empty, searchTextState.text.toString())
+                                } else {
+                                    stringResource(MR.string.location_emergency_add_none_eligible)
+                                },
+                            )
+                        }
+                    }
+                } else {
+                    item {
+                        Text(
+                            modifier = Modifier.padding(bottom = 16.dp, start = 16.dp),
+                            text = stringResource(MR.string.contacts),
+                            style = MaterialTheme.typography.titleLarge,
+                        )
+                    }
+                }
+                uiState.displayItems.forEach { group ->
+                    stickyHeader {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .background(MaterialTheme.colorScheme.surface)
+                                .padding(horizontal = 16.dp, vertical = 8.dp),
+                        ) {
+                            Text(text = group.initial, style = MaterialTheme.typography.titleMedium)
+                        }
+                    }
+                    items(group.contacts, key = { it.odinId.domainName }) { contact ->
+                        ContactItem(
+                            name = contact.name,
+                            subTitle = contact.odinId.domainName,
+                            selectionMode = true,
+                            isSelected = uiState.selectedContacts.contains(contact),
+                            odinId = contact.odinId,
+                            avatarInitials = contact.avatarInitials,
+                            onContactClick = {
+                                onUiAction(EmergencyContactPickerUiAction.ContactClicked(contact))
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyContactPickerScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyContactPickerScreen.kt
@@ -47,10 +47,13 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.chat.createconversation.ContactItem
 import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.ContactAvatar
+import id.homebase.core.ui.screens.contactbook.CircleAddFailureReason
 import id.homebase.core.widget.StyledSearchTextField
 import id.homebase.resources.MR
 import id.homebase.resources.chat_new_conversation_search_placeholder
 import id.homebase.resources.chat_search_result_empty
+import id.homebase.resources.circle_member_add_drive_access_denied
+import id.homebase.resources.circle_member_add_generic_failed
 import id.homebase.resources.contacts
 import id.homebase.resources.location_emergency_add_already_member
 import id.homebase.resources.location_emergency_add_none_eligible
@@ -72,18 +75,29 @@ fun EmergencyContactPickerScreen(
 
     val addedLabel = stringResource(MR.string.location_emergency_add_succeeded)
     val alreadyMemberLabel = stringResource(MR.string.location_emergency_add_already_member)
+    val driveAccessDeniedLabel = stringResource(MR.string.circle_member_add_drive_access_denied)
+    val genericFailedLabel = stringResource(MR.string.circle_member_add_generic_failed)
 
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
             when (event) {
                 EmergencyContactPickerUiEvent.Back -> onNavigateBack()
                 is EmergencyContactPickerUiEvent.AddCompleted -> {
-                    // Failures lead with the actual reason (server title / exception message) —
-                    // a bare "Failed: 1" told the user nothing happened worth acting on.
+                    // Failures lead with the actual reason — a bare "Failed: 1" told the user
+                    // nothing happened worth acting on. Only DriveAccessDenied and a real 400's
+                    // message are genuinely explanatory; an opaque 403 gets a generic message
+                    // rather than surfacing internal detail as if it were actionable.
                     val parts = buildList {
                         if (event.added > 0) add("$addedLabel: ${event.added}")
                         if (event.alreadyMember > 0) add("$alreadyMemberLabel: ${event.alreadyMember}")
-                        event.failures.forEach { add("${it.name}: ${it.reason}") }
+                        event.failures.forEach { f ->
+                            val reason = when (val r = f.reason) {
+                                is CircleAddFailureReason.Raw -> r.message
+                                CircleAddFailureReason.DriveAccessDenied -> driveAccessDeniedLabel
+                                CircleAddFailureReason.OpaqueForbidden -> genericFailedLabel
+                            }
+                            add("${f.name}: $reason")
+                        }
                     }
                     if (parts.isNotEmpty()) {
                         scope.launch {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyContactPickerScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyContactPickerScreen.kt
@@ -48,6 +48,7 @@ import id.homebase.chat.createconversation.ContactItem
 import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.ContactAvatar
 import id.homebase.core.ui.screens.contactbook.CircleAddFailureReason
+import id.homebase.core.ui.theme.HomebaseTheme
 import id.homebase.core.widget.StyledSearchTextField
 import id.homebase.resources.MR
 import id.homebase.resources.chat_new_conversation_search_placeholder
@@ -59,6 +60,7 @@ import id.homebase.resources.location_emergency_add_already_member
 import id.homebase.resources.location_emergency_add_none_eligible
 import id.homebase.resources.location_emergency_add_succeeded
 import id.homebase.resources.location_emergency_add_title
+import id.homebase.resources.location_emergency_add_unvetted_reason
 import id.homebase.resources.menu_back
 import id.homebase.resources.remove
 import kotlinx.coroutines.launch
@@ -129,6 +131,7 @@ private fun EmergencyContactPickerUi(
     searchTextState: TextFieldState,
     onUiAction: (EmergencyContactPickerUiAction) -> Unit,
 ) {
+    val unvettedReason = stringResource(MR.string.location_emergency_add_unvetted_reason)
     Scaffold(
         modifier = Modifier.imePadding(),
         snackbarHost = { SnackbarHost(snackbarHostState) },
@@ -242,10 +245,14 @@ private fun EmergencyContactPickerUi(
                         }
                     }
                     items(group.contacts, key = { it.odinId.domainName }) { contact ->
+                        val eligible = contact.connection?.vetted == true
                         ContactItem(
                             name = contact.name,
                             subTitle = contact.odinId.domainName,
+                            annotation = if (!eligible) unvettedReason else null,
+                            annotationColor = if (!eligible) HomebaseTheme.extendedColors.warning else null,
                             selectionMode = true,
+                            isSelectionEnabled = eligible,
                             isSelected = uiState.selectedContacts.contains(contact),
                             odinId = contact.odinId,
                             avatarInitials = contact.avatarInitials,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyContactPickerUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyContactPickerUiState.kt
@@ -1,0 +1,30 @@
+package id.homebase.core.ui.screens.location
+
+import id.homebase.chat.createconversation.ContactGroup
+import id.homebase.chat.data.ContactUiModel
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
+
+data class EmergencyContactPickerUiState(
+    val displayItems: PersistentList<ContactGroup> = persistentListOf(),
+    val selectedContacts: PersistentList<ContactUiModel> = persistentListOf(),
+    val submitting: Boolean = false,
+)
+
+sealed interface EmergencyContactPickerUiAction {
+    data class ContactClicked(val contact: ContactUiModel) : EmergencyContactPickerUiAction
+    data object AddClicked : EmergencyContactPickerUiAction
+    data object BackClicked : EmergencyContactPickerUiAction
+}
+
+sealed interface EmergencyContactPickerUiEvent {
+    data object Back : EmergencyContactPickerUiEvent
+
+    /** [added] landed as real or pending grants; [alreadyMember] were no-ops (already a member
+     *  or already pending); [failed] hit an unexpected error (network, forbidden, etc). */
+    data class AddCompleted(
+        val added: Int,
+        val alreadyMember: Int,
+        val failed: Int,
+    ) : EmergencyContactPickerUiEvent
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyContactPickerUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyContactPickerUiState.kt
@@ -2,6 +2,7 @@ package id.homebase.core.ui.screens.location
 
 import id.homebase.chat.createconversation.ContactGroup
 import id.homebase.chat.data.ContactUiModel
+import id.homebase.core.ui.screens.contactbook.CircleAddFailureReason
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 
@@ -19,7 +20,7 @@ sealed interface EmergencyContactPickerUiAction {
 
 /** One failed add attempt, carrying the actual server/client reason so the user sees why —
  *  not just that something failed. */
-data class EmergencyContactAddFailure(val name: String, val reason: String)
+data class EmergencyContactAddFailure(val name: String, val reason: CircleAddFailureReason)
 
 sealed interface EmergencyContactPickerUiEvent {
     data object Back : EmergencyContactPickerUiEvent

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyContactPickerUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyContactPickerUiState.kt
@@ -17,14 +17,19 @@ sealed interface EmergencyContactPickerUiAction {
     data object BackClicked : EmergencyContactPickerUiAction
 }
 
+/** One failed add attempt, carrying the actual server/client reason so the user sees why —
+ *  not just that something failed. */
+data class EmergencyContactAddFailure(val name: String, val reason: String)
+
 sealed interface EmergencyContactPickerUiEvent {
     data object Back : EmergencyContactPickerUiEvent
 
     /** [added] landed as real or pending grants; [alreadyMember] were no-ops (already a member
-     *  or already pending); [failed] hit an unexpected error (network, forbidden, etc). */
+     *  or already pending); [failures] hit a real error (network, forbidden, an unrecognized
+     *  400, etc) — kept selected on the picker so the user can see who still needs attention. */
     data class AddCompleted(
         val added: Int,
         val alreadyMember: Int,
-        val failed: Int,
+        val failures: List<EmergencyContactAddFailure>,
     ) : EmergencyContactPickerUiEvent
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyContactPickerViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyContactPickerViewModel.kt
@@ -1,0 +1,114 @@
+package id.homebase.core.ui.screens.location
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.runtime.snapshotFlow
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
+import id.homebase.api.client.ClientException
+import id.homebase.api.client.OdinClientErrorCode
+import id.homebase.api.client.connections.ConnectionStatus
+import id.homebase.chat.selectmembers.filterAndGroup
+import id.homebase.chat.services.convo.contact.ConnectionService
+import id.homebase.chat.services.convo.contact.ContactService
+import id.homebase.core.config.EMERGENCY_LOCATION_CIRCLE_ID
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlin.uuid.Uuid
+
+private const val TAG = "EmergencyContactPickerViewModel"
+
+/**
+ * Grant-eligibility candidate list for the emergency-location-access circle: connected AND
+ * vetted contacts (auto-connected/unconfirmed identities 400 on add — CannotGrantAutoConnected
+ * MoreCircles — so they're filtered out here rather than offered and rejected), excluding
+ * anyone already a real member. Real members come from the already-loaded bulk circle-members
+ * read ([ConnectionService.circles]) — cheap and authoritative; a duplicate add attempt on a
+ * still-pending contact simply hits the server's real IdentityAlreadyMemberOfCircle response
+ * (handled in [addSelected]) rather than being pre-filtered from a guess.
+ */
+class EmergencyContactPickerViewModel(
+    private val contactService: ContactService,
+    private val connectionService: ConnectionService,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(EmergencyContactPickerUiState())
+    val uiState: StateFlow<EmergencyContactPickerUiState> = _uiState.asStateFlow()
+    val searchTextState = TextFieldState()
+
+    private val _events = MutableSharedFlow<EmergencyContactPickerUiEvent>(extraBufferCapacity = 4)
+    val events: SharedFlow<EmergencyContactPickerUiEvent> = _events.asSharedFlow()
+
+    init {
+        viewModelScope.launch {
+            contactService.start()
+            combine(
+                contactService.contacts,
+                connectionService.circles,
+                snapshotFlow { searchTextState.text.toString() },
+            ) { contacts, circleState, query ->
+                val members = circleState.membersOf(EMERGENCY_LOCATION_CIRCLE_ID)
+                contacts
+                    .filter { it.connection?.status == ConnectionStatus.Connected && it.connection?.vetted == true }
+                    .filterNot { members.contains(it.odinId.domainName.lowercase()) }
+                    .filterAndGroup(query)
+            }.collect { groups ->
+                _uiState.update { it.copy(displayItems = groups.toPersistentList()) }
+            }
+        }
+    }
+
+    fun onUiAction(action: EmergencyContactPickerUiAction) {
+        when (action) {
+            is EmergencyContactPickerUiAction.ContactClicked -> {
+                val selected = uiState.value.selectedContacts.toMutableList()
+                if (!selected.remove(action.contact)) selected.add(action.contact)
+                _uiState.update { it.copy(selectedContacts = selected.toPersistentList()) }
+            }
+
+            EmergencyContactPickerUiAction.AddClicked -> addSelected()
+            EmergencyContactPickerUiAction.BackClicked -> _events.tryEmit(EmergencyContactPickerUiEvent.Back)
+        }
+    }
+
+    private fun addSelected() {
+        if (uiState.value.submitting) return
+        val targets = uiState.value.selectedContacts
+        if (targets.isEmpty()) return
+        _uiState.update { it.copy(submitting = true) }
+        viewModelScope.launch {
+            val circleId = Uuid.parseHex(EMERGENCY_LOCATION_CIRCLE_ID)
+            var added = 0
+            var alreadyMember = 0
+            var failed = 0
+            for (contact in targets) {
+                try {
+                    connectionService.addToCircle(circleId, contact.odinId)
+                    added++
+                } catch (e: ClientException) {
+                    if (e.errorCode == OdinClientErrorCode.IdentityAlreadyMemberOfCircle) {
+                        alreadyMember++
+                    } else {
+                        Logger.w(e, TAG) { "addToCircle failed for ${contact.odinId}: ${e.errorCode}" }
+                        failed++
+                    }
+                } catch (e: Exception) {
+                    Logger.w(e, TAG) { "addToCircle failed for ${contact.odinId}" }
+                    failed++
+                }
+            }
+            _uiState.update { it.copy(submitting = false, selectedContacts = persistentListOf()) }
+            _events.tryEmit(EmergencyContactPickerUiEvent.AddCompleted(added, alreadyMember, failed))
+            if (failed == 0) _events.tryEmit(EmergencyContactPickerUiEvent.Back)
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyContactPickerViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyContactPickerViewModel.kt
@@ -10,6 +10,7 @@ import id.homebase.api.client.OdinClientErrorCode
 import id.homebase.api.client.connections.ConnectionStatus
 import id.homebase.chat.data.ContactUiModel
 import id.homebase.chat.selectmembers.filterAndGroup
+import id.homebase.core.ui.screens.contactbook.toCircleAddFailureReason
 import id.homebase.chat.services.convo.contact.ConnectionService
 import id.homebase.chat.services.convo.contact.ContactService
 import id.homebase.core.config.EMERGENCY_LOCATION_CIRCLE_ID
@@ -102,12 +103,12 @@ class EmergencyContactPickerViewModel(
                             alreadyMember++
                         } else {
                             Logger.w(e, TAG) { "addToCircle failed for ${contact.odinId}: ${e.errorCode}" }
-                            failures += EmergencyContactAddFailure(contact.name, e.message ?: "Failed")
+                            failures += EmergencyContactAddFailure(contact.name, e.toCircleAddFailureReason())
                             stillFailed += contact
                         }
                     } catch (e: Exception) {
                         Logger.w(e, TAG) { "addToCircle failed for ${contact.odinId}" }
-                        failures += EmergencyContactAddFailure(contact.name, e.message ?: "Failed")
+                        failures += EmergencyContactAddFailure(contact.name, e.toCircleAddFailureReason())
                         stillFailed += contact
                     }
                 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyContactPickerViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyContactPickerViewModel.kt
@@ -8,6 +8,7 @@ import co.touchlab.kermit.Logger
 import id.homebase.api.client.ClientException
 import id.homebase.api.client.OdinClientErrorCode
 import id.homebase.api.client.connections.ConnectionStatus
+import id.homebase.chat.data.ContactUiModel
 import id.homebase.chat.selectmembers.filterAndGroup
 import id.homebase.chat.services.convo.contact.ConnectionService
 import id.homebase.chat.services.convo.contact.ContactService
@@ -89,26 +90,35 @@ class EmergencyContactPickerViewModel(
             val circleId = Uuid.parseHex(EMERGENCY_LOCATION_CIRCLE_ID)
             var added = 0
             var alreadyMember = 0
-            var failed = 0
-            for (contact in targets) {
-                try {
-                    connectionService.addToCircle(circleId, contact.odinId)
-                    added++
-                } catch (e: ClientException) {
-                    if (e.errorCode == OdinClientErrorCode.IdentityAlreadyMemberOfCircle) {
-                        alreadyMember++
-                    } else {
-                        Logger.w(e, TAG) { "addToCircle failed for ${contact.odinId}: ${e.errorCode}" }
-                        failed++
+            val failures = mutableListOf<EmergencyContactAddFailure>()
+            val stillFailed = mutableListOf<ContactUiModel>()
+            try {
+                for (contact in targets) {
+                    try {
+                        connectionService.addToCircle(circleId, contact.odinId)
+                        added++
+                    } catch (e: ClientException) {
+                        if (e.errorCode == OdinClientErrorCode.IdentityAlreadyMemberOfCircle) {
+                            alreadyMember++
+                        } else {
+                            Logger.w(e, TAG) { "addToCircle failed for ${contact.odinId}: ${e.errorCode}" }
+                            failures += EmergencyContactAddFailure(contact.name, e.message ?: "Failed")
+                            stillFailed += contact
+                        }
+                    } catch (e: Exception) {
+                        Logger.w(e, TAG) { "addToCircle failed for ${contact.odinId}" }
+                        failures += EmergencyContactAddFailure(contact.name, e.message ?: "Failed")
+                        stillFailed += contact
                     }
-                } catch (e: Exception) {
-                    Logger.w(e, TAG) { "addToCircle failed for ${contact.odinId}" }
-                    failed++
                 }
+            } finally {
+                // Only drop entries that actually resolved (succeeded or already-member) — a
+                // failed one stays selected and visible so the user can see who still needs
+                // attention, instead of the selection silently vanishing on failure (#1096).
+                _uiState.update { it.copy(submitting = false, selectedContacts = stillFailed.toPersistentList()) }
+                _events.tryEmit(EmergencyContactPickerUiEvent.AddCompleted(added, alreadyMember, failures))
+                if (failures.isEmpty()) _events.tryEmit(EmergencyContactPickerUiEvent.Back)
             }
-            _uiState.update { it.copy(submitting = false, selectedContacts = persistentListOf()) }
-            _events.tryEmit(EmergencyContactPickerUiEvent.AddCompleted(added, alreadyMember, failed))
-            if (failed == 0) _events.tryEmit(EmergencyContactPickerUiEvent.Back)
         }
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyContactPickerViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyContactPickerViewModel.kt
@@ -30,13 +30,17 @@ import kotlin.uuid.Uuid
 private const val TAG = "EmergencyContactPickerViewModel"
 
 /**
- * Grant-eligibility candidate list for the emergency-location-access circle: connected AND
- * vetted contacts (auto-connected/unconfirmed identities 400 on add — CannotGrantAutoConnected
- * MoreCircles — so they're filtered out here rather than offered and rejected), excluding
- * anyone already a real member. Real members come from the already-loaded bulk circle-members
- * read ([ConnectionService.circles]) — cheap and authoritative; a duplicate add attempt on a
- * still-pending contact simply hits the server's real IdentityAlreadyMemberOfCircle response
- * (handled in [addSelected]) rather than being pre-filtered from a guess.
+ * Grant-eligibility candidate list for the emergency-location-access circle: every connected
+ * contact, excluding anyone already a real member. Real members come from the already-loaded
+ * bulk circle-members read ([ConnectionService.circles]) — cheap and authoritative; a duplicate
+ * add attempt on a still-pending contact simply hits the server's real
+ * IdentityAlreadyMemberOfCircle response (handled in [addSelected]) rather than being
+ * pre-filtered from a guess.
+ *
+ * A connected-but-unvetted (unconfirmed) contact is still shown — hiding it entirely made it
+ * look like the contact didn't exist, which was confusing — but it renders disabled with a
+ * reason ([EmergencyContactPickerScreen]) and can't be selected ([onUiAction]), since the server
+ * 400s circles/add for those identities (CannotGrantAutoConnectedMoreCircles).
  */
 class EmergencyContactPickerViewModel(
     private val contactService: ContactService,
@@ -60,7 +64,7 @@ class EmergencyContactPickerViewModel(
             ) { contacts, circleState, query ->
                 val members = circleState.membersOf(EMERGENCY_LOCATION_CIRCLE_ID)
                 contacts
-                    .filter { it.connection?.status == ConnectionStatus.Connected && it.connection?.vetted == true }
+                    .filter { it.connection?.status == ConnectionStatus.Connected }
                     .filterNot { members.contains(it.odinId.domainName.lowercase()) }
                     .filterAndGroup(query)
             }.collect { groups ->
@@ -72,9 +76,11 @@ class EmergencyContactPickerViewModel(
     fun onUiAction(action: EmergencyContactPickerUiAction) {
         when (action) {
             is EmergencyContactPickerUiAction.ContactClicked -> {
-                val selected = uiState.value.selectedContacts.toMutableList()
-                if (!selected.remove(action.contact)) selected.add(action.contact)
-                _uiState.update { it.copy(selectedContacts = selected.toPersistentList()) }
+                if (action.contact.connection?.vetted == true) {
+                    val selected = uiState.value.selectedContacts.toMutableList()
+                    if (!selected.remove(action.contact)) selected.add(action.contact)
+                    _uiState.update { it.copy(selectedContacts = selected.toPersistentList()) }
+                }
             }
 
             EmergencyContactPickerUiAction.AddClicked -> addSelected()
@@ -98,6 +104,8 @@ class EmergencyContactPickerViewModel(
                     try {
                         connectionService.addToCircle(circleId, contact.odinId)
                         added++
+                    } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+                        throw e
                     } catch (e: ClientException) {
                         if (e.errorCode == OdinClientErrorCode.IdentityAlreadyMemberOfCircle) {
                             alreadyMember++

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
@@ -335,11 +335,10 @@ fun LocationDashboardContent(
         // "Who you can locate" (contacts carrying our iCanLocate flag) and "Who can
         // locate you" (members of our emergency-location-access circle) sit as
         // subsections under one grouping header. The "+" (add emergency contacts)
-        // lives on the group header since it applies to this pairing as a whole.
-        DashboardSection(
-            title = stringResource(MR.string.location_emergency_contacts_section),
-            onManage = onManageEmergencyAccess,
-        ) {
+        // lives on the "Who can locate you" subsection specifically — that's the
+        // list it actually adds to — rather than the shared group header, which
+        // sat too far above it to read as belonging to that list (#1096).
+        DashboardSection(title = stringResource(MR.string.location_emergency_contacts_section)) {
             SubsectionLabel(text = stringResource(MR.string.location_locatable_section))
             Card(modifier = Modifier.fillMaxWidth()) {
                 PeopleListBody(
@@ -362,7 +361,10 @@ fun LocationDashboardContent(
                 )
             }
 
-            SubsectionLabel(text = stringResource(MR.string.location_emergency_access_section))
+            SubsectionLabel(
+                text = stringResource(MR.string.location_emergency_access_section),
+                onManage = onManageEmergencyAccess,
+            )
             Card(modifier = Modifier.fillMaxWidth()) {
                 var confirmRemove by remember { mutableStateOf<ContactUiModel?>(null) }
                 val pendingIds = remember(uiState.whoCanLocateMePending) {
@@ -370,7 +372,11 @@ fun LocationDashboardContent(
                 }
                 PeopleListBody(
                     loaded = uiState.whoCanLocateMeLoaded,
-                    members = uiState.whoCanLocateMe + uiState.whoCanLocateMePending,
+                    // distinctBy is a final guard, not the fix — LocationViewModel already keeps
+                    // these two lists mutually exclusive; this just makes the render site immune
+                    // to any future regression of that invariant (#1096).
+                    members = (uiState.whoCanLocateMe + uiState.whoCanLocateMePending)
+                        .distinctBy { it.odinId },
                     emptyText = stringResource(MR.string.location_emergency_access_none),
                     onExpandedChange = onWhoCanLocateMeExpandedChange,
                     rowTrailing = { member ->
@@ -520,16 +526,35 @@ private fun DashboardSection(
  * A lightweight subsection heading rendered inside a [DashboardSection]'s body — used to
  * label the two "who can locate" halves under the shared "Emergency contacts" header
  * without giving each the full titleMedium/divider weight of a top-level section. Mirrors
- * the "Sharing with" / "Sharing with you" labels in the live-sharing section.
+ * the "Sharing with" / "Sharing with you" labels in the live-sharing section. An optional
+ * [onManage] renders the same compact "+" affordance [DashboardSection] uses, for a subsection
+ * whose add action belongs next to its own heading rather than the group header above it.
  */
 @Composable
-private fun SubsectionLabel(text: String) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.titleSmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(top = 8.dp).semantics { heading() },
-    )
+private fun SubsectionLabel(text: String, onManage: (() -> Unit)? = null) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f).semantics { heading() },
+        )
+        if (onManage != null) {
+            Icon(
+                imageVector = Icons.Default.Add,
+                contentDescription = stringResource(MR.string.location_emergency_access_manage),
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier
+                    .clip(CircleShape)
+                    .clickable(onClick = onManage)
+                    .padding(4.dp)
+                    .size(22.dp),
+            )
+        }
+    }
 }
 
 /**

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
@@ -97,6 +97,10 @@ import id.homebase.resources.location_emergency_access_more
 import id.homebase.resources.location_emergency_access_none
 import id.homebase.resources.location_emergency_access_section
 import id.homebase.resources.location_emergency_contacts_section
+import id.homebase.resources.location_emergency_remove_cd
+import id.homebase.resources.location_emergency_remove_confirm_body
+import id.homebase.resources.location_emergency_remove_confirm_title
+import id.homebase.resources.location_emergency_status_pending
 import id.homebase.resources.location_locatable_broken_cd
 import id.homebase.resources.location_locatable_none
 import id.homebase.resources.location_locatable_section
@@ -106,6 +110,7 @@ import id.homebase.resources.location_locate_age_hours
 import id.homebase.resources.location_locate_no_data
 import id.homebase.resources.location_status_pending
 import id.homebase.resources.location_status_points_today
+import id.homebase.resources.remove
 import id.homebase.resources.stop_sharing
 import kotlin.time.Clock
 import kotlin.time.Instant
@@ -131,6 +136,8 @@ fun LocationDashboardContent(
     onManageEmergencyAccess: () -> Unit,
     onLocatableExpandedChange: (Boolean) -> Unit,
     onLocateContact: (ContactUiModel) -> Unit,
+    onWhoCanLocateMeExpandedChange: (Boolean) -> Unit,
+    onRemoveEmergencyContact: (ContactUiModel) -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -357,11 +364,45 @@ fun LocationDashboardContent(
 
             SubsectionLabel(text = stringResource(MR.string.location_emergency_access_section))
             Card(modifier = Modifier.fillMaxWidth()) {
+                var confirmRemove by remember { mutableStateOf<ContactUiModel?>(null) }
+                val pendingIds = remember(uiState.whoCanLocateMePending) {
+                    uiState.whoCanLocateMePending.map { it.odinId }.toSet()
+                }
                 PeopleListBody(
                     loaded = uiState.whoCanLocateMeLoaded,
-                    members = uiState.whoCanLocateMe,
+                    members = uiState.whoCanLocateMe + uiState.whoCanLocateMePending,
                     emptyText = stringResource(MR.string.location_emergency_access_none),
+                    onExpandedChange = onWhoCanLocateMeExpandedChange,
+                    rowTrailing = { member ->
+                        EmergencyContactTrailing(
+                            name = member.name,
+                            pending = pendingIds.contains(member.odinId),
+                            onRemoveClick = { confirmRemove = member },
+                        )
+                    },
                 )
+                confirmRemove?.let { contact ->
+                    AlertDialog(
+                        onDismissRequest = { confirmRemove = null },
+                        title = { Text(stringResource(MR.string.location_emergency_remove_confirm_title)) },
+                        text = {
+                            Text(
+                                stringResource(MR.string.location_emergency_remove_confirm_body, contact.name)
+                            )
+                        },
+                        confirmButton = {
+                            TextButton(onClick = {
+                                confirmRemove = null
+                                onRemoveEmergencyContact(contact)
+                            }) { Text(stringResource(MR.string.remove)) }
+                        },
+                        dismissButton = {
+                            TextButton(onClick = { confirmRemove = null }) {
+                                Text(stringResource(MR.string.cancel))
+                            }
+                        },
+                    )
+                }
             }
         }
 
@@ -802,6 +843,32 @@ private fun LocateStatusTrailing(status: LocateVerifyStatus?) {
                             else MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
+        }
+    }
+}
+
+/**
+ * Trailing content for a "who can locate me" row: an optional "Pending" label (a sealed circle
+ * deposit that hasn't converted into a real grant yet — live-read on section expand, see
+ * [LocationUiState.whoCanLocateMePending]) plus a remove button (works for both a real grant
+ * and a still-pending one; revoke drops either).
+ */
+@Composable
+private fun EmergencyContactTrailing(name: String, pending: Boolean, onRemoveClick: () -> Unit) {
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        if (pending) {
+            Text(
+                text = stringResource(MR.string.location_emergency_status_pending),
+                style = MaterialTheme.typography.labelMedium,
+                color = HomebaseTheme.extendedColors.warning,
+            )
+        }
+        IconButton(onClick = onRemoveClick) {
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = stringResource(MR.string.location_emergency_remove_cd, name),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationDashboardContent.kt
@@ -383,6 +383,7 @@ fun LocationDashboardContent(
                         EmergencyContactTrailing(
                             name = member.name,
                             pending = pendingIds.contains(member.odinId),
+                            removing = uiState.removingEmergencyContacts.contains(member.odinId.domainName),
                             onRemoveClick = { confirmRemove = member },
                         )
                     },
@@ -879,21 +880,33 @@ private fun LocateStatusTrailing(status: LocateVerifyStatus?) {
  * and a still-pending one; revoke drops either).
  */
 @Composable
-private fun EmergencyContactTrailing(name: String, pending: Boolean, onRemoveClick: () -> Unit) {
+private fun EmergencyContactTrailing(
+    name: String,
+    pending: Boolean,
+    removing: Boolean,
+    onRemoveClick: () -> Unit,
+) {
     Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-        if (pending) {
+        if (pending && !removing) {
             Text(
                 text = stringResource(MR.string.location_emergency_status_pending),
                 style = MaterialTheme.typography.labelMedium,
                 color = HomebaseTheme.extendedColors.warning,
             )
         }
-        IconButton(onClick = onRemoveClick) {
-            Icon(
-                imageVector = Icons.Default.Close,
-                contentDescription = stringResource(MR.string.location_emergency_remove_cd, name),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        if (removing) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(24.dp).padding(4.dp),
+                strokeWidth = 2.dp,
             )
+        } else {
+            IconButton(onClick = onRemoveClick) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = stringResource(MR.string.location_emergency_remove_cd, name),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationScreen.kt
@@ -34,7 +34,6 @@ import id.homebase.resources.location_consent_decline
 import id.homebase.resources.location_consent_text
 import id.homebase.resources.location_consent_title
 import id.homebase.api.client.location.LocationPreviewProvider
-import id.homebase.core.util.getUriHandler
 import id.homebase.resources.location_dashboard_title
 import id.homebase.resources.location_history_title
 import id.homebase.resources.location_menu_dashboard
@@ -54,6 +53,7 @@ fun LocationScreen(
     onNavigateToHistory: () -> Unit,
     onNavigateToFindDevice: (Uuid?) -> Unit,
     onNavigateToLiveMap: () -> Unit,
+    onNavigateToEmergencyContactAdd: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -188,7 +188,6 @@ fun LocationScreen(
     )
     val showDashboard = dashboardOverride ?: defaultsToDashboard
     val previewProvider = koinInject<LocationPreviewProvider>()
-    val uriHandler = getUriHandler()
 
     var menuOpen by remember { mutableStateOf(false) }
 
@@ -262,11 +261,15 @@ fun LocationScreen(
                 onStopSharingWithEveryone = { execute(LocationUiAction.StopSharingWithEveryone) },
                 onOpenDevice = { onNavigateToFindDevice(it) },
                 onOpenSetup = { dashboardOverride = false },
-                onManageEmergencyAccess = {
-                    uiState.emergencyManageUrl?.let { uriHandler.openUrl(it) }
-                },
+                onManageEmergencyAccess = onNavigateToEmergencyContactAdd,
                 onLocatableExpandedChange = { execute(LocationUiAction.SetLocatableExpanded(it)) },
                 onLocateContact = { pendingLocate = it },
+                onWhoCanLocateMeExpandedChange = {
+                    execute(LocationUiAction.SetWhoCanLocateMeExpanded(it))
+                },
+                onRemoveEmergencyContact = {
+                    execute(LocationUiAction.RemoveEmergencyContact(it.odinId.domainName))
+                },
             )
         } else {
             LocationContent(

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
@@ -42,6 +42,15 @@ data class LocationUiState(
     val whoCanLocateMe: List<ContactUiModel> = emptyList(),
     /** False until circle membership has loaded at least once (drives the loading spinner). */
     val whoCanLocateMeLoaded: Boolean = false,
+    /**
+     * Contacts whose emergency-circle grant is still a sealed deposit rather than a real
+     * [whoCanLocateMe] entry — live-read via a per-contact `/connections/status` fan-out
+     * triggered on section expand (there is no bulk "list pending" endpoint), never cached
+     * across app restarts. Empty until the section has been expanded at least once.
+     */
+    val whoCanLocateMePending: List<ContactUiModel> = emptyList(),
+    /** True while the expand-triggered pending-status fan-out is in flight. */
+    val whoCanLocateMePendingChecking: Boolean = false,
     /** Contacts we can locate (the `iCanLocate` app-data flag) — the "who you can locate" list. */
     val whoICanLocate: List<ContactUiModel> = emptyList(),
     /** False until the locatable-contacts list has loaded at least once (drives the spinner). */
@@ -49,9 +58,6 @@ data class LocationUiState(
     /** Per-entry temporal-verify status for the "who I can locate" list, keyed by odinId.domainName.
      *  Absent key = not yet requested (renders nothing until the section is expanded). */
     val whoICanLocateStatus: Map<String, LocateVerifyStatus> = emptyMap(),
-    /** Owner-console deep link to manage the Emergency Location Access circle (the actual location
-     *  drive grant); null until the identity is known. */
-    val emergencyManageUrl: String? = null,
     val mapProvider: LocationMapProvider = LocationMapProvider.DEFAULT,
     /** Show the "Live location sharing" dashboard section: I'm sharing, or a recent inbound point exists. */
     val liveSharingVisible: Boolean = false,
@@ -203,6 +209,14 @@ sealed interface LocationUiAction {
      *  link-freshness verify loop (immediate first pass, then every [LOCATE_VERIFY_TTL_MS]);
      *  collapsed cancels it. */
     data class SetLocatableExpanded(val expanded: Boolean) : LocationUiAction
+
+    /** "Who can locate me" section expanded/collapsed. Expanded triggers a one-shot live
+     *  pending-status fan-out (see [LocationUiState.whoCanLocateMePending]). */
+    data class SetWhoCanLocateMeExpanded(val expanded: Boolean) : LocationUiAction
+
+    /** Revoke an emergency-circle grant (real or still-pending) for [odinId]. */
+    data class RemoveEmergencyContact(val odinId: String) : LocationUiAction
+
     data object RequestWhileInUseClicked : LocationUiAction
     data object RequestAlwaysClicked : LocationUiAction
     data object OpenSystemSettingsClicked : LocationUiAction
@@ -227,4 +241,7 @@ sealed interface LocationUiEvent {
 
     /** Emergency retrieval failed (the request notice was still sent) — snackbar. */
     data object LocateFetchFailed : LocationUiEvent
+
+    /** An add/remove call against the emergency-location circle failed — snackbar. */
+    data object EmergencyContactActionFailed : LocationUiEvent
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationUiState.kt
@@ -51,6 +51,9 @@ data class LocationUiState(
     val whoCanLocateMePending: List<ContactUiModel> = emptyList(),
     /** True while the expand-triggered pending-status fan-out is in flight. */
     val whoCanLocateMePendingChecking: Boolean = false,
+    /** odinId domains currently being removed from the emergency circle — drives a per-row
+     *  spinner in place of the remove "X" so a tap has visible feedback while in flight. */
+    val removingEmergencyContacts: Set<String> = emptySet(),
     /** Contacts we can locate (the `iCanLocate` app-data flag) — the "who you can locate" list. */
     val whoICanLocate: List<ContactUiModel> = emptyList(),
     /** False until the locatable-contacts list has loaded at least once (drives the spinner). */

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
@@ -604,6 +604,8 @@ class LocationViewModel(
                             .filterNot { contact -> contact.odinId.domainName == odinId },
                     )
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Logger.w(e, TAG) { "removeFromCircle failed for $odinId" }
                 _events.tryEmit(LocationUiEvent.EmergencyContactActionFailed)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
@@ -2,7 +2,9 @@ package id.homebase.core.ui.screens.location
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
 import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.connections.ConnectionStatus
 import id.homebase.api.client.peer.temporal.TemporalDriveReadProvider
 import id.homebase.api.common.OdinId
 import id.homebase.api.client.contacts.ContactRepository
@@ -31,6 +33,8 @@ import id.homebase.chat.services.livelocation.LiveLocationReceiveStore
 import id.homebase.core.util.initials
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -51,6 +55,9 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.time.Clock
+import kotlin.uuid.Uuid
+
+private const val TAG = "LocationViewModel"
 
 class LocationViewModel(
     private val locationPreferences: LocationPreferences,
@@ -474,6 +481,11 @@ class LocationViewModel(
 
             is LocationUiAction.SetLocatableExpanded -> setLocatableExpanded(action.expanded)
 
+            is LocationUiAction.SetWhoCanLocateMeExpanded ->
+                if (action.expanded) checkWhoCanLocateMePending()
+
+            is LocationUiAction.RemoveEmergencyContact -> removeEmergencyContact(action.odinId)
+
             is LocationUiAction.ConfirmEmergencyLocate -> confirmEmergencyLocate(action)
 
             // Permission requests are dispatched at the screen level (the
@@ -516,6 +528,81 @@ class LocationViewModel(
                 }
             } finally {
                 _uiState.update { it.copy(locateSubmitInFlight = false) }
+            }
+        }
+    }
+
+    private var whoCanLocateMePendingJob: Job? = null
+
+    /**
+     * One-shot, expand-triggered live read (never a periodic loop — a sealed deposit doesn't
+     * change moment to moment, and a conversion to real membership already flips whoCanLocateMe
+     * via ConnectionService's normal refresh). There is no bulk "list pending members of a
+     * circle" endpoint, so this is the only way to learn who's still pending: fan out a real
+     * `/connections/status` read across current connections (excluding already-real members)
+     * and keep only those with our circle in their `accessGrant.pendingCircleIds`. Nothing here
+     * is remembered locally — a re-expand re-derives the answer from the server every time.
+     */
+    private fun checkWhoCanLocateMePending() {
+        if (whoCanLocateMePendingJob?.isActive == true) return
+        whoCanLocateMePendingJob = viewModelScope.launch {
+            _uiState.update { it.copy(whoCanLocateMePendingChecking = true) }
+            try {
+                val self = runCatching { credentialsManager.getActiveDomain() }
+                    .getOrNull()?.domainName?.lowercase()
+                val realMembers = connectionService.circles.value.membersOf(EMERGENCY_LOCATION_CIRCLE_ID)
+                val circleId = Uuid.parseHex(EMERGENCY_LOCATION_CIRCLE_ID)
+                val candidates = connectionService.connections.value.map.values
+                    .filter { it.status == ConnectionStatus.Connected }
+                    .map { it.odinId }
+                    .filterNot { it.domainName.lowercase() == self }
+                    .filterNot { realMembers.contains(it.domainName.lowercase()) }
+
+                val pending = coroutineScope {
+                    candidates
+                        .map { odinId ->
+                            async {
+                                val status = runCatching { connectionService.getConnectionStatus(odinId) }
+                                    .getOrNull()
+                                odinId.takeIf { status?.accessGrant?.pendingCircleIds?.contains(circleId) == true }
+                            }
+                        }
+                        .awaitAll()
+                        .filterNotNull()
+                }
+
+                _uiState.update {
+                    it.copy(
+                        whoCanLocateMePending = pending
+                            .map { odinId -> contactService.resolveByOdinId(odinId) }
+                            .sortedBy { contact -> contact.name.lowercase() },
+                        whoCanLocateMePendingChecking = false,
+                    )
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Logger.w(e, TAG) { "checkWhoCanLocateMePending failed" }
+                _uiState.update { it.copy(whoCanLocateMePendingChecking = false) }
+            }
+        }
+    }
+
+    /** Revoke [odinId]'s emergency-circle grant, real or still-pending — one API call covers
+     *  both (revoke also silently drops a still-sealed deposit). */
+    private fun removeEmergencyContact(odinId: String) {
+        viewModelScope.launch {
+            try {
+                connectionService.removeFromCircle(Uuid.parseHex(EMERGENCY_LOCATION_CIRCLE_ID), OdinId(odinId))
+                _uiState.update {
+                    it.copy(
+                        whoCanLocateMePending = it.whoCanLocateMePending
+                            .filterNot { contact -> contact.odinId.domainName == odinId },
+                    )
+                }
+            } catch (e: Exception) {
+                Logger.w(e, TAG) { "removeFromCircle failed for $odinId" }
+                _events.tryEmit(LocationUiEvent.EmergencyContactActionFailed)
             }
         }
     }
@@ -593,18 +680,10 @@ class LocationViewModel(
             val devices = runCatching { deviceDirectory.loadDevices() }
                 .getOrDefault(emptyList())
 
-            // The "who can locate you" list itself comes from the emergency-contact flag (collected
-            // reactively in init). Here we only resolve the owner-console deep link for managing the
-            // Emergency Location Access circle (the actual location-drive grant).
-            val domain = runCatching { credentialsManager.getActiveCredentials()?.domain?.domainName }
-                .getOrNull()
-            val manageUrl = domain?.let { "https://$it/owner/circles/$EMERGENCY_LOCATION_CIRCLE_ID" }
-
             _uiState.update {
                 it.copy(
                     todayTraces = traces,
                     devices = devices,
-                    emergencyManageUrl = manageUrl,
                 )
             }
         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.auth.CredentialsManager
-import id.homebase.api.client.connections.ConnectionStatus
 import id.homebase.api.client.peer.temporal.TemporalDriveReadProvider
 import id.homebase.api.common.OdinId
 import id.homebase.api.client.contacts.ContactRepository
@@ -33,8 +32,6 @@ import id.homebase.chat.services.livelocation.LiveLocationReceiveStore
 import id.homebase.core.util.initials
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -132,10 +129,21 @@ class LocationViewModel(
                     .asSequence()
                     .filterNot { it == self }
                     .map { contactService.resolveByOdinId(OdinId(it)) }
+                    .distinctBy { it.odinId }
                     .sortedBy { it.name.lowercase() }
                     .toList()
                 _uiState.update {
-                    it.copy(whoCanLocateMe = members, whoCanLocateMeLoaded = circleState.isLoaded)
+                    it.copy(
+                        whoCanLocateMe = members,
+                        whoCanLocateMeLoaded = circleState.isLoaded,
+                        // Drop anyone who just converted from pending to real — closes the
+                        // window where a stale pending snapshot and a freshly-updated real
+                        // membership list briefly disagree and render the same person twice
+                        // (#1096). checkWhoCanLocateMePending re-derives the full pending set
+                        // on its own cadence; this only prevents the transient overlap.
+                        whoCanLocateMePending = it.whoCanLocateMePending
+                            .filterNot { pending -> members.any { m -> m.odinId == pending.odinId } },
+                    )
                 }
             }
         }
@@ -150,6 +158,7 @@ class LocationViewModel(
                 .map { list ->
                     list.mapNotNull { it.toContactUiModel() }
                         .filterNot { it.odinId.domainName.lowercase() == self }
+                        .distinctBy { it.odinId }
                         .sortedBy { it.name.lowercase() }
                 }
                 .collect { members ->
@@ -535,13 +544,17 @@ class LocationViewModel(
     private var whoCanLocateMePendingJob: Job? = null
 
     /**
-     * One-shot, expand-triggered live read (never a periodic loop — a sealed deposit doesn't
-     * change moment to moment, and a conversion to real membership already flips whoCanLocateMe
-     * via ConnectionService's normal refresh). There is no bulk "list pending members of a
-     * circle" endpoint, so this is the only way to learn who's still pending: fan out a real
-     * `/connections/status` read across current connections (excluding already-real members)
-     * and keep only those with our circle in their `accessGrant.pendingCircleIds`. Nothing here
-     * is remembered locally — a re-expand re-derives the answer from the server every time.
+     * Live read, never a periodic loop (a sealed deposit doesn't change moment to moment, and a
+     * conversion to real membership already flips whoCanLocateMe via ConnectionService's normal
+     * refresh). Runs on every [refresh] (screen entry/resume) rather than only on section-expand
+     * — a contact just added from the picker lands as a pending deposit far more often than not,
+     * and gating this behind manual expand left it invisible until the user thought to tap the
+     * section, which reads as "the add silently failed" (#1096). The explicit
+     * [LocationUiAction.SetWhoCanLocateMeExpanded] trigger stays too, so opening the section
+     * mid-session (no intervening resume) still gets a fresh read. Delegates the actual fan-out
+     * to [ConnectionService.findPendingMembers] — circle-agnostic, shared with the Contact
+     * Book's generic circle-management screen — and applies the one Location-specific rule: you
+     * are never your own emergency contact.
      */
     private fun checkWhoCanLocateMePending() {
         if (whoCanLocateMePendingJob?.isActive == true) return
@@ -550,31 +563,20 @@ class LocationViewModel(
             try {
                 val self = runCatching { credentialsManager.getActiveDomain() }
                     .getOrNull()?.domainName?.lowercase()
-                val realMembers = connectionService.circles.value.membersOf(EMERGENCY_LOCATION_CIRCLE_ID)
                 val circleId = Uuid.parseHex(EMERGENCY_LOCATION_CIRCLE_ID)
-                val candidates = connectionService.connections.value.map.values
-                    .filter { it.status == ConnectionStatus.Connected }
-                    .map { it.odinId }
+                val pending = connectionService.findPendingMembers(circleId)
                     .filterNot { it.domainName.lowercase() == self }
-                    .filterNot { realMembers.contains(it.domainName.lowercase()) }
-
-                val pending = coroutineScope {
-                    candidates
-                        .map { odinId ->
-                            async {
-                                val status = runCatching { connectionService.getConnectionStatus(odinId) }
-                                    .getOrNull()
-                                odinId.takeIf { status?.accessGrant?.pendingCircleIds?.contains(circleId) == true }
-                            }
-                        }
-                        .awaitAll()
-                        .filterNotNull()
-                }
 
                 _uiState.update {
                     it.copy(
+                        // Exclude against the CURRENT whoCanLocateMe, not the snapshot findPendingMembers
+                        // started from — someone can convert from pending to real while this fan-out is
+                        // still in flight, and rendering both lists un-deduped briefly shows them twice
+                        // (#1096).
                         whoCanLocateMePending = pending
+                            .distinct()
                             .map { odinId -> contactService.resolveByOdinId(odinId) }
+                            .filterNot { contact -> it.whoCanLocateMe.any { m -> m.odinId == contact.odinId } }
                             .sortedBy { contact -> contact.name.lowercase() },
                         whoCanLocateMePendingChecking = false,
                     )
@@ -668,6 +670,11 @@ class LocationViewModel(
             refreshCounts()
         }
         loadDashboard()
+        // Re-derive "who can locate me" pending status on every resume (not just on manual
+        // section-expand) — otherwise returning here right after adding someone shows nothing
+        // for them until the section happens to be expanded, which reads as "the add failed"
+        // (#1096: a real add landed as a pending deposit and stayed invisible until expand).
+        checkWhoCanLocateMePending()
     }
 
     /** Dashboard data: today's traces (map preview), the device list, and the

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationViewModel.kt
@@ -593,6 +593,8 @@ class LocationViewModel(
     /** Revoke [odinId]'s emergency-circle grant, real or still-pending — one API call covers
      *  both (revoke also silently drops a still-sealed deposit). */
     private fun removeEmergencyContact(odinId: String) {
+        if (odinId in _uiState.value.removingEmergencyContacts) return
+        _uiState.update { it.copy(removingEmergencyContacts = it.removingEmergencyContacts + odinId) }
         viewModelScope.launch {
             try {
                 connectionService.removeFromCircle(Uuid.parseHex(EMERGENCY_LOCATION_CIRCLE_ID), OdinId(odinId))
@@ -605,6 +607,8 @@ class LocationViewModel(
             } catch (e: Exception) {
                 Logger.w(e, TAG) { "removeFromCircle failed for $odinId" }
                 _events.tryEmit(LocationUiEvent.EmergencyContactActionFailed)
+            } finally {
+                _uiState.update { it.copy(removingEmergencyContacts = it.removingEmergencyContacts - odinId) }
             }
         }
     }


### PR DESCRIPTION
## Summary

**Connections API layer** (`homebase-api`)
- Fixes the circle-membership client to actually match server behavior: adds the missing `pendingCircleIds` field, fixes a live deserialize failure on `RedactedCircleGrant`/`RedactedAppCircleGrant.circleId` (server's `GuidId` is no-hyphen N-format; the standard `Uuid` parser threw on it), captures the 403 body's `title` instead of discarding it, and renames `ConnectionStatus.Pending` → `None` to match its `"none"` wire value.
- Adds `OdinClientErrorCode.CannotSourceDriveStorageKeyForGrant` (4173) — the server can now tell a circle-add 403 apart from an opaque one (missing permission, contact not connected). Both add-to-circle flows classify failures via a shared `CircleAddFailureReason` and show a specific, actionable message for 4173 instead of a generic one for every 403.

**Emergency contacts** (Location dashboard)
- Replaces "Add emergency contacts" — previously an owner-console URL opened in the browser — with an in-app multi-select contact picker, plus a remove action (with a per-row spinner while in flight) on each "who can locate me" row.
- The "+" now sits next to the "Who can locate you" subsection it actually acts on, instead of the shared "Emergency contacts" header above it.

**Generic circle membership** (Contact Book)
- Any circle in the Circles tab gets the same add/remove flow, built on a new `ConnectionService.findPendingMembers(circleId)` — shared, circle-agnostic live fan-out (no bulk "list pending" endpoint exists). System-managed circles (Confirmed/Auto-connected) stay read-only since their membership comes from the vetting flow, not manual curation.
- Contact detail now shows every circle the contact belongs to, real or pending (previously real-only, as plain name chips with no id/status/drives to act on). A new `ConnectionService.findPendingCircles(odinId)` — the inverse of `findPendingMembers`, one identity many circles — backs this with a single status read instead of a fan-out. Tapping a chip opens a dialog: circle name, this contact's status, the rest of the roster, and the drives the circle grants access to (resolved from the already-loaded circle definition; friendly names for this app's own known drives, generic fallback otherwise).
- `CircleMembersSheet` is now shared across both entry points (Circles tab: manageable; contact detail: view-only) via a generalized callback surface instead of a `ContactBookUiAction`-typed one.

**Correctness fixes found via live testing against a real server**
- `findPendingMembers`/`findPendingCircles` could race `ConnectionService`'s async post-launch hydrate+refresh on a cold start, silently reporting "nobody pending" with no error to explain why — now bounded-wait for `connections`/`circles` to load first.
- Pending checks only ran on manual section-expand, so a contact just added looked like the add had failed until the user found a non-obvious expand affordance — now also runs on every relevant screen resume.
- Real-member (reactive) and pending-member (one-shot snapshot) lists could transiently disagree when a grant converted mid-check, rendering the same person twice — deduped at every layer.
- `ContactBookViewModel`'s circle sheet and Circles tab were one-shot snapshots disconnected from `ConnectionService`'s live data — an add from a different ViewModel instance never reached them, so they sat stale until closed and reopened. Both now derive reactively from `ConnectionService.circles`, plus a resume-triggered re-check for the specific case (a pending-only change) where `StateFlow` conflates the update and never re-emits at all.
- A failed add showed a bare "Failed: 1" with no explanation and silently cleared the whole selection, indistinguishable from nothing happening. Now shows the actual reason per contact and keeps failed entries selected for a retry.

## Test plan
- [x] `:homebase-api:compileKotlinJvm` / `:homebase-api:compileAndroidMain`
- [x] `:homebase-chat:compileKotlinJvm` / `:homebase-chat:compileAndroidMain`
- [x] `:homebase-core:compileKotlinJvm` / `:homebase-core:compileAndroidMain`
- [x] `homebase-api:jvmTest`, `homebase-chat:jvmTest`, `homebase-core:jvmTest`
- [x] `homebase-common:jvmTest --tests "*ArchitectureTest*"` (Konsist hardcoded-string check)
- [ ] Manual: add/remove an emergency contact and a generic circle member on-device; confirm Pending badges show/clear without reopening; confirm the contact-detail circle dialog and drives list render correctly; confirm a 4173 circle-add shows the drive-access-denied message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
