### PR TITLE
feat(contacts): circle picker on every accept path, and review reques…

### DIFF
--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationNavigationEvent.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationNavigationEvent.kt
@@ -14,6 +14,16 @@ sealed class NotificationNavigationEvent {
     data class OpenUrl(val url: String) : NotificationNavigationEvent()
 
     /**
+     * Open the contact-detail screen for [odinId] (the requester) so an incoming connection
+     * request can be reviewed and accepted in-app. Emitted for a tapped owner-app
+     * connection-request push, which would otherwise bounce out to the owner web console
+     * (`/owner/connections`) in the browser — the app can review it itself, including the
+     * add-to-circles picker on accept. The screen shows the requester's public profile with
+     * Accept/Reject as long as the request is still pending.
+     */
+    data class OpenConnectionRequest(val odinId: String) : NotificationNavigationEvent()
+
+    /**
      * Open the moments detail (Instagram-Reels-style vertical pager) landing on
      * [momentId]. Emitted for a tapped moment-post or comment notification (both
      * ride on the chat appId; see NotificationService.resolveMomentsTap).

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
@@ -15,6 +15,7 @@ import id.homebase.core.config.COMMUNITY_APP_ID
 import id.homebase.core.config.FEED_APP_ID
 import id.homebase.core.config.MAIL_APP_ID
 import id.homebase.core.config.OWNER_APP_ID
+import id.homebase.core.config.OWNER_CONNECTION_REQUEST_TYPE_ID
 import id.homebase.core.navigation.ActiveConversation
 import id.homebase.core.settings.UserPreferences
 import id.homebase.core.sync.awaitAuthRestored
@@ -93,6 +94,30 @@ internal fun buildCompanionAppUrlEvent(
 
 /** Apps whose notifications open the logged-in identity's own web app in the browser. */
 internal val COMPANION_APP_IDS = setOf(COMMUNITY_APP_ID, OWNER_APP_ID, MAIL_APP_ID, FEED_APP_ID)
+
+/**
+ * Routes a tapped owner-app connection-request notification to the in-app contact detail for the
+ * requester, where it can be reviewed and accepted (with the add-to-circles picker) — instead of
+ * the owner web console in the browser, which is where every other owner notification goes via
+ * [buildCompanionAppUrlEvent].
+ *
+ * Unlike the companion URLs, this one is keyed on the *sender*: they're the identity asking to
+ * connect, so their contact detail is the thing to open. Their host is never contacted for a
+ * session — the screen reads our own pending-request list and their public profile.
+ *
+ * @return the event to emit, or null when this isn't an owner connection-request tap or the
+ *   payload carries no sender — both fall through to the normal companion-URL handling, since
+ *   without a domain there is no contact screen to open.
+ */
+internal fun buildConnectionRequestTapEvent(
+    appId: String,
+    typeId: String,
+    senderId: String?,
+): NotificationNavigationEvent.OpenConnectionRequest? {
+    if (appId != OWNER_APP_ID || typeId != OWNER_CONNECTION_REQUEST_TYPE_ID) return null
+    val sender = senderId?.trim()?.lowercase()?.ifBlank { null } ?: return null
+    return NotificationNavigationEvent.OpenConnectionRequest(sender)
+}
 
 /**
  * How long a companion-app tap waits for credentials to be restored before
@@ -590,6 +615,8 @@ class NotificationService(
             val momentsTap = if (appId == Uuid.parse(AppConfig.APP_ID).toString()) {
                 resolveMomentsTap(typeId, tagId)
             } else null
+            val connectionRequestTap =
+                buildConnectionRequestTapEvent(appId, typeId, notification.senderId)
             when {
                 // Moments posts/comments ride on the chat appId but are routed to the
                 // moments detail (reels) screen, not ChatList. A post carries
@@ -632,6 +659,20 @@ class NotificationService(
                     // leaving other senders' notifications in the tray.
                     clearConversationNotifications(typeId)
                     emitNavigationEvent(NotificationNavigationEvent.OpenConversation(typeId))
+                }
+
+                // An incoming connection request is reviewable in-app (contact detail shows the
+                // requester's public profile with Accept/Reject + the circle picker), so it opens
+                // there instead of bouncing to the owner web console like the owner app's other
+                // notifications. Sits ahead of the companion branch, which OWNER_APP_ID would
+                // otherwise claim; a payload with no sender leaves this null and falls through to
+                // it unchanged, since without a domain there's no contact to open.
+                connectionRequestTap != null -> {
+                    Logger.i(tag = "NotificationService") {
+                        "Connection-request tap — opening contact detail for " +
+                                connectionRequestTap.odinId
+                    }
+                    emitNavigationEvent(connectionRequestTap)
                 }
 
                 appId in COMPANION_APP_IDS -> {

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/CompanionAppUrlTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/CompanionAppUrlTest.kt
@@ -7,6 +7,9 @@ import id.homebase.core.config.COMMUNITY_APP_ID
 import id.homebase.core.config.FEED_APP_ID
 import id.homebase.core.config.MAIL_APP_ID
 import id.homebase.core.config.OWNER_APP_ID
+import id.homebase.core.config.OWNER_CONNECTION_ACCEPTED_TYPE_ID
+import id.homebase.core.config.OWNER_CONNECTION_REQUEST_TYPE_ID
+import id.homebase.core.config.OWNER_FOLLOWER_TYPE_ID
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
@@ -192,6 +195,73 @@ class CompanionAppUrlTest {
 
         assertNull(
             resolveCompanionAppUrlEvent(COMMUNITY_APP_ID, authState, "c", "m", 2.seconds)
+        )
+    }
+
+    // endregion
+
+    // region buildConnectionRequestTapEvent — the one owner tap that stays in-app
+
+    @Test
+    fun connectionRequest_opensRequesterContactDetail() {
+        // The sender is the identity asking to connect, so their contact detail — where the
+        // request is reviewed and accepted — is what opens, NOT the owner web console.
+        assertEquals(
+            NotificationNavigationEvent.OpenConnectionRequest("sam.dotyou.cloud"),
+            buildConnectionRequestTapEvent(
+                appId = OWNER_APP_ID,
+                typeId = OWNER_CONNECTION_REQUEST_TYPE_ID,
+                senderId = "sam.dotyou.cloud",
+            ),
+        )
+    }
+
+    @Test
+    fun connectionRequest_normalizesSenderCase() {
+        // The contact uniqueId is md5 of the lowercased domain, so the event must carry the
+        // lowercased form or the screen keys onto a different (non-existent) contact.
+        assertEquals(
+            NotificationNavigationEvent.OpenConnectionRequest("sam.dotyou.cloud"),
+            buildConnectionRequestTapEvent(
+                OWNER_APP_ID, OWNER_CONNECTION_REQUEST_TYPE_ID, " Sam.DotYou.Cloud "
+            ),
+        )
+    }
+
+    @Test
+    fun connectionRequest_withoutSender_fallsThroughToCompanionUrl() {
+        // No domain means no contact screen to open — the tap must fall through to the owner
+        // web console rather than navigating somewhere meaningless.
+        assertNull(
+            buildConnectionRequestTapEvent(OWNER_APP_ID, OWNER_CONNECTION_REQUEST_TYPE_ID, null)
+        )
+        assertNull(
+            buildConnectionRequestTapEvent(OWNER_APP_ID, OWNER_CONNECTION_REQUEST_TYPE_ID, "  ")
+        )
+    }
+
+    @Test
+    fun otherOwnerNotifications_stillOpenTheWebConsole() {
+        // Only the connection-request type is handled in-app; followers, accepted connections
+        // and introductions keep going to /owner/connections.
+        assertNull(
+            buildConnectionRequestTapEvent(OWNER_APP_ID, OWNER_FOLLOWER_TYPE_ID, "sam.dotyou.cloud")
+        )
+        assertNull(
+            buildConnectionRequestTapEvent(
+                OWNER_APP_ID, OWNER_CONNECTION_ACCEPTED_TYPE_ID, "sam.dotyou.cloud"
+            )
+        )
+    }
+
+    @Test
+    fun nonOwnerApp_withSameTypeId_returnsNull() {
+        // typeId alone must not trigger the in-app route — it's only meaningful under the
+        // owner appId (chat reuses typeId as the conversation id).
+        assertNull(
+            buildConnectionRequestTapEvent(
+                AppConfig.APP_ID, OWNER_CONNECTION_REQUEST_TYPE_ID, "sam.dotyou.cloud"
+            )
         )
     }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -435,6 +435,29 @@ fun AppNavHost(
 
                 is NotificationNavigationEvent.OpenUrl -> uriHandler.openUrl(event.url)
 
+                is NotificationNavigationEvent.OpenConnectionRequest -> {
+                    val domain = event.odinId.lowercase()
+                    Logger.i(tag = "AppNavHost") { "OpenConnectionRequest received: $domain" }
+                    // Cold-start safety, as in OpenMoment below: a tap can land while the host is
+                    // still on Route.AppLoading, whose ChatList navigation pops (inclusive) —
+                    // anything pushed before that would go with it. Gate on ChatList being in the
+                    // stack (immediate when warm).
+                    navController.currentBackStack.firstContaining {
+                        it.destination.hasRoute(Route.ChatList::class)
+                    }
+                    // Push the contact book first so back-press from the request lands on the
+                    // contacts tab rather than dropping straight out to chat.
+                    openContactBook()
+                    navController.navigate(
+                        // Same synthetic key the contact book uses for an identity with no saved
+                        // contact record — a pending requester never has one.
+                        Route.ContactBookDetail(
+                            uniqueId = Md5.toGuidId(domain).toString(),
+                            odinId = domain,
+                        )
+                    )
+                }
+
                 is NotificationNavigationEvent.OpenMoment -> {
                     val momentId = Uuid.parseOrNull(event.momentId)
                     Logger.i(tag = "AppNavHost") {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/AssignableCircles.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/AssignableCircles.kt
@@ -1,0 +1,30 @@
+package id.homebase.core.ui.screens.contactbook
+
+import id.homebase.chat.services.convo.contact.CircleMembershipState
+import id.homebase.core.config.AUTO_CONNECTIONS_CIRCLE_ID
+import id.homebase.core.config.CONFIRMED_CONNECTIONS_CIRCLE_ID
+import id.homebase.core.ui.screens.contactbook.detail.ContactCircleUi
+
+/** True for the server-managed system circles, which are surfaced through the connection status
+ *  rather than as user-assignable circles. */
+fun isSystemCircle(id: String): Boolean =
+    id.equals(CONFIRMED_CONNECTIONS_CIRCLE_ID, ignoreCase = true) ||
+        id.equals(AUTO_CONNECTIONS_CIRCLE_ID, ignoreCase = true)
+
+/**
+ * Every user-defined circle the signed-in user could add a contact to — independent of any
+ * contact's membership. Disabled circles, the system circles, and unnamed circles are excluded;
+ * the result is deduped by id and sorted A–Z.
+ *
+ * Feeds the accept-with-circles picker on both incoming-request surfaces (contact detail's
+ * [id.homebase.core.ui.screens.contactbook.detail.PendingRequestProfile] and the Add Contact
+ * flow), so both offer the same list.
+ */
+fun CircleMembershipState.assignableCircles(): List<ContactCircleUi> =
+    circles
+        .map { it.circle }
+        .filterNot { it.disabled || isSystemCircle(it.id) }
+        .filter { it.name.isNotBlank() }
+        .map { ContactCircleUi(it.id, it.name, pending = false) }
+        .distinctBy { it.id.lowercase() }
+        .sortedBy { it.name.lowercase() }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactScreen.kt
@@ -68,7 +68,9 @@ import id.homebase.core.connections.ConnectRequestAction
 import id.homebase.core.connections.ConnectRequestBottomSheet
 import id.homebase.core.connections.ConnectRequestViewModel
 import id.homebase.core.connections.RecipientResolution
+import id.homebase.core.ui.screens.contactbook.components.CirclePickerChips
 import id.homebase.core.ui.screens.contactbook.components.PhoneNumberField
+import id.homebase.core.ui.screens.contactbook.detail.ContactCircleUi
 import id.homebase.core.widget.HomebaseIdField
 import id.homebase.resources.MR
 import id.homebase.resources.add_contact_already_connected
@@ -329,6 +331,7 @@ private fun ByIdentitySection(
             RelationActions(
                 relation = uiState.relation,
                 odinId = resolution.identity.odinId,
+                assignableCircles = uiState.assignableCircles,
                 actionInProgress = uiState.actionInProgress,
                 identityOnly = identityOnly,
                 onSendConnectionRequest = onSendConnectionRequest,
@@ -391,11 +394,17 @@ private fun ResolvedIdentityCard(identity: PublicIdentity) {
 private fun RelationActions(
     relation: IdentityRelation,
     odinId: OdinId,
+    assignableCircles: List<ContactCircleUi>,
     actionInProgress: Boolean,
     identityOnly: Boolean,
     onSendConnectionRequest: (OdinId) -> Unit,
     onAction: (AddContactAction) -> Unit,
 ) {
+    // Circle ids the user has ticked to add this identity to on Accept. Keyed by the resolved
+    // identity so correcting the Homebase ID clears a selection made for the previous one (a
+    // transient picker — no need to survive process death).
+    var selectedCircleIds by remember(odinId.domainName) { mutableStateOf(emptySet<String>()) }
+
     when (relation) {
         IdentityRelation.NONE ->
             ConnectRequestOffer(onClick = { onSendConnectionRequest(odinId) })
@@ -408,12 +417,30 @@ private fun RelationActions(
                 color = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
             )
+            // Optional: pick which of the user's own circles to add this identity to on Accept.
+            // The circles ride the accept request atomically (see AcceptConnectionRequestV2).
+            CirclePickerChips(
+                circles = assignableCircles,
+                selectedIds = selectedCircleIds,
+                onToggle = { id ->
+                    selectedCircleIds = if (id in selectedCircleIds) {
+                        selectedCircleIds - id
+                    } else {
+                        selectedCircleIds + id
+                    }
+                },
+                enabled = !actionInProgress,
+                modifier = Modifier.padding(bottom = 12.dp),
+                centered = false,
+            )
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 Button(
-                    onClick = { onAction(AddContactAction.AcceptRequestClicked) },
+                    onClick = {
+                        onAction(AddContactAction.AcceptRequestClicked(selectedCircleIds.toList()))
+                    },
                     enabled = !actionInProgress,
                     modifier = Modifier.weight(1f),
                 ) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactUiState.kt
@@ -5,6 +5,7 @@ package id.homebase.core.ui.screens.contactbook.add
 import androidx.compose.runtime.Immutable
 import id.homebase.core.connections.RecipientResolution
 import id.homebase.core.ui.screens.contactbook.ContactDraft
+import id.homebase.core.ui.screens.contactbook.detail.ContactCircleUi
 import io.github.vinceglb.filekit.PlatformFile
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -39,6 +40,12 @@ data class AddContactUiState(
     val relation: IdentityRelation = IdentityRelation.NONE,
     /** True when the resolved identity is already saved in the contact book. */
     val alreadySaved: Boolean = false,
+    /**
+     * All user-defined circles the signed-in user could add a contact to (system circles
+     * excluded), A–Z. Feeds the "Add to circles" picker offered next to Accept on an incoming
+     * request — the selection rides the accept call atomically.
+     */
+    val assignableCircles: List<ContactCircleUi> = emptyList(),
     val draft: ContactDraft = ContactDraft(),
     val photo: PlatformFile? = null,
     val isSaving: Boolean = false,
@@ -58,8 +65,12 @@ sealed interface AddContactAction {
     data object SaveClicked : AddContactAction
     /** Open (or reuse) the 1:1 conversation with the resolved, already-connected identity. */
     data object MessageClicked : AddContactAction
-    /** Accept the incoming request from the resolved identity. */
-    data object AcceptRequestClicked : AddContactAction
+    /**
+     * Accept the incoming request from the resolved identity, placing them into [circleIds]
+     * (32-char N-format ids from [AddContactUiState.assignableCircles]) as part of the same
+     * call. Empty = accept without adding to any circle.
+     */
+    data class AcceptRequestClicked(val circleIds: List<String>) : AddContactAction
     /** Reject the incoming request from the resolved identity. */
     data object RejectRequestClicked : AddContactAction
     /** Cancel the outgoing request to the resolved identity. */

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/add/AddContactViewModel.kt
@@ -8,16 +8,22 @@ import co.touchlab.kermit.Logger
 import id.homebase.api.client.ClientException
 import id.homebase.api.client.OdinClientErrorCode
 import id.homebase.api.client.connections.ConnectionStatus
+import id.homebase.api.client.contacts.Contact
 import id.homebase.api.client.contacts.ContactRepository
 import id.homebase.api.client.identity.PublicIdentityRepository
 import id.homebase.api.client.identity.displayNameOrDomain
 import id.homebase.api.common.OdinId
+import id.homebase.chat.data.IncomingConnectionRequestUiModel
+import id.homebase.chat.data.OutgoingConnectionRequestUiModel
 import id.homebase.chat.services.convo.ConversationService
+import id.homebase.chat.services.convo.contact.CircleMembershipState
 import id.homebase.chat.services.convo.contact.ConnectionService
+import id.homebase.chat.services.convo.contact.ConnectionState
 import id.homebase.chat.services.requests.ConnectionRequestService
 import id.homebase.core.connections.RecipientResolution
 import id.homebase.core.ui.screens.contactbook.ContactDraft
 import id.homebase.core.ui.screens.contactbook.ContactSaveResult
+import id.homebase.core.ui.screens.contactbook.assignableCircles
 import id.homebase.core.ui.screens.contactbook.saveContactDraft
 import io.github.vinceglb.filekit.PlatformFile
 import kotlinx.coroutines.Job
@@ -34,6 +40,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 /**
  * Drives the full-screen Add Contact flow. By default it leads with the Homebase ID and resolves
@@ -54,20 +61,37 @@ class AddContactViewModel(
 
     private val _state = MutableStateFlow(AddContactUiState())
 
+    /** The network-side inputs the state fold needs, bundled so [state]'s outer combine stays
+     *  within the typed (non-vararg) arities. */
+    private data class RelationInputs(
+        val conn: ConnectionState,
+        val circ: CircleMembershipState,
+        val incoming: List<IncomingConnectionRequestUiModel>,
+        val outgoing: List<OutgoingConnectionRequestUiModel>,
+        val contacts: List<Contact>,
+    )
+
     /**
-     * Public state, with [AddContactUiState.relation] and [AddContactUiState.alreadySaved] folded
-     * in live from the connection map, the pending incoming/outgoing request lists, and the saved
-     * contacts. This is what lets the resolved-identity card offer exactly the applicable action
-     * (send / accept / reject / cancel / nothing) and avoid offering to save a contact twice.
+     * Public state, with [AddContactUiState.relation], [AddContactUiState.alreadySaved] and
+     * [AddContactUiState.assignableCircles] folded in live from the connection map, the circle
+     * definitions, the pending incoming/outgoing request lists, and the saved contacts. This is
+     * what lets the resolved-identity card offer exactly the applicable action (send / accept /
+     * reject / cancel / nothing) and avoid offering to save a contact twice.
      */
     val state: StateFlow<AddContactUiState> =
         combine(
             _state,
-            connectionService.connections,
-            connectionRequestService.incomingRequests,
-            connectionRequestService.outgoingRequests,
-            repo.contacts,
-        ) { s, conn, incoming, outgoing, contacts ->
+            combine(
+                connectionService.connections,
+                connectionService.circles,
+                connectionRequestService.incomingRequests,
+                connectionRequestService.outgoingRequests,
+                repo.contacts,
+            ) { conn, circ, incoming, outgoing, contacts ->
+                RelationInputs(conn, circ, incoming, outgoing, contacts)
+            },
+        ) { s, inputs ->
+            val (conn, circ, incoming, outgoing, contacts) = inputs
             val domain = (s.resolution as? RecipientResolution.Resolved)
                 ?.identity?.odinId?.domainName?.lowercase()
             val status = domain?.let { d ->
@@ -87,7 +111,11 @@ class AddContactViewModel(
             }
             val alreadySaved = domain != null &&
                 contacts.any { it.content.odinId?.lowercase() == domain }
-            s.copy(relation = relation, alreadySaved = alreadySaved)
+            s.copy(
+                relation = relation,
+                alreadySaved = alreadySaved,
+                assignableCircles = circ.assignableCircles(),
+            )
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AddContactUiState())
 
     private val _events = MutableSharedFlow<AddContactEvent>(extraBufferCapacity = 8)
@@ -129,9 +157,16 @@ class AddContactViewModel(
                 _state.update { it.copy(mode = AddContactMode.BY_IDENTITY) }
             AddContactAction.SaveClicked -> save()
             AddContactAction.MessageClicked -> openConversation()
-            AddContactAction.AcceptRequestClicked -> handleRequestAction(
-                AddContactEvent.RequestAccepted,
-            ) { connectionRequestService.acceptIncomingRequest(it) }
+            is AddContactAction.AcceptRequestClicked -> {
+                // Circle ids arrive as 32-char N-format strings; the accept API takes Uuids. Drop
+                // any that fail to parse rather than aborting the accept.
+                val circleUuids = action.circleIds.mapNotNull {
+                    runCatching { Uuid.parseHex(it) }.getOrNull()
+                }
+                handleRequestAction(AddContactEvent.RequestAccepted) {
+                    connectionRequestService.acceptIncomingRequest(it, circleUuids)
+                }
+            }
             AddContactAction.RejectRequestClicked -> handleRequestAction(
                 AddContactEvent.RequestRejected,
             ) { connectionRequestService.rejectIncomingRequest(it) }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/CirclePickerChips.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/CirclePickerChips.kt
@@ -1,0 +1,86 @@
+package id.homebase.core.ui.screens.contactbook.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import id.homebase.core.ui.screens.contactbook.detail.ContactCircleUi
+import id.homebase.resources.MR
+import id.homebase.resources.contactbook_detail_add_to_circles
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * "Add to circles" multi-select chip row shown alongside an incoming connection request's
+ * Accept button. The chosen circle ids ride the accept call atomically (see
+ * [id.homebase.api.client.connections.AcceptConnectionRequestV2]) rather than being applied as
+ * follow-up membership writes.
+ *
+ * Renders nothing when [circles] is empty — an identity with no user-defined circles gets the
+ * plain Accept button. Selection is owned by the caller so it can be keyed to the identity in
+ * view and reset when that changes.
+ *
+ * @param centered centers the label and chips (the full-screen pending-request profile); false
+ *   start-aligns them to match the Add Contact form's left-aligned fields.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun CirclePickerChips(
+    circles: List<ContactCircleUi>,
+    selectedIds: Set<String>,
+    onToggle: (String) -> Unit,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+    centered: Boolean = true,
+) {
+    if (circles.isEmpty()) return
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(MR.string.contactbook_detail_add_to_circles),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.fillMaxWidth(),
+            textAlign = if (centered) TextAlign.Center else TextAlign.Start,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = if (centered) Arrangement.Center else Arrangement.Start,
+        ) {
+            circles.forEach { circle ->
+                val selected = circle.id in selectedIds
+                FilterChip(
+                    selected = selected,
+                    enabled = enabled,
+                    onClick = { onToggle(circle.id) },
+                    label = { Text(circle.name) },
+                    leadingIcon = if (selected) {
+                        {
+                            Icon(
+                                Icons.Outlined.Check,
+                                contentDescription = null,
+                                modifier = Modifier.size(FilterChipDefaults.IconSize),
+                            )
+                        }
+                    } else null,
+                    modifier = Modifier.padding(horizontal = 4.dp),
+                )
+            }
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.Message
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.outlined.Block
-import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.ContactEmergency
 import androidx.compose.material.icons.outlined.Delete
@@ -115,12 +114,9 @@ import id.homebase.resources.contactbook_detail_tab_about
 import id.homebase.resources.contactbook_detail_tab_activity
 import id.homebase.resources.contactbook_detail_tab_details
 import id.homebase.resources.contactbook_detail_unblock
-import id.homebase.resources.contactbook_detail_accept
 import id.homebase.resources.contactbook_detail_cancel_request
 import id.homebase.resources.contactbook_detail_not_connected
 import id.homebase.resources.contactbook_detail_pending
-import id.homebase.resources.contactbook_detail_reject
-import id.homebase.resources.contactbook_detail_request_incoming
 import id.homebase.resources.contactbook_detail_request_outgoing
 import id.homebase.resources.contactbook_error_connection_forbidden
 import id.homebase.resources.contactbook_error_delete
@@ -267,7 +263,7 @@ fun ContactDetailScreen(
                     assignableCircles = uiState.assignableCircles,
                     onAccept = { selectedCircleIds ->
                         viewModel.onAction(
-                            ContactDetailAction.AcceptRequestWithCircles(selectedCircleIds)
+                            ContactDetailAction.AcceptRequestClicked(selectedCircleIds)
                         )
                     },
                     onReject = { viewModel.onAction(ContactDetailAction.RejectRequestClicked) },
@@ -544,7 +540,9 @@ private fun DetailHeader(
     val connected = status == ConnectionStatus.Connected
     val blocked = status == ConnectionStatus.Blocked
     val pending = status == ConnectionStatus.None
-    val requestIncoming = uiState.requestDirection == RequestDirection.INCOMING
+    // No incoming-request state here: a pending incoming request takes over the whole body with
+    // [PendingRequestProfile] (which owns Accept/Reject plus the circle picker), so this header
+    // only ever renders once that request is gone — accepted, rejected, or never there.
     val requestOutgoing = uiState.requestDirection == RequestDirection.OUTGOING
     // Has a Homebase identity but no active connection, pending request, or block.
     val canConnect = uiState.hasOdinId && !connected && !blocked && !pending &&
@@ -590,7 +588,7 @@ private fun DetailHeader(
         // belongs right next to the status.
         if (uiState.hasOdinId) {
             val statusColor = when {
-                connected || requestIncoming -> MaterialTheme.colorScheme.primary
+                connected -> MaterialTheme.colorScheme.primary
                 blocked -> MaterialTheme.colorScheme.error
                 else -> MaterialTheme.colorScheme.onSurfaceVariant
             }
@@ -602,7 +600,6 @@ private fun DetailHeader(
                     text = stringResource(
                         when {
                             connected -> MR.string.contactbook_connected
-                            requestIncoming -> MR.string.contactbook_detail_request_incoming
                             requestOutgoing -> MR.string.contactbook_detail_request_outgoing
                             pending -> MR.string.contactbook_detail_pending
                             blocked -> MR.string.contactbook_detail_blocked
@@ -677,25 +674,6 @@ private fun DetailHeader(
                     Icon(Icons.Outlined.PersonAddAlt1, contentDescription = null, modifier = Modifier.size(18.dp))
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(stringResource(MR.string.contactbook_detail_connect))
-                }
-            }
-            requestIncoming -> {
-                Spacer(modifier = Modifier.height(12.dp))
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    FilledTonalButton(
-                        onClick = { onAction(ContactDetailAction.AcceptRequestClicked) },
-                        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 8.dp),
-                    ) {
-                        Icon(Icons.Outlined.Check, contentDescription = null, modifier = Modifier.size(18.dp))
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(stringResource(MR.string.contactbook_detail_accept))
-                    }
-                    OutlinedButton(
-                        onClick = { onAction(ContactDetailAction.RejectRequestClicked) },
-                        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 8.dp),
-                    ) {
-                        Text(stringResource(MR.string.contactbook_detail_reject))
-                    }
                 }
             }
             requestOutgoing -> {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailUiState.kt
@@ -120,11 +120,9 @@ sealed interface ContactDetailAction {
     data object BlockClicked : ContactDetailAction
     data object UnblockClicked : ContactDetailAction
     data object DisconnectClicked : ContactDetailAction
-    /** Accept an incoming connection request from this contact. */
-    data object AcceptRequestClicked : ContactDetailAction
     /** Accept an incoming request and add the contact to the chosen circles (their 32-char
      *  N-format ids). Empty list = accept without adding to any circle (#921 Part B). */
-    data class AcceptRequestWithCircles(val circleIds: List<String>) : ContactDetailAction
+    data class AcceptRequestClicked(val circleIds: List<String>) : ContactDetailAction
     /** Reject (decline) an incoming connection request from this contact. */
     data object RejectRequestClicked : ContactDetailAction
     /** Cancel (withdraw) an outgoing connection request to this contact. */

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/ContactDetailViewModel.kt
@@ -31,8 +31,6 @@ import id.homebase.chat.data.IncomingConnectionRequestUiModel
 import id.homebase.chat.data.OutgoingConnectionRequestUiModel
 import id.homebase.api.client.contacts.Contact
 import id.homebase.api.client.contacts.ContactRepository
-import id.homebase.core.config.AUTO_CONNECTIONS_CIRCLE_ID
-import id.homebase.core.config.CONFIRMED_CONNECTIONS_CIRCLE_ID
 import id.homebase.core.config.locationLabeledDrive
 import id.homebase.core.contactbook.ContactOverrideStore
 import id.homebase.core.contactbook.ReconcileAction
@@ -40,6 +38,8 @@ import id.homebase.core.contactbook.reconcileAction
 import id.homebase.core.contactbook.setICanLocate
 import id.homebase.core.ui.navigation.Route
 import id.homebase.core.ui.screens.contactbook.CircleMemberStatus
+import id.homebase.core.ui.screens.contactbook.assignableCircles
+import id.homebase.core.ui.screens.contactbook.isSystemCircle
 import id.homebase.core.ui.screens.contactbook.CircleMembersUi
 import id.homebase.core.ui.screens.contactbook.RequestDirection
 import id.homebase.core.ui.screens.contactbook.model.ContactBookEntry
@@ -270,8 +270,6 @@ class ContactDetailViewModel(
                 // (circ.circlesFor); pending membership is a live-read snapshot (pendingCircleIds,
                 // refreshed by refreshPendingCircles) merged in here, since there's no bulk
                 // "list this contact's pending circles" endpoint to observe reactively.
-                fun isSystemCircle(id: String) = id.equals(CONFIRMED_CONNECTIONS_CIRCLE_ID, ignoreCase = true) ||
-                    id.equals(AUTO_CONNECTIONS_CIRCLE_ID, ignoreCase = true)
                 val realCircles = domain?.let { d -> circ.circlesFor(d) }.orEmpty()
                     .filterNot { it.disabled || isSystemCircle(it.id) }
                 val realIds = realCircles.map { it.id.lowercase() }.toSet()
@@ -288,13 +286,7 @@ class ContactDetailViewModel(
                 // Every user-defined circle the user could add a contact to — independent of this
                 // contact's membership. Same system-circle exclusion as the chips above; feeds the
                 // pending-request circle picker (#921 Part B).
-                val assignableCircles = circ.circles
-                    .map { it.circle }
-                    .filterNot { it.disabled || isSystemCircle(it.id) }
-                    .filter { it.name.isNotBlank() }
-                    .map { ContactCircleUi(it.id, it.name, pending = false) }
-                    .distinctBy { it.id.lowercase() }
-                    .sortedBy { it.name.lowercase() }
+                val assignableCircles = circ.assignableCircles()
                 _uiState.update {
                     it.copy(
                         entry = entry,
@@ -534,10 +526,7 @@ class ContactDetailViewModel(
             ContactDetailAction.BlockClicked -> _uiState.update { it.copy(confirm = ContactDetailConfirm.BLOCK) }
             ContactDetailAction.DisconnectClicked ->
                 _uiState.update { it.copy(confirm = ContactDetailConfirm.DISCONNECT) }
-            ContactDetailAction.AcceptRequestClicked -> handleRequestAction(
-                event = ContactDetailEvent.RequestAccepted,
-            ) { connectionRequestService.acceptIncomingRequest(it) }
-            is ContactDetailAction.AcceptRequestWithCircles -> {
+            is ContactDetailAction.AcceptRequestClicked -> {
                 // Circle ids arrive as 32-char N-format strings; the accept API takes Uuids. Drop
                 // any that fail to parse rather than aborting the accept.
                 val circleUuids = action.circleIds.mapNotNull {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/PendingRequestProfile.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/detail/PendingRequestProfile.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
@@ -22,8 +20,6 @@ import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FilledTonalButton
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -37,11 +33,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import id.homebase.core.ui.screens.contactbook.components.CirclePickerChips
 import id.homebase.core.ui.screens.contactbook.components.ContactBookAvatar
 import id.homebase.core.ui.screens.contactbook.model.ContactBookEntry
 import id.homebase.resources.MR
 import id.homebase.resources.contactbook_detail_accept
-import id.homebase.resources.contactbook_detail_add_to_circles
 import id.homebase.resources.contactbook_detail_reject
 import id.homebase.resources.contactbook_detail_request_incoming
 import org.jetbrains.compose.resources.stringResource
@@ -53,12 +49,11 @@ import org.jetbrains.compose.resources.stringResource
  * short bio summary — so the Accept/Reject decision has real context instead of the empty
  * "Contact details: None" / "connect to see…" placeholders.
  *
- * This owns the whole pending presentation (rather than reusing the shared [DetailHeader] +
- * tabs) so the pre-connection state's logic lives in one place; the Accept/Reject buttons just
- * dispatch the same [ContactDetailAction]s the header would. Accepting flips the parent screen
- * to the full connected detail in place — no navigation.
+ * This owns the whole pending presentation (rather than reusing the shared header + tabs) so the
+ * pre-connection state's logic lives in one place — it is the *only* place the detail screen
+ * offers Accept/Reject, since the header renders only once the request is gone. Accepting flips
+ * the parent screen to the full connected detail in place — no navigation.
  */
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun PendingRequestProfile(
     entry: ContactBookEntry,
@@ -145,44 +140,18 @@ fun PendingRequestProfile(
         // The circles ride the accept request atomically (see AcceptConnectionRequestV2).
         if (assignableCircles.isNotEmpty()) {
             Spacer(modifier = Modifier.height(24.dp))
-            Text(
-                text = stringResource(MR.string.contactbook_detail_add_to_circles),
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.fillMaxWidth(),
-                textAlign = TextAlign.Center,
+            CirclePickerChips(
+                circles = assignableCircles,
+                selectedIds = selectedCircleIds,
+                onToggle = { id ->
+                    selectedCircleIds = if (id in selectedCircleIds) {
+                        selectedCircleIds - id
+                    } else {
+                        selectedCircleIds + id
+                    }
+                },
+                enabled = !actionInProgress,
             )
-            Spacer(modifier = Modifier.height(8.dp))
-            FlowRow(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Center,
-            ) {
-                assignableCircles.forEach { circle ->
-                    val selected = circle.id in selectedCircleIds
-                    FilterChip(
-                        selected = selected,
-                        enabled = !actionInProgress,
-                        onClick = {
-                            selectedCircleIds = if (selected) {
-                                selectedCircleIds - circle.id
-                            } else {
-                                selectedCircleIds + circle.id
-                            }
-                        },
-                        label = { Text(circle.name) },
-                        leadingIcon = if (selected) {
-                            {
-                                Icon(
-                                    Icons.Outlined.Check,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(FilterChipDefaults.IconSize),
-                                )
-                            }
-                        } else null,
-                        modifier = Modifier.padding(horizontal = 4.dp),
-                    )
-                }
-            }
         }
 
         Spacer(modifier = Modifier.height(28.dp))


### PR DESCRIPTION
…ts in-app

Accepting an incoming connection request could only choose circles from the contact-detail pending profile. The Add Contact flow's Accept sent an empty circleIds list, and tapping a connection-request push left the app entirely for the owner web console.

- Extract the "Add to circles" chips as CirclePickerChips and the circle derivation as CircleMembershipState.assignableCircles(), shared by both accept surfaces instead of a copy.
- Wire the picker into AddContactScreen: AddContactViewModel folds connectionService.circles into its state (nested combine to stay within the typed combine arities) and AcceptRequestClicked now carries the selection.
- Drop the contact-detail header's Accept/Reject arm: DetailHeader renders only when !isPendingIncoming, which is the exact complement of the arm's own condition, so it could never appear. Its action and the two other dead requestIncoming reads go with it.
- Route an owner connection-request tap to the requester's contact detail via the new buildConnectionRequestTapEvent + OpenConnectionRequest event. Other owner notifications, and payloads with no sender, still open /owner/connections.

Note: the request card appears once incomingRequests contains the sender, so a tap after a websocket drop can briefly show the plain contact detail until the reconnect refresh lands. The state is a live combine, so it self-corrects.