### PR TITLE
feat(diagnostics): background-observability baseline instrumentation (#1109)

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/DriveFcmService.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/DriveFcmService.kt
@@ -10,6 +10,7 @@ import androidx.work.WorkManager
 import co.touchlab.kermit.Logger
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import id.homebase.api.diagnostics.BgTrace
 import id.homebase.core.location.PushLocationCapture
 import id.homebase.core.notifications.NotificationService
 import kotlinx.coroutines.runBlocking
@@ -37,6 +38,8 @@ class DriveFcmService : FirebaseMessagingService() {
             "received: priority=${pri(message.priority)} originalPriority=${pri(message.originalPriority)}" +
                 "$downgraded dataKeys=${message.data.size} notif=${message.notification != null}"
         }
+        // #1109 background wake-cause attribution (an FCM push woke the process).
+        BgTrace.log(BgTrace.wake("fcm", "priority=${pri(message.priority)}"))
 
         // Hand the FCM payload to the shared NotificationEntry via a worker —
         // the worker runs the same onPushArrived(...) body iOS calls inline,

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/liverelay/LiveRelayProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/liverelay/LiveRelayProvider.kt
@@ -3,6 +3,7 @@ package id.homebase.api.client.liverelay
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.OdinApiProviderBase
 import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.diagnostics.BgTrace
 import id.homebase.api.serialization.OdinSystemSerializer
 import io.ktor.client.HttpClient
 import kotlinx.serialization.Serializable
@@ -38,6 +39,9 @@ class LiveRelayProvider(
         Logger.i(tag = TAG) {
             "SEND ch=$channelKey n=${recipients.size} bytes=${blob.length} -> ${response.status}"
         }
+        // #1109 background wake-cause attribution: a location fix that produced an outbound live-share
+        // relay (vs a plain history point). Greppable alongside the other background wake causes.
+        BgTrace.log(BgTrace.wake("live-share-send", "ch=$channelKey -> ${response.status}"))
         return ok
     }
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/OdinWebSocketClient.kt
@@ -12,6 +12,7 @@ import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.common.SecureByteArray
 import id.homebase.api.crypto.AesCbc
 import id.homebase.api.crypto.ByteArrayUtil
+import id.homebase.api.diagnostics.BgTrace
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.DriveSyncManager
 import id.homebase.api.sync.DriveWebSocketUpsertWorker
@@ -108,7 +109,10 @@ class OdinWebSocketClient(
             val previous = field
             field = value
             pingSupervisor.isInForeground = value
-            if (!previous && value) wakeForReconnect()
+            if (!previous && value) {
+                BgTrace.log("ws-wake bg->fg (reconnect kicked)")
+                wakeForReconnect()
+            }
         }
 
     @Volatile
@@ -265,6 +269,9 @@ class OdinWebSocketClient(
         val wsRoute = if (isWasm) "ws-token-wasm" else "ws-token"
         val wsUrl = "wss://${identity}/api/v2/notify/$wsRoute"
         Logger.i(tag = "WebSocket") { "WS[$instanceId] Connecting to WebSocket at $wsUrl" }
+        // #1109 baseline: greppable connect-attempt line tagged with fg/bg. A `state=bg` attempt is
+        // the background-reconnect red flag #1108 targets — it should drop to ~0 once that lands.
+        BgTrace.log(BgTrace.wsConnect(isInForeground, wsUrl))
 
         // Auth for the v2 ws-token route is carried on the WebSocket upgrade itself
         // via Sec-WebSocket-Protocol — no cookie, no Authorization header. We send
@@ -596,6 +603,12 @@ class OdinWebSocketClient(
                 Logger.i(tag = "LiveRelay") {
                     "RECV from=${d.senderOdinId.domainName} ch=${d.channelKey} " +
                         "bytes=${d.blob.length} receivedAt=${d.receivedAt}"
+                }
+                // #1109 background wake-cause attribution — only interesting while backgrounded (a
+                // foreground RECV isn't a background wake). Distinguishes WS-driven background
+                // activity from FCM / location / live-share-send.
+                if (!isInForeground) {
+                    BgTrace.log(BgTrace.wake("ws-recv", "from=${d.senderOdinId.domainName} ch=${d.channelKey}"))
                 }
                 eventBus.emit(
                     BackendEvent.LiveRelayReceived(

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/diagnostics/BgTrace.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/diagnostics/BgTrace.kt
@@ -1,0 +1,46 @@
+package id.homebase.api.diagnostics
+
+import co.touchlab.kermit.Logger
+
+/**
+ * One greppable tag for the app's background-observability baseline (#1109). All lines share the
+ * `BgTrace` Kermit tag so a day's `homebase.log` yields a clean background breakdown from a single
+ * `grep BgTrace` — instead of hand-correlating scattered `LiveRelay` / GPS-profile / WS logs.
+ *
+ * Line shapes are built by the pure formatter functions below so they can be unit-tested and stay
+ * stable for downstream log tooling. This is log-only; nothing here changes behavior.
+ *
+ * Categories emitted today:
+ * - `transition …`  — foreground↔background flip with the duration of the window just ended.
+ * - `ws-connect …`  — a notify-WS connect attempt, tagged with foreground/background state. A
+ *                     `state=bg` attempt is the red flag #1108 targets (a background reconnect with
+ *                     no reason to be connected).
+ * - `wake cause=…`  — why the process was active in the background (fcm / location-delivery /
+ *                     ws-recv / live-share-send).
+ *
+ * Deferred to companion issues (documented so the format stays consistent when they land):
+ * - `ip-target …`   — stored-ip vs dns connect-target decision → lands with #1107 (the code that
+ *                     makes the choice).
+ */
+object BgTrace {
+    const val TAG = "BgTrace"
+
+    /**
+     * A foreground↔background transition. [windowMs] is the duration of the window that just ended
+     * (time spent in the *previous* state). [profile] is the active location tracking profile, or
+     * null when unknown (omitted from the line).
+     */
+    fun transition(toForeground: Boolean, windowMs: Long, profile: String?): String =
+        "transition ${if (toForeground) "bg->fg" else "fg->bg"} windowMs=$windowMs" +
+            (profile?.let { " profile=$it" } ?: "")
+
+    /** A notify-WS connect attempt, tagged with the app's foreground/background state. */
+    fun wsConnect(foreground: Boolean, url: String): String =
+        "ws-connect state=${if (foreground) "fg" else "bg"} url=$url"
+
+    /** Why the process was active in the background. [cause] is a stable slug; [detail] is free-form. */
+    fun wake(cause: String, detail: String): String = "wake cause=$cause $detail"
+
+    /** Emit a pre-formatted [line] under the shared [TAG]. */
+    fun log(line: String) = Logger.i(tag = TAG) { line }
+}

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/diagnostics/BgTraceFormatTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/diagnostics/BgTraceFormatTest.kt
@@ -1,0 +1,58 @@
+package id.homebase.api.diagnostics
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Locks the #1109 background-observability line shapes. Downstream log tooling greps these, so the
+ * exact formats are a contract, not an implementation detail.
+ */
+class BgTraceFormatTest {
+
+    @Test
+    fun transitionForegroundToBackgroundWithProfile() {
+        assertEquals(
+            "transition fg->bg windowMs=123456 profile=HistoryBackground",
+            BgTrace.transition(toForeground = false, windowMs = 123456, profile = "HistoryBackground"),
+        )
+    }
+
+    @Test
+    fun transitionBackgroundToForegroundWithProfile() {
+        assertEquals(
+            "transition bg->fg windowMs=5000 profile=LiveForeground",
+            BgTrace.transition(toForeground = true, windowMs = 5000, profile = "LiveForeground"),
+        )
+    }
+
+    @Test
+    fun transitionOmitsProfileWhenNull() {
+        assertEquals(
+            "transition fg->bg windowMs=42",
+            BgTrace.transition(toForeground = false, windowMs = 42, profile = null),
+        )
+    }
+
+    @Test
+    fun wsConnectForeground() {
+        assertEquals(
+            "ws-connect state=fg url=wss://example.homebase.id/api/v2/notify/ws-token",
+            BgTrace.wsConnect(foreground = true, url = "wss://example.homebase.id/api/v2/notify/ws-token"),
+        )
+    }
+
+    @Test
+    fun wsConnectBackgroundIsTheRedFlagShape() {
+        // The greppable red flag #1108 targets: a background WS connect attempt.
+        assertEquals(
+            "ws-connect state=bg url=wss://example.homebase.id/api/v2/notify/ws-token",
+            BgTrace.wsConnect(foreground = false, url = "wss://example.homebase.id/api/v2/notify/ws-token"),
+        )
+    }
+
+    @Test
+    fun wakeCauseLine() {
+        assertEquals("wake cause=fcm priority=high", BgTrace.wake("fcm", "priority=high"))
+        assertEquals("wake cause=location-delivery points=3", BgTrace.wake("location-delivery", "points=3"))
+    }
+}

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/LocationUpdatesReceiver.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/location/tracking/LocationUpdatesReceiver.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import co.touchlab.kermit.Logger
 import com.google.android.gms.location.LocationResult
 import id.homebase.api.coroutines.supervisedScope
+import id.homebase.api.diagnostics.BgTrace
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
@@ -36,6 +37,8 @@ class LocationUpdatesReceiver : BroadcastReceiver(), KoinComponent {
 
         // Info so the cold-process background path is auditable in homebase.log.
         logger.i { "Background batch: ${points.size} points" }
+        // #1109 background wake-cause attribution (a fused-location delivery woke the process).
+        BgTrace.log(BgTrace.wake("location-delivery", "points=${points.size}"))
         val pendingResult = goAsync()
         scope.launch {
             try {

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -10,6 +10,8 @@ import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.client.peer.PeerWebSocketManager
 import id.homebase.api.client.websockets.OdinWebSocketClient
 import id.homebase.api.common.OdinId
+import id.homebase.api.common.time.UnixTimeUtc
+import id.homebase.api.diagnostics.BgTrace
 import id.homebase.api.sync.DriveSyncManager
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.OutboxSync
@@ -52,6 +54,12 @@ class AuthConnectionCoordinator(
     private val peerWebSocketManager: PeerWebSocketManager,
     private val onPostAuthenticated: () -> Unit = {},
     /**
+     * Active location-tracking profile label for the #1109 background-transition line, or null when
+     * unknown/none. Injected as a lambda (wired in AppModule to LocationTrackingCoordinator) so this
+     * auth layer stays decoupled from the location module. Default `{ null }` keeps it optional.
+     */
+    private val locationProfileLabel: () -> String? = { null },
+    /**
      * Initial value of [headless]. True only on platforms that can cold-wake the
      * process in the background (see [PlatformInfo.supportsBackgroundWake]); those
      * defer foreground-only work until [promoteToForeground]. Defaults to false so
@@ -74,6 +82,12 @@ class AuthConnectionCoordinator(
         }
     )
     private var wsClient: OdinWebSocketClient? = null
+
+    // #1109 background-transition tracking: the last foreground/background state we logged and when,
+    // so setForeground() can emit the duration of the window that just ended. Seeded foreground=true
+    // at process start (the app opens in the foreground); lastTransitionAtMs anchors the first window.
+    private var currentForeground: Boolean = true
+    private var lastTransitionAtMs: Long = UnixTimeUtc().milliseconds
 
     // Peer (owner-hosted) drives mounted this session, alias -> (owner, drive). Lets [unmountDrive]
     // tear down the right per-owner peer websocket given only a driveId. Guarded by [peerOwnersMutex]
@@ -521,6 +535,15 @@ class AuthConnectionCoordinator(
     }
 
     fun setForeground(foreground: Boolean) {
+        // #1109: one consolidated, greppable transition line carrying the duration of the window that
+        // just ended plus the active location profile — so a day's log gives a clean fg/bg breakdown
+        // (and background-window attribution) from a single `grep BgTrace` instead of hand-stitching.
+        if (foreground != currentForeground) {
+            val now = UnixTimeUtc().milliseconds
+            BgTrace.log(BgTrace.transition(foreground, now - lastTransitionAtMs, locationProfileLabel()))
+            currentForeground = foreground
+            lastTransitionAtMs = now
+        }
         wsClient?.isInForeground = foreground
     }
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTrackingCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/location/tracking/LocationTrackingCoordinator.kt
@@ -120,6 +120,14 @@ class LocationTrackingCoordinator(
         "allowHistory=${preferences.allowLocationHistory.value} liveShare=${liveShareActive()} " +
             "trackerAvailable=${tracker.isAvailable} permission=${isLocationPermissionGranted()}"
 
+    /**
+     * The currently-armed tracking profile's name, or null when GPS isn't running. Read by the #1109
+     * background-transition log (via an injected lambda in AuthConnectionCoordinator) to attribute a
+     * background window to its active location profile. Mirrors [lastProfile], which is null while the
+     * radio is stopped.
+     */
+    fun currentProfileLabel(): String? = lastProfile?.name
+
     /** The acquisition profile for the current foreground state + consumers (#846). */
     private fun currentProfile(): TrackingProfile =
         demand.resolveProfile(isForeground, preferences.allowLocationHistory.value, liveShareActive())

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -625,7 +625,10 @@ val appModule = module {
                 // the right GPS hold. reset() pokes the coordinator via refreshGpsHold().
                 get<LiveLocationShareService>().reset()
                 get<LocationTrackingCoordinator>().reset()
-            }
+            },
+            // #1109: attribute a background window to the active location profile in the
+            // BgTrace transition line. Lambda keeps the auth layer decoupled from the location module.
+            locationProfileLabel = { get<LocationTrackingCoordinator>().currentProfileLabel() },
         )
     }
     single {


### PR DESCRIPTION
Fixes #1109

Log-only baseline instrumentation so the app's background behavior greps out from a single `BgTrace` tag — the measurable baseline for #1107 (stored-IP-first) and #1108 (no background WS). **No behavior change.**

## What lands
New `id.homebase.api.diagnostics.BgTrace` (homebase-api commonMain → reachable from every module) with pure, unit-tested formatters. Three categories:

- **`transition fg<->bg`** — one consolidated line per foreground/background flip carrying the duration of the window just ended + active location profile. Hooked in `AuthConnectionCoordinator.setForeground()`; the profile comes via an injected lambda (`AppModule` → `LocationTrackingCoordinator.currentProfileLabel()`) so the auth layer stays decoupled.
- **`ws-connect state=fg|bg`** — every notify-WS connect attempt tagged with foreground/background (`OdinWebSocketClient.connectOnce`). Today there is **no** signal that the WS reconnects while backgrounded; a `state=bg` line is exactly the red flag #1108 targets. Plus `ws-wake bg->fg` on the reconnect edge.
- **`wake cause=…`** — why the process was active in the background, at the four wake entry points: `fcm` (DriveFcmService), `location-delivery` (LocationUpdatesReceiver), `ws-recv` (OdinWebSocketClient, background only), `live-share-send` (LiveRelayProvider).

## Deferred (documented for format consistency)
- stored-ip vs dns `ip-target` line → lands with **#1107** (the code that makes the choice).
- actual background WS close/park → lands with **#1108** (this instrumentation proves the `state=bg` attempts drop to ~0).

## Verification
- `BgTraceFormatTest` (commonTest) pins the exact line shapes; green on JVM.
- Compiles across JVM/Android/wasmJs for homebase-api/common/core/chat + `:androidApp:compileDevKotlin` (DriveFcmService).
- Rebased on latest `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)