### PR TITLE
fix(chat): stop logging raw AES conversation keys

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -1041,7 +1041,7 @@ class ConversationService(
         val domain = credentialsManager.requireActiveDomain()
         val leaveFile = getConversationHomebaseFile(conversationId)
         val preVersionTag = leaveFile?.fileMetadata?.versionTag
-        Logger.d { "leaveGroup START: conversationId=$conversationId forceLocalOnly=$forceLocalOnly isEncrypted=${leaveFile?.fileMetadata?.isEncrypted} aesKey=${leaveFile?.keyHeader?.aesKey?.unsafeBytes?.toBase64() ?: "NO FILE"}" }
+        Logger.d { "leaveGroup START: conversationId=$conversationId forceLocalOnly=$forceLocalOnly isEncrypted=${leaveFile?.fileMetadata?.isEncrypted}" }
         audit.pre("convo: isGroup=${conversation.isGroupConversation} legacyGroup=${conversation.isLegacyGroup} state=${conversation.conversationState} participants=${conversation.participants.size} admins=${conversation.admins.size} amIAdmin=${conversation.admins.contains(domain)}")
         audit.pre("file: exists=${leaveFile != null} versionTag=$preVersionTag")
 
@@ -1189,8 +1189,6 @@ class ConversationService(
 //                outboxSync.tryEnqueue(it)
 //            }
 
-//        val postLeaveFile = getConversationHomebaseFile(conversationId)
-//        Logger.d { "leaveGroup END: conversationId=$conversationId aesKey=${postLeaveFile?.keyHeader?.aesKey?.unsafeBytes?.toBase64() ?: "NO FILE"}" }
     }
 
     suspend fun acceptRejoin(conversationId: Uuid) {
@@ -1355,7 +1353,7 @@ class ConversationService(
         if (conversationFile == null) error("No conversation found")
         val preVersionTag = conversationFile.fileMetadata.versionTag
 
-        Logger.d { "updateConversationInternal: conversationId=$conversationId isEncrypted=${conversationFile.fileMetadata.isEncrypted} aesKey=${conversationFile.keyHeader.aesKey.unsafeBytes.toBase64()} ivLen=${conversationFile.keyHeader.iv.size} keyLen=${conversationFile.keyHeader.aesKey.unsafeBytes.size}" }
+        Logger.d { "updateConversationInternal: conversationId=$conversationId isEncrypted=${conversationFile.fileMetadata.isEncrypted} ivLen=${conversationFile.keyHeader.iv.size} keyLen=${conversationFile.keyHeader.aesKey.unsafeBytes.size}" }
 
         val keyHeader = KeyHeader(
             iv = ByteArrayUtil.getRndByteArray(16),
@@ -1468,7 +1466,7 @@ class ConversationService(
                 manifest = manifest
             )
 
-        Logger.d { "updateConversationInternal PRE-REQUEST: conversationId=$conversationId aesKey=${keyHeader.aesKey.unsafeBytes.toBase64()} versionTag=${conversationFile.fileMetadata.versionTag}" }
+        Logger.d { "updateConversationInternal PRE-REQUEST: conversationId=$conversationId versionTag=${conversationFile.fileMetadata.versionTag}" }
 
         // Full-shape log of what we're about to enqueue. Lets us read the
         // log and see exactly which recipients are on this push, whether the
@@ -1501,7 +1499,7 @@ class ConversationService(
                 thumbnails = thumbs
             )
 
-        Logger.d { "updateConversationInternal POST-ENCRYPT: conversationId=$conversationId aesKey=${keyHeader.aesKey.unsafeBytes.toBase64()} requestKeyHeader=${request.keyHeader?.aesKey?.unsafeBytes?.toBase64()}" }
+        Logger.d { "updateConversationInternal POST-ENCRYPT: conversationId=$conversationId keyHeaderPresent=${request.keyHeader != null}" }
 
         // Optimistically apply the participant/content change to the local DB immediately.
         // This ensures that any code running after this call (e.g. updateConversationTags)
@@ -2099,7 +2097,7 @@ class ConversationService(
         // tag"), and the outbox then pointlessly retries for hours. Skip the
         // server roundtrip and delete the local row directly.
         val isLocalOnlyPlaceholder = deleteFile != null && deleteFile.fileMetadata.versionTag == null
-        Logger.d { "deleteConversation: conversationId=$conversationId localOnly=$isLocalOnlyPlaceholder isEncrypted=${deleteFile?.fileMetadata?.isEncrypted} aesKey=${deleteFile?.keyHeader?.aesKey?.unsafeBytes?.toBase64() ?: "NO FILE"}" }
+        Logger.d { "deleteConversation: conversationId=$conversationId localOnly=$isLocalOnlyPlaceholder isEncrypted=${deleteFile?.fileMetadata?.isEncrypted}" }
 
         if (isLocalOnlyPlaceholder) {
             audit.step(1, "local-only placeholder — bypass server, delete local row + remove in-memory entry")


### PR DESCRIPTION
## Summary
- `ConversationService.kt` was logging the raw base64 AES key for a conversation (`keyHeader.aesKey.unsafeBytes.toBase64()`) at Debug level in `leaveGroup`, `updateConversationInternal` (×2 sites), and `deleteConversation`, plus a dead commented-out line doing the same.
- These logs persist to the on-device `homebase.log` file and are exportable via the app's "Submit Debug Log" feature, so the conversation's decryption key could end up in a log a user shares or that's pulled from a compromised device.
- Found during a security review of all commits on `main` since 2026-04-01 (unrelated to that review's original purpose — this is a real, standing issue, not evidence of tampering).

## Changes
- Removed the `aesKey=...toBase64()` interpolation from all five live log lines, keeping the rest of each line's diagnostic context (conversation ID, encryption flag, key length as an integer where relevant).
- Deleted the one dead commented-out log line doing the same thing.

## Test plan
- [x] `./gradlew :homebase-chat:compileKotlinJvm` passes
- [ ] Manual smoke test: leave group / update conversation / delete conversation still log expected diagnostic context, with no `aesKey=` in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)