### PR TITLE
fix(chat): poll View results no longer renders every failure as "No votes"

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/reactions/DriveFileGroupReactionProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/reactions/DriveFileGroupReactionProvider.kt
@@ -51,10 +51,19 @@ data class GroupReactionItem(
     val created: Long
 )
 
+/**
+ * Response of `GET /drives/{driveId}/files/{fileId}/group-reactions`.
+ *
+ * [cursor] is the server's `GetReactionsResponse.Cursor`, an `int?` (a rowid) —
+ * NOT a string. It was typed `String?` here, which made the strict
+ * (`isLenient = false`) decoder throw `JsonDecodingException` on any response
+ * that actually carried one, i.e. whenever a file has more reactions than the
+ * page size. That exception took the WHOLE roster with it at every call site.
+ */
 @Serializable
 data class GetGroupReactionsResponse(
     val reactions: List<GroupReactionItem>,
-    val cursor: String? = null
+    val cursor: Int? = null
 )
 
 @Serializable
@@ -176,7 +185,7 @@ class DriveFileGroupReactionProvider(
     suspend fun listReactions(
         driveId: Uuid,
         fileId: Uuid,
-        cursor: String? = null,
+        cursor: Int? = null,
         maxRecords: Int? = null
     ): GetGroupReactionsResponse {
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/reactions/DriveFileGroupReactionProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/reactions/DriveFileGroupReactionProvider.kt
@@ -51,15 +51,6 @@ data class GroupReactionItem(
     val created: Long
 )
 
-/**
- * Response of `GET /drives/{driveId}/files/{fileId}/group-reactions`.
- *
- * [cursor] is the server's `GetReactionsResponse.Cursor`, an `int?` (a rowid) —
- * NOT a string. It was typed `String?` here, which made the strict
- * (`isLenient = false`) decoder throw `JsonDecodingException` on any response
- * that actually carried one, i.e. whenever a file has more reactions than the
- * page size. That exception took the WHOLE roster with it at every call site.
- */
 @Serializable
 data class GetGroupReactionsResponse(
     val reactions: List<GroupReactionItem>,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventDetailDialog.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventDetailDialog.kt
@@ -172,7 +172,18 @@ private fun EventDetailContent(
         key1 = messageId,
         key2 = ownReactions,
     ) {
-        value = runCatching { actionService.getReactions(messageId) }.getOrDefault(emptyList())
+        value = runCatching { actionService.getReactions(messageId) }
+            .onFailure { t ->
+                // The RSVP roster is *omitted* when empty rather than rendered as
+                // "nobody" (see the `takeIf { it.isNotEmpty() }` below), so a failure
+                // here degrades to a missing section, not a wrong answer. Still log
+                // it — this was silently swallowed, which is how #1178 stayed
+                // undiagnosable on the Poll screen for so long.
+                Logger.w(tag = "EventDetailDialog", throwable = t) {
+                    "RSVP roster load failed for messageId=$messageId"
+                }
+            }
+            .getOrDefault(emptyList())
     }
 
     val times = rememberEventTimes(descriptor)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/poll/PollBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/poll/PollBubble.kt
@@ -236,6 +236,9 @@ fun PollBubble(
             messageId = messageId,
             conversationId = conversationId,
             ownReactions = ownReactions,
+            // Same header summary this bubble counts from, so the detail screen
+            // can never report a lower tally than the bubble that opened it.
+            reactionSummary = reactionSummary,
             organizer = organizer,
             onDismiss = { showDetail = false },
         )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/poll/PollBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/poll/PollBubble.kt
@@ -236,8 +236,6 @@ fun PollBubble(
             messageId = messageId,
             conversationId = conversationId,
             ownReactions = ownReactions,
-            // Same header summary this bubble counts from, so the detail screen
-            // can never report a lower tally than the bubble that opened it.
             reactionSummary = reactionSummary,
             organizer = organizer,
             onDismiss = { showDetail = false },
@@ -275,7 +273,8 @@ private fun PollOptionRow(
         ) {
             if (!closed) {
                 // Open: leading indicator — filled check if voted, outline circle otherwise.
-                val indicatorTint = if (isOwn) MaterialTheme.colorScheme.primary else contentColor.copy(alpha = 0.45f)
+                val indicatorTint =
+                    if (isOwn) MaterialTheme.colorScheme.primary else contentColor.copy(alpha = 0.45f)
                 Icon(
                     imageVector = if (isOwn) Icons.Default.CheckCircle else Icons.Default.RadioButtonUnchecked,
                     contentDescription = null,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/poll/PollDetailDialog.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/poll/PollDetailDialog.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -24,6 +25,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -40,6 +42,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.auth.OwnerSessionRepository
+import id.homebase.api.client.drives.files.ReactionSummary
 import id.homebase.api.common.OdinId
 import id.homebase.chat.services.ChatMessageActionService
 import id.homebase.chat.services.ChatMessageSenderService
@@ -58,12 +61,16 @@ import id.homebase.core.avatars.PublicAvatar
 import id.homebase.core.util.initials
 import id.homebase.core.widget.EmojiReaction
 import id.homebase.resources.MR
+import id.homebase.resources.action_retry
 import id.homebase.resources.chat_poll_details_title
 import id.homebase.resources.chat_poll_end
 import id.homebase.resources.chat_poll_end_failed
 import id.homebase.resources.chat_poll_no_votes
 import id.homebase.resources.chat_poll_one_vote
 import id.homebase.resources.chat_poll_question_section
+import id.homebase.resources.chat_poll_roster_error
+import id.homebase.resources.chat_poll_roster_loading
+import id.homebase.resources.chat_poll_roster_partial
 import id.homebase.resources.chat_poll_vote_count
 import id.homebase.resources.chat_poll_you
 import id.homebase.resources.close
@@ -72,11 +79,29 @@ import kotlin.uuid.Uuid
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 
+/** Load state of the per-user voter roster. Loading and failure are distinct
+ *  states on purpose: rendering either of them as "No votes" (which is what
+ *  `runCatching{}.getOrDefault(emptyList())` did) is a wrong answer, not a
+ *  missing one — see #1178. */
+private sealed interface RosterState {
+    data object Loading : RosterState
+    data class Loaded(val reactions: List<EmojiReaction>) : RosterState
+    data class Failed(val error: Throwable) : RosterState
+}
+
 /**
  * Fullscreen read-only roster for a Poll message. Shows the question in a tonal
  * box, then per-option sections with a count and the voter roster (avatar + name,
  * "You" for the current user). Only the organizer can end an open poll via the
  * End poll button. Votes are NOT editable here — voting is done in [PollBubble].
+ *
+ * **Two sources, deliberately.** The per-option COUNT comes from [reactionSummary],
+ * the header `reactionPreview` the bubble itself counts from, so this screen can
+ * never report fewer votes than the bubble behind it. The voter LIST comes from a
+ * live `getReactions` read of the server's per-file reaction table, which is a
+ * different store and can be short (see `ChatMessageActionService.getReactions`).
+ * [PollVote.tally] merges them and flags the shortfall; a partial roster is
+ * footnoted rather than silently under-reported.
  *
  * Mirrors [id.homebase.chat.event.EventDetailDialog]'s roster load pattern
  * (`produceState` + `ContactService`) and
@@ -93,6 +118,8 @@ fun PollDetailDialog(
     // The viewer's own votes — keys the roster re-fetch so tallies refresh when the
     // viewer votes while the dialog is open (mirrors EventDetailDialog).
     ownReactions: ImmutableList<String> = persistentListOf(),
+    // Authoritative per-option counts — the same header summary PollBubble renders.
+    reactionSummary: ReactionSummary? = null,
 ) {
     Dialog(
         onDismissRequest = onDismiss,
@@ -104,6 +131,7 @@ fun PollDetailDialog(
             conversationId = conversationId,
             organizer = organizer,
             ownReactions = ownReactions,
+            reactionSummary = reactionSummary,
             onDismiss = onDismiss,
         )
     }
@@ -117,6 +145,7 @@ private fun PollDetailContent(
     conversationId: Uuid,
     organizer: OdinId?,
     ownReactions: ImmutableList<String>,
+    reactionSummary: ReactionSummary?,
     onDismiss: () -> Unit,
 ) {
     val actionService: ChatMessageActionService = koinInject()
@@ -132,15 +161,38 @@ private fun PollDetailContent(
 
     val selfOdinId = ownerSession.user.value?.odinId
 
-    // Roster fetch — re-fires when messageId OR the viewer's own votes change, so a
-    // vote cast while the dialog is open refreshes the roster/tally (matching
-    // EventDetailDialog). null = loading, empty = no reactions yet.
-    val rosterReactions: List<EmojiReaction>? by produceState<List<EmojiReaction>?>(
-        initialValue = null,
+    // Roster fetch — re-fires when messageId OR the viewer's own votes change (so a
+    // vote cast while the dialog is open refreshes the list), and when the user taps
+    // Retry after a failure. A throw here is a real failure and is surfaced as one;
+    // it used to be flattened into an empty list and rendered as "No votes".
+    var retryToken by remember(messageId) { mutableStateOf(0) }
+    val rosterState: RosterState by produceState<RosterState>(
+        initialValue = RosterState.Loading,
         key1 = messageId,
         key2 = ownReactions,
+        key3 = retryToken,
     ) {
-        value = runCatching { actionService.getReactions(messageId) }.getOrDefault(emptyList())
+        value = RosterState.Loading
+        value = runCatching { actionService.getReactions(messageId) }
+            .fold(
+                onSuccess = { RosterState.Loaded(it) },
+                onFailure = { t ->
+                    Logger.w(tag = "PollDetailDialog", throwable = t) {
+                        "Roster load failed for messageId=$messageId"
+                    }
+                    RosterState.Failed(t)
+                },
+            )
+    }
+
+    val roster = (rosterState as? RosterState.Loaded)?.reactions
+    val tallies = remember(reactionSummary, roster, descriptor.options.size, selfOdinId) {
+        PollVote.tally(
+            summary = reactionSummary,
+            roster = roster,
+            optionCount = descriptor.options.size,
+            selfOdinId = selfOdinId,
+        )
     }
 
     val showEndButton = organizer != null && selfOdinId != null &&
@@ -204,12 +256,29 @@ private fun PollDetailContent(
 
             Spacer(Modifier.height(24.dp))
 
+            // Roster status — only ever shown for the two states that are NOT
+            // "nobody voted". A genuinely empty poll falls through to the
+            // per-option "No votes" labels below.
+            when (rosterState) {
+                RosterState.Loading -> {
+                    RosterLoadingRow()
+                    Spacer(Modifier.height(16.dp))
+                }
+
+                is RosterState.Failed -> {
+                    RosterErrorRow(onRetry = { retryToken++ })
+                    Spacer(Modifier.height(16.dp))
+                }
+
+                is RosterState.Loaded -> Unit
+            }
+
             // Per-option sections
             descriptor.options.forEachIndexed { i, optionLabel ->
                 PollOptionSection(
-                    index = i,
                     label = optionLabel,
-                    reactions = rosterReactions ?: emptyList(),
+                    tally = tallies[i],
+                    showPartialNote = rosterState !is RosterState.Loading,
                     contactService = contactService,
                     selfOdinId = selfOdinId,
                 )
@@ -273,16 +342,70 @@ private fun PollDetailContent(
     }
 }
 
+/** Spinner + label shown while the voter roster is in flight. */
+@Composable
+private fun RosterLoadingRow() {
+    val loadingText = stringResource(MR.string.chat_poll_roster_loading)
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier.size(16.dp),
+            strokeWidth = 2.dp,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Spacer(Modifier.width(12.dp))
+        Text(
+            text = loadingText,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+/** Error banner + Retry for a failed roster read. The per-option counts below
+ *  still render from the header summary, so the screen degrades to "the numbers
+ *  the bubble showed, minus the names" instead of claiming nobody voted. */
+@Composable
+private fun RosterErrorRow(onRetry: () -> Unit) {
+    val errorText = stringResource(MR.string.chat_poll_roster_error)
+    val retryText = stringResource(MR.string.action_retry)
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.errorContainer,
+    ) {
+        Row(
+            modifier = Modifier.padding(start = 16.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = errorText,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+                modifier = Modifier.weight(1f),
+            )
+            TextButton(onClick = onRetry) {
+                Text(
+                    text = retryText,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                )
+            }
+        }
+    }
+}
+
 @Composable
 private fun PollOptionSection(
-    index: Int,
     label: String,
-    reactions: List<EmojiReaction>,
+    tally: PollOptionTally,
+    showPartialNote: Boolean,
     contactService: ContactService,
     selfOdinId: OdinId?,
 ) {
-    val voters = reactions.filter { PollVote.optionOf(it.emoji) == index }
-    val n = voters.size
+    val voters = tally.voters
+    val n = tally.count
 
     // Count text built outside Text() — Konsist bars string literals in Text calls.
     val noVotesText = stringResource(MR.string.chat_poll_no_votes)
@@ -316,18 +439,33 @@ private fun PollOptionSection(
     if (voters.isNotEmpty()) {
         Spacer(Modifier.height(4.dp))
         val youLabel = stringResource(MR.string.chat_poll_you)
-        // Self first, then others — consistent with EventDetailDialog roster ordering intent.
-        val sorted = voters.sortedByDescending { it.odinId == selfOdinId }
+        // Already self-first — PollVote.tally owns the ordering.
         Column {
-            sorted.forEach { reactor ->
+            voters.forEach { voter ->
                 PollVoterRow(
-                    odinId = reactor.odinId,
-                    isOwner = reactor.odinId == selfOdinId,
+                    odinId = voter,
+                    isOwner = voter == selfOdinId,
                     youLabel = youLabel,
                     contactService = contactService,
                 )
             }
         }
+    }
+
+    // The count came from the header summary; the names came from the per-file
+    // reaction read. When the latter is short, say so instead of letting the two
+    // silently disagree. Deliberately OUTSIDE the `voters.isNotEmpty()` block —
+    // the #1178 case is "3 votes, zero names", which is exactly when this note
+    // matters most. Suppressed while the roster is still loading, where a
+    // shortfall says nothing yet.
+    if (showPartialNote && tally.isPartial) {
+        val partialText = stringResource(MR.string.chat_poll_roster_partial, voters.size, n)
+        Text(
+            text = partialText,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = 4.dp),
+        )
     }
 }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/poll/PollDetailDialog.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/poll/PollDetailDialog.kt
@@ -79,10 +79,7 @@ import kotlin.uuid.Uuid
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 
-/** Load state of the per-user voter roster. Loading and failure are distinct
- *  states on purpose: rendering either of them as "No votes" (which is what
- *  `runCatching{}.getOrDefault(emptyList())` did) is a wrong answer, not a
- *  missing one — see #1178. */
+
 private sealed interface RosterState {
     data object Loading : RosterState
     data class Loaded(val reactions: List<EmojiReaction>) : RosterState
@@ -115,10 +112,7 @@ fun PollDetailDialog(
     conversationId: Uuid,
     organizer: OdinId?,
     onDismiss: () -> Unit,
-    // The viewer's own votes — keys the roster re-fetch so tallies refresh when the
-    // viewer votes while the dialog is open (mirrors EventDetailDialog).
     ownReactions: ImmutableList<String> = persistentListOf(),
-    // Authoritative per-option counts — the same header summary PollBubble renders.
     reactionSummary: ReactionSummary? = null,
 ) {
     Dialog(
@@ -196,7 +190,7 @@ private fun PollDetailContent(
     }
 
     val showEndButton = organizer != null && selfOdinId != null &&
-        organizer == selfOdinId && !descriptor.closed
+            organizer == selfOdinId && !descriptor.closed
 
     val detailsTitleText = stringResource(MR.string.chat_poll_details_title)
     val endPollText = stringResource(MR.string.chat_poll_end)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/poll/PollVote.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/poll/PollVote.kt
@@ -1,7 +1,9 @@
 package id.homebase.chat.poll
 
 import id.homebase.api.client.drives.files.ReactionSummary
+import id.homebase.api.common.OdinId
 import id.homebase.chat.services.decodeReactionCode
+import id.homebase.core.widget.EmojiReaction
 
 /**
  * Encodes/decodes poll votes as chat reaction codes. A vote for option index
@@ -56,4 +58,54 @@ object PollVote {
         }
         return out
     }
+
+    /**
+     * Merges the two disagreeing sources the detail screen has to reconcile:
+     * the header [ReactionSummary] (what the bubble counts — authoritative for
+     * HOW MANY) and the fetched per-user [roster] (authoritative for WHO, but
+     * possibly short — see `ChatMessageActionService.getReactions`).
+     *
+     * The reported count is `max(summaryCount, votersShown)` so the detail
+     * screen can never claim fewer votes than the bubble, nor fewer than the
+     * rows it is actually rendering. [selfOdinId] sorts first in every option's
+     * voter list.
+     */
+    fun tally(
+        summary: ReactionSummary?,
+        roster: List<EmojiReaction>?,
+        optionCount: Int,
+        selfOdinId: OdinId?,
+    ): List<PollOptionTally> {
+        val counts = counts(summary, optionCount)
+        val votersByOption = roster.orEmpty()
+            .mapNotNull { reaction -> optionOf(reaction.emoji)?.let { it to reaction.odinId } }
+            .filter { (option, _) -> option in 0 until optionCount }
+            .groupBy({ it.first }, { it.second })
+
+        return (0 until optionCount).map { option ->
+            val voters = votersByOption[option].orEmpty()
+                .distinct()
+                .sortedByDescending { it == selfOdinId }
+            PollOptionTally(
+                index = option,
+                count = maxOf(counts[option], voters.size),
+                voters = voters,
+            )
+        }
+    }
+}
+
+/**
+ * One option's row in the poll detail roster.
+ *
+ * [count] comes from the header summary, [voters] from the live per-user read.
+ * [isPartial] means we know about more votes than we can name — the screen must
+ * say so rather than silently under-report the roster.
+ */
+data class PollOptionTally(
+    val index: Int,
+    val count: Int,
+    val voters: List<OdinId>,
+) {
+    val isPartial: Boolean get() = voters.size < count
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
@@ -116,10 +116,13 @@ class ChatMessageActionService(
         // one that ever reached the window. Marking that read (#1135) clears the badge
         // that is the only signal the tail is missing.
         val newReadTime = viewedRecords.maxOf { it.sqlUserDate }
-        val convoLatest = participantLookup.getConversationById(conversationId)?.latestMessageTimestamp
+        val convoLatest =
+            participantLookup.getConversationById(conversationId)?.latestMessageTimestamp
         Logger.d(tag = TAG) {
             "newReadTime(ms)=${newReadTime.toEpochMilliseconds()} " +
-                    "(clampedViewedMax=${viewedRecords.maxOf { it.userDate }.toEpochMilliseconds()} " +
+                    "(clampedViewedMax=${
+                        viewedRecords.maxOf { it.userDate }.toEpochMilliseconds()
+                    } " +
                     "convoLatest=${convoLatest?.toEpochMilliseconds()} " +
                     "viewed=${viewedRecords.size} receipt-eligible=${unreadRecords.size})"
         }
@@ -163,9 +166,9 @@ class ChatMessageActionService(
         if (convo != null && convo.resolveLastReadAdvance(newReadTime) == null) {
             Logger.d(tag = TAG) {
                 "convo=$conversationId resolveLastReadAdvance suppressed " +
-                    "(currentMs=${convo.lastRead.toEpochMilliseconds()} " +
-                    "latestMs=${convo.latestMessageTimestamp.toEpochMilliseconds()} " +
-                    "newMs=${newReadTime.toEpochMilliseconds()}) — skipping upsert + enrich"
+                        "(currentMs=${convo.lastRead.toEpochMilliseconds()} " +
+                        "latestMs=${convo.latestMessageTimestamp.toEpochMilliseconds()} " +
+                        "newMs=${newReadTime.toEpochMilliseconds()}) — skipping upsert + enrich"
             }
             return
         }
@@ -368,22 +371,7 @@ class ChatMessageActionService(
         }
     }
 
-    /**
-     * Per-user reaction roster for a message, read live from the server's
-     * per-file reaction table (`GET .../group-reactions`).
-     *
-     * This is a DIFFERENT store from the header `reactionPreview` the bubbles
-     * count from: the server maintains the preview as an incrementally
-     * bumped counter (odin-core `ReactionPreviewCalculator`) and the client
-     * layers an optimistic delta on top of it (`OptimisticWriter.writeReactionToggle`),
-     * which is only rolled back when the outbox *enqueue* fails — not when the
-     * upload does. So the roster can legitimately be SMALLER than the preview
-     * count, and callers must not present it as the authoritative tally.
-     *
-     * Throws — deliberately. `requireFileId` throws for an unknown messageId and
-     * the endpoint 400s when the fileId isn't resolvable on the drive. Callers
-     * must render that as an error, never as "nobody reacted".
-     */
+    
     suspend fun getReactions(messageId: Uuid): List<EmojiReaction> {
         val fileId = requireFileId(messageId)
         val response = reactionProvider.listReactions(chatDrive, fileId)
@@ -530,7 +518,11 @@ class ChatMessageActionService(
      * [localOnly] = true keeps the change on this device only (no outbox). Auto-expiry
      * pruning now syncs, so this defaults false; kept for any purely-local unpin.
      */
-    suspend fun unpinMessage(messageId: Uuid, localOnly: Boolean = false, dismiss: Boolean = false) {
+    suspend fun unpinMessage(
+        messageId: Uuid,
+        localOnly: Boolean = false,
+        dismiss: Boolean = false
+    ) {
         updateMessageTags(messageId, localOnly = localOnly) { tags ->
             val cleared = tags - ChatProtocol.MessagePinnedTag - ChatProtocol.ManualPinnedTag
             if (dismiss) cleared + ChatProtocol.AutoPinDismissedTag else cleared

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
@@ -227,6 +227,7 @@ class ChatMessageActionService(
 
     private companion object {
         const val TAG = "MarkAsRead"
+        const val REACTIONS_TAG = "ChatReactions"
     }
 
     suspend fun toggleReaction(conversationId: Uuid, messageId: Uuid, emoji: String):
@@ -367,18 +368,49 @@ class ChatMessageActionService(
         }
     }
 
+    /**
+     * Per-user reaction roster for a message, read live from the server's
+     * per-file reaction table (`GET .../group-reactions`).
+     *
+     * This is a DIFFERENT store from the header `reactionPreview` the bubbles
+     * count from: the server maintains the preview as an incrementally
+     * bumped counter (odin-core `ReactionPreviewCalculator`) and the client
+     * layers an optimistic delta on top of it (`OptimisticWriter.writeReactionToggle`),
+     * which is only rolled back when the outbox *enqueue* fails — not when the
+     * upload does. So the roster can legitimately be SMALLER than the preview
+     * count, and callers must not present it as the authoritative tally.
+     *
+     * Throws — deliberately. `requireFileId` throws for an unknown messageId and
+     * the endpoint 400s when the fileId isn't resolvable on the drive. Callers
+     * must render that as an error, never as "nobody reacted".
+     */
     suspend fun getReactions(messageId: Uuid): List<EmojiReaction> {
         val fileId = requireFileId(messageId)
         val response = reactionProvider.listReactions(chatDrive, fileId)
 
-        return response.reactions.map {
+        // Decode per row, not all-or-nothing: one malformed reactionContent used
+        // to throw out of the map() and wipe the entire roster. Same guarded
+        // decode the count path (PollVote.counts) already goes through.
+        val decoded = response.reactions.mapNotNull { item ->
+            val emoji = decodeReactionCode(item.reactionContent)
+            if (emoji == null) {
+                Logger.w(tag = REACTIONS_TAG) {
+                    "getReactions: skipping undecodable reactionContent from ${item.odinId} on message=$messageId"
+                }
+                return@mapNotNull null
+            }
             EmojiReaction(
                 messageId = messageId,
-                odinId = it.odinId,
-                created = UnixTimeUtc(it.created),
-                emoji = OdinSystemSerializer.deserialize<ReactionContent>(it.reactionContent).emoji
+                odinId = item.odinId,
+                created = UnixTimeUtc(item.created),
+                emoji = emoji,
             )
         }
+
+        Logger.d(tag = REACTIONS_TAG) {
+            "getReactions: message=$messageId fileId=$fileId rows=${response.reactions.size} decoded=${decoded.size}"
+        }
+        return decoded
     }
 
     suspend fun requireFileId(messageId: Uuid): Uuid {

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/poll/PollVoteTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/poll/PollVoteTest.kt
@@ -2,9 +2,16 @@ package id.homebase.chat.poll
 
 import id.homebase.api.client.drives.files.ReactionEntry
 import id.homebase.api.client.drives.files.ReactionSummary
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.time.UnixTimeUtc
+import id.homebase.core.widget.EmojiReaction
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 class PollVoteTest {
     @Test fun code_round_trips() {
@@ -33,6 +40,90 @@ class PollVoteTest {
         assertEquals(2, counts[0])
         assertEquals(1, counts[1])
     }
+
+    // --- tally(): the detail screen's summary-vs-roster reconciliation (#1178) ---
+
+    @Test fun tally_reports_summary_count_when_roster_is_empty() {
+        // The exact #1178 shape: the bubble shows 3 from the header summary while the
+        // live per-user read comes back empty. The detail screen must still say 3 and
+        // flag the roster as partial — never "No votes".
+        val tallies = PollVote.tally(
+            summary = summaryOf(0 to 3),
+            roster = emptyList(),
+            optionCount = 3,
+            selfOdinId = null,
+        )
+        assertEquals(3, tallies[0].count)
+        assertEquals(emptyList(), tallies[0].voters)
+        assertTrue(tallies[0].isPartial)
+        assertEquals(0, tallies[1].count)
+        assertFalse(tallies[1].isPartial)
+    }
+
+    @Test fun tally_treats_a_failed_roster_the_same_as_a_missing_one() {
+        // null roster = load failed / still loading. Counts survive; nothing is invented.
+        val tallies = PollVote.tally(
+            summary = summaryOf(1 to 2),
+            roster = null,
+            optionCount = 2,
+            selfOdinId = null,
+        )
+        assertEquals(2, tallies[1].count)
+        assertTrue(tallies[1].isPartial)
+    }
+
+    @Test fun tally_is_never_lower_than_the_roster_it_renders() {
+        // Header summary lags behind (peer reaction not yet in the preview): the count
+        // must rise to the number of voters actually listed, not under-report them.
+        val tallies = PollVote.tally(
+            summary = summaryOf(0 to 1),
+            roster = listOf(vote(0, "alice.dev"), vote(0, "bob.dev")),
+            optionCount = 1,
+            selfOdinId = null,
+        )
+        assertEquals(2, tallies[0].count)
+        assertFalse(tallies[0].isPartial)
+    }
+
+    @Test fun tally_puts_self_first_and_dedupes() {
+        val self = OdinId("me.dev")
+        val tallies = PollVote.tally(
+            summary = summaryOf(0 to 2),
+            roster = listOf(vote(0, "alice.dev"), vote(0, "me.dev"), vote(0, "alice.dev")),
+            optionCount = 1,
+            selfOdinId = self,
+        )
+        assertEquals(listOf(self, OdinId("alice.dev")), tallies[0].voters)
+    }
+
+    @Test fun tally_ignores_votes_for_out_of_range_options() {
+        val tallies = PollVote.tally(
+            summary = null,
+            roster = listOf(vote(5, "alice.dev"), vote(0, "bob.dev")),
+            optionCount = 1,
+            selfOdinId = null,
+        )
+        assertEquals(1, tallies.size)
+        assertEquals(listOf(OdinId("bob.dev")), tallies[0].voters)
+    }
+
+    private fun summaryOf(vararg optionToCount: Pair<Int, Int>) = ReactionSummary(
+        reactions = optionToCount.associate { (option, count) ->
+            "k$option" to ReactionEntry(
+                key = "k$option",
+                count = count,
+                reactionContent = json(PollVote.codeFor(option)),
+            )
+        }
+    )
+
+    @OptIn(ExperimentalUuidApi::class)
+    private fun vote(option: Int, odinId: String) = EmojiReaction(
+        messageId = Uuid.NIL,
+        emoji = PollVote.codeFor(option),
+        odinId = OdinId(odinId),
+        created = UnixTimeUtc.ZeroTime,
+    )
 
     private fun json(code: String) = """{"emoji":"$code"}"""
 }

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -906,6 +906,9 @@
     <string name="chat_poll_end_failed">Kunne ikke afslutte afstemningen. Prøv igen.</string>
     <string name="chat_poll_ended_self">Du afsluttede afstemningen: "%1$s"</string>
     <string name="chat_poll_ended_other">%1$s afsluttede afstemningen: "%2$s"</string>
+    <string name="chat_poll_roster_loading">Indlæser stemmer…</string>
+    <string name="chat_poll_roster_error">Kunne ikke indlæse hvem der stemte.</string>
+    <string name="chat_poll_roster_partial">Viser %1$d af %2$d stemmer</string>
 
     <string name="chat_unknown_message_type">Ukendt beskedtype — opdatér venligst appen.</string>
     <string name="chat_unknown_message_type_diagnostic">(type %1$d)</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -912,6 +912,9 @@
     <string name="chat_poll_end_failed">Couldn't end the poll. Please try again.</string>
     <string name="chat_poll_ended_self">You ended the poll: "%1$s"</string>
     <string name="chat_poll_ended_other">%1$s ended the poll: "%2$s"</string>
+    <string name="chat_poll_roster_loading">Loading votes…</string>
+    <string name="chat_poll_roster_error">Couldn't load who voted.</string>
+    <string name="chat_poll_roster_partial">Showing %1$d of %2$d voters</string>
 
     <string name="chat_unknown_message_type">Unknown message type — please update the app.</string>
     <string name="chat_unknown_message_type_diagnostic">(type %1$d)</string>


### PR DESCRIPTION
Fixes #1178.

Poll "View results" showed **No votes** for every option while the bubble behind it showed real tallies — and showed nothing the bubble didn't, so the screen had no purpose.

## Root cause

**The bubble and the detail screen were never reading the same store, and the detail screen rendered every failure as zero.**

Server-side, `ReactionPreviewCalculator` maintains the header `reactionPreview` as an **incrementally bumped counter** (`Count++` / `Count--`) — it is never recomputed from the `driveReactions` table. On the client, `OptimisticWriter.writeReactionToggle` layers an optimistic delta on top, and `toggleReaction` only rolls that back when the outbox **enqueue** fails, not when the upload does. The bubble counts that. The detail screen did a live `GET .../group-reactions` read of the actual table. So "bubble 3 / roster 0" is reachable **with no client bug at all**, and the header count is not evidence that rows exist.

On top of that, `runCatching { … }.getOrDefault(emptyList())` plus `rosterReactions ?: emptyList()` collapsed *loading*, `requireFileId`'s `invalid message id`, HTTP 400/403/404, and JSON decode failures into the same "No votes" — with no logging anywhere on the path. That is why the screen gave a **wrong** answer instead of a missing one.

It also surfaced a real decode bug on that exact path: `GetGroupReactionsResponse.cursor` was typed `String?` against the server's `int?`. With `isLenient = false`, any response actually carrying a cursor (a file with more reactions than the page size) threw `JsonDecodingException` and took the **whole** roster down — invisibly, because the swallow hid it.

**Disproved along the way:** ending a poll orphans nothing. Every server update path preserves `fileId`, `globalTransitId` and `reactionPreview` (`DriveStorageServiceBase.OverwriteFile`, `OverwriteMetadataInternal`, `UpdateActiveFileHeader`), no path deletes reaction rows on update, and client-side `OptimisticWriter.writeUpdate` copies the existing file. **This reproduces on an open poll too** — the issue's End-poll theory was a coincidence.

**Still unproven:** a stale client-minted temp `fileId` for self-sent messages would 400 the roster read (`V2DriveGroupReactionController.ResolveGlobalTransitId` hard-400s on an unresolvable fileId). Fixing that means touching the outbox/sync fileId lifecycle, which is too risky without evidence — so this PR **instruments** it rather than guessing, per CLAUDE.md.

## What changed

- **`DriveFileGroupReactionProvider`** — `cursor: String?` → `Int?`, matching the server.
- **`ChatMessageActionService.getReactions`** — decodes per row via the existing `decodeReactionCode` instead of an unguarded `deserialize<ReactionContent>` that let one bad row wipe the list; logs skipped rows plus a `message=… fileId=… rows=… decoded=…` line. KDoc records the two-store contract and that it throws deliberately.
- **`PollVote.tally`** (new) — merges header counts with the roster as `max(summaryCount, votersShown)`, self-first, deduped. New `PollOptionTally.isPartial`.
- **`PollDetailDialog`** — real `Loading` / `Loaded` / `Failed` states replacing the swallow; spinner, error banner + Retry, and a "Showing N of M voters" footnote placed **outside** the `voters.isNotEmpty()` block, because the #1178 case is "3 votes, zero names" — exactly when that note matters most.
- **`PollBubble`** — passes its own `reactionSummary` through, so the detail screen can never report fewer votes than the bubble.
- **`EventDetailDialog`** — logs its previously-silent roster failure. UI left alone: its roster is gated on `takeIf { isNotEmpty() }`, so a failure *omits* the section rather than claiming nobody RSVP'd. It never gave a wrong answer.

## Verification

`homebase-chat:jvmTest homebase-common:jvmTest --rerun-tasks` → **1504 tests, 0 failures** (includes the Konsist `ArchitectureTest`, so no hardcoded strings). 5 new `PollVoteTest` cases cover the count floor, failed-vs-missing roster equivalence, self-first ordering, and out-of-range options.

Device-verified on Android (Redmi Note 5 Pro, A11), real account, in a group:

1. Open poll → vote → **View votes** → roster renders "You", `Alpha · 1 vote`. Log: `rows=1 decoded=1`.
2. **End poll** → reopen → roster still correct, End-poll button correctly gone. Confirms ending orphans nothing.
3. **Forced failure** (airplane mode) → error banner "Couldn't load who voted." + Retry, `Alpha` **still reads "1 vote"** from the header summary, plus "Showing 0 of 1 voters". *On `main` this exact state rendered "Alpha — No votes" — the reported bug.*
4. **Retry** after restoring network → banner clears, roster loads.

**Not verified:** the reporter's original 3-vote poll with peer voters was not located on the device (poll questions live in the descriptor and aren't reachable by message search), so the specific failure they hit was never reproduced. What this PR guarantees is that the same failure can no longer *render as zero votes* — and the new `ChatReactions` logging will name the cause on the next occurrence.

## Follow-ups (not in this PR)

- Temp-fileId window in the outbox/sync lifecycle — instrumented, not fixed.
- odin-core: `DriveQuery.GetReactionsByFileAsync` never populates `Reaction.Created` (always epoch 0); and the incremental-counter vs. table divergence is server-side by design.
- `ReactionsBottomSheet`'s `summaryCounts` + footnote pattern on `feat-native-feed-core` covers the same ground — worth unifying once that lands.
