### PR TITLE
test(share): lock the never-send-empty guard policy (#1097)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -39,6 +39,7 @@ import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.core.emoji.EmojiNormalization.distinctByEmoji
 import id.homebase.core.settings.UserPreferences
 import id.homebase.core.share.ShareContentProcessor
+import id.homebase.core.share.resolveMessageBody
 import id.homebase.core.util.ScrollPosition
 import id.homebase.core.util.resolveContentType
 import id.homebase.core.widget.ReactionDisplayItem
@@ -921,11 +922,23 @@ internal class MessageActionsHandler(
         if (descriptor.targetConversationId != conversationId.toString()) return
 
         Logger.i(tag = "ConversationListViewModel") {
-            "Processing shared content: type=${descriptor.contentType}, files=${descriptor.fileNames.size}"
+            "Processing shared content: type=${descriptor.contentType}, files=${descriptor.fileNames.size}, " +
+                "textLen=${descriptor.text?.length}, hasUrl=${!descriptor.url.isNullOrBlank()}"
         }
 
         try {
-            val text = descriptor.text ?: descriptor.url ?: ""
+            val text = descriptor.resolveMessageBody()
+
+            // Never send an empty message: a share that resolves to nothing is a failed
+            // extraction, and silently sending a blank bubble loses the user's content
+            // without telling them (#1097).
+            if (descriptor.fileNames.isEmpty() && text.isBlank()) {
+                Logger.w(tag = "ConversationListViewModel") {
+                    "Shared content resolved to nothing (type=${descriptor.contentType}) — not sending"
+                }
+                sendEvent(ShowErrorMessage("Couldn't read the shared content — please try sharing again."))
+                return
+            }
 
             if (descriptor.fileNames.isEmpty()) {
                 // Text/URL only

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -39,6 +39,7 @@ import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.core.emoji.EmojiNormalization.distinctByEmoji
 import id.homebase.core.settings.UserPreferences
 import id.homebase.core.share.ShareContentProcessor
+import id.homebase.core.share.hasSendableContent
 import id.homebase.core.share.resolveMessageBody
 import id.homebase.core.util.ScrollPosition
 import id.homebase.core.util.resolveContentType
@@ -931,8 +932,9 @@ internal class MessageActionsHandler(
 
             // Never send an empty message: a share that resolves to nothing is a failed
             // extraction, and silently sending a blank bubble loses the user's content
-            // without telling them (#1097).
-            if (descriptor.fileNames.isEmpty() && text.isBlank()) {
+            // without telling them (#1097). Policy lives in hasSendableContent() so it
+            // is locked by SharedContentDescriptorTest rather than only by this branch.
+            if (!descriptor.hasSendableContent()) {
                 Logger.w(tag = "ConversationListViewModel") {
                     "Shared content resolved to nothing (type=${descriptor.contentType}) — not sending"
                 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/share/SharedContentDescriptor.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/share/SharedContentDescriptor.kt
@@ -41,6 +41,18 @@ fun SharedContentDescriptor.resolveMessageBody(): String {
     }
 }
 
+/**
+ * Whether this share carries anything worth sending.
+ *
+ * A share that resolves to nothing is a failed extraction, and sending it anyway
+ * produces a blank bubble — silent data loss, since the sender believes they shared
+ * something (#1097). The caller surfaces an error instead of sending.
+ *
+ * Files alone are sendable: an image share carries no body text by design.
+ */
+fun SharedContentDescriptor.hasSendableContent(): Boolean =
+    fileNames.isNotEmpty() || resolveMessageBody().isNotBlank()
+
 @Serializable
 enum class SharedContentType {
     TEXT,

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/share/SharedContentDescriptor.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/share/SharedContentDescriptor.kt
@@ -18,6 +18,29 @@ data class SharedContentDescriptor(
     val targetConversationId: String,
 )
 
+/**
+ * Body to send for a text/URL share — the iOS counterpart of Android's whole
+ * `EXTRA_TEXT`, which already carries caption and link together.
+ *
+ * Two ways a link gets lost if [text] and [url] are treated as either/or (#1097):
+ * a blank [text] shadows the [url] (iOS vends an empty `public.plain-text` next to
+ * the real link for some hosts, e.g. Google Maps) and sends an empty message; a
+ * non-blank [text] shadows it and sends the caption without the link. So blank is
+ * treated as absent, and a caption is carried *alongside* its link rather than
+ * instead of it — unless the caption already contains the link, which is the common
+ * case and must not be duplicated.
+ */
+fun SharedContentDescriptor.resolveMessageBody(): String {
+    val sharedText = text?.takeIf { it.isNotBlank() }
+    val sharedUrl = url?.takeIf { it.isNotBlank() }
+    return when {
+        sharedText == null -> sharedUrl.orEmpty()
+        sharedUrl == null -> sharedText
+        sharedText.contains(sharedUrl) -> sharedText
+        else -> "${sharedText.trimEnd()}\n$sharedUrl"
+    }
+}
+
 @Serializable
 enum class SharedContentType {
     TEXT,

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/share/SharedContentDescriptorTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/share/SharedContentDescriptorTest.kt
@@ -2,13 +2,21 @@ package id.homebase.core.share
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class SharedContentDescriptorTest {
 
-    private fun descriptor(text: String?, url: String?) = SharedContentDescriptor(
+    private fun descriptor(
+        text: String?,
+        url: String?,
+        fileNames: List<String> = emptyList(),
+    ) = SharedContentDescriptor(
         contentType = if (url != null) SharedContentType.URL else SharedContentType.TEXT,
         text = text,
         url = url,
+        fileNames = fileNames,
+        mimeTypes = fileNames.map { "image/jpeg" },
         targetConversationId = "c0ffee",
     )
 
@@ -62,5 +70,37 @@ class SharedContentDescriptorTest {
     fun nothing_usable_resolves_blank() {
         assertEquals("", descriptor(text = null, url = null).resolveMessageBody())
         assertEquals("", descriptor(text = "  ", url = "  ").resolveMessageBody())
+    }
+
+    // --- never-send-empty guard -------------------------------------------------
+    // The policy behind processPendingSharedContent's refusal branch. Sending a share
+    // that resolved to nothing produces a blank bubble, which is silent data loss: the
+    // sender believes they shared something. Refusing turns any future extraction miss
+    // into a visible failure instead.
+
+    /** The #1097 shape that reached users: nothing survived extraction. Must not send. */
+    @Test
+    fun share_with_nothing_usable_is_not_sendable() {
+        assertFalse(descriptor(text = null, url = null).hasSendableContent())
+        assertFalse(descriptor(text = "", url = null).hasSendableContent())
+        assertFalse(descriptor(text = "   ", url = "  ").hasSendableContent())
+    }
+
+    /** A blank text next to a real link is sendable — the link is the content (#1097). */
+    @Test
+    fun blank_text_with_a_url_is_still_sendable() {
+        assertTrue(descriptor(text = "", url = "https://maps.app.goo.gl/abc123").hasSendableContent())
+    }
+
+    /** Files carry no body text by design, so an image share must not be refused. */
+    @Test
+    fun file_only_share_is_sendable_without_any_text() {
+        assertTrue(descriptor(text = null, url = null, fileNames = listOf("share_1.jpg")).hasSendableContent())
+        assertTrue(descriptor(text = "  ", url = null, fileNames = listOf("share_1.jpg")).hasSendableContent())
+    }
+
+    @Test
+    fun ordinary_text_share_is_sendable() {
+        assertTrue(descriptor(text = "hello", url = null).hasSendableContent())
     }
 }

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/share/SharedContentDescriptorTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/share/SharedContentDescriptorTest.kt
@@ -1,0 +1,66 @@
+package id.homebase.core.share
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SharedContentDescriptorTest {
+
+    private fun descriptor(text: String?, url: String?) = SharedContentDescriptor(
+        contentType = if (url != null) SharedContentType.URL else SharedContentType.TEXT,
+        text = text,
+        url = url,
+        targetConversationId = "c0ffee",
+    )
+
+    /**
+     * The #1097 regression: iOS vends an empty `public.plain-text` next to the real
+     * Google Maps link, so `text` is blank-but-not-null. A `text ?: url` fallback
+     * returns that blank and sends an empty message while the link sits unused.
+     */
+    @Test
+    fun blank_text_falls_through_to_url() {
+        val mapsLink = "https://maps.app.goo.gl/abc123"
+        assertEquals(mapsLink, descriptor(text = "", url = mapsLink).resolveMessageBody())
+        assertEquals(mapsLink, descriptor(text = "   ", url = mapsLink).resolveMessageBody())
+        assertEquals(mapsLink, descriptor(text = "\n", url = mapsLink).resolveMessageBody())
+    }
+
+    @Test
+    fun absent_text_falls_through_to_url() {
+        val link = "https://example.com"
+        assertEquals(link, descriptor(text = null, url = link).resolveMessageBody())
+    }
+
+    /**
+     * A caption must ride *with* its link, not replace it — Android sends the whole
+     * EXTRA_TEXT (caption + link), and dropping the link here is the same data loss
+     * as #1097 wearing a different hat.
+     */
+    @Test
+    fun caption_and_url_are_sent_together() {
+        assertEquals(
+            "Taj Mahal\nhttps://maps.app.goo.gl/abc123",
+            descriptor(text = "Taj Mahal", url = "https://maps.app.goo.gl/abc123").resolveMessageBody(),
+        )
+    }
+
+    /** The common case: the host puts the link in the text too. Don't send it twice. */
+    @Test
+    fun url_already_present_in_text_is_not_duplicated() {
+        val link = "https://maps.app.goo.gl/abc123"
+        assertEquals("Taj Mahal $link", descriptor(text = "Taj Mahal $link", url = link).resolveMessageBody())
+        assertEquals(link, descriptor(text = link, url = link).resolveMessageBody())
+    }
+
+    @Test
+    fun plain_text_share_is_unaffected() {
+        assertEquals("hello", descriptor(text = "hello", url = null).resolveMessageBody())
+    }
+
+    /** Nothing usable resolves to blank, which the caller turns into an error instead of a send. */
+    @Test
+    fun nothing_usable_resolves_blank() {
+        assertEquals("", descriptor(text = null, url = null).resolveMessageBody())
+        assertEquals("", descriptor(text = "  ", url = "  ").resolveMessageBody())
+    }
+}

--- a/iosApp/ShareExtension/SharedContentSaver.swift
+++ b/iosApp/ShareExtension/SharedContentSaver.swift
@@ -100,7 +100,10 @@ struct SharedContentSaver {
                 if provider.hasItemConformingToTypeIdentifier(UTType.plainText.identifier) {
                     group.enter()
                     provider.loadItem(forTypeIdentifier: UTType.plainText.identifier, options: nil) { item, _ in
-                        if let string = item as? String {
+                        // A blank vend must not overwrite a real `text`, nor stand in as one:
+                        // a blank-but-non-nil text shadows `url` on the Kotlin side and sends an
+                        // empty message. Mirrors the attributedContentText guard above (#1097).
+                        if let string = item as? String, !string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                             text = string
                         }
                         group.leave()


### PR DESCRIPTION
Implements regression test **#4** from #1097's test plan ("never-send-empty guard test").

> ⚠️ **Stacked on #1098** — base branch is `fix-1097-ios-share-blank-text-shadows-url`, since the guard being tested lives there. Merge #1098 first; this will retarget to `main` automatically.

## Why not the test as literally specified

The plan asks to fake `ShareContentProcessor.readPendingContent()`, call `MessageActionsHandler.processPendingSharedContent`, and assert no message is sent.

That isn't cheap here. `MessageActionsHandler` takes **17 constructor params**, and its services are final Kotlin classes with no interfaces:

```
ChatMessageSenderService  -> class    (final, no interface)
ConversationService       -> class
ContactService            -> class
ChatMessageStream         -> class
...
```

So they can't be hand-faked, and **mockk isn't a project dependency** — `homebase-chat` test deps are just `kotlin("test")` + compose-ui-test. Getting there means adding a mocking framework and standing up a 17-param graph, to assert one boolean branch.

This repo already has a cheaper convention for exactly this shape — **extract the policy, lock the policy** — e.g. `ConversationListPendingTapResolutionTest`, which "locks down the resolution policy used by the VM's collector".

## What this does instead

The refusal branch now reads its decision from a pure `hasSendableContent()`:

```kotlin
fun SharedContentDescriptor.hasSendableContent(): Boolean =
    fileNames.isNotEmpty() || resolveMessageBody().isNotBlank()
```

```kotlin
if (!descriptor.hasSendableContent()) { /* error, don't send */ }
```

Same protection, no mocking, and the handler branch becomes too small to hide a bug in.

## Both mutations verified red

| Mutation | Test that caught it |
|---|---|
| `hasSendableContent() = true` (guard dropped) | `share_with_nothing_usable_is_not_sendable` **FAILED** |
| `hasSendableContent() = body.isNotBlank()` (forgets files) | `file_only_share_is_sendable_without_any_text` **FAILED** |

The second is the one worth having: dropping the `fileNames` term would refuse **every image share**, and nothing covered that before.

## Coverage added

- share with nothing usable → not sendable (the #1097 shape that reached users)
- blank text **+ real url** → still sendable (the link is the content)
- file-only share, no text → sendable (images carry no body by design)
- ordinary text share → sendable

`homebase-common:jvmTest` + `homebase-chat:jvmTest` green.

## Note on the rest of the plan

Plan items #1 and #3 are premised on the hypothesis the on-device evidence refuted (see #1098): #1 tests extraction, which demonstrably works, and #3 tests `text=null`, which never broke. Neither goes red for this bug. Not implemented — recommend correcting the plan rather than building `NSExtensionContext` mock infrastructure for a bug that isn't there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)