### PR TITLE
fix(chat): don't lose messages written while a conversation loads (#1135)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/MessageUiModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/MessageUiModel.kt
@@ -26,6 +26,18 @@ data class MessageUiModel(
     val conversationId: Uuid, // groupId
     val content: String, // the message
     val userDate: Instant, // User-specified message timestamp (from appData.userDate)
+    /**
+     * The value stored in `DriveMainIndex.userDate` for this message
+     * (`HomebaseFile.sqlUserDateMs`), i.e. [userDate] *without* the
+     * display-safety clamp to the server-stamped `transitCreated`.
+     *
+     * Read-bookkeeping must compare on this scale: `selectAllUnreadCount`
+     * filters on the SQL column, so advancing `lastReadTime` to the clamped
+     * [userDate] can leave the badge stuck on a message the user has read.
+     * Rendering and ordering keep using [userDate]. Defaults to [userDate] for
+     * synthetic models that have no SQL row.
+     */
+    val sqlUserDate: Instant = userDate,
     val modified: Instant?, // When the message was last modified
     val created: Instant, // Server-side creation timestamp
     val originalAuthor: OdinId?,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
@@ -102,20 +102,22 @@ class ChatMessageActionService(
             return
         }
 
-        // The MessageUiModel.userDate carried here is the *clamped* value from
-        // ChatMessageStream.mapToMessageData (`min(appData.userDate, transitCreated)`).
-        // selectAllUnreadCount filters on the *un-clamped* DriveMainIndex.userDate,
-        // so capping newReadTime at `viewedRecords.maxOf { userDate }` can leave
-        // the badge stuck on a row whose appData.userDate exceeded transitCreated.
-        // The conversation's `latestMessageTimestamp` (sourced from the SQL column
-        // since `enrichWithLastMessages` was fixed) is authoritative — use it as
-        // a floor when it's ahead of the per-file value.
-        val viewedMax = viewedRecords.maxOf { it.userDate }
+        // Advance no further than the newest message the user actually saw.
+        // `MessageUiModel.userDate` is the *clamped* display value
+        // (`min(appData.userDate, transitCreated)`) while selectAllUnreadCount
+        // filters on the un-clamped DriveMainIndex.userDate — so read-bookkeeping
+        // runs on `sqlUserDate`, which is that same SQL column. Using the clamped
+        // value here is what stuck the badge at 1 for a message that had been read.
+        //
+        // The conversation's `latestMessageTimestamp` is deliberately NOT used as a
+        // floor: it belongs to the newest message in the DB, which is not necessarily
+        // one that ever reached the window. Marking that read (#1135) clears the badge
+        // that is the only signal the tail is missing.
+        val newReadTime = viewedRecords.maxOf { it.sqlUserDate }
         val convoLatest = participantLookup.getConversationById(conversationId)?.latestMessageTimestamp
-        val newReadTime = if (convoLatest != null && convoLatest > viewedMax) convoLatest else viewedMax
         Logger.d(tag = TAG) {
             "newReadTime(ms)=${newReadTime.toEpochMilliseconds()} " +
-                    "(viewedMax=${viewedMax.toEpochMilliseconds()} " +
+                    "(clampedViewedMax=${viewedRecords.maxOf { it.userDate }.toEpochMilliseconds()} " +
                     "convoLatest=${convoLatest?.toEpochMilliseconds()} " +
                     "viewed=${viewedRecords.size} receipt-eligible=${unreadRecords.size})"
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -148,17 +148,46 @@ class ChatMessageStream(
     suspend fun loadConversation(conversationId: Uuid) {
         val start = TimeSource.Monotonic.markNow()
         Logger.d("ChatMessageStream: loadConversation($conversationId)")
-        val result = fetchMessages(
+        // Register the load before reading: until setInitialWindow runs there is no
+        // window, and both reconcilers skip windowless conversations — so a write
+        // committing inside the fetch would be invisible to the fetch's SQLite
+        // snapshot AND dropped by them, leaving a stale window cached forever (#1135).
+        paginatedState.beginInitialLoad(conversationId)
+        val racedConcurrentWrite = try {
+            val result = fetchMessages(
+                conversationId = conversationId,
+                limit = PaginatedConversationState.PAGE_SIZE,
+            )
+            val elapsed = start.elapsedNow()
+            Logger.d("ChatMessageStream: loadConversation($conversationId) → ${result.records.size} messages in $elapsed (hasMore=${result.hasMoreRows})")
+            paginatedState.setInitialWindow(
+                conversationId = conversationId,
+                messages = result.records,
+                olderCursor = result.cursor,
+                hasOlderMessages = result.hasMoreRows,
+            )
+            paginatedState.endInitialLoad(conversationId)
+        } catch (t: Throwable) {
+            // Without this a thrown fetch leaves the conversation permanently
+            // "loading", so every later reconciler flags it and no one clears it.
+            paginatedState.endInitialLoad(conversationId)
+            throw t
+        }
+        if (!racedConcurrentWrite) return
+
+        // Exactly one re-read: the window now exists, so anything landing from
+        // here on is picked up by the reconcilers. Looping until quiet would
+        // never terminate under sustained sync traffic.
+        val fresh = fetchMessages(
             conversationId = conversationId,
             limit = PaginatedConversationState.PAGE_SIZE,
         )
-        val elapsed = start.elapsedNow()
-        Logger.d("ChatMessageStream: loadConversation($conversationId) → ${result.records.size} messages in $elapsed (hasMore=${result.hasMoreRows})")
+        Logger.d("ChatMessageStream: loadConversation($conversationId) raced a concurrent write → re-read ${fresh.records.size} messages (hasMore=${fresh.hasMoreRows})")
         paginatedState.setInitialWindow(
             conversationId = conversationId,
-            messages = result.records,
-            olderCursor = result.cursor,
-            hasOlderMessages = result.hasMoreRows,
+            messages = fresh.records,
+            olderCursor = fresh.cursor,
+            hasOlderMessages = fresh.hasMoreRows,
         )
     }
 
@@ -275,7 +304,6 @@ class ChatMessageStream(
      * rather than silently landing on the latest page.
      */
     suspend fun loadConversationAroundMessage(conversationId: Uuid, messageUniqueId: Uuid): Boolean {
-        val start = TimeSource.Monotonic.markNow()
         val target = getMessage(messageUniqueId) ?: run {
             Logger.d(tag = "ChatPaging") {
                 "loadAround($conversationId, $messageUniqueId) anchor not in DB; falling back to loadConversation"
@@ -283,6 +311,27 @@ class ChatMessageStream(
             loadConversation(conversationId)
             return false
         }
+        // Same read-then-register race as loadConversation, and this is the path a
+        // scroll-anchored open takes (#1135).
+        paginatedState.beginInitialLoad(conversationId)
+        val racedConcurrentWrite = try {
+            seedWindowAround(conversationId, messageUniqueId, target)
+            paginatedState.endInitialLoad(conversationId)
+        } catch (t: Throwable) {
+            paginatedState.endInitialLoad(conversationId)
+            throw t
+        }
+        if (racedConcurrentWrite) seedWindowAround(conversationId, messageUniqueId, target)
+        return true
+    }
+
+    /** Build (or rebuild) a window centered on [target]. */
+    private suspend fun seedWindowAround(
+        conversationId: Uuid,
+        messageUniqueId: Uuid,
+        target: MessageUiModel,
+    ) {
+        val start = TimeSource.Monotonic.markNow()
         val halfPage = PaginatedConversationState.PAGE_SIZE / 2
         val olderHalfCursor = QueryBatchCursor(
             paging = TimeRowCursor(UnixTimeUtc(target.userDate), 0L)
@@ -316,7 +365,6 @@ class ChatMessageStream(
             "loadAround($conversationId, $messageUniqueId) older=${olderHalf.records.size}+anchor+newer=${newerHalf.records.size} " +
                 "windowSize=${combined.size} hasOlder=${olderHalf.hasMoreRows} hasNewer=${newerHalf.hasMoreRows} took=${start.elapsedNow()}"
         }
-        return true
     }
 
     /**
@@ -338,6 +386,9 @@ class ChatMessageStream(
      * preserved.
      */
     private suspend fun refreshCachedWindows() {
+        // Conversations mid-initial-load have no window to walk yet; flag them so
+        // loadConversation re-reads instead of caching its pre-write snapshot.
+        paginatedState.markAllInitialLoadsDirty()
         val snapshot = paginatedState.windows.value
         if (snapshot.isEmpty()) return
         for ((conversationId, window) in snapshot) {
@@ -371,7 +422,13 @@ class ChatMessageStream(
         Logger.d("ChatMessageStream: processIncrementalBatch ${messages.size} messages across ${grouped.size} conversation(s)")
         grouped.forEach { (conversationId, msgs) ->
             if (isConversationLeft(conversationId)) return@forEach
-            val window = paginatedState.getWindow(conversationId) ?: return@forEach
+            val window = paginatedState.getWindow(conversationId) ?: run {
+                // No window yet. If that's because an initial load is mid-fetch,
+                // flag it — otherwise this batch is lost to both this gate and the
+                // loader's pre-write snapshot (#1135).
+                paginatedState.markInitialLoadDirty(conversationId)
+                return@forEach
+            }
             // Gate: when the user has paged backwards (hasNewerMessages == true), the
             // window doesn't include the latest messages. Stream events that arrive while
             // the user is deep in history would land out of order; defer them until the

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -178,6 +178,10 @@ class ChatMessageStream(
         // Exactly one re-read: the window now exists, so anything landing from
         // here on is picked up by the reconcilers. Looping until quiet would
         // never terminate under sustained sync traffic.
+        //
+        // merge = true because the re-read has its own snapshot boundary: a batch
+        // upserted into the (now existing) window while this fetch runs is absent
+        // from its results, and a replacing write would drop it permanently.
         val fresh = fetchMessages(
             conversationId = conversationId,
             limit = PaginatedConversationState.PAGE_SIZE,
@@ -188,6 +192,7 @@ class ChatMessageStream(
             messages = fresh.records,
             olderCursor = fresh.cursor,
             hasOlderMessages = fresh.hasMoreRows,
+            merge = true,
         )
     }
 
@@ -321,15 +326,22 @@ class ChatMessageStream(
             paginatedState.endInitialLoad(conversationId)
             throw t
         }
-        if (racedConcurrentWrite) seedWindowAround(conversationId, messageUniqueId, target)
+        if (racedConcurrentWrite) {
+            seedWindowAround(conversationId, messageUniqueId, target, merge = true)
+        }
         return true
     }
 
-    /** Build (or rebuild) a window centered on [target]. */
+    /**
+     * Build (or rebuild) a window centered on [target]. [merge] is set on the
+     * raced re-seed so a write upserted into the window while this fetch runs
+     * survives the write-back — see [PaginatedConversationState.setInitialWindow].
+     */
     private suspend fun seedWindowAround(
         conversationId: Uuid,
         messageUniqueId: Uuid,
         target: MessageUiModel,
+        merge: Boolean = false,
     ) {
         val start = TimeSource.Monotonic.markNow()
         val halfPage = PaginatedConversationState.PAGE_SIZE / 2
@@ -360,6 +372,7 @@ class ChatMessageStream(
             hasOlderMessages = olderHalf.hasMoreRows,
             newerCursor = newerHalf.cursor,
             hasNewerMessages = newerHalf.hasMoreRows,
+            merge = merge,
         )
         Logger.d(tag = "ChatPaging") {
             "loadAround($conversationId, $messageUniqueId) older=${olderHalf.records.size}+anchor+newer=${newerHalf.records.size} " +

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/MessageMapper.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/MessageMapper.kt
@@ -58,6 +58,7 @@ import id.homebase.resources.chat_poll_ended_other
 import id.homebase.resources.chat_poll_ended_self
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.serialization.json.JsonPrimitive
+import kotlin.time.Instant
 import kotlin.uuid.Uuid
 
 /**
@@ -169,6 +170,7 @@ suspend fun mapToMessageData(
                 fileId = header.fileId,
                 conversationId = appData.groupId!!,
                 userDate = deletedUserDate.toInstant(),
+                sqlUserDate = Instant.fromEpochMilliseconds(header.sqlUserDateMs()),
                 modified = metadata.updated.toInstant(),
                 created = metadata.created.toInstant(),
                 originalAuthor = metadata.originalAuthor,
@@ -315,6 +317,7 @@ suspend fun mapToMessageData(
             conversationId = appData.groupId!!,
             content = messageAppData.getMessage(),
             userDate = userDate.toInstant(),
+            sqlUserDate = Instant.fromEpochMilliseconds(header.sqlUserDateMs()),
             modified = metadata.updated.toInstant(),
             created = metadata.created.toInstant(),
             originalAuthor = metadata.originalAuthor,
@@ -354,6 +357,7 @@ suspend fun mapToMessageData(
                 conversationId = appData.groupId!!,
                 content = "Failed to parse message from server",
                 userDate = metadata.created.toInstant(),
+                sqlUserDate = Instant.fromEpochMilliseconds(header.sqlUserDateMs()),
                 modified = metadata.updated.toInstant(),
                 created = metadata.created.toInstant(),
                 originalAuthor = metadata.originalAuthor,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/PaginatedConversationState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/PaginatedConversationState.kt
@@ -8,6 +8,7 @@ import id.homebase.chat.data.MessageUiModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.flow.update
 import kotlin.uuid.Uuid
 
@@ -58,6 +59,21 @@ class PaginatedConversationState(
     val windows: StateFlow<Map<Uuid, MessageWindow>> = _windows.asStateFlow()
 
     /**
+     * Conversations whose initial load is in flight, each mapped to whether a
+     * concurrent write landed while that load ran.
+     *
+     * A conversation has no window until [setInitialWindow], so a DriveSync/WS
+     * write committing mid-fetch is invisible to the fetch's SQLite snapshot
+     * *and* skipped by both reconcilers — the stale window is then cached
+     * forever (#1135). Registering the load here gives those reconcilers
+     * something to flag; the loader re-reads once when it sees the flag.
+     *
+     * Same `MutableStateFlow` CAS discipline as [_windows] so the flag is safe
+     * against reconcilers running on other dispatchers.
+     */
+    private val _initialLoads = MutableStateFlow<Map<Uuid, Boolean>>(emptyMap())
+
+    /**
      * Drop every cached message window. Called on logout so the previous
      * identity's open-conversation messages don't survive in memory into the
      * next session; windows reload lazily via [setInitialWindow] when the user
@@ -65,7 +81,42 @@ class PaginatedConversationState(
      */
     fun reset() {
         _windows.value = emptyMap()
+        _initialLoads.value = emptyMap()
     }
+
+    /** Register [conversationId] as mid-initial-load. Pair with [endInitialLoad]. */
+    fun beginInitialLoad(conversationId: Uuid) {
+        _initialLoads.update { it + (conversationId to false) }
+    }
+
+    /**
+     * Record that a write landed for [conversationId] while its initial load is
+     * in flight. No-op when no load is in flight.
+     */
+    fun markInitialLoadDirty(conversationId: Uuid) {
+        _initialLoads.update { current ->
+            if (current.containsKey(conversationId)) current + (conversationId to true) else current
+        }
+    }
+
+    /**
+     * Flag every in-flight initial load. Used by the whole-drive post-sync
+     * refresh, which walks [windows] and so cannot see a conversation that
+     * doesn't have one yet.
+     */
+    fun markAllInitialLoadsDirty() {
+        _initialLoads.update { current ->
+            if (current.isEmpty()) current else current.mapValues { true }
+        }
+    }
+
+    /**
+     * Clear [conversationId]'s in-flight marker, returning true when a write
+     * landed while it was set — i.e. the caller's fetch may have missed rows
+     * and must re-read.
+     */
+    fun endInitialLoad(conversationId: Uuid): Boolean =
+        _initialLoads.getAndUpdate { it - conversationId }[conversationId] == true
 
     fun hasCachedMessages(conversationId: Uuid): Boolean =
         _windows.value.containsKey(conversationId)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/PaginatedConversationState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/PaginatedConversationState.kt
@@ -124,6 +124,20 @@ class PaginatedConversationState(
     fun getWindow(conversationId: Uuid): MessageWindow? =
         _windows.value[conversationId]
 
+    /**
+     * @param merge keep any message the existing window holds that [messages]
+     *  doesn't ([messages] wins on id conflicts), instead of replacing it
+     *  wholesale. Set ONLY by the raced-load re-read: that second fetch takes
+     *  its own SQLite snapshot, so a write upserted into the (by then existing)
+     *  window while it ran would otherwise be replaced away and lost for good —
+     *  the exact #1135 failure, just one fetch later. Cursors always come from
+     *  [messages]: the survivors sit at the newest end, so the fresh page's
+     *  older-side cursor stays valid and any over-fetch is deduped by
+     *  [prependOlderMessages].
+     *
+     *  The union must happen inside this single atomic update — a caller-side
+     *  read-then-write would race exactly the same way.
+     */
     fun setInitialWindow(
         conversationId: Uuid,
         messages: List<MessageUiModel>,
@@ -131,10 +145,20 @@ class PaginatedConversationState(
         hasOlderMessages: Boolean = false,
         newerCursor: QueryBatchCursor? = null,
         hasNewerMessages: Boolean = false,
+        merge: Boolean = false,
     ) {
         _windows.update { current ->
+            val existing = if (merge) current[conversationId]?.messages.orEmpty() else emptyList()
+            val combined = if (existing.isEmpty()) {
+                messages
+            } else {
+                val byId = LinkedHashMap<Uuid, MessageUiModel>()
+                for (msg in existing) byId[msg.id] = msg
+                for (msg in messages) byId[msg.id] = msg
+                byId.values.toList()
+            }
             current + (conversationId to MessageWindow(
-                messages = messages.sortedBy { it.userDate },
+                messages = combined.sortedBy { it.userDate },
                 olderCursor = olderCursor,
                 newerCursor = newerCursor,
                 hasOlderMessages = hasOlderMessages,

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTest.kt
@@ -218,6 +218,67 @@ class ChatMessageActionServiceTest {
     }
 
     @Test
+    fun markAsReadByFiles_clampsToNewestRenderedMessage_notTheConversationsLatest() = runTest {
+        // #1135: loadConversation raced a sync batch and the thread's tail was
+        // missing, so `latestMessageTimestamp` was ~10h ahead of anything on
+        // screen. Advancing lastRead to it marked never-rendered messages read and
+        // cleared the badge — the only signal the tail was missing.
+        ChatMessageActionServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = Uuid.random()
+            val peer = "alice.test"
+
+            val rendered = listOf(100L, 200L).map {
+                fixture.seedMessage(conversationId = convoId, senderDomain = peer, userDateMs = it)
+            }
+            fixture.participantLookup.setLastRead(
+                convoId,
+                lastRead = kotlin.time.Instant.fromEpochMilliseconds(0L),
+                latestMessageTimestamp = kotlin.time.Instant.fromEpochMilliseconds(999_999L),
+            )
+
+            service.markAsReadByFiles(convoId, rendered)
+
+            assertEquals(
+                200L, fixture.dbm.chatReadCount.selectLastReadTimeMs(convoId),
+                "lastRead must stop at the newest rendered message, never at a message " +
+                    "that only exists in the conversation's latestMessageTimestamp",
+            )
+            assertEquals(
+                200L,
+                fixture.localLastReadUpdater.calls.single().newLastReadTime.milliseconds,
+            )
+        }
+    }
+
+    @Test
+    fun markAsReadByFiles_advancesOnSqlUserDate_notTheClampedDisplayUserDate() = runTest {
+        // The counterpart the removed `latestMessageTimestamp` floor used to cover:
+        // MessageUiModel.userDate is clamped to transitCreated for display, while
+        // selectAllUnreadCount filters on the un-clamped DriveMainIndex.userDate.
+        // Advancing on the clamped value leaves the badge stuck on a message the
+        // user has demonstrably read.
+        ChatMessageActionServiceTestFixture().use { fixture ->
+            val service = fixture.build(scope = this)
+            val convoId = Uuid.random()
+
+            val clampedTail = fixture.seedMessage(
+                conversationId = convoId,
+                senderDomain = "alice.test",
+                userDateMs = 200L,
+                sqlUserDateMs = 500L,
+            )
+
+            service.markAsReadByFiles(convoId, listOf(clampedTail))
+
+            assertEquals(
+                500L, fixture.dbm.chatReadCount.selectLastReadTimeMs(convoId),
+                "read bookkeeping must run on the SQL userDate the unread count queries",
+            )
+        }
+    }
+
+    @Test
     fun markAsReadByFiles_enrichesTargetConversation() = runTest {
         ChatMessageActionServiceTestFixture().use { fixture ->
             val service = fixture.build(scope = this)

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageActionServiceTestFixture.kt
@@ -290,6 +290,9 @@ class ChatMessageActionServiceTestFixture(
         conversationId: Uuid,
         senderDomain: String,
         userDateMs: Long,
+        /** DriveMainIndex.userDate. Diverges from [userDateMs] when the display
+         *  value was clamped down to the server-stamped transitCreated. */
+        sqlUserDateMs: Long = userDateMs,
         alreadyRead: Boolean = false,
         isDeleted: Boolean = false,
         isPendingSend: Boolean = false,
@@ -303,6 +306,7 @@ class ChatMessageActionServiceTestFixture(
             conversationId = conversationId,
             content = "",
             userDate = Instant.fromEpochMilliseconds(userDateMs),
+            sqlUserDate = Instant.fromEpochMilliseconds(sqlUserDateMs),
             modified = null,
             created = Instant.fromEpochMilliseconds(userDateMs),
             originalAuthor = OdinId(senderDomain),
@@ -550,7 +554,7 @@ class ChatMessageActionServiceTestFixture(
  * Each instance gets its own unique cache subdirectory so multiple test classes'
  * Coil DiskCache instances don't contend on the same on-disk journal.
  */
-private class NoopFileOperationsProvider : FileOperationsProvider {
+internal class NoopFileOperationsProvider : FileOperationsProvider {
     private val uniqueCacheDir: String =
         java.nio.file.Files.createTempDirectory("hb-chat-test-cache").toString()
     private fun nope(): Nothing =

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageStreamLoadRaceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageStreamLoadRaceTest.kt
@@ -1,0 +1,449 @@
+@file:OptIn(ExperimentalUuidApi::class, ExperimentalCoroutinesApi::class)
+
+package id.homebase.chat.services
+
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.Transacter
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlCursor
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlPreparedStatement
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import id.homebase.api.client.auth.ApiCredentials
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.auth.OwnerSessionRepository
+import id.homebase.api.client.connections.ConnectionNetworkProvider
+import id.homebase.api.client.contacts.ContactRepository
+import id.homebase.api.client.contacts.ContactsProvider
+import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.client.drives.cache.DriveFileProviderCached
+import id.homebase.api.client.drives.files.DriveFileProvider
+import id.homebase.api.client.eventbus.BackendEvent
+import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.client.identity.PublicIdentityRepository
+import id.homebase.api.client.profile.PublicProfileProviderCached
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.SecureByteArray
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.sync.database.MainIndexMetaHelpers
+import id.homebase.api.sync.database.OdinDatabase
+import id.homebase.api.sync.database.Outbox
+import id.homebase.api.sync.database.OutboxSync
+import id.homebase.api.sync.database.OutboxUploader
+import id.homebase.chat.services.convo.contact.ConnectionCacheRepository
+import id.homebase.chat.services.convo.contact.ConnectionService
+import id.homebase.chat.services.convo.contact.ContactService
+import id.homebase.chat.services.outbox.OptimisticWriter
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respondError
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Regression coverage for #1135 — a DriveSync/WS write that commits *between*
+ * the start of `loadConversation`'s fetch and `setInitialWindow`.
+ *
+ * The fetch reads a pre-write SQLite snapshot, and both reconcilers
+ * (`refreshCachedWindows` on `DriveEvent.Stopped`, `processIncrementalBatch` on
+ * `DataEvent.BatchReceived`) skip a conversation that has no window yet — so the
+ * message was dropped by all three paths and the stale window was cached and
+ * reused on every subsequent open.
+ *
+ * The race is made deterministic with [GatedSqlDriver]: it lets the paging
+ * SELECT run, then parks the reader thread *after* the snapshot has been taken.
+ * The test writes the racing row and fires the sync event while the reader is
+ * parked, then releases it.
+ */
+class ChatMessageStreamLoadRaceTest {
+
+    private val testIdentityId: Uuid = Uuid.parse("7b1be23b-48bb-4304-bc7b-db5910c09a92")
+    private val chatDriveId: Uuid = Uuid.parse("9ff813af-f2d6-1e2f-9b9d-b189e72d1a11")
+    private val testDomain: String = "owner.test"
+    private val conversationId: Uuid = Uuid.parse("11111111-1111-1111-1111-111111111111")
+
+    @Test
+    fun loadConversation_rowCommittedMidFetch_isRecoveredViaDriveSyncStopped() = runTest {
+        val fixture = buildFixture(this)
+        val alreadySynced = fixture.seedMessage(userDateMs = 1_000L)
+        val racingMessage = fixture.buildMessageFile(userDateMs = 2_000L)
+
+        fixture.gate.armNextRead()
+        val load = launch { fixture.stream.loadConversation(conversationId) }
+        advanceUntilIdle()
+
+        // Reader is now parked holding the pre-write snapshot.
+        fixture.gate.readTaken.await()
+        fixture.commit(racingMessage)
+        fixture.eventBus.emit(
+            BackendEvent.DriveEvent.Stopped(
+                driveId = chatDriveId,
+                totalCount = 1,
+                result = BackendEvent.DriveResult.Completed,
+            )
+        )
+        advanceUntilIdle()
+
+        fixture.gate.releaseRead()
+        load.join()
+
+        val racingId = racingMessage.fileMetadata.appData.uniqueId!!
+        assertTrue(
+            fixture.stream.isMessageInWindow(conversationId, alreadySynced),
+            "the pre-existing message must still be in the window",
+        )
+        assertTrue(
+            fixture.stream.isMessageInWindow(conversationId, racingId),
+            "a row committed while loadConversation was mid-fetch must end up in the window — " +
+                "the fetch's snapshot predates it and both reconcilers skip a windowless conversation",
+        )
+        fixture.close()
+    }
+
+    @Test
+    fun loadConversation_rowCommittedMidFetch_isRecoveredViaBatchReceived() = runTest {
+        val fixture = buildFixture(this)
+        fixture.seedMessage(userDateMs = 1_000L)
+        val racingMessage = fixture.buildMessageFile(userDateMs = 2_000L)
+
+        // processIncrementalBatch maps on Dispatchers.Default before reaching its
+        // window gate, so "the event was emitted" is not "the gate was evaluated".
+        // isConversationLeft is called immediately before that gate with no
+        // suspension in between — use it as the barrier.
+        val batchAtWindowGate = CompletableDeferred<Unit>()
+        fixture.stream.isConversationLeft = { id ->
+            if (id == conversationId) batchAtWindowGate.complete(Unit)
+            false
+        }
+
+        fixture.gate.armNextRead()
+        val load = launch { fixture.stream.loadConversation(conversationId) }
+        advanceUntilIdle()
+
+        fixture.gate.readTaken.await()
+        fixture.commit(racingMessage)
+        fixture.eventBus.emit(
+            BackendEvent.DataEvent.BatchReceived(
+                driveId = chatDriveId,
+                batchData = listOf(racingMessage),
+            )
+        )
+        batchAtWindowGate.await()
+
+        fixture.gate.releaseRead()
+        load.join()
+
+        assertTrue(
+            fixture.stream.isMessageInWindow(
+                conversationId,
+                racingMessage.fileMetadata.appData.uniqueId!!,
+            ),
+            "a WS-pushed batch for a conversation whose initial load is mid-fetch must not be dropped",
+        )
+        fixture.close()
+    }
+
+    @Test
+    fun loadConversationAroundMessage_rowCommittedMidFetch_isRecovered() = runTest {
+        // The scroll-anchored open — the common cold-open path — builds its window
+        // with the same read-then-register shape and must be equally immune.
+        val fixture = buildFixture(this)
+        val anchor = fixture.seedMessage(userDateMs = 1_000L)
+        val racingMessage = fixture.buildMessageFile(userDateMs = 2_000L)
+
+        // loadAround issues anchor-lookup → older half (DESC) → newer half (ASC).
+        // Park on the newer half: it is the last read, and the racing row sorts
+        // into it, so the pre-park snapshot provably excludes it.
+        fixture.gate.armNextRead { sql -> sql.contains("ORDER BY") && sql.contains("ASC") }
+        val load = launch { fixture.stream.loadConversationAroundMessage(conversationId, anchor) }
+        advanceUntilIdle()
+
+        fixture.gate.readTaken.await()
+        fixture.commit(racingMessage)
+        fixture.eventBus.emit(
+            BackendEvent.DriveEvent.Stopped(
+                driveId = chatDriveId,
+                totalCount = 1,
+                result = BackendEvent.DriveResult.Completed,
+            )
+        )
+        advanceUntilIdle()
+
+        fixture.gate.releaseRead()
+        load.join()
+
+        assertTrue(
+            fixture.stream.isMessageInWindow(
+                conversationId,
+                racingMessage.fileMetadata.appData.uniqueId!!,
+            ),
+            "a row committed while loadAround was mid-fetch must end up in the window",
+        )
+        fixture.close()
+    }
+
+    @Test
+    fun loadConversation_withoutAConcurrentWrite_readsTheDatabaseOnce() = runTest {
+        // Guard on the other side of the fix: the re-read must be conditional,
+        // not an unconditional second page fetch on every conversation open.
+        val fixture = buildFixture(this)
+        val onlyMessage = fixture.seedMessage(userDateMs = 1_000L)
+        val readsBefore = fixture.gate.readCount
+
+        fixture.stream.loadConversation(conversationId)
+        advanceUntilIdle()
+
+        assertTrue(fixture.stream.isMessageInWindow(conversationId, onlyMessage))
+        assertEquals(
+            1, fixture.gate.readCount - readsBefore,
+            "an uncontended load must issue exactly one paging query",
+        )
+        fixture.close()
+    }
+
+    // ---------- fixture ----------
+
+    private suspend fun buildFixture(scope: TestScope): Fixture {
+        val inner = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        OdinDatabase.Schema.create(inner)
+        val gate = GatedSqlDriver(inner)
+        val dbm = DatabaseManager({ gate })
+        val credentialsManager = CredentialsManager().apply {
+            setActiveCredentials(
+                ApiCredentials.create(
+                    domain = OdinId(testDomain),
+                    clientAccessToken = "test-token",
+                    sharedSecret = SecureByteArray(ByteArray(16)),
+                )
+            )
+        }
+        val eventBus = EventBus()
+        val httpClient = HttpClient(MockEngine { respondError(HttpStatusCode.InternalServerError) })
+        val fileOps = NoopFileOperationsProvider()
+        val outboxSync = OutboxSync(
+            databaseManager = dbm,
+            uploader = ThrowingUploader,
+            eventBus = eventBus,
+            scope = scope.backgroundScope,
+        ).also { it.setOnline(false) }
+
+        val stream = ChatMessageStream(
+            credentialsManager = credentialsManager,
+            contactService = ContactService(
+                contactRepository = ContactRepository(
+                    contactsProvider = ContactsProvider(httpClient, credentialsManager) { _, _ -> null },
+                    contactPayloadReader = { _, _, _ -> null },
+                    databaseManager = dbm,
+                    credentialsManager = credentialsManager,
+                    eventBus = eventBus,
+                    scope = scope.backgroundScope,
+                ),
+                connections = ConnectionService(
+                    provider = ConnectionNetworkProvider(httpClient, credentialsManager),
+                    eventBus = eventBus,
+                    scope = scope.backgroundScope,
+                    cache = ConnectionCacheRepository(dbm, credentialsManager),
+                ),
+                scope = scope.backgroundScope,
+            ),
+            ownerSessionRepository = OwnerSessionRepository(
+                publicIdentityRepository = PublicIdentityRepository(httpClient),
+                publicProfileProviderCached = PublicProfileProviderCached(httpClient, fileOps),
+                eventBus = eventBus,
+                scope = scope.backgroundScope,
+            ),
+            dbm = dbm,
+            eventBus = eventBus,
+            scope = scope.backgroundScope,
+            driveFileProvider = DriveFileProvider(
+                httpClient,
+                credentialsManager,
+                DriveFileProviderCached(httpClient, credentialsManager, fileOps),
+            ),
+            optimisticWriter = OptimisticWriter(
+                credentialsManager = credentialsManager,
+                dbm = dbm,
+                eventBus = eventBus,
+                outboxSync = outboxSync,
+            ),
+        )
+        return Fixture(dbm, eventBus, gate, stream)
+    }
+
+    private inner class Fixture(
+        val dbm: DatabaseManager,
+        val eventBus: EventBus,
+        val gate: GatedSqlDriver,
+        val stream: ChatMessageStream,
+    ) {
+        fun close() = dbm.close()
+
+        /** Build a chat-message header without writing it to `DriveMainIndex`. */
+        fun buildMessageFile(userDateMs: Long, uniqueId: Uuid = Uuid.random()): HomebaseFile {
+            val content =
+                """{"message":"msg-${uniqueId.toString().take(8)}","deliveryStatus":20,"isEdited":false,"version":1}"""
+                    .replace("\"", "\\\"")
+            return OdinSystemSerializer.deserialize<HomebaseFile>(
+                """{
+                    "fileId": "${Uuid.random()}",
+                    "driveId": "$chatDriveId",
+                    "fileState": "active",
+                    "fileSystemType": "standard",
+                    "serverFileIsEncrypted": false,
+                    "keyHeader": {
+                        "iv": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+                        "aesKey": {"bytes": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}
+                    },
+                    "fileMetadata": {
+                        "globalTransitId": "${Uuid.random()}",
+                        "created": $userDateMs,
+                        "updated": $userDateMs,
+                        "transitCreated": $userDateMs,
+                        "transitUpdated": 0,
+                        "isEncrypted": false,
+                        "senderOdinId": "$testDomain",
+                        "originalAuthor": "$testDomain",
+                        "appData": {
+                            "uniqueId": "$uniqueId",
+                            "tags": null,
+                            "fileType": ${ChatProtocol.MessageFileType},
+                            "dataType": 0,
+                            "groupId": "$conversationId",
+                            "userDate": $userDateMs,
+                            "content": "$content",
+                            "previewThumbnail": null,
+                            "archivalStatus": 0
+                        },
+                        "localAppData": null,
+                        "referencedFile": null,
+                        "reactionPreview": null,
+                        "versionTag": "${Uuid.random()}",
+                        "payloads": [],
+                        "dataSource": null
+                    },
+                    "serverMetadata": {
+                        "accessControlList": {
+                            "requiredSecurityGroup": "owner",
+                            "circleIdList": null,
+                            "odinIdList": null
+                        },
+                        "doNotIndex": false,
+                        "allowDistribution": true,
+                        "fileSystemType": "standard",
+                        "fileByteCount": 100,
+                        "originalRecipientCount": 0,
+                        "transferHistory": null
+                    },
+                    "priority": 300,
+                    "fileByteCount": 100
+                }"""
+            )
+        }
+
+        /** Write [file] into `DriveMainIndex` — the DriveSync commit being raced. */
+        suspend fun commit(file: HomebaseFile) {
+            val record = MainIndexMetaHelpers.HomebaseFileProcessor(dbm)
+                .convertFileHeaderToDriveMainIndexRecord(testIdentityId, chatDriveId, file)
+            MainIndexMetaHelpers.upsertDriveMainIndex(dbm, record)
+        }
+
+        suspend fun seedMessage(userDateMs: Long): Uuid {
+            val file = buildMessageFile(userDateMs)
+            commit(file)
+            return file.fileMetadata.appData.uniqueId!!
+        }
+    }
+}
+
+/**
+ * `SqlDriver` decorator that parks the reader thread immediately AFTER a single
+ * armed `executeQuery` has run — the query's result set is already materialised,
+ * so the caller provably holds a pre-park snapshot of the database while the
+ * test mutates it from another thread.
+ *
+ * Blocking here is intentional and safe: reads run on `DatabaseManager`'s IO
+ * read dispatcher, never on the test scheduler.
+ */
+private class GatedSqlDriver(private val delegate: SqlDriver) : SqlDriver {
+
+    private val armed = AtomicBoolean(false)
+    private val release = CountDownLatch(1)
+
+    @Volatile
+    private var matches: (String) -> Boolean = { true }
+
+    /** Completed once the armed query has produced its snapshot. */
+    val readTaken = CompletableDeferred<Unit>()
+
+    private val reads = AtomicInteger(0)
+
+    /** Total `executeQuery` calls seen; tests read deltas around a single call. */
+    val readCount: Int get() = reads.get()
+
+    /** Park on the next query, optionally only one whose SQL satisfies [matching]. */
+    fun armNextRead(matching: (String) -> Boolean = { true }) {
+        matches = matching
+        armed.set(true)
+    }
+
+    fun releaseRead() = release.countDown()
+
+    override fun <R> executeQuery(
+        identifier: Int?,
+        sql: String,
+        mapper: (SqlCursor) -> QueryResult<R>,
+        parameters: Int,
+        binders: (SqlPreparedStatement.() -> Unit)?,
+    ): QueryResult<R> {
+        val gated = armed.get() && matches(sql) && armed.compareAndSet(true, false)
+        reads.incrementAndGet()
+        val result = delegate.executeQuery(identifier, sql, mapper, parameters, binders)
+        if (gated) {
+            readTaken.complete(Unit)
+            release.await()
+        }
+        return result
+    }
+
+    override fun execute(
+        identifier: Int?,
+        sql: String,
+        parameters: Int,
+        binders: (SqlPreparedStatement.() -> Unit)?,
+    ): QueryResult<Long> = delegate.execute(identifier, sql, parameters, binders)
+
+    override fun newTransaction(): QueryResult<Transacter.Transaction> = delegate.newTransaction()
+
+    override fun currentTransaction(): Transacter.Transaction? = delegate.currentTransaction()
+
+    override fun addListener(vararg queryKeys: String, listener: Query.Listener) =
+        delegate.addListener(queryKeys = queryKeys, listener = listener)
+
+    override fun removeListener(vararg queryKeys: String, listener: Query.Listener) =
+        delegate.removeListener(queryKeys = queryKeys, listener = listener)
+
+    override fun notifyListeners(vararg queryKeys: String) =
+        delegate.notifyListeners(queryKeys = queryKeys)
+
+    override fun close() = delegate.close()
+}
+
+private object ThrowingUploader : OutboxUploader {
+    override suspend fun upload(outboxRecord: Outbox, eventBus: EventBus) {
+        error("OutboxUploader.upload should never be called in ChatMessageStreamLoadRaceTest")
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageStreamLoadRaceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageStreamLoadRaceTest.kt
@@ -46,8 +46,8 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -82,12 +82,12 @@ class ChatMessageStreamLoadRaceTest {
         val alreadySynced = fixture.seedMessage(userDateMs = 1_000L)
         val racingMessage = fixture.buildMessageFile(userDateMs = 2_000L)
 
-        fixture.gate.armNextRead()
+        val fetchA = fixture.gate.armNextRead()
         val load = launch { fixture.stream.loadConversation(conversationId) }
         advanceUntilIdle()
 
         // Reader is now parked holding the pre-write snapshot.
-        fixture.gate.readTaken.await()
+        fetchA.reached.await()
         fixture.commit(racingMessage)
         fixture.eventBus.emit(
             BackendEvent.DriveEvent.Stopped(
@@ -98,7 +98,7 @@ class ChatMessageStreamLoadRaceTest {
         )
         advanceUntilIdle()
 
-        fixture.gate.releaseRead()
+        fetchA.release()
         load.join()
 
         val racingId = racingMessage.fileMetadata.appData.uniqueId!!
@@ -130,11 +130,11 @@ class ChatMessageStreamLoadRaceTest {
             false
         }
 
-        fixture.gate.armNextRead()
+        val fetchA = fixture.gate.armNextRead()
         val load = launch { fixture.stream.loadConversation(conversationId) }
         advanceUntilIdle()
 
-        fixture.gate.readTaken.await()
+        fetchA.reached.await()
         fixture.commit(racingMessage)
         fixture.eventBus.emit(
             BackendEvent.DataEvent.BatchReceived(
@@ -144,7 +144,7 @@ class ChatMessageStreamLoadRaceTest {
         )
         batchAtWindowGate.await()
 
-        fixture.gate.releaseRead()
+        fetchA.release()
         load.join()
 
         assertTrue(
@@ -153,6 +153,76 @@ class ChatMessageStreamLoadRaceTest {
                 racingMessage.fileMetadata.appData.uniqueId!!,
             ),
             "a WS-pushed batch for a conversation whose initial load is mid-fetch must not be dropped",
+        )
+        fixture.close()
+    }
+
+    @Test
+    fun loadConversation_rowCommittedDuringTheReRead_survivesTheWriteBack() = runTest {
+        // The re-read has its own snapshot boundary. By then the window exists, so a
+        // batch landing mid-re-read IS upserted into it by processIncrementalBatch —
+        // but the re-read's own write-back would replace that window with a page that
+        // predates the upsert. Same permanent loss as #1135, one fetch later, and with
+        // no reconciler left to heal it until the next DriveEvent.Stopped.
+        val fixture = buildFixture(this)
+        fixture.seedMessage(userDateMs = 1_000L)
+        val duringFetchA = fixture.buildMessageFile(userDateMs = 2_000L)
+        val duringReRead = fixture.buildMessageFile(userDateMs = 3_000L)
+
+        val batchAtWindowGate = CompletableDeferred<Unit>()
+        fixture.stream.isConversationLeft = { id ->
+            if (id == conversationId) batchAtWindowGate.complete(Unit)
+            false
+        }
+
+        val fetchA = fixture.gate.armNextRead()
+        val load = launch { fixture.stream.loadConversation(conversationId) }
+        advanceUntilIdle()
+
+        // Commit during the initial fetch — this is what triggers the re-read.
+        fetchA.reached.await()
+        fixture.commit(duringFetchA)
+        fixture.eventBus.emit(
+            BackendEvent.DriveEvent.Stopped(
+                driveId = chatDriveId,
+                totalCount = 1,
+                result = BackendEvent.DriveResult.Completed,
+            )
+        )
+        advanceUntilIdle()
+
+        // Arm the re-read's query before letting the initial fetch finish.
+        val reRead = fixture.gate.armNextRead()
+        fetchA.release()
+        reRead.reached.await()
+
+        // Commit during the re-read. The window exists now, so the WS path upserts it.
+        fixture.commit(duringReRead)
+        fixture.eventBus.emit(
+            BackendEvent.DataEvent.BatchReceived(
+                driveId = chatDriveId,
+                batchData = listOf(duringReRead),
+            )
+        )
+        batchAtWindowGate.await()
+
+        reRead.release()
+        load.join()
+
+        assertTrue(
+            fixture.stream.isMessageInWindow(
+                conversationId,
+                duringFetchA.fileMetadata.appData.uniqueId!!,
+            ),
+            "the re-read must still deliver the row that triggered it",
+        )
+        assertTrue(
+            fixture.stream.isMessageInWindow(
+                conversationId,
+                duringReRead.fileMetadata.appData.uniqueId!!,
+            ),
+            "a row upserted into the window while the re-read was in flight must survive " +
+                "its write-back — the re-read merges, it does not replace",
         )
         fixture.close()
     }
@@ -168,11 +238,11 @@ class ChatMessageStreamLoadRaceTest {
         // loadAround issues anchor-lookup → older half (DESC) → newer half (ASC).
         // Park on the newer half: it is the last read, and the racing row sorts
         // into it, so the pre-park snapshot provably excludes it.
-        fixture.gate.armNextRead { sql -> sql.contains("ORDER BY") && sql.contains("ASC") }
+        val fetchA = fixture.gate.armNextRead { sql -> sql.contains("ORDER BY") && sql.contains("ASC") }
         val load = launch { fixture.stream.loadConversationAroundMessage(conversationId, anchor) }
         advanceUntilIdle()
 
-        fixture.gate.readTaken.await()
+        fetchA.reached.await()
         fixture.commit(racingMessage)
         fixture.eventBus.emit(
             BackendEvent.DriveEvent.Stopped(
@@ -183,7 +253,7 @@ class ChatMessageStreamLoadRaceTest {
         )
         advanceUntilIdle()
 
-        fixture.gate.releaseRead()
+        fetchA.release()
         load.join()
 
         assertTrue(
@@ -370,37 +440,37 @@ class ChatMessageStreamLoadRaceTest {
 }
 
 /**
- * `SqlDriver` decorator that parks the reader thread immediately AFTER a single
- * armed `executeQuery` has run — the query's result set is already materialised,
- * so the caller provably holds a pre-park snapshot of the database while the
- * test mutates it from another thread.
+ * `SqlDriver` decorator that parks the reader thread immediately AFTER an armed
+ * `executeQuery` has run — the query's result set is already materialised, so the
+ * caller provably holds a pre-park snapshot of the database while the test mutates
+ * it from another thread.
+ *
+ * One stop is armed at a time; a test that needs to park twice (initial fetch and
+ * re-read) arms the second before releasing the first.
  *
  * Blocking here is intentional and safe: reads run on `DatabaseManager`'s IO
  * read dispatcher, never on the test scheduler.
  */
 private class GatedSqlDriver(private val delegate: SqlDriver) : SqlDriver {
 
-    private val armed = AtomicBoolean(false)
-    private val release = CountDownLatch(1)
+    class ReadStop internal constructor(internal val matches: (String) -> Boolean) {
+        internal val gate = CountDownLatch(1)
 
-    @Volatile
-    private var matches: (String) -> Boolean = { true }
+        /** Completes once the parked query has produced its snapshot. */
+        val reached = CompletableDeferred<Unit>()
 
-    /** Completed once the armed query has produced its snapshot. */
-    val readTaken = CompletableDeferred<Unit>()
+        fun release() = gate.countDown()
+    }
 
+    private val armed = AtomicReference<ReadStop?>(null)
     private val reads = AtomicInteger(0)
 
     /** Total `executeQuery` calls seen; tests read deltas around a single call. */
     val readCount: Int get() = reads.get()
 
     /** Park on the next query, optionally only one whose SQL satisfies [matching]. */
-    fun armNextRead(matching: (String) -> Boolean = { true }) {
-        matches = matching
-        armed.set(true)
-    }
-
-    fun releaseRead() = release.countDown()
+    fun armNextRead(matching: (String) -> Boolean = { true }): ReadStop =
+        ReadStop(matching).also { armed.set(it) }
 
     override fun <R> executeQuery(
         identifier: Int?,
@@ -409,12 +479,14 @@ private class GatedSqlDriver(private val delegate: SqlDriver) : SqlDriver {
         parameters: Int,
         binders: (SqlPreparedStatement.() -> Unit)?,
     ): QueryResult<R> {
-        val gated = armed.get() && matches(sql) && armed.compareAndSet(true, false)
+        val candidate = armed.get()
+        val stop = candidate
+            ?.takeIf { it.matches(sql) && armed.compareAndSet(it, null) }
         reads.incrementAndGet()
         val result = delegate.executeQuery(identifier, sql, mapper, parameters, binders)
-        if (gated) {
-            readTaken.complete(Unit)
-            release.await()
+        if (stop != null) {
+            stop.reached.complete(Unit)
+            stop.gate.await()
         }
         return result
     }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageStreamLoadRaceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageStreamLoadRaceTest.kt
@@ -76,13 +76,23 @@ class ChatMessageStreamLoadRaceTest {
     private val testDomain: String = "owner.test"
     private val conversationId: Uuid = Uuid.parse("11111111-1111-1111-1111-111111111111")
 
+    // Connection warm-up (sqlite_master, PRAGMAs), #887's pinned-bar refresh (a
+    // DriveLocalTagIndex read), and background service reads all pass through the
+    // gate on the same 4-wide read pool as the message-page fetch. An unqualified
+    // armNextRead() matches whichever of them the pool happens to run first, so the
+    // gate can park on the wrong query and mis-sequence the choreography — it passes
+    // locally but hangs on CI (runTest timeout). This index hint is emitted only by
+    // the per-conversation message-paging SELECT (groupId filter + userDate sort),
+    // so it parks on that read alone.
+    private val messagePageRead: (String) -> Boolean = { it.contains("idx_chatmessage_convid_userDate") }
+
     @Test
     fun loadConversation_rowCommittedMidFetch_isRecoveredViaDriveSyncStopped() = runTest {
         val fixture = buildFixture(this)
         val alreadySynced = fixture.seedMessage(userDateMs = 1_000L)
         val racingMessage = fixture.buildMessageFile(userDateMs = 2_000L)
 
-        val fetchA = fixture.gate.armNextRead()
+        val fetchA = fixture.gate.armNextRead(messagePageRead)
         val load = launch { fixture.stream.loadConversation(conversationId) }
         advanceUntilIdle()
 
@@ -130,7 +140,7 @@ class ChatMessageStreamLoadRaceTest {
             false
         }
 
-        val fetchA = fixture.gate.armNextRead()
+        val fetchA = fixture.gate.armNextRead(messagePageRead)
         val load = launch { fixture.stream.loadConversation(conversationId) }
         advanceUntilIdle()
 
@@ -175,7 +185,7 @@ class ChatMessageStreamLoadRaceTest {
             false
         }
 
-        val fetchA = fixture.gate.armNextRead()
+        val fetchA = fixture.gate.armNextRead(messagePageRead)
         val load = launch { fixture.stream.loadConversation(conversationId) }
         advanceUntilIdle()
 
@@ -192,7 +202,7 @@ class ChatMessageStreamLoadRaceTest {
         advanceUntilIdle()
 
         // Arm the re-read's query before letting the initial fetch finish.
-        val reRead = fixture.gate.armNextRead()
+        val reRead = fixture.gate.armNextRead(messagePageRead)
         fetchA.release()
         reRead.reached.await()
 
@@ -238,7 +248,7 @@ class ChatMessageStreamLoadRaceTest {
         // loadAround issues anchor-lookup → older half (DESC) → newer half (ASC).
         // Park on the newer half: it is the last read, and the racing row sorts
         // into it, so the pre-park snapshot provably excludes it.
-        val fetchA = fixture.gate.armNextRead { sql -> sql.contains("ORDER BY") && sql.contains("ASC") }
+        val fetchA = fixture.gate.armNextRead { messagePageRead(it) && it.contains("ASC") }
         val load = launch { fixture.stream.loadConversationAroundMessage(conversationId, anchor) }
         advanceUntilIdle()
 
@@ -477,8 +487,14 @@ private class GatedSqlDriver(private val delegate: SqlDriver) : SqlDriver {
     /** SQL of every `executeQuery`, in order — lets tests count reads by query shape. */
     val readSqls: List<String> get() = readSql.toList()
 
-    /** Park on the next query, optionally only one whose SQL satisfies [matching]. */
-    fun armNextRead(matching: (String) -> Boolean = { true }): ReadStop =
+    /**
+     * Park on the next query whose SQL satisfies [matching]. There is deliberately
+     * no match-all default: connection warm-up (sqlite_master, PRAGMAs), the pinned
+     * bar's DriveLocalTagIndex read, and background service reads all pass through
+     * this gate on the same read pool, so a caller must name the query it means to
+     * park on or it will race them.
+     */
+    fun armNextRead(matching: (String) -> Boolean): ReadStop =
         ReadStop(matching).also { armed.set(it) }
 
     override fun <R> executeQuery(

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/PaginatedConversationStateTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/PaginatedConversationStateTest.kt
@@ -98,6 +98,73 @@ class PaginatedConversationStateTest {
         assertTrue(state.windows.value.isEmpty())
     }
 
+    // ---------- initial-load race bookkeeping (#1135) ----------
+
+    @Test
+    fun endInitialLoad_reportsWhetherAWriteLandedDuringTheLoad() {
+        val state = PaginatedConversationState()
+
+        state.beginInitialLoad(convoId)
+        assertFalse(state.endInitialLoad(convoId), "quiet load must not ask for a re-read")
+
+        state.beginInitialLoad(convoId)
+        state.markInitialLoadDirty(convoId)
+        assertTrue(state.endInitialLoad(convoId), "a write during the load must ask for a re-read")
+    }
+
+    @Test
+    fun endInitialLoad_clearsTheMarker_soALaterWriteIsNotAttributedToTheFinishedLoad() {
+        // The failure path calls endInitialLoad too; if the marker survived, every
+        // later sync round would keep flagging the conversation forever.
+        val state = PaginatedConversationState()
+        state.beginInitialLoad(convoId)
+        state.endInitialLoad(convoId)
+
+        state.markInitialLoadDirty(convoId)
+        state.markAllInitialLoadsDirty()
+
+        assertFalse(state.endInitialLoad(convoId))
+    }
+
+    @Test
+    fun markInitialLoadDirty_isScopedToTheConversation() {
+        val state = PaginatedConversationState()
+        val otherConvoId = Uuid.parse("44444444-4444-4444-4444-444444444444")
+        state.beginInitialLoad(convoId)
+        state.beginInitialLoad(otherConvoId)
+
+        state.markInitialLoadDirty(otherConvoId)
+
+        assertFalse(state.endInitialLoad(convoId))
+        assertTrue(state.endInitialLoad(otherConvoId))
+    }
+
+    @Test
+    fun markAllInitialLoadsDirty_flagsEveryInFlightLoad() {
+        // refreshCachedWindows walks `windows`, which a mid-load conversation is
+        // absent from — so the post-sync path has to flag them all.
+        val state = PaginatedConversationState()
+        val otherConvoId = Uuid.parse("55555555-5555-5555-5555-555555555555")
+        state.beginInitialLoad(convoId)
+        state.beginInitialLoad(otherConvoId)
+
+        state.markAllInitialLoadsDirty()
+
+        assertTrue(state.endInitialLoad(convoId))
+        assertTrue(state.endInitialLoad(otherConvoId))
+    }
+
+    @Test
+    fun reset_dropsInFlightLoadMarkers() {
+        val state = PaginatedConversationState()
+        state.beginInitialLoad(convoId)
+        state.markInitialLoadDirty(convoId)
+
+        state.reset()
+
+        assertFalse(state.endInitialLoad(convoId), "logout must not leave a re-read pending")
+    }
+
     @Test
     fun prependOlderMessages_keepsAscendingOrder_andDedupesByMessageId() {
         val state = PaginatedConversationState()

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/PaginatedConversationStateTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/PaginatedConversationStateTest.kt
@@ -98,6 +98,50 @@ class PaginatedConversationStateTest {
         assertTrue(state.windows.value.isEmpty())
     }
 
+    @Test
+    fun setInitialWindow_merge_keepsConcurrentUpsertsAndLetsTheFreshPageWinOnConflicts() {
+        // The raced re-read's write-back. Anything upserted into the window while
+        // that fetch ran is absent from its results; replacing would drop it.
+        val state = PaginatedConversationState()
+        val stale = message(userDateMs = 10, conversationId = convoId)
+        val upsertedDuringReRead = message(userDateMs = 30, conversationId = convoId)
+        state.setInitialWindow(convoId, listOf(stale, upsertedDuringReRead))
+
+        val refreshed = stale.copy(content = "edited")
+        val fromReRead = message(userDateMs = 20, conversationId = convoId)
+        state.setInitialWindow(
+            conversationId = convoId,
+            messages = listOf(refreshed, fromReRead),
+            olderCursor = QueryBatchCursor(paging = TimeRowCursor(UnixTimeUtc(10), 0L)),
+            hasOlderMessages = true,
+            merge = true,
+        )
+
+        val window = state.getWindow(convoId)!!
+        assertEquals(
+            listOf(stale.id, fromReRead.id, upsertedDuringReRead.id),
+            window.messages.map { it.id },
+            "a message the fresh page doesn't carry must survive the merge",
+        )
+        assertEquals(
+            "edited", window.messages.first { it.id == stale.id }.content,
+            "the fresh page wins on id conflicts",
+        )
+        assertTrue(window.hasOlderMessages, "cursors come from the fresh page")
+    }
+
+    @Test
+    fun setInitialWindow_withoutMerge_replaces() {
+        val state = PaginatedConversationState()
+        val gone = message(userDateMs = 10, conversationId = convoId)
+        state.setInitialWindow(convoId, listOf(gone))
+
+        val fresh = message(userDateMs = 20, conversationId = convoId)
+        state.setInitialWindow(convoId, listOf(fresh))
+
+        assertEquals(listOf(fresh.id), state.getWindow(convoId)!!.messages.map { it.id })
+    }
+
     // ---------- initial-load race bookkeeping (#1135) ----------
 
     @Test


### PR DESCRIPTION
Fixes #1135.

## TL;DR

**What was broken.** Opening a conversation read the DB, *then* registered the window. A DriveSync/WS write landing in that gap was invisible to the read (pre-write SQLite snapshot) *and* dropped by both reconcilers, which skip conversations that have no window yet. The stale window was then cached and reused forever — the thread permanently missing its newest messages while the conversation-list row showed them.

**The fix.** Register the load *before* the read. The reconcilers now flag an in-flight load instead of dropping the batch, and the loader re-reads once if it sees the flag. Bookkeeping is a second `MutableStateFlow` map in `PaginatedConversationState`, same CAS discipline as `_windows` — no new locks. The marker is cleared on the throw path too, so a failed fetch can't wedge a conversation into permanent "loading".

**Two things beyond what the issue asked for:**
1. The same guard on `loadConversationAroundMessage`. The issue names only `loadConversation`, but the anchor path has the identical read-then-register shape — and device logs confirm it is the *common* open (`hasCached=false savedAnchor=… → loadAround`), so omitting it would have left the bug reproducible on the most frequent path.
2. The re-read **merges** instead of replacing. Caught in review: a batch landing during the re-read is upserted into the by-then-existing window, then clobbered by a replacing write-back — the same permanent loss, one fetch later, with nothing armed to heal it.

**Second defect** (the maintainer's question on the issue). `MarkAsRead` now clamps to the newest *rendered* message and the `convoLatest` floor is gone. It compares on `sqlUserDate` — the un-clamped SQL column — rather than the display `userDate`, because that floor existed to paper over the clamped-vs-un-clamped mismatch; deleting it naively would have re-broken a stuck unread badge.

**How it was verified.** Each race test was proven to **fail** with its own fix disabled, not merely to pass with it. Determinism comes from a `GatedSqlDriver` on the `driverProvider` seam `DatabaseManager` already exposes, parking the reader after the result set materialises. 1004 `homebase-chat` tests green; CI green on Android/Desktop/iOS. On device the read clamp is visibly correct — `newReadTime` tracks scroll position and only reaches `convoLatest` at the bottom.

## Update — merged `main` (#887) & fixed a test-only CI flake

`main` was merged in (bringing the #887 pinned-messages bar). `ChatMessageStream.kt` was resolved so auto-pin + pinned-bar refresh run on both the raced and common paths. **Production code for this fix is unchanged by the flake resolution below** — only the test's DB gate changed.

**Symptom.** `ChatMessageStreamLoadRaceTest.loadConversation_rowCommittedMidFetch_isRecoveredViaDriveSyncStopped` failed on CI (`AssertionError` at the `runTest {` lambda line — a `runTest` timeout, not an assertion) while passing locally 12/12.

**Root cause (instrumented, not guessed).** #887 added a pinned-bar read (`DriveLocalTagIndex`) to `loadConversation`/`refreshCachedWindows`. The test's `GatedSqlDriver.armNextRead()` matched **any** query, and reads run on a 4-wide pool (`READ_PARALLELISM=4`). Capturing the gate's query stream showed **5 of 7** queries flowing through it are non-paging — `sqlite_master`, three connection-warm-up `PRAGMA`s, and the new `DriveLocalTagIndex` read. Which one parks the gate is therefore a race: locally the paging read wins every time; on CI it sometimes parks on a non-paging read and the choreography hangs.

Ruled out the competing "`markAllInitialLoadsDirty` vs `endInitialLoad`" theory: the fixture uses `scope.backgroundScope` (shares the test's `StandardTestDispatcher`, so `advanceUntilIdle()` fully drains `refreshCachedWindows`), and the captured stream showed the re-read reliably fires (`pagingReads=2`) — the dirty flag is set in time.

**Fix (test-only).** Park the gate only on the per-conversation message-paging `SELECT`, identified by its `idx_chatmessage_convid_userDate` index hint (pinned/PRAGMA/background reads never carry it), at all five gate sites; and drop the match-all `armNextRead()` default that was the footgun. Verified with a 12× full-class stress run (60 executions), 0 failures.

---

## The race

`loadConversation` did read-then-register: it awaited `fetchMessages` and only then called `setInitialWindow`. Both reconcilers skip windowless conversations — `refreshCachedWindows` iterates `paginatedState.windows.value`, and `processIncrementalBatch` early-returns on `getWindow() == null`. So a DriveSync/WS write committing between the start of the fetch and `setInitialWindow` was invisible to the fetch's SQLite snapshot **and** dropped by both reconcilers. The stale window was then cached and reused on every subsequent open, so the thread stayed wrong indefinitely while the conversation-list row (which re-queries separately, after the commit) showed the newer preview.

## Fix — the issue's preferred option 1

`PaginatedConversationState` gains a second `MutableStateFlow<Map<Uuid, Boolean>>` beside `_windows`, using the same `update {}` / `getAndUpdate {}` CAS discipline the class already uses. Key present = initial load in flight; value = a write landed during it.

- `loadConversation` registers **before** `fetchMessages`. `endInitialLoad` runs on the success path and on the `catch`+rethrow path — without the latter, a thrown fetch would leave the conversation permanently "loading" and flagged by every later sync round.
- `refreshCachedWindows` calls `markAllInitialLoadsDirty()` at the top. It walks `windows`, which a mid-load conversation is absent from, so it can't do this per-conversation.
- `processIncrementalBatch`'s window gate marks the load dirty instead of silently dropping the batch. This is **additive** — it only fires in the `getWindow() == null` branch, so live upserts into existing windows are untouched.
- When the flag is set the loader re-reads **once**. Not a loop: the window exists after the first `setInitialWindow`, so anything landing later is handled by the reconcilers normally.

### Also covered: `loadConversationAroundMessage`

The issue names only `loadConversation`, but the anchor path has the identical read-then-register shape — and per `ConversationListViewModel` it is the path a scroll-anchored cold open takes, i.e. the *common* open. Leaving it out would have left the bug reproducible on the most frequent path. The existing body was extracted into a private `seedWindowAround(...)` so the re-seed isn't duplicated.

### Review follow-up: the re-read must merge, not replace

Caught in review — the first version of the fix reintroduced the same defect one fetch later:

```
endInitialLoad(id)      // marker cleared, dirty = true
fresh = fetchMessages() // fetch B — window exists now, but no marker armed
setInitialWindow(fresh) // REPLACES
```

A batch committing during fetch B is upserted into the (by then existing) window by `processIncrementalBatch`, but fetch B's snapshot predates it, so the replacing write-back drops it. Same permanent loss, and with no marker armed nothing heals it until some later `DriveEvent.Stopped` happens to fire — a WS `BatchReceived` outside a sync round leaves it lost forever.

`setInitialWindow` gained a `merge` flag: keep any message the existing window holds that the fresh page doesn't, fresh winning on id conflicts, unioned inside the single atomic `_windows.update {}` (a caller-side read-then-write would race the same way). Cursors still come from the fresh page — survivors sit at the newest end, so the older-side cursor stays valid and `prependOlderMessages` already dedupes any over-fetch.

Only the two re-read paths set it. The initial seed still replaces, which is required: `loadConversationAroundMessage` is called with `hasCached=true` to *re-centre* a window on an out-of-window jump target, and merging there would retain messages the centred page deliberately excludes, leaving survivors older than the new `olderCursor` (a gap).

## Second defect: `MarkAsRead` over-advanced

Per the maintainer's answer on the issue, read state now clamps to the newest **rendered** message rather than the conversation's latest. Previously `MarkAsRead` advanced `lastRead` to `convoLatest` while `viewedMax` was ~10h older — marking as read messages that were never in the thread, clearing the unread badge and destroying the only signal that the tail was missing.

Simply dropping the `convoLatest` floor would have re-broken what it was added for: `MessageUiModel.userDate` is clamped to `transitCreated`, while `selectAllUnreadCount` filters the un-clamped `DriveMainIndex.userDate`, and that mismatch stuck a badge at 1. So instead the SQL-faithful value rides on the model as `MessageUiModel.sqlUserDate`, sourced from the existing `HomebaseFile.sqlUserDateMs()` helper (already used by `QueryBatch` for exactly this un-clamp reason) and defaulted to `userDate` for synthetic models. `newReadTime` is now `viewedRecords.maxOf { it.sqlUserDate }` with no floor. That satisfies "clamp to the newest rendered message" *and* keeps the badge-unstick. `convoLatest` is retained for the diagnostic log line only.

## Tests

`homebase-chat:jvmTest` — 1004 tests, 0 failures. New:

- `ChatMessageStreamLoadRaceTest` (5): mid-fetch recovery via `Stopped`, via `BatchReceived`, via `loadAround`; the mid-re-read merge; and an uncontended-load guard pinning that the re-read stays conditional.
- `PaginatedConversationStateTest` (+7): marker lifecycle, scoping, `reset`, and both `setInitialWindow` merge/replace semantics.
- `ChatMessageActionServiceTest` (+2): the rendered-message clamp, and that it advances on `sqlUserDate` not the clamped display value.

Every race test was individually verified to **fail** with its corresponding fix disabled (production temporarily env-gated, then reverted) — not just to pass with it.

Determinism comes from the seam `DatabaseManager` already exposes (its `driverProvider` lambda), via a `GatedSqlDriver` decorator that runs the query then parks the reader thread after the result set is materialised, giving a provable "caller holds a pre-write snapshot" window. Blocking there is safe: reads run on the IO read dispatcher, never the test scheduler.

Also green: `homebase-common:jvmTest`, `homebase-api:jvmTest`, and `compileKotlinJvm` / `compileAndroidMain` / `compileKotlinIosSimulatorArm64`.

## Out of scope

`loadConversationAroundMessage` still falls back to the newest page when the anchor isn't in the local DB, without ever fetching the tapped file from the server — the independent defect the issue calls out. `resolveForNotification` already demonstrates the `driveFileProvider.getFileHeaderByUid` pattern that would fix it.

## Device verification (Android, Redmi Note 5 Pro, SDK 30)

**Verified:**
- Conversation opens go through `loadConversationAroundMessage`, not `loadConversation` — `(ChatPaging) open hasCached=false savedAnchor=… → loadAround(…)`. This confirms on a real device that extending the fix to the anchor path was necessary, not speculative; it is the common open.
- That open logged exactly one seed and no re-read, i.e. `endInitialLoad` correctly reported "no concurrent write" on an uncontended load — the behaviour `loadConversation_withoutAConcurrentWrite_readsTheDatabaseOnce` pins. Marker registered and cleared with no leak.
- Thread tail is complete and agrees with the conversation-list preview (the core #1135 symptom): the list showed `11:22 Michael: So never forget....` and that message is present as the newest in the thread. Window came back `windowSize=67 hasOlder=true hasNewer=false`.
- **The MarkAsRead clamp, demonstrated live.** Scrolling from mid-history to the bottom, `newReadTime` tracked the rendered set and only reached `convoLatest` on actually reaching the newest message:

```
newReadTime=1784686905316   convoLatest=1784798577229
newReadTime=1784779142376   convoLatest=1784798577229
newReadTime=1784780829056   convoLatest=1784798577229
newReadTime=1784781100289   convoLatest=1784798577229
newReadTime=1784798577229   convoLatest=1784798577229   <- only at the bottom
```

  The old `max(viewedMax, convoLatest)` would have jumped to `1784798577229` on the first mark.
- **`sqlUserDate` was load-bearing, on real data.** Two samples show the SQL value ahead of the clamped display value — `newReadTime=1784779142376` vs `clampedViewedMax=1784779141817` (559ms), and `1784780953497` vs `1784780952195` (1302ms). Clamping on the display value would have left read state lagging on this device's actual data.

**Not verified on device:**
- A live inbound batch rendering into an open conversation. No `processIncrementalBatch` fired during the session, so the "window exists → upsert" path is JVM-test-verified only. This is the regression worth a second look, since a leaked in-flight marker would manifest exactly there.
- The raced re-read itself (`raced a concurrent write` count: 0). Reproducing needs a sync round landing inside a slow fetch on a cold-wake push tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)