### PR TITLE
fix(chat): apply cold-load last-message preview unconditionally (#1148)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/ConversationUiModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/ConversationUiModel.kt
@@ -151,10 +151,25 @@ data class ConversationUiModel(
 
     companion object {
         /**
-         * Patches the conversation's last-message fields if [msg] is at least
-         * as recent as the current [latestMessageTimestamp].
+         * Patches the conversation's last-message fields from [msg].
          *
-         * The "recency" comparison is driven by [latestTimestampOverrideMs]
+         * The preview is applied **unconditionally**; only the
+         * [latestMessageTimestamp] sort key is protected against regression.
+         * The single production caller is
+         * [id.homebase.chat.services.convo.ConversationMapper.applyLastMessage]
+         * on the cold-load / post-sync enrichment path, where the
+         * `selectAllConversationPlusLastMessage` row IS the authority for "what
+         * is the last message" and the row being patched always still carries
+         * `mapToBasic`'s `" "` placeholder. That query excludes status messages
+         * (`dataType = 202`) while `applyIncomingMessageBump` advances the sort
+         * key for them, so the persisted `localAppData.latestMessageTimestamp`
+         * seed can legitimately be *newer* than the newest real message — under
+         * the old `candidate >= latestMessageTimestamp` guard the preview lost
+         * that comparison and the row rendered "No messages yet" next to a
+         * correct timestamp (#1148). Live arrivals keep their own recency guard
+         * in [id.homebase.chat.services.convo.applyIncomingMessageBump].
+         *
+         * The candidate timestamp is driven by [latestTimestampOverrideMs]
          * when the caller knows the SQL-side userDate (e.g. from
          * `selectAllConversationPlusLastMessage`'s `msgUserDate` projection,
          * or from `HomebaseFile.sqlUserDateMs()` for files just written to
@@ -177,21 +192,18 @@ data class ConversationUiModel(
             val candidate = latestTimestampOverrideMs
                 ?.let { Instant.fromEpochMilliseconds(it) }
                 ?: msg.userDate
-            if (candidate >= latestMessageTimestamp) {
-                return this.copy(
-                    lastMessage = msg.content.truncateToCodePoints(40),
-                    latestMessageTimestamp = candidate,
-                    lastMessageDeliveryStatus = msg.messageAppData.deliveryStatus,
-                    lastMessageIsPendingSend = msg.isPendingSend,
-                    lastMessageIsDeleted = msg.isDeleted,
-                    lastMessageFirstPayload = msg.payloads?.firstOrNull(),
-                    lastMessageHasMultiplePayloads = (msg.payloads?.size ?: 0) > 1,
-                    lastMessageContent = msg.messageContent,
-                    lastMessageIsFromActiveUser = msg.isFromActiveUser(activeUserDomain),
-                    lastMessageSender = msg.originalAuthor,
-                )
-            }
-            return this
+            return this.copy(
+                lastMessage = msg.content.truncateToCodePoints(40),
+                latestMessageTimestamp = maxOf(candidate, latestMessageTimestamp),
+                lastMessageDeliveryStatus = msg.messageAppData.deliveryStatus,
+                lastMessageIsPendingSend = msg.isPendingSend,
+                lastMessageIsDeleted = msg.isDeleted,
+                lastMessageFirstPayload = msg.payloads?.firstOrNull(),
+                lastMessageHasMultiplePayloads = (msg.payloads?.size ?: 0) > 1,
+                lastMessageContent = msg.messageContent,
+                lastMessageIsFromActiveUser = msg.isFromActiveUser(activeUserDomain),
+                lastMessageSender = msg.originalAuthor,
+            )
         }
     }
 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/data/ConversationUiModelUpdateWithLatestMessageTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/data/ConversationUiModelUpdateWithLatestMessageTest.kt
@@ -121,6 +121,31 @@ class ConversationUiModelUpdateWithLatestMessageTest {
         assertEquals(ahead, result.latestMessageTimestamp.toEpochMilliseconds())
     }
 
+    /**
+     * #1148 — a status message ("You updated the conversation photo") advances
+     * `latestMessageTimestamp` and gets that value persisted into `localAppData`,
+     * but `selectAllConversationPlusLastMessage` excludes `dataType = 202`. Cold-load
+     * enrichment therefore arrives with a message OLDER than the seeded sort key; the
+     * old `candidate >= latestMessageTimestamp` guard rejected it and the row kept
+     * `mapToBasic`'s `" "` placeholder, rendering "No messages yet" beside a correct
+     * timestamp. The preview must apply anyway; the sort key must not regress.
+     */
+    @Test
+    fun appliesPreview_whenSeedTimestampIsNewerThanEnrichmentMessage() {
+        val statusMs = 2_000_000_000_000L // status message time, persisted in localAppData
+        val realMs = 1_999_999_000_000L   // newest non-status message the SQL JOIN can return
+        val convo = convo(latestMs = statusMs)
+
+        val result = convo.updateWithLatestMessage(
+            msg = peerMessage(clampedUserDateMs = realMs),
+            activeUserDomain = me,
+            latestTimestampOverrideMs = realMs,
+        )
+
+        assertEquals("hi", result.lastMessage)
+        assertEquals(statusMs, result.latestMessageTimestamp.toEpochMilliseconds())
+    }
+
     @Test
     fun propagates_isPendingSend_forStuckOutgoingLastMessage() {
         val convo = convo(latestMs = 0L)


### PR DESCRIPTION
## Symptom

A group conversation with plenty of history shows **"No messages yet"** as its preview line in the conversation list, while the timestamp column on the same row shows a correct recent time ("Yesterday"). Opening the thread shows every message is there. The thread ends with a **status message** ("You updated the conversation photo"), with the last real user message just above it. Observed on Android; the code path is common, so Desktop/iOS are affected identically.

## Root cause

The persisted list sort key ends up *newer* than the newest message the last-message query is allowed to return, and the enrichment step then silently refuses to apply the preview. Every link verified by code reading, and the whole chain is now pinned by a test (see below).

1. `applyIncomingMessageBump` advances `latestMessageTimestamp` for **every** arrival including status messages — only the unread `increment` is gated on `!m.isStatusMessage` (`ConversationMessageBump.kt:82`, `:108-113`).
2. Mark-as-read persists that sort key into the conversation file's `localAppData` (`ConversationService.kt:2698-2705` → `OptimisticWriter.stampConversationLastReadTime(latestMessageTimestamp = convo.latestMessageTimestamp)`).
3. On cold start `ConversationMapper.mapToBasic` seeds the row with `lastMessage = " "` and `latestMessageTimestamp = localAppData.latestMessageTimestamp` — i.e. the **status message's** time (`ConversationMapper.kt:213`, `:222`).
4. `enrichWithLastMessages` runs `selectAllConversationPlusLastMessage`, which **excludes `dataType = 202`** (`ChatReadCount.sq:51`) — so it returns the newest *real* message, which is older.
5. `applyLastMessage` → `ConversationUiModel.updateWithLatestMessage` was guarded by `candidate >= latestMessageTimestamp`. The real last message loses that comparison, the function returns the row **unchanged**, and `lastMessage` stays at the `" "` placeholder.
6. `ConversationItem` renders a blank preview as the `chat_no_messages` fallback (`ConversationItem.kt:418-427`).

That is why the time column looks right while the preview is empty. `mapToBasic`'s own comment claims *"applyLastMessage overwrites this once the real last message is loaded"* — the `>=` guard meant it didn't.

## The fix

Drop the recency guard on the cold-load enrichment path: `updateWithLatestMessage` now applies the preview **unconditionally** and clamps only the sort key with `maxOf(candidate, latestMessageTimestamp)`.

**Why the guard was safe to drop here rather than parameterised away:** every production call to `mapToConversationUi` passes `lastMsg = null`, so `applyLastMessage` — and therefore `updateWithLatestMessage` — is reached from exactly one place in production: `ConversationStream.enrichWithLastMessages`. Both of its call sites (`start()` and the post-`DriveEvent.Stopped` reload) run immediately after `loadBasicConversations()`, which wholesale-replaces the list with freshly mapped rows carrying `lastMessage = " "`. So the row being patched never holds a live-arrival preview that could be downgraded, and no extra flag/overload is needed to scope the change.

**What it overwrites vs. leaves alone:**

- **Overwritten unconditionally** — the denormalised preview fields: `lastMessage`, `lastMessageDeliveryStatus`, `lastMessageIsPendingSend`, `lastMessageIsDeleted`, `lastMessageFirstPayload`, `lastMessageHasMultiplePayloads`, `lastMessageContent`, `lastMessageIsFromActiveUser`, `lastMessageSender`. The SQL row is the authority for *what the last message is* on this path.
- **Monotonic, never dragged backwards** — `latestMessageTimestamp`. Applying the older real message's time unconditionally would move the row's sort key (and its time column) backwards past the status message, changing list ordering. `maxOf` keeps the row showing the newest activity while the preview still lands.
- **Untouched** — everything else (`unreadCount`, `lastRead`, `dirty`, membership/structural fields).

Live arrivals are unaffected: `applyIncomingMessageBump` has its own `>`/`==`/`<` recency logic and never calls this function.

### Why not the alternatives

- **Stop status messages advancing `latestMessageTimestamp`** — would change list ordering for group-admin activity (a rename/photo change/member add would no longer float the thread). Deliberately rejected.
- **Fall back to the seed timestamp when the preview is blank** — hides the mismatch instead of fixing it.

## Test

One test added to `ConversationUiModelUpdateWithLatestMessageTest`, the class that already locks down this exact function: seed a row whose `latestMessageTimestamp` is newer than the enrichment message, assert the preview text applies *and* the sort key does not regress.

The issue noted the diagnosis was from code reading and not reproduced under instrumentation. This test is that confirmation — it reproduces the exact failure mode against the pre-fix code:

```
ConversationUiModelUpdateWithLatestMessageTest > appliesPreview_whenSeedTimestampIsNewerThanEnrichmentMessage FAILED
    org.junit.ComparisonFailure: expected:<[hi]> but was:<[ ]>
5 tests completed, 1 failed
```

`< >` is `mapToBasic`'s placeholder — the rejected patch, exactly as diagnosed. With the fix:

```
> Task :homebase-chat:jvmTest
BUILD SUCCESSFUL
classes=142 tests=1015 failures/errors=0 skipped=3
```

The pre-existing `override_doesNotRegress_whenAlreadyAhead` case still passes, which is what pins the sort key's monotonicity.

## Verification

- `./gradlew :homebase-chat:jvmTest --rerun-tasks` → BUILD SUCCESSFUL, 1015 tests, 0 failures.
- `./gradlew :homebase-chat:compileKotlinJvm :homebase-chat:compileAndroidMain :homebase-chat:compileKotlinWasmJs` → BUILD SUCCESSFUL (only pre-existing warnings).
- No UI/Composable or string changes, so no `homebase-common` Konsist surface touched.

Fixes #1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)