### PR TITLE
build: print assertion messages and stack traces for failed tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
 plugins {
     // this is necessary to avoid the plugins to be loaded multiple times
     // in each subproject's classloader
@@ -28,6 +30,17 @@ subprojects {
                     because("Using encrypted SQLite JDBC driver")
                 }
             }
+        }
+    }
+
+    // Without this a CI failure prints only `java.lang.AssertionError at Foo.kt:171`
+    // — no assertion message, no stack. For a coroutine test that line is the
+    // `runTest` lambda, so it doesn't even say which assertion blew, and an
+    // intermittent failure is undiagnosable from the logs alone.
+    tasks.withType<Test>().configureEach {
+        testLogging {
+            events("failed")
+            exceptionFormat = TestExceptionFormat.FULL
         }
     }
 }


### PR DESCRIPTION
## Why

A failed test in CI currently looks like this — the whole report:

```
ChatMessageStreamLoadRaceTest[jvm] > loadConversation_rowCommittedDuringTheReRead_survivesTheWriteBack[jvm] FAILED
    java.lang.AssertionError at ChatMessageStreamLoadRaceTest.kt:171
```

No message. No stack. And for a coroutine test, `:171` is the `runTest` lambda
line — **not** the assertion — so the log doesn't even say *which* of the test's
two assertions blew.

Those assertions have good messages already written ("the re-read must still
deliver the row that triggered it", "…must survive its write-back"). Gradle
simply never prints them, because there is **no `testLogging` block anywhere in
the build** — I grepped every `.kts`.

This is what made the intermittent `ChatMessageStreamLoadRaceTest` failures
impossible to work on: three occurrences so far, every one CI-only, none
reproducible locally (I ran it 8× clean, then 4× more under 12 CPU hogs on 8
cores — never failed), and no evidence in the logs to reason from. Without this,
the only options are guess-a-fix or delete the test.

## The change

Six lines into the `subprojects { }` block that already exists in the root build
file. Applies to every `Test` task, so Android unit tests are covered too. Only
**failures** are logged — passing runs are byte-identical to today.

## Verified by A/B

Injected a deliberately failing probe test and ran it with and without the block.

**Before** (current `main`):
```
ResendHelpersTest[jvm] > deliberatelyBrokenProbe[jvm] FAILED
    java.lang.AssertionError at ResendHelpersTest.kt:96
```

**After:**
```
ResendHelpersTest[jvm] > deliberatelyBrokenProbe[jvm] FAILED
    java.lang.AssertionError: PROBE: this message must appear in CI output expected:<[11111111-2222-3333-4444-555555555555]> but was:<[6e87beb3-412a-4a8c-aaec-b21a7ec620a7]>
        at org.junit.Assert.fail(Assert.java:89)
        ...
        at id.homebase.chat.services.ResendHelpersTest.deliberatelyBrokenProbe(ResendHelpersTest.kt:96)
```

Message, expected-vs-actual, and the real assertion line. The probe was removed
before committing — the diff is `build.gradle.kts` only.

`:homebase-chat:`, `:homebase-api:`, `:homebase-common:`, `:homebase-auth:` and
`:homebase-core:` `jvmTest` all green.

## Follow-up

This doesn't fix the `ChatMessageStreamLoadRaceTest` flake — it makes the next
occurrence diagnosable. I'd rather land this and read a real failure than patch
a race I can't reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)