### PR TITLE
fix(chat): resolve attachment MIME from the picked URI, not the sandbox copy (#1149)

### DIFF
--- a/homebase-chat/src/androidMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.android.kt
+++ b/homebase-chat/src/androidMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.android.kt
@@ -5,8 +5,8 @@ import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.cacheDir
 import io.github.vinceglb.filekit.copyTo
+import io.github.vinceglb.filekit.mimeType
 import io.github.vinceglb.filekit.name
-import kotlin.uuid.Uuid
 
 // Native PlatformFile carries a real path / content:// URI; the existing path-based send
 // pipeline (and resolveToFilePath for content URIs) already handles it. No copy needed at send time.
@@ -17,7 +17,7 @@ actual suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): S
 // copying through FileKit's copyTo (which reads the content URI) yields a stable plain file the
 // send path can always read — equivalent to the downstream resolveToFilePath copy, just earlier.
 actual suspend fun PlatformFile.materializeForUpload(fileOps: FileOperationsProvider): PlatformFile {
-    val dest = PlatformFile(FileKit.cacheDir, "chat_attach_${Uuid.random()}_$name")
+    val dest = PlatformFile(FileKit.cacheDir, sandboxCopyName(name, mimeType()?.toString()))
     copyTo(dest)
     return dest
 }

--- a/homebase-chat/src/appleMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.apple.kt
+++ b/homebase-chat/src/appleMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.apple.kt
@@ -5,8 +5,8 @@ import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.cacheDir
 import io.github.vinceglb.filekit.copyTo
+import io.github.vinceglb.filekit.mimeType
 import io.github.vinceglb.filekit.name
-import kotlin.uuid.Uuid
 
 // iOS PlatformFile carries a real file path; the path-based send pipeline reads it directly.
 // No copy needed at send time — the scoped copy happened at pick time (materializeForUpload).
@@ -16,10 +16,11 @@ actual suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): S
 // (this runs in the picker-callback launch before any further suspension). FileKit's copyTo opens
 // the source through its NSURL — which still holds the scope grant here — and writes a plain
 // sandbox file, so the later scope-less path read in the send path always succeeds.
-// Preserve the original name so the send path's content-type / display-name resolution is unchanged;
-// prefix with a uuid to keep concurrent picks from colliding.
+// Keep the original name (plus a MIME-derived extension when it has none) so the send path's
+// content-type / display-name resolution still works; prefix with a uuid so concurrent picks
+// can't collide. See sandboxCopyName.
 actual suspend fun PlatformFile.materializeForUpload(fileOps: FileOperationsProvider): PlatformFile {
-    val dest = PlatformFile(FileKit.cacheDir, "chat_attach_${Uuid.random()}_$name")
+    val dest = PlatformFile(FileKit.cacheDir, sandboxCopyName(name, mimeType()?.toString()))
     copyTo(dest)
     return dest
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentHandler.kt
@@ -11,7 +11,6 @@ import id.homebase.core.audio.AudioRecorder
 import id.homebase.core.audio.AudioWaveFormGenerator
 import id.homebase.core.clipboard.platformFileFromPath
 import id.homebase.core.localization.TranslationUtil
-import id.homebase.core.util.detectContentTypeFromExtensionOrHint
 import id.homebase.chat.services.image.StickerImageProcessor
 import id.homebase.chat.services.image.removeBackground
 import id.homebase.chat.services.image.warmUpBackgroundRemoval
@@ -22,8 +21,6 @@ import id.homebase.resources.chat_attach_file_failed
 import id.homebase.resources.chat_message_audio_recording_help
 import id.homebase.resources.chat_remove_background_failed
 import io.github.vinceglb.filekit.PlatformFile
-import io.github.vinceglb.filekit.mimeType
-import io.github.vinceglb.filekit.name
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
@@ -124,6 +121,9 @@ internal class AttachmentHandler(
         scope.launch {
             try {
                 val newFiles = action.files.map { picked ->
+                    // Read the type off the PICKED handle first — the copy below is a plain file
+                    // whose extension-less photo-picker name resolves to octet-stream (#1149).
+                    val ct = picked.pickedContentType()
                     // Copy the picked file into the sandbox NOW, while the picker's iOS
                     // security scope is still live. The send path later reads the file by
                     // path from a separate coroutine, where a path-rebuilt NSURL has no
@@ -131,21 +131,25 @@ internal class AttachmentHandler(
                     // file". No-op on web; a cheap sandbox copy elsewhere. See
                     // AttachmentUploadResolve.materializeForUpload.
                     val it = picked.materializeForUpload(fileOperationsProvider)
-                    val ct = it.mimeType()?.toString()
-                        ?: detectContentTypeFromExtensionOrHint(it.name)
                     when {
                         ct.startsWith("video/") -> AttachmentPendingFile.FileVideo(
                             Uuid.generateV7(),
                             it,
                             thumbnailBytes = null,
+                            sourceContentType = ct,
                         )
 
                         action.isImage || ct.startsWith("image/") -> AttachmentPendingFile.FileImage(
                             Uuid.generateV7(),
-                            it
+                            it,
+                            sourceContentType = ct,
                         )
 
-                        else -> AttachmentPendingFile.File(Uuid.generateV7(), it)
+                        else -> AttachmentPendingFile.File(
+                            Uuid.generateV7(),
+                            it,
+                            sourceContentType = ct,
+                        )
                     }
                 }
                 val conversation = uiState.value.activeConversations.find {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.kt
@@ -1,7 +1,12 @@
 package id.homebase.chat.conversationlist
 
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.core.util.extensionForMimeType
+import id.homebase.core.util.resolveContentType
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.mimeType
+import io.github.vinceglb.filekit.name
+import kotlin.uuid.Uuid
 
 /**
  * Resolves a picked [PlatformFile] to a path that [fileOps] can read for upload.
@@ -42,6 +47,30 @@ expect suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): S
  *   keeps its bytes and [toUploadPath]'s web actual materializes them at send time via `readBytes()`.
  */
 expect suspend fun PlatformFile.materializeForUpload(fileOps: FileOperationsProvider): PlatformFile
+
+/**
+ * Content type of a **freshly picked** [PlatformFile], resolved before [materializeForUpload]
+ * throws the evidence away.
+ *
+ * Only the picked handle knows the real type: on Android it is a `content://` URI whose
+ * `ContentResolver.getType()` answers `image/jpeg`, while the sandbox copy is a plain file that can
+ * only be typed from its name — and the system photo picker's display names (`photopicker-1000022602`)
+ * carry no extension, so the copy resolves to `application/octet-stream` and the message ships as a
+ * generic file chip with no thumbnail (#1149). Carry this to `AttachmentInput.contentType`.
+ */
+internal fun PlatformFile.pickedContentType(): String =
+    resolveContentType(fileName = name, platformMimeType = mimeType()?.toString())
+
+/**
+ * Name for the pick-time sandbox copy: the original name behind a collision-proof prefix, plus an
+ * extension derived from [mimeType] when the picker's name has none. Belt to [pickedContentType]'s
+ * braces — it keeps the copy self-describing for anything that only sees the file (#1149).
+ */
+internal fun sandboxCopyName(name: String, mimeType: String?): String {
+    val hasExtension = name.substringAfterLast('.', "").isNotEmpty()
+    val ext = if (hasExtension) null else mimeType?.let(::extensionForMimeType)
+    return "chat_attach_${Uuid.random()}_$name" + if (ext != null) ".$ext" else ""
+}
 
 /**
  * A handle the in-editor video decoder/player can read **immediately**, without the expensive

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -377,6 +377,8 @@ sealed class AttachmentPendingFile(val attachmentId: Uuid) {
          * from the tray; threaded into [AttachmentInput.forceSticker] at send time.
          */
         val forceSticker: Boolean = false,
+        /** See [File.sourceContentType]. */
+        val sourceContentType: String? = null,
     ) : AttachmentPendingFile(id)
     data class FileVideo(
         val id: Uuid,
@@ -396,8 +398,20 @@ sealed class AttachmentPendingFile(val attachmentId: Uuid) {
         // (a browser-picked PlatformFile has no path, so file.toString() isn't readable); on
         // native it equals file.toString(). Populated by AttachmentHandler.extractThumbnailAsync.
         val playablePath: String? = null,
+        /** See [File.sourceContentType]. */
+        val sourceContentType: String? = null,
     ) : AttachmentPendingFile(id)
-    data class File(val id: Uuid, val file: PlatformFile) : AttachmentPendingFile(id)
+    data class File(
+        val id: Uuid,
+        val file: PlatformFile,
+        // Content type read from the ORIGINAL picked handle (see PlatformFile.pickedContentType),
+        // before the pick-time sandbox copy dropped it. [file] here is that copy: a plain file whose
+        // type can only come from its name, and Android's photo picker vends extension-less names
+        // ("photopicker-1000022602") that resolve to application/octet-stream — which ships the
+        // message as a thumbnail-less generic file chip (#1149). Null falls back to resolving from
+        // [file] (share-received / already-local files, whose names carry extensions).
+        val sourceContentType: String? = null,
+    ) : AttachmentPendingFile(id)
     data class Gallery(
         val id: Uuid,
         val image: GalleryImage,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -689,7 +689,7 @@ internal class MessageActionsHandler(
                         attachments.add(
                             AttachmentInput(
                                 filePath = attachment.file.toUploadPath(fileOperationsProvider),
-                                contentType = resolveContentType(
+                                contentType = attachment.sourceContentType ?: resolveContentType(
                                     fileName = attachment.file.name,
                                     platformMimeType = attachment.file.mimeType()?.toString(),
                                 ),
@@ -700,7 +700,8 @@ internal class MessageActionsHandler(
 
                     is AttachmentPendingFile.FileImage -> {
                         attachments.add(
-                            attachment.file.toImageAttachmentInput(fileOperationsProvider)
+                            attachment.file
+                                .toImageAttachmentInput(fileOperationsProvider, attachment.sourceContentType)
                                 .copy(forceSticker = attachment.forceSticker),
                         )
                     }
@@ -709,7 +710,7 @@ internal class MessageActionsHandler(
                         attachments.add(
                             AttachmentInput(
                                 filePath = attachment.file.toUploadPath(fileOperationsProvider),
-                                contentType = resolveContentType(
+                                contentType = attachment.sourceContentType ?: resolveContentType(
                                     fileName = attachment.sourceFileName ?: attachment.file.name,
                                     platformMimeType = attachment.file.mimeType()?.toString(),
                                 ),

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventComposerSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventComposerSheet.kt
@@ -71,6 +71,7 @@ import id.homebase.chat.composer.ComposerEditableField
 import id.homebase.chat.composer.ComposerRow
 import id.homebase.chat.composer.ComposerTitleField
 import id.homebase.chat.conversationlist.materializeForUpload
+import id.homebase.chat.conversationlist.pickedContentType
 import id.homebase.core.location.rememberCurrentGps
 import id.homebase.core.location.tracking.GpsFixResult
 import id.homebase.chat.services.ChatMessageSenderService
@@ -178,13 +179,13 @@ private fun EventComposerContent(
     val coverGalleryPicker = rememberFilePickerLauncher(type = FileKitType.Image) { file ->
         if (file != null) scope.launch {
             coverInput = file.materializeForUpload(fileOperationsProvider)
-                .toImageAttachmentInput(fileOperationsProvider)
+                .toImageAttachmentInput(fileOperationsProvider, file.pickedContentType())
         }
     }
     val coverCameraLauncher = rememberCameraManager { file ->
         if (file != null) scope.launch {
             coverInput = file.materializeForUpload(fileOperationsProvider)
-                .toImageAttachmentInput(fileOperationsProvider)
+                .toImageAttachmentInput(fileOperationsProvider, file.pickedContentType())
         }
     }
     // Deferred picker launch — presenting the picker synchronously from the

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/ImageAttachmentResolve.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/ImageAttachmentResolve.kt
@@ -14,10 +14,19 @@ import io.github.vinceglb.filekit.name
  * of MessageActionsHandler.addMessageWithFiles: real upload path + content-type
  * detection + HEIC->JPEG transcode (iPhone photos default to HEIC). Caller adds
  * forceSticker via copy() if needed.
+ *
+ * [sourceContentType] is the type read off the ORIGINAL picked handle (see
+ * `PlatformFile.pickedContentType`). Pass it whenever the receiver is a pick-time sandbox
+ * copy: the copy's name may carry no extension, and this receiver can otherwise only be
+ * typed from that name (#1149).
  */
-suspend fun PlatformFile.toImageAttachmentInput(fileOps: FileOperationsProvider): AttachmentInput {
+suspend fun PlatformFile.toImageAttachmentInput(
+    fileOps: FileOperationsProvider,
+    sourceContentType: String? = null,
+): AttachmentInput {
     var filePath = toUploadPath(fileOps)
-    var contentType = resolveContentType(fileName = name, platformMimeType = mimeType()?.toString())
+    var contentType = sourceContentType
+        ?: resolveContentType(fileName = name, platformMimeType = mimeType()?.toString())
     if (contentType == "image/heic" || contentType == "image/heif") {
         val heicBytes = fileOps.readFileBytes(filePath)
         val jpegBytes = convertHeicToJpeg(heicBytes)

--- a/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.jvm.kt
+++ b/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.jvm.kt
@@ -5,8 +5,8 @@ import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.cacheDir
 import io.github.vinceglb.filekit.copyTo
+import io.github.vinceglb.filekit.mimeType
 import io.github.vinceglb.filekit.name
-import kotlin.uuid.Uuid
 
 // Desktop PlatformFile carries a real filesystem path; the path-based send pipeline reads it
 // directly. No copy needed at send time.
@@ -16,7 +16,7 @@ actual suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): S
 // contract so all native platforms behave the same. Desktop has no security scope, but copying a
 // real filesystem path is cheap and harmless and keeps the send path reading a sandbox file.
 actual suspend fun PlatformFile.materializeForUpload(fileOps: FileOperationsProvider): PlatformFile {
-    val dest = PlatformFile(FileKit.cacheDir, "chat_attach_${Uuid.random()}_$name")
+    val dest = PlatformFile(FileKit.cacheDir, sandboxCopyName(name, mimeType()?.toString()))
     copyTo(dest)
     return dest
 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/builder/ImageAttachmentContentTypeTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/builder/ImageAttachmentContentTypeTest.kt
@@ -1,0 +1,69 @@
+package id.homebase.chat.services.builder
+
+import id.homebase.api.file.FileOperationsProvider
+import id.homebase.chat.conversationlist.sandboxCopyName
+import io.github.vinceglb.filekit.PlatformFile
+import io.ktor.client.request.forms.InputProvider
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression guard for #1149: photo-picker images sent as `application/octet-stream` and rendered
+ * as generic file chips.
+ *
+ * Android's system photo picker vends display names with NO extension
+ * (`photopicker-1000022602`), and the pick-time sandbox copy is a plain file — so the only handle
+ * that knows the type is the picked `content://` URI (`ContentResolver.getType()` == image/jpeg).
+ * Resolving from the copy lands on octet-stream, which skips thumbnail generation
+ * (`MessageAttachmentBuilder` gates on `contentType.startsWith("image/")`) and makes every renderer
+ * draw a file chip.
+ */
+class ImageAttachmentContentTypeTest {
+
+    @Test
+    fun dotlessPickerName_keepsContentUriMime() = runTest {
+        val copy = PlatformFile("/tmp/chat_attach_0f9c_photopicker-1000022602")
+
+        val input = copy.toImageAttachmentInput(NoopFileOps(), sourceContentType = "image/jpeg")
+
+        assertEquals("image/jpeg", input.contentType)
+    }
+
+    @Test
+    fun dotlessPickerName_withoutCarriedMime_fallsBackToTheNameAndIsUseless() = runTest {
+        // Documents WHY the carry-through is needed: the copy alone resolves to octet-stream.
+        val copy = PlatformFile("/tmp/chat_attach_0f9c_photopicker-1000022602")
+
+        assertEquals("application/octet-stream", copy.toImageAttachmentInput(NoopFileOps()).contentType)
+    }
+
+    @Test
+    fun sandboxCopyName_appendsExtensionWhenPickerNameHasNone() {
+        val name = sandboxCopyName("photopicker-1000022602", "image/jpeg")
+
+        assertTrue(name.endsWith("_photopicker-1000022602.jpg"), "expected .jpg suffix, got: $name")
+    }
+
+    @Test
+    fun sandboxCopyName_keepsAnExistingExtensionAndSurvivesAnUnmappedMime() {
+        assertTrue(sandboxCopyName("IMG_2026.jpeg", "image/jpeg").endsWith("_IMG_2026.jpeg"))
+        assertTrue(sandboxCopyName("raw-shot", "image/x-not-a-real-mime").endsWith("_raw-shot"))
+        assertTrue(sandboxCopyName("raw-shot", null).endsWith("_raw-shot"))
+    }
+}
+
+private class NoopFileOps : FileOperationsProvider {
+    override fun openFileInput(path: String): InputProvider = throw NotImplementedError()
+    override suspend fun readFileBytes(path: String): ByteArray = throw NotImplementedError()
+    override fun deleteTempFile(path: String): Boolean = false
+    override fun getCacheDirectory(): String = "/tmp"
+    override fun getFileSize(path: String): Long = 0L
+    override suspend fun writeBytesToTempFile(bytes: ByteArray, prefix: String, suffix: String): String =
+        throw NotImplementedError()
+    override suspend fun writeBytesToShareOutboundFile(bytes: ByteArray, suffix: String): String =
+        throw NotImplementedError()
+    override suspend fun writeStream(path: String, data: Flow<ByteArray>) = throw NotImplementedError()
+}


### PR DESCRIPTION
## Symptom

Two images picked from the gallery and sent arrive — for sender and recipients — as **two generic file chips**: blank document icon plus a download arrow. No thumbnail, no inline preview, no full-screen viewer. The upload itself succeeds; only the type is wrong.

Intermittent because most gallery items come back with a display name that *does* carry an extension (`IMG_2026….jpg`), so the extension fallback saves them. Android's **system photo picker** vends `photopicker-NNNNNNNNNN` — no extension — and those break.

## Root cause

The payload's `contentType` ends up `application/octet-stream` because the MIME is resolved from the **pick-time sandbox copy**, whose filename has no extension, instead of from the originally picked URI.

1. `AttachmentHandler.handleAttachPlatformFile` copied the picked file into the cache **first**, then read the MIME from the copy.
2. The copy was named `chat_attach_<uuid>_<original name>` — a plain file. Verified against FileKit 0.13.0 bytecode: Android's `PlatformFile.mimeType()` uses `ContentResolver.getType(uri)` for an `AndroidFile.UriWrapper` but **extension-only** (`MimeTypeMap.getMimeTypeFromExtension`) for a `FileWrapper`. So the copy returns `null` and the original `content://` URI — the only handle that knew `image/jpeg` — is already gone.
3. Send time re-resolved from that same copy (`ImageAttachmentResolve.kt`, plus the File / FileVideo / Audio arms of `MessageActionsHandler.addMessageWithFiles`).
4. `detectContentTypeFromExtensionOrHint` does `substringAfterLast('.')`; on a dot-less name that returns the whole string, the map lookup misses, and it falls through to `application/octet-stream`.
5. `MessageAttachmentBuilder.build` only generates thumbnails under `contentType.startsWith("image/")` → the payload shipped with **no preview thumbnail at all**.
6. Every renderer keys off the same prefix (`MediaItem`, `MessageBubble`, `MediaMessage`, `MessageContentLabel`), so the bubble drew the file chip.

`isImage = true` from the gallery launcher only steers the *pending* classification into `AttachmentPendingFile.FileImage`; it never overrode the resolved `contentType`.

## The fix

**Read the type off the picked handle, before materializing, and carry it through.**

- `AttachmentUploadResolve.kt:61` — new `internal fun PlatformFile.pickedContentType()`: `resolveContentType(fileName = name, platformMimeType = mimeType()?.toString())`. Using `resolveContentType` (not the raw MIME) matters: a document-picker file whose content URI type *is* `application/octet-stream` but whose name says `.pdf` must still resolve to `application/pdf`, so this can never regress relative to the old copy-based read.
- `AttachmentHandler.kt:126` — call it on `picked` **before** `materializeForUpload`, and store the result as `sourceContentType` on the resulting `FileImage` / `FileVideo` / `File`.
- `ConversationListUiState.kt` — `sourceContentType: String? = null` on those three `AttachmentPendingFile` variants (same shape as the existing `FileVideo.sourceFileName` precedent). Null keeps today's behaviour for share-received / already-local files.
- `MessageActionsHandler.kt:692,704,713` + `ImageAttachmentResolve.kt:25` — consult `sourceContentType` at every send site, falling back to the old resolution when it is null. `toImageAttachmentInput` gained an optional `sourceContentType` param.
- `EventComposerSheet.kt:182,188` — the Event cover-photo pickers had the identical `materializeForUpload(...).toImageAttachmentInput(...)` shape; fixed the same way.

**Plus: stop the coin flip at the source.** `sandboxCopyName(name, mimeType)` (`AttachmentUploadResolve.kt:69`) appends an extension derived from the picked MIME when the picker's name has none — `extensionForMimeType` already existed in `ContentTypeUtil.kt`. The android / apple / jvm `materializeForUpload` actuals now use it (one line each). Web's actual is a no-op that keeps the original `PlatformFile`, so it was never affected.

### Deliberately not done

- **Magic-byte sniffing** (`ImageFormatDetector.detectFormat`) as a third fallback — belt-and-braces on a fix that already works; the extra path isn't wanted.
- **No back-migration.** Already-sent messages keep their octet-stream payloads and will keep rendering as file chips. No render-time heuristic was added.
- `detectContentTypeFromExtensionOrHint`'s missing `substringAfterLast('.', "")` default is left alone — it makes dot-less names resolve to octet-stream by accident rather than by intent, but it is not the cause and changing it would alter behaviour for files named exactly like an extension.

## Test

`homebase-chat/src/jvmTest/.../ImageAttachmentContentTypeTest.kt` — a dot-less picker name plus a `content://`-sourced `image/jpeg` must still yield `image/jpeg` at `AttachmentInput` time. Written first against the pre-fix tree:

```
ImageAttachmentContentTypeTest[jvm] > dotlessPickerName_keepsContentUriMime[jvm] FAILED
    org.junit.ComparisonFailure at ImageAttachmentContentTypeTest.kt:14
    expected:<image/jpeg> but was:<application/octet-stream>
1 test completed, 1 failed
```

After the fix, 4/4 pass (`tests="4" skipped="0" failures="0" errors="0"`). A sibling case pins the octet-stream fallback so the reason for the carry-through stays documented, and two cover `sandboxCopyName` (appends `.jpg` for a dot-less name; leaves an existing extension and an unmapped MIME alone).

## Verification

| Command | Result |
|---|---|
| `:homebase-chat:jvmTest :homebase-api:jvmTest --rerun-tasks` | BUILD SUCCESSFUL — 1018 + 1094 tests, 0 failures |
| `:homebase-chat:compileKotlinJvm` / `compileAndroidMain` / `compileKotlinWasmJs` / `compileKotlinIosSimulatorArm64` | BUILD SUCCESSFUL (all four targets) |
| `:homebase-core:` same four targets | BUILD SUCCESSFUL |
| `:androidApp:compileDebugKotlin` | BUILD SUCCESSFUL |

`homebase-common` was not touched, so its Konsist architecture tests are unaffected.

Still needs on-device confirmation on Android: pick two photos through the **system photo picker** (the gallery/paperclip route, not the in-app gallery grid) and check they render as image bubbles with thumbnails on both sender and recipient.

Fixes #1149

🤖 Generated with [Claude Code](https://claude.com/claude-code)
