### PR TITLE
fix(test): drop @Ignore arguments in commonTest so the iOS test compile passes

### DIFF
--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/navigation/NotificationTapColdStartTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/navigation/NotificationTapColdStartTest.kt
@@ -185,14 +185,18 @@ class NotificationTapColdStartTest {
      * subsequent popBackStack(ChatList, inclusive=false) then brings ChatList
      * back to the top, which reads pendingConversationId and routes.
      */
-    @Ignore(
-        "CMP SkikoComposeUiTest.closeScene moves a still-INITIALIZED NavBackStackEntry " +
-            "(destination=TestDetail) to DESTROYED during desktop scene teardown, throwing " +
-            "IllegalStateException AFTER the test body passes. Harness bug, not product. The " +
-            "back-stack gate regression is covered meanwhile by BackStackGateTest. Remove " +
-            "@Ignore when CMP fixes desktop nav teardown — natural trigger is the " +
-            "composeMultiplatform 1.10.3 -> 1.11.0 bump."
-    )
+    // Ignored: CMP SkikoComposeUiTest.closeScene moves a still-INITIALIZED
+    // NavBackStackEntry (destination=TestDetail) to DESTROYED during desktop scene
+    // teardown, throwing IllegalStateException AFTER the test body passes. Harness
+    // bug, not product. The back-stack gate regression is covered meanwhile by
+    // BackStackGateTest. Remove @Ignore when CMP fixes desktop nav teardown —
+    // natural trigger is the composeMultiplatform 1.10.3 -> 1.11.0 bump.
+    //
+    // The reason is a comment, not an @Ignore("…") argument: this is commonTest, and
+    // kotlin.test.Ignore only takes a value on JVM/Android (where it typealiases to
+    // org.junit.Ignore). On native/JS it has no parameters, so the argument form
+    // compiles on JVM but breaks compileTestKotlinIosSimulatorArm64.
+    @Ignore
     @Test
     fun warm_start_notification_tap_from_detail_navigates_via_chatlist() = runComposeUiTest {
         val events = Channel<NotificationNavigationEvent>(Channel.BUFFERED)
@@ -269,14 +273,11 @@ class NotificationTapColdStartTest {
         kotlin.test.assertNotNull(navControllerRef)
     }
 
-    @Ignore(
-        "CMP SkikoComposeUiTest.closeScene moves a still-INITIALIZED NavBackStackEntry " +
-            "(destination=TestDetail) to DESTROYED during desktop scene teardown, throwing " +
-            "IllegalStateException AFTER the test body passes. Harness bug, not product. The " +
-            "back-stack gate regression is covered meanwhile by BackStackGateTest. Remove " +
-            "@Ignore when CMP fixes desktop nav teardown — natural trigger is the " +
-            "composeMultiplatform 1.10.3 -> 1.11.0 bump."
-    )
+    // Ignored for the same CMP desktop nav-teardown harness bug as
+    // warm_start_notification_tap_from_detail_navigates_via_chatlist above — see the
+    // full note there, including why the reason is a comment rather than an
+    // @Ignore("…") argument.
+    @Ignore
     @Test
     fun broken_top_only_gate_hangs_when_on_detail() = runComposeUiTest {
         // Negative control: same warm-on-Detail scenario as the test above,


### PR DESCRIPTION
`:homebase-core:compileTestKotlinIosSimulatorArm64` is currently **failing on `main`**:

```
e: NotificationTapColdStartTest.kt:189 Too many arguments for 'constructor(): Ignore'
e: NotificationTapColdStartTest.kt:273 Too many arguments for 'constructor(): Ignore'
```

## Cause

`kotlin.test.Ignore` accepts a value **only on JVM/Android**, where it typealiases to `org.junit.Ignore`. On native and JS it's a plain annotation with no parameters. So `@Ignore("reason")` compiles happily under `jvmTest` but breaks every native test compile — and both call sites are in `commonTest`, which has to satisfy the native form.

Since CI runs the iOS test compile, this has been red for every PR.

## Fix

Reasons move verbatim into comments above each annotation. They explain the CMP desktop nav-teardown harness bug and the condition for removing the `@Ignore` (the composeMultiplatform 1.10.3 → 1.11.0 bump) — worth keeping, and worth more than the annotation argument was. The first one also records *why* the reason can't live in the annotation, so it doesn't get "tidied" back into the broken form.

The other two `@Ignore("…")` in the repo (`FFmpegCompressBaselineJvmTest`, `CompressVideoBenchmarkTest`) are in `jvmTest` / `androidDeviceTest` source sets and are correct as-is — left alone.

No test behaviour changes: both tests stay ignored.

## Testing

- [x] `:homebase-core:compileTestKotlinIosSimulatorArm64` — **now passes** (was the failure above)
- [x] `:homebase-core:jvmTest --tests "id.homebase.core.ui.navigation.*"` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)