### PR TITLE
fix(auth): make logout unwedgeable + add dev-menu Force Logout

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthFlowManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthFlowManager.kt
@@ -23,6 +23,7 @@ import id.homebase.api.storage.SecureStorage
 import id.homebase.api.sync.DriveSyncManager
 import id.homebase.api.share.ShareAuthBridge
 import io.ktor.client.HttpClient
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -331,17 +332,30 @@ class YouAuthFlowManager(
         }
     }
 
-    /** Logout and clear credentials. */
-    suspend fun logout() {
+    /**
+     * Logout and clear credentials.
+     *
+     * Every teardown step is individually guarded: once we've decided to log out, no single
+     * failing step may block the `_authState` flip below. A corrupted shared secret or DB key
+     * makes calls like [DriveSyncManager.clearStorage] throw, and an unguarded throw here used
+     * to leave the app wedged half-authenticated with a dead logout button — recoverable only
+     * by clearing app data.
+     *
+     * Pass [force] to skip the backend notify entirely (dev menu escape hatch) — the server
+     * round-trip needs valid credentials, which is exactly what's broken in that state.
+     */
+    suspend fun logout(force: Boolean = false) {
         // Notify the backend first — this needs valid credentials.
-        try {
-            val credentials = CredentialStorage.getCredentials()
-            if (credentials != null) {
-                val provider = YouAuthProvider(httpClient, credentials.identity)
-                provider.logout()
+        if (!force) {
+            try {
+                val credentials = CredentialStorage.getCredentials()
+                if (credentials != null) {
+                    val provider = YouAuthProvider(httpClient, credentials.identity)
+                    provider.logout()
+                }
+            } catch (e: Exception) {
+                Logger.e(throwable = e, tag = TAG) { "Error during logout" }
             }
-        } catch (e: Exception) {
-            Logger.e(throwable = e, tag = TAG) { "Error during logout" }
         }
 
         // Tear down background work that reads credentials BEFORE nulling them.
@@ -351,29 +365,27 @@ class YouAuthFlowManager(
         // IllegalStateException: No active credentials set). stop() is idempotent;
         // AuthConnectionCoordinator.disconnect() will call it again when the
         // authState flip below lands.
-        driveSyncManager.stop()
+        stepOrLog("driveSyncManager.stop") { driveSyncManager.stop() }
 
         // Wipe all identity-scoped state BEFORE flipping _authState to Unauthenticated.
         // Emitting Unauthenticated tears down the authenticated nav graph (and with it
         // SettingsViewModel.viewModelScope, which is the coroutine currently running
         // this logout). If we emit first, driveSyncManager.clearStorage() — and any
         // other cache clears — get cancelled mid-flight, leaving stale DB rows behind.
-        credentialsManager.removeActiveCredentials()
-        driveSyncManager.clearStorage()
-        driveFileProviderCached.clearCaches()
-        publicProfileProviderCached.clearCaches()
+        stepOrLog("removeActiveCredentials") { credentialsManager.removeActiveCredentials() }
+        stepOrLog("clearStorage") { driveSyncManager.clearStorage() }
+        stepOrLog("driveFileProvider.clearCaches") { driveFileProviderCached.clearCaches() }
+        stepOrLog("publicProfileProvider.clearCaches") { publicProfileProviderCached.clearCaches() }
         // Platform caches (Coil memory cache, orphan coil3_disk_cache dir, anything
-        // else the app-level module wants to flush). Wrapped in runCatching so a
-        // failing hook can't block the authState flip that follows — we'd rather
-        // log out with a stale Coil entry than get stuck half-authenticated.
-        runCatching { clearPlatformCaches() }
-            .onFailure { Logger.e(throwable = it, tag = TAG) { "clearPlatformCaches failed" } }
-        CredentialStorage.clearCredentials()
-        ShareAuthBridge.clearAuth()
+        // else the app-level module wants to flush).
+        stepOrLog("clearPlatformCaches") { clearPlatformCaches() }
+        stepOrLog("clearCredentials") { CredentialStorage.clearCredentials() }
+        stepOrLog("clearAuth") { ShareAuthBridge.clearAuth() }
 
         _authState.value = YouAuthState.Unauthenticated
         Logger.i(tag = TAG) { "User logged out" }
     }
+
 
     /** Check if authentication is in progress. */
     val isAuthenticating: Boolean
@@ -414,5 +426,20 @@ class YouAuthFlowManager(
                 cancelAuth()
             }
         }
+    }
+}
+
+/**
+ * Run one logout teardown step, logging and swallowing any failure so the caller can always
+ * reach the `_authState` flip. Cancellation is rethrown — it means our own scope is going away,
+ * which is a different situation from a step that simply failed.
+ */
+internal suspend fun stepOrLog(name: String, step: suspend () -> Unit) {
+    try {
+        step()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Logger.e(throwable = e, tag = "YouAuth") { "Logout step '$name' failed — continuing" }
     }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthFlowManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthFlowManager.kt
@@ -372,15 +372,23 @@ class YouAuthFlowManager(
         // SettingsViewModel.viewModelScope, which is the coroutine currently running
         // this logout). If we emit first, driveSyncManager.clearStorage() — and any
         // other cache clears — get cancelled mid-flight, leaving stale DB rows behind.
+        //
+        // Credentials go first. They are what "logged in" actually means: CredentialStorage is
+        // the persistent copy that restoreSession() reads on the next launch, so if it survives,
+        // the user is silently signed back in no matter what the UI showed. Everything below it
+        // is cache/row cleanup — worth doing, but none of it can un-log-you-out. Ordering the
+        // fragile DB teardown ahead of the credential wipe (as this used to) meant a throwing
+        // clearStorage() left the Keychain populated.
         stepOrLog("removeActiveCredentials") { credentialsManager.removeActiveCredentials() }
+        stepOrLog("clearCredentials") { CredentialStorage.clearCredentials() }
+        stepOrLog("clearAuth") { ShareAuthBridge.clearAuth() }
+
         stepOrLog("clearStorage") { driveSyncManager.clearStorage() }
         stepOrLog("driveFileProvider.clearCaches") { driveFileProviderCached.clearCaches() }
         stepOrLog("publicProfileProvider.clearCaches") { publicProfileProviderCached.clearCaches() }
         // Platform caches (Coil memory cache, orphan coil3_disk_cache dir, anything
         // else the app-level module wants to flush).
         stepOrLog("clearPlatformCaches") { clearPlatformCaches() }
-        stepOrLog("clearCredentials") { CredentialStorage.clearCredentials() }
-        stepOrLog("clearAuth") { ShareAuthBridge.clearAuth() }
 
         _authState.value = YouAuthState.Unauthenticated
         Logger.i(tag = TAG) { "User logged out" }

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/youauth/LogoutStepOrLogTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/youauth/LogoutStepOrLogTest.kt
@@ -1,0 +1,45 @@
+package id.homebase.api.youauth
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * [stepOrLog] is what keeps logout from wedging: a teardown step that throws (corrupt DB key,
+ * unreadable keychain) must not stop the caller from reaching the `_authState` flip that
+ * actually signs the user out.
+ */
+class LogoutStepOrLogTest {
+
+    @Test
+    fun failingStepDoesNotPropagate() = runTest {
+        stepOrLog("boom") { error("teardown blew up") }
+    }
+
+    @Test
+    fun laterStepsStillRunAfterAnEarlierFailure() = runTest {
+        val ran = mutableListOf<String>()
+
+        stepOrLog("first") { ran += "first"; error("blew up") }
+        stepOrLog("second") { ran += "second" }
+
+        assertEquals(listOf("first", "second"), ran)
+    }
+
+    @Test
+    fun cancellationIsRethrown() = runTest {
+        assertFailsWith<CancellationException> {
+            stepOrLog("cancelled") { throw CancellationException("scope gone") }
+        }
+    }
+
+    @Test
+    fun successfulStepRuns() = runTest {
+        var ran = false
+        stepOrLog("ok") { ran = true }
+        assertTrue(ran)
+    }
+}

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/storage/SecureStorage.native.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/storage/SecureStorage.native.kt
@@ -21,6 +21,7 @@ import platform.Foundation.CFBridgingRetain
 import platform.Foundation.NSData
 import platform.Foundation.NSString
 import platform.Foundation.NSUTF8StringEncoding
+import platform.Foundation.NSUserDefaults
 import platform.Foundation.create
 import platform.Foundation.dataUsingEncoding
 import platform.Security.SecItemAdd
@@ -50,6 +51,38 @@ import platform.Security.kSecValueData
  */
 actual object SecureStorage {
     private const val SERVICE_NAME = "id.homebase.api.securestorage"
+
+    /**
+     * Marker written to NSUserDefaults on first use. UserDefaults lives in the app container and
+     * IS destroyed when the app is deleted; the Keychain is NOT. Its absence therefore means
+     * "this install has never run before".
+     */
+    private const val INSTALL_MARKER = "id.homebase.api.securestorage.installed"
+
+    init {
+        purgeKeychainIfFreshInstall()
+    }
+
+    /**
+     * Drop Keychain state left behind by a previous install.
+     *
+     * iOS deliberately preserves Keychain items across app deletion, which for us is actively
+     * harmful: this service holds both the YouAuth credentials and the SQLCipher key
+     * ([id.homebase.api.sync.database.DatabaseKeyManager]), while the database file itself lives
+     * in the app container and IS deleted. A reinstall would otherwise restore a session for an
+     * identity whose local data is gone, and hand a brand-new empty database the key of the old
+     * one — a mismatch that makes every subsequent DB read throw.
+     *
+     * Keeping this in `init` means it runs exactly once, on the first touch of this object,
+     * before any get/put can observe stale values — no startup-ordering wiring required.
+     */
+    private fun purgeKeychainIfFreshInstall() {
+        val defaults = NSUserDefaults.standardUserDefaults
+        if (defaults.boolForKey(INSTALL_MARKER)) return
+
+        clear()
+        defaults.setBool(true, INSTALL_MARKER)
+    }
 
     private fun createBaseQuery(key: String): CFDictionaryRef? {
         val dict = CFDictionaryCreateMutable(

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1225,6 +1225,10 @@
     <string name="dev_menu_network_last_good_ip_none">none captured yet</string>
     <string name="dev_menu_force_sync">Force Sync All</string>
     <string name="dev_menu_clear_data">Clear All Data</string>
+    <string name="dev_menu_force_logout">Force Logout (local only)</string>
+    <string name="dev_menu_force_logout_confirm_title">Force logout?</string>
+    <string name="dev_menu_force_logout_confirm_message">Clears credentials and all local data without contacting the server. Use this when the normal logout fails. You will need to sign in again, and anything not yet synced will be lost.</string>
+    <string name="dev_menu_force_logout_confirm_action">Force logout</string>
     <string name="dev_menu_test_notification">Test Rich Notification</string>
     <string name="dev_menu_test_temporal_read">Test temporal location read (Frodo)</string>
     <string name="dev_menu_test_scheduled_push">Test scheduled push notifications</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/devmenu/DeveloperMenuScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/devmenu/DeveloperMenuScreen.kt
@@ -58,6 +58,10 @@ import id.homebase.resources.cancel
 import id.homebase.resources.dev_menu_allow_ten_bit_video
 import id.homebase.resources.dev_menu_allow_ten_bit_video_description
 import id.homebase.resources.dev_menu_clear_data
+import id.homebase.resources.dev_menu_force_logout
+import id.homebase.resources.dev_menu_force_logout_confirm_action
+import id.homebase.resources.dev_menu_force_logout_confirm_message
+import id.homebase.resources.dev_menu_force_logout_confirm_title
 import id.homebase.resources.dev_menu_crash_confirm_action
 import id.homebase.resources.dev_menu_crash_confirm_message
 import id.homebase.resources.dev_menu_crash_confirm_title
@@ -138,6 +142,7 @@ fun DeveloperMenuUi(
 ) {
     val scrollState = rememberScrollState()
     var showCrashConfirm by remember { mutableStateOf(false) }
+    var showForceLogoutConfirm by remember { mutableStateOf(false) }
     val clipboard = LocalClipboard.current
     val clipboardScope = rememberCoroutineScope()
 
@@ -161,6 +166,32 @@ fun DeveloperMenuUi(
             },
             dismissButton = {
                 TextButton(onClick = { showCrashConfirm = false }) {
+                    Text(stringResource(MR.string.cancel))
+                }
+            },
+        )
+    }
+
+    if (showForceLogoutConfirm) {
+        AlertDialog(
+            onDismissRequest = { showForceLogoutConfirm = false },
+            title = { Text(stringResource(MR.string.dev_menu_force_logout_confirm_title)) },
+            text = { Text(stringResource(MR.string.dev_menu_force_logout_confirm_message)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showForceLogoutConfirm = false
+                        onAction(DeveloperMenuUiAction.ForceLogout)
+                    },
+                ) {
+                    Text(
+                        text = stringResource(MR.string.dev_menu_force_logout_confirm_action),
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showForceLogoutConfirm = false }) {
                     Text(stringResource(MR.string.cancel))
                 }
             },
@@ -235,6 +266,11 @@ fun DeveloperMenuUi(
                         label = stringResource(MR.string.dev_menu_clear_data),
                         showChevron = false,
                         onClick = { onAction(DeveloperMenuUiAction.ClearAllData) }
+                    )
+                    HelpClickableRow(
+                        label = stringResource(MR.string.dev_menu_force_logout),
+                        showChevron = false,
+                        onClick = { showForceLogoutConfirm = true }
                     )
                 }
             }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/devmenu/DeveloperMenuViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/devmenu/DeveloperMenuViewModel.kt
@@ -17,6 +17,7 @@ import id.homebase.api.client.peer.temporal.TemporalDriveReadProvider
 import id.homebase.api.common.OdinId
 import id.homebase.api.sync.DriveSyncManager
 import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.youauth.YouAuthFlowManager
 import id.homebase.core.config.locationLabeledDrive
 import id.homebase.core.notifications.RichNotificationData
 import id.homebase.core.notifications.RichNotificationDisplayer
@@ -38,6 +39,7 @@ class DeveloperMenuViewModel(
     private val userPreferences: UserPreferences,
     private val temporalDriveReadProvider: TemporalDriveReadProvider,
     private val serverIpStore: ServerIpStore,
+    private val youAuthFlowManager: YouAuthFlowManager,
 ) : ViewModel() {
 
     companion object {
@@ -84,6 +86,10 @@ class DeveloperMenuViewModel(
 
             is DeveloperMenuUiAction.ClearAllData -> {
                 clearAllData()
+            }
+
+            is DeveloperMenuUiAction.ForceLogout -> {
+                forceLogout()
             }
 
             is DeveloperMenuUiAction.TriggerTestCrash -> {
@@ -268,6 +274,20 @@ class DeveloperMenuViewModel(
     }
 
     /**
+     * Unconditional local logout — the escape hatch for a wedged session (corrupted shared
+     * secret, stale auth token, unreadable DB) where the normal Settings logout can't complete.
+     * Skips the backend notify, which is precisely the call that needs the credentials we no
+     * longer trust, and clears local state regardless of what fails on the way. The nav graph
+     * tears down on the resulting Unauthenticated flip, so no event is sent afterwards.
+     */
+    private fun forceLogout() {
+        viewModelScope.launch {
+            Logger.w(tag = "DeveloperMenu") { "Force logout triggered" }
+            youAuthFlowManager.logout(force = true)
+        }
+    }
+
+    /**
      * Intentionally crash the app to verify crash reporting end-to-end. Throws
      * an uncaught exception on the calling (main) thread so it propagates through
      * the platform crash handlers we install at startup — Firebase's native
@@ -311,6 +331,7 @@ sealed interface DeveloperMenuUiAction {
     data object ForceSyncAll : DeveloperMenuUiAction
     data object RunNetworkDiagnostics : DeveloperMenuUiAction
     data object ClearAllData : DeveloperMenuUiAction
+    data object ForceLogout : DeveloperMenuUiAction
     data object TriggerTestCrash : DeveloperMenuUiAction
     data object ForceReconnectWebSocket : DeveloperMenuUiAction
     data object ToggleAllowTenBitVideo : DeveloperMenuUiAction

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsViewModel.kt
@@ -2,6 +2,7 @@ package id.homebase.core.ui.screens.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
 import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.api.youauth.YouAuthFlowManager
 import id.homebase.core.logging.LoggerConfig
@@ -20,6 +21,10 @@ class SettingsViewModel(
     private val notificationService: NotificationService,
     private val shareCacheStorage: ShareCacheStorage,
 ) : ViewModel() {
+
+    private companion object {
+        const val TAG = "Settings"
+    }
 
     private val _uiState = MutableStateFlow(SettingsUiState())
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
@@ -107,9 +112,16 @@ class SettingsViewModel(
         _uiState.update { it.copy(isLoggingOut = true) }
 
         viewModelScope.launch {
-            LoggerConfig.purgeLogs()
-            notificationService.deleteToken()
-            shareCacheStorage.clearConversationCache()
+            // Pre-steps are best-effort: a failing log purge or cache clear must not stop the
+            // actual logout below. Before this guard, a throw here left isLoggingOut stuck true,
+            // which permanently deadened the logout button for the rest of the process.
+            runCatching { LoggerConfig.purgeLogs() }
+                .onFailure { Logger.e(throwable = it, tag = TAG) { "purgeLogs failed" } }
+            runCatching { notificationService.deleteToken() }
+                .onFailure { Logger.e(throwable = it, tag = TAG) { "deleteToken failed" } }
+            runCatching { shareCacheStorage.clearConversationCache() }
+                .onFailure { Logger.e(throwable = it, tag = TAG) { "clearConversationCache failed" } }
+
             youAuthFlowManager.logout()
             sendEvent(SettingsUiEvent.LoggedOut)
         }


### PR DESCRIPTION
## Why

I hit a state where the app was logged in but stuck: the session was bad (shared secret / auth token), the app couldn't recover on its own, **and the logout button also failed**. On iOS, uninstalling and reinstalling reproduced the same bad state.

Turned out to be three separate defects.

## 1. Logout could wedge permanently

`SettingsViewModel.handleLogout` ran three calls unguarded before the actual logout:

```kotlin
LoggerConfig.purgeLogs()
notificationService.deleteToken()
shareCacheStorage.clearConversationCache()
youAuthFlowManager.logout()   // never reached if any of the above throws
```

`isLoggingOut` is the authoritative one-in-flight gate and was never reset. So one throw meant logout was skipped *and* the flag stuck at `true` — every subsequent tap returned early and the button was dead for the rest of the process. That is the "logout button also fails" symptom, and it's unrecoverable without killing the app.

`YouAuthFlowManager.logout()` had the same shape internally: ~7 unguarded teardown steps ahead of the `_authState` flip. If e.g. `driveSyncManager.clearStorage()` throws against an unreadable DB, the flip never lands and the app sits half-authenticated.

Both now run each step through `stepOrLog()`, which logs and continues, so the `Unauthenticated` flip is always reached. `CancellationException` is rethrown — our own scope going away is a different situation from a step failing, and swallowing it would break structured concurrency.

Each failing step now names itself in the log, so the underlying cause stays diagnosable instead of being masked:

```
adb shell run-as id.homebase.feed.debug cat files/logs/homebase.log | grep "Logout step"
```

### Step order (second commit)

Guarding every step fixed the wedge but opened a quieter hole: the flip to `Unauthenticated` became reachable with the credentials still on disk. `CredentialStorage.clearCredentials()` sat at position 8, *behind* `clearStorage()` and three cache clears — so a throw in any of those meant the UI reported a clean logout while the Keychain still held the youauth trio, and the next launch's `restoreSession()` silently signed you back in.

Credentials now go first, since they're what "logged in" actually means:

```kotlin
stepOrLog("removeActiveCredentials") { ... }
stepOrLog("clearCredentials")        { ... }   // persistent copy restoreSession() reads
stepOrLog("clearAuth")               { ... }

stepOrLog("clearStorage")            { ... }   // fragile — now can't outrank the wipe
stepOrLog("driveFileProvider.clearCaches")     { ... }
...
```

Everything after the credential wipe is cache and row cleanup: worth doing, but none of it can un-log-you-out. The "wipe identity state before the flip" ordering the original comment describes is unchanged.

## 2. No escape hatch

New `logout(force = true)` skips the backend notify — that call needs valid credentials, which is exactly what's broken in the state this exists to escape. Everything else is identical.

Surfaced as **Developer Menu → Database & Storage → Force Logout (local only)**, behind a confirm dialog (reuses the existing crash-confirm pattern). Reachable via Settings → Help → tap the developer row 5×.

Works on both platforms — it's all commonMain, and `SecureStorage` is expect/actual:
- **iOS** → real Keychain `SecItemDelete` for identity / client auth token / shared secret
- **Android** → removes the KeyStore-encrypted entries from `secure_storage_prefs`

## 3. iOS: uninstall didn't recover

iOS deliberately preserves Keychain items across app deletion, while the app container (and the database in it) *is* destroyed. So reinstall → `restoreSession()` finds the surviving youauth trio → declares you authenticated → you land straight back in a session whose shared secret the server no longer honours.

`NSUserDefaults` lives in the container and *is* wiped on uninstall, so its absence marks a genuine first run. The check sits in `SecureStorage`'s `init`, which means it runs once on first touch of the object — before any `get`/`put` can observe stale values, and with no startup-ordering wiring to get wrong.

Android needs nothing here: `SharedPreferences` are destroyed on uninstall, so the orphan case doesn't exist.

## ⚠️ Open decision — please weigh in before merge

`INSTALL_MARKER` has never been written on any device, so **as written, the first launch of this build purges the Keychain for every existing iOS user** — a one-time forced re-login for the whole iOS base.

That self-heals affected devices with no user action, but the blast radius is unrelated to the fix's actual purpose. The alternative is to fire the purge only when the Keychain holds state but no database file exists (the true post-uninstall orphan):

```kotlin
val dbExists = NSFileManager.defaultManager
    .fileExistsAtPath("${iosDatabasesDir()}/$DB_FILE_NAME")
if (!dbExists) clear()
```

Healthy upgrades would then be untouched, and uninstall + reinstall still becomes a working recovery path. `iosDatabasesDir()` is reachable from `SecureStorage.native.kt`, so it's a ~3-line change. Happy to switch — say the word.

## Note on a wrong turn

I initially suspected the SQLCipher key (`DatabaseKeyManager`, same Keychain service) drifting from the DB file. Reading `DatabaseManager.initializeWithRecovery` (line 296), that case is already self-healing — failed open → `deleteOnDiskFiles()` → `clearKey()` → regenerate → retry. Not the cause; recording it so nobody re-investigates. Note that Force Logout deliberately does **not** clear the DB key: `clearStorage()` already wipes every row, and a key/file mismatch self-heals.

## Testing

- `LogoutStepOrLogTest` (new, commonTest) — a throwing step doesn't propagate, later steps still run, cancellation rethrows.
- **The step *ordering* is not unit-covered.** Asserting it needs a constructed `YouAuthFlowManager`, which pulls in `DriveSyncManager` (5 deps incl. `DatabaseManager`) and `DriveFileProviderCached` (→ `FileOperationsProvider`, real filesystem). That harness costs far more than the two-line move it would protect, so the invariant is stated in a comment above the steps instead. Worth revisiting if these deps ever get interfaces.
- `homebase-api:jvmTest`, `homebase-core:jvmTest`, `homebase-common:jvmTest` — green.
- Compile: JVM + Android + `iosSimulatorArm64` — green.
- **Not yet device-verified.** The iOS Keychain purge in particular is the kind of thing that needs a real install/uninstall/reinstall cycle on a device, not just a green build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

