### PR TITLE
fix(chat): don't scrim a photo with an upload overlay when editing its caption (#1155)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveOutboxUploader.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveOutboxUploader.kt
@@ -279,7 +279,9 @@ class DriveOutboxUploader(
         val gate = WholePercentProgressGate()
         val updateResult = driveUploadProvider.updateFileByUniqueId(updateRequest, onProgress = { sent, total ->
             gate.admit(percentOf(sent, total))?.let { pct ->
-                eventBus.emit(BackendEvent.OutboxEvent.ItemProgress(outboxRecord.driveId, outboxRecord.uniqueId, pct, sent))
+                // isCreate stays true: update-shaped on the wire, but this row is a
+                // create and still carries `original.payloads` — real media bytes.
+                eventBus.emit(BackendEvent.OutboxEvent.ItemProgress(outboxRecord.driveId, outboxRecord.uniqueId, pct, sent, isCreate = true))
             }
         })
         val rStatus = updateResult?.recipientStatus
@@ -306,7 +308,7 @@ class DriveOutboxUploader(
         val gate = WholePercentProgressGate()
         val result = driveUploadProvider.updateFileByUniqueId(request, onProgress = { sent, total ->
             gate.admit(percentOf(sent, total))?.let { pct ->
-                eventBus.emit(BackendEvent.OutboxEvent.ItemProgress(outboxRecord.driveId, outboxRecord.uniqueId, pct, sent))
+                eventBus.emit(BackendEvent.OutboxEvent.ItemProgress(outboxRecord.driveId, outboxRecord.uniqueId, pct, sent, isCreate = false))
             }
         })
         val rStatus = result?.recipientStatus

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/eventbus/BackendEvent.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/eventbus/BackendEvent.kt
@@ -154,7 +154,12 @@ sealed interface BackendEvent {
             val driveId: Uuid,
             val uniqueId: Uuid,
             val progress: Float,  // 0.0 to 1.0
-            val bytesSent: Long? = null
+            val bytesSent: Long? = null,
+            // True when the outbox row is a file *create*, which carries the item's
+            // payloads. False for a header-only update (an edit): the bytes moving
+            // are metadata, not media, so a media-progress UI must not react to it
+            // (#1155).
+            val isCreate: Boolean = true
         ) : OutboxEvent  // New: For ongoing upload progress updates
 
         data class ItemFailed(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -693,6 +693,11 @@ class ConversationListViewModel(
             eventBus.events.filter { it is BackendEvent.OutboxEvent.ItemProgress }
                 .collect { event ->
                     event as BackendEvent.OutboxEvent.ItemProgress
+                    // A header-only update (editing a caption) still streams a
+                    // multipart body, so it reports byte progress — but no media is
+                    // moving. Reacting to it scrimmed the photo and parked it on
+                    // "Finalizing…" for the whole round-trip (#1155).
+                    if (!event.isCreate) return@collect
                     _messagesUiState.update { state ->
                         state.copy(
                             uploadProgress = (state.uploadProgress + (event.uniqueId to UploadStatus.Uploading(
@@ -728,6 +733,10 @@ class ConversationListViewModel(
             eventBus.events.filter { it is BackendEvent.OutboxEvent.ItemCompleted }
                 .collect { event ->
                     event as BackendEvent.OutboxEvent.ItemCompleted
+                    // Completed is the tail of a progression already on screen, never
+                    // its start. Without this an edit — which shows no progress at all
+                    // now — would still flash the scrim for 800ms on completion (#1155).
+                    if (_messagesUiState.value.uploadProgress[event.uniqueId] == null) return@collect
                     viewModelScope.launch {
                         _messagesUiState.update { state ->
                             state.copy(

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceUpdateMessageTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceUpdateMessageTest.kt
@@ -4,6 +4,7 @@ import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.drives.FileSystemType
 import id.homebase.api.client.drives.HomebaseFile
 import id.homebase.api.client.drives.files.DriveOutboxUploader
+import id.homebase.api.client.drives.files.PayloadDescriptor
 import id.homebase.api.client.drives.query.QueryBatchCursor
 import id.homebase.api.client.drives.upload.UpdateFileByUniqueIdRequest
 import id.homebase.api.client.drives.upload.UploadAppFileMetaData
@@ -606,6 +607,110 @@ class ChatMessageSenderServiceUpdateMessageTest {
                 originalUserDate,
                 storedUserDate,
                 "the optimistic write must keep the SQL userDate invariant across a coalesced edit (#900)",
+            )
+        }
+    }
+
+    /**
+     * Editing the caption of a delivered image must not touch the image (#1155).
+     *
+     * The enqueued update is a delta: a media key absent from the manifest is
+     * preserved server-side, and only `dflt_key` (the text-overflow payload) is
+     * ever listed for deletion. So the media key must appear nowhere — neither as
+     * an AppendOrOverwrite (which would re-upload the bytes) nor as a
+     * DeletePayload (which would destroy the image).
+     *
+     * This is also what makes the `isCreate = false` progress gate safe: chat's
+     * edit path enqueues an UpdateFile row that never carries media, so its byte
+     * progress must not drive the media upload overlay.
+     */
+    @Test
+    fun `updateMessage on a delivered image edits the caption without re-uploading or deleting the media`() = runTest {
+        val messageLookup = SeedableMessageLookup()
+        val mediaKey = "chat_web0"
+
+        ChatMessageSenderServiceTestFixture().use { fixture ->
+            val service = fixture.build(
+                messageLookup = { _: DatabaseManager -> messageLookup },
+            )
+            messageLookup.backFilesWith(fixture)
+
+            val conversationId = fixture.seedConversation(others = listOf("bob.test"))
+            val messageId = Uuid.random()
+            val versionTag = Uuid.random()
+            val keyHeader = KeyHeader.newRandom16()
+
+            fixture.optimisticWriter.writeNewFile(
+                driveId = fixture.chatDriveId,
+                keyHeader = keyHeader,
+                unecryptedMetadata = UploadFileMetadata(
+                    allowDistribution = true,
+                    isEncrypted = true,
+                    appData = UploadAppFileMetaData(
+                        uniqueId = messageId,
+                        groupId = conversationId,
+                        fileType = ChatProtocol.MessageFileType,
+                        userDate = 1_000L,
+                        content = "original caption",
+                    ),
+                ),
+                originalRecipientCount = 1,
+                fileSystemType = FileSystemType.Standard,
+            )
+
+            messageLookup.seed(
+                MessageUiModel(
+                    id = messageId,
+                    globalTransitId = null,
+                    fileId = Uuid.random(),
+                    conversationId = conversationId,
+                    content = "original caption",
+                    userDate = Instant.fromEpochMilliseconds(1_000L),
+                    modified = null,
+                    created = Instant.fromEpochMilliseconds(1_000L),
+                    originalAuthor = OdinId(fixture.testDomain),
+                    sender = OdinId(fixture.testDomain),
+                    displayName = fixture.testDomain,
+                    isDeleted = false,
+                    isPendingSend = false,
+                    versionTag = versionTag,
+                    messageAppData = MessageAppData(),
+                    reactionPreview = null,
+                    previewThumbnail = null,
+                    payloads = persistentListOf(
+                        PayloadDescriptor(key = mediaKey, contentType = "image/jpeg"),
+                    ),
+                    keyHeader = keyHeader,
+                    hasMore = false,
+                    messageContent = null,
+                )
+            )
+
+            service.updateMessage(
+                messageId = messageId,
+                versionTag = versionTag,
+                content = "edited caption",
+            )
+
+            val rows = fixture.drainOutboxInDependencyOrder()
+            val updateRow = rows.mapNotNull { it.asUpdateFileRequestOrNull() }.firstOrNull()
+            assertNotNull(updateRow, "a caption edit on a delivered message must enqueue an UpdateFile row")
+
+            val manifestKeys = updateRow.instructions.manifest?.payloadDescriptors.orEmpty()
+            assertTrue(
+                manifestKeys.none { it.payloadKey == mediaKey },
+                "the media key must not appear in the update manifest — found ${manifestKeys.map { it.payloadKey to it.operationType }}",
+            )
+            // Pins that the edit touches ONE key and it is the text-overflow one, so
+            // the assertion above can't pass just because the manifest came out empty.
+            assertEquals(
+                listOf(ChatProtocol.DefaultPayloadKey),
+                manifestKeys.map { it.payloadKey },
+                "a short caption edit must reference only the text-overflow payload",
+            )
+            assertTrue(
+                updateRow.payloads.orEmpty().none { it.key == mediaKey },
+                "the update must not re-send the media bytes",
             )
         }
     }


### PR DESCRIPTION
## Symptom

Editing the caption of an image message covered the photo with the dark upload
scrim and showed **"Finalizing…"** for the whole server round-trip. On a slow
link it sits there long enough to look like the image is being re-uploaded.

Fixes #1155.

## What actually happens (investigated, not assumed)

The issue asked to confirm by measurement whether either edit path moves image
bytes. **Neither does:**

**Delivered message** (`ChatMessageSenderService.kt:506+`) — the enqueued
`UpdateFileByUniqueIdRequest` is a delta. `payloads` comes from
`buildMessageContentAndBundle(payloadBundle = null)`, so it only ever holds the
text-overflow payload; `toDeletePayloads` only ever holds `dflt_key`
(`ChatProtocol.kt:125`). The media key is in neither, so the server preserves
it. The new test asserts the manifest contains **exactly** `[dflt_key]`.

**Still-queued create** (`:444`) — `amendPendingCreate` (`EditCoalesce.kt:33`)
carries `existingCreate.payloads` through by reference and re-encrypts only the
text-overflow payload. No media re-encryption, no re-staging. Already covered by
`AmendPendingCreateTest` (`keepsMedia_replacesOverflow`,
`multipleMediaPreserved_inOrder`).

So work item 2 in the issue ("if branch 1 re-encrypts media, reuse the staged
payloads") needs no change — it already does.

## Root cause of the spinner

`ItemProgress` reports **HTTP body** byte progress for every outbox upload type,
and `ConversationListViewModel.kt:696` mapped all of it to
`UploadStatus.Uploading`, which `MediaMessage.showsMediaOverlay` renders as the
media scrim. A header-only edit still streams a multipart body, so it produces
byte progress. That small body hits 100% almost instantly — which is why what
the user sees for the entire round-trip is the `progress >= 1f` branch:
**"Finalizing…"** (`MediaMessage.kt:345`).

## Fix

- `ItemProgress` gains `isCreate`. Only a create carries the item's payloads.
  `retryAsUpdate` passes `true` explicitly — it is update-shaped on the wire but
  the row is a create still carrying `original.payloads`, i.e. real media bytes.
- The VM ignores non-create progress.
- The VM applies `Completed` only when a progression is **already** on screen.
  Without this the edit still flashed the scrim for the 800 ms completion tick.
  Side benefit: read receipts, reactions and tag updates no longer each launch
  an 800 ms no-op coroutine that writes and then removes a map entry nobody
  renders.

Why gating on create rather than "does the map already have an entry": a create
queued before an app restart has no in-memory entry, and must still show its
overlay when the outbox drains. Gating on the row type keeps that working.

## Verification

- New test: `updateMessage on a delivered image edits the caption without re-uploading or deleting the media` — asserts an `UpdateFile` row is enqueued, the media key appears in neither the manifest nor `payloads`, and the manifest references only `dflt_key` (so the negative assertion can't pass on an empty manifest).
- `:homebase-chat:jvmTest`, `:homebase-api:jvmTest`, `:homebase-core:jvmTest` — green.
- `:homebase-api:compileAndroidMain`, `:homebase-chat:compileAndroidMain`, `:homebase-api:compileKotlinWasmJs` — green.

### Not device-verified
Reproducing needs a throttled 2G link. The change is grounded in the traced
mechanism, and the invariant the gate depends on is pinned by the new test.

### Not covered by a test
The emit-site mapping itself (`updateFile → false`, `uploadNewFile`/`retryAsUpdate → true`).
Driving it would need a `MockEngine` round-trip through `DriveOutboxUploader`
just to observe `onUpload` callbacks; it is three literal call sites, and a
wrong value there reproduces exactly this user-visible bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)