### PR TITLE
fix(chat): clear pending clock on outbox send-success, not just server echo (#1120)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -124,16 +124,9 @@ class ChatMessageStream(
                         }
                     }
 
-                    // The outbox uploaded this item successfully. Clear the
-                    // message's isPendingSendTag NOW rather than waiting for the
-                    // server-canonical copy to sync back and replace the optimistic
-                    // row — that echo can be missed by the open conversation window
-                    // when DriveSync (silent) applies it before the duplicate WS
-                    // push is guard-rejected on equal `modified`, leaving the bubble
-                    // stuck on the pending clock until a cold reload (#1120; same
-                    // live-refresh gap class as #1042). Non-message completions
-                    // (conversation/admin files, reactions, receipts) are ignored in
-                    // markSendSucceeded.
+                    // Upload succeeded — clear isPendingSendTag now instead of
+                    // waiting for the server echo, which the open window can miss
+                    // (#1120). See markSendSucceeded.
                     is BackendEvent.OutboxEvent.ItemCompleted -> {
                         if (event.driveId == chatDrive) {
                             scope.launch { markSendSucceeded(event.uniqueId) }
@@ -708,19 +701,16 @@ class ChatMessageStream(
     }
 
     /**
-     * An outbox item for [uniqueId] uploaded successfully. If it's a chat *message*
-     * still carrying [ChatProtocol.isPendingSendTag], drop that tag now so the bubble
-     * flips from the pending clock to the Sent tick immediately — instead of relying
-     * solely on the server echo replacing the optimistic row, which the open window
-     * can miss (see the `ItemCompleted` handler / #1120).
+     * An outbox item for [uniqueId] uploaded successfully — drop its
+     * [ChatProtocol.isPendingSendTag] so the bubble flips from the pending clock to
+     * the Sent tick. Relying on the server echo alone isn't enough: DriveSync applies
+     * the echo silently, then the duplicate WS push is guard-rejected on equal
+     * `modified` and emits no BatchReceived, so an open window keeps serving the stale
+     * pending model until a cold reload (#1120).
      *
-     * Non-message completions (a conversation/admin file, a reaction, a read receipt)
-     * carry no message bubble and are ignored via the [ChatProtocol.MessageFileType]
-     * gate. Safe and idempotent: if the echo already cleared the tag,
-     * [tagsForSendSuccess] returns null and we no-op (no redundant upsert/BatchReceived).
-     * The local `updated` bump is +1 ms (`updateLocalTags`), far below the server
-     * `modified`, so a later echo still passes the DriveMainIndex guard and replaces
-     * the row.
+     * The `updated` bump is +1 ms, far below the server `modified`, so the echo still
+     * passes the DriveMainIndex guard and replaces the row. Idempotent — a tag already
+     * cleared gives null from [tagsForSendSuccess] and no-ops.
      */
     private suspend fun markSendSucceeded(uniqueId: Uuid) {
         val file = getMessageFile(uniqueId) ?: return

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -86,6 +86,22 @@ class ChatMessageStream(
                         }
                     }
 
+                    // The outbox uploaded this item successfully. Clear the
+                    // message's isPendingSendTag NOW rather than waiting for the
+                    // server-canonical copy to sync back and replace the optimistic
+                    // row — that echo can be missed by the open conversation window
+                    // when DriveSync (silent) applies it before the duplicate WS
+                    // push is guard-rejected on equal `modified`, leaving the bubble
+                    // stuck on the pending clock until a cold reload (#1120; same
+                    // live-refresh gap class as #1042). Non-message completions
+                    // (conversation/admin files, reactions, receipts) are ignored in
+                    // markSendSucceeded.
+                    is BackendEvent.OutboxEvent.ItemCompleted -> {
+                        if (event.driveId == chatDrive) {
+                            scope.launch { markSendSucceeded(event.uniqueId) }
+                        }
+                    }
+
                     is BackendEvent.DriveEvent.Stopped -> {
                         if (event.driveId != chatDrive) return@collect
                         Logger.d("ChatMessageStream: Stopped(totalCount=${event.totalCount}, result=${event.result})")
@@ -459,6 +475,30 @@ class ChatMessageStream(
 
         val newTags = existingTags
             .filterNot { it == ChatProtocol.isPendingSendTag } + ChatProtocol.isFailedSendTag
+        optimisticWriter.updateLocalTags(chatDrive, uniqueId, newTags)
+    }
+
+    /**
+     * An outbox item for [uniqueId] uploaded successfully. If it's a chat *message*
+     * still carrying [ChatProtocol.isPendingSendTag], drop that tag now so the bubble
+     * flips from the pending clock to the Sent tick immediately — instead of relying
+     * solely on the server echo replacing the optimistic row, which the open window
+     * can miss (see the `ItemCompleted` handler / #1120).
+     *
+     * Non-message completions (a conversation/admin file, a reaction, a read receipt)
+     * carry no message bubble and are ignored via the [ChatProtocol.MessageFileType]
+     * gate. Safe and idempotent: if the echo already cleared the tag,
+     * [tagsForSendSuccess] returns null and we no-op (no redundant upsert/BatchReceived).
+     * The local `updated` bump is +1 ms (`updateLocalTags`), far below the server
+     * `modified`, so a later echo still passes the DriveMainIndex guard and replaces
+     * the row.
+     */
+    private suspend fun markSendSucceeded(uniqueId: Uuid) {
+        val file = getMessageFile(uniqueId) ?: return
+        if (file.fileMetadata.appData.fileType != ChatProtocol.MessageFileType) return
+
+        val existingTags = file.fileMetadata.localAppData?.tags.orEmpty()
+        val newTags = tagsForSendSuccess(existingTags) ?: return
         optimisticWriter.updateLocalTags(chatDrive, uniqueId, newTags)
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ResendHelpers.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ResendHelpers.kt
@@ -75,6 +75,20 @@ fun tagsForRetry(existing: List<Uuid>): List<Uuid> {
 }
 
 /**
+ * Local-tag list for a message whose send just SUCCEEDED (outbox `ItemCompleted`):
+ * drop [ChatProtocol.isPendingSendTag] so the bubble stops showing the pending
+ * clock. Returns null when the tag isn't present — the server echo already
+ * cleared it, or it was never pending — so the caller can skip a redundant
+ * upsert + BatchReceived. The success counterpart to [tagsForRetry].
+ */
+fun tagsForSendSuccess(existing: List<Uuid>): List<Uuid>? =
+    if (ChatProtocol.isPendingSendTag in existing) {
+        existing.filterNot { it == ChatProtocol.isPendingSendTag }
+    } else {
+        null
+    }
+
+/**
  * Builds the update request for retrying a message the server already has
  * (a later edit's update failed). Mirrors `ChatMessageSenderService.updateMessage`'s
  * update branch and `DriveOutboxUploader.retryAsUpdate`:

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/services/ResendHelpersTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/services/ResendHelpersTest.kt
@@ -2,6 +2,7 @@ package id.homebase.chat.services
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.uuid.Uuid
 
 class ResendHelpersTest {
@@ -93,5 +94,29 @@ class ResendHelpersTest {
     @Test
     fun emptyTagsGainPending() {
         assertEquals(listOf(ChatProtocol.isPendingSendTag), tagsForRetry(emptyList()))
+    }
+
+    // ---- tagsForSendSuccess (#1120) ----
+
+    @Test
+    fun pendingTagDroppedOnSuccess() {
+        val result = tagsForSendSuccess(listOf(otherTag, ChatProtocol.isPendingSendTag))
+        assertEquals(listOf(otherTag), result)
+    }
+
+    @Test
+    fun noPendingTagIsNoOp() {
+        // Already cleared by the server echo (or never pending) → null, so the
+        // caller skips a redundant upsert + BatchReceived.
+        assertNull(tagsForSendSuccess(listOf(otherTag)))
+        assertNull(tagsForSendSuccess(emptyList()))
+    }
+
+    @Test
+    fun onlyPendingTagDroppedOthersKept() {
+        assertEquals(
+            listOf(otherTag),
+            tagsForSendSuccess(listOf(ChatProtocol.isPendingSendTag, otherTag)),
+        )
     }
 }


### PR DESCRIPTION
## Symptom

A sent/forwarded message's bubble stays stuck on the **pending clock**
(`Icons.Default.Alarm`) — sometimes forever — while the **message-details** screen
and the recipient both show **Sent / Delivered**. Fixes #1120. (Inverse of the
conversation-list bug fixed in #1076/#1082, and same live-refresh gap class as #1042.)

## Root cause (traced, not guessed)

`isPendingSendTag` is a **local-only** tag (never uploaded to the server), and it is
**only ever cleared as a side effect** of the server-canonical copy syncing back and
replacing the optimistic row in `DriveMainIndex`. There is no explicit "send succeeded
→ clear the tag" step.

The optimistic row's `updated = ZeroTime` guarantees the *DB* row gets replaced on the
first echo (so **a cold reload always fixes it**). But the **open conversation window**
goes stale in this race:

1. `DriveSync` (silent — no `BatchReceived`) applies the echo to the DB first, bumping
   `modified` from `0` to the server timestamp and clearing the tag.
2. The duplicate WebSocket push then arrives with **equal `modified`** and is
   **guard-rejected** by `WHERE excluded.modified > DriveMainIndex.modified`.
3. `DriveWebSocketUpsertWorker` only **force-emits guard-rejected _soft-deletes_** (the
   #1042 fix) — not guard-rejected tag-clears — so **no `BatchReceived`** reaches the
   live window, and it keeps serving the stale `MessageUiModel(isPendingSend=true)`.

Result: bubble on the clock; details screen (which does a live server probe, bypassing
local state) correctly says Sent. They disagree until a cold reload.

## Fix

Stop depending solely on the async echo. On the **guaranteed** outbox `ItemCompleted`
signal, explicitly drop the message's `isPendingSendTag` — via
`OptimisticWriter.updateLocalTags`, a **local** write that also **emits `BatchReceived`**.
This removes the echo dependence **and** refreshes the live window in one move. It's the
exact success-side mirror of the existing `OutboxItemDropped → markSendFailed` handler.

- `ResendHelpers.tagsForSendSuccess()` — pure helper, inverse of `tagsForRetry`; returns
  `null` (no-op) when the pending tag isn't present.
- `ChatMessageStream`: new `OutboxEvent.ItemCompleted → markSendSucceeded`, gated on
  `ChatProtocol.MessageFileType`.

## Why it's safe

- `updateLocalTags` bumps `updated` by **+1 ms** (not `now()`), staying far below the
  server `modified`, so a later echo **still passes the guard** and replaces the row —
  the clear does not lock the echo out.
- The `MessageFileType` gate ignores non-message completions (conversation/admin files,
  reactions, read receipts). A spurious fire **no-ops** (`tagsForSendSuccess` → null).
- **No #1076/#1082 regression:** the tag is cleared only *after* a genuine upload
  success, so a still-sending message keeps its clock.
- Covers **edits** too (an edit re-stamps the pending tag; keying on `uniqueId` clears it
  on the edit's own `ItemCompleted`).

## Tests / verification

- `ResendHelpersTest`: 3 new `tagsForSendSuccess` cases (drop-on-success, no-op when
  absent, keep-other-tags). Authored before the helper (red-by-construction), now green.
- Full `:homebase-chat:jvmTest` suite green (incl. Konsist architecture checks).
- `:homebase-chat:compileKotlinJvm` + `:compileAndroidMain` green.

### Not device-verified — and why
This is an intermittent race. A normal send already flips to the tick via the echo, so a
device eyeball can't distinguish the fix; it can only confirm no regression on the happy
path. The fix is grounded in the traced mechanism + the deterministic `ItemCompleted`
signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
