### PR TITLE
feat(chat): show shared media in group settings, like 1:1 (#1157)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationsettings/ConversationOverviewSection.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationsettings/ConversationOverviewSection.kt
@@ -1,0 +1,101 @@
+package id.homebase.chat.conversationsettings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import id.homebase.chat.widget.MediaItem
+import id.homebase.core.config.chatTargetDrive
+import id.homebase.core.image.ImageSize
+import id.homebase.resources.MR
+import id.homebase.resources.contact_info_recent_media
+import id.homebase.resources.conversation_media_see_all
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * "Recent media" header + horizontal strip of the conversation's shared images and
+ * videos, with a "See all" that opens the full grid.
+ *
+ * Kind-agnostic: rendered by both [ConversationSettingsScreen] (1:1) and
+ * `GroupSettingsScreen` (#1157), which previously showed no shared media at all.
+ * [ConversationOverview] is keyed by conversation, not by conversation kind, so
+ * there is nothing 1:1-specific here — keep it that way.
+ *
+ * The header appears when the conversation has *anything* shared (files, audio,
+ * dice rolls and locations included), because those kinds have no strip of their
+ * own and are reachable only through "See all" → the media screen's tabs. Only
+ * images/videos get the strip.
+ *
+ * Tiles are deliberately bare — no sender overlay, in a group either. Attribution
+ * lives on the "See all" screen (`ConversationMediaScreen`'s files/audio rows show
+ * "sender · date") and in the full-screen viewer, so the strip stays a clean
+ * visual index.
+ */
+@Composable
+fun ConversationOverviewSection(
+    overview: ConversationOverview,
+    onMediaClick: (SharedMediaItem) -> Unit,
+    onSeeAll: () -> Unit,
+) {
+    val hasAnything = overview.media.isNotEmpty() || overview.files.isNotEmpty() ||
+            overview.audio.isNotEmpty() || overview.diceRolls.isNotEmpty() ||
+            overview.locations.isNotEmpty()
+
+    if (hasAnything) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(MR.string.contact_info_recent_media),
+                style = MaterialTheme.typography.titleSmall,
+                modifier = Modifier.weight(1f),
+            )
+            TextButton(onClick = onSeeAll) {
+                Text(text = stringResource(MR.string.conversation_media_see_all))
+            }
+        }
+    }
+
+    if (overview.media.isNotEmpty()) {
+        val strip = remember(overview.media) { overview.media.take(50) }
+        Spacer(modifier = Modifier.height(4.dp))
+        LazyRow(
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            items(strip) { item ->
+                MediaItem(
+                    payload = item.payload,
+                    fileId = item.fileId,
+                    driveId = chatTargetDrive.alias,
+                    previewThumbnail = item.previewThumbnail,
+                    keyHeader = item.keyHeader,
+                    imageSize = ImageSize.THUMB_MEDIUM,
+                    isSticker = item.isSticker,
+                    modifier = Modifier.size(76.dp),
+                    shape = RoundedCornerShape(12.dp),
+                    onClick = { onMediaClick(item) },
+                    sharedTransitionScope = null,
+                    animatedVisibilityScope = null,
+                )
+            }
+        }
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationsettings/ConversationSettingsScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationsettings/ConversationSettingsScreen.kt
@@ -194,7 +194,7 @@ fun ConversationSettingsUi(
                     }
 
                     uiState.overview?.let { overview ->
-                        OverviewSection(
+                        ConversationOverviewSection(
                             overview = overview,
                             onMediaClick = { fullScreenItem = it },
                             onSeeAll = { onSeeAllMedia(conversationId) },
@@ -219,60 +219,6 @@ fun ConversationSettingsUi(
                 snackbarHostState = snackbarHostState,
                 onDismiss = { fullScreenItem = null },
             )
-        }
-    }
-}
-
-@Composable
-private fun OverviewSection(
-    overview: ConversationOverview,
-    onMediaClick: (SharedMediaItem) -> Unit,
-    onSeeAll: () -> Unit,
-) {
-    val hasAnything = overview.media.isNotEmpty() || overview.files.isNotEmpty() ||
-            overview.audio.isNotEmpty() || overview.diceRolls.isNotEmpty() ||
-            overview.locations.isNotEmpty()
-
-    if (hasAnything) {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = stringResource(MR.string.contact_info_recent_media),
-                style = MaterialTheme.typography.titleSmall,
-                modifier = Modifier.weight(1f),
-            )
-            TextButton(onClick = onSeeAll) {
-                Text(text = stringResource(MR.string.conversation_media_see_all))
-            }
-        }
-    }
-
-    if (overview.media.isNotEmpty()) {
-        val strip = remember(overview.media) { overview.media.take(50) }
-        Spacer(modifier = Modifier.height(4.dp))
-        LazyRow(
-            modifier = Modifier.fillMaxWidth(),
-            contentPadding = PaddingValues(horizontal = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            items(strip) { item ->
-                MediaItem(
-                    payload = item.payload,
-                    fileId = item.fileId,
-                    driveId = chatTargetDrive.alias,
-                    previewThumbnail = item.previewThumbnail,
-                    keyHeader = item.keyHeader,
-                    imageSize = ImageSize.THUMB_MEDIUM,
-                    isSticker = item.isSticker,
-                    modifier = Modifier.size(76.dp),
-                    shape = RoundedCornerShape(12.dp),
-                    onClick = { onMediaClick(item) },
-                    sharedTransitionScope = null,
-                    animatedVisibilityScope = null,
-                )
-            }
         }
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsScreen.kt
@@ -82,12 +82,16 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.api.common.OdinId
+import id.homebase.chat.conversationsettings.ConversationOverviewSection
+import id.homebase.chat.conversationsettings.SharedMediaItem
 import id.homebase.chat.createconversation.ContactItem
 import id.homebase.chat.services.convo.contact.ContactConnectionState
 import id.homebase.chat.widget.AvatarNameDisplay
+import id.homebase.chat.widget.ChatMediaFullScreenHost
 import id.homebase.chat.widget.ErrorInfoItem
 import id.homebase.chat.widget.LoadingListItem
 import id.homebase.core.HomebaseConstants
+import id.homebase.core.config.chatTargetDrive
 import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.ContactAvatar
 import id.homebase.core.avatars.ConversationAvatarModel
@@ -178,6 +182,7 @@ fun GroupSettingsScreen(
     onShowContactInfo: (odinId: String) -> Unit,
     onAddMembers: (conversationId: String) -> Unit,
     onEditGroup: (conversationId: String) -> Unit,
+    onSeeAllMedia: (conversationId: String) -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val scope = rememberCoroutineScope()
@@ -273,6 +278,12 @@ fun GroupSettingsScreen(
     // the viewer covers the whole screen, including the top bar. Null = closed.
     var fullScreenAvatar by remember { mutableStateOf<HomebaseImageData?>(null) }
 
+    // A shared-media tile opened full-screen. Separate from [fullScreenAvatar]:
+    // that one is the group photo and uses the zoomable avatar viewer, this one
+    // is a chat attachment and goes through the same ChatMediaFullScreenHost the
+    // 1:1 settings screen uses (save/share/jump-to-message actions).
+    var fullScreenItem by remember { mutableStateOf<SharedMediaItem?>(null) }
+
     SharedTransitionLayout(modifier = Modifier.fillMaxSize()) {
         AnimatedContent(
             targetState = fullScreenAvatar,
@@ -288,14 +299,25 @@ fun GroupSettingsScreen(
                     GroupSettingsUi(
                         snackbarHostState = snackbarHostState,
                         uiState = uiState,
+                        conversationId = viewModel.route.conversationId,
                         onUiAction = viewModel::onUiAction,
                         onAvatarClick = { fullScreenAvatar = it },
+                        onMediaClick = { fullScreenItem = it },
+                        onSeeAllMedia = onSeeAllMedia,
+                        isMediaViewerOpen = fullScreenItem != null,
                         sharedTransitionScope = this@SharedTransitionLayout,
                         animatedVisibilityScope = this@AnimatedContent,
                     )
                     if (uiState.isLeaving) {
                         LeavingGroupOverlay()
                     }
+                    ChatMediaFullScreenHost(
+                        item = fullScreenItem,
+                        driveId = chatTargetDrive.alias,
+                        title = uiState.conversation?.name.orEmpty(),
+                        snackbarHostState = snackbarHostState,
+                        onDismiss = { fullScreenItem = null },
+                    )
                 }
             } else {
                 GroupAvatarFullScreenViewer(
@@ -417,35 +439,44 @@ private fun GroupAvatarFullScreenViewer(
 fun GroupSettingsUi(
     snackbarHostState: SnackbarHostState,
     uiState: GroupSettingsUiState,
+    conversationId: String,
     onUiAction: (GroupSettingsUiAction) -> Unit,
     onAvatarClick: (HomebaseImageData) -> Unit = {},
+    onMediaClick: (SharedMediaItem) -> Unit = {},
+    onSeeAllMedia: (conversationId: String) -> Unit = {},
+    /** True while a shared-media tile is open full-screen; suppresses this screen's
+     *  app bar so the viewer's own top bar doesn't stack under it (same reason as
+     *  ConversationSettingsScreen). */
+    isMediaViewerOpen: Boolean = false,
     sharedTransitionScope: SharedTransitionScope? = null,
     animatedVisibilityScope: AnimatedVisibilityScope? = null,
 ) {
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
-            TopAppBar(
-                title = {},
-                navigationIcon = {
-                    IconButton(onClick = { onUiAction(GroupSettingsUiAction.BackClicked) }) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(MR.string.menu_back)
-                        )
-                    }
-                },
-                actions = {
-                    if (uiState.isCurrentUserGroupAdmin && !uiState.isLegacyGroup) {
-                        IconButton(onClick = { onUiAction(GroupSettingsUiAction.EditGroupClicked) }) {
+            if (!isMediaViewerOpen) {
+                TopAppBar(
+                    title = {},
+                    navigationIcon = {
+                        IconButton(onClick = { onUiAction(GroupSettingsUiAction.BackClicked) }) {
                             Icon(
-                                Icons.Outlined.Edit,
-                                contentDescription = stringResource(MR.string.chat_message_edit)
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = stringResource(MR.string.menu_back)
                             )
                         }
-                    }
-                },
-            )
+                    },
+                    actions = {
+                        if (uiState.isCurrentUserGroupAdmin && !uiState.isLegacyGroup) {
+                            IconButton(onClick = { onUiAction(GroupSettingsUiAction.EditGroupClicked) }) {
+                                Icon(
+                                    Icons.Outlined.Edit,
+                                    contentDescription = stringResource(MR.string.chat_message_edit)
+                                )
+                            }
+                        }
+                    },
+                )
+            }
         },
     ) { padding ->
         Column(
@@ -481,6 +512,19 @@ fun GroupSettingsUi(
                             animatedVisibilityScope = animatedVisibilityScope,
                         )
                         Spacer(modifier = Modifier.height(32.dp))
+                    }
+                    // Shared media, above the member list — mirrors the 1:1 settings
+                    // screen (#1157). A LazyRow inside a LazyColumn item is fine: the
+                    // scroll axes are perpendicular.
+                    uiState.overview?.let { overview ->
+                        item {
+                            ConversationOverviewSection(
+                                overview = overview,
+                                onMediaClick = onMediaClick,
+                                onSeeAll = { onSeeAllMedia(conversationId) },
+                            )
+                            Spacer(modifier = Modifier.height(16.dp))
+                        }
                     }
                     if (uiState.isLegacyGroup) {
                         item {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsUiState.kt
@@ -5,6 +5,7 @@ import id.homebase.api.client.connections.IntroductionPreflightStatus
 import id.homebase.api.client.drives.files.TransferStatus
 import id.homebase.api.client.peer.FileExistsOnPeerResponse
 import id.homebase.api.common.OdinId
+import id.homebase.chat.conversationsettings.ConversationOverview
 import id.homebase.chat.data.ContactUiModel
 import id.homebase.chat.data.ConversationUiModel
 import kotlin.uuid.Uuid
@@ -51,6 +52,12 @@ data class GroupSettingsUiState(
      *  on non-group / legacy-group conversations (legacy groups inline admins, so a
      *  separate "DB-admin: absent" row would be a false positive). */
     val filesDiagnostic: GroupFilesDiagnostic? = null,
+    /** Media/files/audio/dice/location shared in this group, for the "Recent media"
+     *  strip + "See all" (#1157 — groups previously showed none of this, only 1:1 did).
+     *  Loaded independently of the rest so the header paints before the message scan
+     *  finishes; null while loading or when the scan failed. */
+    val overview: ConversationOverview? = null,
+    val isOverviewLoading: Boolean = true,
     val uiEvent: GroupSettingsUiEvent? = null,
     val uiDialog: GroupSettingsUiDialog? = null,
     val uiSheet: GroupSettingsUiSheet? = null,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsViewModel.kt
@@ -12,12 +12,15 @@ import id.homebase.api.client.drives.files.RecipientTransferHistoryEntry
 import id.homebase.api.client.drives.files.TransferStatus
 import id.homebase.api.client.peer.PeerDriveQueryProvider
 import id.homebase.api.common.OdinId
+import id.homebase.chat.conversationsettings.ConversationSettingsViewModel
+import id.homebase.chat.conversationsettings.collectConversationOverview
 import id.homebase.chat.data.ConversationUiModel
 import id.homebase.chat.groupsettings.GroupSettingsUiEvent.Back
 import id.homebase.chat.groupsettings.GroupSettingsUiEvent.Error
 import id.homebase.chat.groupsettings.GroupSettingsUiEvent.ShowAddMembers
 import id.homebase.chat.groupsettings.GroupSettingsUiEvent.ShowContactInfo
 import id.homebase.chat.groupsettings.GroupSettingsUiEvent.ShowEditGroup
+import id.homebase.chat.services.ChatMessageStream
 import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.convo.ConversationService
 import id.homebase.chat.services.convo.ConversationStream
@@ -25,10 +28,12 @@ import id.homebase.chat.services.convo.GroupHealService
 import id.homebase.chat.services.convo.HealGroupResult
 import id.homebase.chat.services.convo.HealPhase
 import id.homebase.chat.services.convo.HealPlan
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
@@ -56,6 +61,7 @@ class GroupSettingsViewModel(
     private val credentialsManager: CredentialsManager,
     private val driveFileProvider: DriveFileProvider,
     private val peerDriveQueryProvider: PeerDriveQueryProvider,
+    private val chatMessageStream: ChatMessageStream,
 ) : ViewModel() {
 
     val route = savedStateHandle.toRoute<Route.GroupSettings>()
@@ -69,6 +75,7 @@ class GroupSettingsViewModel(
     private var lastPeerAuditKey: PeerAuditKey? = null
 
     init {
+        loadOverview()
         viewModelScope.launch {
             conversationStream.start()
             // conversationStream.conversations is a StateFlow over the WHOLE
@@ -88,6 +95,45 @@ class GroupSettingsViewModel(
                 .collect { conversation ->
                     loadData(conversation)
                 }
+        }
+    }
+
+    /**
+     * Loads the media/files/audio/dice/location overview of this group (#1157).
+     *
+     * Same contract as [id.homebase.chat.conversationsettings.ConversationSettingsViewModel.loadOverview]:
+     * runs independently of the conversation collector in [init] so the header and
+     * member list paint before the (heavier) message scan finishes, and a failure
+     * only clears the loading flag — the rest of the screen is unaffected.
+     *
+     * One-shot, not re-run on new messages: the strip is a snapshot of what's on this
+     * device when the screen opens, matching the 1:1 screen. Re-scanning
+     * [SUMMARY_MESSAGE_CAP] messages on every conversation re-emit would be far more
+     * expensive than the audit this VM already gates.
+     */
+    private fun loadOverview() {
+        viewModelScope.launch {
+            try {
+                // Parsed inside the try, not at call time: this VM otherwise never
+                // parses route.conversationId (it string-compares it), so hoisting the
+                // parse would turn a malformed id into a ViewModel-construction crash
+                // instead of an empty media strip.
+                val conversationId = Uuid.parse(route.conversationId)
+                val batch = chatMessageStream.fetchMessages(
+                    conversationId = conversationId,
+                    // Shared with the 1:1 screen deliberately — the two strips must
+                    // scan the same depth or "Recent media" means something different
+                    // depending on conversation kind.
+                    limit = ConversationSettingsViewModel.SUMMARY_MESSAGE_CAP,
+                )
+                val overview = withContext(Dispatchers.Default) {
+                    collectConversationOverview(batch)
+                }
+                _uiState.update { it.copy(overview = overview, isOverviewLoading = false) }
+            } catch (e: Exception) {
+                Logger.e("Failed to load group overview", e)
+                _uiState.update { it.copy(isOverviewLoading = false) }
+            }
         }
     }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -1198,6 +1198,12 @@ fun AppNavHost(
                                     onEditGroup = {
                                         navController.navigate(Route.GroupEdit(it))
                                     },
+                                    // Same destination the 1:1 settings screen uses —
+                                    // ConversationMedia is keyed by conversationId only,
+                                    // so it needs no group-specific handling (#1157).
+                                    onSeeAllMedia = { conversationId ->
+                                        navController.navigate(Route.ConversationMedia(conversationId))
+                                    },
                                 )
                             }
                         }


### PR DESCRIPTION
Closes #1157.

## Problem

Tapping a **1:1** header opens settings with a "Recent media" strip and a "See all" into the full media grid. Tapping a **group** header opens group settings with no shared media at all. Shared media matters *more* in a group — it's the only place to see everything the group has posted.

## Change

- Extracts the 1:1 screen's `private OverviewSection` into a public `ConversationOverviewSection`, in the same package as the `ConversationOverview` model it renders. Nothing about it was 1:1-specific; `ConversationSettingsScreen` now calls the shared one (no behaviour change there).
- `GroupSettingsViewModel` gains a `ChatMessageStream` dep and a `loadOverview()` mirroring the 1:1 one, called from `init` so it runs independently of the conversation collector — the header and member list paint before the message scan finishes.
- `GroupSettingsScreen` renders the section in a `LazyColumn` `item {}` above the member list, and gains `ChatMediaFullScreenHost` plus the top-bar suppression the 1:1 screen uses so the viewer's bar doesn't stack under the screen's.
- `AppNavHost` wires `onSeeAllMedia` → `Route.ConversationMedia(conversationId)` — the same destination as 1:1, which is keyed by `conversationId` only and needs no group-specific handling.

## On the issue's step 3

"Verify sender attribution on tiles" was mostly already done: `SharedMediaItem.senderName` is populated from `message.displayName` (`ConversationOverview.kt:107`, `:159`) and the files/audio rows already render "sender · date" (`ConversationMediaScreen.kt:285`, `:370`). The only place without attribution is `MediaGridTab` — left as-is per the decision to keep the grid clean; attribution lives on the "See all" screen and in the full-screen viewer.

## Decisions worth reviewing

- `SUMMARY_MESSAGE_CAP` is **referenced** from `ConversationSettingsViewModel`, not duplicated. If the two scan depths diverged, "Recent media" would silently mean something different depending on conversation kind.
- `loadOverview()` is **one-shot**, not re-run when the conversation re-emits — same as the 1:1 screen. Re-scanning 1000 messages on every new message would cost more than the peer audit this VM already gates. Consequence: the strip is a snapshot from when the screen opened.
- `Uuid.parse(route.conversationId)` sits **inside** the coroutine's `try`, unlike the 1:1 copy which hoists it to call time. This VM otherwise only string-compares the id, so hoisting would turn a malformed id into a ViewModel-construction crash instead of an empty strip.

## Testing

- [x] `:homebase-chat` + `:homebase-core` compile on JVM, Android, and iOS (`compileKotlinJvm`, `compileAndroidMain`, `compileKotlinIosSimulatorArm64`)
- [x] `:homebase-chat:jvmTest` and `:homebase-common:jvmTest` pass (incl. the Konsist `stringResource` architecture check — no new string literals; existing `contact_info_recent_media` / `conversation_media_see_all` resources reused)
- [ ] **Not run on a device.** The layout in a real group, and whether the strip populates against real group data, still need a build.

## Known nit for the device pass

The group `LazyColumn` uses `contentPadding = 16.dp` while the section adds its own `horizontal = 16.dp`, so the strip may sit inset further than it does on the 1:1 screen (which is a plain `Column`). Worth an eyeball before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)