### PR TITLE
feat(sync): sync the Profile drive at startup like Chat/Contacts (#1105)

### DIFF
--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/config/AppConfig.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/config/AppConfig.kt
@@ -227,14 +227,12 @@ val vaultTargetDriveAccessRequest: List<TargetDriveAccessRequest> = listOf(
 // Chat and Contacts power messaging.
 // See ADDING_ADDON_APPS.md §"Mandatory vs Optional Drives" for the full model.
 //
-// Profile drive intentionally omitted: owner display name / avatar are loaded via
-// the public unauthenticated `https://{odinId}/pub/profile` endpoint
-// (PublicProfileProviderCached), not through the drive sync engine. Adding
-// profileLabeledDrive here would start additional HTTP polling on every login for
-// content nothing currently reads — wire it in only when a feature actually needs
-// the profile drive synced into the local SQLDelight index.
+// Profile drive is synced like Chat/Contacts so the owner's standard-profile attributes
+// (fileType=77) are indexed locally and available offline (#1105). Display name / avatar
+// continue to come from the public `https://{odinId}/pub/profile` endpoint
+// (PublicProfileProviderCached) — that's a separate, cache-backed path.
 val mandatorySyncDrives: List<LabeledDrive> =
-    listOf(chatLabeledDrive, contactLabeledDrive /*, profileLabeledDrive */)
+    listOf(chatLabeledDrive, contactLabeledDrive, profileLabeledDrive)
 
 // Feed-specific permission config
 val feedTargetDriveAccessRequest: List<TargetDriveAccessRequest> = listOf(


### PR DESCRIPTION
Refs #1105.

## Change
Adds `profileLabeledDrive` to `mandatorySyncDrives`, so the Profile drive is synced into the local SQLDelight index at startup like Chat and Contacts. The owner's standard-profile attributes (`fileType=77`) are now indexed locally and available offline, instead of the Profile drive being the lone unsynced system drive.

Display name / avatar are unaffected — they continue to load from the public `/pub/profile` endpoint via `PublicProfileProviderCached` (a separate, cache-backed path). The app already holds Read permission on the Profile drive (the editor's existing prefill read), so the sync engine can pull it with no permission change.

## On #1105's question
The issue asked whether Profile *should* be synced. Worth recording: the premise that "almost every system drive is synced, Profile is the exception" doesn't match the code — only Chat and Contacts were mandatory-synced; Stickers/Location/Vault/Feed are all on-demand. So Profile wasn't a unique exception. This PR nonetheless brings it in line with the two indexed drives per the decision to sync it.

## Scope / follow-up
This wires up the **sync** only. `ProfileRepository.loadAttributes` still does its remote read, so nothing consumes the local copy yet. Flipping the profile editor's *display* read to the local index is a deliberate follow-up — the same `loadAttributes`/`photoAttribute` methods also back the 409-recovery and photo-dedup reads in `save`/`uploadPhoto`, which must stay authoritative (remote) or saves loop / photos duplicate under contention. That split is a separate, careful change.

## Testing
- [x] `:homebase-common:compileKotlinJvm` passes
- [ ] Verify the Profile drive appears in the cold-start sync fan-out and its attributes land in the local index

🤖 Generated with [Claude Code](https://claude.com/claude-code)