### PR TITLE
fix(notifications): resolve AppViewModel via koinViewModel so notification taps aren't swallowed

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/App.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/App.kt
@@ -14,8 +14,10 @@ import id.homebase.core.logging.StartupLogger
 import id.homebase.core.settings.ThemeState
 import id.homebase.core.settings.UserPreferences
 import id.homebase.core.ui.navigation.AppNavHost
+import id.homebase.core.ui.navigation.AppViewModel
 import id.homebase.core.ui.theme.HomebaseTheme
 import org.koin.compose.koinInject
+import org.koin.compose.viewmodel.koinViewModel
 
 /** Main application entry point. Sets up theme, and navigation. */
 @OptIn(ExperimentalMaterial3Api::class)
@@ -37,7 +39,19 @@ fun App(
         followsSystemTheme = prefState.theme == ThemeState.System,
     ) {
         AppNavHost(
-            viewModel = koinInject(),
+            // koinViewModel(), NOT koinInject(). AppViewModel is registered with
+            // viewModelOf(), which is a *factory* definition — koinInject() resolves
+            // it outside any ViewModelStore, so every Activity recreation minted a
+            // fresh AppViewModel whose onCleared() was never called. Each orphan kept
+            // its collectNotificationEvents() coroutine alive on
+            // NotificationService.navigationEvents, which is a single-consumer
+            // Channel.receiveAsFlow(): N live collectors round-robin the events, and
+            // an orphan that wins a turn forwards into its own channel that nothing
+            // reads. Result — notification taps and share deep links silently went
+            // nowhere (build 1788 log: three consecutive events "forwarded" by
+            // AppViewModel with no matching AppNavHost receipt, after four Activity
+            // onCreates in one process).
+            viewModel = koinViewModel<AppViewModel>(),
             navController = navController,
             youAuthFlowManager = youAuthFlowManager
         )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppViewModel.kt
@@ -60,7 +60,24 @@ class AppViewModel(
     private var credentialsJob: Job? = null
     private var upgradeCheckJob: Job? = null
 
+    // Diagnostic only. AppViewModel must be resolved with koinViewModel() so the
+    // Activity's ViewModelStore owns exactly one live instance and clears it on
+    // destroy. When it was resolved with koinInject() instead, every Activity
+    // recreation leaked another instance whose collectNotificationEvents() kept
+    // competing for NotificationService's single-consumer nav Channel — an orphan
+    // winning a turn swallowed the tap. That failure was invisible in the log
+    // (one "forwarded" line either way); this makes it loud.
+    private val instanceId = ++instancesCreated
+
     init {
+        liveInstances++
+        if (liveInstances > 1) {
+            Logger.w(tag = "AppViewModel") {
+                "instance #$instanceId created while $liveInstances are live — notification " +
+                    "taps will be round-robined into orphan channels. AppViewModel must be " +
+                    "resolved with koinViewModel(), not koinInject()."
+            }
+        }
         collectNotificationEvents()
         registerShareHandler { conversationId -> handleShareIntent(conversationId) }
         registerMomentShareHandler { handleMomentShareIntent() }
@@ -91,6 +108,7 @@ class AppViewModel(
 
     override fun onCleared() {
         super.onCleared()
+        liveInstances--
         unregisterShareHandler()
         unregisterMomentShareHandler()
         unregisterPermissionCallbackHandler()
@@ -131,7 +149,9 @@ class AppViewModel(
     private fun collectNotificationEvents() {
         viewModelScope.launch {
             notificationService.navigationEvents.collect { event ->
-                Logger.i(tag = "AppViewModel") { "navigationEvent forwarded: $event" }
+                Logger.i(tag = "AppViewModel") {
+                    "navigationEvent forwarded (vm#$instanceId): $event"
+                }
                 _navigationEvents.trySend(event)
             }
         }
@@ -227,6 +247,11 @@ class AppViewModel(
         _navigationEvents.trySend(NotificationNavigationEvent.OpenMomentCompose)
     }
 
+    private companion object {
+        // Main-thread only (ViewModel construction / clearing), so plain vars.
+        var instancesCreated = 0
+        var liveInstances = 0
+    }
 }
 
 @Immutable

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/navigation/NavigationEventSingleConsumerTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/navigation/NavigationEventSingleConsumerTest.kt
@@ -1,0 +1,104 @@
+package id.homebase.core.ui.navigation
+
+import id.homebase.core.notifications.NotificationNavigationEvent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression test for the silent notification-tap drop captured in
+ * homebase_1785203524243.log (build 1788, 2026-07-28).
+ *
+ * Log evidence — three consecutive navigation events were accepted by an
+ * AppViewModel and never reached AppNavHost:
+ *
+ *   01:09:42 (AppViewModel) navigationEvent forwarded: OpenConversation(… ShareIntent)
+ *   01:10:19 (AppViewModel) navigationEvent forwarded: OpenConversation(… ShareIntent)
+ *   01:45:51 (NotificationService) navigationEvent emit: OpenMoment(ab793c7f-…)
+ *   01:45:51 (AppViewModel) navigationEvent forwarded: OpenMoment(ab793c7f-…)
+ *   <silence — no "(AppNavHost) OpenMoment received">
+ *
+ * Every earlier event in the same process (13:26 through 23:39) went
+ * emit -> forwarded -> AppNavHost cleanly. What changed in between: four
+ * Activity onCreates (00:16:48 x2, 01:02:29, 01:02:36) with no process
+ * restart.
+ *
+ * Cause: App.kt resolved AppViewModel with koinInject() against a
+ * viewModelOf() (factory) definition, so each Activity recreation minted a
+ * new AppViewModel outside any ViewModelStore. onCleared() was therefore
+ * never called, viewModelScope was never cancelled, and every orphan kept
+ * collecting NotificationService.navigationEvents — which is
+ * `Channel(BUFFERED).receiveAsFlow()`, a **single-consumer** flow. N live
+ * collectors round-robin the stream; an orphan that wins a turn logs
+ * "forwarded" and trySends into its own channel that no AppNavHost reads.
+ * With 5 instances and only the newest wired to the UI, 4 of every 5 taps
+ * vanished.
+ *
+ * This test pins the channel semantics that make the leak fatal rather than
+ * merely wasteful: it is the single-consumer split, not a lost subscription,
+ * that eats the events. The fix is upstream — App.kt uses koinViewModel() so
+ * exactly one instance is ever live.
+ */
+class NavigationEventSingleConsumerTest {
+
+    private fun event(id: String) =
+        NotificationNavigationEvent.OpenConversation(conversationId = id)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun multiple_collectors_split_a_single_consumer_channel_instead_of_each_seeing_every_event() =
+        runTest {
+            val source = Channel<NotificationNavigationEvent>(Channel.BUFFERED)
+            val flow = source.receiveAsFlow()
+
+            // Four orphaned AppViewModels plus the one AppNavHost is wired to.
+            val received = List(5) { mutableListOf<NotificationNavigationEvent>() }
+            val jobs = received.map { sink ->
+                launch { flow.collect { sink += it } }
+            }
+            runCurrent()
+
+            repeat(5) { source.trySend(event("0000000$it-0000-0000-0000-000000000000")) }
+            runCurrent()
+
+            val total = received.sumOf { it.size }
+            assertEquals(
+                5,
+                total,
+                "Channel.receiveAsFlow() must hand each event to exactly one collector; " +
+                    "if this ever becomes a broadcast the orphan-instance leak stops being " +
+                    "fatal and this test's premise is void",
+            )
+            assertTrue(
+                received.any { it.size < 5 },
+                "At least one collector must have missed events — this is the mechanism " +
+                    "that swallowed the OpenMoment tap at 01:45:51",
+            )
+
+            jobs.forEach { it.cancel() }
+        }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun single_collector_receives_every_event() = runTest {
+        // The post-fix shape: exactly one live AppViewModel, so every event
+        // forwarded from NotificationService reaches AppNavHost.
+        val source = Channel<NotificationNavigationEvent>(Channel.BUFFERED)
+        val received = mutableListOf<NotificationNavigationEvent>()
+        val job = launch { source.receiveAsFlow().collect { received += it } }
+        runCurrent()
+
+        val sent = List(5) { event("0000000$it-0000-0000-0000-000000000000") }
+        sent.forEach { source.trySend(it) }
+        runCurrent()
+
+        assertEquals(sent, received.toList())
+        job.cancel()
+    }
+}


### PR DESCRIPTION
Tapping a push notification did nothing. Diagnosed from `homebase_1785203524243.log` (build 1788).

## Cause

`App.kt:40` resolved `AppViewModel` with `koinInject()`, but it's registered as `viewModelOf(::AppViewModel)` — a **factory** definition. That constructs it outside any `ViewModelStore`, so `onCleared()` never fires and `viewModelScope` is never cancelled. Every Activity recreation leaks another permanently-live instance, each still collecting `NotificationService.navigationEvents`.

That flow is `Channel(BUFFERED).receiveAsFlow()` — **single-consumer**. N live `AppViewModel`s round-robin the stream, but only the newest is wired to `AppNavHost`. When an orphan wins a turn it logs `navigationEvent forwarded`, `trySend`s into its own channel, and nothing ever reads it.

The tap dies silently — the log looks identical whether the event was routed or dropped, which is why this went unnoticed.

## Log evidence

One process, started 12:54:40:

| | |
|---|---|
| One Activity onCreate at 12:56:55 → 1 instance | **all 8** events 13:26 → 23:39 went emit → forwarded → `AppNavHost` |
| Four more onCreates (00:16:48 ×2, 01:02:29, 01:02:36), no process restart → 5 instances | the next **3** were forwarded with **no** `AppNavHost` receipt |

The three dropped: `01:09:42` ShareIntent, `01:10:19` ShareIntent, `01:45:51` OpenMoment. Not moments-specific — share-intent deep links died the same way.

The `(AppNavHost) OpenMoment received` log line sits *before* the `isActivated` gate, so its absence proves the collector never saw the event rather than that it saw it and declined to route.

## Changes

- **`App.kt`** — `koinInject()` → `koinViewModel<AppViewModel>()`, with a comment so it doesn't drift back. The Activity's `ViewModelStore` now owns exactly one live instance and clears it on destroy.
- **`AppViewModel.kt`** — live-instance counter. A second concurrent instance logs a warning, and forwards are tagged `navigationEvent forwarded (vm#N)`. This class of failure was invisible before; now a recurrence is loud.
- **`NavigationEventSingleConsumerTest.kt`** (new) — pins the single-consumer channel split that makes the leak fatal rather than merely wasteful, plus the post-fix single-collector case.

## Testing

- [x] `:homebase-core` compiles on JVM, Android, and iOS
- [x] `:homebase-core:jvmTest --tests "id.homebase.core.ui.navigation.*"` passes
- [ ] **Not verified on a device** — confirming the fix needs a build and a real push tap.

## Pre-existing failure, not from this PR

`:homebase-core:compileTestKotlinIosSimulatorArm64` is already red on `main`: `NotificationTapColdStartTest.kt:189` and `:273` use `@Ignore("message")`, but `kotlin.test.Ignore` takes no arguments. Present at merge-base `768b9cb9c` and untouched here. Worth a separate fix, since CI runs the iOS test compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)