### PR TITLE
feat(api): add DriveQueryProvider.queryBatchCollection

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/QueryBatchCollectionRequest.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/QueryBatchCollectionRequest.kt
@@ -1,0 +1,29 @@
+package id.homebase.api.client.drives
+
+import id.homebase.api.client.drives.query.FileQueryParams
+import id.homebase.api.serialization.UuidSerializer
+import kotlinx.serialization.Serializable
+import kotlin.uuid.Uuid
+
+/**
+ * Request body for POST /drives/query-batch-collection — runs multiple named
+ * query-batch sections against one or more drives in a single round trip.
+ */
+@Serializable
+data class QueryBatchCollectionRequest(
+    val queries: List<CollectionQueryParamSection>
+)
+
+/**
+ * One named section of a [QueryBatchCollectionRequest]. `name` must be unique within
+ * the request (the server rejects duplicates with a 400) and is echoed back on the
+ * matching [QueryBatchResponse] so results can be correlated.
+ */
+@Serializable
+data class CollectionQueryParamSection(
+    val name: String,
+    @Serializable(with = UuidSerializer::class)
+    val driveId: Uuid,
+    val queryParams: FileQueryParams,
+    val resultOptionsRequest: QueryBatchResultOptionsRequest
+)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/QueryBatchCollectionResponse.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/QueryBatchCollectionResponse.kt
@@ -1,0 +1,14 @@
+package id.homebase.api.client.drives
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Response body for POST /drives/query-batch-collection. One [QueryBatchResponse] per
+ * requested section, matched back by [QueryBatchResponse.name]. A section whose drive
+ * didn't exist or wasn't readable comes back with `invalidDrive = true` and empty
+ * `searchResults` rather than failing the whole collection.
+ */
+@Serializable
+data class QueryBatchCollectionResponse(
+    val results: List<QueryBatchResponse>
+)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/query/DriveQueryProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/query/DriveQueryProvider.kt
@@ -4,6 +4,8 @@ import id.homebase.api.client.OdinApiProviderBase
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.common.OdinId
 import id.homebase.api.common.time.UnixTimeUtc
+import id.homebase.api.client.drives.QueryBatchCollectionRequest
+import id.homebase.api.client.drives.QueryBatchCollectionResponse
 import id.homebase.api.client.drives.QueryBatchRequest
 import id.homebase.api.client.drives.QueryBatchResponse
 import id.homebase.api.client.drives.ServerFile
@@ -89,6 +91,34 @@ class DriveQueryProvider(
     }
 
     /**
+     * Run multiple named query-batch sections against one or more drives in a single round
+     * trip: POST /drives/query-batch-collection. Each section is matched back to its request
+     * by [QueryBatchResponse.name]; a section targeting a drive the caller can't read comes
+     * back with `invalidDrive = true` rather than failing the whole collection.
+     */
+    suspend fun queryBatchCollection(request: QueryBatchCollectionRequest): QueryBatchCollectionResponse {
+        request.queries.forEach { ValidationUtil.requireValidUuid(it.driveId, "driveId") }
+
+        val creds = requireCreds()
+        val url = apiUrl(creds.domain, "/drives/query-batch-collection")
+
+        val jsonRequest = OdinSystemSerializer.serialize(request)
+
+        val apiResponse = encryptedPostJson(
+            url = url,
+            token = creds.accessToken,
+            jsonBody = jsonRequest,
+            secret = creds.secret
+        )
+
+        throwForFailure(apiResponse)
+
+        val internal = deserialize<QueryBatchCollectionResponseInternalRaw>(apiResponse.body)
+        val results = internal.results.map { section -> mapQueryBatchResponseInternal(section, creds.secret) }
+        return QueryBatchCollectionResponse(results = results)
+    }
+
+    /**
      * Decode a query-batch response body into a [QueryBatchResponse], salvaging individually
      * corrupt file metadata rather than failing the whole batch. Shared by the own-host and
      * over-peer query paths — both receive headers encrypted under the caller's [secret].
@@ -103,7 +133,13 @@ class DriveQueryProvider(
         secret: SecureByteArray,
     ): QueryBatchResponse {
         val internal = deserialize<QueryBatchResponseInternalRaw>(body)
+        return mapQueryBatchResponseInternal(internal, secret)
+    }
 
+    private suspend fun mapQueryBatchResponseInternal(
+        internal: QueryBatchResponseInternalRaw,
+        secret: SecureByteArray,
+    ): QueryBatchResponse {
         if (internal.invalidDrive) {
             return QueryBatchResponse.fromInvalidDrive(internal.name ?: "")
         }
@@ -222,6 +258,11 @@ data class QueryBatchResponseInternalRaw(
     val cursorState: String? = null,
     val searchResults: List<JsonObject> = emptyList(),
     val hasMoreRows: Boolean = false
+)
+
+@Serializable
+data class QueryBatchCollectionResponseInternalRaw(
+    val results: List<QueryBatchResponseInternalRaw> = emptyList()
 )
 
 @Serializable

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/query/DriveQueryProviderQueryBatchCollectionTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/query/DriveQueryProviderQueryBatchCollectionTest.kt
@@ -1,0 +1,152 @@
+package id.homebase.api.client.drives.query
+
+import id.homebase.api.client.CryptoHelper
+import id.homebase.api.client.auth.ApiCredentials
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.CollectionQueryParamSection
+import id.homebase.api.client.drives.QueryBatchCollectionRequest
+import id.homebase.api.client.drives.QueryBatchResultOptionsRequest
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.SecureByteArray
+import id.homebase.api.serialization.OdinSystemSerializer
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * [DriveQueryProvider.queryBatchCollection] — POST /drives/query-batch-collection. Pins the
+ * request shape (no driveId path segment; each section's driveId rides in the body instead)
+ * and the per-section decode: a healthy section's rows go through the same salvage-decode as
+ * [DriveQueryProvider.queryBatch], and an invalidDrive section comes back empty rather than
+ * failing the whole collection.
+ */
+class DriveQueryProviderQueryBatchCollectionTest {
+
+    // MockEngine decrypts the captured request body with this shared secret to inspect the
+    // QueryBatchCollectionRequest actually sent over the wire.
+    private val sharedSecret = ByteArray(16)
+
+    private suspend fun buildProvider(mockEngine: MockEngine): DriveQueryProvider {
+        val credentialsManager = CredentialsManager()
+        credentialsManager.setActiveCredentials(
+            ApiCredentials.create(
+                domain = OdinId("test.homebase.id"),
+                clientAccessToken = "fake-token",
+                sharedSecret = SecureByteArray(sharedSecret.copyOf())
+            )
+        )
+        return DriveQueryProvider(HttpClient(mockEngine), credentialsManager)
+    }
+
+    private suspend fun parseRequest(request: HttpRequestData): QueryBatchCollectionRequest {
+        val envelope = request.body.toByteArray().decodeToString()
+        val json = CryptoHelper.decryptContentAsString(envelope, sharedSecret)
+        return OdinSystemSerializer.deserialize(json)
+    }
+
+    /** Minimal ServerFile shape that decodes cleanly (mirrors ContactFixtures' fixture). */
+    private fun serverFileJson(fileId: Uuid, driveId: Uuid): String = """
+        {
+          "fileId": "$fileId",
+          "driveId": "$driveId",
+          "fileState": "active",
+          "fileSystemType": "standard",
+          "sharedSecretEncryptedKeyHeader": { "encryptionVersion": 1, "iv": "AAAA", "encryptedAesKey": "AAAA" },
+          "fileMetadata": {
+            "versionTag": "11111111-1111-1111-1111-111111111111",
+            "appData": { "uniqueId": "$fileId", "fileType": 100 }
+          },
+          "serverMetadata": {}
+        }
+    """.trimIndent()
+
+    @Test
+    fun decodesEachNamedSectionIndependently() = runTest {
+        val photosDriveId = Uuid.random()
+        val docsDriveId = Uuid.random()
+        val fileId = Uuid.random()
+
+        lateinit var capturedRequest: HttpRequestData
+        val mockEngine = MockEngine { request ->
+            capturedRequest = request
+            respond(
+                """
+                {
+                  "results": [
+                    {
+                      "name": "photos",
+                      "invalidDrive": false,
+                      "queryTime": 0,
+                      "includeMetadataHeader": false,
+                      "cursorState": "next-page-cursor",
+                      "hasMoreRows": true,
+                      "searchResults": [${serverFileJson(fileId, photosDriveId)}]
+                    },
+                    {
+                      "name": "docs",
+                      "invalidDrive": true,
+                      "queryTime": 0,
+                      "includeMetadataHeader": false,
+                      "cursorState": null,
+                      "hasMoreRows": false,
+                      "searchResults": []
+                    }
+                  ]
+                }
+                """.trimIndent(),
+                HttpStatusCode.OK,
+            )
+        }
+
+        val provider = buildProvider(mockEngine)
+        val request = QueryBatchCollectionRequest(
+            queries = listOf(
+                CollectionQueryParamSection(
+                    name = "photos",
+                    driveId = photosDriveId,
+                    queryParams = FileQueryParams(fileType = listOf(100)),
+                    resultOptionsRequest = QueryBatchResultOptionsRequest(maxRecords = 50),
+                ),
+                CollectionQueryParamSection(
+                    name = "docs",
+                    driveId = docsDriveId,
+                    queryParams = FileQueryParams(fileType = listOf(200)),
+                    resultOptionsRequest = QueryBatchResultOptionsRequest(maxRecords = 25),
+                ),
+            )
+        )
+
+        val response = provider.queryBatchCollection(request)
+
+        // Request shape: no driveId path segment — each section's driveId rides in the body.
+        assertEquals("/api/v2/drives/query-batch-collection", capturedRequest.url.encodedPath)
+        val sentBody = parseRequest(capturedRequest)
+        assertEquals(listOf("photos", "docs"), sentBody.queries.map { it.name })
+        assertEquals(photosDriveId, sentBody.queries[0].driveId)
+        assertEquals(50, sentBody.queries[0].resultOptionsRequest.maxRecords)
+
+        // Response: sections come back matched by name, each decoded independently.
+        assertEquals(2, response.results.size)
+
+        val photos = response.results.first { it.name == "photos" }
+        assertFalse(photos.invalidDrive)
+        assertEquals("next-page-cursor", photos.cursorState)
+        assertTrue(photos.hasMoreRows)
+        assertEquals(1, photos.searchResults.size)
+        assertEquals(fileId, photos.searchResults[0].fileId)
+
+        val docs = response.results.first { it.name == "docs" }
+        assertTrue(docs.invalidDrive)
+        assertTrue(docs.searchResults.isEmpty())
+        assertFalse(docs.hasMoreRows)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a client for the V2 `POST /drives/query-batch-collection` endpoint, letting callers run multiple named query-batch sections (each with its own drive/filters/paging options) in a single round trip.
- Refactors `DriveQueryProvider`'s per-file salvage-decode (bad/corrupt `fileMetadata` degrades to a placeholder instead of failing the batch) into a shared helper so both `queryBatch` and the new `queryBatchCollection` use identical decode behavior.
- New request/response types: `QueryBatchCollectionRequest`/`CollectionQueryParamSection` and `QueryBatchCollectionResponse`, reusing the existing `FileQueryParams`, `QueryBatchResultOptionsRequest`, and `QueryBatchResponse` types.

No call sites are wired up yet — this only adds the provider method.

## Test plan
- [x] `./gradlew :homebase-api:compileKotlinJvm`
- [x] `./gradlew :homebase-api:jvmTest --tests "id.homebase.api.client.drives.query.DriveQueryProviderQueryBatchCollectionTest"` — pins the request shape (no `driveId` path segment, per-section fields round-trip) and per-section response decode (healthy section reuses the salvage-decode path; `invalidDrive` section comes back empty without failing the collection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)