### PR TITLE
fix(search): render search field text at bodyLarge, not TopAppBar titleLarge (#1147)

### DIFF
--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/StyledSearchTextField.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/StyledSearchTextField.kt
@@ -42,6 +42,8 @@ fun StyledSearchTextField(
     TextField(
         state = textFieldState,
         modifier = modifier,
+        // Not LocalTextStyle: both search bars sit in a TopAppBar title slot, which provides titleLarge (22sp).
+        textStyle = MaterialTheme.typography.bodyLarge,
         lineLimits = TextFieldLineLimits.SingleLine,
         placeholder = {
             Text(placeHolderText)


### PR DESCRIPTION
## Symptom

Text typed into the chat search bar rendered at app-bar **title** size (22sp) instead of a text-field size. In the 40dp-tall field the glyphs nearly filled the box and a longer query scrolled out of view — `home.bishwajeetparhi.dev` showed as `ome.bishwajeetparhi.dev`, with the leading character pushed off the left edge.

## Root cause

M3's `TextField` defaults `textStyle` to `LocalTextStyle.current`, and `StyledSearchTextField` passed no `textStyle`. Both chat search bars render it inside a `TopAppBar` `title` slot, and `TopAppBar` wraps that slot in `ProvideContentColorTextStyle(…, titleTextStyle, …)` — so the ambient style there is `titleLarge` (22sp) and the input text inherited it.

## What changed

One line in `homebase-common/.../widget/StyledSearchTextField.kt` — pass `textStyle = MaterialTheme.typography.bodyLarge` explicitly, so the field's text size no longer depends on whatever slot it is dropped into.

The placeholder needed no change: M3's `CommonDecorationBox` decorates the placeholder with `MaterialTheme.typography.bodyLarge` read from the theme (verified in the material3 1.9.0 bytecode — `TextFieldImplKt$CommonDecorationBox$3$decoratedPlaceholder$1` is constructed from `MaterialTheme.typography.bodyLarge`), not from `LocalTextStyle` or from `textStyle`. It was already 16sp; the typed text now matches it.

The `heightIn(max = 40.dp)` cap in `MinimalSearchTextField` is left alone. With `bodyLarge` the line box is 24dp (16sp / 24sp line height) inside a 40dp field with `vertical = 0.dp` content padding — 8dp of slack above and below at default font scale, no crowding. Raising it to 48dp would change app-bar layout at all four `MinimalSearchTextField` call sites for no benefit.

## Verification

```
./gradlew :homebase-common:compileKotlinJvm                          # BUILD SUCCESSFUL
./gradlew :homebase-common:jvmTest --tests ...StyledSearchTextFieldTest   # BUILD SUCCESSFUL (5 tests)
./gradlew :homebase-chat:compileKotlinJvm :homebase-core:compileKotlinJvm # BUILD SUCCESSFUL
```

No signature change, so no consumer could break. The other seven call sites (`CreateConversationScreen`, `SelectMembersScreen`, `AddGroupMembersScreen`, `CircleMemberPickerScreen`, `EmergencyContactPickerScreen`, `SharePickerScreen`, `EmojiSelection`) all render in a Scaffold body where the ambient style is already `MaterialTheme.typography.bodyLarge` (M3's `MaterialTheme` calls `ProvideTextStyle(typography.bodyLarge)`), so this is a no-op for them.

On-device visual confirmation of the two app-bar search bars still pending.

Fixes #1147

🤖 Generated with [Claude Code](https://claude.com/claude-code)