### PR TITLE
feat(splash): branded launch screen on Android and iOS (#1162)

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -141,6 +141,7 @@ dependencies {
 
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.browser)
     implementation(libs.androidx.media3.exoplayer)

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -65,6 +65,7 @@
             android:exported="true"
             android:name=".MainActivity"
             android:windowSoftInputMode="adjustResize"
+            android:theme="@style/Theme.Homebase.Splash"
             android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
 import co.touchlab.kermit.Logger
 import com.mmk.kmpnotifier.extensions.onCreateOrOnNewIntent
@@ -42,6 +43,9 @@ class MainActivity : AppCompatActivity() {
     private val authConnectionCoordinator: AuthConnectionCoordinator by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // Must run before super.onCreate — swaps Theme.Homebase.Splash for the real app
+        // theme (postSplashScreenTheme) once the window exists.
+        installSplashScreen()
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 

--- a/androidApp/src/main/res/drawable/ic_splash_logo.xml
+++ b/androidApp/src/main/res/drawable/ic_splash_logo.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Splash logo: the Homebase app icon as a vector, so it stays crisp at the 288dp splash
+     canvas on every density instead of upscaling a mipmap. Android res/ has no SVG support
+     and a splash icon is a *window* attribute resolved before any app code runs, so this is
+     the hand-converted twin of icons/homebase_logo_rounded.svg — keep the two in sync.
+
+     432-unit canvas (the adaptive-icon canvas) with the 288-unit tile inscribed, which is
+     also the splash spec's "288dp icon, content within the inner 2/3". Mark and gradient
+     geometry come from the shipped AppIcon marketing asset.
+
+     The rounded corners never actually show on Android: both the API 31+ splash and
+     core-splashscreen's backport circle-mask the icon (see the library's
+     splashscreen_icon_mask_* dimens), with no opt-out, so this renders as the disc the
+     launcher already shows. The corners are kept so the geometry stays identical to the
+     SVG, which iOS renders unmasked as the rounded tile its home-screen icon uses. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="288dp"
+    android:height="288dp"
+    android:viewportWidth="432"
+    android:viewportHeight="432">
+
+    <path android:pathData="M136.4,72h159.2a64.4,64.4 0 0 1 64.4,64.4v159.2a64.4,64.4 0 0 1 -64.4,64.4h-159.2a64.4,64.4 0 0 1 -64.4,-64.4v-159.2a64.4,64.4 0 0 1 64.4,-64.4z">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:startX="299.9"
+                android:startY="324.8"
+                android:endX="-82.0"
+                android:endY="-170.2"
+                android:type="linear">
+                <item android:offset="0.0" android:color="#415A84" />
+                <item android:offset="0.2" android:color="#4F4D89" />
+                <item android:offset="0.3" android:color="#58458D" />
+                <item android:offset="0.5" android:color="#5B438E" />
+                <item android:offset="0.7" android:color="#57458C" />
+                <item android:offset="0.8" android:color="#534A8B" />
+                <item android:offset="1.0" android:color="#425985" />
+            </gradient>
+        </aapt:attr>
+    </path>
+
+    <group
+        android:translateX="138.6"
+        android:translateY="115.9"
+        android:scaleX="0.09089"
+        android:scaleY="0.09096">
+        <path
+            android:fillColor="#FFFFFF"
+            android:pathData="M1417.9 567.5C1574.47 567.5 1701.4 440.573 1701.4 284C1701.4 127.427 1574.47 0.5 1417.9 0.5C1261.33 0.5 1134.4 127.427 1134.4 284C1134.4 440.573 1261.33 567.5 1417.9 567.5Z" />
+        <path
+            android:fillColor="#FFFFFF"
+            android:pathData="M1417.9 816.9H851C694.4 816.9 567.5 690 567.5 533.4V284C567.5 127.4 440.6 0.5 284 0.5C127.4 0.5 0.5 127.4 0.5 284V1916.8C0.5 2073.4 127.4 2200.3 284 2200.3C440.6 2200.3 567.5 2073.4 567.5 1916.8V1383.9C567.7 1227.5 694.5 1100.7 851 1100.7C1007.5 1100.7 1134.3 1227.5 1134.5 1383.9V1916.8C1134.5 2073.4 1261.4 2200.3 1418 2200.3C1574.6 2200.3 1701.5 2073.4 1701.5 1916.8V1100.4C1701.5 943.8 1574.6 816.9 1418 816.9H1417.9Z" />
+    </group>
+</vector>

--- a/androidApp/src/main/res/values-night/colors.xml
+++ b/androidApp/src/main/res/values-night/colors.xml
@@ -12,4 +12,6 @@
     <color name="crash_on_surface">#E2E1E5</color>
     <color name="crash_surface_variant">#303133</color>
     <color name="crash_on_surface_variant">#BEBFC5</color>
+
+    <color name="splash_background">#000000</color>
 </resources>

--- a/androidApp/src/main/res/values-night/themes.xml
+++ b/androidApp/src/main/res/values-night/themes.xml
@@ -5,4 +5,8 @@
     <style name="Theme.Homebase.Crash" parent="Theme.Homebase.Crash.Base">
         <item name="android:windowLightStatusBar">false</item>
     </style>
+
+    <style name="Theme.Homebase.Splash" parent="Theme.Homebase.Splash.Base">
+        <item name="android:windowLightStatusBar">false</item>
+    </style>
 </resources>

--- a/androidApp/src/main/res/values/colors.xml
+++ b/androidApp/src/main/res/values/colors.xml
@@ -12,4 +12,8 @@
     <color name="crash_on_surface">#1B1B1D</color>
     <color name="crash_surface_variant">#E7EBF3</color>
     <color name="crash_on_surface_variant">#545863</color>
+
+    <!-- Splash background follows the system theme — plain white/black, brand colour comes
+         from the logo alone. Night value in values-night/colors.xml. -->
+    <color name="splash_background">#FFFFFF</color>
 </resources>

--- a/androidApp/src/main/res/values/themes.xml
+++ b/androidApp/src/main/res/values/themes.xml
@@ -24,4 +24,18 @@
     <style name="Theme.Homebase.Crash" parent="Theme.Homebase.Crash.Base">
         <item name="android:windowLightStatusBar">true</item>
     </style>
+
+    <!-- Launch theme for MainActivity. core-splashscreen backports the API 31 splash to
+         minSdk, so one theme covers every device: the branded logo centred on a plain
+         white/black system-theme background, then postSplashScreenTheme swaps in the real
+         app theme at installSplashScreen(). -->
+    <style name="Theme.Homebase.Splash.Base" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@color/splash_background</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_splash_logo</item>
+        <item name="postSplashScreenTheme">@style/Theme.Material3.DayNight.NoActionBar</item>
+    </style>
+
+    <style name="Theme.Homebase.Splash" parent="Theme.Homebase.Splash.Base">
+        <item name="android:windowLightStatusBar">true</item>
+    </style>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -120,6 +120,7 @@ jetbrains-compose-ui-backhandler = { module = "org.jetbrains.compose.ui:ui-backh
 jetbrains-compose-ui-test = { module = "org.jetbrains.compose.ui:ui-test", version.ref = "composeMultiplatform" }
 jetbrains-compose-ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatform" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
+androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version = "1.0.1" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-testRunner" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-testCore" }
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-testExt" }

--- a/icons/homebase_logo_rounded.svg
+++ b/icons/homebase_logo_rounded.svg
@@ -1,0 +1,27 @@
+<!-- Homebase app icon as a standalone logo: homebase_gradient.svg's stops on a rounded
+     tile, with homebase_icon.svg's mark on top. Geometry is taken from the shipped
+     AppIcon marketing asset (mark is 53.7% x 69.5% of the tile, centred); the corner
+     radius is the 22.37% iOS icon-grid value so the tile reads as the app icon rather
+     than a raw square.
+
+     width/height are the intended render size in points (the 288-unit tile lands at 96pt,
+     the WhatsApp/Signal launch-logo scale); viewBox carries the art's native 432 units,
+     which is the Android adaptive-icon canvas the tile is inscribed in. -->
+<svg width="144" height="144" viewBox="0 0 432 432" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="homebaseTile" x1="299.9" y1="324.8" x2="-82.0" y2="-170.2" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#415A84"/>
+      <stop offset="0.2" stop-color="#4F4D89"/>
+      <stop offset="0.3" stop-color="#58458D"/>
+      <stop offset="0.5" stop-color="#5B438E"/>
+      <stop offset="0.7" stop-color="#57458C"/>
+      <stop offset="0.8" stop-color="#534A8B"/>
+      <stop offset="1" stop-color="#425985"/>
+    </linearGradient>
+  </defs>
+  <rect x="72" y="72" width="288" height="288" rx="64.4" fill="url(#homebaseTile)"/>
+  <g transform="translate(138.6,115.9) scale(0.09089,0.09096)" fill="#FFFFFF">
+    <path d="M1417.9 567.5C1574.47 567.5 1701.4 440.573 1701.4 284C1701.4 127.427 1574.47 0.5 1417.9 0.5C1261.33 0.5 1134.4 127.427 1134.4 284C1134.4 440.573 1261.33 567.5 1417.9 567.5Z"/>
+    <path d="M1417.9 816.9H851C694.4 816.9 567.5 690 567.5 533.4V284C567.5 127.4 440.6 0.5 284 0.5C127.4 0.5 0.5 127.4 0.5 284V1916.8C0.5 2073.4 127.4 2200.3 284 2200.3C440.6 2200.3 567.5 2073.4 567.5 1916.8V1383.9C567.7 1227.5 694.5 1100.7 851 1100.7C1007.5 1100.7 1134.3 1227.5 1134.5 1383.9V1916.8C1134.5 2073.4 1261.4 2200.3 1418 2200.3C1574.6 2200.3 1701.5 2073.4 1701.5 1916.8V1100.4C1701.5 943.8 1574.6 816.9 1418 816.9H1417.9Z"/>
+  </g>
+</svg>

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -909,7 +909,6 @@
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "We need access to your photo library to attach image to chat message";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1008,7 +1007,6 @@
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "We need access to your photo library to attach image to chat message";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1198,7 +1196,6 @@
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "We need access to your photo library to attach image to chat message";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/iosApp/iosApp/Assets.xcassets/LaunchBackground.colorset/Contents.json
+++ b/iosApp/iosApp/Assets.xcassets/LaunchBackground.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : { "alpha" : "1.000", "blue" : "1.000", "green" : "1.000", "red" : "1.000" }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [ { "appearance" : "luminosity", "value" : "dark" } ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : { "alpha" : "1.000", "blue" : "0.000", "green" : "0.000", "red" : "0.000" }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : { "author" : "xcode", "version" : 1 }
+}

--- a/iosApp/iosApp/Assets.xcassets/LaunchLogo.imageset/Contents.json
+++ b/iosApp/iosApp/Assets.xcassets/LaunchLogo.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images": [
+    {
+      "filename": "homebase_logo_rounded.svg",
+      "idiom": "universal",
+      "scale": "1x"
+    }
+  ],
+  "info": {
+    "author": "xcode",
+    "version": 1
+  },
+  "properties": {
+    "preserves-vector-representation": true
+  }
+}

--- a/iosApp/iosApp/Assets.xcassets/LaunchLogo.imageset/homebase_logo_rounded.svg
+++ b/iosApp/iosApp/Assets.xcassets/LaunchLogo.imageset/homebase_logo_rounded.svg
@@ -1,0 +1,27 @@
+<!-- Homebase app icon as a standalone logo: homebase_gradient.svg's stops on a rounded
+     tile, with homebase_icon.svg's mark on top. Geometry is taken from the shipped
+     AppIcon marketing asset (mark is 53.7% x 69.5% of the tile, centred); the corner
+     radius is the 22.37% iOS icon-grid value so the tile reads as the app icon rather
+     than a raw square.
+
+     width/height are the intended render size in points (the 288-unit tile lands at 96pt,
+     the WhatsApp/Signal launch-logo scale); viewBox carries the art's native 432 units,
+     which is the Android adaptive-icon canvas the tile is inscribed in. -->
+<svg width="144" height="144" viewBox="0 0 432 432" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="homebaseTile" x1="299.9" y1="324.8" x2="-82.0" y2="-170.2" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#415A84"/>
+      <stop offset="0.2" stop-color="#4F4D89"/>
+      <stop offset="0.3" stop-color="#58458D"/>
+      <stop offset="0.5" stop-color="#5B438E"/>
+      <stop offset="0.7" stop-color="#57458C"/>
+      <stop offset="0.8" stop-color="#534A8B"/>
+      <stop offset="1" stop-color="#425985"/>
+    </linearGradient>
+  </defs>
+  <rect x="72" y="72" width="288" height="288" rx="64.4" fill="url(#homebaseTile)"/>
+  <g transform="translate(138.6,115.9) scale(0.09089,0.09096)" fill="#FFFFFF">
+    <path d="M1417.9 567.5C1574.47 567.5 1701.4 440.573 1701.4 284C1701.4 127.427 1574.47 0.5 1417.9 0.5C1261.33 0.5 1134.4 127.427 1134.4 284C1134.4 440.573 1261.33 567.5 1417.9 567.5Z"/>
+    <path d="M1417.9 816.9H851C694.4 816.9 567.5 690 567.5 533.4V284C567.5 127.4 440.6 0.5 284 0.5C127.4 0.5 0.5 127.4 0.5 284V1916.8C0.5 2073.4 127.4 2200.3 284 2200.3C440.6 2200.3 567.5 2073.4 567.5 1916.8V1383.9C567.7 1227.5 694.5 1100.7 851 1100.7C1007.5 1100.7 1134.3 1227.5 1134.5 1383.9V1916.8C1134.5 2073.4 1261.4 2200.3 1418 2200.3C1574.6 2200.3 1701.5 2073.4 1701.5 1916.8V1100.4C1701.5 943.8 1574.6 816.9 1418 816.9H1417.9Z"/>
+  </g>
+</svg>

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -54,5 +54,18 @@
 	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>
 	<true/>
+	<!-- Launch screen: the app logo centred on a plain white/black background that follows
+	     the system appearance, so a cold start is branded instead of a blank white window.
+	     Declared here rather than via INFOPLIST_KEY_UILaunchScreen_* build settings —
+	     _Generation = YES emits an empty UILaunchScreen dict and ignores its siblings. -->
+	<key>UILaunchScreen</key>
+	<dict>
+		<key>UILaunchScreenBackgroundColorName</key>
+		<string>LaunchBackground</string>
+		<key>UIImageName</key>
+		<string>LaunchLogo</string>
+		<key>UIImageRespectsSafeAreaInsets</key>
+		<false/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Closes #1162.

Cold start showed a blank white (light) or dark-grey (night) window from process start
until Compose painted its first frame — no logo, no branding. Android had no splash at
all; iOS had Xcode's synthesized *empty* one.

Both platforms now show the app logo centred on a plain white/black background that
follows the system appearance — the WhatsApp/Signal shape — handing off to the app
surface without a colour jump.

## Verified

Device-verified in **both** light and dark on a **Redmi Note 5 Pro (API 30)** and the
**iPhone 17 simulator**. API 30 matters: below Android 12 there is no system splash
whatsoever, so that handset was showing a fully blank window.

## The asset

`icons/homebase_logo_rounded.svg` is the single source of truth — the gradient tile from
`homebase_gradient.svg` with the mark from `homebase_icon.svg`, geometry measured off the
shipped `AppIcon` marketing asset rather than eyeballed.

## Android

- `androidx.core:core-splashscreen`, so one theme covers every device instead of only
  API 31+.
- `Theme.Homebase.Splash` + night variant, `postSplashScreenTheme` back to the Material 3
  theme, `installSplashScreen()` before `super.onCreate`.
- `drawable/ic_splash_logo.xml` is the hand-converted twin of the SVG. Android `res/` has
  no SVG support, and a splash icon is a *window* attribute resolved before any app code
  runs — nothing exists yet that could parse one. Vector rather than a mipmap so it stays
  crisp at the 288dp splash canvas.

**The rounded corners never show on Android.** Both the API 31+ splash and the
core-splashscreen backport circle-mask the icon with no opt-out (see the library's
`splashscreen_icon_mask_*` dimens). Confirmed by `aapt2 dump xmltree` on the built APK:
the rounded-square path is in there, and the device still draws a disc. That matches
Android's own circular launcher icon, so it is consistent — the corners are kept only so
the geometry stays identical to the SVG.

## iOS

- The asset catalog takes the SVG directly — `actool` expands it to 1x/2x/3x **and**
  retains the vector — so one file replaces three PNGs.
- `UILaunchScreen` is declared in `Info.plist` rather than via
  `INFOPLIST_KEY_UILaunchScreen_*` build settings. With `_Generation = YES` the built
  plist came out with an **empty** `UILaunchScreen` dict and the sibling `_ImageName` /
  `_BackgroundColor` keys silently dropped; the three build settings are removed.

iOS does not mask, so it shows the rounded tile — matching *its* home-screen icon. One
source asset, each platform's native shape.

## Not covered

Desktop. Its window is created already sized and empty by `application { Window(...) }`,
which is a different (and much milder) problem — worth a follow-up, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
