### PR TITLE
fix(contactbook): clear search when the searched contact is deleted (#876)

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -140,6 +140,7 @@ import id.homebase.core.contactbook.ContactBookPreferences
 import id.homebase.core.ui.screens.contactbook.CircleMemberPickerScreen
 import id.homebase.core.ui.screens.contactbook.ContactBookScreen
 import id.homebase.core.ui.screens.contactbook.add.AddContactScreen
+import id.homebase.core.ui.screens.contactbook.ContactBookUiAction
 import id.homebase.core.ui.screens.contactbook.ContactBookUiEvent
 import id.homebase.core.ui.screens.contactbook.ContactBookViewModel
 import id.homebase.core.ui.screens.contactbook.detail.ContactDetailScreen
@@ -891,6 +892,15 @@ fun AppNavHost(
                                     viewModel = koinViewModel(),
                                     connectRequestViewModel = koinViewModel(),
                                     onBack = { navController.popBackStack() },
+                                    onDeleted = {
+                                        // The deleted contact may have been the search's only
+                                        // match — clear the query so the contact book shows the
+                                        // full list instead of a stale empty "no results" (#876).
+                                        contactBookViewModel.onAction(
+                                            ContactBookUiAction.SearchChanged("")
+                                        )
+                                        navController.popBackStack()
+                                    },
                                     onOpenConversation = { conversationId ->
                                         navController.selectConversationOnChatList(conversationId)
                                         navController.popBackStack(Route.ChatList, inclusive = false)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailScreen.kt
@@ -140,6 +140,9 @@ fun ContactDetailScreen(
     viewModel: ContactDetailViewModel,
     connectRequestViewModel: ConnectRequestViewModel,
     onBack: () -> Unit,
+    // Separate from onBack: fired only when the contact was actually deleted, so the
+    // contact book can clear a search whose only match may just have disappeared (#876).
+    onDeleted: () -> Unit = onBack,
     onOpenConversation: (Uuid) -> Unit,
     onSeeAllMedia: (conversationId: String) -> Unit,
     onOpenContact: (uniqueId: String, odinId: String?) -> Unit,
@@ -169,6 +172,7 @@ fun ContactDetailScreen(
                 is ContactDetailEvent.OpenConversation -> onOpenConversation(event.conversationId)
                 is ContactDetailEvent.SeeAllMedia -> onSeeAllMedia(event.conversationId)
                 ContactDetailEvent.Back -> onBack()
+                ContactDetailEvent.DeletedAndBack -> onDeleted()
                 ContactDetailEvent.Error -> snackbarHostState.showSnackbar(errSave)
                 ContactDetailEvent.Forbidden -> snackbarHostState.showSnackbar(errForbidden)
                 ContactDetailEvent.DeleteError -> snackbarHostState.showSnackbar(errDelete)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailUiState.kt
@@ -131,6 +131,13 @@ sealed interface ContactDetailEvent {
     data class OpenConversation(val conversationId: Uuid) : ContactDetailEvent
     data class SeeAllMedia(val conversationId: String) : ContactDetailEvent
     data object Back : ContactDetailEvent
+
+    /**
+     * The contact was deleted and the screen should close. Distinct from [Back] so the
+     * contact book can clear its search query — the deleted contact may have been the
+     * query's only match, and a plain back must NOT clear an in-progress search (#876).
+     */
+    data object DeletedAndBack : ContactDetailEvent
     data object Error : ContactDetailEvent
     /** 403 — app lacks manage-contacts permission. */
     data object Forbidden : ContactDetailEvent

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailViewModel.kt
@@ -688,7 +688,7 @@ class ContactDetailViewModel(
                         }
                         // repo.delete does the optimistic remove and restores on failure.
                         val event = try {
-                            if (contactRepository.delete(entry.uniqueId)) ContactDetailEvent.Back
+                            if (contactRepository.delete(entry.uniqueId)) ContactDetailEvent.DeletedAndBack
                             else ContactDetailEvent.DeleteError
                         } catch (e: ForbiddenException) {
                             ContactDetailEvent.DeleteForbidden


### PR DESCRIPTION
Closes #876.

## Problem
Search for a contact → open it → delete it → return: the search text was still there but the list was empty, because the only match was the contact just deleted (the query lives in `ContactBookViewModel`, which survives the detail-screen round-trip).

## Fix
Exactly the mechanism proposed in the issue — an explicit delete signal, reusing the existing `SearchChanged("")` reset path:

- `ContactDetailEvent.DeletedAndBack` (new): emitted only on successful delete. Plain `Back` is untouched, so browsing in/out of a contact **preserves** an in-progress search.
- `ContactDetailScreen` gains `onDeleted: () -> Unit = onBack` and routes the new event to it.
- `AppNavHost` wires `onDeleted` to dispatch `ContactBookUiAction.SearchChanged("")` on the shared `contactBookViewModel`, then `popBackStack()`. The existing `searchActive` reset already drops the field's focus/selected state.

## Acceptance criteria
- [x] Search → open → delete → return shows the full contact list with the search cleared
- [x] Returning without deleting preserves the in-progress search (`Back` path unchanged)
- [x] No stale empty "no results" state after deleting a query's only match

## Testing
- [x] `:homebase-core:compileKotlinJvm` and `:homebase-core:jvmTest` pass
- [ ] Manual: the delete-and-return flow on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)