### PR TITLE
fix(chat): document renders a compact file card, not a media-height grey void (#1103)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
@@ -54,6 +54,29 @@ import org.jetbrains.compose.resources.stringResource
 import kotlin.uuid.Uuid
 
 /**
+ * True when a single payload renders as a compact [DocumentMediaItem] file card (icon + name +
+ * size + download) rather than a visual media tile — so it must hug its content instead of being
+ * stretched to a media-height box, which leaves the card floating atop a grey void (#1103).
+ *
+ * Mirrors [MediaItem]'s routing: link-preview and location payloads have their own cards (false);
+ * image, video, HLS and audio are media (false); everything else that routes to DocumentMediaItem
+ * (pdf, zip, rar, apk, and the text and application MIME families) is a document (true). Keep in
+ * sync with the content-type branches in [MediaItem] if a new document type is added there.
+ */
+internal fun PayloadDescriptor.rendersAsDocumentCard(): Boolean {
+    if (key == ChatProtocol.PAYLOAD_KEY_LINKS || key == ChatProtocol.PAYLOAD_KEY_LOCATION) return false
+    val ct = contentType ?: return false
+    if (ct.startsWith("image/") || ct.startsWith("video/") || ct.startsWith("audio/")) return false
+    if (ct == "application/vnd.apple.mpegurl") return false // HLS video, not a document
+    return ct == "application/pdf" ||
+        ct == "application/zip" ||
+        ct == "application/x-rar-compressed" ||
+        ct == "application/vnd.android.package-archive" ||
+        ct.startsWith("text/") ||
+        ct.startsWith("application/")
+}
+
+/**
  * Media message component that decides between single item or gallery view.
  *
  * - Single payload: Renders MediaItem with max 50% width, preserving aspect ratio
@@ -148,7 +171,13 @@ fun MediaMessage(
                     aspect != null &&
                     Dimens.MediaBubble.maxHeight.value * aspect <
                     Dimens.MediaBubble.minWidthWithContent.value
+                // A document renders as a compact file card, not a media tile. It must hug its
+                // content — no media height (neither the maxHeight fill nor the minHeight floor),
+                // or the card floats atop a grey void (#1103).
+                val isDocument = remember(payloads) { payloads[0].rendersAsDocumentCard() }
                 val sizedModifier = when {
+                    isDocument ->
+                        widthModifier
                     fillsBubble ->
                         widthModifier.fillMaxWidth().height(Dimens.MediaBubble.maxHeight)
                     narrowCaptioned ->

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
@@ -125,6 +125,10 @@ class BubbleLayoutInvariantTest {
         val caption: Caption,
         val reply: Boolean = false,
         val aspect: Aspect = Aspect.LANDSCAPE,
+        // A single non-media document payload (a .log) instead of images. Has no
+        // previewThumbnail/aspect and a non-image contentType, so it renders as the
+        // compact DocumentMediaItem file card — the #1103 regression dimension.
+        val document: Boolean = false,
     )
 
     private fun imagePayload(i: Int, aspect: Aspect = Aspect.LANDSCAPE) = PayloadDescriptor(
@@ -134,6 +138,16 @@ class BubbleLayoutInvariantTest {
         previewThumbnail = ThumbnailDescriptor(
             pixelWidth = aspect.w, pixelHeight = aspect.h, contentType = "image/jpeg", content = "",
         ),
+    )
+
+    // A document attachment: no thumbnail, non-media contentType. Renders via
+    // DocumentMediaItem (icon + name + size), which hugs its content.
+    private fun documentPayload() = PayloadDescriptor(
+        key = "chat_file0",
+        contentType = "text/plain",
+        iv = Base64.encode(ByteArray(16)),
+        descriptorContent = "server.log",
+        bytesWritten = 3_300_000,
     )
 
     private fun Case.message(): MessageUiModel {
@@ -157,7 +171,11 @@ class BubbleLayoutInvariantTest {
             messageAppData = MessageAppData(replyPreview = reply),
             reactionPreview = null,
             previewThumbnail = null,
-            payloads = (0 until images).map { imagePayload(it, aspect) }.toPersistentList(),
+            payloads = if (document) {
+                listOf(documentPayload()).toPersistentList()
+            } else {
+                (0 until images).map { imagePayload(it, aspect) }.toPersistentList()
+            },
             keyHeader = KeyHeader(iv = ByteArray(16), aesKey = SecureByteArray(ByteArray(16))),
             versionTag = Uuid.random(),
             isPendingSend = false,
@@ -365,6 +383,32 @@ class BubbleLayoutInvariantTest {
                 failures += "[${case.name}] media should fill bubble: media=[${media.left.value},${media.right.value}] bubble=[${bubble.left.value},${bubble.right.value}]"
         }
         assertTrue(failures.isEmpty(), "media-only invariant failures:\n" + failures.joinToString("\n"))
+    }
+
+    /**
+     * #1103: a single document (a .log — no thumbnail, non-media contentType) must render as a
+     * compact file card that hugs its content, NOT stretched to a media-height box. The
+     * regression (#1028/#1032, commit f3bee10eb) forced a fill-width document to
+     * Dimens.MediaBubble.maxHeight (a tall grey void below the file row); the no-caption path
+     * also floored it to minHeight. After the fix a document gets NO media height at all, so
+     * the tagged media node is the ~72dp card (48dp icon + 12dp padding ×2) — well under the
+     * 100dp media floor. Covers no-caption, inline-caption, and block-caption paths.
+     */
+    @Test
+    fun singleDocument_compactCard_noMediaVoid() = runComposeUiTest {
+        val floor = Dimens.MediaBubble.minHeight.value
+        val failures = mutableListOf<String>()
+        for (sent in listOf(true, false))
+            for (cap in listOf(Caption.NONE, Caption.SHORT, Caption.BLOCK)) {
+                render(Case("file/$cap/${if (sent) "sent" else "recv"}", sent, images = 0, caption = cap, document = true))
+                val media = boundsOf(ChatBubbleTestTags.MEDIA)
+                val h = media.bottom.value - media.top.value
+                // Strictly below the media floor proves the doc dropped BOTH the maxHeight fill
+                // (caption path) and the heightIn(min) floor (no-caption path) — i.e. no void.
+                if (h >= floor - tol)
+                    failures += "[file/$cap/${if (sent) "sent" else "recv"}] document got media height=$h (>= minHeight=$floor); expected a compact file card"
+            }
+        assertTrue(failures.isEmpty(), "document compact-card failures:\n" + failures.joinToString("\n"))
     }
 
     /**


### PR DESCRIPTION
Fixes #1103.

## Problem
A single **document** payload (a `.log`, `.pdf`, `.zip`, `text/*`, `application/*`) has no thumbnail and no aspect ratio, but `MediaMessage` still routed it through the media-sizing branches:
- **with a caption** (block path, `fillWidth = true`) it matched `fillsBubble` → forced to `Dimens.MediaBubble.maxHeight` (**320dp**) — the compact file card floating atop a tall grey `surfaceContainerHigh` void;
- **without a caption** it fell to `heightIn(min = 100dp)` — a smaller void.

Regression from `f3bee10eb` (#1028/#1032), which added the `fillsBubble` branch without excluding non-media payloads.

## Fix
Add an `isDocument` branch **first** in the `sizedModifier` `when` (so it wins over `fillsBubble`/`narrowCaptioned`), giving a document **no media height at all** — it hugs its content. `rendersAsDocumentCard()` mirrors `MediaItem`'s content-type routing (link-preview / location / image / video / HLS / audio are excluded; pdf / zip / rar / apk / `text/*` / `application/*` are documents).

## Test
Extends the existing `BubbleLayoutInvariantTest` with a **document dimension** asserting the media node never reaches the 100dp media floor across no-caption / inline-caption / block-caption paths.
- **RED** (pre-fix): `320dp` (block caption) / `100dp` (otherwise).
- **GREEN** (post-fix): ~72dp compact card.

## Verified on-device (Android, Redmi Note 5 Pro)
A `.log` with a two-paragraph caption renders as a compact file card **directly above** the caption — no grey void. `describe` measured the media node at **0.092 of screen height (~76dp)** vs ~0.4 (320dp) before.

## Scope note
Fix is on the **single-payload** path (the reported bug). A document mixed into a 2+-item `MediaGallery` grid is a separate, rarer case (fixed-cell grid) and is intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)