### PR TITLE
fix(event): make event description autolink + selectable (#1117)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventDetailDialog.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventDetailDialog.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -58,6 +59,7 @@ import id.homebase.api.common.OdinId
 import kotlinx.collections.immutable.ImmutableList
 import id.homebase.chat.services.ChatMessageActionService
 import id.homebase.chat.services.convo.contact.ContactService
+import id.homebase.chat.widget.ChatMarkdown
 import id.homebase.chat.widget.MediaItem
 import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.OwnerAvatar
@@ -230,11 +232,19 @@ private fun EventDetailContent(
 
             if (descriptor.description.isNotBlank()) {
                 Spacer(Modifier.height(16.dp))
-                Text(
-                    text = descriptor.description,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
+                // Route through ChatMarkdown so URLs in the description autolink
+                // (tappable, opened via LocalUriHandler) exactly like a chat text
+                // bubble — the event description bypassed that entirely and was
+                // inert plain text (#1117). SelectionContainer adds copy-by-drag on
+                // top; unlike the meeting-URL ActionRow this block is not inside a
+                // clickable Surface, so nothing eats the selection gesture.
+                SelectionContainer {
+                    ChatMarkdown(
+                        content = descriptor.description,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
             }
 
             Spacer(Modifier.height(16.dp))


### PR DESCRIPTION
Fixes #1117

## Problem

The Event detail dialog rendered `descriptor.description` as a bare `Text` — no link annotation, no selection. A URL in the description (the reported case: a Facebook event link) was **dead, inert text**: you couldn't tap it to open, and couldn't drag-select it to copy it out by hand. A normal chat text bubble autolinks for free; the event description bypassed that entirely.

## Fix

`EventDetailDialog.kt`, the description block only:

```kotlin
SelectionContainer {
    ChatMarkdown(
        content = descriptor.description,
        style = MaterialTheme.typography.bodyMedium,
        color = MaterialTheme.colorScheme.onSurface,
    )
}
```

- **Tappable** — `ChatMarkdown` (the single read-only chat markdown renderer) emits URLs as native Compose `LinkAnnotation`s opened via `LocalUriHandler`, exactly like a message bubble. This is the real fix the issue recommends ("routing the event description through it is probably the whole fix").
- **Selectable** — `SelectionContainer` adds drag-to-copy as the floor. Unlike the meeting-URL `ActionRow`, this block is **not** inside a `clickable` Surface, so nothing eats the selection gesture — the Desktop selection-eating caveat the issue flags does not apply here.

+2 imports (`SelectionContainer`, `ChatMarkdown`); `Text` stays (used elsewhere in the file).

## Scope

Description in the detail dialog only — the reported surface. The in-chat `EventBubble` meeting-URL row is also inert, but tapping the bubble opens this dialog, and the issue scopes the fix to the description.

## Verification

- `:homebase-chat:compileKotlinJvm` clean.
- **Device-verified on Android** (Redmi Note 5 Pro, Android 11): created an event with `Join here https://github.com/homebase-id/chat-kmp/issues/1117 and copy me` as the description →
  - tapping the URL opened Chrome to issue #1117 ✅
  - long-press started a selection with a **Copy / Select all** toolbar ✅
  - link-tap and selection coexist — `SelectionContainer` does not swallow the link tap ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
