### PR TITLE
feat(web): seamless login from an existing owner-console session (#853)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthFlowManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthFlowManager.kt
@@ -33,6 +33,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlin.concurrent.Volatile
 import kotlin.io.encoding.Base64
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 
 /** Authentication state for the YouAuth flow. */
 @Immutable
@@ -62,6 +64,20 @@ private data class AuthCodeFlowState(
     val identity: OdinId,
     val password: SecureByteArray,
     val keyPair: EccKeyPair
+)
+
+/**
+ * [AuthCodeFlowState] flattened for persistence across a full-page redirect (web seamless
+ * login). The popup flow keeps the app — and the in-memory [AuthCodeFlowState] — alive; the
+ * redirect flow reloads the whole app, so everything `completeAuth` needs must survive in
+ * storage. The private key inside [keyPair] is already encrypted with [passwordB64]'s bytes.
+ */
+@Serializable
+private data class PersistedRedirectFlow(
+    val identityDomain: String,
+    val passwordB64: String,
+    val keyPair: EccKeyPair,
+    val state: String
 )
 
 /**
@@ -97,6 +113,7 @@ class YouAuthFlowManager(
 
     companion object {
         private val TAG = "YouAuthFlowManager"
+        private val json = Json { ignoreUnknownKeys = true }
     }
 
     init {
@@ -184,6 +201,10 @@ class YouAuthFlowManager(
      * @param appId Application ID
      * @param appName Application name
      * @param drives List of drive access requests
+     * @param persistForRedirect Persist the flow state (ECC key pair, password, CSRF state) to
+     *   [SecureStorage] so `completeAuth` can restore it after a full-page navigation. Used by
+     *   the web seamless-login path, which redirects the top window to the authorize endpoint
+     *   (unloading the app) instead of opening a popup. See issue #853.
      */
     suspend fun authorize(
         identity: OdinId,
@@ -194,7 +215,8 @@ class YouAuthFlowManager(
         circlePermissions: List<AppCirclePermissionType>? = null,
         circleDrives: List<TargetDriveAccessRequest>? = null,
         circles: List<String>? = null,
-        clientFriendlyName: String? = null
+        clientFriendlyName: String? = null,
+        persistForRedirect: Boolean = false
     ): String {
         if (_authState.value == YouAuthState.Authenticating ||
             _authState.value is YouAuthState.Authenticated
@@ -215,6 +237,21 @@ class YouAuthFlowManager(
 
             // Register for callback
             callbackRegistry[state] = authCodeFlowState
+
+            if (persistForRedirect) {
+                SecureStorage.put(
+                    YouAuthStorageKeys.PENDING_REDIRECT_FLOW,
+                    json.encodeToString(
+                        PersistedRedirectFlow.serializer(),
+                        PersistedRedirectFlow(
+                            identityDomain = identity.domainName,
+                            passwordB64 = Base64.encode(password.unsafeBytes),
+                            keyPair = keyPair,
+                            state = state
+                        )
+                    )
+                )
+            }
 
             // Build redirect URI
             val redirectUri = RedirectConfig.buildRedirectUri(appId)
@@ -261,7 +298,7 @@ class YouAuthFlowManager(
 
     /** Complete the authentication flow after browser callback. */
     private suspend fun completeAuth(url: String, state: String, queryParams: Map<String, String>) {
-        val authCodeFlowState = callbackRegistry[state]
+        val authCodeFlowState = callbackRegistry[state] ?: restorePersistedRedirectFlow(state)
         if (authCodeFlowState == null) {
             // Duplicate or late callback — registry entry was already consumed.
             // Don't stomp on the current _authState.
@@ -328,7 +365,40 @@ class YouAuthFlowManager(
             _authState.value = YouAuthState.Error(e.message ?: "Unknown error")
         } finally {
             callbackRegistry.remove(state)
+            SecureStorage.remove(YouAuthStorageKeys.PENDING_REDIRECT_FLOW)
             callbackReceived = false
+        }
+    }
+
+    /**
+     * Restore a redirect-flow [AuthCodeFlowState] persisted by [authorize] with
+     * `persistForRedirect = true`. Returns null unless a persisted flow exists AND its CSRF
+     * `state` matches the callback's — a mismatched state means the callback is stale or forged
+     * and must not consume the pending flow's key material.
+     *
+     * On success, flips [authState] to [YouAuthState.Authenticating]: this app instance booted
+     * fresh after the redirect (restoreSession found no credentials and reported
+     * Unauthenticated), and the token exchange is now genuinely in progress.
+     */
+    private fun restorePersistedRedirectFlow(state: String): AuthCodeFlowState? {
+        val serialized = SecureStorage.get(YouAuthStorageKeys.PENDING_REDIRECT_FLOW) ?: return null
+        return try {
+            val persisted = json.decodeFromString(PersistedRedirectFlow.serializer(), serialized)
+            if (persisted.state != state) {
+                Logger.w(tag = TAG) { "Persisted redirect flow state mismatch — ignoring callback" }
+                null
+            } else {
+                _authState.value = YouAuthState.Authenticating
+                AuthCodeFlowState(
+                    identity = OdinId(persisted.identityDomain),
+                    password = SecureByteArray(persisted.passwordB64),
+                    keyPair = persisted.keyPair
+                )
+            }
+        } catch (e: Exception) {
+            Logger.e(throwable = e, tag = TAG) { "Failed to restore persisted redirect flow" }
+            SecureStorage.remove(YouAuthStorageKeys.PENDING_REDIRECT_FLOW)
+            null
         }
     }
 
@@ -407,6 +477,7 @@ class YouAuthFlowManager(
         if (_authState.value == YouAuthState.Authenticating) {
             Logger.i(tag = TAG) { "Authentication cancelled by user" }
             callbackRegistry.clear()
+            SecureStorage.remove(YouAuthStorageKeys.PENDING_REDIRECT_FLOW)
             callbackReceived = false
             _authState.value = YouAuthState.Unauthenticated
             credentialsManager.removeActiveCredentials()

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthStorageKeys.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/YouAuthStorageKeys.kt
@@ -13,4 +13,12 @@ object YouAuthStorageKeys {
 
     /** The last used username */
     const val USERNAME = "youauth_username"
+
+    /**
+     * Serialized in-flight auth flow state (ECC key pair + password + CSRF state) for the
+     * web redirect flow, where a full-page navigation to the authorize endpoint unloads the
+     * app and the in-memory callback registry with it. See [YouAuthFlowManager.authorize]
+     * with `persistForRedirect = true`.
+     */
+    const val PENDING_REDIRECT_FLOW = "youauth_pending_redirect_flow"
 }

--- a/webApp/src/wasmJsMain/kotlin/id/homebase/app/SeamlessOwnerLogin.kt
+++ b/webApp/src/wasmJsMain/kotlin/id/homebase/app/SeamlessOwnerLogin.kt
@@ -1,0 +1,75 @@
+package id.homebase.app
+
+import kotlinx.browser.document
+import kotlinx.browser.sessionStorage
+import kotlinx.browser.window
+
+/**
+ * Seamless owner-session login for the web app (issue #853).
+ *
+ * When the wasm bundle is hosted on the identity's own domain (production serves it under
+ * `/apps/chat-wasm/`), the owner console's session cookie lives on the same origin. Instead of
+ * showing the login form + YouAuth popup, we navigate the top window straight to the authorize
+ * endpoint: the cookie rides along, odin-core skips consent for same-origin first-party apps
+ * (`YouAuthUnifiedService.NeedConsent` — "Apps on /owner doesn't need consent"), and the user
+ * lands back here with the callback params, already authorized. This mirrors the JS chat app's
+ * `AutoAuthorize` component in odin-js.
+ *
+ * The redirect unloads the app, so [YouAuthFlowManager.authorize] is called with
+ * `persistForRedirect = true` to keep the ECDH key material available for the finalize step
+ * after reboot.
+ */
+object SeamlessOwnerLogin {
+    /**
+     * One-shot-per-tab guard against redirect loops: a finalize error routes back to the auth
+     * screen, which must NOT immediately re-redirect (odin-core has a known redirect-loop
+     * wrinkle in this flow — see the TODO in `YouAuthUnifiedService.NeedConsent`). The flag
+     * also, deliberately, suppresses auto-relogin after an explicit logout in the same tab:
+     * the user asked to be logged out; silently signing them back in would be hostile.
+     */
+    private const val ATTEMPTED_FLAG = "youauth_seamless_attempted"
+
+    private const val CALLBACK_PATH_SEGMENT = "authorization-code-callback"
+
+    /**
+     * The app is eligible for seamless login when it's served from an owner-apps path on the
+     * identity domain (mirrors odin-js's `pathname.startsWith(OWNER_APPS_ROOT)` check). The
+     * dev server (localhost, root path) and any external hosting fall through to the normal
+     * popup flow.
+     */
+    fun isEligible(): Boolean = window.location.pathname.startsWith("/apps/")
+
+    /** The identity is implicit in the origin — no manual Homebase-ID entry. */
+    fun identityFromOrigin(): String = window.location.host
+
+    /**
+     * If the current URL is a top-level YouAuth callback (redirect flow — the popup flow's
+     * callback never boots the app; index.html intercepts it via `window.opener` and closes),
+     * capture the full URL for [YouAuthFlowManager.handleCallback] and clean the address bar
+     * back to the app's base so the SPA router never sees the callback path. Returns null on
+     * a normal boot.
+     */
+    fun consumePendingCallbackUrl(): String? {
+        val location = window.location
+        if (!location.pathname.contains(CALLBACK_PATH_SEGMENT)) return null
+        if (!location.search.contains("state=")) return null
+        val href = location.href
+        window.history.replaceState(null, "", document.baseURI)
+        return href
+    }
+
+    /**
+     * Mark the seamless attempt for this tab session. Returns false if an attempt was already
+     * made (loop guard) — callers must then fall through to the normal login screen.
+     */
+    fun markAttemptedOnce(): Boolean {
+        if (sessionStorage.getItem(ATTEMPTED_FLAG) != null) return false
+        sessionStorage.setItem(ATTEMPTED_FLAG, "1")
+        return true
+    }
+
+    /** Top-level navigation to the authorize URL — unloads the app by design. */
+    fun navigateToAuthorize(url: String) {
+        window.location.href = url
+    }
+}

--- a/webApp/src/wasmJsMain/kotlin/id/homebase/app/main.wasm.kt
+++ b/webApp/src/wasmJsMain/kotlin/id/homebase/app/main.wasm.kt
@@ -4,13 +4,23 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.ComposeViewport
 import androidx.navigation.ExperimentalBrowserHistoryApi
 import androidx.navigation.bindToBrowserNavigation
+import id.homebase.api.common.OdinId
 import id.homebase.api.sync.database.DatabaseDriverFactory
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.initWebSqlJs
+import id.homebase.api.youauth.YouAuthFlowManager
+import id.homebase.api.youauth.YouAuthState
 import id.homebase.core.App
 import id.homebase.core.auth.AuthConnectionCoordinator
+import id.homebase.core.config.AUTO_CONNECTIONS_CIRCLE_ID
+import id.homebase.core.config.AppConfig
+import id.homebase.core.config.CONFIRMED_CONNECTIONS_CIRCLE_ID
+import id.homebase.core.config.appPermissions
+import id.homebase.core.config.circleDriveTargetRequest
+import id.homebase.core.config.targetDriveAccessRequest
 import id.homebase.core.di.allModules
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.koin.core.context.GlobalContext
 import org.koin.core.context.startKoin
@@ -24,6 +34,43 @@ fun main() {
         initWebSqlJs()
         DatabaseManager.initializeWithRecovery(DatabaseDriverFactory())
         startKoin { modules(allModules) }
+
+        // Seamless owner-session login (issue #853). Two halves, both no-ops on the dev server:
+        //  - Boot after the authorize redirect: the URL carries the callback params; feed them
+        //    to handleCallback (which restores the persisted ECDH state) and boot the UI while
+        //    the token exchange finishes.
+        //  - Fresh unauthenticated boot on an identity origin: skip the login form, redirect
+        //    the top window to the authorize endpoint, and let the owner cookie do the work.
+        val youAuthFlowManager = GlobalContext.get().get<YouAuthFlowManager>()
+        val callbackUrl = SeamlessOwnerLogin.consumePendingCallbackUrl()
+        if (callbackUrl != null) {
+            launch { youAuthFlowManager.handleCallback(callbackUrl) }
+        } else if (SeamlessOwnerLogin.isEligible()) {
+            // Wait for restoreSession() (launched in the manager's init) to decide whether
+            // stored credentials exist — redirecting while already authenticated would be wrong.
+            val authState = youAuthFlowManager.authState.first { it != YouAuthState.Initializing }
+            if (authState == YouAuthState.Unauthenticated && SeamlessOwnerLogin.markAttemptedOnce()) {
+                try {
+                    val authorizeUrl = youAuthFlowManager.authorize(
+                        identity = OdinId(SeamlessOwnerLogin.identityFromOrigin()),
+                        appId = AppConfig.APP_ID,
+                        appName = AppConfig.APP_NAME,
+                        drives = targetDriveAccessRequest,
+                        permissions = appPermissions,
+                        circleDrives = circleDriveTargetRequest,
+                        circles = listOf(CONFIRMED_CONNECTIONS_CIRCLE_ID, AUTO_CONNECTIONS_CIRCLE_ID),
+                        persistForRedirect = true
+                    )
+                    SeamlessOwnerLogin.navigateToAuthorize(authorizeUrl)
+                    return@launch // page is navigating away — don't boot the UI
+                } catch (e: Exception) {
+                    // Fall through to the normal login screen; the attempt flag prevents loops.
+                    println("SeamlessOwnerLogin: seamless authorize failed — ${e.message}")
+                    youAuthFlowManager.cancelAuth()
+                }
+            }
+        }
+
         // Promote AuthConnectionCoordinator out of headless mode. Like desktop,
         // the web app has no FCM cold-wake — loading the page IS the foreground
         // signal — so without this the Authenticated branch defers connect()


### PR DESCRIPTION
Closes #853.

## What
On web (wasmJs), when the app is hosted on the identity's own domain (`/apps/...` path), skip the login form + YouAuth popup entirely: navigate the top window to the existing `/api/owner/v1/youauth/authorize` endpoint. The owner console's session cookie rides along, and odin-core's same-origin first-party rule (`YouAuthUnifiedService.NeedConsent` — "Apps on /owner doesn't need consent") skips the consent screen. The user lands back in the app already authorized. This mirrors the JS chat app's `AutoAuthorize` flow in odin-js — see the [investigation comment](https://github.com/homebase-id/chat-kmp/issues/853#issuecomment-5038762376) for the full mechanism.

**No backend or owner-console changes needed** — the consent-skip and app-registration flows already exist server-side. And since this repo's `APP_ID` is the same GUID as odin-js's `CHAT_APP_ID`, users of the JS chat app already have the app registered → true zero-prompt login.

## How
- **`YouAuthFlowManager`**: `authorize()` gains `persistForRedirect` — the redirect unloads the app, so the ECDH key pair, password, and CSRF state are persisted to `SecureStorage` (new `PENDING_REDIRECT_FLOW` key) and restored by `completeAuth` on the post-redirect boot. A state mismatch rejects the callback without consuming the pending flow's key material; the persisted flow is cleared on completion and on `cancelAuth()`.
- **`SeamlessOwnerLogin`** (new, webApp): eligibility check (`pathname.startsWith("/apps/")`, mirroring odin-js's owner-root check), identity derived from origin (no manual entry), callback-URL capture + address-bar cleanup before the SPA router boots, and a per-tab `sessionStorage` loop guard.
- **`main.wasm.kt`**: boot wiring — callback params present → finalize in-app; fresh unauthenticated boot on an identity origin → redirect to authorize instead of showing the login form. Waits for `restoreSession()` to resolve so an authenticated boot never redirects.

## Safeguards
- Loop guard: one seamless attempt per tab session — a finalize error falls through to the normal login form instead of re-redirecting (odin-core has a known redirect-loop wrinkle in this flow).
- The same flag deliberately suppresses auto-relogin after an explicit logout in the same tab.
- Dev server (localhost, root path) and external hosts are ineligible → existing popup flow unchanged.
- Native platforms untouched (all new behavior is wasmJs-only).

## Testing
- [x] `:webApp:compileKotlinWasmJs`, `:homebase-api:compileKotlinJvm`, `:homebase-api:compileAndroidMain`, `:homebase-api:compileKotlinIosSimulatorArm64` all pass
- [x] `homebase-api:jvmTest` passes
- [ ] **Needs a deployed run on an identity domain** — the seamless path is deliberately unreachable on the dev server. Verify: logged-in owner → open web chat → lands authenticated, no popup; logged-out → owner login → straight in; logout → login form (no auto-relogin); popup flow still works from external hosting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)