### PR TITLE
feat(moments): choose a circle as a share target (#1087 v1)

### DIFF
--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -449,6 +449,7 @@
     <string name="moments_audience_section_recent">Recent</string>
     <string name="moments_audience_section_groups">Groups</string>
     <string name="moments_audience_section_circles">Circles</string>
+    <string name="moments_audience_view_circle_members">View circle members</string>
     <string name="moments_audience_section_contacts">Contacts</string>
     <string name="moments_audience_post">Post</string>
     <string name="moments_audience_save_privately">Save privately</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -448,6 +448,7 @@
     <string name="moments_audience_to_myself_only">To myself only</string>
     <string name="moments_audience_section_recent">Recent</string>
     <string name="moments_audience_section_groups">Groups</string>
+    <string name="moments_audience_section_circles">Circles</string>
     <string name="moments_audience_section_contacts">Contacts</string>
     <string name="moments_audience_post">Post</string>
     <string name="moments_audience_save_privately">Save privately</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentsRecipient.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentsRecipient.kt
@@ -50,4 +50,20 @@ sealed interface MomentsRecipient {
          *  provenance on the moment's [MomentSource.Audience]. */
         val groupId: Uuid,
     ) : MomentsRecipient
+
+    /**
+     * A user-defined circle. [odinIds] is a **snapshot** of the circle's current members at the
+     * time the picker built the list (v1 member-expansion, #1087): posting fans the moment out to
+     * exactly these members, so someone added to the circle after posting won't receive it.
+     */
+    data class Circle(
+        override val id: MomentsRecipientId,
+        override val displayName: String,
+        override val odinIds: List<OdinId>,
+        override val avatarInitials: String,
+        override val avatarUrl: String,
+        val memberCount: Int,
+        /** The underlying circle's id (32-char N-format). */
+        val circleId: String,
+    ) : MomentsRecipient
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentsRecipientLookupService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentsRecipientLookupService.kt
@@ -2,9 +2,13 @@ package id.homebase.core.moments.services
 
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.connections.CircleWithMembers
 import id.homebase.api.common.OdinId
 import id.homebase.chat.data.ContactUiModel
+import id.homebase.chat.services.convo.contact.ConnectionService
 import id.homebase.chat.services.convo.contact.ContactService
+import id.homebase.core.config.AUTO_CONNECTIONS_CIRCLE_ID
+import id.homebase.core.config.CONFIRMED_CONNECTIONS_CIRCLE_ID
 import id.homebase.core.util.initials
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -29,6 +33,7 @@ private const val TAG = "MomentsRecipientLookupService"
 class MomentsRecipientLookupService(
     private val contactService: ContactService,
     private val groupService: MomentGroupService,
+    private val connectionService: ConnectionService,
     private val mruStore: MomentsUserStateStore,
     private val credentialsManager: CredentialsManager,
     private val scope: CoroutineScope,
@@ -51,18 +56,27 @@ class MomentsRecipientLookupService(
             combine(
                 contactService.contacts,
                 groupService.groups,
+                connectionService.circles,
                 mruStore.stableKeys,
-            ) { contacts, groups, mru ->
-                Triple(contacts, groups, mru)
-            }.collect { (contacts, groups, mru) ->
+            ) { contacts, groups, circleState, mru ->
+                LookupInputs(contacts, groups, circleState.circles, mru)
+            }.collect { inputs ->
                 val activeUserDomain = credentialsManager.getActiveDomain()
-                val (snapshot, keyMap) =
-                    buildRecipients(contacts, groups, mru, activeUserDomain)
+                val (snapshot, keyMap) = buildRecipients(
+                    inputs.contacts, inputs.groups, inputs.circles, inputs.mru, activeUserDomain,
+                )
                 stableKeyById = keyMap
                 _recipients.value = snapshot
             }
         }
     }
+
+    private data class LookupInputs(
+        val contacts: List<ContactUiModel>,
+        val groups: List<MomentGroup>,
+        val circles: List<CircleWithMembers>,
+        val mru: List<String>,
+    )
 
     /**
      * Bumps [recipients] to the head of the MRU list and persists them so the
@@ -100,11 +114,13 @@ class MomentsRecipientLookupService(
     private fun buildRecipients(
         contacts: List<ContactUiModel>,
         groups: List<MomentGroup>,
+        circles: List<CircleWithMembers>,
         mru: List<String>,
         activeUserDomain: OdinId?,
     ): Pair<MomentsRecipientsSnapshot, Map<MomentsRecipientId, String>> {
         val contactsRaw = mutableListOf<Pair<MomentsRecipient, String>>()
         val groupsRaw = mutableListOf<Pair<MomentsRecipient, String>>()
+        val circlesRaw = mutableListOf<Pair<MomentsRecipient, String>>()
 
         for (contact in contacts) {
             // Self-contact (if the drive ever lists the active user) is not a
@@ -139,13 +155,42 @@ class MomentsRecipientLookupService(
             groupsRaw += recipient to "momentgroup:${group.id}"
         }
 
+        for (cwm in circles) {
+            val def = cwm.circle
+            // User-defined circles only: drop the disabled ones and the Confirmed/Auto system
+            // circles (Emergency and any other user circle stay). Mirrors the contact-detail
+            // circle filter (#921/#916).
+            if (def.disabled) continue
+            if (def.id.equals(CONFIRMED_CONNECTIONS_CIRCLE_ID, ignoreCase = true) ||
+                def.id.equals(AUTO_CONNECTIONS_CIRCLE_ID, ignoreCase = true)
+            ) continue
+            if (def.name.isBlank()) continue
+            // Snapshot the members (v1 member expansion); self isn't a transit recipient.
+            val others = cwm.members.filterNot { it == activeUserDomain }
+            if (others.isEmpty()) continue
+
+            val recipient = MomentsRecipient.Circle(
+                id = MomentsRecipientId(Uuid.random()),
+                displayName = def.name,
+                odinIds = others,
+                avatarInitials = def.name.initials(),
+                avatarUrl = "",
+                memberCount = others.size,
+                circleId = def.id,
+            )
+            circlesRaw += recipient to "circle:${def.id.lowercase()}"
+        }
+
         val mruIndex = mru.withIndex().associate { (i, k) -> k to i }
         fun isMru(p: Pair<MomentsRecipient, String>) = mruIndex.containsKey(p.second)
 
-        val recentRaw = (contactsRaw + groupsRaw).filter { isMru(it) }
+        val recentRaw = (contactsRaw + groupsRaw + circlesRaw).filter { isMru(it) }
         val recentSorted = recentRaw.sortedBy { mruIndex.getValue(it.second) }
 
         val nonRecentGroups = groupsRaw
+            .filterNot { isMru(it) }
+            .sortedBy { it.first.displayName.lowercase() }
+        val nonRecentCircles = circlesRaw
             .filterNot { isMru(it) }
             .sortedBy { it.first.displayName.lowercase() }
         val nonRecentContacts = contactsRaw
@@ -155,9 +200,10 @@ class MomentsRecipientLookupService(
         val snapshot = MomentsRecipientsSnapshot(
             recent = recentSorted.map { it.first },
             groups = nonRecentGroups.map { it.first },
+            circles = nonRecentCircles.map { it.first },
             contacts = nonRecentContacts.map { it.first },
         )
-        val keyMap = (recentSorted + nonRecentGroups + nonRecentContacts)
+        val keyMap = (recentSorted + nonRecentGroups + nonRecentCircles + nonRecentContacts)
             .associate { (recipient, key) -> recipient.id to key }
         return snapshot to keyMap
     }
@@ -170,21 +216,25 @@ class MomentsRecipientLookupService(
  *                     May contain entries from either source.
  * @property groups    Moments groups (defined via `MomentGroupService`) NOT in
  *                     [recent], sorted alphabetically by title.
+ * @property circles   User-defined circles (system circles excluded) NOT in
+ *                     [recent], sorted alphabetically by name.
  * @property contacts  Address-book contacts NOT in [recent], sorted
  *                     alphabetically by displayName.
  */
 data class MomentsRecipientsSnapshot(
     val recent: List<MomentsRecipient>,
     val groups: List<MomentsRecipient>,
+    val circles: List<MomentsRecipient>,
     val contacts: List<MomentsRecipient>,
 ) {
-    /** Flat MRU-first view — recent + groups + contacts. */
-    val all: List<MomentsRecipient> get() = recent + groups + contacts
+    /** Flat MRU-first view — recent + groups + circles + contacts. */
+    val all: List<MomentsRecipient> get() = recent + groups + circles + contacts
 
     companion object {
         fun empty(): MomentsRecipientsSnapshot = MomentsRecipientsSnapshot(
             recent = emptyList(),
             groups = emptyList(),
+            circles = emptyList(),
             contacts = emptyList(),
         )
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentsRecipientLookupService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentsRecipientLookupService.kt
@@ -166,8 +166,9 @@ class MomentsRecipientLookupService(
             ) continue
             if (def.name.isBlank()) continue
             // Snapshot the members (v1 member expansion); self isn't a transit recipient.
+            // Empty circles are kept (they render greyed-out + non-selectable in the picker so the
+            // count is always visible) — the audience screen gates selection on odinIds.isNotEmpty().
             val others = cwm.members.filterNot { it == activeUserDomain }
-            if (others.isEmpty()) continue
 
             val recipient = MomentsRecipient.Circle(
                 id = MomentsRecipientId(Uuid.random()),

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleRoster.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/CircleRoster.kt
@@ -1,0 +1,34 @@
+package id.homebase.core.ui.screens.contactbook
+
+import id.homebase.api.crypto.Md5
+import id.homebase.core.ui.screens.contactbook.model.ContactBookEntry
+import id.homebase.core.ui.screens.contactbook.model.ContactBookSource
+
+/**
+ * Resolve a set of circle-member domains (odinIds) to contact-book rows for display in
+ * [id.homebase.core.ui.screens.contactbook.components.CircleMembersSheet]. Identities that
+ * aren't in the address book fall back to a synthetic domain-named entry rather than being
+ * dropped, so the roster always accounts for every member. Shared by contact detail and the
+ * moments audience circle roster.
+ */
+fun resolveCircleMemberEntries(
+    domains: Set<String>,
+    contacts: List<ContactBookEntry>,
+): List<ContactBookEntry> {
+    val byOdin = contacts.filter { !it.odinId.isNullOrBlank() }.associateBy { it.odinId!!.lowercase() }
+    return domains.map { domain -> byOdin[domain.lowercase()] ?: syntheticCircleMemberEntry(domain) }
+}
+
+/** A minimal entry for an identity not in the address book — keyed by the same md5→guid the
+ *  server derives, so it dedups against a real entry if one appears later. */
+private fun syntheticCircleMemberEntry(domain: String): ContactBookEntry {
+    val uid = Md5.toGuidId(domain.lowercase())
+    return ContactBookEntry(
+        uniqueId = uid,
+        fileId = uid,
+        versionTag = null,
+        odinId = domain,
+        displayName = domain,
+        source = ContactBookSource.CONNECTION,
+    )
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentAddRecipientsSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentAddRecipientsSheet.kt
@@ -235,6 +235,12 @@ private fun AddRecipientRow(
                 options = avatarOptions,
                 imageVector = Icons.Default.People,
             )
+
+            is MomentsRecipient.Circle -> FallbackAvatar(
+                initials = recipient.avatarInitials,
+                options = avatarOptions,
+                imageVector = Icons.Default.People,
+            )
         }
         Column(modifier = Modifier.weight(1f)) {
             Text(

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentAudienceScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentAudienceScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.Group
+import androidx.compose.material.icons.outlined.Groups
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
@@ -57,6 +58,7 @@ import id.homebase.resources.moments_audience_create_group
 import id.homebase.resources.moments_audience_post
 import id.homebase.resources.moments_audience_post_failed
 import id.homebase.resources.moments_audience_save_privately
+import id.homebase.resources.moments_audience_section_circles
 import id.homebase.resources.moments_audience_section_contacts
 import id.homebase.resources.moments_audience_section_groups
 import id.homebase.resources.moments_audience_section_recent
@@ -93,6 +95,7 @@ fun MomentAudienceScreen(
     val searchHint = stringResource(MR.string.moments_create_search_hint)
     val recentLabel = stringResource(MR.string.moments_audience_section_recent)
     val groupsLabel = stringResource(MR.string.moments_audience_section_groups)
+    val circlesLabel = stringResource(MR.string.moments_audience_section_circles)
     val contactsLabel = stringResource(MR.string.moments_audience_section_contacts)
     val createGroupLabel = stringResource(MR.string.moments_audience_create_group)
 
@@ -123,6 +126,7 @@ fun MomentAudienceScreen(
     ) { innerPadding ->
         val recent = uiState.filteredRecent
         val groupsSection = uiState.filteredGroups
+        val circlesSection = uiState.filteredCircles
         val contactsSection = uiState.filteredContacts
 
         LazyColumn(
@@ -214,6 +218,20 @@ fun MomentAudienceScreen(
                 )
             }
 
+            // Circles — share to everyone in a user-defined circle in one tap (#1087).
+            if (circlesSection.isNotEmpty()) {
+                section(circlesLabel)
+                items(circlesSection, key = { "ci-${it.id.raw}" }) { recipient ->
+                    RecipientRow(
+                        recipient = recipient,
+                        selected = recipient.id in uiState.selected,
+                        onClick = {
+                            viewModel.onAction(MomentAudienceUiAction.ToggleRecipient(recipient.id))
+                        },
+                    )
+                }
+            }
+
             if (contactsSection.isNotEmpty()) {
                 section(contactsLabel)
                 items(contactsSection, key = { "c-${it.id.raw}" }) { recipient ->
@@ -274,17 +292,28 @@ private fun RecipientRow(
                 options = avatarOptions,
                 imageVector = Icons.Outlined.Group,
             )
+
+            is MomentsRecipient.Circle -> FallbackAvatar(
+                initials = recipient.avatarInitials,
+                options = avatarOptions,
+                imageVector = Icons.Outlined.Groups,
+            )
         }
         Column(modifier = Modifier.weight(1f)) {
             Text(
                 text = recipient.displayName,
                 style = MaterialTheme.typography.bodyLarge,
             )
-            if (recipient is MomentsRecipient.Group) {
+            val memberCount = when (recipient) {
+                is MomentsRecipient.Group -> recipient.memberCount
+                is MomentsRecipient.Circle -> recipient.memberCount
+                is MomentsRecipient.Individual -> null
+            }
+            if (memberCount != null) {
                 Text(
                     text = stringResource(
                         MR.string.number_of_members,
-                        recipient.memberCount.toString(),
+                        memberCount.toString(),
                     ),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentAudienceScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentAudienceScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.Group
 import androidx.compose.material.icons.outlined.Groups
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
@@ -45,6 +46,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -52,6 +54,7 @@ import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.FallbackAvatar
 import id.homebase.core.avatars.PublicAvatar
 import id.homebase.core.moments.services.MomentsRecipient
+import id.homebase.core.ui.screens.contactbook.components.CircleMembersSheet
 import id.homebase.resources.MR
 import id.homebase.resources.menu_back
 import id.homebase.resources.moments_audience_create_group
@@ -64,6 +67,7 @@ import id.homebase.resources.moments_audience_section_groups
 import id.homebase.resources.moments_audience_section_recent
 import id.homebase.resources.moments_audience_title
 import id.homebase.resources.moments_audience_to_myself_only
+import id.homebase.resources.moments_audience_view_circle_members
 import id.homebase.resources.moments_compose_comments_enabled
 import id.homebase.resources.moments_create_search_hint
 import id.homebase.resources.moments_create_selected_count
@@ -128,6 +132,15 @@ fun MomentAudienceScreen(
         val groupsSection = uiState.filteredGroups
         val circlesSection = uiState.filteredCircles
         val contactsSection = uiState.filteredContacts
+
+        // Only circle rows expose a "view members" affordance; everything else gets null.
+        val infoClickFor: (MomentsRecipient) -> (() -> Unit)? = { recipient ->
+            if (recipient is MomentsRecipient.Circle) {
+                { viewModel.onAction(MomentAudienceUiAction.ShowCircleMembers(recipient.id)) }
+            } else {
+                null
+            }
+        }
 
         LazyColumn(
             modifier = Modifier
@@ -198,6 +211,7 @@ fun MomentAudienceScreen(
                         onClick = {
                             viewModel.onAction(MomentAudienceUiAction.ToggleRecipient(recipient.id))
                         },
+                        onInfoClick = infoClickFor(recipient),
                     )
                 }
             }
@@ -215,10 +229,13 @@ fun MomentAudienceScreen(
                     onClick = {
                         viewModel.onAction(MomentAudienceUiAction.ToggleRecipient(recipient.id))
                     },
+                    onInfoClick = infoClickFor(recipient),
                 )
             }
 
-            // Circles — share to everyone in a user-defined circle in one tap (#1087).
+            // Circles — share to everyone in a user-defined circle in one tap (#1087). Empty
+            // circles are shown greyed-out + non-selectable (RecipientRow gates on member count);
+            // the "i" affordance opens the view-only roster.
             if (circlesSection.isNotEmpty()) {
                 section(circlesLabel)
                 items(circlesSection, key = { "ci-${it.id.raw}" }) { recipient ->
@@ -228,6 +245,7 @@ fun MomentAudienceScreen(
                         onClick = {
                             viewModel.onAction(MomentAudienceUiAction.ToggleRecipient(recipient.id))
                         },
+                        onInfoClick = infoClickFor(recipient),
                     )
                 }
             }
@@ -241,9 +259,22 @@ fun MomentAudienceScreen(
                         onClick = {
                             viewModel.onAction(MomentAudienceUiAction.ToggleRecipient(recipient.id))
                         },
+                        onInfoClick = infoClickFor(recipient),
                     )
                 }
             }
+        }
+
+        // View-only roster for a tapped circle — reuses the contact-book sheet with management
+        // affordances disabled (manageable = false). Members are the circle's snapshot audience.
+        uiState.circleDetail?.let { detail ->
+            CircleMembersSheet(
+                state = detail,
+                onDismiss = { viewModel.onAction(MomentAudienceUiAction.DismissCircleMembers) },
+                onMemberClick = {},
+                onAddMemberClick = {},
+                onRemoveMemberClick = {},
+            )
         }
     }
 }
@@ -266,61 +297,87 @@ private fun RecipientRow(
     recipient: MomentsRecipient,
     selected: Boolean,
     onClick: () -> Unit,
+    onInfoClick: (() -> Unit)? = null,
 ) {
+    // A circle with no members can't be a share target — show it, greyed, but don't let it be
+    // selected (odinIds is the exact fan-out set, and it's empty). Everything else is selectable.
+    val selectable = recipient !is MomentsRecipient.Circle || recipient.odinIds.isNotEmpty()
+    val contentAlpha = if (selectable) 1f else 0.38f
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
+            .clickable(enabled = selectable, onClick = onClick)
             .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        // Render avatars the same way chat does: individuals resolve their
-        // public profile image from the odinId via PublicAvatar; groups fall
-        // back to chat's group glyph (mirrors ConversationAvatar's
-        // GroupFallback). See ConversationAvatar.kt / PublicAvatar.kt.
-        val avatarOptions = AvatarOptions(size = 40.dp)
-        when (recipient) {
-            is MomentsRecipient.Individual -> PublicAvatar(
-                odinId = recipient.odinId,
-                initials = recipient.avatarInitials,
-                options = avatarOptions,
-            )
+        // Avatar + label are dimmed together when the row isn't selectable; the info affordance
+        // and selection indicator keep full opacity so the "view members" tap stays clear.
+        Row(
+            modifier = Modifier.weight(1f).alpha(contentAlpha),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            // Render avatars the same way chat does: individuals resolve their
+            // public profile image from the odinId via PublicAvatar; groups fall
+            // back to chat's group glyph (mirrors ConversationAvatar's
+            // GroupFallback). See ConversationAvatar.kt / PublicAvatar.kt.
+            val avatarOptions = AvatarOptions(size = 40.dp)
+            when (recipient) {
+                is MomentsRecipient.Individual -> PublicAvatar(
+                    odinId = recipient.odinId,
+                    initials = recipient.avatarInitials,
+                    options = avatarOptions,
+                )
 
-            is MomentsRecipient.Group -> FallbackAvatar(
-                initials = recipient.avatarInitials,
-                options = avatarOptions,
-                imageVector = Icons.Outlined.Group,
-            )
+                is MomentsRecipient.Group -> FallbackAvatar(
+                    initials = recipient.avatarInitials,
+                    options = avatarOptions,
+                    imageVector = Icons.Outlined.Group,
+                )
 
-            is MomentsRecipient.Circle -> FallbackAvatar(
-                initials = recipient.avatarInitials,
-                options = avatarOptions,
-                imageVector = Icons.Outlined.Groups,
-            )
-        }
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = recipient.displayName,
-                style = MaterialTheme.typography.bodyLarge,
-            )
-            val memberCount = when (recipient) {
-                is MomentsRecipient.Group -> recipient.memberCount
-                is MomentsRecipient.Circle -> recipient.memberCount
-                is MomentsRecipient.Individual -> null
+                is MomentsRecipient.Circle -> FallbackAvatar(
+                    initials = recipient.avatarInitials,
+                    options = avatarOptions,
+                    imageVector = Icons.Outlined.Groups,
+                )
             }
-            if (memberCount != null) {
+            Column {
                 Text(
-                    text = stringResource(
-                        MR.string.number_of_members,
-                        memberCount.toString(),
-                    ),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    text = recipient.displayName,
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+                val memberCount = when (recipient) {
+                    is MomentsRecipient.Group -> recipient.memberCount
+                    is MomentsRecipient.Circle -> recipient.memberCount
+                    is MomentsRecipient.Individual -> null
+                }
+                if (memberCount != null) {
+                    Text(
+                        text = stringResource(
+                            MR.string.number_of_members,
+                            memberCount.toString(),
+                        ),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+        if (onInfoClick != null) {
+            IconButton(onClick = onInfoClick) {
+                Icon(
+                    imageVector = Icons.Outlined.Info,
+                    contentDescription = stringResource(MR.string.moments_audience_view_circle_members),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
         }
-        SelectionIndicator(selected = selected)
+        // Always shown so the row keeps a consistent trailing column; dimmed (and never
+        // "selected") for a non-selectable empty circle so it reads as unavailable, not checkable.
+        Box(modifier = Modifier.alpha(contentAlpha)) {
+            SelectionIndicator(selected = selectable && selected)
+        }
     }
 }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentAudienceUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentAudienceUiState.kt
@@ -3,6 +3,7 @@ package id.homebase.core.ui.screens.moments
 import id.homebase.core.moments.services.MomentsRecipient
 import id.homebase.core.moments.services.MomentsRecipientId
 import id.homebase.core.moments.services.MomentsRecipientsSnapshot
+import id.homebase.core.ui.screens.contactbook.CircleMembersUi
 
 data class MomentAudienceUiState(
     val recipients: MomentsRecipientsSnapshot = MomentsRecipientsSnapshot.empty(),
@@ -12,6 +13,8 @@ data class MomentAudienceUiState(
     val draftReady: Boolean = false,
     val commentsEnabled: Boolean = true,
     val selfOnly: Boolean = false,
+    /** Non-null while the "who's in this circle" roster sheet is open (view-only). */
+    val circleDetail: CircleMembersUi? = null,
 ) {
     val canPost: Boolean
         get() = draftReady && !isPosting && (selfOnly || selected.isNotEmpty())
@@ -43,6 +46,10 @@ sealed interface MomentAudienceUiAction {
     data class CommentsEnabledChanged(val enabled: Boolean) : MomentAudienceUiAction
     data object ToggleSelfOnly : MomentAudienceUiAction
     data object PostClicked : MomentAudienceUiAction
+
+    /** Open the view-only roster for a circle recipient (the "i" affordance on a circle row). */
+    data class ShowCircleMembers(val id: MomentsRecipientId) : MomentAudienceUiAction
+    data object DismissCircleMembers : MomentAudienceUiAction
 }
 
 sealed interface MomentAudienceUiEvent {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentAudienceUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentAudienceUiState.kt
@@ -24,6 +24,10 @@ data class MomentAudienceUiState(
     val filteredGroups: List<MomentsRecipient>
         get() = recipients.groups.matching(query)
 
+    /** User-defined circles matching the search query. */
+    val filteredCircles: List<MomentsRecipient>
+        get() = recipients.circles.matching(query)
+
     /** Address-book contacts matching the search query. */
     val filteredContacts: List<MomentsRecipient>
         get() = recipients.contacts.matching(query)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentAudienceViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentAudienceViewModel.kt
@@ -3,6 +3,7 @@ package id.homebase.core.ui.screens.moments
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
+import id.homebase.api.client.contacts.ContactRepository
 import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.chat.conversationlist.AttachmentPendingFile
 import id.homebase.core.moments.services.MomentCreateFlowState
@@ -11,6 +12,10 @@ import id.homebase.core.moments.services.MomentsPostSenderService
 import id.homebase.core.moments.services.MomentsRecipient
 import id.homebase.core.moments.services.MomentsRecipientId
 import id.homebase.core.moments.services.MomentsRecipientLookupService
+import id.homebase.core.ui.screens.contactbook.CircleMembersUi
+import id.homebase.core.ui.screens.contactbook.model.ContactBookEntry
+import id.homebase.core.ui.screens.contactbook.model.toContactBookEntry
+import id.homebase.core.ui.screens.contactbook.resolveCircleMemberEntries
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -26,6 +31,7 @@ class MomentAudienceViewModel(
     private val recipientLookup: MomentsRecipientLookupService,
     private val postSender: MomentsPostSenderService,
     private val flowState: MomentCreateFlowState,
+    private val contactRepository: ContactRepository,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(
@@ -36,6 +42,10 @@ class MomentAudienceViewModel(
     private val _events = MutableSharedFlow<MomentAudienceUiEvent>(extraBufferCapacity = 4)
     val events: SharedFlow<MomentAudienceUiEvent> = _events.asSharedFlow()
 
+    // Address-book entries, kept current so the circle-roster sheet can resolve each snapshot
+    // odinId to a name/avatar (falling back to a synthetic domain row for non-contacts).
+    private var latestContacts: List<ContactBookEntry> = emptyList()
+
     init {
         viewModelScope.launch {
             recipientLookup.recipients.collect { list ->
@@ -45,6 +55,12 @@ class MomentAudienceViewModel(
         viewModelScope.launch {
             flowState.draft.collect { draft ->
                 _uiState.update { it.copy(draftReady = draft != null) }
+            }
+        }
+        viewModelScope.launch { contactRepository.ensureLoaded() }
+        viewModelScope.launch {
+            contactRepository.contacts.collect { list ->
+                latestContacts = list.mapNotNull { it.toContactBookEntry() }
             }
         }
     }
@@ -71,6 +87,40 @@ class MomentAudienceViewModel(
                 }
 
             MomentAudienceUiAction.PostClicked -> post()
+
+            is MomentAudienceUiAction.ShowCircleMembers -> showCircleMembers(action.id)
+
+            MomentAudienceUiAction.DismissCircleMembers ->
+                _uiState.update { it.copy(circleDetail = null) }
+        }
+    }
+
+    /**
+     * Opens the view-only roster for a circle recipient. The roster is built purely from the
+     * recipient's member snapshot (the exact set the moment fans out to), resolved against the
+     * address book — no live pending-member fan-out, since a pending (not-yet-real) grant is NOT
+     * part of the snapshot and would not receive the moment, so listing it here would misrepresent
+     * the audience.
+     */
+    private fun showCircleMembers(id: MomentsRecipientId) {
+        val circle = _uiState.value.recipients.all
+            .filterIsInstance<MomentsRecipient.Circle>()
+            .firstOrNull { it.id == id } ?: return
+        val members = resolveCircleMemberEntries(
+            circle.odinIds.map { it.domainName }.toSet(),
+            latestContacts,
+        ).sortedBy { it.sortKey }
+        _uiState.update {
+            it.copy(
+                circleDetail = CircleMembersUi(
+                    circleId = circle.circleId,
+                    circleName = circle.displayName,
+                    manageable = false,
+                    members = members,
+                    isLoading = false,
+                    pendingChecking = false,
+                ),
+            )
         }
     }
 


### PR DESCRIPTION
Closes #1087 (v1 — member expansion).

## What
A **Circles** section in the Moment audience picker (between Groups and Contacts). Selecting a circle shares the Moment with everyone in it in one tap; the row shows the circle name + member count.

## How
It's small because the recipient model already abstracts everyone as "a name + a list of odinIds" (a Group is just a recipient whose `odinIds` is its members). A Circle is the same shape:

- **`MomentsRecipient.Circle`** — new recipient kind (members snapshot + `memberCount` + `circleId`).
- **`MomentsRecipientLookupService`** — sources circles from `ConnectionService.circles`, excludes the Confirmed/Auto **system** circles (Emergency and other user circles stay, per the #921/#916 convention) and self, and folds circles into the recent/MRU pool like groups.
- **`MomentAudienceUiState` / `MomentAudienceScreen`** — a `filteredCircles` list + a Circles section with a distinct Groups glyph and member count.
- **Post path: no changes.** `MomentAudienceViewModel` already does `selectedRecipients.flatMap { it.odinIds }.distinct()` → `TransitOptions.recipients`, so a circle's members fan out unchanged. I confirmed Moments distribute by recipient fan-out, not a drive ACL — so the "ideal" dynamic-ACL path isn't available without re-architecting distribution; v1 member-expansion is the right fit.

## v1 caveat (by design)
**Static snapshot:** the picker snapshots the circle's *current* members at selection time. Someone added to the circle *after* you post won't receive that Moment. This is inherent to member expansion and matches the issue's v1 proposal.

## Testing
- [x] Compiles JVM + iOS; `homebase-core` + `homebase-common` (Konsist) suites pass
- [ ] On-device: circle appears in the picker, selecting it shares with all members, respects self-only / comments toggles

## Note for review
A **circle-only** post currently records its recipients as the member odinIds (no "shared with <circle>" provenance in the feed) — `MomentSource.Audience` only captures group provenance today. Recording circle provenance would be a small follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)