### PR TITLE
fix(video): 10-bit capture fails closed + decode-failure message (#959)

### DIFF
--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/video/FFmpegUtils.android.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/video/FFmpegUtils.android.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.core.net.toUri
 import com.arthenica.ffmpegkit.FFmpegKit
 import com.arthenica.ffmpegkit.FFmpegKitConfig
+import com.arthenica.ffmpegkit.FFprobeKit
 import com.arthenica.ffmpegkit.FFmpegSession
 import com.arthenica.ffmpegkit.FFmpegSessionCompleteCallback
 import com.arthenica.ffmpegkit.ReturnCode
@@ -258,15 +259,55 @@ actual object FFmpegUtils {
         val videoMime: String?,
         val widthPx: Int,
         val heightPx: Int,
-        val bitDepth: Int,
-        val isHdr: Boolean,
+        /** Null when MediaExtractor didn't expose the profile/color keys — see [readBitDepth]. */
+        val bitDepth: Int?,
+        val isHdr: Boolean?,
     )
 
     actual suspend fun probeVideo(inputPath: String): VideoTrackInfo? = withContext(Dispatchers.IO) {
         if (!File(inputPath).exists()) return@withContext null
         val p = probeVideoTrack(inputPath)
         if (p.videoMime == null && p.widthPx == 0 && p.heightPx == 0) return@withContext null
-        VideoTrackInfo(p.videoMime, p.widthPx, p.heightPx, p.bitDepth, p.isHdr)
+
+        // MediaExtractor is fast but omits KEY_PROFILE / colour-transfer for many in-app camera
+        // captures, leaving bit depth / HDR undetermined (null). Rather than assume 8-bit SDR
+        // (the fail-open that shipped undecodable 10-bit High-10 clips, #959), resolve the nulls
+        // with an authoritative ffprobe read — so an in-budget 8-bit clip still passes through and
+        // a 10-bit one is caught. If ffprobe also can't tell, the value stays null and the planner
+        // fails closed (re-encodes) anyway.
+        var bitDepth = p.bitDepth
+        var isHdr = p.isHdr
+        if (bitDepth == null || isHdr == null) {
+            val tags = ffprobeColorTags(inputPath)
+            if (bitDepth == null) bitDepth = bitDepthFromPixFmt(tags?.pixFmt)
+            if (isHdr == null) isHdr = isHdrFromColorTags(tags?.colorTransfer, tags?.colorPrimaries)
+        }
+        VideoTrackInfo(p.videoMime, p.widthPx, p.heightPx, bitDepth, isHdr)
+    }
+
+    private data class ColorTags(
+        val pixFmt: String?,
+        val colorTransfer: String?,
+        val colorPrimaries: String?,
+    )
+
+    /**
+     * Authoritative colour-tag read via FFprobeKit's MediaInformation — the fallback when the fast
+     * MediaExtractor probe leaves bit depth / HDR undetermined (#959). Returns null on any failure;
+     * the caller then leaves the values null and the planner re-encodes to be safe.
+     */
+    private fun ffprobeColorTags(inputPath: String): ColorTags? = try {
+        val info = FFprobeKit.getMediaInformation(inputPath)?.mediaInformation
+        val stream = info?.streams?.firstOrNull { it.type == "video" }
+        if (stream == null) null
+        else ColorTags(
+            pixFmt = stream.getStringProperty("pix_fmt"),
+            colorTransfer = stream.getStringProperty("color_transfer"),
+            colorPrimaries = stream.getStringProperty("color_primaries"),
+        )
+    } catch (e: Exception) {
+        Log.w(TAG, "ffprobe colour-tag fallback failed for $inputPath", e)
+        null
     }
 
     private fun probeVideoTrack(inputPath: String): VideoTrackProbe {
@@ -275,8 +316,8 @@ actual object FFmpegUtils {
         var videoMime: String? = null
         var widthPx = 0
         var heightPx = 0
-        var bitDepth = 8
-        var isHdr = false
+        var bitDepth: Int? = null
+        var isHdr: Boolean? = null
 
         val extractor = android.media.MediaExtractor()
         try {
@@ -307,15 +348,17 @@ actual object FFmpegUtils {
     }
 
     /**
-     * Luma bit depth of the video track, inferred from the codec profile.
-     * Returns 8 when the profile is missing or a known 8-bit one. 10-bit
-     * profiles (H.264 High 10, HEVC Main 10, VP9 Profile 2, AV1 Main with
-     * 10-bit) must be re-encoded so the output can be pinned to 8-bit.
+     * Luma bit depth of the video track, inferred from the codec profile — or **null** when
+     * `KEY_PROFILE` is absent (MediaExtractor omits it for many in-app camera captures). Null must
+     * NOT be assumed 8-bit (that fail-open shipped 10-bit High-10 clips receivers can't decode,
+     * #959): the caller resolves null via an authoritative ffprobe read. A present profile yields 10
+     * for the known 10-bit profiles (H.264 High 10, HEVC Main 10, VP9 Profile 2/3), else 8.
      */
-    private fun readBitDepth(fmt: android.media.MediaFormat): Int {
-        val profile = if (fmt.containsKey(android.media.MediaFormat.KEY_PROFILE)) {
-            try { fmt.getInteger(android.media.MediaFormat.KEY_PROFILE) } catch (_: Exception) { -1 }
-        } else -1
+    private fun readBitDepth(fmt: android.media.MediaFormat): Int? {
+        if (!fmt.containsKey(android.media.MediaFormat.KEY_PROFILE)) return null
+        val profile = try {
+            fmt.getInteger(android.media.MediaFormat.KEY_PROFILE)
+        } catch (_: Exception) { return null }
         val tenBitProfiles = setOf(
             android.media.MediaCodecInfo.CodecProfileLevel.AVCProfileHigh10,
             android.media.MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10,
@@ -331,21 +374,22 @@ actual object FFmpegUtils {
 
     /**
      * HDR detection mirroring Signal's MediaCodecCompat.isHdrVideo (see
-     * [VideoThumbnailsMediaCodec]'s copy): a PQ/HLG colour-transfer, or static
-     * HDR10 / dynamic HDR10+ metadata on the track.
+     * [VideoThumbnailsMediaCodec]'s copy): a PQ/HLG colour-transfer, or static HDR10 / dynamic
+     * HDR10+ metadata on the track. Returns **null** when none of those keys are present at all
+     * (undeterminable — the caller resolves it via ffprobe rather than assuming SDR, #959).
      */
-    private fun readIsHdr(fmt: android.media.MediaFormat): Boolean {
-        val transfer = if (fmt.containsKey(android.media.MediaFormat.KEY_COLOR_TRANSFER)) {
-            try { fmt.getInteger(android.media.MediaFormat.KEY_COLOR_TRANSFER) } catch (_: Exception) { -1 }
-        } else -1
-        if (transfer == android.media.MediaFormat.COLOR_TRANSFER_ST2084 ||
-            transfer == android.media.MediaFormat.COLOR_TRANSFER_HLG
-        ) return true
-        if (fmt.containsKey(android.media.MediaFormat.KEY_HDR_STATIC_INFO)) return true
-        if (android.os.Build.VERSION.SDK_INT >= 29 &&
+    private fun readIsHdr(fmt: android.media.MediaFormat): Boolean? {
+        val hasTransfer = fmt.containsKey(android.media.MediaFormat.KEY_COLOR_TRANSFER)
+        val hasStatic = fmt.containsKey(android.media.MediaFormat.KEY_HDR_STATIC_INFO)
+        val hasPlus = android.os.Build.VERSION.SDK_INT >= 29 &&
             fmt.containsKey(android.media.MediaFormat.KEY_HDR10_PLUS_INFO)
-        ) return true
-        return false
+        if (!hasTransfer && !hasStatic && !hasPlus) return null
+        if (hasStatic || hasPlus) return true
+        val transfer = try {
+            fmt.getInteger(android.media.MediaFormat.KEY_COLOR_TRANSFER)
+        } catch (_: Exception) { return null }
+        return transfer == android.media.MediaFormat.COLOR_TRANSFER_ST2084 ||
+            transfer == android.media.MediaFormat.COLOR_TRANSFER_HLG
     }
 
     private fun readDim(format: android.media.MediaFormat, primary: String, display: String): Int {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/FFmpegUtils.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/FFmpegUtils.kt
@@ -13,8 +13,11 @@ data class VideoTrackInfo(
     val codec: String?,
     val widthPx: Int,
     val heightPx: Int,
-    val bitDepth: Int,
-    val isHdr: Boolean,
+    /** Luma bit depth, or null when the probe couldn't determine it. Null must be treated as
+     *  "possibly 10-bit" (fail closed) — see [FfmpegCompressPlanner.isAlreadyOptimal] (#959). */
+    val bitDepth: Int?,
+    /** HDR flag, or null when the probe couldn't determine it (fail closed, as with [bitDepth]). */
+    val isHdr: Boolean?,
 )
 
 @LowLevelFfmpegApi

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/FfmpegCompressPlanner.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/FfmpegCompressPlanner.kt
@@ -116,8 +116,10 @@ object FfmpegCompressPlanner {
         inputBytes: Long,
         rotationDegrees: Int = 0,
         encoder: String = "libx264",
-        probedBitDepth: Int = 8,
-        probedIsHdr: Boolean = false,
+        // Null = the probe couldn't determine this; treated as "possibly 10-bit/HDR" and re-encoded
+        // (fail closed) rather than passed through. See [isAlreadyOptimal] (#959).
+        probedBitDepth: Int? = null,
+        probedIsHdr: Boolean? = null,
         allowTenBit: Boolean = false,
     ): FfmpegCompressPlan {
         // Reason in display dims from here on — FFmpeg auto-rotate has already
@@ -183,7 +185,8 @@ object FfmpegCompressPlanner {
             // allowTenBit (dev/test only): keep a >8-bit source at 10-bit
             // (yuv420p10le → High 10) so the 10-bit pipeline can be inspected.
             // 8-bit sources stay 8-bit regardless — the flag permits, not forces.
-            val outputPixFmt = if (allowTenBit && probedBitDepth > 8) "yuv420p10le" else "yuv420p"
+            val outputPixFmt =
+                if (allowTenBit && (probedBitDepth ?: 0) > 8) "yuv420p10le" else "yuv420p"
             add("-pix_fmt"); add(outputPixFmt)
             add("-c:a"); add("aac")
             add("-b:a"); add("${targets.audioBitrateBps / 1000}k")
@@ -222,13 +225,24 @@ object FfmpegCompressPlanner {
         inputBytes: Long,
         durationMs: Long,
         targets: QualityTargets,
-        bitDepth: Int = 8,
-        isHdr: Boolean = false,
+        bitDepth: Int? = null,
+        isHdr: Boolean? = null,
         allowTenBit: Boolean = false,
     ): Boolean {
         if (codecMime == null || widthPx <= 0 || heightPx <= 0 || durationMs <= 0) return false
-        if (bitDepth > 8 && !allowTenBit) return false
-        if (isHdr) return false
+        // Fail closed on the 8-bit-SDR pin. Pass-through requires the probe to POSITIVELY confirm
+        // 8-bit AND not-HDR; a null (undeterminable) bit depth or HDR flag means the probe could
+        // not rule out a 10-bit/HDR source — Android's MediaExtractor omits KEY_PROFILE /
+        // color-transfer for many in-app camera captures — so we re-encode (the encode leg pins
+        // yuv420p) rather than ship the original 10-bit High-10 bytes untouched (#959).
+        if (!allowTenBit) {
+            if (bitDepth != 8) return false      // null or >8 → re-encode
+            if (isHdr != false) return false     // null or true → re-encode
+        } else {
+            // Toggle on: the user opted into 10-bit pass-through, but a positively-detected HDR
+            // source still re-encodes (HDR is a decode problem beyond bit depth).
+            if (isHdr == true) return false
+        }
         if (!isH264(codecMime)) return false
         val shortEdgePx = minOf(widthPx, heightPx)
         if (shortEdgePx > targets.shortEdgePx) return false

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoProbeTags.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoProbeTags.kt
@@ -1,0 +1,37 @@
+package id.homebase.api.video
+
+/**
+ * Shared ffprobe colour-tag parsing, used by every platform's authoritative probe path so the
+ * 8-bit/HDR determination is identical across Android (FFprobeKit fallback), JVM (ffprobe binary),
+ * and iOS. All functions are fail-closed: they return **null** ("couldn't determine") rather than
+ * defaulting to 8-bit/SDR, so an undeterminable source is re-encoded, never passed through (#959).
+ */
+
+/**
+ * Luma bit depth inferred from an ffprobe `pix_fmt` token, or null when the token is blank/absent
+ * (undeterminable). ffmpeg names 10/12-bit formats with a `10`/`12` infix (e.g. `yuv420p10le`,
+ * `p010le`); a present token without one is a positive 8-bit result.
+ */
+internal fun bitDepthFromPixFmt(pixFmt: String?): Int? {
+    val f = pixFmt?.trim()?.lowercase()
+    return when {
+        f.isNullOrBlank() -> null
+        "12" in f -> 12
+        "10" in f || f.startsWith("p010") -> 10
+        else -> 8
+    }
+}
+
+/**
+ * HDR flag from ffprobe colour tags, or null when neither the transfer nor the primaries tag is
+ * present (undeterminable). A PQ (`smpte2084`) or HLG (`arib-std-b67`) transfer, or BT.2020
+ * primaries, marks HDR.
+ */
+internal fun isHdrFromColorTags(colorTransfer: String?, colorPrimaries: String?): Boolean? {
+    val transfer = colorTransfer?.trim()?.lowercase()
+    val primaries = colorPrimaries?.trim()?.lowercase()
+    if (transfer.isNullOrBlank() && primaries.isNullOrBlank()) return null
+    return transfer == "smpte2084" ||
+        transfer == "arib-std-b67" ||
+        (primaries?.startsWith("bt2020") == true)
+}

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/video/FfmpegCompressPlannerTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/video/FfmpegCompressPlannerTest.kt
@@ -54,6 +54,7 @@ class FfmpegCompressPlannerTest {
             codecMime = "video/avc", widthPx = 320, heightPx = 180,
             inputBytes = 26_000L, durationMs = 6_000L,
             targets = standardTargets,
+            bitDepth = 8, isHdr = false,
         )
         assertTrue(ok)
     }
@@ -66,6 +67,7 @@ class FfmpegCompressPlannerTest {
             codecMime = "h264", widthPx = 320, heightPx = 180,
             inputBytes = 26_000L, durationMs = 6_000L,
             targets = standardTargets,
+            bitDepth = 8, isHdr = false,
         )
         assertTrue(ok)
     }
@@ -76,6 +78,7 @@ class FfmpegCompressPlannerTest {
             codecMime = "Video/AVC", widthPx = 320, heightPx = 180,
             inputBytes = 26_000L, durationMs = 6_000L,
             targets = standardTargets,
+            bitDepth = 8, isHdr = false,
         )
         assertTrue(ok)
     }
@@ -99,6 +102,7 @@ class FfmpegCompressPlannerTest {
             codecMime = "video/avc", widthPx = 720, heightPx = 1280,
             inputBytes = 1_000_000L, durationMs = 5_000L,
             targets = standardTargets,
+            bitDepth = 8, isHdr = false,
         )
         assertTrue(targetMet, "short edge at target should pass")
         val overTarget = FfmpegCompressPlanner.isAlreadyOptimal(
@@ -143,6 +147,57 @@ class FfmpegCompressPlannerTest {
             bitDepth = 8, isHdr = true,
         )
         assertFalse(ok)
+    }
+
+    @Test
+    fun alreadyOptimal_unknownBitDepth_false() {
+        // #959: probe couldn't determine bit depth (null). Must NOT pass through — a 10-bit HLG
+        // capture whose KEY_PROFILE was absent used to be mis-classified 8-bit and shipped
+        // undecodable. Fail closed: re-encode.
+        val ok = FfmpegCompressPlanner.isAlreadyOptimal(
+            codecMime = "video/avc", widthPx = 320, heightPx = 180,
+            inputBytes = 26_000L, durationMs = 6_000L,
+            targets = standardTargets,
+            bitDepth = null, isHdr = false,
+        )
+        assertFalse(ok)
+    }
+
+    @Test
+    fun alreadyOptimal_unknownHdr_false() {
+        // #959: HDR undeterminable (null colour-transfer). Fail closed.
+        val ok = FfmpegCompressPlanner.isAlreadyOptimal(
+            codecMime = "video/avc", widthPx = 320, heightPx = 180,
+            inputBytes = 26_000L, durationMs = 6_000L,
+            targets = standardTargets,
+            bitDepth = 8, isHdr = null,
+        )
+        assertFalse(ok)
+    }
+
+    @Test
+    fun alreadyOptimal_defaultsFailClosed() {
+        // With no bit-depth/HDR passed at all (defaults), the predicate must fail closed — a caller
+        // that forgot to thread the probe result never accidentally passes a 10-bit source through.
+        val ok = FfmpegCompressPlanner.isAlreadyOptimal(
+            codecMime = "video/avc", widthPx = 320, heightPx = 180,
+            inputBytes = 26_000L, durationMs = 6_000L,
+            targets = standardTargets,
+        )
+        assertFalse(ok)
+    }
+
+    @Test
+    fun alreadyOptimal_unknownBitDepth_withTenBitToggle_true() {
+        // Toggle ON: the user opted into 10-bit pass-through, so an undeterminable bit depth no
+        // longer forces a re-encode; only a positively-detected HDR source still would.
+        val ok = FfmpegCompressPlanner.isAlreadyOptimal(
+            codecMime = "video/avc", widthPx = 320, heightPx = 180,
+            inputBytes = 26_000L, durationMs = 6_000L,
+            targets = standardTargets,
+            bitDepth = null, isHdr = false, allowTenBit = true,
+        )
+        assertTrue(ok)
     }
 
     @Test
@@ -228,6 +283,7 @@ class FfmpegCompressPlannerTest {
             probedWidthPx = 320, probedHeightPx = 180,
             probedCodecMime = "video/avc",
             inputDurationMs = 6_000L, inputBytes = 26_000L,
+            probedBitDepth = 8, probedIsHdr = false,
         )
         assertNotNull(plan.skipReason)
         assertEquals(emptyList(), plan.args)

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/video/VideoProbeTagsTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/video/VideoProbeTagsTest.kt
@@ -1,0 +1,30 @@
+package id.homebase.api.video
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class VideoProbeTagsTest {
+
+    // --- bitDepthFromPixFmt (#959: null when undeterminable, never a fail-open 8) ---
+
+    @Test fun bitDepth_null_pixFmt_isNull() = assertNull(bitDepthFromPixFmt(null))
+    @Test fun bitDepth_blank_pixFmt_isNull() = assertNull(bitDepthFromPixFmt("  "))
+
+    @Test fun bitDepth_yuv420p_is8() = assertEquals(8, bitDepthFromPixFmt("yuv420p"))
+    @Test fun bitDepth_yuv420p10le_is10() = assertEquals(10, bitDepthFromPixFmt("yuv420p10le"))
+    @Test fun bitDepth_p010le_is10() = assertEquals(10, bitDepthFromPixFmt("p010le"))
+    @Test fun bitDepth_12bit_is12() = assertEquals(12, bitDepthFromPixFmt("yuv420p12le"))
+    @Test fun bitDepth_caseAndSpace_normalized() = assertEquals(10, bitDepthFromPixFmt("  YUV420P10LE "))
+
+    // --- isHdrFromColorTags (null when no tags present at all) ---
+
+    @Test fun hdr_bothAbsent_isNull() = assertNull(isHdrFromColorTags(null, null))
+    @Test fun hdr_bothBlank_isNull() = assertNull(isHdrFromColorTags(" ", ""))
+
+    @Test fun hdr_pq_isTrue() = assertEquals(true, isHdrFromColorTags("smpte2084", ""))
+    @Test fun hdr_hlg_isTrue() = assertEquals(true, isHdrFromColorTags("arib-std-b67", ""))
+    @Test fun hdr_bt2020_primaries_isTrue() = assertEquals(true, isHdrFromColorTags("", "bt2020nc"))
+    @Test fun hdr_sdr_bt709_isFalse() = assertEquals(false, isHdrFromColorTags("bt709", "bt709"))
+    @Test fun hdr_caseAndSpace_normalized() = assertEquals(true, isHdrFromColorTags(" SMPTE2084 ", null))
+}

--- a/homebase-api/src/jvmMain/java/id/homebase/api/video/FFmpegUtils.jvm.kt
+++ b/homebase-api/src/jvmMain/java/id/homebase/api/video/FFmpegUtils.jvm.kt
@@ -206,8 +206,8 @@ actual object FFmpegUtils {
         val codec: String?,
         val widthPx: Int,
         val heightPx: Int,
-        val bitDepth: Int = 8,
-        val isHdr: Boolean = false,
+        val bitDepth: Int? = null,
+        val isHdr: Boolean? = null,
     )
 
     actual suspend fun probeVideo(inputPath: String): VideoTrackInfo? = withContext(Dispatchers.IO) {
@@ -242,27 +242,6 @@ actual object FFmpegUtils {
             isHdr = isHdrFromColorTags(colorTransfer, colorPrimaries),
         )
     }
-
-    /**
-     * Luma bit depth inferred from ffprobe's `pix_fmt` token. ffmpeg names
-     * 10/12-bit formats with a `10`/`12` infix (e.g. `yuv420p10le`, `p010le`).
-     * Defaults to 8 for any 8-bit or unrecognised format.
-     */
-    private fun bitDepthFromPixFmt(pixFmt: String): Int = when {
-        pixFmt.isBlank() -> 8
-        "12" in pixFmt -> 12
-        "10" in pixFmt || pixFmt.startsWith("p010") -> 10
-        else -> 8
-    }
-
-    /**
-     * HDR detection from ffprobe colour tags: a PQ (`smpte2084`) or HLG
-     * (`arib-std-b67`) transfer, or BT.2020 primaries.
-     */
-    private fun isHdrFromColorTags(colorTransfer: String, colorPrimaries: String): Boolean =
-        colorTransfer == "smpte2084" ||
-            colorTransfer == "arib-std-b67" ||
-            colorPrimaries.startsWith("bt2020")
 
     private fun formatSeconds(ms: Long): String {
         // Locale-safe (avoid comma decimal separator in some default locales).

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/video/FFmpegUtils.native.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/video/FFmpegUtils.native.kt
@@ -237,8 +237,10 @@ actual object FFmpegUtils {
         val heightPx = probe?.heightPx ?: 0
         val codecMime = probe?.codec  // short form, e.g. "h264" / "hevc"; null forces re-encode
         val rotation = probe?.rotation ?: 0
-        val bitDepth = probe?.bitDepth ?: 8
-        val isHdr = probe?.isHdr ?: false
+        // Keep null when the probe couldn't determine these — the planner fails closed and
+        // re-encodes rather than passing a possibly-10-bit source through untouched (#959).
+        val bitDepth = probe?.bitDepth
+        val isHdr = probe?.isHdr
 
         val attrs = fileManager.attributesOfItemAtPath(inputPath, null)
         val inputBytes = (attrs?.get(NSFileSize) as? NSNumber)?.longValue ?: 0L
@@ -263,7 +265,7 @@ actual object FFmpegUtils {
         // unreadable file), so the hardware encoder is never handed a degenerate command.
         val dimensionsUnknown = widthPx <= 0 || heightPx <= 0
         val encoders =
-            if ((allowTenBit && bitDepth > 8) || dimensionsUnknown) listOf("libx264")
+            if ((allowTenBit && (bitDepth ?: 0) > 8) || dimensionsUnknown) listOf("libx264")
             else listOf("h264_videotoolbox", "libx264")
         for ((index, encoder) in encoders.withIndex()) {
             val plan = FfmpegCompressPlanner.plan(

--- a/homebase-api/src/nativeMain/kotlin/id/homebase/api/video/FFmpegUtils.native.kt
+++ b/homebase-api/src/nativeMain/kotlin/id/homebase/api/video/FFmpegUtils.native.kt
@@ -138,8 +138,9 @@ actual object FFmpegUtils {
         val widthPx: Int,
         val heightPx: Int,
         val rotation: Int,
-        val bitDepth: Int,
-        val isHdr: Boolean,
+        /** Null when the probe couldn't determine it — planner fails closed (#959). */
+        val bitDepth: Int?,
+        val isHdr: Boolean?,
     )
 
     /**
@@ -157,27 +158,18 @@ actual object FFmpegUtils {
     private fun probeVideoNative(inputPath: String): NativeVideoProbe? {
         val v = bridge.getMediaInformation(inputPath)?.streams?.firstOrNull { it.type == "video" }
         if (v != null && (v.width ?: 0) > 0 && (v.height ?: 0) > 0) {
-            val pixFmt = v.pixelFormat?.lowercase().orEmpty()
-            val transfer = v.colorTransfer?.lowercase().orEmpty()
-            val primaries = v.colorPrimaries?.lowercase().orEmpty()
             return NativeVideoProbe(
                 codec = v.codec,
                 widthPx = v.width ?: 0,
                 heightPx = v.height ?: 0,
                 rotation = v.rotation ?: 0,
-                bitDepth = bitDepthFromPixFmt(pixFmt),
-                isHdr = transfer == "smpte2084" || transfer == "arib-std-b67" ||
-                    primaries.startsWith("bt2020"),
+                // Shared, fail-closed parsing (#959): null when the tags are absent, so an
+                // undeterminable source re-encodes rather than passing through as assumed 8-bit.
+                bitDepth = bitDepthFromPixFmt(v.pixelFormat),
+                isHdr = isHdrFromColorTags(v.colorTransfer, v.colorPrimaries),
             )
         }
         return avProbeVideoTrack(inputPath)
-    }
-
-    private fun bitDepthFromPixFmt(pixFmt: String): Int = when {
-        pixFmt.isBlank() -> 8
-        "12" in pixFmt -> 12
-        "10" in pixFmt || pixFmt.startsWith("p010") -> 10
-        else -> 8
     }
 
     /** AVFoundation track probe — native iOS metadata for files ffprobe can't read. */
@@ -194,10 +186,10 @@ actual object FFmpegUtils {
             ((deg % 360) + 360) % 360
         }
         // codec=null on the AVFoundation path: these files are re-encoded regardless
-        // (HEVC -> H.264), so the already-optimal short-circuit must stay off, and the
-        // real output codec is filled in post-encode. bitDepth/HDR default to 8-bit SDR
-        // (the planner's safe yuv420p pin); 10-bit/HDR detection here is a follow-up.
-        return NativeVideoProbe(codec = null, widthPx = w, heightPx = h, rotation = rotation, bitDepth = 8, isHdr = false)
+        // (HEVC -> H.264), so the already-optimal short-circuit must stay off. bitDepth/HDR are
+        // left null (AVFoundation can't read pix_fmt) — harmless since null codec already forces
+        // a re-encode, and consistent with the fail-closed contract (#959).
+        return NativeVideoProbe(codec = null, widthPx = w, heightPx = h, rotation = rotation, bitDepth = null, isHdr = null)
     }
 
     @OptIn(ExperimentalForeignApi::class)

--- a/homebase-api/src/nativeTest/kotlin/id/homebase/api/video/FFmpegProbeFallbackNativeTest.kt
+++ b/homebase-api/src/nativeTest/kotlin/id/homebase/api/video/FFmpegProbeFallbackNativeTest.kt
@@ -6,8 +6,8 @@ import kotlinx.coroutines.runBlocking
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 /**
  * Regression coverage for the iPhone `.mov`-send crash fix. When FFmpegKit's bundled ffprobe
@@ -53,10 +53,11 @@ class FFmpegProbeFallbackNativeTest {
             )
             assertEquals(160, info.widthPx, "AVFoundation must read the real width from the .mov video track")
             assertEquals(90, info.heightPx, "AVFoundation must read the real height from the .mov video track")
-            // The AVFoundation fallback can't read pixel format, so it reports SDR 8-bit by
-            // design (documented in avProbeVideoTrack) — the safe default for encoder selection.
-            assertEquals(8, info.bitDepth, "AVFoundation fallback reports 8-bit by default")
-            assertFalse(info.isHdr, "AVFoundation fallback reports SDR by default")
+            // The AVFoundation fallback can't read pixel format, so it reports bit depth / HDR as
+            // null ("undeterminable") — the planner then fails closed and re-encodes rather than
+            // assuming 8-bit SDR (#959). (This path re-encodes regardless: codec is null too.)
+            assertNull(info.bitDepth, "AVFoundation fallback can't determine bit depth → null")
+            assertNull(info.isHdr, "AVFoundation fallback can't determine HDR → null")
         } finally {
             cleanupStagedSampleVideo(path)
         }

--- a/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/video/FFmpegUtils.web.kt
+++ b/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/video/FFmpegUtils.web.kt
@@ -60,8 +60,9 @@ actual object FFmpegUtils {
     actual suspend fun probeVideo(inputPath: String): VideoTrackInfo? {
         val bytes = readOkioBytes(inputPath) ?: return null
         val p = FFmpegBridge.probe(bytes) ?: return null
-        // mp4box probe doesn't expose bit depth / colour info; default to 8-bit SDR.
-        return VideoTrackInfo(p.codec, p.widthPx, p.heightPx, 8, false)
+        // mp4box probe doesn't expose bit depth / colour info — report null (undeterminable) so the
+        // planner fails closed and re-encodes rather than assuming 8-bit SDR (#959).
+        return VideoTrackInfo(p.codec, p.widthPx, p.heightPx, null, null)
     }
 
     /**

--- a/homebase-chat/src/androidMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.android.kt
+++ b/homebase-chat/src/androidMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.android.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.C
+import androidx.media3.common.Format
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
@@ -32,7 +33,12 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DataSpec
 import androidx.media3.datasource.TransferListener
+import androidx.media3.exoplayer.ExoPlaybackException
 import androidx.media3.exoplayer.ExoPlayer
+import id.homebase.resources.MR
+import id.homebase.resources.video_error_generic
+import id.homebase.resources.video_error_ten_bit
+import org.jetbrains.compose.resources.stringResource
 import androidx.media3.exoplayer.hls.HlsMediaSource
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
@@ -128,6 +134,11 @@ actual fun VideoPlayerSurface(
     // can detach it alongside the diagnostics listener.
     var firstFrameListener by remember(data) { mutableStateOf<Player.Listener?>(null) }
 
+    // Resolved once in composable scope (stringResource can't run inside the remembered
+    // listener) and captured by the diagnostics listener's onPlayerError below (#959).
+    val genericPlaybackError = stringResource(MR.string.video_error_generic)
+    val tenBitPlaybackError = stringResource(MR.string.video_error_ten_bit)
+
     // Persistent diagnostics listener — fires for the entire lifetime of the
     // player in this composition. The per-content-type listeners below remove
     // themselves after first frame (they exist to time first-paint), so without
@@ -140,6 +151,13 @@ actual fun VideoPlayerSurface(
                 Logger.e(tag = "VideoIO", throwable = error) {
                     "player error: fileId=${data.fileId} key=${data.payloadKey} code=${error.errorCodeName} message=${error.message}"
                 }
+                // Surface a visible message instead of a dead/black player (#959). A 10-bit source
+                // this device can't decode (e.g. a 10-bit HLG capture from a sender that shipped it
+                // un-downconverted) gets a specific message; everything else a generic one.
+                val format = (error as? ExoPlaybackException)?.rendererFormat
+                state = VpsState.Error(
+                    if (isTenBitFormat(format)) tenBitPlaybackError else genericPlaybackError
+                )
             }
             override fun onPlayerErrorChanged(error: PlaybackException?) {
                 if (error == null) {
@@ -513,6 +531,24 @@ private fun playbackStateName(state: Int): String = when (state) {
     Player.STATE_READY -> "READY"
     Player.STATE_ENDED -> "ENDED"
     else -> "UNKNOWN($state)"
+}
+
+/**
+ * Whether the renderer format that failed to decode is 10-bit — either the [ColorInfo] reports a
+ * 10-bit luma/chroma depth, or the codec string names a 10-bit profile (H.264 High 10 = `avc1.6e…`,
+ * HEVC Main 10 = `hev1.2…`/`hvc1.2…`). Drives the specific "Unable to play 10-bit video" message
+ * versus the generic one (#959).
+ */
+@OptIn(UnstableApi::class)
+private fun isTenBitFormat(format: Format?): Boolean {
+    if (format == null) return false
+    format.colorInfo?.let { color ->
+        if (color.lumaBitdepth == 10 || color.chromaBitdepth == 10) return true
+    }
+    val codecs = format.codecs?.lowercase() ?: return false
+    return codecs.startsWith("avc1.6e") ||
+        codecs.startsWith("hev1.2") ||
+        codecs.startsWith("hvc1.2")
 }
 
 @UnstableApi

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -932,6 +932,8 @@
     <string name="moment_video_watch_again">Watch again</string>
     <string name="moment_video_fill_screen">Fill screen</string>
     <string name="moment_video_fit_screen">Fit to screen</string>
+    <string name="video_error_generic">Unable to play this video on this device</string>
+    <string name="video_error_ten_bit">Unable to play 10-bit video on this device</string>
     <string name="chat_message_download_file">Download file</string>
     <string name="chat_message_file_type_icon">File type icon</string>
     <string name="chat_message_pdf_preview">PDF preview</string>


### PR DESCRIPTION
Refs #959. Covers parts 1 (the actual fix) and 2 (receiver error UI). Part 3 (descriptor hevc-vs-avc mismatch) left as a follow-up.

## The bug
A 10-bit HLG in-app capture on a Pixel 8 shipped as AVC High-10 (`avc1.6E0028`) **with the 8-bit pin ON** — undecodable on most Android receivers, which showed a silent black player. The 8-bit policy was never overridden; it was *bypassed* by a probe that fails open.

## Part 1 — fail closed + authoritative probe (the fix)
`FfmpegCompressPlanner.isAlreadyOptimal` correctly disqualifies pass-through for 10-bit/HDR, but its inputs came from `MediaExtractor`, which returned **8-bit/SDR when `KEY_PROFILE` / color-transfer were absent** (frequently, for camera captures). So a 10-bit source was misclassified "already optimal" and passed through un-re-encoded.

- `VideoTrackInfo.bitDepth`/`isHdr` are now **nullable** — null = "probe couldn't determine" (matches the type's own docstring). Every platform probe reports null instead of fabricating 8-bit SDR.
- `isAlreadyOptimal` **fails closed**: pass-through requires a *positive* 8-bit-SDR probe; null → re-encode (the encode leg already pins `yuv420p`). Defaults changed to null so a caller that forgets to thread the probe can't accidentally pass a 10-bit source through.
- **Authoritative fallback (avoids needless transcodes):** when Android's `MediaExtractor` leaves bit depth/HDR undetermined, resolve it with an `FFprobeKit` read of `pix_fmt`/`color_transfer` — so a genuinely-8-bit in-budget clip still passes through, and only actually-10-bit ones re-encode. Parsing shared with the JVM path via `VideoProbeTags` (also fail-closed).

## Part 2 — decode-failure message (no more dead player)
The Android player's `onPlayerError` only logged, leaving a cleared spinner over black. It now flips to the existing `VpsState.Error` and shows **"Unable to play 10-bit video on this device"** when the failing renderer format is 10-bit (ColorInfo 10-bit luma/chroma, or a High-10/Main-10 codec string), else a generic message. Strings via `stringResource`.

## Tests
- [x] Planner regression cases: null-bit-depth → re-encode, null-HDR → re-encode, defaults-fail-closed, toggle-on behavior
- [x] Unit tests for the shared `pix_fmt` / colour-tag parsing
- [x] Compiles JVM / Android / iOS / wasm; full `homebase-api` suite + Konsist pass
- [ ] **Needs a Pixel 8 (10-bit HLG camera) to verify end-to-end:** capture with the toggle OFF → received payload is 8-bit `yuv420p` (ffprobe) and plays on a non-Pixel device; and confirm the decode-failure message renders

## Not in this PR
Part 3: reconcile the descriptor `codec` field (`hevc`) with the wire codec (`avc`). Follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)