### PR TITLE
fix(ios): stop a blank shared text from shadowing the link (#1097)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -39,6 +39,7 @@ import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.core.emoji.EmojiNormalization.distinctByEmoji
 import id.homebase.core.settings.UserPreferences
 import id.homebase.core.share.ShareContentProcessor
+import id.homebase.core.share.resolveMessageBody
 import id.homebase.core.util.ScrollPosition
 import id.homebase.core.util.resolveContentType
 import id.homebase.core.widget.ReactionDisplayItem
@@ -921,11 +922,23 @@ internal class MessageActionsHandler(
         if (descriptor.targetConversationId != conversationId.toString()) return
 
         Logger.i(tag = "ConversationListViewModel") {
-            "Processing shared content: type=${descriptor.contentType}, files=${descriptor.fileNames.size}"
+            "Processing shared content: type=${descriptor.contentType}, files=${descriptor.fileNames.size}, " +
+                "textLen=${descriptor.text?.length}, hasUrl=${!descriptor.url.isNullOrBlank()}"
         }
 
         try {
-            val text = descriptor.text ?: descriptor.url ?: ""
+            val text = descriptor.resolveMessageBody()
+
+            // Never send an empty message: a share that resolves to nothing is a failed
+            // extraction, and silently sending a blank bubble loses the user's content
+            // without telling them (#1097).
+            if (descriptor.fileNames.isEmpty() && text.isBlank()) {
+                Logger.w(tag = "ConversationListViewModel") {
+                    "Shared content resolved to nothing (type=${descriptor.contentType}) — not sending"
+                }
+                sendEvent(ShowErrorMessage("Couldn't read the shared content — please try sharing again."))
+                return
+            }
 
             if (descriptor.fileNames.isEmpty()) {
                 // Text/URL only

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/share/SharedContentDescriptor.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/share/SharedContentDescriptor.kt
@@ -18,6 +18,29 @@ data class SharedContentDescriptor(
     val targetConversationId: String,
 )
 
+/**
+ * Body to send for a text/URL share — the iOS counterpart of Android's whole
+ * `EXTRA_TEXT`, which already carries caption and link together.
+ *
+ * Two ways a link gets lost if [text] and [url] are treated as either/or (#1097):
+ * a blank [text] shadows the [url] (iOS vends an empty `public.plain-text` next to
+ * the real link for some hosts, e.g. Google Maps) and sends an empty message; a
+ * non-blank [text] shadows it and sends the caption without the link. So blank is
+ * treated as absent, and a caption is carried *alongside* its link rather than
+ * instead of it — unless the caption already contains the link, which is the common
+ * case and must not be duplicated.
+ */
+fun SharedContentDescriptor.resolveMessageBody(): String {
+    val sharedText = text?.takeIf { it.isNotBlank() }
+    val sharedUrl = url?.takeIf { it.isNotBlank() }
+    return when {
+        sharedText == null -> sharedUrl.orEmpty()
+        sharedUrl == null -> sharedText
+        sharedText.contains(sharedUrl) -> sharedText
+        else -> "${sharedText.trimEnd()}\n$sharedUrl"
+    }
+}
+
 @Serializable
 enum class SharedContentType {
     TEXT,

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/share/SharedContentDescriptorTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/share/SharedContentDescriptorTest.kt
@@ -1,0 +1,66 @@
+package id.homebase.core.share
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SharedContentDescriptorTest {
+
+    private fun descriptor(text: String?, url: String?) = SharedContentDescriptor(
+        contentType = if (url != null) SharedContentType.URL else SharedContentType.TEXT,
+        text = text,
+        url = url,
+        targetConversationId = "c0ffee",
+    )
+
+    /**
+     * The #1097 regression: iOS vends an empty `public.plain-text` next to the real
+     * Google Maps link, so `text` is blank-but-not-null. A `text ?: url` fallback
+     * returns that blank and sends an empty message while the link sits unused.
+     */
+    @Test
+    fun blank_text_falls_through_to_url() {
+        val mapsLink = "https://maps.app.goo.gl/abc123"
+        assertEquals(mapsLink, descriptor(text = "", url = mapsLink).resolveMessageBody())
+        assertEquals(mapsLink, descriptor(text = "   ", url = mapsLink).resolveMessageBody())
+        assertEquals(mapsLink, descriptor(text = "\n", url = mapsLink).resolveMessageBody())
+    }
+
+    @Test
+    fun absent_text_falls_through_to_url() {
+        val link = "https://example.com"
+        assertEquals(link, descriptor(text = null, url = link).resolveMessageBody())
+    }
+
+    /**
+     * A caption must ride *with* its link, not replace it — Android sends the whole
+     * EXTRA_TEXT (caption + link), and dropping the link here is the same data loss
+     * as #1097 wearing a different hat.
+     */
+    @Test
+    fun caption_and_url_are_sent_together() {
+        assertEquals(
+            "Taj Mahal\nhttps://maps.app.goo.gl/abc123",
+            descriptor(text = "Taj Mahal", url = "https://maps.app.goo.gl/abc123").resolveMessageBody(),
+        )
+    }
+
+    /** The common case: the host puts the link in the text too. Don't send it twice. */
+    @Test
+    fun url_already_present_in_text_is_not_duplicated() {
+        val link = "https://maps.app.goo.gl/abc123"
+        assertEquals("Taj Mahal $link", descriptor(text = "Taj Mahal $link", url = link).resolveMessageBody())
+        assertEquals(link, descriptor(text = link, url = link).resolveMessageBody())
+    }
+
+    @Test
+    fun plain_text_share_is_unaffected() {
+        assertEquals("hello", descriptor(text = "hello", url = null).resolveMessageBody())
+    }
+
+    /** Nothing usable resolves to blank, which the caller turns into an error instead of a send. */
+    @Test
+    fun nothing_usable_resolves_blank() {
+        assertEquals("", descriptor(text = null, url = null).resolveMessageBody())
+        assertEquals("", descriptor(text = "  ", url = "  ").resolveMessageBody())
+    }
+}

--- a/iosApp/ShareExtension/SharedContentSaver.swift
+++ b/iosApp/ShareExtension/SharedContentSaver.swift
@@ -100,7 +100,10 @@ struct SharedContentSaver {
                 if provider.hasItemConformingToTypeIdentifier(UTType.plainText.identifier) {
                     group.enter()
                     provider.loadItem(forTypeIdentifier: UTType.plainText.identifier, options: nil) { item, _ in
-                        if let string = item as? String {
+                        // A blank vend must not overwrite a real `text`, nor stand in as one:
+                        // a blank-but-non-nil text shadows `url` on the Kotlin side and sends an
+                        // empty message. Mirrors the attributedContentText guard above (#1097).
+                        if let string = item as? String, !string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                             text = string
                         }
                         group.leave()


### PR DESCRIPTION
Fixes #1097 — sharing a Google Maps link into a chat sent an **empty message**.

## The issue's diagnosis was backwards

The issue named extraction as the "prime suspect" and explicitly ruled out the consumer:

> It **already** uses `url` when `text` is null. So **suspect #2 (consumer drops url) is refuted** — don't chase the common Kotlin send path.

That fallback only fires on **null**. Extraction works fine; the consumer is what loses the link.

## Evidence (iPhone 15, iOS 26.5, real Google Maps share)

| Evidence | Source | Conclusion |
|---|---|---|
| `Processing shared content: type=URL, files=0` | device `homebase.log` | Swift sets `URL` only in the `else if url != nil` branch → **link extracted fine** |
| `{"message":"","deliveryStatus":20,...}` | device `odin-2.db` | body actually sent was empty |

Both together force the conclusion: `descriptor.text` was non-null but **blank**, so

```kotlin
val text = descriptor.text ?: descriptor.url ?: ""   // "" is not null -> returns ""
```

returned `""` and shadowed a perfectly good url.

The blank originates from an asymmetry in the Swift: `attributedContentText` guards with `!attributedText.isEmpty`, but the `plainText` branch assigned `item as? String` **unguarded** — so the empty `public.plain-text` that Maps vends alongside the link became `""`.

**Confirmed by the fix itself:** post-fix the same share logs `textLen=null, hasUrl=true` where it was `""` before — the guard caught exactly that blank vend.

## Changes

- **`resolveMessageBody()`** (new, in `homebase-common`) — blank text is treated as absent, so it can't shadow the url. Also carries a caption *alongside* its link rather than instead of it, matching Android (which sends the whole `EXTRA_TEXT` = caption + link), and skips the join when the caption already contains the link so it isn't duplicated.
- **`SharedContentSaver.swift`** — don't record a blank text, killing the bad value at source.
- **Never send an empty message** — a share resolving to nothing now surfaces an error instead of silently sending a blank bubble (issue's fix #3).

## Tests

`SharedContentDescriptorTest` — 6 cases, verified **red** against the old `text ?: url` logic:

```
blank_text_falls_through_to_url  FAILED   <- old logic
nothing_usable_resolves_blank    FAILED   <- old logic
BUILD SUCCESSFUL                          <- with fix
```

`homebase-common:jvmTest` + `homebase-chat:jvmTest` green.

## Deliberately not done

- **The issue's fix #1 (rework extraction to try `NSURL`/`String`/`Data` coercions).** The evidence refutes it — extraction demonstrably works. Speculative churn in a hotfix.
- **The issue's regression-test plan #1 and #3.** Both are premised on the refuted hypothesis: #1 tests extraction (which works) and #3 tests `text=null` (which already worked). Neither ever goes red for this bug. The test here covers `text=""`, the real case.
- **Test #4 (never-send-empty handler test)** — legitimate, but needs `MessageActionsHandler`'s full dependency graph. Follow-up PR.

## Verification

Verified end-to-end on a physical iPhone 15 (iOS 26.5) with the real Google Maps app: link now arrives instead of a blank bubble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)