### PR TITLE
feat(auth): stop the notify WS reconnecting while backgrounded (#1108)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/diagnostics/BgTrace.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/diagnostics/BgTrace.kt
@@ -38,6 +38,13 @@ object BgTrace {
     fun wsConnect(foreground: Boolean, url: String): String =
         "ws-connect state=${if (foreground) "fg" else "bg"} url=$url"
 
+    /**
+     * The notify WS was closed and left closed for the background window (#1108) — the positive
+     * greppable confirmation that background reconnects are being suppressed. [reason] is a stable
+     * slug (e.g. "backgrounded-push-covered").
+     */
+    fun wsPark(reason: String): String = "ws-park reason=$reason"
+
     /** Why the process was active in the background. [cause] is a stable slug; [detail] is free-form. */
     fun wake(cause: String, detail: String): String = "wake cause=$cause $detail"
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -60,6 +60,15 @@ class AuthConnectionCoordinator(
      */
     private val locationProfileLabel: () -> String? = { null },
     /**
+     * Whether this platform has a push + background-worker fallback for sync while backgrounded
+     * (FCM/APNs → WorkManager/BGTask HTTP sync) — wired in AppModule to
+     * [PlatformInfo.supportsBackgroundWake] (true on Android/iOS, false on Desktop/Web). When true,
+     * the notify WS is closed while backgrounded (#1108) and reconnected on foreground; when false
+     * (no push path) the WS is kept connected regardless of foreground state. Default false = keep
+     * the WS (fail safe for a platform that forgets to wire this).
+     */
+    private val backgroundSyncViaPush: Boolean = false,
+    /**
      * Initial value of [headless]. True only on platforms that can cold-wake the
      * process in the background (see [PlatformInfo.supportsBackgroundWake]); those
      * defer foreground-only work until [promoteToForeground]. Defaults to false so
@@ -94,6 +103,13 @@ class AuthConnectionCoordinator(
     // because mounts arrive from both the Authenticated branch and the registry observer coroutine.
     private val peerDriveOwners = mutableMapOf<Uuid, Pair<OdinId, TargetDrive>>()
     private val peerOwnersMutex = kotlinx.coroutines.sync.Mutex()
+
+    // Serializes the compound WS lifecycle transitions that close+rebuild [wsClient] — the #1108
+    // background close/reconnect ([applyWsHold]) and the drive-subscription reconnect
+    // ([reconnectWebSocket]) — so a foreground/background toggle can't interleave a drive-mount
+    // reconnect and leave two clients or a half-torn-down one. connect() is called WHILE holding
+    // this lock and must never take it itself (it doesn't) to avoid re-entrant deadlock.
+    private val wsLifecycleMutex = kotlinx.coroutines.sync.Mutex()
 
     // Coalesces bursts of mountDrive/unmountDrive calls into a single WebSocket reconnect.
     // [OdinWebSocketClient] freezes its drive-subscription list at construction time, so we
@@ -271,7 +287,17 @@ class AuthConnectionCoordinator(
                 // runPostAuthenticatedOnce() is a no-op if the foreground path already ran it.
                 runPostAuthenticatedOnce()
 
-                connect(extraDrives = initialDrives)
+                // #1108: don't open the notify WS if we authenticated while already backgrounded on a
+                // push-capable platform — FCM + WorkManager HTTP cover background sync. setForeground(true)
+                // reconnects on the next foreground. (Both this and applyWsHold branch on the same live
+                // currentForeground, so they stay consistent without sharing a lock here.)
+                if (shouldKeepWebSocketConnected(currentForeground, backgroundSyncViaPush)) {
+                    connect(extraDrives = initialDrives)
+                } else {
+                    Logger.i(tag = "AuthLifecycle") {
+                        "AuthCC: Authenticated — backgrounded on push-capable platform, deferring WS connect"
+                    }
+                }
                 // Owner-hosted (peer) drives don't ride the own-host WebSocket — open a per-owner
                 // peer websocket for each so live community updates arrive over the owner's host.
                 startPeerConnections(initialDrives)
@@ -544,7 +570,49 @@ class AuthConnectionCoordinator(
             currentForeground = foreground
             lastTransitionAtMs = now
         }
+        // Keep backoff/ping cadence in sync for the cases where the WS stays open (Desktop/Web, or a
+        // foreground transition before applyWsHold reconnects).
         wsClient?.isInForeground = foreground
+        // #1108: close the WS when backgrounded on a push-capable platform; reconnect on foreground.
+        scope.launch { applyWsHold() }
+    }
+
+    /**
+     * Idempotent WS "hold" mirroring [LocationTrackingCoordinator]'s GPS hold (#1108): keep the notify
+     * WS connected only when [shouldKeepWebSocketConnected] is true, otherwise close it for the
+     * background window and rely on FCM push + WorkManager HTTP sync. Reads [currentForeground] LIVE
+     * inside the lock, so two out-of-order launches (a rapid bg→fg) still converge on the latest
+     * state — the last to run re-reads the shared field.
+     */
+    private suspend fun applyWsHold() {
+        wsLifecycleMutex.withLock {
+            val authResolved = lastAuthenticatedDrives != null && !headless
+            when (wsHoldDecision(currentForeground, backgroundSyncViaPush, wsClient != null, authResolved)) {
+                // Rebuild a WS we tore down for background. connect()'s own wsClient != null guard
+                // makes a redundant call a no-op.
+                WsHoldAction.CONNECT -> {
+                    Logger.i(tag = "AuthLifecycle") { "AuthCC: foregrounded — reconnecting WS" }
+                    connect()
+                }
+                WsHoldAction.PARK -> {
+                    val old = wsClient!! // PARK is only returned when a client is present
+                    wsClient = null
+                    old.close()
+                    // close() sets the client's terminal `closed` flag BEFORE cancelling its loop, so
+                    // its handleDisconnected() early-returns and the onDisconnected callback never
+                    // fires. Mark offline here ourselves — otherwise isOnline stays stale-true and
+                    // BackgroundSyncOrchestrator.syncIfAuthenticated() would skip the FCM→HTTP
+                    // background sync ("WS online — skipping"), silently breaking background sync.
+                    outboxSync.setOnline(false)
+                    _connectionState.update { connectionStateAfterWsPark(it) }
+                    BgTrace.log(BgTrace.wsPark("backgrounded-push-covered"))
+                    Logger.i(tag = "AuthLifecycle") {
+                        "AuthCC: WS[${old.instanceId}] closed for background (push-covered)"
+                    }
+                }
+                WsHoldAction.NONE -> {}
+            }
+        }
     }
 
     /**
@@ -639,10 +707,14 @@ class AuthConnectionCoordinator(
     // No-op when [wsClient] is null: logged-out or pre-auth bursts don't need a reconnect —
     // the next organic [connect] call (on login or reconnect) will read the fresh registry.
     private suspend fun reconnectWebSocket() {
-        val old = wsClient ?: return
-        wsClient = null
-        old.close()
-        connect()
+        // Serialized with [applyWsHold] so a background close and a drive-subscription reconnect
+        // can't interleave. connect() is invoked while holding the lock and must not take it.
+        wsLifecycleMutex.withLock {
+            val old = wsClient ?: return@withLock
+            wsClient = null
+            old.close()
+            connect()
+        }
     }
 
     private suspend fun disconnect() {
@@ -749,6 +821,46 @@ internal fun normalizeDriveId(driveId: String): String = driveId.lowercase().rep
  */
 internal fun drivesToPrune(active: Set<Uuid>, mandatory: Set<Uuid>, granted: Set<String>): List<Uuid> =
     active.filter { it !in mandatory && normalizeDriveId(it.toString()) !in granted }
+
+/**
+ * Whether the notify WebSocket should be kept connected (#1108). Keep it while [foreground]; and on
+ * platforms WITHOUT a push fallback ([backgroundSyncViaPush] == false, i.e. Desktop/Web) keep it
+ * regardless. Suppress it only when backgrounded on a push-capable platform (Android/iOS), where FCM
+ * push + WorkManager HTTP sync cover background work. Pure so the policy is unit-tested directly.
+ */
+internal fun shouldKeepWebSocketConnected(foreground: Boolean, backgroundSyncViaPush: Boolean): Boolean =
+    foreground || !backgroundSyncViaPush
+
+internal enum class WsHoldAction { CONNECT, PARK, NONE }
+
+/**
+ * The action [AuthConnectionCoordinator.applyWsHold] should take (#1108), given the desired state.
+ * [wsPresent] = a live wsClient currently exists; [authResolved] = auth has resolved this session and
+ * we're out of headless mode (so a rebuild is legitimate). CONNECT rebuilds a WS we tore down for
+ * background; PARK closes the live WS for the background window; NONE leaves things as they are. Pure
+ * so the control flow — including "don't connect before auth resolves" and "don't park a WS that's
+ * already gone" — is unit-tested directly.
+ */
+internal fun wsHoldDecision(
+    foreground: Boolean,
+    backgroundSyncViaPush: Boolean,
+    wsPresent: Boolean,
+    authResolved: Boolean,
+): WsHoldAction = when {
+    shouldKeepWebSocketConnected(foreground, backgroundSyncViaPush) ->
+        if (!wsPresent && authResolved) WsHoldAction.CONNECT else WsHoldAction.NONE
+    wsPresent -> WsHoldAction.PARK
+    else -> WsHoldAction.NONE
+}
+
+/**
+ * The connection state after the WS is parked for background (#1108): offline and not connecting.
+ * Extracted so a test locks the invariant that a park marks us offline — required because
+ * OdinWebSocketClient.close() never fires onDisconnected, so without this the state would stay
+ * stale-connected and BackgroundSyncOrchestrator would skip the FCM→HTTP background sync.
+ */
+internal fun connectionStateAfterWsPark(current: AuthConnectionState): AuthConnectionState =
+    current.copy(isConnected = false, isConnecting = false)
 
 @Immutable
 data class AuthConnectionState(

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/auth/WebSocketHoldPolicyTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/auth/WebSocketHoldPolicyTest.kt
@@ -1,0 +1,101 @@
+package id.homebase.core.auth
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Locks the #1108 background-WS policy: suppress the notify WS only when backgrounded on a
+ * push-capable platform (Android/iOS). Foreground always keeps it; a platform with no push fallback
+ * (Desktop/Web) always keeps it. Also covers the `wsHoldDecision` control flow and — the bug this
+ * change nearly shipped — that parking the WS marks the connection offline (so the FCM→HTTP
+ * background sync engages instead of being skipped as "WS online").
+ */
+class WebSocketHoldPolicyTest {
+
+    @Test
+    fun foregroundAlwaysKeepsTheWs() {
+        assertTrue(shouldKeepWebSocketConnected(foreground = true, backgroundSyncViaPush = true))
+        assertTrue(shouldKeepWebSocketConnected(foreground = true, backgroundSyncViaPush = false))
+    }
+
+    @Test
+    fun backgroundedOnPushCapablePlatformSuppressesTheWs() {
+        // The one case that changes: Android/iOS in the background rely on FCM/APNs + HTTP.
+        assertFalse(shouldKeepWebSocketConnected(foreground = false, backgroundSyncViaPush = true))
+    }
+
+    @Test
+    fun backgroundedWithoutPushFallbackKeepsTheWs() {
+        // Desktop/Web have no push path, so the WS must stay up even when the window loses focus.
+        assertTrue(shouldKeepWebSocketConnected(foreground = false, backgroundSyncViaPush = false))
+    }
+
+    /* ---- wsHoldDecision control flow ---- */
+
+    @Test
+    fun backgroundedOnPushPlatformWithLiveWsParks() {
+        // The core #1108 behavior: an already-connected WS is closed when we go background.
+        assertEquals(
+            WsHoldAction.PARK,
+            wsHoldDecision(foreground = false, backgroundSyncViaPush = true, wsPresent = true, authResolved = true),
+        )
+    }
+
+    @Test
+    fun foregroundingWithNoWsReconnectsOnceAuthResolved() {
+        assertEquals(
+            WsHoldAction.CONNECT,
+            wsHoldDecision(foreground = true, backgroundSyncViaPush = true, wsPresent = false, authResolved = true),
+        )
+    }
+
+    @Test
+    fun doesNotConnectBeforeAuthResolves() {
+        // The Authenticated branch owns the initial connect; applyWsHold must not race it in.
+        assertEquals(
+            WsHoldAction.NONE,
+            wsHoldDecision(foreground = true, backgroundSyncViaPush = true, wsPresent = false, authResolved = false),
+        )
+    }
+
+    @Test
+    fun doesNotParkAWsThatIsAlreadyGone() {
+        assertEquals(
+            WsHoldAction.NONE,
+            wsHoldDecision(foreground = false, backgroundSyncViaPush = true, wsPresent = false, authResolved = true),
+        )
+    }
+
+    @Test
+    fun desktopBackgroundedNeverParksEvenWithLiveWs() {
+        // No push fallback → keep the WS; a present client stays (NONE, not PARK).
+        assertEquals(
+            WsHoldAction.NONE,
+            wsHoldDecision(foreground = false, backgroundSyncViaPush = false, wsPresent = true, authResolved = true),
+        )
+    }
+
+    @Test
+    fun alreadyConnectedForegroundIsANoOp() {
+        assertEquals(
+            WsHoldAction.NONE,
+            wsHoldDecision(foreground = true, backgroundSyncViaPush = true, wsPresent = true, authResolved = true),
+        )
+    }
+
+    /* ---- the bug: parking must mark us offline ---- */
+
+    @Test
+    fun parkingTheWsMarksTheConnectionOffline() {
+        // Regression guard for the bug found during implementation: OdinWebSocketClient.close() never
+        // fires onDisconnected, so applyWsHold must flip the state offline itself. If it didn't,
+        // isOnline (= connectionState.isConnected) would stay true and BackgroundSyncOrchestrator
+        // would skip the FCM→HTTP background sync ("WS online — skipping").
+        val connected = AuthConnectionState(isConnecting = false, isConnected = true)
+        val parked = connectionStateAfterWsPark(connected)
+        assertFalse(parked.isConnected, "a parked WS must report disconnected so background HTTP sync runs")
+        assertFalse(parked.isConnecting, "a parked WS is not mid-connect")
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -513,6 +513,10 @@ val appModule = module {
             // (Android/iOS). Desktop/Web report false → start in foreground mode so
             // a missing promoteToForeground() can't hang the app on "syncing".
             startsHeadless = get<PlatformInfo>().supportsBackgroundWake,
+            // #1108: close the notify WS while backgrounded on platforms that have an FCM/APNs +
+            // background-worker HTTP fallback (Android/iOS). Desktop/Web (false) keep the WS, as they
+            // have no push path. Same capability that governs headless cold-wake.
+            backgroundSyncViaPush = get<PlatformInfo>().supportsBackgroundWake,
             onPostAuthenticated = {
                 // Live Relay receive store: resolve it FIRST and independent of the other services
                 // so its app-lifetime init{} collector is guaranteed up — a throw in a later


### PR DESCRIPTION
Fixes #1108

While backgrounded on a push-capable platform, the notify WebSocket kept reconnecting for zero benefit — a dead-DNS travel network produced **315 fruitless reconnects overnight**. Background sync doesn't need the WS: an FCM push runs `DriveSyncWorker` → the same HTTP `syncAll()`, and `BackgroundSyncOrchestrator` already does this *only when the WS is offline*.

## What changed
Close the WS on background, reconnect on foreground — mirroring the existing GPS-hold pattern:

- **`shouldKeepWebSocketConnected(foreground, backgroundSyncViaPush)`** — pure policy. Keep while foreground; on platforms with no push fallback (Desktop/Web) keep regardless; suppress only when backgrounded on Android/iOS.
- **`applyWsHold()`** closes `wsClient` on background / reconnects on foreground, serialized with `reconnectWebSocket()` under a new `wsLifecycleMutex`. Reads `currentForeground` live so out-of-order fg/bg launches converge.
- **`setForeground()`** kicks `applyWsHold()`; the Authenticated-branch `connect()` is gated by the same predicate so a background re-auth won't reopen the WS.
- Gated on `PlatformInfo.supportsBackgroundWake` — **not** on `setForeground(false)` alone, which also fires on Desktop/Web window-blur/tab-hide (they have no push fallback and must keep the WS).

## The subtle bug caught during implementation
`OdinWebSocketClient.close()` sets its terminal `closed` flag **before** cancelling the loop, so `handleDisconnected()` early-returns and **`onDisconnected` never fires**. If we relied on that, `isOnline` would stay stale-`true` and `BackgroundSyncOrchestrator.syncIfAuthenticated()` would **skip** the FCM→HTTP sync ("WS online — skipping"), silently breaking background sync. `applyWsHold` marks offline itself (`outboxSync.setOnline(false)` + `connectionState`).

## Tests
`WebSocketHoldPolicyTest` (pure, `homebase-common` jvmTest):
- `shouldKeepWebSocketConnected` truth table.
- `wsHoldDecision` control flow — parks a live WS when backgrounded on push; reconnects on foreground once auth resolves; doesn't connect before auth; doesn't park an absent WS; Desktop never parks.
- **Regression guard for the bug**: `connectionStateAfterWsPark` marks the connection offline (so background HTTP sync engages).

Cold background wake was already handled by the `headless` flag; this adds the warm case. #1109's `BgTrace` lines are the runtime baseline — a new `ws-park` line positively confirms suppression, and `ws-connect state=bg` should drop to ~0.

**Accepted regression:** a backgrounded live-location share stops updating the peer's position until foreground (server flush-on-connect catches up). Follow-up can add a live-share RECV keep-alive if it bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)